### PR TITLE
pacific: osd: Override recovery, backfill and sleep related config options during OSD and mclock scheduler initialization.

### DIFF
--- a/doc/rados/configuration/index.rst
+++ b/doc/rados/configuration/index.rst
@@ -39,6 +39,7 @@ To optimize the performance of your cluster, refer to the following:
    mon-lookup-dns
    Heartbeat Settings <mon-osd-interaction>
    OSD Settings <osd-config-ref>
+   DmClock Settings <mclock-config-ref>
    BlueStore Settings <bluestore-config-ref>
    FileStore Settings <filestore-config-ref>
    Journal Settings <journal-ref>

--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -1,0 +1,361 @@
+========================
+ mClock Config Reference
+========================
+
+.. index:: mclock; configuration
+
+This dmclock related configuration parameters can be applied using mclock
+profiles. The purpose of the mclock profiles is to mask the low level details
+from a user trying to configure mclock for a specific purpose. At a high level,
+for each OSD in the enviroment the steps involve,
+
+- providing an input related to the total capacity of OSD(s) and
+- choosing the desired mclock profile to enable
+
+Based on the profile specified, the OSD determines and applies the lower level
+mclock and Ceph parameters. The parameters applied by the mclock profile
+enables tuning of the QoS between client, background recovery/backfill ops and
+other internal entities (aka best effort clients) within Ceph that generate IOPS
+(for e.g. scrubs, snap trim, PG deletions etc.).
+
+
+.. index:: mclock; profile definition
+
+mClock Profiles - Definition and Purpose
+========================================
+
+A mclock profile is *“a configuration setting that when applied on a running
+Ceph cluster enables the throttling of the operations(IOPS) belonging to
+different client classes (background recovery, scrub, snaptrim, client op,
+osd subop)”*.
+
+The purpose of the mclock profile is to help with the following,
+
+- Based on the capacity limits provided and the mclock profile selected,
+  determine the low level mclock resource control parameters,
+- Transparently apply the lower level mclock resource control parameters and
+  some Ceph configuration parameters depending on the profile.
+
+The lower level mclock resource control parameters are the *reservation, weight
+and limit* that provide control of the resource shares as already described in
+the `OSD Config Reference`_ section.
+
+
+.. index:: mclock; profile types
+
+mClock Profile Types
+====================
+
+mclock profiles can be broadly classified into two types,
+
+- **Built-in**: A user can choose between the following built-in profiles types,
+
+  - **high_client_ops** (*default*):
+    This profile allocates more reservation and limit to external clients ops
+    when compared to background recoveries and other internal clients within
+    Ceph. This profile is enabled by default.
+  - **high_recovery_ops**:
+    This profile allocates more reservation to background recoveries when
+    compared to external clients and other internal clients within Ceph. For
+    e.g. an admin may enable this profile temporarily to speed-up background
+    recoveries during non-peak hours.
+  - **balanced**:
+    This profile allocates equal reservations to client ops and background
+    recovery ops.
+
+- **Custom**: A user may enable this profile to have complete control over all the
+  mclock and Ceph configuration parameters. Using this profile is not
+  recommended unless one has a deep understanding of mclock and the related
+  Ceph configuration options.
+
+.. note:: Across the built-in profiles, for internal clients of mclock (for e.g.
+          scrub, snap trim etc.) are given slightly lower reservations but
+          higher weight and no limit. This is to ensure that these operations
+          are able to complete quickly if there are no other competing services.
+
+
+.. index:: mclock; built-in profiles
+
+mClock Built-in Profiles
+========================
+
+When a built-in profile is enabled, the mClock scheduler calculates the low
+level mclock parameters [*reservation, weight, limit*] based on the profile
+enabled for each client type. The mclock parameters are calculated based on
+the max OSD capacity provided beforehand. As a result, the following mclock
+config parameters cannot be modified when using any of the built-in profiles,
+
+- ``osd_mclock_scheduler_client_res``
+- ``osd_mclock_scheduler_client_wgt``
+- ``osd_mclock_scheduler_client_lim``
+- ``osd_mclock_scheduler_background_recovery_res``
+- ``osd_mclock_scheduler_background_recovery_wgt``
+- ``osd_mclock_scheduler_background_recovery_lim``
+- ``osd_mclock_scheduler_background_best_effort_res``
+- ``osd_mclock_scheduler_background_best_effort_wgt``
+- ``osd_mclock_scheduler_background_best_effort_lim``
+
+Additionally, the following Ceph options will not be modifiable by the user,
+
+- ``osd_max_backfills``
+- ``osd_recovery_max_active``
+
+This is because the above options are internally modified by the mclock
+scheduler in order to maximize the impact of the set profile.
+
+By default the *high_client_ops* profile will be enabled to provide larger chunk
+of the bandwidth allocation to client ops. Background recovery ops are given
+lower allocation and so take a longer time to complete. But there might be
+instances that necessitate giving higher allocations to either client ops or
+recovery ops. In order to satisfy such an eventuality, alternate built-in
+profiles mentioned above may be enabled.
+
+Additionally, if a built-in profile is active, the following Ceph config sleep
+options will be disabled,
+
+- ``osd_recovery_sleep``
+- ``osd_recovery_sleep_hdd``
+- ``osd_recovery_sleep_ssd``
+- ``osd_recovery_sleep_hybrid``
+- ``osd_scrub_sleep``
+- ``osd_delete_sleep``
+- ``osd_delete_sleep_hdd``
+- ``osd_delete_sleep_ssd``
+- ``osd_delete_sleep_hybrid``
+- ``osd_snap_trim_sleep``
+- ``osd_snap_trim_sleep_hdd``
+- ``osd_snap_trim_sleep_ssd``
+- ``osd_snap_trim_sleep_hybrid``
+
+The above sleep options are disabled to ensure that mclock scheduler is able
+determine when to pick the next op from its operation queue and transfer
+it to the operation sequencer. This results in the desired QoS to be provided
+across all its clients.
+
+
+.. index:: mclock; enable built-in profile
+
+Steps to Enable mClock Profile
+==============================
+
+The following sections outline the steps required to enable a mclock profile:
+
+Determine OSD Capacity Using Benchmark Tests
+--------------------------------------------
+
+To allow mclock to fulfill the QoS goals across its clients, the most important
+criteria is to have a good understanding of each OSD capacity in terms of their
+baseline throughputs (IOPS) across the Ceph nodes. To determine the capacity,
+appropriate benchmarking tests must be manually performed and the steps for
+this is broadly outlined below.
+
+Any existing benchmarking tool may be employed for this purpose and the
+following steps employs the *Ceph Benchmarking Tool* (aka cbt_). Regardless of
+the tool used, the steps described below remain the same.
+
+As already described in the `OSD Config Reference`_ section, the number of
+shards and the bluestore throttle parameters have an impact on the mclock op
+queues. Therefore, it is critical to set these values carefully in order to
+maximize the impact of the mclock scheduler.
+
+:Number of Operational Shards:
+  The recommendation is to use the default number of shards as defined by the
+  configuration options ``osd_op_num_shards``, ``osd_op_num_shards_hdd``, and
+  ``osd_op_num_shards_ssd``. In general, a lower number of shards will increase
+  the impact of the mclock queues.
+
+:Bluestore Throttle Parameters:
+  The recommendation is to use the default values as defined by
+  ``bluestore_throttle_bytes`` and ``bluestore_throttle_deferred_bytes``. But
+  these parameters may also be determined during the benchmarking phase as
+  described below.
+
+Benchmarking Test Steps Using CBT
+`````````````````````````````````
+
+The steps below uses the default shards and details the steps to determine the
+correct bluestore throttle values if desired,
+
+.. note:: These steps although manual for now will be automated in the future.
+
+1. On the Ceph node hosting the OSDs, download cbt_ from git.
+2. Install cbt and all the dependencies mentioned on the cbt github page.
+3. Construct the Ceph configuration file and the cbt yaml file.
+4. Ensure that the bluestore throttle options ( i.e.
+   ``bluestore_throttle_bytes`` and ``bluestore_throttle_deferred_bytes``) are
+   set to the default values.
+5. Ensure that the test is performed on similar device types to get reliable
+   OSD capacity data.
+6. The OSDs can be grouped together with the desired replication factor for the
+   test to ensure reliability of OSD capacity data.
+7. After ensuring that the OSDs nodes are in the desired configuration, run a
+   simple 4KiB random write workload on the OSD(s) for 300 secs.
+8. Note the overall throughput(IOPS) obtained from the cbt output file. This
+   value would be the baseline throughput(IOPS) with the default bluestore
+   throttle options.
+9. If the intent is to determine the bluestore throttle values for your
+   environment, then set the two options, ``bluestore_throttle_bytes`` and
+   ``bluestore_throttle_deferred_bytes`` to 32 KiB(32768 Bytes) each to begin
+   with. Otherwise, you may skip to the next section.
+10. Run the 4KiB random write workload as before on the OSD(s) for 300 secs.
+11. Note the overall throughput from the cbt log files and compare the value
+    against the baseline throughput in step 8.
+12. If the throughput doesn't match with the baseline, increment the bluestore
+    throttle options by 2x and repeat steps 9 through 11 until the obtained
+    throughput is very close to the baseline value.
+
+For e.g., during benchmarking on a machine with NVMe SSDs a value of 256 KiB for
+both bluestore throttle and deferred bytes was determined to maximize the impact
+of mclock. For HDDs, the corresponding value was 40 MiB where the overall
+throughput was roughly equal to the baseline throughput. Note that in general
+for HDDs, the bluestore throttle values are expected to be higher when compared
+to SSDs.
+
+.. _cbt: https://github.com/ceph/cbt
+
+
+Specify Max OSD Capacity
+------------------------
+
+The steps in this section may be performed only if the max osd capacity is
+different from the default values (SSDs: 21500 IOPS and HDDs: 315 IOPS). The
+option ``osd_mclock_max_capacity_iops_[hdd, ssd]`` may be set by specifying it
+in either the **[global]** section or in a specific OSD section **[osd.x]** of
+your Ceph configuration file.
+
+Alternatively, the following commands may be used,
+
+``$ ceph config set [global, osd] osd_mclock_max_capacity_iops_[hdd,ssd]
+<value>``
+
+For e.g., the following command sets the max capacity for all the OSDs in a
+Ceph node whose underlying device type are SSDs,
+
+``$ ceph config set osd osd_mclock_max_capacity_iops_ssd 25000``
+
+To set the capacity for a specific OSD, say osd.0, whose underlying device type
+is HDD use,
+
+``$ ceph config set osd.0 osd_mclock_max_capacity_iops_hdd 350``
+
+
+Specify mClock Profile to Enable
+---------------------------------
+
+As already mentioned, the default mclock profile is set to *high_client_ops*.
+The other values for the built-in profiles include *balanced* and
+*high_recovery_ops*.
+
+If there is a requirement to change the default profile, then the option
+``osd_mclock_profile`` may be set in the **[global]** or **[osd]** section of
+your Ceph configuration file before bringing up your cluster.
+
+Alternatively, to change the profile during runtime, use the following command,
+
+``$ ceph config set [global,osd] osd_mclock_profile <value>``
+
+For e.g., to change the profile to allow faster recoveries, the following
+command can be used to switch to the *high_recovery_ops* profile,
+
+``$ ceph config set osd osd_mclock_profile high_recovery_ops``
+
+.. note:: The *custom* profile is not recommended unless you are an advanced user.
+
+And that's it! You are ready to run workloads on the cluster and check if the
+QoS requirements are being met.
+
+
+.. index:: mclock; config settings
+
+mClock Config Options
+=====================
+
+``osd_mclock_profile``
+
+:Description: This sets the type of mclock profile to use for providing QoS
+              based on operations belonging to different classes (background
+              recovery, scrub, snaptrim, client op, osd subop). Once a built-in
+              profile is enabled, the lower level mclock resource control
+              parameters [*reservation, weight, limit*] and some Ceph
+              configuration parameters are set transparently. Note that the
+              above does not apply for the *custom* profile.
+
+:Type: String
+:Valid Choices: high_client_ops, high_recovery_ops, balanced, custom
+:Default: ``high_client_ops``
+
+``osd_mclock_max_capacity_iops``
+
+:Description: Max IOPS capacity (at 4KiB block size) to consider per OSD
+              (overrides _ssd and _hdd if non-zero)
+
+:Type: Float
+:Default: ``0.0``
+
+``osd_mclock_max_capacity_iops_hdd``
+
+:Description: Max IOPS capacity (at 4KiB block size) to consider per OSD (for
+              rotational media)
+
+:Type: Float
+:Default: ``315.0``
+
+``osd_mclock_max_capacity_iops_ssd``
+
+:Description: Max IOPS capacity (at 4KiB block size) to consider per OSD (for
+              solid state media)
+
+:Type: Float
+:Default: ``21500.0``
+
+``osd_mclock_cost_per_io_usec``
+
+:Description: Cost per IO in microseconds to consider per OSD (overrides _ssd
+              and _hdd if non-zero)
+
+:Type: Float
+:Default: ``0.0``
+
+``osd_mclock_cost_per_io_usec_hdd``
+
+:Description: Cost per IO in microseconds to consider per OSD (for rotational
+              media)
+
+:Type: Float
+:Default: ``25000.0``
+
+``osd_mclock_cost_per_io_usec_ssd``
+
+:Description: Cost per IO in microseconds to consider per OSD (for solid state
+              media)
+
+:Type: Float
+:Default: ``50.0``
+
+``osd_mclock_cost_per_byte_usec``
+
+:Description: Cost per byte in microseconds to consider per OSD (overrides _ssd
+              and _hdd if non-zero)
+
+:Type: Float
+:Default: ``0.0``
+
+``osd_mclock_cost_per_byte_usec_hdd``
+
+:Description: Cost per byte in microseconds to consider per OSD (for rotational
+              media)
+
+:Type: Float
+:Default: ``5.2``
+
+``osd_mclock_cost_per_byte_usec_ssd``
+
+:Description: Cost per byte in microseconds to consider per OSD (for solid state
+              media)
+
+:Type: Float
+:Default: ``0.011``
+
+
+
+.. _OSD Config Reference: ../osd-config-ref#dmclock-qos

--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -5,7 +5,7 @@
 .. index:: mclock; configuration
 
 Mclock profiles mask the low level details from users, making it
-easier for them to configure mclock.  
+easier for them to configure mclock.
 
 To use mclock, you must provide the following input parameters:
 
@@ -18,7 +18,7 @@ lower-level mclock and Ceph parameters. The parameters applied by the mclock
 profile make it possible to tune the QoS between client I/O, recovery/backfill
 operations, and other background operations (for example, scrub, snap trim, and
 PG deletion). These background activities are considered best-effort internal
-clients of Ceph. 
+clients of Ceph.
 
 
 .. index:: mclock; profile definition
@@ -39,7 +39,7 @@ some Ceph-configuration parameters are transparently applied.
 
 The low-level mclock resource control parameters are the *reservation*,
 *limit*, and *weight* that provide control of the resource shares, as
-described in the `OSD Config Reference`_.
+described in the :ref:`dmclock-qos` section.
 
 
 .. index:: mclock; profile types
@@ -64,14 +64,14 @@ mclock profiles can be broadly classified into two types,
     This profile allocates equal reservation to client ops and background
     recovery ops.
 
-- **Custom**: This profile gives users complete control over all mclock and
-  Ceph configuration parameters. Using this profile is not recommended without
+- **Custom**: This profile gives users complete control over all the mclock
+  configuration parameters. Using this profile is not recommended without
   a deep understanding of mclock and related Ceph-configuration options.
 
 .. note:: Across the built-in profiles, internal clients of mclock (for example
-          "scrub", "snap trim", and "pg deletion") are given slightly lower 
-          reservations, but higher weight and no limit. This ensures that 
-          these operations are able to complete quickly if there are no other 
+          "scrub", "snap trim", and "pg deletion") are given slightly lower
+          reservations, but higher weight and no limit. This ensures that
+          these operations are able to complete quickly if there are no other
           competing services.
 
 
@@ -111,8 +111,8 @@ there might be instances that necessitate giving higher allocations to either
 client ops or recovery ops. In order to deal with such a situation, you can
 enable one of the alternate built-in profiles mentioned above.
 
-If a built-in profile is active, the following Ceph config sleep options will
-be disabled,
+If any mClock profile (including "custom") is active, the following Ceph config
+sleep options will be disabled,
 
 - ``osd_recovery_sleep``
 - ``osd_recovery_sleep_hdd``
@@ -154,7 +154,7 @@ Any existing benchmarking tool can be used for this purpose. The following
 steps use the *Ceph Benchmarking Tool* (cbt_). Regardless of the tool
 used, the steps described below remain the same.
 
-As already described in the `OSD Config Reference`_ section, the number of
+As already described in the :ref:`dmclock-qos` section, the number of
 shards and the bluestore's throttle parameters have an impact on the mclock op
 queues. Therefore, it is critical to set these values carefully in order to
 maximize the impact of the mclock scheduler.
@@ -366,6 +366,3 @@ mClock Config Options
 :Type: Float
 :Default: ``0.011``
 
-
-
-.. _OSD Config Reference: ../osd-config-ref#dmclock-qos

--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -4,19 +4,21 @@
 
 .. index:: mclock; configuration
 
-This dmclock related configuration parameters can be applied using mclock
-profiles. The purpose of the mclock profiles is to mask the low level details
-from a user trying to configure mclock for a specific purpose. At a high level,
-for each OSD in the enviroment the steps involve,
+Mclock profiles mask the low level details from users, making it
+easier for them to configure mclock.  
 
-- providing an input related to the total capacity of OSD(s) and
-- choosing the desired mclock profile to enable
+To use mclock, you must provide the following input parameters:
 
-Based on the profile specified, the OSD determines and applies the lower level
-mclock and Ceph parameters. The parameters applied by the mclock profile
-enables tuning of the QoS between client, background recovery/backfill ops and
-other internal entities (aka best effort clients) within Ceph that generate IOPS
-(for e.g. scrubs, snap trim, PG deletions etc.).
+* total capacity of each OSD
+
+* an mclock profile to enable
+
+Using the settings in the specified profile, the OSD determines and applies the
+lower-level mclock and Ceph parameters. The parameters applied by the mclock
+profile make it possible to tune the QoS between client I/O, recovery/backfill
+operations, and other background operations (for example, scrub, snap trim, and
+PG deletion). These background activities are considered best-effort internal
+clients of Ceph. 
 
 
 .. index:: mclock; profile definition
@@ -29,16 +31,15 @@ Ceph cluster enables the throttling of the operations(IOPS) belonging to
 different client classes (background recovery, scrub, snaptrim, client op,
 osd subop)”*.
 
-The purpose of the mclock profile is to help with the following,
+The mclock profile uses the capacity limits and the mclock profile selected by
+the user to determine the low-level mclock resource control parameters.
 
-- Based on the capacity limits provided and the mclock profile selected,
-  determine the low level mclock resource control parameters,
-- Transparently apply the lower level mclock resource control parameters and
-  some Ceph configuration parameters depending on the profile.
+Depending on the profile, lower-level mclock resource-control parameters and
+some Ceph-configuration parameters are transparently applied.
 
-The lower level mclock resource control parameters are the *reservation, weight
-and limit* that provide control of the resource shares as already described in
-the `OSD Config Reference`_ section.
+The low-level mclock resource control parameters are the *reservation*,
+*limit*, and *weight* that provide control of the resource shares, as
+described in the `OSD Config Reference`_.
 
 
 .. index:: mclock; profile types
@@ -48,30 +49,30 @@ mClock Profile Types
 
 mclock profiles can be broadly classified into two types,
 
-- **Built-in**: A user can choose between the following built-in profiles types,
+- **Built-in**: Users can choose between the following built-in profile types:
 
   - **high_client_ops** (*default*):
-    This profile allocates more reservation and limit to external clients ops
-    when compared to background recoveries and other internal clients within
+    This profile allocates more reservation and limit to external-client ops
+    as compared to background recoveries and other internal clients within
     Ceph. This profile is enabled by default.
   - **high_recovery_ops**:
-    This profile allocates more reservation to background recoveries when
+    This profile allocates more reservation to background recoveries as 
     compared to external clients and other internal clients within Ceph. For
-    e.g. an admin may enable this profile temporarily to speed-up background
+    example, an admin may enable this profile temporarily to speed-up background
     recoveries during non-peak hours.
   - **balanced**:
-    This profile allocates equal reservations to client ops and background
+    This profile allocates equal reservation to client ops and background
     recovery ops.
 
-- **Custom**: A user may enable this profile to have complete control over all the
-  mclock and Ceph configuration parameters. Using this profile is not
-  recommended unless one has a deep understanding of mclock and the related
-  Ceph configuration options.
+- **Custom**: This profile gives users complete control over all mclock and
+  Ceph configuration parameters. Using this profile is not recommended without
+  a deep understanding of mclock and related Ceph-configuration options.
 
-.. note:: Across the built-in profiles, for internal clients of mclock (for e.g.
-          scrub, snap trim etc.) are given slightly lower reservations but
-          higher weight and no limit. This is to ensure that these operations
-          are able to complete quickly if there are no other competing services.
+.. note:: Across the built-in profiles, internal clients of mclock (for example
+          "scrub", "snap trim", and "pg deletion") are given slightly lower 
+          reservations, but higher weight and no limit. This ensures that 
+          these operations are able to complete quickly if there are no other 
+          competing services.
 
 
 .. index:: mclock; built-in profiles
@@ -80,10 +81,10 @@ mClock Built-in Profiles
 ========================
 
 When a built-in profile is enabled, the mClock scheduler calculates the low
-level mclock parameters [*reservation, weight, limit*] based on the profile
+level mclock parameters [*reservation*, *weight*, *limit*] based on the profile
 enabled for each client type. The mclock parameters are calculated based on
 the max OSD capacity provided beforehand. As a result, the following mclock
-config parameters cannot be modified when using any of the built-in profiles,
+config parameters cannot be modified when using any of the built-in profiles:
 
 - ``osd_mclock_scheduler_client_res``
 - ``osd_mclock_scheduler_client_wgt``
@@ -95,7 +96,7 @@ config parameters cannot be modified when using any of the built-in profiles,
 - ``osd_mclock_scheduler_background_best_effort_wgt``
 - ``osd_mclock_scheduler_background_best_effort_lim``
 
-Additionally, the following Ceph options will not be modifiable by the user,
+The following Ceph options will not be modifiable by the user:
 
 - ``osd_max_backfills``
 - ``osd_recovery_max_active``
@@ -103,15 +104,15 @@ Additionally, the following Ceph options will not be modifiable by the user,
 This is because the above options are internally modified by the mclock
 scheduler in order to maximize the impact of the set profile.
 
-By default the *high_client_ops* profile will be enabled to provide larger chunk
-of the bandwidth allocation to client ops. Background recovery ops are given
-lower allocation and so take a longer time to complete. But there might be
-instances that necessitate giving higher allocations to either client ops or
-recovery ops. In order to satisfy such an eventuality, alternate built-in
-profiles mentioned above may be enabled.
+By default, the *high_client_ops* profile is enabled to ensure that a larger
+chunk of the bandwidth allocation goes to client ops. Background recovery ops
+are given lower allocation (and therefore take a longer time to complete). But
+there might be instances that necessitate giving higher allocations to either
+client ops or recovery ops. In order to deal with such a situation, you can
+enable one of the alternate built-in profiles mentioned above.
 
-Additionally, if a built-in profile is active, the following Ceph config sleep
-options will be disabled,
+If a built-in profile is active, the following Ceph config sleep options will
+be disabled,
 
 - ``osd_recovery_sleep``
 - ``osd_recovery_sleep_hdd``
@@ -127,10 +128,10 @@ options will be disabled,
 - ``osd_snap_trim_sleep_ssd``
 - ``osd_snap_trim_sleep_hybrid``
 
-The above sleep options are disabled to ensure that mclock scheduler is able
-determine when to pick the next op from its operation queue and transfer
-it to the operation sequencer. This results in the desired QoS to be provided
-across all its clients.
+The above sleep options are disabled to ensure that mclock scheduler is able to
+determine when to pick the next op from its operation queue and transfer it to
+the operation sequencer. This results in the desired QoS being provided across
+all its clients.
 
 
 .. index:: mclock; enable built-in profile
@@ -138,34 +139,34 @@ across all its clients.
 Steps to Enable mClock Profile
 ==============================
 
-The following sections outline the steps required to enable a mclock profile:
+The following sections outline the steps required to enable a mclock profile.
 
-Determine OSD Capacity Using Benchmark Tests
---------------------------------------------
+Determining OSD Capacity Using Benchmark Tests
+----------------------------------------------
 
-To allow mclock to fulfill the QoS goals across its clients, the most important
-criteria is to have a good understanding of each OSD capacity in terms of their
-baseline throughputs (IOPS) across the Ceph nodes. To determine the capacity,
-appropriate benchmarking tests must be manually performed and the steps for
-this is broadly outlined below.
+To allow mclock to fulfill its QoS goals across its clients, it is most
+important to have a good understanding of each OSD's capacity in terms of its
+baseline throughputs (IOPS) across the Ceph nodes. To determine this capacity,
+you must perform appropriate benchmarking tests. The steps for performing these
+benchmarking tests are broadly outlined below.
 
-Any existing benchmarking tool may be employed for this purpose and the
-following steps employs the *Ceph Benchmarking Tool* (aka cbt_). Regardless of
-the tool used, the steps described below remain the same.
+Any existing benchmarking tool can be used for this purpose. The following
+steps use the *Ceph Benchmarking Tool* (cbt_). Regardless of the tool
+used, the steps described below remain the same.
 
 As already described in the `OSD Config Reference`_ section, the number of
-shards and the bluestore throttle parameters have an impact on the mclock op
+shards and the bluestore's throttle parameters have an impact on the mclock op
 queues. Therefore, it is critical to set these values carefully in order to
 maximize the impact of the mclock scheduler.
 
 :Number of Operational Shards:
-  The recommendation is to use the default number of shards as defined by the
+  We recommend using the default number of shards as defined by the
   configuration options ``osd_op_num_shards``, ``osd_op_num_shards_hdd``, and
   ``osd_op_num_shards_ssd``. In general, a lower number of shards will increase
   the impact of the mclock queues.
 
 :Bluestore Throttle Parameters:
-  The recommendation is to use the default values as defined by
+  We recommend using the default values as defined by
   ``bluestore_throttle_bytes`` and ``bluestore_throttle_deferred_bytes``. But
   these parameters may also be determined during the benchmarking phase as
   described below.

--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -174,10 +174,10 @@ maximize the impact of the mclock scheduler.
 Benchmarking Test Steps Using CBT
 `````````````````````````````````
 
-The steps below uses the default shards and details the steps to determine the
-correct bluestore throttle values if desired,
+The steps below use the default shards and detail the steps used to determine the
+correct bluestore throttle values.
 
-.. note:: These steps although manual for now will be automated in the future.
+.. note:: These steps, although manual in April 2021, will be automated in the future.
 
 1. On the Ceph node hosting the OSDs, download cbt_ from git.
 2. Install cbt and all the dependencies mentioned on the cbt github page.
@@ -192,8 +192,8 @@ correct bluestore throttle values if desired,
 7. After ensuring that the OSDs nodes are in the desired configuration, run a
    simple 4KiB random write workload on the OSD(s) for 300 secs.
 8. Note the overall throughput(IOPS) obtained from the cbt output file. This
-   value would be the baseline throughput(IOPS) with the default bluestore
-   throttle options.
+   value is the baseline throughput(IOPS) when the default bluestore
+   throttle options are in effect.
 9. If the intent is to determine the bluestore throttle values for your
    environment, then set the two options, ``bluestore_throttle_bytes`` and
    ``bluestore_throttle_deferred_bytes`` to 32 KiB(32768 Bytes) each to begin
@@ -205,9 +205,9 @@ correct bluestore throttle values if desired,
     throttle options by 2x and repeat steps 9 through 11 until the obtained
     throughput is very close to the baseline value.
 
-For e.g., during benchmarking on a machine with NVMe SSDs a value of 256 KiB for
+For example, during benchmarking on a machine with NVMe SSDs, a value of 256 KiB for
 both bluestore throttle and deferred bytes was determined to maximize the impact
-of mclock. For HDDs, the corresponding value was 40 MiB where the overall
+of mclock. For HDDs, the corresponding value was 40 MiB, where the overall
 throughput was roughly equal to the baseline throughput. Note that in general
 for HDDs, the bluestore throttle values are expected to be higher when compared
 to SSDs.
@@ -215,33 +215,38 @@ to SSDs.
 .. _cbt: https://github.com/ceph/cbt
 
 
-Specify Max OSD Capacity
-------------------------
+Specifying  Max OSD Capacity
+----------------------------
 
 The steps in this section may be performed only if the max osd capacity is
 different from the default values (SSDs: 21500 IOPS and HDDs: 315 IOPS). The
-option ``osd_mclock_max_capacity_iops_[hdd, ssd]`` may be set by specifying it
-in either the **[global]** section or in a specific OSD section **[osd.x]** of
-your Ceph configuration file.
+option ``osd_mclock_max_capacity_iops_[hdd, ssd]`` can be set by specifying it
+in either the **[global]** section or in a specific OSD section (**[osd.x]** of
+your Ceph configuration file).
 
-Alternatively, the following commands may be used,
+Alternatively, commands of the following form may be used:
 
-``$ ceph config set [global, osd] osd_mclock_max_capacity_iops_[hdd,ssd]
-<value>``
+  .. prompt:: bash #
 
-For e.g., the following command sets the max capacity for all the OSDs in a
-Ceph node whose underlying device type are SSDs,
+     ceph config set [global, osd] osd_mclock_max_capacity_iops_[hdd,ssd] <value>
 
-``$ ceph config set osd osd_mclock_max_capacity_iops_ssd 25000``
+For example, the following command sets the max capacity for all the OSDs in a
+Ceph node whose underlying device type is SSDs:
 
-To set the capacity for a specific OSD, say osd.0, whose underlying device type
-is HDD use,
+  .. prompt:: bash #
 
-``$ ceph config set osd.0 osd_mclock_max_capacity_iops_hdd 350``
+    ceph config set osd osd_mclock_max_capacity_iops_ssd 25000
+
+To set the capacity for a specific OSD (for example "osd.0") whose underlying
+device type is HDD, use a command like this:
+
+  .. prompt:: bash #
+
+    ceph config set osd.0 osd_mclock_max_capacity_iops_hdd 350
 
 
-Specify mClock Profile to Enable
----------------------------------
+Specifying Which mClock Profile to Enable
+-----------------------------------------
 
 As already mentioned, the default mclock profile is set to *high_client_ops*.
 The other values for the built-in profiles include *balanced* and
@@ -251,14 +256,18 @@ If there is a requirement to change the default profile, then the option
 ``osd_mclock_profile`` may be set in the **[global]** or **[osd]** section of
 your Ceph configuration file before bringing up your cluster.
 
-Alternatively, to change the profile during runtime, use the following command,
+Alternatively, to change the profile during runtime, use the following command:
 
-``$ ceph config set [global,osd] osd_mclock_profile <value>``
+  .. prompt:: bash #
 
-For e.g., to change the profile to allow faster recoveries, the following
-command can be used to switch to the *high_recovery_ops* profile,
+    ceph config set [global,osd] osd_mclock_profile <value>
 
-``$ ceph config set osd osd_mclock_profile high_recovery_ops``
+For example, to change the profile to allow faster recoveries, the following
+command can be used to switch to the *high_recovery_ops* profile:
+
+  .. prompt:: bash #
+
+    ceph config set osd osd_mclock_profile high_recovery_ops
 
 .. note:: The *custom* profile is not recommended unless you are an advanced user.
 

--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -569,8 +569,8 @@ Operations
 QoS Based on mClock
 -------------------
 
-Ceph's use of mClock is currently experimental and should
-be approached with an exploratory mindset.
+Ceph's use of mClock is now more refined and can be used by following the
+steps as described in `mClock Config Reference`_.
 
 Core Concepts
 `````````````
@@ -597,7 +597,7 @@ words, the share of each type of service is controlled by three tags:
 #. weight: the proportional share of capacity if extra capacity or system
    oversubscribed.
 
-In Ceph operations are graded with "cost". And the resources allocated
+In Ceph, operations are graded with "cost". And the resources allocated
 for serving various services are consumed by these "costs". So, for
 example, the more reservation a services has, the more resource it is
 guaranteed to possess, as long as it requires. Assuming there are 2
@@ -619,10 +619,9 @@ competitor "1". In the case of client ops, it is not clamped by the
 limit setting, so it can make use of all the resources if there is no
 recovery ongoing.
 
-CURRENT IMPLEMENTATION NOTE: the current experimental implementation
-does not enforce the limit values. As a first approximation we decided
-not to prevent operations that would otherwise enter the operation
-sequencer from doing so.
+CURRENT IMPLEMENTATION NOTE: the current implementation enforces the limit
+values. Therefore, if a service crosses the enforced limit, the op remains
+in the operation queue until the limit is restored.
 
 Subtleties of mClock
 ````````````````````
@@ -644,7 +643,7 @@ means if *W* is sufficiently large and therefore *1/W* is sufficiently
 small, the calculated tag may never be assigned as it will get a value
 of the current time. The ultimate lesson is that values for weight
 should not be too large. They should be under the number of requests
-one expects to ve serviced each second.
+one expects to be serviced each second.
 
 Caveats
 ```````
@@ -1125,3 +1124,4 @@ Miscellaneous
 .. _Pool & PG Config Reference: ../pool-pg-config-ref
 .. _Journal Config Reference: ../journal-ref
 .. _cache target dirty high ratio: ../../operations/pools#cache-target-dirty-high-ratio
+.. _mClock Config Reference: ../mclock-config-ref

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3204,18 +3204,22 @@ std::vector<Option> get_global_options() {
 
     Option("osd_snap_trim_sleep", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0)
+    .set_flag(Option::FLAG_RUNTIME)
     .set_description("Time in seconds to sleep before next snap trim (overrides values below)"),
 
     Option("osd_snap_trim_sleep_hdd", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(5)
+    .set_flag(Option::FLAG_RUNTIME)
     .set_description("Time in seconds to sleep before next snap trim for HDDs"),
 
     Option("osd_snap_trim_sleep_ssd", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0)
+    .set_flag(Option::FLAG_RUNTIME)
     .set_description("Time in seconds to sleep before next snap trim for SSDs"),
 
     Option("osd_snap_trim_sleep_hybrid", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(2)
+    .set_flag(Option::FLAG_RUNTIME)
     .set_description("Time in seconds to sleep before next snap trim when data is on HDD and journal is on SSD"),
 
     Option("osd_scrub_invalid_stats", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -3437,6 +3441,7 @@ std::vector<Option> get_global_options() {
 
     Option("osd_scrub_sleep", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0)
+    .set_flag(Option::FLAG_RUNTIME)
     .set_description("Duration to inject a delay during scrubbing"),
 
     Option("osd_scrub_extended_sleep", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
@@ -3745,18 +3750,22 @@ std::vector<Option> get_global_options() {
 
     Option("osd_delete_sleep", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0)
+    .set_flag(Option::FLAG_RUNTIME)
     .set_description("Time in seconds to sleep before next removal transaction (overrides values below)"),
 
     Option("osd_delete_sleep_hdd", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(5)
+    .set_flag(Option::FLAG_RUNTIME)
     .set_description("Time in seconds to sleep before next removal transaction for HDDs"),
 
     Option("osd_delete_sleep_ssd", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(1)
+    .set_flag(Option::FLAG_RUNTIME)
     .set_description("Time in seconds to sleep before next removal transaction for SSDs"),
 
     Option("osd_delete_sleep_hybrid", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(1)
+    .set_flag(Option::FLAG_RUNTIME)
     .set_description("Time in seconds to sleep before next removal transaction when data is on HDD and journal is on SSD"),
 
     Option("osd_failsafe_full_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2323,6 +2323,9 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
       this);
     shards.push_back(one_shard);
   }
+
+  // override some config options if mclock is enabled on all the shards
+  maybe_override_options_for_qos();
 }
 
 OSD::~OSD()
@@ -9920,6 +9923,15 @@ const char** OSD::get_tracked_conf_keys() const
     "osd_recovery_sleep_hdd",
     "osd_recovery_sleep_ssd",
     "osd_recovery_sleep_hybrid",
+    "osd_delete_sleep",
+    "osd_delete_sleep_hdd",
+    "osd_delete_sleep_ssd",
+    "osd_delete_sleep_hybrid",
+    "osd_snap_trim_sleep",
+    "osd_snap_trim_sleep_hdd",
+    "osd_snap_trim_sleep_ssd",
+    "osd_snap_trim_sleep_hybrid"
+    "osd_scrub_sleep",
     "osd_recovery_max_active",
     "osd_recovery_max_active_hdd",
     "osd_recovery_max_active_ssd",
@@ -9969,46 +9981,9 @@ void OSD::handle_conf_change(const ConfigProxy& conf,
       changed.count("osd_recovery_max_active") ||
       changed.count("osd_recovery_max_active_hdd") ||
       changed.count("osd_recovery_max_active_ssd")) {
-    if (cct->_conf.get_val<std::string>("osd_op_queue") == "mclock_scheduler" &&
-        cct->_conf.get_val<std::string>("osd_mclock_profile") != "custom") {
-      // Set ceph config option to meet QoS goals
-      // Set high value for recovery max active
-      uint32_t recovery_max_active = 1000;
-      if (cct->_conf->osd_recovery_max_active) {
-        cct->_conf.set_val(
-            "osd_recovery_max_active", std::to_string(recovery_max_active));
-      }
-      if (store_is_rotational) {
-        cct->_conf.set_val(
-            "osd_recovery_max_active_hdd", std::to_string(recovery_max_active));
-      } else {
-        cct->_conf.set_val(
-            "osd_recovery_max_active_ssd", std::to_string(recovery_max_active));
-      }
-      // Set high value for osd_max_backfill
-      cct->_conf.set_val("osd_max_backfills", std::to_string(1000));
-
-      // Disable recovery sleep
-      cct->_conf.set_val("osd_recovery_sleep", std::to_string(0));
-      cct->_conf.set_val("osd_recovery_sleep_hdd", std::to_string(0));
-      cct->_conf.set_val("osd_recovery_sleep_ssd", std::to_string(0));
-      cct->_conf.set_val("osd_recovery_sleep_hybrid", std::to_string(0));
-
-      // Disable delete sleep
-      cct->_conf.set_val("osd_delete_sleep", std::to_string(0));
-      cct->_conf.set_val("osd_delete_sleep_hdd", std::to_string(0));
-      cct->_conf.set_val("osd_delete_sleep_ssd", std::to_string(0));
-      cct->_conf.set_val("osd_delete_sleep_hybrid", std::to_string(0));
-
-      // Disable snap trim sleep
-      cct->_conf.set_val("osd_snap_trim_sleep", std::to_string(0));
-      cct->_conf.set_val("osd_snap_trim_sleep_hdd", std::to_string(0));
-      cct->_conf.set_val("osd_snap_trim_sleep_ssd", std::to_string(0));
-      cct->_conf.set_val("osd_snap_trim_sleep_hybrid", std::to_string(0));
-
-      // Disable scrub sleep
-      cct->_conf.set_val("osd_scrub_sleep", std::to_string(0));
-    } else {
+    if (!maybe_override_options_for_qos() &&
+        changed.count("osd_max_backfills")) {
+      // Scheduler is not "mclock". Fallback to earlier behavior
       service.local_reserver.set_max(cct->_conf->osd_max_backfills);
       service.remote_reserver.set_max(cct->_conf->osd_max_backfills);
     }
@@ -10100,6 +10075,54 @@ void OSD::handle_conf_change(const ConfigProxy& conf,
     service.poolctx.stop();
     service.poolctx.start(conf.get_val<std::uint64_t>("osd_asio_thread_count"));
   }
+}
+
+bool OSD::maybe_override_options_for_qos()
+{
+  // If the scheduler enabled is mclock, override the recovery, backfill
+  // and sleep options so that mclock can meet the QoS goals.
+  if (cct->_conf.get_val<std::string>("osd_op_queue") == "mclock_scheduler") {
+    dout(1) << __func__
+            << ": Changing recovery/backfill/sleep settings for QoS" << dendl;
+
+    // Set high value for recovery max active
+    uint32_t rec_max_active = 1000;
+    cct->_conf.set_val(
+      "osd_recovery_max_active", std::to_string(rec_max_active));
+    cct->_conf.set_val(
+      "osd_recovery_max_active_hdd", std::to_string(rec_max_active));
+    cct->_conf.set_val(
+      "osd_recovery_max_active_ssd", std::to_string(rec_max_active));
+
+    // Set high value for osd_max_backfill
+    uint32_t max_backfills = 1000;
+    cct->_conf.set_val("osd_max_backfills", std::to_string(max_backfills));
+    service.local_reserver.set_max(max_backfills);
+    service.remote_reserver.set_max(max_backfills);
+
+    // Disable recovery sleep
+    cct->_conf.set_val("osd_recovery_sleep", std::to_string(0));
+    cct->_conf.set_val("osd_recovery_sleep_hdd", std::to_string(0));
+    cct->_conf.set_val("osd_recovery_sleep_ssd", std::to_string(0));
+    cct->_conf.set_val("osd_recovery_sleep_hybrid", std::to_string(0));
+
+    // Disable delete sleep
+    cct->_conf.set_val("osd_delete_sleep", std::to_string(0));
+    cct->_conf.set_val("osd_delete_sleep_hdd", std::to_string(0));
+    cct->_conf.set_val("osd_delete_sleep_ssd", std::to_string(0));
+    cct->_conf.set_val("osd_delete_sleep_hybrid", std::to_string(0));
+
+    // Disable snap trim sleep
+    cct->_conf.set_val("osd_snap_trim_sleep", std::to_string(0));
+    cct->_conf.set_val("osd_snap_trim_sleep_hdd", std::to_string(0));
+    cct->_conf.set_val("osd_snap_trim_sleep_ssd", std::to_string(0));
+    cct->_conf.set_val("osd_snap_trim_sleep_hybrid", std::to_string(0));
+
+    // Disable scrub sleep
+    cct->_conf.set_val("osd_scrub_sleep", std::to_string(0));
+    return true;
+  }
+  return false;
 }
 
 void OSD::update_log_config()

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2065,6 +2065,7 @@ private:
   float get_osd_snap_trim_sleep();
 
   int get_recovery_max_active();
+  bool maybe_override_options_for_qos();
 
   void scrub_purged_snaps();
   void probe_smart(const std::string& devid, std::ostream& ss);

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -334,8 +334,6 @@ void mClockScheduler::enable_mclock_profile_settings()
 
   // Set the mclock config parameters
   set_profile_config();
-  // Set recovery specific Ceph options
-  set_global_recovery_options();
 }
 
 void mClockScheduler::set_profile_config()
@@ -370,39 +368,6 @@ void mClockScheduler::set_profile_config()
     std::to_string(best_effort.wgt));
   cct->_conf.set_val("osd_mclock_scheduler_background_best_effort_lim",
     std::to_string(best_effort.lim));
-}
-
-void mClockScheduler::set_global_recovery_options()
-{
-  // Set high value for recovery max active and max backfill
-  int rec_max_active = 1000;
-  int max_backfills = 1000;
-  cct->_conf.set_val("osd_recovery_max_active", std::to_string(rec_max_active));
-  cct->_conf.set_val("osd_max_backfills", std::to_string(max_backfills));
-
-  // Disable recovery sleep
-  cct->_conf.set_val("osd_recovery_sleep", std::to_string(0));
-  cct->_conf.set_val("osd_recovery_sleep_hdd", std::to_string(0));
-  cct->_conf.set_val("osd_recovery_sleep_ssd", std::to_string(0));
-  cct->_conf.set_val("osd_recovery_sleep_hybrid", std::to_string(0));
-
-  // Disable delete sleep
-  cct->_conf.set_val("osd_delete_sleep", std::to_string(0));
-  cct->_conf.set_val("osd_delete_sleep_hdd", std::to_string(0));
-  cct->_conf.set_val("osd_delete_sleep_ssd", std::to_string(0));
-  cct->_conf.set_val("osd_delete_sleep_hybrid", std::to_string(0));
-
-  // Disable snap trim sleep
-  cct->_conf.set_val("osd_snap_trim_sleep", std::to_string(0));
-  cct->_conf.set_val("osd_snap_trim_sleep_hdd", std::to_string(0));
-  cct->_conf.set_val("osd_snap_trim_sleep_ssd", std::to_string(0));
-  cct->_conf.set_val("osd_snap_trim_sleep_hybrid", std::to_string(0));
-
-  // Disable scrub sleep
-  cct->_conf.set_val("osd_scrub_sleep", std::to_string(0));
-
-  // Apply the changes
-  cct->_conf.apply_changes(nullptr);
 }
 
 int mClockScheduler::calc_scaled_cost(int item_cost)
@@ -526,7 +491,10 @@ void mClockScheduler::handle_conf_change(
       changed.count("osd_mclock_scheduler_client_lim") ||
       changed.count("osd_mclock_scheduler_background_recovery_res") ||
       changed.count("osd_mclock_scheduler_background_recovery_wgt") ||
-      changed.count("osd_mclock_scheduler_background_recovery_lim")) {
+      changed.count("osd_mclock_scheduler_background_recovery_lim") ||
+      changed.count("osd_mclock_scheduler_background_best_effort_res") ||
+      changed.count("osd_mclock_scheduler_background_best_effort_wgt") ||
+      changed.count("osd_mclock_scheduler_background_best_effort_lim")) {
     if (mclock_profile == "custom") {
       client_registry.update_from_config(conf);
     }

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -169,9 +169,6 @@ public:
   // Set mclock config parameter based on allocations
   void set_profile_config();
 
-  // Set recovery specific Ceph settings for profiles
-  void set_global_recovery_options();
-
   // Calculate scale cost per item
   int calc_scaled_cost(int cost);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50606

---

backport of https://github.com/ceph/ceph/pull/41004
parent tracker: https://tracker.ceph.com/issues/50501

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh