### PR TITLE
crimson/seastore: dump crimson perf counters

### DIFF
--- a/src/crimson/admin/osd_admin.h
+++ b/src/crimson/admin/osd_admin.h
@@ -14,7 +14,7 @@ class OsdStatusHook;
 class SendBeaconHook;
 class DumpPGStateHistory;
 class SeastarMetricsHook;
-
+class DumpPerfCountersHook;
 
 template<class Hook, class... Args>
 std::unique_ptr<AdminSocketHook> make_asok_hook(Args&&... args);

--- a/src/crimson/common/perf_counters_collection.cc
+++ b/src/crimson/common/perf_counters_collection.cc
@@ -18,6 +18,13 @@ PerfCountersCollectionImpl* PerfCountersCollection:: get_perf_collection()
   return perf_collection.get();
 }
 
+void PerfCountersCollection::dump_formatted(ceph::Formatter *f, bool schema,
+                                            const std::string &logger,
+                                            const std::string &counter)
+{
+  perf_collection->dump_formatted(f, schema, logger, counter);
+}
+
 PerfCountersCollection::ShardedPerfCountersCollection PerfCountersCollection::sharded_perf_coll;
 
 }

--- a/src/crimson/common/perf_counters_collection.h
+++ b/src/crimson/common/perf_counters_collection.h
@@ -22,7 +22,9 @@ public:
   PerfCountersCollection();
   ~PerfCountersCollection();
   PerfCountersCollectionImpl* get_perf_collection();
-
+  void dump_formatted(ceph::Formatter *f, bool schema,
+                      const std::string &logger = "",
+                      const std::string &counter = "");
 };
 
 inline PerfCountersCollection::ShardedPerfCountersCollection& sharded_perf_coll(){

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -442,6 +442,7 @@ seastar::future<> OSD::start_asok_admin()
       asok->register_command(make_asok_hook<FlushPgStatsHook>(*this)),
       asok->register_command(make_asok_hook<DumpPGStateHistory>(std::as_const(*this))),
       asok->register_command(make_asok_hook<SeastarMetricsHook>()),
+      asok->register_command(make_asok_hook<DumpPerfCountersHook>(std::as_const(*this))),
       // PG commands
       asok->register_command(make_asok_hook<pg::QueryCommand>(*this)),
       asok->register_command(make_asok_hook<pg::MarkUnfoundLostCommand>(*this)));


### PR DESCRIPTION
Signed-off-by: chunmei-liu <chunmei.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
