### PR TITLE
cephfs.pyx: Fix docstring of get_layout

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -2581,9 +2581,9 @@ cdef class LibCephFS(object):
 
     def get_layout(self, fd):
         """
-        Set ceph client session timeout. Must be called before mount.
+        Get the file layout from an open file descriptor.
 
-        :param fd: file descriptor of the file/directory for which to get the layout
+        :param fd: the open file descriptor referring to the file to get the layout of.
         """
 
         if not isinstance(fd, int):


### PR DESCRIPTION
It was copy-pasted from another function.

Fixed by copy-pasting the docstring from the C docs.

Signed-off-by: Niklas Hambuechen <mail@nh2.me>