### PR TITLE
rgw: radosgw_admin remove bucket not purging past 1,000 objects

### DIFF
--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -214,7 +214,12 @@ Object* RadosBucket::create_object(const rgw_obj_key &key)
   return nullptr;
 }
 
-int RadosBucket::remove_bucket(const DoutPrefixProvider* dpp, bool delete_children, std::string prefix, std::string delimiter, bool forward_to_master, req_info* req_info, optional_yield y)
+int RadosBucket::remove_bucket(const DoutPrefixProvider* dpp,
+			       bool delete_children,
+			       std::string prefix,
+			       std::string delimiter,
+			       bool forward_to_master,
+			       req_info* req_info, optional_yield y)
 {
   int ret;
 
@@ -229,13 +234,12 @@ int RadosBucket::remove_bucket(const DoutPrefixProvider* dpp, bool delete_childr
 
   ListResults results;
 
-  bool is_truncated = false;
   do {
     results.objs.clear();
 
-      ret = list(dpp, params, 1000, results, y);
-      if (ret < 0)
-	return ret;
+    ret = list(dpp, params, 1000, results, y);
+    if (ret < 0)
+      return ret;
 
     if (!results.objs.empty() && !delete_children) {
       ldpp_dout(dpp, -1) << "ERROR: could not remove non-empty bucket " << info.bucket.name <<
@@ -251,7 +255,7 @@ int RadosBucket::remove_bucket(const DoutPrefixProvider* dpp, bool delete_childr
 	return ret;
       }
     }
-  } while(is_truncated);
+  } while(results.is_truncated);
 
   /* If there's a prefix, then we are aborting multiparts as well */
   if (!prefix.empty()) {


### PR DESCRIPTION
The zipper refactoring combines use of old is_truncated variable and
newer structure that manages is_truncated. This prevented advancing
past the first page of 1,000 entries.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>

Fixes: https://tracker.ceph.com/issues/50620