### PR TITLE
rgw: fix bucket object listing when marker matches prefix

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -498,6 +498,7 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   bool has_delimiter = !op.delimiter.empty();
 
   if (has_delimiter &&
+      start_after_key > op.filter_prefix &&
       boost::algorithm::ends_with(start_after_key, op.delimiter)) {
     // advance past all subdirectory entries if we start after a
     // subdirectory


### PR DESCRIPTION
When an iniitial marker that ends with a delimiter is provided, it
prevents listing of that "subdirectory" due to new logic at the cls
level to make listing more efficient. The fix catches that situation.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>

Fixes: https://tracker.ceph.com/issues/50621