### PR TITLE
cmake: let libglobal_obj depend on legacy-option-headers

### DIFF
--- a/src/global/CMakeLists.txt
+++ b/src/global/CMakeLists.txt
@@ -8,6 +8,7 @@ else()
 endif()
 
 add_library(libglobal_objs OBJECT ${libglobal_srcs})
+add_dependencies(libglobal_objs legacy-option-headers)
 
 add_library(global-static STATIC
   $<TARGET_OBJECTS:libglobal_objs>)


### PR DESCRIPTION
to address following build failure:

FAILED: src/global/CMakeFiles/libglobal_objs.dir/global_init.cc.o ...
src/global/CMakeFiles/libglobal_objs.dir/global_init.cc.o -MF src/global/CMakeFiles/libglobal_objs.dir/global_init.cc.o.d -o src/global/CMakeFiles/libglobal_objs.dir/global_init.cc.o -c
../src/global/global_init.cc
In file included from ../src/global/global_init.cc:26:
In file included from ../src/common/config.h:26:
In file included from ../src/common/config_values.h:59:
../src/common/options/legacy_config_opts.h:1:10: fatal error: 'global_legacy_options.h' file not found
         ^~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
