### PR TITLE
ceph_test_rados_api_service: more retries for servicemkap

### DIFF
--- a/src/test/librados/service.cc
+++ b/src/test/librados/service.cc
@@ -120,7 +120,7 @@ TEST(LibRadosService, StatusFormat) {
     });
   }
 
-  int retry = 5;
+  int retry = 15;
   while (retry) {
     rados_t cluster;
 

--- a/src/test/librados/service.cc
+++ b/src/test/librados/service.cc
@@ -163,7 +163,6 @@ TEST(LibRadosService, StatusFormat) {
     sleep(2);
     retry--;
   }
-  ASSERT_NE(0, retry);
 
   {
     std::scoped_lock<std::mutex> l(lock);
@@ -173,6 +172,7 @@ TEST(LibRadosService, StatusFormat) {
   for (int i = 0; i < nthreads; ++i)
     threads[i].join();
 
+  ASSERT_NE(0, retry);
   ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rold), 0);
 }
 


### PR DESCRIPTION
Otherwise, this fails intermittently with

/build/ceph-16.2.1-257-g717ce59b/src/test/librados/service.cc:166: Failure
Expected: (0) != (retry), actual: 0 vs 0

Fixes: https://tracker.ceph.com/issues/50595
Signed-off-by: Sage Weil <sage@newdream.net>