### PR TITLE
cephadm: Add Rocky Linux to supported DISTRO_NAMES

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -5872,6 +5872,7 @@ class YumDnf(Packager):
         'centos': ('centos', 'el'),
         'rhel': ('centos', 'el'),
         'scientific': ('centos', 'el'),
+        'rocky': ('centos', 'el'),
         'fedora': ('fedora', 'fc'),
     }
 


### PR DESCRIPTION
Rocky Linux is a RHEL clone. I did a test-installation of ceph pacific on Rocky Linux RC1 with cephadm. As far as I can see, everything works as expected.

Fixes: none

Signed-off-by: Dennis Körner <koerner@netzwerge.de>

