### PR TITLE
pacific: cephadm: may batch 1

### DIFF
--- a/doc/cephadm/compatibility.rst
+++ b/doc/cephadm/compatibility.rst
@@ -3,6 +3,8 @@
 Compatibility and Stability
 ===========================
 
+.. _cephadm-compatibility-with-podman:
+
 Compatibility with Podman Versions
 ----------------------------------
 
@@ -24,6 +26,10 @@ Those versions are expected to work:
 +-----------+-------+-------+-------+-------+-------+
 | >= 16.2.1 | False | True  | True  | False | True  |
 +-----------+-------+-------+-------+-------+-------+
+
+.. warning:: 
+  Only podman versions that are 2.0.0 and higher work with Ceph Pacific, with the exception of podman version 2.2.1, which does not work with Ceph Pacific. kubic stable is known to work with Ceph Pacific, but it must be run with a newer kernel.
+
 
 .. _cephadm-stability:
 

--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -278,7 +278,6 @@ names etc. When cephadm initiates an ssh connection to a remote host,
 the host name  can be resolved in four different ways:
 
 -  a custom ssh config resolving the name to an IP
--  via an externally maintained ``/etc/hosts``
 -  via explicitly providing an IP address to cephadm: ``ceph orch host add <hostname> <IP>``
 -  automatic name resolution via DNS.
 

--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -117,7 +117,21 @@ To remove a label, run::
 
   ceph orch host label rm my_hostname my_label
 
-  
+
+.. _cephadm-special-host-labels:
+
+Special host labels
+-------------------
+
+The following host labels have a special meaning to cephadm.  All start with ``_``.
+
+* ``_no_schedule``: *Do not schedule or deploy daemons on this host*.
+
+  This label prevents cephadm from deploying daemons on this host.  If it is added to
+  an existing host that already contains Ceph daemons, it will cause cephadm to move
+  those daemons elsewhere (except OSDs, which are not removed automatically).
+
+
 Maintenance Mode
 ================
 

--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -37,7 +37,7 @@ To add each new host to the cluster, perform two steps:
 
    .. prompt:: bash #
 
-     ceph orch host add *newhost*
+     ceph orch host add *newhost* [*<label1> ...*]
 
    For example:
 
@@ -45,7 +45,16 @@ To add each new host to the cluster, perform two steps:
 
      ceph orch host add host2
      ceph orch host add host3
-     
+
+   One or more labels can also be included to immediately label the
+   new host.  For example, by default the ``_admin`` label will make
+   cephadm maintain a copy of the ``ceph.conf`` file and a
+   ``client.admin`` keyring file in ``/etc/ceph``:
+
+   .. prompt:: bash #
+
+       ceph orch host add host4 _admin
+
 .. _cephadm-removing-hosts:
 
 Removing Hosts

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -148,11 +148,14 @@ This command will:
   host.
 * Generate a new SSH key for the Ceph cluster and add it to the root
   user's ``/root/.ssh/authorized_keys`` file.
+* Write a copy of the public key to ``/etc/ceph/ceph.pub``.
 * Write a minimal configuration file to ``/etc/ceph/ceph.conf``. This
   file is needed to communicate with the new cluster.
 * Write a copy of the ``client.admin`` administrative (privileged!)
   secret key to ``/etc/ceph/ceph.client.admin.keyring``.
-* Write a copy of the public key to ``/etc/ceph/ceph.pub``.
+* Add the ``_admin`` label to the bootstrap host.  By default, any host
+  with this label will (also) get a copy of ``/etc/ceph/ceph.conf`` and
+  ``/etc/ceph/ceph.client.admin.keyring``.
 
 Further information about cephadm bootstrap 
 -------------------------------------------
@@ -271,6 +274,16 @@ Adding Hosts
 ============
 
 Next, add all hosts to the cluster by following :ref:`cephadm-adding-hosts`.
+
+By default, a ``ceph.conf`` file and a copy of the ``client.admin`` keyring
+are maintained in ``/etc/ceph`` on all hosts with the ``_admin`` label, which is initially
+applied only to the bootstrap host. We usually recommend that one or more other hosts be
+given the ``_admin`` label so that the Ceph CLI (e.g., via ``cephadm shell``) is easily
+accessible on multiple hosts.  To add the ``_admin`` label to additional host(s),
+
+  .. prompt:: bash #
+
+    ceph orch host label add *<host>* _admin
 
 Adding additional MONs
 ======================

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -23,6 +23,13 @@ Requirements
 Any modern Linux distribution should be sufficient.  Dependencies
 are installed automatically by the bootstrap process below.
 
+See the section :ref:`Compatibility With Podman
+Versions<cephadm-compatibility-with-podman>` for a table of Ceph versions that
+are compatible with Podman. Not every version of Podman is compatible with
+Ceph.
+
+
+
 .. _get-cephadm:
 
 Install cephadm

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -184,7 +184,13 @@ available options.
 
 * You can pass any initial Ceph configuration options to the new
   cluster by putting them in a standard ini-style configuration file
-  and using the ``--config *<config-file>*`` option.
+  and using the ``--config *<config-file>*`` option.  For example::
+
+      $ cat <<EOF > initial-ceph.conf
+      [global]
+      osd crush chooseleaf type = 0
+      EOF
+      $ ./cephadm bootstrap --config initial-ceph.conf ...
 
 * The ``--ssh-user *<user>*`` option makes it possible to choose which ssh
   user cephadm will use to connect to hosts. The associated ssh key will be

--- a/doc/cephadm/nfs.rst
+++ b/doc/cephadm/nfs.rst
@@ -10,7 +10,7 @@ Deploying NFS ganesha
 =====================
 
 Cephadm deploys NFS Ganesha using a pre-defined RADOS *pool*
-and optional *namespace*
+and optional *namespace*.
 
 To deploy a NFS Ganesha gateway, run the following command:
 
@@ -18,24 +18,25 @@ To deploy a NFS Ganesha gateway, run the following command:
 
     ceph orch apply nfs *<svc_id>* *<pool>* *<namespace>* --placement="*<num-daemons>* [*<host1>* ...]"
 
-For example, to deploy NFS with a service id of *foo*, that will use the RADOS
-pool *nfs-ganesha* and namespace *nfs-ns*:
+For example, to deploy NFS with a service id of *foo* that will use the RADOS
+pool *nfs-ganesha* and the namespace *nfs-ns*, run this command:
 
 .. prompt:: bash #
 
    ceph orch apply nfs foo nfs-ganesha nfs-ns
 
 .. note::
-   Create the *nfs-ganesha* pool first if it doesn't exist.
+   If the *nfs-ganesha* doesn't exist, create it.
 
-See :ref:`orchestrator-cli-placement-spec` for details of the placement specification.
+See :ref:`orchestrator-cli-placement-spec` for the details of the placement
+specification.
 
 Service Specification
 =====================
 
-Alternatively, an NFS service can also be applied using a YAML specification. 
+Alternatively, an NFS service can be applied using a YAML specification. 
 
-A service of type ``nfs`` requires a pool name and may contain
+A service of type ``nfs`` requires a pool name and can contain
 an optional namespace:
 
 .. code-block:: yaml
@@ -50,11 +51,11 @@ an optional namespace:
       pool: mypool
       namespace: mynamespace
 
-where ``pool`` is a RADOS pool where NFS client recovery data is stored
-and ``namespace`` is a RADOS namespace where NFS client recovery
-data is stored in the pool.
+In this example, ``pool`` is a RADOS pool where NFS client recovery data is
+stored and ``namespace`` is a RADOS namespace where NFS client recovery data
+is stored.
 
-The specification can then be applied using:
+The specification can then be applied by running the following command:
 
 .. prompt:: bash #
 

--- a/doc/cephadm/nfs.rst
+++ b/doc/cephadm/nfs.rst
@@ -26,7 +26,7 @@ pool *nfs-ganesha* and the namespace *nfs-ns*, run this command:
    ceph orch apply nfs foo nfs-ganesha nfs-ns
 
 .. note::
-   If the *nfs-ganesha* doesn't exist, create it.
+   If the *nfs-ganesha* pool doesn't exist, create it.
 
 See :ref:`orchestrator-cli-placement-spec` for the details of the placement
 specification.

--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -318,6 +318,14 @@ hosts, please enable this by running::
 
   ceph config set mgr mgr/cephadm/manage_etc_ceph_ceph_conf true
 
+If enabled, by default cephadm will update ``ceph.conf`` on all cluster hosts. To
+change the set of hosts that get a managed config file, you can update the
+``mgr/cephadm/manage_etc_ceph_ceph_conf_hosts`` setting to a different placement
+spec (see :ref:`orchestrator-cli-placement-spec`).  For example, to limit config
+file updates to hosts with the ``foo`` label::
+
+  ceph config set mgr mgr/cephadm/manage_etc_ceph_ceph_conf_host label:foo
+
 To set up an initial configuration before bootstrapping
 the cluster, create an initial ``ceph.conf`` file. For example::
 

--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -306,7 +306,7 @@ Cephadm can distribute copies of the ``ceph.conf`` and client keyring
 files to hosts.  For example, it is usually a good idea to store a
 copy of the config and ``client.admin`` keyring on any hosts that will
 be used to administer the cluster via the CLI.  By default, cephadm will do
-this for any nodes with the ``admin`` label (which normally includes the bootstrap
+this for any nodes with the ``_admin`` label (which normally includes the bootstrap
 host).
 
 When a client keyring is placed under management, cephadm will:
@@ -330,7 +330,7 @@ To place a keyring under management::
 
 - By default, the *path* will be ``/etc/ceph/client.{entity}.keyring``, which is where
   Ceph looks by default.  Be careful specifying alternate locations as existing files
-  maybe overwritten.
+  may be overwritten.
 - A placement of ``*`` (all hosts) is common.
 - The mode defaults to ``0600`` and ownership to ``0:0`` (user root, group root).
 

--- a/doc/cephadm/osd.rst
+++ b/doc/cephadm/osd.rst
@@ -368,20 +368,24 @@ Example command:
 Advanced OSD Service Specifications
 ===================================
 
-:ref:`orchestrator-cli-service-spec` of type ``osd`` are a way to describe a cluster layout using the properties of disks.
-It gives the user an abstract way tell ceph which disks should turn into an OSD
-with which configuration without knowing the specifics of device names and paths.
+:ref:`orchestrator-cli-service-spec`\s of type ``osd`` are a way to describe a
+cluster layout, using the properties of disks. Service specifications give the
+user an abstract way to tell Ceph which disks should turn into OSDs with which
+configurations, without knowing the specifics of device names and paths.
 
-Instead of doing this
+Service specifications make it possible to define a yaml or json file that can
+be used to reduce the amount of manual work involved in creating OSDs.
+
+For example, instead of running the following command:
 
 .. prompt:: bash [monitor.1]#
 
   ceph orch daemon add osd *<host>*:*<path-to-device>*
 
-for each device and each host, we can define a yaml|json file that allows us to describe
-the layout. Here's the most basic example.
+for each device and each host, we can define a yaml or json file that allows us
+to describe the layout. Here's the most basic example.
 
-Create a file called i.e. osd_spec.yml
+Create a file called (for example) ``osd_spec.yml``:
 
 .. code-block:: yaml
 
@@ -392,32 +396,37 @@ Create a file called i.e. osd_spec.yml
     data_devices:                    <- the type of devices you are applying specs to
       all: true                      <- a filter, check below for a full list
 
-This would translate to:
+This means :
 
-Turn any available(ceph-volume decides what 'available' is) into an OSD on all hosts that match
-the glob pattern '*'. (The glob pattern matches against the registered hosts from `host ls`)
-There will be a more detailed section on host_pattern down below.
+#. Turn any available (ceph-volume decides what 'available' is) into an OSD on
+   all hosts that match the glob pattern '*'. (The glob pattern matches against
+   the registered hosts from `host ls`) A more detailed section on host_pattern
+   is available below.
 
-and pass it to `osd create` like so
+#. Then pass it to `osd create` like this:
 
-.. prompt:: bash [monitor.1]#
+   .. prompt:: bash [monitor.1]#
 
-  ceph orch apply osd -i /path/to/osd_spec.yml
+     ceph orch apply osd -i /path/to/osd_spec.yml
 
-This will go out on all the matching hosts and deploy these OSDs.
+   This instruction will be issued to all the matching hosts, and will deploy
+   these OSDs.
 
-Since we want to have more complex setups, there are more filters than just the 'all' filter.
+   Setups more complex than the one specified by the ``all`` filter are
+   possible. See :ref:`osd_filters` for details.
 
-Also, there is a `--dry-run` flag that can be passed to the `apply osd` command, which gives you a synopsis
-of the proposed layout.
+   A ``--dry-run`` flag can be passed to the ``apply osd`` command to display a
+   synopsis of the proposed layout.
 
 Example
 
 .. prompt:: bash [monitor.1]#
 
-  [monitor.1]# ceph orch apply osd -i /path/to/osd_spec.yml --dry-run
+   ceph orch apply osd -i /path/to/osd_spec.yml --dry-run
 
 
+
+.. _osd_filters:
 
 Filters
 -------

--- a/doc/cephadm/osd.rst
+++ b/doc/cephadm/osd.rst
@@ -398,10 +398,10 @@ Create a file called (for example) ``osd_spec.yml``:
 
 This means :
 
-#. Turn any available (ceph-volume decides what 'available' is) into an OSD on
-   all hosts that match the glob pattern '*'. (The glob pattern matches against
-   the registered hosts from `host ls`) A more detailed section on host_pattern
-   is available below.
+#. Turn any available device (ceph-volume decides what 'available' is) into an
+   OSD on all hosts that match the glob pattern '*'. (The glob pattern matches
+   against the registered hosts from `host ls`) A more detailed section on
+   host_pattern is available below.
 
 #. Then pass it to `osd create` like this:
 

--- a/doc/cephadm/osd.rst
+++ b/doc/cephadm/osd.rst
@@ -171,21 +171,43 @@ For example:
 Declarative State
 -----------------
 
-Note that the effect of ``ceph orch apply`` is persistent; that is, drives which are added to the system
-or become available (say, by zapping) after the command is complete will be automatically found and added to the cluster.
+The effect of ``ceph orch apply`` is persistent. This means that drives that
+are added to the system after the ``ceph orch apply`` command completes will be
+automatically found and added to the cluster.  It also means that drives that
+become available (by zapping, for example) after the ``ceph orch apply``
+command completes will be automatically found and added to the cluster.
 
-That is, after using::
+We will examine the effects of the following command:
 
-    ceph orch apply osd --all-available-devices
+   .. prompt:: bash #
 
-* If you add new disks to the cluster they will automatically be used to create new OSDs.
-* A new OSD will be created automatically if you remove an OSD and clean the LVM physical volume.
+     ceph orch apply osd --all-available-devices
+
+After running the above command: 
+
+* If you add new disks to the cluster, they will automatically be used to
+  create new OSDs.
+* If you remove an OSD and clean the LVM physical volume, a new OSD will be
+  created automatically.
+
+To disable the automatic creation of OSD on available devices, use the
+``unmanaged`` parameter:
 
 If you want to avoid this behavior (disable automatic creation of OSD on available devices), use the ``unmanaged`` parameter:
 
 .. prompt:: bash #
 
    ceph orch apply osd --all-available-devices --unmanaged=true
+
+.. note::
+
+  Keep these three facts in mind:
+
+  - The default behavior of ``ceph orch apply`` causes cephadm constantly to reconcile. This means that cephadm creates OSDs as soon as new drives are detected.
+
+  - Setting ``unmanaged: True`` disables the creation of OSDs. If ``unmanaged: True`` is set, nothing will happen even if you apply a new OSD service.
+
+  - ``ceph orch daemon add`` creates OSDs, but does not add an OSD service.
 
 * For cephadm, see also :ref:`cephadm-spec-unmanaged`.
 

--- a/doc/cephadm/osd.rst
+++ b/doc/cephadm/osd.rst
@@ -432,18 +432,15 @@ Filters
 -------
 
 .. note::
-   Filters are applied using a `AND` gate by default. This essentially means that a drive needs to fulfill all filter
-   criteria in order to get selected.
-   If you wish to change this behavior you can adjust this behavior by setting
+   Filters are applied using an `AND` gate by default. This means that a drive
+   must fulfill all filter criteria in order to get selected. This behavior can
+   be adjusted by setting ``filter_logic: OR`` in the OSD specification. 
 
-    `filter_logic: OR`  # valid arguments are `AND`, `OR`
+Filters are used to assign disks to groups, using their attributes to group
+them. 
 
-   in the OSD Specification.
-
-You can assign disks to certain groups by their attributes using filters.
-
-The attributes are based off of ceph-volume's disk query. You can retrieve the information
-with
+The attributes are based off of ceph-volume's disk query. You can retrieve
+information about the attributes with this command:
 
 .. code-block:: bash
 
@@ -452,7 +449,7 @@ with
 Vendor or Model:
 ^^^^^^^^^^^^^^^^
 
-You can target specific disks by their Vendor or by their Model
+Specific disks can be targeted by vendor or model:
 
 .. code-block:: yaml
 
@@ -468,7 +465,7 @@ or
 Size:
 ^^^^^
 
-You can also match by disk `Size`.
+Specific disks can be targeted by `Size`:
 
 .. code-block:: yaml
 
@@ -477,7 +474,7 @@ You can also match by disk `Size`.
 Size specs:
 ___________
 
-Size specification of format can be of form:
+Size specifications can be of the following forms:
 
 * LOW:HIGH
 * :HIGH
@@ -486,34 +483,34 @@ Size specification of format can be of form:
 
 Concrete examples:
 
-Includes disks of an exact size
+To include disks of an exact size
 
 .. code-block:: yaml
 
     size: '10G'
 
-Includes disks which size is within the range
+To include disks within a given range of size: 
 
 .. code-block:: yaml
 
     size: '10G:40G'
 
-Includes disks less than or equal to 10G in size
+To include disks that are less than or equal to 10G in size:
 
 .. code-block:: yaml
 
     size: ':10G'
 
-
-Includes disks equal to or greater than 40G in size
+To include disks equal to or greater than 40G in size:
 
 .. code-block:: yaml
 
     size: '40G:'
 
-Sizes don't have to be exclusively in Gigabyte(G).
+Sizes don't have to be specified exclusively in Gigabytes(G).
 
-Supported units are Megabyte(M), Gigabyte(G) and Terrabyte(T). Also appending the (B) for byte is supported. MB, GB, TB
+Other units of size are supported: Megabyte(M), Gigabyte(G) and Terrabyte(T).
+Appending the (B) for byte is also supported: ``MB``, ``GB``, ``TB``.
 
 
 Rotational:
@@ -545,14 +542,14 @@ Note: This is exclusive for the data_devices section.
 Limiter:
 ^^^^^^^^
 
-When you specified valid filters but want to limit the amount of matching disks you can use the 'limit' directive.
+If you have specified some valid filters but want to limit the number of disks that they match, use the ``limit`` directive:
 
 .. code-block:: yaml
 
     limit: 2
 
-For example, if you used `vendor` to match all disks that are from `VendorA` but only want to use the first two
-you could use `limit`.
+For example, if you used `vendor` to match all disks that are from `VendorA`
+but want to use only the first two, you could use `limit`:
 
 .. code-block:: yaml
 
@@ -560,7 +557,7 @@ you could use `limit`.
     vendor: VendorA
     limit: 2
 
-Note: Be aware that `limit` is really just a last resort and shouldn't be used if it can be avoided.
+Note: `limit` is a last resort and shouldn't be used if it can be avoided.
 
 
 Additional Options

--- a/doc/cephadm/osd.rst
+++ b/doc/cephadm/osd.rst
@@ -446,8 +446,8 @@ information about the attributes with this command:
 
   ceph-volume inventory </path/to/disk>
 
-Vendor or Model:
-^^^^^^^^^^^^^^^^
+Vendor or Model
+^^^^^^^^^^^^^^^
 
 Specific disks can be targeted by vendor or model:
 
@@ -462,8 +462,8 @@ or
     vendor: disk_vendor_name
 
 
-Size:
-^^^^^
+Size
+^^^^
 
 Specific disks can be targeted by `Size`:
 
@@ -471,8 +471,8 @@ Specific disks can be targeted by `Size`:
 
     size: size_spec
 
-Size specs:
-___________
+Size specs
+__________
 
 Size specifications can be of the following forms:
 
@@ -513,8 +513,8 @@ Other units of size are supported: Megabyte(M), Gigabyte(G) and Terrabyte(T).
 Appending the (B) for byte is also supported: ``MB``, ``GB``, ``TB``.
 
 
-Rotational:
-^^^^^^^^^^^
+Rotational
+^^^^^^^^^^
 
 This operates on the 'rotational' attribute of the disk.
 
@@ -527,8 +527,8 @@ This operates on the 'rotational' attribute of the disk.
 `0` to match all disks that are non-rotational (SSD, NVME etc)
 
 
-All:
-^^^^
+All
+^^^
 
 This will take all disks that are 'available'
 
@@ -539,8 +539,8 @@ Note: This is exclusive for the data_devices section.
     all: true
 
 
-Limiter:
-^^^^^^^^
+Limiter
+^^^^^^^
 
 If you have specified some valid filters but want to limit the number of disks that they match, use the ``limit`` directive:
 

--- a/doc/cephadm/service-management.rst
+++ b/doc/cephadm/service-management.rst
@@ -132,6 +132,10 @@ For the orchestrator to deploy a *service*, it needs to know where to deploy
 specification.  Placement specifications can either be passed as command line arguments
 or in a YAML files.
 
+.. note::
+
+   cephadm will not deploy daemons on hosts with the ``_no_schedule`` label; see :ref:`cephadm-special-host-labels`.
+
 Explicit placements
 -------------------
 

--- a/qa/suites/rados/cephadm/smoke-roleless/2-services/client-keyring.yaml
+++ b/qa/suites/rados/cephadm/smoke-roleless/2-services/client-keyring.yaml
@@ -1,0 +1,40 @@
+tasks:
+- cephadm.shell:
+    host.a:
+      - ceph orch host label add `hostname` foo
+      - ceph auth get-or-create client.foo mon 'allow r'
+      - ceph orch client-keyring set client.foo label:foo --mode 770 --owner 11111:22222
+- exec:
+    host.a:
+      - while ! test -e /etc/ceph/ceph.client.foo.keyring ; do sleep 1 ; done
+      - ls -al /etc/ceph/ceph.client.foo.keyring | grep rwxrwx---
+      - ls -al /etc/ceph/ceph.client.foo.keyring | grep 11111
+      - ls -al /etc/ceph/ceph.client.foo.keyring | grep 22222
+      - test -e /etc/ceph/ceph.conf
+- exec:
+    host.b:
+      - test ! -e /etc/ceph/ceph.client.foo.keyring
+- cephadm.shell:
+    host.b:
+      - ceph orch host label add `hostname` foo
+- exec:
+    host.b:
+      - while ! test -e /etc/ceph/ceph.client.foo.keyring ; do sleep 1 ; done
+      - ls -al /etc/ceph/ceph.client.foo.keyring | grep rwxrwx---
+      - ls -al /etc/ceph/ceph.client.foo.keyring | grep 11111
+      - ls -al /etc/ceph/ceph.client.foo.keyring | grep 22222
+- cephadm.shell:
+    host.b:
+      - ceph orch host label rm `hostname` foo
+- exec:
+    host.b:
+      - while test -e /etc/ceph/ceph.client.foo.keyring ; do sleep 1 ; done
+- exec:
+    host.a:
+      - test -e /etc/ceph/ceph.client.foo.keyring
+- cephadm.shell:
+    host.a:
+      - ceph orch client-keyring rm client.foo
+- exec:
+    host.a:
+      - while test -e /etc/ceph/ceph.client.foo.keyring ; do sleep 1 ; done

--- a/qa/suites/rados/cephadm/smoke-singlehost/0-distro$
+++ b/qa/suites/rados/cephadm/smoke-singlehost/0-distro$
@@ -1,0 +1,1 @@
+../smoke/distro

--- a/qa/suites/rados/cephadm/smoke-singlehost/1-start.yaml
+++ b/qa/suites/rados/cephadm/smoke-singlehost/1-start.yaml
@@ -1,0 +1,27 @@
+tasks:
+- cephadm:
+    roleless: true
+    single_host_defaults: true
+- cephadm.shell:
+    host.a:
+      - ceph orch status
+      - ceph orch ps
+      - ceph orch ls
+      - ceph orch host ls
+      - ceph orch device ls
+roles:
+- - host.a
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+  - client.0
+openstack:
+- volumes: # attached to each instance
+    count: 4
+    size: 10 # GB
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd shutdown pgref assert: true

--- a/qa/suites/rados/cephadm/smoke-singlehost/2-services/rgw.yaml
+++ b/qa/suites/rados/cephadm/smoke-singlehost/2-services/rgw.yaml
@@ -1,0 +1,12 @@
+tasks:
+- cephadm.apply:
+    specs:
+      - service_type: rgw
+        service_id: foo
+        placement:
+          count_per_host: 4
+          host_pattern: "*"
+        spec:
+          rgw_frontend_port: 8000
+- sleep:
+    interval: 60

--- a/qa/suites/rados/cephadm/smoke-singlehost/2-services/rgw.yaml
+++ b/qa/suites/rados/cephadm/smoke-singlehost/2-services/rgw.yaml
@@ -8,5 +8,5 @@ tasks:
           host_pattern: "*"
         spec:
           rgw_frontend_port: 8000
-- sleep:
-    interval: 60
+- cephadm.wait_for_service:
+    service: rgw.foo

--- a/qa/suites/rados/cephadm/smoke-singlehost/3-final.yaml
+++ b/qa/suites/rados/cephadm/smoke-singlehost/3-final.yaml
@@ -1,0 +1,8 @@
+tasks:
+- cephadm.shell:
+    host.a:
+      - ceph orch status
+      - ceph orch ps
+      - ceph orch ls
+      - ceph orch host ls
+      - ceph orch device ls

--- a/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-centos_8.3-octopus.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-centos_8.3-octopus.yaml
@@ -14,6 +14,7 @@ tasks:
     allow_ptrace: false
     # deploy additional mons the "old" (octopus) way
     add_mons_via_daemon_add: true
+    avoid_pacific_features: true
 
 
 roles:

--- a/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-ubuntu_20.04-15.2.9.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-ubuntu_20.04-15.2.9.yaml
@@ -10,6 +10,7 @@ tasks:
     allow_ptrace: false
     # deploy additional mons the "old" (octopus) way
     add_mons_via_daemon_add: true
+    avoid_pacific_features: true
 
 roles:
 - - mon.a

--- a/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-ubuntu_20.04.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-ubuntu_20.04.yaml
@@ -10,6 +10,7 @@ tasks:
     allow_ptrace: false
     # deploy additional mons the "old" (octopus) way
     add_mons_via_daemon_add: true
+    avoid_pacific_features: true
 
 roles:
 - - mon.a

--- a/qa/suites/upgrade/octopus-x/parallel/1-tasks.yaml
+++ b/qa/suites/upgrade/octopus-x/parallel/1-tasks.yaml
@@ -14,6 +14,7 @@ tasks:
         osd_class_default_list: "*"
     # deploy additional mons the "old" (octopus) way
     add_mons_via_daemon_add: true
+    avoid_pacific_features: true
 - print: "**** done end installing octopus cephadm ..."
 
 - cephadm.shell:

--- a/qa/suites/upgrade/octopus-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/octopus-x/stress-split/1-start.yaml
@@ -13,6 +13,7 @@ tasks:
         osd_class_default_list: "*"
     # deploy additional mons the "old" (octopus) way
     add_mons_via_daemon_add: true
+    avoid_pacific_features: true
 
 - cephadm.shell:
     mon.a:

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -69,6 +69,8 @@ def update_archive_setting(ctx, key, value):
     """
     Add logs directory to job's info log file
     """
+    if ctx.archive is None:
+        return
     with open(os.path.join(ctx.archive, 'info.yaml'), 'r+') as info_file:
         info_yaml = yaml.safe_load(info_file)
         info_file.seek(0)

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -397,6 +397,8 @@ def ceph_bootstrap(ctx, config):
             cmd += ['--skip-monitoring-stack']
         if config.get('single_host_defaults'):
             cmd += ['--single-host-defaults']
+        if not config.get('avoid_pacific_features', False):
+            cmd += ['--skip-admin-label']
         # bootstrap makes the keyring root 0600, so +r it for our purposes
         cmd += [
             run.Raw('&&'),
@@ -437,10 +439,20 @@ def ceph_bootstrap(ctx, config):
             _shell(ctx, cluster_name, bootstrap_remote,
                    ['ceph', 'config', 'set', 'mgr', 'mgr/cephadm/allow_ptrace', 'true'])
 
+        if not config.get('avoid_pacific_features', False):
+            log.info('Distributing conf and client.admin keyring to all hosts + 0755')
+            _shell(ctx, cluster_name, bootstrap_remote,
+                   ['ceph', 'orch', 'client-keyring', 'set', 'client.admin',
+                    '*', '--mode', '0755'],
+                   check_status=False)
+
         # add other hosts
         for remote in ctx.cluster.remotes.keys():
             if remote == bootstrap_remote:
                 continue
+
+            # note: this may be redundant (see above), but it avoids
+            # us having to wait for cephadm to do it.
             log.info('Writing (initial) conf and keyring to %s' % remote.shortname)
             remote.write_file(
                 path='/etc/ceph/{}.conf'.format(cluster_name),

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -393,6 +393,8 @@ def ceph_bootstrap(ctx, config):
             cmd += ['--skip-dashboard']
         if config.get('skip_monitoring_stack'):
             cmd += ['--skip-monitoring-stack']
+        if config.get('single_host_defaults'):
+            cmd += ['--single-host-defaults']
         # bootstrap makes the keyring root 0600, so +r it for our purposes
         cmd += [
             run.Raw('&&'),

--- a/qa/tasks/mgr/test_dashboard.py
+++ b/qa/tasks/mgr/test_dashboard.py
@@ -39,6 +39,12 @@ class TestDashboard(MgrTestCase):
         self.wait_until_true(_check_connection, timeout=30)
 
     def test_standby(self):
+        # skip this test if mgr_standby_modules=false
+        if self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                "config", "get", "mgr", "mgr_standby_modules").strip() == "false":
+            log.info("Skipping test_standby since mgr_standby_modules=false")
+            return
+
         original_active_id = self.mgr_cluster.get_active_id()
         original_uri = self._get_uri("dashboard")
         log.info("Originally running manager '{}' at {}".format(

--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -415,8 +415,11 @@ expect_false $CEPHADM rm-daemon --fsid $FSID --name mon.a
 # mgr does not
 $CEPHADM rm-daemon --fsid $FSID --name mgr.x
 
+expect_false $CEPHADM zap-osds --fsid $FSID
+$CEPHADM zap-osds --fsid $FSID --force
+
 ## rm-cluster
-expect_false $CEPHADM rm-cluster --fsid $FSID
-$CEPHADM rm-cluster --fsid $FSID --force
+expect_false $CEPHADM rm-cluster --fsid $FSID --zap-osds
+$CEPHADM rm-cluster --fsid $FSID --force --zap-osds
 
 echo PASS

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4147,6 +4147,14 @@ def command_bootstrap(ctx):
     if not ctx.skip_dashboard:
         prepare_dashboard(ctx, uid, gid, cli, wait_for_mgr_restart)
 
+    if ctx.output_config == '/etc/ceph/ceph.conf' and not ctx.skip_admin_label:
+        logger.info('Enabling client.admin keyring and conf on hosts with "admin" label')
+        try:
+            cli(['orch', 'client-keyring', 'set', 'client.admin', 'label:_admin'])
+            cli(['orch', 'host', 'label', 'add', get_hostname(), '_admin'])
+        except Exception:
+            logger.info('Unable to set up "admin" label; assuming older version of Ceph')
+
     if ctx.apply_spec:
         logger.info('Applying %s to cluster' % ctx.apply_spec)
 
@@ -7684,6 +7692,10 @@ def _get_parser():
     parser_bootstrap.add_argument(
         '--output-pub-ssh-key',
         help="location to write the cluster's public SSH key")
+    parser_bootstrap.add_argument(
+        '--skip-admin-label',
+        action='store_true',
+        help='do not create admin label for ceph.conf and client.admin keyring distribution')
     parser_bootstrap.add_argument(
         '--skip-ssh',
         action='store_true',

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3963,6 +3963,12 @@ def command_bootstrap(ctx):
             except PermissionError:
                 raise Error(f'Unable to create {dirname} due to permissions failure. Retry with root, or sudo or preallocate the directory.')
 
+    if ctx.config and os.path.exists(ctx.config):
+        with open(ctx.config) as f:
+            user_conf = f.read()
+    else:
+        user_conf = None
+
     if not ctx.skip_prepare_host:
         command_prepare_host(ctx)
     else:
@@ -4056,6 +4062,19 @@ def command_bootstrap(ctx):
 
     # create mgr
     create_mgr(ctx, uid, gid, fsid, mgr_id, mgr_key, config, cli)
+
+    if user_conf:
+        # user given config settings were already assimilated earlier
+        # but if the given settings contained any attributes in
+        # the mgr (e.g. mgr/cephadm/container_image_prometheus)
+        # they don't seem to be stored if there isn't a mgr yet.
+        # Since re-assimilating the same conf settings should be
+        # idempotent we can just do it aain here.
+        with tempfile.NamedTemporaryFile(buffering=0) as tmp:
+            tmp.write(user_conf.encode('utf-8'))
+            cli(['config', 'assimilate-conf',
+                 '-i', '/var/lib/ceph/user.conf'],
+                {tmp.name: '/var/lib/ceph/user.conf:z'})
 
     def json_loads_retry(cli_func):
         for sleep_secs in [1, 4, 4]:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3174,6 +3174,8 @@ class CephContainer:
 
         if self.host_network:
             cmd_args.append('--net=host')
+        if self.ctx.no_hosts:
+            cmd_args.append('--no-hosts')
         if self.privileged:
             cmd_args.extend([
                 '--privileged',
@@ -7589,6 +7591,10 @@ def _get_parser():
     parser_shell.add_argument(
         'command', nargs=argparse.REMAINDER,
         help='command (optional)')
+    parser_shell.add_argument(
+        '--no-hosts',
+        action='store_true',
+        help='dont pass /etc/hosts through to the container')
 
     parser_enter = subparsers.add_parser(
         'enter', help='run an interactive shell inside a running daemon container')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3839,6 +3839,7 @@ def prepare_bootstrap_config(
     cp.set('global', 'fsid', fsid)
     cp.set('global', 'mon_host', mon_addr)
     cp.set('global', 'container_image', image)
+
     if not cp.has_section('mon'):
         cp.add_section('mon')
     if (
@@ -3846,6 +3847,30 @@ def prepare_bootstrap_config(
             and not cp.has_option('mon', 'auth allow insecure global id reclaim')
     ):
         cp.set('mon', 'auth_allow_insecure_global_id_reclaim', 'false')
+
+    if ctx.single_host_defaults:
+        logger.info('Adjusting default settings to suit single-host cluster...')
+        # replicate across osds, not hosts
+        if (
+                not cp.has_option('global', 'osd_crush_choose_leaf_type')
+                and not cp.has_option('global', 'osd crush choose leaf type')
+        ):
+            cp.set('global', 'osd_crush_choose_leaf_type', '0')
+        # replica 2x
+        if (
+                not cp.has_option('global', 'osd_pool_default_size')
+                and not cp.has_option('global', 'osd pool default size')
+        ):
+            cp.set('global', 'osd_pool_default_size', '2')
+        # disable mgr standby modules (so we can colocate multiple mgrs on one host)
+        if not cp.has_section('mgr'):
+            cp.add_section('mgr')
+        if (
+                not cp.has_option('mgr', 'mgr_standby_modules')
+                and not cp.has_option('mgr', 'mgr standby modules')
+        ):
+            cp.set('mgr', 'mgr_standby_modules', 'false')
+
     cpf = StringIO()
     cp.write(cpf)
     config = cpf.getvalue()
@@ -7771,6 +7796,10 @@ def _get_parser():
     parser_bootstrap.add_argument(
         '--cluster-network',
         help='subnet to use for cluster replication, recovery and heartbeats (in CIDR notation network/mask)')
+    parser_bootstrap.add_argument(
+        '--single-host-defaults',
+        action='store_true',
+        help='adjust configuration defaults to suit a single-host cluster')
 
     parser_deploy = subparsers.add_parser(
         'deploy', help='deploy a daemon')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6499,6 +6499,8 @@ class HostFacts():
                     security['description'] = 'AppArmor: Enabled'
                     try:
                         profiles = read_file(['/sys/kernel/security/apparmor/profiles'])
+                        if len(profiles) == 0:
+                            return {}
                     except OSError:
                         pass
                     else:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4572,8 +4572,8 @@ def command_ceph_volume(ctx):
         privileged=True,
         volume_mounts=mounts,
     )
-    verbosity = CallVerbosity.VERBOSE if ctx.log_output else CallVerbosity.VERBOSE_ON_FAILURE
-    out, err, code = call_throws(ctx, c.run_cmd(), verbosity=verbosity)
+
+    out, err, code = call_throws(ctx, c.run_cmd())
     if not code:
         print(out)
 
@@ -7079,7 +7079,6 @@ class CephadmDaemon():
         # expects to use
         self.ctx.command = 'inventory --format=json'.split()
         self.ctx.fsid = self.fsid
-        self.ctx.log_output = False
 
         ctr = 0
         exception_encountered = False
@@ -7697,11 +7696,6 @@ def _get_parser():
     parser_ceph_volume.add_argument(
         '--keyring', '-k',
         help='ceph.keyring to pass through to the container')
-    parser_ceph_volume.add_argument(
-        '--log-output',
-        action='store_true',
-        default=True,
-        help='suppress ceph volume output from the log')
     parser_ceph_volume.add_argument(
         'command', nargs=argparse.REMAINDER,
         help='command')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2540,7 +2540,14 @@ def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
 
     ports = ports or []
     if any([port_in_use(ctx, port) for port in ports]):
-        raise Error("TCP Port(s) '{}' required for {} already in use".format(','.join(map(str, ports)), daemon_type))
+        if daemon_type == 'mgr':
+            # non-fatal for mgr when we are in mgr_standby_modules=false, but we can't
+            # tell whether that is the case here.
+            logger.warning(
+                f"ceph-mgr TCP port(s) {','.join(map(str, ports))} already in use"
+            )
+        else:
+            raise Error("TCP Port(s) '{}' required for {} already in use".format(','.join(map(str, ports)), daemon_type))
 
     data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
     if reconfig and not os.path.exists(data_dir):

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2327,19 +2327,20 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
             # these do not search for their keyrings in a data directory
             mounts[data_dir + '/keyring'] = '/etc/ceph/ceph.client.%s.%s.keyring' % (daemon_type, daemon_id)
 
-    if daemon_type in ['mon', 'osd']:
+    if daemon_type in ['mon', 'osd', 'clusterless-ceph-volume']:
         mounts['/dev'] = '/dev'  # FIXME: narrow this down?
         mounts['/run/udev'] = '/run/udev'
-    if daemon_type == 'osd':
+    if daemon_type in ['osd', 'clusterless-ceph-volume']:
         mounts['/sys'] = '/sys'  # for numa.cc, pick_address, cgroups, ...
+        mounts['/run/lvm'] = '/run/lvm'
+        mounts['/run/lock/lvm'] = '/run/lock/lvm'
+    if daemon_type == 'osd':
         # selinux-policy in the container may not match the host.
         if HostFacts(ctx).selinux_enabled:
             selinux_folder = '/var/lib/ceph/%s/selinux' % fsid
             if not os.path.exists(selinux_folder):
                 os.makedirs(selinux_folder, mode=0o755)
             mounts[selinux_folder] = '/sys/fs/selinux:ro'
-        mounts['/run/lvm'] = '/run/lvm'
-        mounts['/run/lock/lvm'] = '/run/lock/lvm'
 
     try:
         if ctx.shared_ceph_folder:  # make easy manager modules/ceph-volume development
@@ -5401,6 +5402,68 @@ def command_rm_daemon(ctx):
 ##################################
 
 
+def _zap(ctx, what):
+    mounts = get_container_mounts(ctx, ctx.fsid, 'clusterless-ceph-volume', None)
+    c = CephContainer(
+        ctx,
+        image=ctx.image,
+        entrypoint='/usr/sbin/ceph-volume',
+        envs=ctx.env,
+        args=['lvm', 'zap', '--destroy', what],
+        privileged=True,
+        volume_mounts=mounts,
+    )
+    logger.info(f'Zapping {what}...')
+    out, err, code = call_throws(ctx, c.run_cmd())
+
+
+@infer_image
+def _zap_osds(ctx):
+    # assume fsid lock already held
+
+    # list
+    mounts = get_container_mounts(ctx, ctx.fsid, 'clusterless-ceph-volume', None)
+    c = CephContainer(
+        ctx,
+        image=ctx.image,
+        entrypoint='/usr/sbin/ceph-volume',
+        envs=ctx.env,
+        args=['inventory', '--format', 'json'],
+        privileged=True,
+        volume_mounts=mounts,
+    )
+    out, err, code = call_throws(ctx, c.run_cmd())
+    if code:
+        raise Error('failed to list osd inventory')
+    try:
+        ls = json.loads(out)
+    except ValueError as e:
+        raise Error(f'Invalid JSON in ceph-volume inventory: {e}')
+
+    for i in ls:
+        matches = [lv.get('cluster_fsid') == ctx.fsid for lv in i.get('lvs', [])]
+        if any(matches) and all(matches):
+            _zap(ctx, i.get('path'))
+        elif any(matches):
+            lv_names = [lv['name'] for lv in i.get('lvs', [])]
+            # TODO: we need to map the lv_names back to device paths (the vg
+            # id isn't part of the output here!)
+            logger.warning(f'Not zapping LVs (not implemented): {lv_names}')
+
+
+def command_zap_osds(ctx):
+    if not ctx.force:
+        raise Error('must pass --force to proceed: '
+                    'this command may destroy precious data!')
+
+    lock = FileLock(ctx, ctx.fsid)
+    lock.acquire()
+
+    _zap_osds(ctx)
+
+##################################
+
+
 def command_rm_cluster(ctx):
     # type: (CephadmContext) -> None
     if not ctx.force:
@@ -5468,6 +5531,7 @@ def command_rm_cluster(ctx):
             for n in range(0, len(files)):
                 if os.path.exists(files[n]):
                     os.remove(files[n])
+
 
 ##################################
 
@@ -7633,6 +7697,18 @@ def _get_parser():
     parser_ceph_volume.add_argument(
         'command', nargs=argparse.REMAINDER,
         help='command')
+
+    parser_zap_osds = subparsers.add_parser(
+        'zap-osds', help='zap all OSDs associated with a particular fsid')
+    parser_zap_osds.set_defaults(func=command_zap_osds)
+    parser_zap_osds.add_argument(
+        '--fsid',
+        required=True,
+        help='cluster FSID')
+    parser_zap_osds.add_argument(
+        '--force',
+        action='store_true',
+        help='proceed, even though this may destroy valuable data')
 
     parser_unit = subparsers.add_parser(
         'unit', help="operate on the daemon's systemd unit")

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -5500,6 +5500,10 @@ def command_rm_cluster(ctx):
     call(ctx, ['systemctl', 'stop', slice_name],
          verbosity=CallVerbosity.DEBUG)
 
+    # osds?
+    if ctx.zap_osds:
+        _zap_osds(ctx)
+
     # rm units
     call_throws(ctx, ['rm', '-f', ctx.unit_dir +  # noqa: W504
                       '/ceph-%s@.service' % ctx.fsid])
@@ -7612,6 +7616,10 @@ def _get_parser():
         '--keep-logs',
         action='store_true',
         help='do not remove log files')
+    parser_rm_cluster.add_argument(
+        '--zap-osds',
+        action='store_true',
+        help='zap OSD devices for this cluster')
 
     parser_run = subparsers.add_parser(
         'run', help='run a ceph daemon, in a container, in the foreground')

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5445,6 +5445,17 @@ std::vector<Option> get_global_options() {
     .add_service("mgr")
     .set_description("Filesystem path to manager modules."),
 
+    Option("mgr_standby_modules", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("Start modules in standby (redirect) mode when mgr is standby")
+    .set_long_description(
+      "By default, the standby modules will answer incoming requests with a "
+      "HTTP redirect to the active manager, allowing users to point their browser at any "
+      "mgr node and find their way to an active mgr.  However, this mode is problematic "
+      "when using a load balancer because (1) the redirect locations are usually private "
+      "IPs and (2) the load balancer can't identify which mgr is the right one to send "
+      "traffic to. If a load balancer is being used, set this to false."),
+
     Option("mgr_disabled_modules", Option::TYPE_STR, Option::LEVEL_ADVANCED)
 #ifdef MGR_DISABLED_MODULES
     .set_default(MGR_DISABLED_MODULES)

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -424,7 +424,8 @@ void MgrStandby::handle_mgr_map(ref_t<MMgrMap> mmap)
     if (map.active_gid != 0 && map.active_name != g_conf()->name.get_id()) {
       // I am the standby and someone else is active, start modules
       // in standby mode to do redirects if needed
-      if (!py_module_registry.is_standby_running()) {
+      if (!py_module_registry.is_standby_running() &&
+	  g_conf().get_val<bool>("mgr_standby_modules")) {
         py_module_registry.standby_start(monc, finisher);
       }
     }

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -74,6 +74,7 @@ const char** MgrStandby::get_tracked_conf_keys() const
     "clog_to_graylog",
     "clog_to_graylog_host",
     "clog_to_graylog_port",
+    "mgr_standby_modules",
     "host",
     "fsid",
     NULL
@@ -95,6 +96,17 @@ void MgrStandby::handle_conf_change(
       changed.count("host") ||
       changed.count("fsid")) {
     _update_log_config();
+  }
+  if (changed.count("mgr_standby_modules") && !active_mgr) {
+    if (g_conf().get_val<bool>("mgr_standby_modules") != py_module_registry.have_standby_modules()) {
+      dout(1) << "mgr_standby_modules now "
+	      << (int)g_conf().get_val<bool>("mgr_standby_modules")
+	      << ", standby modules are "
+	      << (py_module_registry.have_standby_modules() ? "":"not ")
+	      << "active, respawning"
+	      << dendl;
+      respawn();
+    }
   }
 }
 

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -115,6 +115,8 @@ int MgrStandby::init()
   init_async_signal_handler();
   register_async_signal_handler(SIGHUP, sighup_handler);
 
+  cct->_conf.add_observer(this);
+
   std::lock_guard l(lock);
 
   // Start finisher

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -98,6 +98,10 @@ public:
    */
   bool handle_mgr_map(const MgrMap &mgr_map_);
 
+  bool have_standby_modules() const {
+    return !!standby_modules;
+  }
+
   void init();
 
   void upgrade_config(

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -82,6 +82,12 @@ class Inventory:
             self._inventory[host]['labels'].remove(label)
         self.save()
 
+    def has_label(self, host: str, label: str) -> bool:
+        return (
+            host in self._inventory
+            and label in self._inventory[host].get('labels', [])
+        )
+
     def get_addr(self, host: str) -> str:
         self.assert_host(host)
         return self._inventory[host].get('addr', host)

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -247,10 +247,10 @@ class HostCache():
 
     This is needed in order to deploy MONs. As this is mostly read-only.
 
-    4. `last_etc_ceph_ceph_conf` O(hosts)
+    4. `last_client_files` O(hosts)
 
-    Stores the last refresh time for the /etc/ceph/ceph.conf. Used
-    to avoid deploying new configs when failing over to a new mgr.
+    Stores the last digest and owner/mode for files we've pushed to /etc/ceph
+    (ceph.conf or client keyrings).
 
     5. `scheduled_daemon_actions`: O(daemons)
 
@@ -280,7 +280,7 @@ class HostCache():
         self.daemon_config_deps = {}   # type: Dict[str, Dict[str, Dict[str,Any]]]
         self.last_host_check = {}      # type: Dict[str, datetime.datetime]
         self.loading_osdspec_preview = set()  # type: Set[str]
-        self.last_etc_ceph_ceph_conf: Dict[str, datetime.datetime] = {}
+        self.last_client_files: Dict[str, Dict[str, Tuple[str, int, int, int]]] = {}
         self.registry_login_queue: Set[str] = set()
 
         self.scheduled_daemon_actions: Dict[str, Dict[str, str]] = {}
@@ -317,6 +317,7 @@ class HostCache():
                     self.devices[host].append(inventory.Device.from_json(d))
                 self.networks[host] = j.get('networks_and_interfaces', {})
                 self.osdspec_previews[host] = j.get('osdspec_previews', {})
+                self.last_client_files[host] = j.get('last_client_files', {})
                 for name, ts in j.get('osdspec_last_applied', {}).items():
                     self.osdspec_last_applied[host][name] = str_to_datetime(ts)
 
@@ -327,9 +328,6 @@ class HostCache():
                     }
                 if 'last_host_check' in j:
                     self.last_host_check[host] = str_to_datetime(j['last_host_check'])
-                if 'last_etc_ceph_ceph_conf' in j:
-                    self.last_etc_ceph_ceph_conf[host] = str_to_datetime(
-                        j['last_etc_ceph_ceph_conf'])
                 self.registry_login_queue.add(host)
                 self.scheduled_daemon_actions[host] = j.get('scheduled_daemon_actions', {})
 
@@ -394,6 +392,24 @@ class HostCache():
         # type: (str, str, datetime.datetime) -> None
         self.osdspec_last_applied[host][service_name] = ts
 
+    def update_client_file(self,
+                           host: str,
+                           path: str,
+                           digest: str,
+                           mode: int,
+                           uid: int,
+                           gid: int) -> None:
+        if host not in self.last_client_files:
+            self.last_client_files[host] = {}
+        self.last_client_files[host][path] = (digest, mode, uid, gid)
+
+    def removed_client_file(self, host: str, path: str) -> None:
+        if (
+            host in self.last_client_files
+            and path in self.last_client_files[host]
+        ):
+            del self.last_client_files[host][path]
+
     def prime_empty_host(self, host):
         # type: (str) -> None
         """
@@ -409,6 +425,7 @@ class HostCache():
         self.device_refresh_queue.append(host)
         self.osdspec_previews_refresh_queue.append(host)
         self.registry_login_queue.add(host)
+        self.last_client_files[host] = {}
 
     def invalidate_host_daemons(self, host):
         # type: (str) -> None
@@ -464,8 +481,8 @@ class HostCache():
         if host in self.last_host_check:
             j['last_host_check'] = datetime_to_str(self.last_host_check[host])
 
-        if host in self.last_etc_ceph_ceph_conf:
-            j['last_etc_ceph_ceph_conf'] = datetime_to_str(self.last_etc_ceph_ceph_conf[host])
+        if host in self.last_client_files:
+            j['last_client_files'] = self.last_client_files[host]
         if host in self.scheduled_daemon_actions:
             j['scheduled_daemon_actions'] = self.scheduled_daemon_actions[host]
 
@@ -499,6 +516,8 @@ class HostCache():
             del self.daemon_config_deps[host]
         if host in self.scheduled_daemon_actions:
             del self.scheduled_daemon_actions[host]
+        if host in self.last_client_files:
+            del self.last_client_files[host]
         self.mgr.set_store(HOST_CACHE_PREFIX + host, None)
 
     def get_hosts(self):
@@ -587,6 +606,9 @@ class HostCache():
                     self.daemon_config_deps[host][name].get('last_config', None)
         return None, None
 
+    def get_host_client_files(self, host: str) -> Dict[str, Tuple[str, int, int, int]]:
+        return self.last_client_files.get(host, {})
+
     def host_needs_daemon_refresh(self, host):
         # type: (str) -> bool
         if host in self.mgr.offline_hosts:
@@ -653,24 +675,6 @@ class HostCache():
             seconds=self.mgr.host_check_interval)
         return host not in self.last_host_check or self.last_host_check[host] < cutoff
 
-    def host_needs_new_etc_ceph_ceph_conf(self, host: str) -> bool:
-        if not self.mgr.manage_etc_ceph_ceph_conf:
-            return False
-        if self.mgr.paused:
-            return False
-        if host in self.mgr.offline_hosts:
-            return False
-        if not self.mgr.last_monmap:
-            return False
-        if host not in self.last_etc_ceph_ceph_conf:
-            return True
-        if self.mgr.last_monmap > self.last_etc_ceph_ceph_conf[host]:
-            return True
-        if self.mgr.extra_ceph_conf_is_newer(self.last_etc_ceph_ceph_conf[host]):
-            return True
-        # already up to date:
-        return False
-
     def osdspec_needs_apply(self, host: str, spec: ServiceSpec) -> bool:
         if (
             host not in self.devices
@@ -684,11 +688,6 @@ class HostCache():
         if not created or created > self.last_device_change[host]:
             return True
         return self.osdspec_last_applied[host][spec.service_name()] < self.last_device_change[host]
-
-    def update_last_etc_ceph_ceph_conf(self, host: str) -> None:
-        if not self.mgr.last_monmap:
-            return
-        self.last_etc_ceph_ceph_conf[host] = datetime_now()
 
     def host_needs_registry_login(self, host: str) -> bool:
         if host in self.mgr.offline_hosts:

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -530,6 +530,11 @@ class HostCache():
             if host in self.mgr.offline_hosts:
                 dd.status = orchestrator.DaemonDescriptionStatus.error
                 dd.status_desc = 'host is offline'
+            elif self.mgr.inventory._inventory[host].get("status", "").lower() == "maintenance":
+                # We do not refresh daemons on hosts in maintenance mode, so stored daemon statuses
+                # could be wrong. We must assume maintenance is working and daemons are stopped
+                dd.status = orchestrator.DaemonDescriptionStatus.stopped
+                dd.status_desc = 'stopped'
             dd.events = self.mgr.events.get_for_daemon(dd.name())
             return dd
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1691,8 +1691,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self._daemon_action_set_image(action, image, daemon_spec.daemon_type,
                                       daemon_spec.daemon_id)
 
-        if action == 'redeploy' and self.daemon_is_self(daemon_spec.daemon_type,
-                                                        daemon_spec.daemon_id):
+        if (action == 'redeploy' or action == 'restart') and self.daemon_is_self(daemon_spec.daemon_type,
+                                                                                 daemon_spec.daemon_id):
             self.mgr_service.fail_over()
             return ''  # unreachable
 
@@ -1743,7 +1743,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         assert d.daemon_type is not None
         assert d.daemon_id is not None
 
-        if action == 'redeploy' and self.daemon_is_self(d.daemon_type, d.daemon_id) \
+        if (action == 'redeploy' or action == 'restart') and self.daemon_is_self(d.daemon_type, d.daemon_id) \
                 and not self.mgr_service.mgr_map_has_standby():
             raise OrchestratorError(
                 f'Unable to schedule redeploy for {daemon_name}: No standby MGRs')
@@ -1766,7 +1766,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         assert dd.daemon_type is not None
         assert dd.daemon_id is not None
         assert dd.hostname is not None
-        if action == 'redeploy' and self.daemon_is_self(dd.daemon_type, dd.daemon_id) \
+        if (action == 'redeploy' or action == 'restart') and self.daemon_is_self(dd.daemon_type, dd.daemon_id) \
                 and not self.mgr_service.mgr_map_has_standby():
             raise OrchestratorError(
                 f'Unable to schedule redeploy for {daemon_name}: No standby MGRs')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1356,12 +1356,14 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def add_host_label(self, host: str, label: str) -> str:
         self.inventory.add_label(host, label)
         self.log.info('Added label %s to host %s' % (label, host))
+        self._kick_serve_loop()
         return 'Added label %s to host %s' % (label, host)
 
     @handle_orch_error
     def remove_host_label(self, host: str, label: str) -> str:
         self.inventory.rm_label(host, label)
         self.log.info('Removed label %s to host %s' % (label, host))
+        self._kick_serve_loop()
         return 'Removed label %s from host %s' % (label, host)
 
     def _host_ok_to_stop(self, hostname: str, force: bool = False) -> Tuple[int, str]:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -284,6 +284,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Manage and own /etc/ceph/ceph.conf on the hosts.',
         ),
         Option(
+            'manage_etc_ceph_ceph_conf_hosts',
+            type='str',
+            default='*',
+            desc='PlacementSpec describing on which hosts to manage /etc/ceph/ceph.conf',
+        ),
+        Option(
             'registry_url',
             type='str',
             default=None,
@@ -366,6 +372,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.migration_current: Optional[int] = None
             self.config_dashboard = True
             self.manage_etc_ceph_ceph_conf = True
+            self.manage_etc_ceph_ceph_conf_hosts = '*'
             self.registry_url: Optional[str] = None
             self.registry_username: Optional[str] = None
             self.registry_password: Optional[str] = None

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1270,7 +1270,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         return image
 
-    def _hosts_with_daemon_inventory(self) -> List[HostSpec]:
+    def _schedulable_hosts(self) -> List[HostSpec]:
         """
         Returns all usable hosts that went through _refresh_host_daemons().
 
@@ -1281,8 +1281,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         """
         return [
             h for h in self.inventory.all_specs()
-            if self.cache.host_had_daemon_refresh(h.hostname)
-            and h.status.lower() not in ['maintenance', 'offline']
+            if (
+                self.cache.host_had_daemon_refresh(h.hostname)
+                and h.status.lower() not in ['maintenance', 'offline']
+                and '_no_schedule' not in h.labels
+            )
         ]
 
     def _add_host(self, spec):
@@ -2101,7 +2104,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         ha = HostAssignment(
             spec=spec,
-            hosts=self._hosts_with_daemon_inventory(),
+            hosts=self._schedulable_hosts(),
             networks=self.cache.networks,
             daemons=self.cache.get_daemons_by_service(spec.service_name()),
             allow_colo=self.cephadm_services[spec.service_type].allow_colo(),

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1582,7 +1582,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                 continue
             sm[nm] = orchestrator.ServiceDescription(
                 spec=spec,
-                size=spec.placement.get_target_count(self.inventory.all_specs()),
+                size=spec.placement.get_target_count(self._schedulable_hosts()),
                 running=0,
                 events=self.events.get_for_service(spec.service_name()),
                 created=self.spec_store.spec_created[nm],

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1367,6 +1367,28 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         :param host: host name
         """
         assert_valid_host(spec.hostname)
+        # make sure hostname is resolvable before trying to make a connection
+        try:
+            utils.resolve_ip(spec.addr)
+        except OrchestratorError as e:
+            msg = str(e) + f'''
+You may need to supply an address for {spec.addr}
+
+Please make sure that the host is reachable and accepts connections using the cephadm SSH key
+To add the cephadm SSH key to the host:
+> ceph cephadm get-pub-key > ~/ceph.pub
+> ssh-copy-id -f -i ~/ceph.pub {self.ssh_user}@{spec.addr}
+
+To check that the host is reachable open a new shell with the --no-hosts flag:
+> cephadm shell --no-hosts
+
+Then run the following:
+> ceph cephadm get-ssh-config > ssh_config
+> ceph config-key get mgr/cephadm/ssh_identity_key > ~/cephadm_private_key
+> chmod 0600 ~/cephadm_private_key
+> ssh -F ssh_config -i ~/cephadm_private_key {self.ssh_user}@{spec.addr}'''
+            raise OrchestratorError(msg)
+
         out, err, code = CephadmServe(self)._run_cephadm(spec.hostname, cephadmNoImage, 'check-host',
                                                          ['--expect-hostname', spec.hostname],
                                                          addr=spec.addr,

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -56,7 +56,7 @@ from .services.monitoring import GrafanaService, AlertmanagerService, Prometheus
     NodeExporterService
 from .services.exporter import CephadmExporter, CephadmExporterConfig
 from .schedule import HostAssignment
-from .inventory import Inventory, SpecStore, HostCache, EventStore
+from .inventory import Inventory, SpecStore, HostCache, EventStore, ClientKeyringStore, ClientKeyringSpec
 from .upgrade import CephadmUpgrade
 from .template import TemplateMgr
 from .utils import CEPH_TYPES, GATEWAY_TYPES, forall_hosts, cephadmNoImage
@@ -416,6 +416,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         self.spec_store = SpecStore(self)
         self.spec_store.load()
+
+        self.keys = ClientKeyringStore(self)
+        self.keys.load()
 
         # ensure the host lists are in sync
         for h in self.inventory.keys():
@@ -1197,6 +1200,67 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             return self.osd_service.deploy_osd_daemons_for_existing_osds(h, 'osd')
 
         return HandleCommandResult(stdout='\n'.join(run(host)))
+
+    @orchestrator._cli_read_command('orch client-keyring ls')
+    def _client_keyring_ls(self, format: Format = Format.plain) -> HandleCommandResult:
+        if format != Format.plain:
+            output = to_format(self.keys.keys.values(), format, many=True, cls=ClientKeyringSpec)
+        else:
+            table = PrettyTable(
+                ['ENTITY', 'PLACEMENT', 'MODE', 'OWNER', 'PATH'],
+                border=False)
+            table.align = 'l'
+            table.left_padding_width = 0
+            table.right_padding_width = 2
+            for ks in sorted(self.keys.keys.values(), key=lambda ks: ks.entity):
+                table.add_row((
+                    ks.entity, ks.placement.pretty_str(),
+                    utils.file_mode_to_str(ks.mode),
+                    f'{ks.uid}:{ks.gid}',
+                    ks.path,
+                ))
+            output = table.get_string()
+        return HandleCommandResult(stdout=output)
+
+    @orchestrator._cli_write_command('orch client-keyring set')
+    def _client_keyring_set(
+            self,
+            entity: str,
+            placement: str,
+            owner: Optional[str] = None,
+            mode: Optional[str] = None,
+    ) -> HandleCommandResult:
+        if not entity.startswith('client.'):
+            raise OrchestratorError('entity must start with client.')
+        if owner:
+            try:
+                uid, gid = map(int, owner.split(':'))
+            except Exception:
+                raise OrchestratorError('owner must look like "<uid>:<gid>", e.g., "0:0"')
+        else:
+            uid = 0
+            gid = 0
+        if mode:
+            try:
+                imode = int(mode, 8)
+            except Exception:
+                raise OrchestratorError('mode must be an octal mode, e.g. "600"')
+        else:
+            imode = 0o600
+        pspec = PlacementSpec.from_string(placement)
+        ks = ClientKeyringSpec(entity, pspec, mode=imode, uid=uid, gid=gid)
+        self.keys.update(ks)
+        self._kick_serve_loop()
+        return HandleCommandResult()
+
+    @orchestrator._cli_write_command('orch client-keyring rm')
+    def _client_keyring_rm(
+            self,
+            entity: str,
+    ) -> HandleCommandResult:
+        self.keys.rm(entity)
+        self._kick_serve_loop()
+        return HandleCommandResult()
 
     def _get_connection(self, host: str) -> Tuple['remoto.backends.BaseConnection',
                                                   'remoto.backends.LegacyModuleExecute']:

--- a/src/pybind/mgr/cephadm/remotes.py
+++ b/src/pybind/mgr/cephadm/remotes.py
@@ -26,6 +26,25 @@ def choose_python():
     return None
 
 
+def write_file(path: str, content: bytes, mode: int, uid: int, gid: int,
+               mkdir_p: bool = True) -> Optional[str]:
+    try:
+        if mkdir_p:
+            dirname = os.path.dirname(path)
+            if not os.path.exists(dirname):
+                os.makedirs(dirname)
+        tmp_path = path + '.new'
+        with open(tmp_path, 'wb') as f:
+            os.fchown(f.fileno(), uid, gid)
+            os.fchmod(f.fileno(), mode)
+            f.write(content)
+            os.fsync(f.fileno())
+        os.rename(tmp_path, path)
+    except Exception as e:
+        return str(e)
+    return None
+
+
 if __name__ == '__channelexec__':
     for item in channel:  # type: ignore # noqa: F821
         channel.send(eval(item))  # type: ignore # noqa: F821

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -386,22 +386,10 @@ class CephadmServe:
         config = self.mgr.get_minimal_ceph_conf()
 
         try:
-            with self._remote_connection(host) as tpl:
-                conn, connr = tpl
-                out, err, code = remoto.process.check(
-                    conn,
-                    ['mkdir', '-p', '/etc/ceph'])
-                if code:
-                    return f'failed to create /etc/ceph on {host}: {err}'
-                out, err, code = remoto.process.check(
-                    conn,
-                    ['dd', 'of=/etc/ceph/ceph.conf'],
-                    stdin=config.encode('utf-8')
-                )
-                if code:
-                    return f'failed to create /etc/ceph/ceph.conf on {host}: {err}'
-                self.mgr.cache.update_last_etc_ceph_ceph_conf(host)
-                self.mgr.cache.save_host(host)
+            self._write_remote_file(host, '/etc/ceph/ceph.conf',
+                                    config.encode('utf-8'), 0o644, 0, 0)
+            self.mgr.cache.update_last_etc_ceph_ceph_conf(host)
+            self.mgr.cache.save_host(host)
         except OrchestratorError as e:
             return f'failed to create /etc/ceph/ceph.conf on {host}: {str(e)}'
         return None

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1144,6 +1144,24 @@ class CephadmServe:
             self.log.warning(msg)
             raise OrchestratorError(msg)
 
+    def _write_remote_file(self,
+                           host: str,
+                           path: str,
+                           content: bytes,
+                           mode: int,
+                           uid: int,
+                           gid: int) -> None:
+        with self._remote_connection(host) as tpl:
+            conn, connr = tpl
+            try:
+                errmsg = connr.write_file(path, content, mode, uid, gid)
+                if errmsg is not None:
+                    raise OrchestratorError(errmsg)
+            except Exception as e:
+                msg = f"Unable to write {host}:{path}: {e}"
+                self.log.warning(msg)
+                raise OrchestratorError(msg)
+
     @contextmanager
     def _remote_connection(self,
                            host: str,

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1240,7 +1240,10 @@ To add the cephadm SSH key to the host:
 > ceph cephadm get-pub-key > ~/ceph.pub
 > ssh-copy-id -f -i ~/ceph.pub {user}@{addr}
 
-To check that the host is reachable:
+To check that the host is reachable open a new shell with the --no-hosts flag:
+> cephadm shell --no-hosts
+
+Then run the following:
 > ceph cephadm get-ssh-config > ssh_config
 > ceph config-key get mgr/cephadm/ssh_identity_key > ~/cephadm_private_key
 > chmod 0600 ~/cephadm_private_key

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -546,7 +546,7 @@ class CephadmServe:
 
         ha = HostAssignment(
             spec=spec,
-            hosts=self.mgr._hosts_with_daemon_inventory(),
+            hosts=self.mgr._schedulable_hosts(),
             daemons=daemons,
             networks=self.mgr.cache.networks,
             filter_new_host=(

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -560,6 +560,8 @@ class CephadmServe:
 
         try:
             all_slots, slots_to_add, daemons_to_remove = ha.place()
+            daemons_to_remove = [d for d in daemons_to_remove if (d.hostname and self.mgr.inventory._inventory[d.hostname].get(
+                'status', '').lower() not in ['maintenance', 'offline'])]
             self.log.debug('Add %s, remove %s' % (slots_to_add, daemons_to_remove))
         except OrchestratorError as e:
             self.log.error('Failed to apply %s spec %s: %s' % (

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -551,6 +551,18 @@ class MonService(CephService):
 class MgrService(CephService):
     TYPE = 'mgr'
 
+    def allow_colo(self) -> bool:
+        if self.mgr.get_ceph_option('mgr_standby_modules'):
+            # traditional mgr mode: standby daemons' modules listen on
+            # ports and redirect to the primary.  we must not schedule
+            # multiple mgrs on the same host or else ports will
+            # conflict.
+            return False
+        else:
+            # standby daemons do nothing, and therefore port conflicts
+            # are not a concern.
+            return True
+
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         """
         Create a new manager instance on a host.

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -53,7 +53,7 @@ class OSDService(CephService):
                     drive_group.service_id))
                 return None
 
-            logger.info('Applying service osd.%s on host %s...' % (
+            logger.debug('Applying service osd.%s on host %s...' % (
                 drive_group.service_id, host
             ))
             start_ts = datetime_now()

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -70,11 +70,12 @@ def wait(m, c):
 @contextmanager
 def with_host(m: CephadmOrchestrator, name, refresh_hosts=True):
     # type: (CephadmOrchestrator, str) -> None
-    wait(m, m.add_host(HostSpec(hostname=name)))
-    if refresh_hosts:
-        CephadmServe(m)._refresh_hosts_and_daemons()
-    yield
-    wait(m, m.remove_host(name))
+    with mock.patch("cephadm.utils.resolve_ip"):
+        wait(m, m.add_host(HostSpec(hostname=name)))
+        if refresh_hosts:
+            CephadmServe(m)._refresh_hosts_and_daemons()
+        yield
+        wait(m, m.remove_host(name))
 
 
 def assert_rm_service(cephadm: CephadmOrchestrator, srv_name):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -984,6 +984,37 @@ class TestCephadm(object):
             out = wait(cephadm_module, cephadm_module.get_hosts())[0].to_json()
             assert out == HostSpec('test', 'test').to_json()
 
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_dont_touch_offline_or_maintenance_host_daemons(self, cephadm_module):
+        # test daemons on offline/maint hosts not removed when applying specs
+        # test daemons not added to hosts in maint/offline state
+        with with_host(cephadm_module, 'test1'):
+            with with_host(cephadm_module, 'test2'):
+                with with_host(cephadm_module, 'test3'):
+                    with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(host_pattern='*'))):
+                        # should get a mgr on all 3 hosts
+                        # CephadmServe(cephadm_module)._apply_all_services()
+                        assert len(cephadm_module.cache.get_daemons_by_type('mgr')) == 3
+
+                        # put one host in offline state and one host in maintenance state
+                        cephadm_module.inventory._inventory['test2']['status'] = 'offline'
+                        cephadm_module.inventory._inventory['test3']['status'] = 'maintenance'
+                        cephadm_module.inventory.save()
+
+                        # being in offline/maint mode should disqualify hosts from being
+                        # candidates for scheduling
+                        candidates = [
+                            h.hostname for h in cephadm_module._hosts_with_daemon_inventory()]
+                        assert 'test2' not in candidates
+                        assert 'test3' not in candidates
+
+                        with with_service(cephadm_module, ServiceSpec('crash', placement=PlacementSpec(host_pattern='*'))):
+                            # re-apply services. No mgr should be removed from maint/offline hosts
+                            # crash daemon should only be on host not in maint/offline mode
+                            CephadmServe(cephadm_module)._apply_all_services()
+                            assert len(cephadm_module.cache.get_daemons_by_type('mgr')) == 3
+                            assert len(cephadm_module.cache.get_daemons_by_type('crash')) == 1
+
     def test_stale_connections(self, cephadm_module):
         class Connection(object):
             """

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1004,7 +1004,7 @@ class TestCephadm(object):
                         # being in offline/maint mode should disqualify hosts from being
                         # candidates for scheduling
                         candidates = [
-                            h.hostname for h in cephadm_module._hosts_with_daemon_inventory()]
+                            h.hostname for h in cephadm_module._schedulable_hosts()]
                         assert 'test2' not in candidates
                         assert 'test3' not in candidates
 

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -119,3 +119,14 @@ def resolve_ip(hostname: str) -> str:
 
 def ceph_release_to_major(release: str) -> int:
     return ord(release[0]) - ord('a') + 1
+
+
+def file_mode_to_str(mode: int) -> str:
+    r = ''
+    for shift in range(0, 9, 3):
+        r = (
+            f'{"r" if (mode >> shift) & 4 else "-"}'
+            f'{"w" if (mode >> shift) & 2 else "-"}'
+            f'{"x" if (mode >> shift) & 1 else "-"}'
+        ) + r
+    return r

--- a/src/python-common/ceph/deployment/hostspec.py
+++ b/src/python-common/ceph/deployment/hostspec.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import errno
 try:
     from typing import Optional, List, Any
@@ -45,7 +46,7 @@ class HostSpec(object):
         return {
             'hostname': self.hostname,
             'addr': self.addr,
-            'labels': list(set((self.labels))),
+            'labels': list(OrderedDict.fromkeys((self.labels))),
             'status': self.status,
         }
 
@@ -54,7 +55,8 @@ class HostSpec(object):
         host_spec = cls.normalize_json(host_spec)
         _cls = cls(host_spec['hostname'],
                    host_spec['addr'] if 'addr' in host_spec else None,
-                   list(set(host_spec['labels'])) if 'labels' in host_spec else None,
+                   list(OrderedDict.fromkeys(
+                       host_spec['labels'])) if 'labels' in host_spec else None,
                    host_spec['status'] if 'status' in host_spec else None)
         return _cls
 


### PR DESCRIPTION
#40555 ignore apparmor if profiles empty
 #40817 mgr_standby_modules
 #40378 doc: rewrite osd decl state
 #40914 doc: rewrite osd specs
 #40966 doc: rewrite additional opts
 #40969 doc: removing colons
 #40938 _no_schedule
 #40944 python-common ordereddist instead of set
 #40913 fix ctx archive check for teuthology
 #40863 maint-fix
 #41011 fix _scheduleable_hosts conflict
 #41029 doc: nfs
 #40992 doc: adding device to sentence
 #41030 doc: add word
 #41002 orch daemon restart
 #41055 several public networks can be matched
 #41049 re-assimilate user provided conf after mgr
 #40943 mon/mgr vs upgrade
 #40941 client keyring and config
 #40924 check hostname resolution
 #40502 doc: add podman version to install
 #41105 --zap-osds
 #41045 ceph-volume verbose only when fails