### PR TITLE
cmake: restore Lua scripting support for RGW

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -589,7 +589,8 @@ endif(${WITH_LTTNG})
 
 add_subdirectory(global)
 
-if(WITH_CEPHFS)
+# RGW also support Lua scripting
+if(WITH_CEPHFS OR WITH_RADOSGW)
   find_package(Lua 5.3 REQUIRED)
 endif()
 


### PR DESCRIPTION
RGW linkage with Lua was broken by the following commit:

commit 7471fbfa4bf015c972c0e577da2a1ee87f62adfd
Author: Kefu Chai <kchai@redhat.com>
Date:   Mon Apr 26 22:44:16 2021 +0800

    cmake: require lua if WITH_CEPHFS is enabled

    in src/mds/Mantle.cc, the lua C binding APIs are used, so we should only
    require lua if WITH_CEPHFS is enabled.

    Signed-off-by: Kefu Chai <kchai@redhat.com>

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
