### PR TITLE
global: dump the siginfo when handling a fatal signal.

### DIFF
--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -46,14 +46,22 @@ using std::string;
 using ceph::BackTrace;
 using ceph::JSONFormatter;
 
+#ifndef _WIN32
+void install_sighandler(int signum, signal_action_handler_t handler, int flags)
+#else
 void install_sighandler(int signum, signal_handler_t handler, int flags)
+#endif
 {
   int ret;
   struct sigaction oldact;
   struct sigaction act;
   memset(&act, 0, sizeof(act));
 
+#ifndef _WIN32
+  act.sa_sigaction = handler;
+#else
   act.sa_handler = handler;
+#endif
   sigemptyset(&act.sa_mask);
   act.sa_flags = flags;
 
@@ -281,7 +289,38 @@ void generate_crash_dump(char *base,
   }
 }
 
+#ifndef _WIN32
+static void dump_siginfo(std::ostream& os, const siginfo_t& siginfo)
+{
+  os << std::endl << "Dump of siginfo:" << std::endl
+     << "  si_signo: " << siginfo.si_signo << std::endl
+     << "  si_errno: " << siginfo.si_errno << std::endl
+     << "  si_code: " << siginfo.si_code << std::endl
+     << "  si_pid: " << siginfo.si_pid << std::endl
+     << "  si_uid: " << siginfo.si_uid << std::endl
+     << "  si_status: " << siginfo.si_status << std::endl
+     << "  si_utime: " << siginfo.si_utime << std::endl
+     << "  si_stime: " << siginfo.si_stime << std::endl
+     << "  si_int: " << siginfo.si_int << std::endl
+     << "  si_ptr: " << siginfo.si_ptr << std::endl
+     << "  si_overrun: " << siginfo.si_overrun << std::endl
+     << "  si_timerid: " << siginfo.si_timerid << std::endl
+     << "  si_addr: " << siginfo.si_addr << std::endl
+     << "  si_band: " << siginfo.si_band << std::endl
+     << "  si_fd: " << siginfo.si_fd << std::endl
+     << "  si_addr_lsb: " << siginfo.si_addr_lsb << std::endl
+     << "  si_lower: " << siginfo.si_lower << std::endl
+     << "  si_upper: " << siginfo.si_upper << std::endl
+     << "  si_pkey: " << siginfo.si_pkey << std::endl
+     << "  si_call_addr: " << siginfo.si_call_addr << std::endl
+     << "  si_syscall: " << siginfo.si_syscall << std::endl
+     << "  si_arch: " << siginfo.si_arch << std::endl;
+}
+
+static void handle_oneshot_fatal_signal(int signum, siginfo_t *siginfo, void*)
+#else
 static void handle_oneshot_fatal_signal(int signum)
+#endif
 {
   constexpr static pid_t NULL_TID{0};
   static std::atomic<pid_t> handler_tid{NULL_TID};
@@ -325,6 +364,11 @@ static void handle_oneshot_fatal_signal(int signum)
   ClibBackTrace bt(1);
   ostringstream oss;
   bt.print(oss);
+#ifndef _WIN32
+  if (siginfo) {
+    dump_siginfo(oss, *siginfo);
+  }
+#endif
   dout_emergency(oss.str());
 
   char crash_base[PATH_MAX] = { 0 };
@@ -366,7 +410,11 @@ static void handle_oneshot_fatal_signal(int signum)
 
 void install_standard_sighandlers(void)
 {
+#ifndef _WIN32
+  install_sighandler(SIGSEGV, handle_oneshot_fatal_signal, SA_NODEFER | SA_SIGINFO);
+#else
   install_sighandler(SIGSEGV, handle_oneshot_fatal_signal, SA_NODEFER);
+#endif
   install_sighandler(SIGABRT, handle_oneshot_fatal_signal, SA_NODEFER);
   install_sighandler(SIGBUS, handle_oneshot_fatal_signal, SA_NODEFER);
   install_sighandler(SIGILL, handle_oneshot_fatal_signal, SA_NODEFER);

--- a/src/global/signal_handler.h
+++ b/src/global/signal_handler.h
@@ -21,6 +21,10 @@
 #include <string>
 
 typedef void (*signal_handler_t)(int);
+#ifndef _WIN32
+typedef void (*signal_action_handler_t)(int, siginfo_t*, void*);
+#endif
+
 namespace ceph {
   struct BackTrace;
 }
@@ -33,7 +37,11 @@ namespace ceph {
 # define sig_str(signum) sys_siglist[signum]
 #endif
 
+#ifndef _WIN32
+void install_sighandler(int signum, signal_action_handler_t handler, int flags);
+#else
 void install_sighandler(int signum, signal_handler_t handler, int flags);
+#endif
 
 // handles SIGHUP
 void sighup_handler(int signum);

--- a/src/test/signals.cc
+++ b/src/test/signals.cc
@@ -16,7 +16,7 @@
 #define dout_context g_ceph_context
 static volatile sig_atomic_t got_sigusr1 = 0;
 
-static void handle_sigusr1(int signo)
+static void handle_sigusr1(int signo, siginfo_t*, void*)
 {
   got_sigusr1 = 1;
 }


### PR DESCRIPTION
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
