### PR TITLE
nautilus: rgw: during reshard lock contention, adjust logging

### DIFF
--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -429,6 +429,7 @@ RGWBucketReshardLock::RGWBucketReshardLock(RGWRados* _store,
 
 int RGWBucketReshardLock::lock() {
   internal_lock.set_must_renew(false);
+
   int ret;
   if (ephemeral) {
     ret = internal_lock.lock_exclusive_ephemeral(&store->reshard_pool_ctx,
@@ -436,11 +437,19 @@ int RGWBucketReshardLock::lock() {
   } else {
     ret = internal_lock.lock_exclusive(&store->reshard_pool_ctx, lock_oid);
   }
-  if (ret < 0) {
-    ldout(store->ctx(), 0) << "RGWReshardLock::" << __func__ <<
-      " failed to acquire lock on " << lock_oid << " ret=" << ret << dendl;
+
+  if (ret == -EBUSY) {
+    ldout(store->ctx(), 0) << "INFO: RGWReshardLock::" << __func__ <<
+      " found lock on " << lock_oid <<
+      " to be held by another RGW process; skipping for now" << dendl;
+    return ret;
+  } else if (ret < 0) {
+    lderr(store->ctx()) << "ERROR: RGWReshardLock::" << __func__ <<
+      " failed to acquire lock on " << lock_oid << ": " <<
+      cpp_strerror(-ret) << dendl;
     return ret;
   }
+
   reset_time(Clock::now());
 
   return 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50366

---

backport of https://github.com/ceph/ceph/pull/40862
parent tracker: https://tracker.ceph.com/issues/50363

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh