### PR TITLE
nautilus: rgw: Added caching for S3 credentials retrieved from keystone

### DIFF
--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -72,6 +72,57 @@ public:
   }
 }; /* class TokenEngine */
 
+class SecretCache {
+  using token_envelope_t = rgw::keystone::TokenEnvelope;
+
+  struct secret_entry {
+    token_envelope_t token;
+    std::string secret;
+    uint64_t expires;
+    list<std::string>::iterator lru_iter;
+  };
+
+  const boost::intrusive_ptr<CephContext> cct;
+
+  std::map<std::string, secret_entry> secrets;
+  std::list<std::string> secrets_lru;
+
+  Mutex lock;
+
+  const size_t max;
+
+  const uint64_t s3_token_expiry_length;
+
+  SecretCache()
+    : cct(g_ceph_context),
+      lock("rgw::auth::keystone::SecretCache"),
+      max(cct->_conf->rgw_keystone_token_cache_size),
+      s3_token_expiry_length(300) {
+  }
+
+  ~SecretCache() {}
+
+public:
+  SecretCache(const SecretCache&) = delete;
+  void operator=(const SecretCache&) = delete;
+
+  static SecretCache& get_instance() {
+    /* In C++11 this is thread safe. */
+    static SecretCache instance;
+    return instance;
+  }
+
+  bool find(const std::string& token_id, token_envelope_t& token, std::string& secret);
+  boost::optional<boost::tuple<token_envelope_t, std::string>> find(const std::string& token_id) {
+    token_envelope_t token_envlp;
+    std::string secret;
+    if (find(token_id, token_envlp, secret)) {
+      return boost::make_tuple(token_envlp, secret);
+    }
+    return boost::none;
+  }
+  void add(const std::string& token_id, const token_envelope_t& token, const std::string& secret);
+}; /* class SecretCache */
 
 class EC2Engine : public rgw::auth::s3::AWSEngine {
   using acl_strategy_t = rgw::auth::RemoteApplier::acl_strategy_t;
@@ -82,6 +133,7 @@ class EC2Engine : public rgw::auth::s3::AWSEngine {
   const rgw::auth::RemoteApplier::Factory* const apl_factory;
   rgw::keystone::Config& config;
   rgw::keystone::TokenCache& token_cache;
+  rgw::auth::keystone::SecretCache& secret_cache;
 
   /* Helper methods. */
   acl_strategy_t get_acl_strategy(const token_envelope_t& token) const;
@@ -89,9 +141,15 @@ class EC2Engine : public rgw::auth::s3::AWSEngine {
                              const std::vector<std::string>& admin_roles
                             ) const noexcept;
   std::pair<boost::optional<token_envelope_t>, int>
-  get_from_keystone(const DoutPrefixProvider* dpp, const boost::string_view& access_key_id,
+  get_from_keystone(const DoutPrefixProvider* dpp,
+                    const boost::string_view& access_key_id,
                     const std::string& string_to_sign,
                     const boost::string_view& signature) const;
+  std::pair<boost::optional<token_envelope_t>, int>
+  get_access_token(const DoutPrefixProvider* dpp,
+                   const boost::string_view& access_key_id,
+                   const std::string& string_to_sign,
+                   const boost::string_view& signature) const;
   result_t authenticate(const DoutPrefixProvider* dpp,
                         const boost::string_view& access_key_id,
                         const boost::string_view& signature,
@@ -100,6 +158,10 @@ class EC2Engine : public rgw::auth::s3::AWSEngine {
                         const signature_factory_t&,
                         const completer_factory_t& completer_factory,
                         const req_state* s) const override;
+  std::string sign(const DoutPrefixProvider* dpp, const std::string& secret, const std::string& string_to_sign) const;
+  std::pair<boost::optional<std::string>, int> get_secret_from_keystone(const DoutPrefixProvider* dpp,
+                                                                        const std::string& user_id,
+                                                                        const boost::string_view& access_key_id) const;
 public:
   EC2Engine(CephContext* const cct,
             const rgw::auth::s3::AWSEngine::VersionAbstractor* const ver_abstractor,
@@ -108,11 +170,13 @@ public:
             /* The token cache is used ONLY for the retrieving admin token.
              * Due to the architecture of AWS Auth S3 credentials cannot be
              * cached at all. */
-            rgw::keystone::TokenCache& token_cache)
+            rgw::keystone::TokenCache& token_cache,
+	    rgw::auth::keystone::SecretCache& secret_cache)
     : AWSEngine(cct, *ver_abstractor),
       apl_factory(apl_factory),
       config(config),
-      token_cache(token_cache) {
+      token_cache(token_cache),
+      secret_cache(secret_cache) {
   }
 
   using AWSEngine::authenticate;

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -102,6 +102,7 @@ class ExternalAuthStrategy : public rgw::auth::Strategy,
 
   using keystone_config_t = rgw::keystone::CephCtxConfig;
   using keystone_cache_t = rgw::keystone::TokenCache;
+  using secret_cache_t = rgw::auth::keystone::SecretCache;
   using EC2Engine = rgw::auth::keystone::EC2Engine;
 
   boost::optional <EC2Engine> keystone_engine;
@@ -136,7 +137,8 @@ public:
       keystone_engine.emplace(cct, ver_abstractor,
                               static_cast<rgw::auth::RemoteApplier::Factory*>(this),
                               keystone_config_t::get_instance(),
-                              keystone_cache_t::get_instance<keystone_config_t>());
+                              keystone_cache_t::get_instance<keystone_config_t>(),
+			      secret_cache_t::get_instance());
       add_engine(Control::SUFFICIENT, *keystone_engine);
 
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50430

---

backport of https://github.com/ceph/ceph/pull/26095
parent tracker: https://tracker.ceph.com/issues/50428

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh