### PR TITLE
nautilus: build python extensions using distutils

### DIFF
--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -205,6 +205,7 @@ setup(
                 extra_compile_args=flags['cflags']['extras'] + flags['ldflags']['extras'],
             )
         ],
+        compiler_directives={'language_level': sys.version_info.major},
         build_dir=os.environ.get("CYTHON_BUILD_DIR", None),
         include_path=[
             os.path.join(os.path.dirname(__file__), "..", "rados")

--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -47,37 +47,16 @@ else:
 __version__ = '2.0.0'
 
 
-def get_python_flags():
-    cflags = {'I': [], 'extras': []}
-    ldflags = {'l': [], 'L': [], 'extras': []}
-
-    if os.environ.get('VIRTUAL_ENV', None):
-        python = "python"
-    else:
-        python = 'python' + str(sys.version_info.major) + '.' + str(sys.version_info.minor)
-
-    python_config = python + '-config'
-
-    for cflag in filter_unsupported_flags(subprocess.check_output(
-            [python_config, "--cflags"]).strip().decode('utf-8').split()):
-        if cflag.startswith('-I'):
-            cflags['I'].append(cflag.replace('-I', ''))
-        else:
-            cflags['extras'].append(cflag)
-
-    for ldflag in filter_unsupported_flags(subprocess.check_output(
-            [python_config, "--ldflags"]).strip().decode('utf-8').split()):
-        if ldflag.startswith('-l'):
-            ldflags['l'].append(ldflag.replace('-l', ''))
-        if ldflag.startswith('-L'):
-            ldflags['L'].append(ldflag.replace('-L', ''))
-        else:
-            ldflags['extras'].append(ldflag)
-
-    return {
-        'cflags': cflags,
-        'ldflags': ldflags
-    }
+def get_python_flags(libs):
+    py_libs = sum((libs.split() for libs in
+                   distutils.sysconfig.get_config_vars('LIBS', 'SYSLIBS')), [])
+    return dict(
+        include_dirs=[distutils.sysconfig.get_python_inc()],
+        library_dirs=distutils.sysconfig.get_config_vars('LIBDIR', 'LIBPL'),
+        libraries=libs + [lib.replace('-l', '') for lib in py_libs],
+        extra_compile_args=distutils.sysconfig.get_config_var('CFLAGS').split(),
+        extra_link_args=(distutils.sysconfig.get_config_var('LDFLAGS').split() +
+                         distutils.sysconfig.get_config_var('LINKFORSHARED').split()))
 
 
 def check_sanity():
@@ -177,8 +156,6 @@ if (len(sys.argv) >= 2 and
     def cythonize(x, **kwargs):
         return x
 
-flags = get_python_flags()
-
 setup(
     name='cephfs',
     version=__version__,
@@ -199,10 +176,7 @@ setup(
             Extension(
                 "cephfs",
                 [source],
-                include_dirs=flags['cflags']['I'],
-                library_dirs=flags['ldflags']['L'],
-                libraries=['cephfs'] + flags['ldflags']['l'],
-                extra_compile_args=flags['cflags']['extras'] + flags['ldflags']['extras'],
+                **get_python_flags(['cephfs'])
             )
         ],
         compiler_directives={'language_level': sys.version_info.major},

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -557,6 +557,11 @@ def decode_cstr(val, encoding="utf-8"):
     return val.decode(encoding)
 
 
+def flatten_dict(d):
+    items = chain.from_iterable(d.items())
+    return ''.join(i + '\0' for i in items)
+
+
 cdef char* opt_str(s) except? NULL:
     if s is None:
         return NULL
@@ -1537,8 +1542,7 @@ Rados object in state %s." % self.state)
         """
         service = cstr(service, 'service')
         daemon = cstr(daemon, 'daemon')
-        metadata_dict = '\0'.join(chain.from_iterable(metadata.items()))
-        metadata_dict += '\0'
+        metadata_dict = flatten_dict(metadata)
         cdef:
             char *_service = service
             char *_daemon = daemon
@@ -1551,8 +1555,7 @@ Rados object in state %s." % self.state)
 
     @requires(('metadata', dict))
     def service_daemon_update(self, status):
-        status_dict = '\0'.join(chain.from_iterable(status.items()))
-        status_dict += '\0'
+        status_dict = flatten_dict(status)
         cdef:
             char *_status = status_dict
 

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -559,7 +559,7 @@ def decode_cstr(val, encoding="utf-8"):
 
 def flatten_dict(d):
     items = chain.from_iterable(d.items())
-    return ''.join(i + '\0' for i in items)
+    return cstr(''.join(i + '\0' for i in items))
 
 
 cdef char* opt_str(s) except? NULL:

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -199,7 +199,9 @@ setup(
                 libraries=["rados"] + flags['ldflags']['l'],
                 extra_compile_args=flags['cflags']['extras'] + flags['ldflags']['extras'],
             )
-        ], build_dir=os.environ.get("CYTHON_BUILD_DIR", None)
+        ],
+        compiler_directives={'language_level': sys.version_info.major},
+        build_dir=os.environ.get("CYTHON_BUILD_DIR", None)
     ),
     classifiers=[
         'Intended Audience :: Developers',

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -47,37 +47,16 @@ distutils.sysconfig.customize_compiler = monkey_with_compiler
 __version__ = '2.0.0'
 
 
-def get_python_flags():
-    cflags = {'I': [], 'extras': []}
-    ldflags = {'l': [], 'L': [], 'extras': []}
-
-    if os.environ.get('VIRTUAL_ENV', None):
-        python = "python"
-    else:
-        python = 'python' + str(sys.version_info.major) + '.' + str(sys.version_info.minor)
-
-    python_config = python + '-config'
-
-    for cflag in filter_unsupported_flags(subprocess.check_output(
-            [python_config, "--cflags"]).strip().decode('utf-8').split()):
-        if cflag.startswith('-I'):
-            cflags['I'].append(cflag.replace('-I', ''))
-        else:
-            cflags['extras'].append(cflag)
-
-    for ldflag in filter_unsupported_flags(subprocess.check_output(
-            [python_config, "--ldflags"]).strip().decode('utf-8').split()):
-        if ldflag.startswith('-l'):
-            ldflags['l'].append(ldflag.replace('-l', ''))
-        if ldflag.startswith('-L'):
-            ldflags['L'].append(ldflag.replace('-L', ''))
-        else:
-            ldflags['extras'].append(ldflag)
-
-    return {
-        'cflags': cflags,
-        'ldflags': ldflags
-    }
+def get_python_flags(libs):
+    py_libs = sum((libs.split() for libs in
+                   distutils.sysconfig.get_config_vars('LIBS', 'SYSLIBS')), [])
+    return dict(
+        include_dirs=[distutils.sysconfig.get_python_inc()],
+        library_dirs=distutils.sysconfig.get_config_vars('LIBDIR', 'LIBPL'),
+        libraries=libs + [lib.replace('-l', '') for lib in py_libs],
+        extra_compile_args=distutils.sysconfig.get_config_var('CFLAGS').split(),
+        extra_link_args=(distutils.sysconfig.get_config_var('LDFLAGS').split() +
+                         distutils.sysconfig.get_config_var('LINKFORSHARED').split()))
 
 
 def check_sanity():
@@ -173,8 +152,6 @@ if (len(sys.argv) >= 2 and
     def cythonize(x, **kwargs):
         return x
 
-flags = get_python_flags()
-
 setup(
     name='rados',
     version=__version__,
@@ -194,10 +171,7 @@ setup(
             Extension(
                 "rados",
                 [source],
-                include_dirs=flags['cflags']['I'],
-                library_dirs=flags['ldflags']['L'],
-                libraries=["rados"] + flags['ldflags']['l'],
-                extra_compile_args=flags['cflags']['extras'] + flags['ldflags']['extras'],
+                **get_python_flags(['rados'])
             )
         ],
         compiler_directives={'language_level': sys.version_info.major},

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -204,6 +204,7 @@ setup(
                 extra_compile_args=flags['cflags']['extras'] + flags['ldflags']['extras'],
             )
         ],
+        compiler_directives={'language_level': sys.version_info.major},
         build_dir=os.environ.get("CYTHON_BUILD_DIR", None),
         include_path=[
             os.path.join(os.path.dirname(__file__), "..", "rados")

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -47,37 +47,16 @@ else:
 __version__ = '2.0.0'
 
 
-def get_python_flags():
-    cflags = {'I': [], 'extras': []}
-    ldflags = {'l': [], 'L': [], 'extras': []}
-
-    if os.environ.get('VIRTUAL_ENV', None):
-        python = "python"
-    else:
-        python = 'python' + str(sys.version_info.major) + '.' + str(sys.version_info.minor)
-
-    python_config = python + '-config'
-
-    for cflag in filter_unsupported_flags(subprocess.check_output(
-            [python_config, "--cflags"]).strip().decode('utf-8').split()):
-        if cflag.startswith('-I'):
-            cflags['I'].append(cflag.replace('-I', ''))
-        else:
-            cflags['extras'].append(cflag)
-
-    for ldflag in filter_unsupported_flags(subprocess.check_output(
-            [python_config, "--ldflags"]).strip().decode('utf-8').split()):
-        if ldflag.startswith('-l'):
-            ldflags['l'].append(ldflag.replace('-l', ''))
-        if ldflag.startswith('-L'):
-            ldflags['L'].append(ldflag.replace('-L', ''))
-        else:
-            ldflags['extras'].append(ldflag)
-
-    return {
-        'cflags': cflags,
-        'ldflags': ldflags
-    }
+def get_python_flags(libs):
+    py_libs = sum((libs.split() for libs in
+                   distutils.sysconfig.get_config_vars('LIBS', 'SYSLIBS')), [])
+    return dict(
+        include_dirs=[distutils.sysconfig.get_python_inc()],
+        library_dirs=distutils.sysconfig.get_config_vars('LIBDIR', 'LIBPL'),
+        libraries=libs + [lib.replace('-l', '') for lib in py_libs],
+        extra_compile_args=distutils.sysconfig.get_config_var('CFLAGS').split(),
+        extra_link_args=(distutils.sysconfig.get_config_var('LDFLAGS').split() +
+                         distutils.sysconfig.get_config_var('LINKFORSHARED').split()))
 
 
 def check_sanity():
@@ -176,8 +155,6 @@ if (len(sys.argv) >= 2 and
     def cythonize(x, **kwargs):
         return x
 
-flags = get_python_flags()
-
 setup(
     name='rbd',
     version=__version__,
@@ -198,10 +175,7 @@ setup(
             Extension(
                 "rbd",
                 [source],
-                include_dirs=flags['cflags']['I'],
-                library_dirs=flags['ldflags']['L'],
-                libraries=['rbd', 'rados'] + flags['ldflags']['l'],
-                extra_compile_args=flags['cflags']['extras'] + flags['ldflags']['extras'],
+                **get_python_flags(['rbd', 'rados'])
             )
         ],
         compiler_directives={'language_level': sys.version_info.major},

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -205,6 +205,7 @@ setup(
                 extra_compile_args=flags['cflags']['extras'] + flags['ldflags']['extras'],
             )
         ],
+        compiler_directives={'language_level': sys.version_info.major},
         build_dir=os.environ.get("CYTHON_BUILD_DIR", None),
         include_path=[
             os.path.join(os.path.dirname(__file__), "..", "rados")

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -49,37 +49,17 @@ else:
 
 __version__ = '2.0.0'
 
-def get_python_flags():
-    cflags = {'I': [], 'extras': []}
-    ldflags = {'l': [], 'L': [], 'extras': []}
 
-    if os.environ.get('VIRTUAL_ENV', None):
-        python = "python"
-    else:
-        python = 'python' + str(sys.version_info.major) + '.' + str(sys.version_info.minor)
-
-    python_config = python + '-config'
-
-    for cflag in filter_unsupported_flags(subprocess.check_output(
-            [python_config, "--cflags"]).strip().decode('utf-8').split()):
-        if cflag.startswith('-I'):
-            cflags['I'].append(cflag.replace('-I', ''))
-        else:
-            cflags['extras'].append(cflag)
-
-    for ldflag in filter_unsupported_flags(subprocess.check_output(
-            [python_config, "--ldflags"]).strip().decode('utf-8').split()):
-        if ldflag.startswith('-l'):
-            ldflags['l'].append(ldflag.replace('-l', ''))
-        if ldflag.startswith('-L'):
-            ldflags['L'].append(ldflag.replace('-L', ''))
-        else:
-            ldflags['extras'].append(ldflag)
-
-    return {
-        'cflags': cflags,
-        'ldflags': ldflags
-    }
+def get_python_flags(libs):
+    py_libs = sum((libs.split() for libs in
+                   distutils.sysconfig.get_config_vars('LIBS', 'SYSLIBS')), [])
+    return dict(
+        include_dirs=[distutils.sysconfig.get_python_inc()],
+        library_dirs=distutils.sysconfig.get_config_vars('LIBDIR', 'LIBPL'),
+        libraries=libs + [lib.replace('-l', '') for lib in py_libs],
+        extra_compile_args=distutils.sysconfig.get_config_var('CFLAGS').split(),
+        extra_link_args=(distutils.sysconfig.get_config_var('LDFLAGS').split() +
+                         distutils.sysconfig.get_config_var('LINKFORSHARED').split()))
 
 
 def check_sanity():
@@ -178,8 +158,6 @@ if (len(sys.argv) >= 2 and
     def cythonize(x, **kwargs):
         return x
 
-flags = get_python_flags()
-
 setup(
     name='rgw',
     version=__version__,
@@ -199,10 +177,7 @@ setup(
             Extension(
                 "rgw",
                 [source],
-                include_dirs=flags['cflags']['I'],
-                library_dirs=flags['ldflags']['L'],
-                libraries=['rados', 'rgw'] + flags['ldflags']['l'],
-                extra_compile_args=flags['cflags']['extras'] + flags['ldflags']['extras'],
+                **get_python_flags(['rados', 'rgw'])
             )
         ],
         compiler_directives={'language_level': sys.version_info.major},


### PR DESCRIPTION
* fix the build with python3
* do not use python-config for the cflags and ldflags when building cython extensions, use distutils, as `python-config` always points to the one shipped by distro, which prints the python2 settings. while we are using python3 for building the doc

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
