### PR TITLE
os/bluestore/bluefs: Force metadata sync after file rename and file deletion

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -412,6 +412,7 @@ rocksdb::Status BlueRocksEnv::ReuseWritableFile(
   if (r < 0)
     return err_to_status(r);
   result->reset(new BlueRocksWritableFile(fs, h));
+  fs->sync_metadata(false);
   return rocksdb::Status::OK();
 }
 
@@ -452,6 +453,7 @@ rocksdb::Status BlueRocksEnv::DeleteFile(const std::string& fname)
   int r = fs->unlink(dir, file);
   if (r < 0)
     return err_to_status(r);
+  fs->sync_metadata(false);
   return rocksdb::Status::OK();
 }
 
@@ -512,6 +514,7 @@ rocksdb::Status BlueRocksEnv::RenameFile(
   int r = fs->rename(old_dir, old_file, new_dir, new_file);
   if (r < 0)
     return err_to_status(r);
+  fs->sync_metadata(false);
   return rocksdb::Status::OK();
 }
 


### PR DESCRIPTION
Add metadata sync after RocksDB renames or deletes file. It makes possible for RocksDB to
create meaningfull transition change on those actions. Important for log reuse/cycling and
for CURRENT and MANIFEST files.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>

I am wondering if lack of this metadata sync could be responsible for some BlueStore RocksDB problems that we have - especially the one when content of "CURRENT" file was completely corrupted.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
