### PR TITLE
pacific: qa: drop the distro~HEAD directory from the fs suite.

### DIFF
--- a/qa/suites/fs/verify/distro~HEAD
+++ b/qa/suites/fs/verify/distro~HEAD
@@ -1,1 +1,0 @@
-.qa/distros/supported-random-distro$/


### PR DESCRIPTION
It looks 01d85f9ba9264a89d8c031bc221928ef349aa602 accidentally backed up the old `distro` directory into `distro~HEAD` instead of just replacing it with new content. This makes possible to have a teuthology job combining altogether e.g. `distro/{rhel_8}` and `distro~HEAD/{ubuntu_latest}` which leads to selection of
Ubuntu Bionic but without the necessary `exit_on_first_error: false` override for Valgrind.

This commit fixes the problem by removing the extra `distro~HEAD` directory. It applies solely to pacific as backport's source (ec1b82fd24220a8cff442194ca98be9ed7ea1816) is free of the issue.

Fixes: https://tracker.ceph.com/issues/49962
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
