### PR TITLE
ceph-volume: remove legacy release check

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -3,7 +3,7 @@ import argparse
 import logging
 import os
 from textwrap import dedent
-from ceph_volume import process, conf, decorators, terminal, __release__, configuration
+from ceph_volume import process, conf, decorators, terminal, configuration
 from ceph_volume.util import system, disk
 from ceph_volume.util import prepare as prepare_utils
 from ceph_volume.util import encryption as encryption_utils
@@ -185,11 +185,7 @@ def activate_bluestore(osd_lvs, no_systemd=False):
     prime_command = [
         'ceph-bluestore-tool', '--cluster=%s' % conf.cluster,
         'prime-osd-dir', '--dev', osd_lv_path,
-        '--path', osd_path]
-
-    if __release__ != "luminous":
-        # mon-config changes are not available in Luminous
-        prime_command.append('--no-mon-config')
+        '--path', osd_path, '--no-mon-config']
 
     process.run(prime_command)
     # always re-do the symlink regardless if it exists, so that the block,

--- a/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
@@ -145,16 +145,9 @@ class TestOsdMkfsFilestore(object):
 
     @pytest.mark.parametrize('flag', mkfs_filestore_flags)
     def test_keyring_is_used(self, fake_call, monkeypatch, flag):
-        monkeypatch.setattr(prepare, '__release__', 'mimic')
         monkeypatch.setattr(system, 'chown', lambda path: True)
         prepare.osd_mkfs_filestore(1, 'asdf', keyring='secret')
         assert flag in fake_call.calls[0]['args'][0]
-
-    def test_keyring_is_used_luminous(self, fake_call, monkeypatch):
-        monkeypatch.setattr(prepare, '__release__', 'luminous')
-        monkeypatch.setattr(system, 'chown', lambda path: True)
-        prepare.osd_mkfs_filestore(1, 'asdf', keyring='secret')
-        assert '--keyfile' not in fake_call.calls[0]['args'][0]
 
 
 class TestOsdMkfsBluestore(object):
@@ -167,12 +160,6 @@ class TestOsdMkfsBluestore(object):
     def test_keyring_is_not_added(self, fake_call, monkeypatch):
         monkeypatch.setattr(system, 'chown', lambda path: True)
         prepare.osd_mkfs_bluestore(1, 'asdf')
-        assert '--keyfile' not in fake_call.calls[0]['args'][0]
-
-    def test_keyring_is_not_added_luminous(self, fake_call, monkeypatch):
-        monkeypatch.setattr(system, 'chown', lambda path: True)
-        prepare.osd_mkfs_bluestore(1, 'asdf')
-        monkeypatch.setattr(prepare, '__release__', 'luminous')
         assert '--keyfile' not in fake_call.calls[0]['args'][0]
 
     def test_wal_is_added(self, fake_call, monkeypatch):

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -9,7 +9,7 @@ import os
 import logging
 import json
 import time
-from ceph_volume import process, conf, __release__, terminal
+from ceph_volume import process, conf, terminal
 from ceph_volume.util import system, constants, str_to_int, disk
 
 logger = logging.getLogger(__name__)
@@ -512,11 +512,8 @@ def osd_mkfs_filestore(osd_id, fsid, keyring):
     if get_osdspec_affinity():
         command.extend(['--osdspec-affinity', get_osdspec_affinity()])
 
-    if __release__ != 'luminous':
-        # goes through stdin
-        command.extend(['--keyfile', '-'])
-
     command.extend([
+        '--keyfile', '-',
         '--osd-data', path,
         '--osd-journal', journal,
         '--osd-uuid', fsid,


### PR DESCRIPTION
Those conditions don't make sense anymore so we can remove them.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
