### PR TITLE
qa/tasks/cephadm_cases: longer wait for osd to start

### DIFF
--- a/qa/tasks/cephadm_cases/test_cli.py
+++ b/qa/tasks/cephadm_cases/test_cli.py
@@ -49,7 +49,7 @@ class TestCephadmCLI(MgrTestCase):
         self._orch_cmd('daemon', 'stop', 'osd.0')
         self.wait_for_health('OSD_DOWN', 30)
         self._orch_cmd('daemon', 'start', 'osd.0')
-        self.wait_for_health_clear(30)
+        self.wait_for_health_clear(90)
         self._orch_cmd('daemon', 'restart', 'osd.0')
 
     def test_device_ls_wide(self):


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@newdream.net>