### PR TITLE
rbd: don't attempt to interpret image cache state json

### DIFF
--- a/doc/rbd/rbd-persistent-write-back-cache.rst
+++ b/doc/rbd/rbd-persistent-write-back-cache.rst
@@ -70,21 +70,21 @@ Cache Status
 ------------
 
 The persistent write-back cache is enabled when the exclusive lock is acquired,
-and it is closed when the exclusive lock is released. To check the transient
-cache status, users may use the command ``rbd status``.  ::
+and it is closed when the exclusive lock is released. To check the cache status,
+users may use the command ``rbd status``.  ::
 
         rbd status {pool-name}/{image-name}
 
 The status of the cache is shown, including present, clean, cache size and the
-position.
+location. Currently the status is updated only at the time the cache is opened
+and closed and therefore may appear to be out of date (e.g. show that the cache
+is clean when it is actually dirty).
 
 For example::
 
         $ rbd status rbd/foo
         Watchers: none
-        image cache state:
-        clean: false  size: 1 GiB  host: sceph9  path: /tmp
-
+        Image cache state: {"present":"true","empty":"false","clean":"true","cache_type":"ssd","pwl_host":"sceph9","pwl_path":"/tmp/rbd-pwl.rbd.abcdef123456.pool","pwl_size":1073741824}
 
 Discard Cache
 -------------

--- a/doc/rbd/rbd-persistent-write-back-cache.rst
+++ b/doc/rbd/rbd-persistent-write-back-cache.rst
@@ -47,8 +47,8 @@ need to be enabled.::
         rbd persistent cache mode = {cache-mode}
         rbd plugins = pwl_cache
 
-Value of {cache-mode} can be ``rwl`` or ``ssd``. By default it is
-``disabled``
+Value of {cache-mode} can be ``rwl``, ``ssd`` or ``disabled``. By default the
+cache is disabled.
 
 Here are some cache configuration settings:
 
@@ -56,10 +56,12 @@ Here are some cache configuration settings:
   have DAX enabled (see `DAX`_) when using ``rwl`` mode to avoid performance
   degradation.
 
-- ``rbd_persistent_cache_size`` The cache size per image.
+- ``rbd_persistent_cache_size`` The cache size per image. The minimum cache
+  size is 1 GB.
 
 - ``rbd_persistent_cache_log_periodic_stats`` This is a debug option. It is
-  used to emit periodic perf stats to the debug log.
+  used to emit periodic perf stats to the debug log if ``debug rbd pwl`` is
+  set to ``1`` or higher.
 
 The above configurations can be set per-host, per-pool, per-image etc. Eg, to
 set per-host, add the overrides to the appropriate `section`_ in the host's


### PR DESCRIPTION
There are several issues with the current code:

- the value of "present" field is lost to the value of "clean" -- if the
  cache is present but dirty, we report that there is no cache
- the value of "clean" field is lost -- we always report false
- for a cache bigger than 2G, size is reported incorrectly -- 32-bit int
  overflow
- there is no way to get the type of the cache (rwl vs ssd)

Finally, even with all of the above fixed, image cache state output
would still be confusing because it is effectively a snapshot from
the time the cache was loaded.  It is not updated until the cache is
orderly closed.

Given that more changes would be needed to make "rbd status" output
useful and in the meantime it just needs to be correct to allow for
basic troubleshooting, just dump raw json.

Fixes: https://tracker.ceph.com/issues/50613
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>