### PR TITLE
pacific: qa/workunits/rbd: use bionic version of qemu-iotests for focal

### DIFF
--- a/qa/workunits/rbd/qemu-iotests.sh
+++ b/qa/workunits/rbd/qemu-iotests.sh
@@ -5,7 +5,7 @@
 # require the admin ceph user, as there's no way to pass the ceph user
 # to qemu-iotests currently.
 
-testlist='001 002 003 004 005 008 009 010 011 021 025 032 033 055'
+testlist='001 002 003 004 005 008 009 010 011 021 025 032 033'
 
 git clone https://github.com/qemu/qemu.git
 cd qemu
@@ -34,11 +34,6 @@ then
     ln -s /usr/bin/qemu-nbd
 else
     QEMU='/usr/libexec/qemu-kvm'
-
-    # disable test 055 since qemu-kvm (RHEL/CentOS) doesn't support the
-    # required QMP commands under EL7 and Python 3 is not supported by
-    # the test under EL8
-    testlist=$(echo ${testlist} | sed "s/ 055//g")
 fi
 ln -s $QEMU bin/qemu
 

--- a/qa/workunits/rbd/qemu-iotests.sh
+++ b/qa/workunits/rbd/qemu-iotests.sh
@@ -9,7 +9,7 @@ testlist='001 002 003 004 005 008 009 010 011 021 025 032 033 055'
 
 git clone https://github.com/qemu/qemu.git
 cd qemu
-if lsb_release -da 2>&1 | grep -iq 'bionic'; then
+if lsb_release -da 2>&1 | grep -iqE '(bionic|focal)'; then
     # Bionic requires a matching test harness
     git checkout v2.11.0
 elif lsb_release -da 2>&1 | grep -iqE '(xenial|linux release 8)'; then


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50673

---

backport of https://github.com/ceph/ceph/pull/41126
parent tracker: https://tracker.ceph.com/issues/50605