### PR TITLE
pacific: mgr/dashboard: fix bucket versioning when locking is enabled 

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rgw.py
+++ b/qa/tasks/mgr/dashboard/test_rgw.py
@@ -433,6 +433,16 @@ class RgwBucketTest(RgwTestCase):
         self.assertEqual(data['lock_retention_period_days'], 15)
         self.assertEqual(data['lock_retention_period_years'], 0)
         self.assertStatus(200)
+
+        # Update: Disabling bucket versioning should fail if object locking enabled
+        self._put('/api/rgw/bucket/teuth-test-bucket',
+                  params={
+                      'bucket_id': data['id'],
+                      'uid': 'teuth-test-user',
+                      'versioning_state': 'Suspended'
+                  })
+        self.assertStatus(409)
+
         # Delete
         self._delete('/api/rgw/bucket/teuth-test-bucket')
         self.assertStatus(204)

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/buckets.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/buckets.e2e-spec.ts
@@ -35,6 +35,24 @@ describe('RGW buckets page', () => {
     it('should delete bucket', () => {
       buckets.delete(bucket_name);
     });
+
+    it('should create bucket with object locking enabled', () => {
+      buckets.navigateTo('create');
+      buckets.create(
+        bucket_name,
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        'default-placement',
+        true
+      );
+      buckets.getFirstTableCell(bucket_name).should('exist');
+    });
+
+    it('should not allow to edit versioning if object locking is enabled', () => {
+      buckets.edit(bucket_name, 'dev', true);
+      buckets.getDataTables().should('contain.text', 'dev');
+
+      buckets.delete(bucket_name);
+    });
   });
 
   describe('Invalid Input in Create and Edit tests', () => {

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/buckets.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/buckets.po.ts
@@ -19,8 +19,12 @@ export class BucketsPageHelper extends PageHelper {
     return this.selectOption('placement-target', placementTarget);
   }
 
+  private selectLockMode(lockMode: string) {
+    return this.selectOption('lock_mode', lockMode);
+  }
+
   @PageHelper.restrictTo(pages.create.url)
-  create(name: string, owner: string, placementTarget: string) {
+  create(name: string, owner: string, placementTarget: string, isLocking = false) {
     // Enter in bucket name
     cy.get('#bid').type(name);
 
@@ -32,6 +36,15 @@ export class BucketsPageHelper extends PageHelper {
     this.selectPlacementTarget(placementTarget);
     cy.get('#placement-target').should('have.class', 'ng-valid');
 
+    if (isLocking) {
+      cy.get('#lock_enabled').click({ force: true });
+      // Select lock mode:
+      this.selectLockMode('Compliance');
+      cy.get('#lock_mode').should('have.class', 'ng-valid');
+      cy.get('#lock_retention_period_days').type('3');
+      cy.get('#lock_retention_period_years').type('0');
+    }
+
     // Click the create button and wait for bucket to be made
     cy.contains('button', 'Create Bucket').click();
 
@@ -39,12 +52,32 @@ export class BucketsPageHelper extends PageHelper {
   }
 
   @PageHelper.restrictTo(pages.index.url)
-  edit(name: string, new_owner: string) {
+  edit(name: string, new_owner: string, isLocking = false) {
     this.navigateEdit(name);
 
     cy.get('input[name=placement-target]').should('have.value', 'default-placement');
     this.selectOwner(new_owner);
 
+    // If object locking is enabled versioning shouldn't be visible
+    if (isLocking) {
+      cy.get('input[id=versioning]').should('be.disabled');
+      cy.contains('button', 'Edit Bucket').click();
+
+      // wait to be back on buckets page with table visible and click
+      this.getExpandCollapseElement(name).click();
+
+      // check its details table for edited owner field
+      cy.get('.table.table-striped.table-bordered')
+        .first()
+        .should('contains.text', new_owner)
+        .as('bucketDataTable');
+
+      // Check versioning enabled:
+      cy.get('@bucketDataTable').find('tr').its(2).find('td').last().should('have.text', new_owner);
+      cy.get('@bucketDataTable').find('tr').its(11).find('td').last().as('versioningValueCell');
+
+      return cy.get('@versioningValueCell').should('have.text', this.versioningStateEnabled);
+    }
     // Enable versioning
     cy.get('input[id=versioning]').should('not.be.checked');
     cy.get('label[for=versioning]').click();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -147,6 +147,9 @@ export class RgwBucketFormComponent extends CdForm implements OnInit {
             this.isVersioningAlreadyEnabled = this.isVersioningEnabled;
             this.isMfaDeleteAlreadyEnabled = this.isMfaDeleteEnabled;
             this.setMfaDeleteValidators();
+            if (value['lock_enabled']) {
+              this.bucketForm.controls['versioning'].disable();
+            }
           }
         }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50674

---

backport of https://github.com/ceph/ceph/pull/41050
parent tracker: https://tracker.ceph.com/issues/50545

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh