### PR TITLE
pacific: mgr/dashboard: disable NFSv3 support in dashboard

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -322,7 +322,8 @@
                      class="custom-control-input"
                      id="protocolNfsv3"
                      name="protocolNfsv3"
-                     formControlName="protocolNfsv3">
+                     formControlName="protocolNfsv3"
+                     disabled>
               <label i18n
                      class="custom-control-label"
                      for="protocolNfsv3">NFSv3</label>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -98,7 +98,7 @@ describe('NfsFormComponent', () => {
       daemons: [],
       fsal: { fs_name: 'a', name: '', rgw_user_id: '', user_id: '' },
       path: '',
-      protocolNfsv3: true,
+      protocolNfsv3: false,
       protocolNfsv4: true,
       pseudo: '',
       sec_label_xattr: 'security.selinux',
@@ -143,6 +143,15 @@ describe('NfsFormComponent', () => {
     component.isEdit = true;
     component.ngOnInit();
     expect(component.nfsForm.get('cluster_id').disabled).toBeTruthy();
+  });
+
+  it('should mark NFSv4 protocol as required', () => {
+    component.nfsForm.patchValue({
+      protocolNfsv4: false
+    });
+    component.nfsForm.updateValueAndValidity({ emitEvent: false });
+    expect(component.nfsForm.valid).toBeFalsy();
+    expect(component.nfsForm.get('protocolNfsv4').hasError('required')).toBeTruthy();
   });
 
   describe('should submit request', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -174,7 +174,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
         })
       }),
       path: new FormControl(''),
-      protocolNfsv3: new FormControl(true, {
+      protocolNfsv3: new FormControl(false, {
         validators: [
           CdValidators.requiredIf({ protocolNfsv4: false }, (value: boolean) => {
             return !value;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50662

---

backport of https://github.com/ceph/ceph/pull/41081
parent tracker: https://tracker.ceph.com/issues/49718

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh