### PR TITLE
cmake: Replace boost download url

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -154,7 +154,7 @@ function(do_build_boost root_dir version)
     set(boost_sha256 953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb)
     string(REPLACE "." "_" boost_version_underscore ${boost_version} )
     set(boost_url 
-      https://dl.bintray.com/boostorg/release/${boost_version}/source/boost_${boost_version_underscore}.tar.bz2)
+      https://boostorg.jfrog.io/artifactory/main/release/${boost_version}/source/boost_${boost_version_underscore}.tar.bz2)
     if(CMAKE_VERSION VERSION_GREATER 3.7)
       set(boost_url
         "${boost_url} http://downloads.sourceforge.net/project/boost/boost/${boost_version}/boost_${boost_version_underscore}.tar.bz2")

--- a/make-dist
+++ b/make-dist
@@ -180,7 +180,7 @@ tar cvf $outfile.version.tar $outfile/src/.git_version $outfile/ceph.spec
 # at the three URLs referenced below (may involve uploading to download.ceph.com)
 boost_version=1.75.0
 download_boost $boost_version 953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb \
-               https://dl.bintray.com/boostorg/release/$boost_version/source \
+               https://boostorg.jfrog.io/artifactory/main/release/$boost_version/source \
                https://downloads.sourceforge.net/project/boost/boost/$boost_version \
                https://download.ceph.com/qa
 download_liburing 0.7 8e2842cfe947f3a443af301bdd6d034455536c38a455c7a700d0c1ad165a7543 \


### PR DESCRIPTION
Boost has moved downloads to JFrog Artifactory
https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html

Signed-off-by: Rafał Wądołowski <rwadolowski@cloudferro.com>

