### PR TITLE
mgr/cephadm: OSD drive groups previews are not generated

### DIFF
--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -228,6 +228,7 @@ class OSDService(CephService):
                 cmd = self.driveselection_to_ceph_volume(ds,
                                                          osd_id_claims.get(host, []),
                                                          preview=True)
+
                 if not cmd:
                     logger.debug("No data_devices, skipping DriveGroup: {}".format(
                         osdspec.service_name()))
@@ -243,8 +244,16 @@ class OSDService(CephService):
                         concat_out = {}
 
                     ret_all.append({'data': concat_out,
+                                    'err': '',
                                     'osdspec': osdspec.service_id,
                                     'host': host})
+                elif err:
+                    err_filtered = [line for line in err if ' stderr ' in line]
+                    ret_all.append({'data': {},
+                                    'err': '\n'.join([line[line.find(" stderr ") + 8:] for line in err_filtered]),
+                                    'osdspec': osdspec.service_id,
+                                    'host': host})
+
         return ret_all
 
     def resolve_hosts_for_osdspecs(self,

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -119,7 +119,7 @@ def generate_preview_tables(data: Any, osd_only: bool = False) -> str:
     warning = [x.get('warning') for x in data if x.get('warning')]
     osd_table = preview_table_osd(data)
     service_table = preview_table_services(data)
-
+    errors_summary = preview_osd_error_summary(data)
     if osd_only:
         tables = f"""
 {''.join(warning)}
@@ -144,7 +144,14 @@ OSDSPEC PREVIEWS
 ################
 {osd_table}
 """
-        return tables
+    errors_summary_output = ''
+    if errors_summary:
+        errors_summary_output = f"""\n
+Errors Summary
+##############
+{errors_summary}
+"""
+    return tables + errors_summary_output
 
 
 def preview_table_osd(data: List) -> str:
@@ -184,6 +191,19 @@ def preview_table_services(data: List) -> str:
             table.add_row((item.get('service_type'), item.get('service_name'),
                            " ".join(item.get('add')), " ".join(item.get('remove'))))
     return table.get_string()
+
+
+def preview_osd_error_summary(data: List) -> str:
+    result = ""
+    for osd_data in data:
+        if osd_data.get('service_type') != 'osd':
+            continue
+        for host, specs in osd_data.get('data').items():
+            for spec in specs:
+                if spec.get('err'):
+                    dd = spec.get('err')
+                    result += f'{result}\n{host}:\n{dd}:\n'
+    return result
 
 
 class OrchestratorCli(OrchestratorClientMixin, MgrModule,


### PR DESCRIPTION
The osd preview was not presented despite it was properly generated.
Now if we have information in the previews, it is going to be presented.
Apart of the main fix, some minor improvements:
- Display message when the drive group file does not produce OSDs
- Display error message from ceph-volume if needed

Resolves: https://tracker.ceph.com/issues/50690

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

**_Details:_**

If it is needed to generate the preview, we warn about to execute again the command to get the results

```
[ceph: root@ceph-node-00 ~]# ceph orch apply -i osd_node0.yml --dry-run
WARNING! Dry-Runs are snapshots of a certain point in time and are bound 
to the current inventory setup. If any on these conditions changes, the 
preview will be invalid. Please make sure to have a minimal 
timeframe between planning and applying the specs.
####################
SERVICESPEC PREVIEWS
####################
+---------+------+--------+-------------+
|SERVICE  |NAME  |ADD_TO  |REMOVE_FROM  |
+---------+------+--------+-------------+
+---------+------+--------+-------------+
################
OSDSPEC PREVIEWS
################
Preview data is being generated.. Please re-run this command in a bit.
```

After a few seconds if we execute again the command we can see clearly that:
           The drive group provided does not produce OSDs

```
[ceph: root@ceph-node-00 ~]# ceph orch apply -i osd_node0.yml --dry-run
WARNING! Dry-Runs are snapshots of a certain point in time and are bound 
to the current inventory setup. If any on these conditions changes, the 
preview will be invalid. Please make sure to have a minimal 
timeframe between planning and applying the specs.
####################
SERVICESPEC PREVIEWS
####################
+---------+------+--------+-------------+
|SERVICE  |NAME  |ADD_TO  |REMOVE_FROM  |
+---------+------+--------+-------------+
+---------+------+--------+-------------+
################
OSDSPEC PREVIEWS
################
The drive group specification provided does not generate any OSD.
```

Using another drive group that produces OSDs:

```
[ceph: root@ceph-node-00 ~]# ceph orch apply -i osd_nc2.yml --dry-run
WARNING! Dry-Runs are snapshots of a certain point in time and are bound 
to the current inventory setup. If any on these conditions changes, the 
preview will be invalid. Please make sure to have a minimal 
timeframe between planning and applying the specs.
####################
SERVICESPEC PREVIEWS
####################
+---------+------+--------+-------------+
|SERVICE  |NAME  |ADD_TO  |REMOVE_FROM  |
+---------+------+--------+-------------+
+---------+------+--------+-------------+
################
OSDSPEC PREVIEWS
################
+---------+--------------------+--------------------------+----------+----------+-----+
|SERVICE  |NAME                |HOST                      |DATA      |DB        |WAL  |
+---------+--------------------+--------------------------+----------+----------+-----+
|osd      |osd_no_collocated2  |ceph-node-02.cephlab.com  |/dev/vdb  |/dev/vdc  |-    |
+---------+--------------------+--------------------------+----------+----------+-----+
```

And if there is any kind of problem in the host when we execute the ceph-volume command,
the error s going to be reported;

```
[ceph: root@ceph-node-00 ~]# ceph orch apply -i osd_error.yml --dry-run
WARNING! Dry-Runs are snapshots of a certain point in time and are bound 
to the current inventory setup. If any on these conditions changes, the 
preview will be invalid. Please make sure to have a minimal 
timeframe between planning and applying the specs.
####################
SERVICESPEC PREVIEWS
####################
+---------+------+--------+-------------+
|SERVICE  |NAME  |ADD_TO  |REMOVE_FROM  |
+---------+------+--------+-------------+
+---------+------+--------+-------------+
################
OSDSPEC PREVIEWS
################
+---------+------+------+------+----+-----+
|SERVICE  |NAME  |HOST  |DATA  |DB  |WAL  |
+---------+------+------+------+----+-----+
+---------+------+------+------+----+-----+
Errors Summary
##############
ceph-node-01.cephlab.com:
WARNING: The same type, major and minor should not be used for multiple devices.
 stderr: lsblk: /dev/sdb: not a block device
 stderr: blkid: error: /dev/sdb: No such file or directory
 stderr: Unknown device, --name=, --path=, or absolute path in /dev/ or /sys expected.
usage: ceph-volume lvm batch [-h] [--db-devices [DB_DEVICES [DB_DEVICES ...]]]
                             [--wal-devices [WAL_DEVICES [WAL_DEVICES ...]]]
                             [--journal-devices [JOURNAL_DEVICES [JOURNAL_DEVICES ...]]]
                             [--auto] [--no-auto] [--bluestore] [--filestore]
                             [--report] [--yes]
                             [--format {json,json-pretty,pretty}] [--dmcrypt]
                             [--crush-device-class CRUSH_DEVICE_CLASS]
                             [--no-systemd]
                             [--osds-per-device OSDS_PER_DEVICE]
                             [--data-slots DATA_SLOTS]
                             [--block-db-size BLOCK_DB_SIZE]
                             [--block-db-slots BLOCK_DB_SLOTS]
                             [--block-wal-size BLOCK_WAL_SIZE]
                             [--block-wal-slots BLOCK_WAL_SLOTS]
                             [--journal-size JOURNAL_SIZE]
                             [--journal-slots JOURNAL_SLOTS] [--prepare]
                             [--osd-ids [OSD_IDS [OSD_IDS ...]]]
                             [DEVICES [DEVICES ...]]
ceph-volume lvm batch: error: Unable to proceed with non-existing device: /dev/sdb:
```





<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
