### PR TITLE
pacific: systemd: remove `ProtectClock=true` for `ceph-osd@.service`

### DIFF
--- a/systemd/ceph-fuse@.service.in
+++ b/systemd/ceph-fuse@.service.in
@@ -14,7 +14,6 @@ MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 # ceph-fuse requires access to /dev fuse device
 PrivateDevices=no
-ProtectClock=true
 ProtectControlGroups=true
 ProtectHostname=true
 ProtectKernelLogs=true

--- a/systemd/ceph-immutable-object-cache@.service.in
+++ b/systemd/ceph-immutable-object-cache@.service.in
@@ -14,7 +14,6 @@ MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 PrivateDevices=yes
 PrivateTmp=true
-ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
 ProtectHostname=true

--- a/systemd/ceph-mds@.service.in
+++ b/systemd/ceph-mds@.service.in
@@ -17,7 +17,6 @@ MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 PrivateDevices=yes
 PrivateTmp=true
-ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
 ProtectHostname=true

--- a/systemd/ceph-mgr@.service.in
+++ b/systemd/ceph-mgr@.service.in
@@ -16,7 +16,6 @@ LockPersonality=true
 NoNewPrivileges=true
 PrivateDevices=yes
 PrivateTmp=true
-ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
 ProtectHostname=true

--- a/systemd/ceph-mon@.service.in
+++ b/systemd/ceph-mon@.service.in
@@ -22,7 +22,6 @@ MemoryDenyWriteExecute=true
 NoNewPrivileges=false
 PrivateDevices=yes
 PrivateTmp=true
-ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
 ProtectHostname=true

--- a/systemd/ceph-osd@.service.in
+++ b/systemd/ceph-osd@.service.in
@@ -18,7 +18,6 @@ MemoryDenyWriteExecute=true
 # Need NewPrivileges via `sudo smartctl`
 NoNewPrivileges=false
 PrivateTmp=true
-ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
 ProtectHostname=true

--- a/systemd/ceph-radosgw@.service.in
+++ b/systemd/ceph-radosgw@.service.in
@@ -16,7 +16,6 @@ MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 PrivateDevices=yes
 PrivateTmp=true
-ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
 ProtectHostname=true

--- a/systemd/ceph-rbd-mirror@.service.in
+++ b/systemd/ceph-rbd-mirror@.service.in
@@ -16,7 +16,6 @@ MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 PrivateDevices=yes
 PrivateTmp=true
-ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
 ProtectHostname=true

--- a/systemd/cephfs-mirror@.service.in
+++ b/systemd/cephfs-mirror@.service.in
@@ -15,7 +15,6 @@ MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 PrivateDevices=yes
 PrivateTmp=true
-ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
 ProtectHostname=true


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50381

---

backport of https://github.com/ceph/ceph/pull/40845
parent tracker: https://tracker.ceph.com/issues/50347

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh