### PR TITLE
debian/ceph-common.postinst: fix indent and cleanups

### DIFF
--- a/debian/ceph-common.postinst
+++ b/debian/ceph-common.postinst
@@ -1,4 +1,5 @@
 #!/bin/sh
+# -*- mode:sh; tab-width:8; indent-tabs-mode:nil -*-
 # vim: set noet ts=8:
 # postinst script for ceph-mds
 #
@@ -41,7 +42,7 @@ case "$1" in
        if ! getent group | grep -q "^$SERVER_GROUP:" ; then
           echo -n "Adding group $SERVER_GROUP.."
           addgroup --quiet --system --gid $SERVER_GID \
-	      $SERVER_GROUP 2>/dev/null ||true
+              $SERVER_GROUP 2>/dev/null ||true
           echo "..done"
        fi
        # 2. create user if not existing
@@ -51,8 +52,8 @@ case "$1" in
                  --system \
                  --no-create-home \
                  --disabled-password \
-	         --uid $SERVER_UID \
-	         --gid $SERVER_GID \
+                 --uid $SERVER_UID \
+                 --gid $SERVER_GID \
                  $SERVER_USER 2>/dev/null || true
          echo "..done"
        fi
@@ -70,27 +71,25 @@ case "$1" in
        fi
        echo "..done"
 
-       # 5. adjust file and directory permissions
-       if ! dpkg-statoverride --list $SERVER_HOME >/dev/null
-       then
+       # 4. adjust file and directory permissions
+       if ! dpkg-statoverride --list $SERVER_HOME >/dev/null; then
            chown $SERVER_USER:$SERVER_GROUP $SERVER_HOME
            chmod u=rwx,g=rx,o= $SERVER_HOME
        fi
-       if ! dpkg-statoverride --list /var/log/ceph >/dev/null
-       then
-	   # take care not to touch cephadm log subdirs
+       if ! dpkg-statoverride --list /var/log/ceph >/dev/null; then
+           # take care not to touch cephadm log subdirs
            chown $SERVER_USER:$SERVER_GROUP /var/log/ceph
-	   chown $SERVER_USER:$SERVER_GROUP /var/log/ceph/*.log* || true
-	   # members of group ceph can log here, but cannot remove
-	   # others' files.  non-members cannot read any logs.
+           chown $SERVER_USER:$SERVER_GROUP /var/log/ceph/*.log* || true
+           # members of group ceph can log here, but cannot remove
+           # others' files.  non-members cannot read any logs.
            chmod u=rwx,g=rwxs,o=t /var/log/ceph
        fi
 
-       # 6. fix /var/run/ceph
+       # 5. fix /var/run/ceph
        if [ -d /var/run/ceph ]; then
-	   echo -n "Fixing /var/run/ceph ownership.."
-	   chown $SERVER_USER:$SERVER_GROUP /var/run/ceph
-	   echo "..done"
+           echo -n "Fixing /var/run/ceph ownership.."
+           chown $SERVER_USER:$SERVER_GROUP /var/run/ceph
+           echo "..done"
        fi
 
        # create /run/ceph.  fail softly if systemd isn't present or
@@ -98,7 +97,7 @@ case "$1" in
        [ -x /bin/systemd-tmpfiles ] && systemd-tmpfiles --create || true
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
-	:
+       :
     ;;
 
     *)


### PR DESCRIPTION
* add editor variables for emacs
* replace tab with 8 spaces
* move "then" to previous line to be more consistent

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
