### PR TITLE
doc/cephadm: rewrite "deploy. mon. w/cephadm" 2/2

### DIFF
--- a/doc/cephadm/monitoring.rst
+++ b/doc/cephadm/monitoring.rst
@@ -77,23 +77,27 @@ monitoring by following the steps below.
 
      ceph orch apply grafana 1
 
-Cephadm takes care of the configuration of Prometheus, Grafana, and Alertmanager
-automatically.
+Manually setting the Grafana URL
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-However, there is one exception to this rule. In a some setups, the Dashboard
-user's browser might not be able to access the Grafana URL configured in Ceph
-Dashboard. One such scenario is when the cluster and the accessing user are each
-in a different DNS zone.
+Cephadm automatically configures Prometheus, Grafana, and Alertmanager in
+all cases except one.
 
-For this case, there is an extra configuration option for Ceph Dashboard, which
-can be used to configure the URL for accessing Grafana by the user's browser.
-This value will never be altered by cephadm. To set this configuration option,
-issue the following command::
+In a some setups, the Dashboard user's browser might not be able to access the
+Grafana URL that is configured in Ceph Dashboard. This can happen when the
+cluster and the accessing user are in different DNS zones.
 
-  $ ceph dashboard set-grafana-frontend-api-url <grafana-server-api>
+If this is the case, you can use a configuration option for Ceph Dashboard
+to set the URL that the user's browser will use to access Grafana. This
+value will never be altered by cephadm. To set this configuration option,
+issue the following command:
 
-It may take a minute or two for services to be deployed.  Once
-completed, you should see something like this from ``ceph orch ls``
+   .. prompt:: bash $
+
+     ceph dashboard set-grafana-frontend-api-url <grafana-server-api>
+
+It might take a minute or two for services to be deployed. After the
+services have been deployed, you should see something like this when you issue the command ``ceph orch ls``:
 
 .. code-block:: console
 


### PR DESCRIPTION
This is the second half of PR#41241.

This PR creates a sub-subsection that explains
a configuration step that is sometimes necessary
when configuring monitoring in Ceph clusters. (The
configuration step involves DNS zones.)

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
