### PR TITLE
doc/_ext: fixes related to mgr option rendering

### DIFF
--- a/doc/_ext/ceph_confval.py
+++ b/doc/_ext/ceph_confval.py
@@ -199,7 +199,10 @@ class CephOption(ObjectDescription):
     required_arguments = 1
     optional_arguments = 0
     final_argument_whitespace = False
-    option_spec = {'default': directives.unchanged}
+    option_spec = {
+        'module': directives.unchanged,
+        'default': directives.unchanged
+    }
 
 
     doc_field_types = [
@@ -372,7 +375,8 @@ class CephOption(ObjectDescription):
         signode += addnodes.desc_name(sig, sig)
         # normalize whitespace like XRefRole does
         name = ws_re.sub(' ', sig)
-        cur_module = self.env.ref_context.get('ceph:module')
+        cur_module = self.options.get('module',
+                                      self.env.ref_context.get('ceph:module'))
         if cur_module:
             return '/'.join(['mgr', cur_module, name])
         else:

--- a/doc/_ext/ceph_confval.py
+++ b/doc/_ext/ceph_confval.py
@@ -350,6 +350,9 @@ class CephOption(ObjectDescription):
             opt = self._load_yaml().get(name)
         if opt is None:
             raise self.error(f'Option "{name}" not found!')
+        if cur_module and 'type' not in opt:
+            # the type of module option defaults to 'str'
+            opt['type'] = 'str'
         desc = opt.get('fmt_desc') or opt.get('long_desc') or opt.get('desc')
         opt_default = opt.get('default')
         default = self.options.get('default', opt_default)

--- a/doc/_ext/ceph_confval.py
+++ b/doc/_ext/ceph_confval.py
@@ -41,7 +41,7 @@ TEMPLATE = '''
   {%- elif opt.type == 'bool' %}
    :default: ``{{ default | string | lower }}``
   {%- else %}
-   :default: ``{{ default }}``
+   :default: {{ default | literal }}
   {%- endif -%}
 {%- endif %}
 {%- if opt.enum_values %}

--- a/doc/_ext/ceph_confval.py
+++ b/doc/_ext/ceph_confval.py
@@ -369,7 +369,11 @@ class CephOption(ObjectDescription):
         signode += addnodes.desc_name(sig, sig)
         # normalize whitespace like XRefRole does
         name = ws_re.sub(' ', sig)
-        return name
+        cur_module = self.env.ref_context.get('ceph:module')
+        if cur_module:
+            return '/'.join(['mgr', cur_module, name])
+        else:
+            return name
 
     def transform_content(self, contentnode: addnodes.desc_content) -> None:
         name = self.arguments[0]
@@ -384,18 +388,10 @@ class CephOption(ObjectDescription):
                              name: str,
                              sig: str,
                              signode: addnodes.desc_signature) -> None:
-        cur_module = self.env.ref_context.get('ceph:module')
-        if cur_module:
-            prefix = '-'.join(['mgr', cur_module, self.objtype])
-        else:
-            prefix = self.objtype
-        node_id = make_id(self.env, self.state.document, prefix, name)
+        node_id = make_id(self.env, self.state.document, self.objtype, name)
         signode['ids'].append(node_id)
         self.state.document.note_explicit_target(signode)
-        if cur_module:
-            entry = f'{cur_module} {name}; mgr module option'
-        else:
-            entry = f'{name}; configuration option'
+        entry = f'{name}; configuration option'
         self.indexnode['entries'].append(('pair', entry, node_id, '', None))
         std = self.env.get_domain('std')
         std.note_object(self.objtype, name, node_id, location=signode)

--- a/doc/_ext/ceph_confval.py
+++ b/doc/_ext/ceph_confval.py
@@ -339,8 +339,12 @@ class CephOption(ObjectDescription):
         CephOption.mgr_opts[module] = dict((opt['name'], opt) for opt in opts)
         return CephOption.mgr_opts[module]
 
+    def _current_module(self) -> str:
+        return self.options.get('module',
+                                self.env.ref_context.get('ceph:module'))
+
     def _render_option(self, name) -> str:
-        cur_module = self.env.ref_context.get('ceph:module')
+        cur_module = self._current_module()
         if cur_module:
             opt = self._load_module(cur_module).get(name)
         else:
@@ -369,8 +373,7 @@ class CephOption(ObjectDescription):
         signode += addnodes.desc_name(sig, sig)
         # normalize whitespace like XRefRole does
         name = ws_re.sub(' ', sig)
-        cur_module = self.options.get('module',
-                                      self.env.ref_context.get('ceph:module'))
+        cur_module = self._current_module()
         if cur_module:
             return '/'.join(['mgr', cur_module, name])
         else:

--- a/doc/_ext/ceph_confval.py
+++ b/doc/_ext/ceph_confval.py
@@ -398,6 +398,10 @@ class CephOption(ObjectDescription):
         std.note_object(self.objtype, name, node_id, location=signode)
 
 
+def _reset_ref_context(app, env, docname):
+    env.ref_context.pop('ceph:module', None)
+
+
 def setup(app) -> Dict[str, Any]:
     app.add_config_value('ceph_confval_imports',
                          default=[],
@@ -430,6 +434,7 @@ def setup(app) -> Dict[str, Any]:
     )
     app.add_directive_to_domain('std', 'mgr_module', CephModule)
     app.add_directive_to_domain('std', 'confval', CephOption, override=True)
+    app.connect('env-purge-doc', _reset_ref_context)
 
     return {
         'version': 'builtin',

--- a/doc/mgr/prometheus.rst
+++ b/doc/mgr/prometheus.rst
@@ -29,6 +29,14 @@ Configuration
 
     The Prometheus manager module needs to be restarted for configuration changes to be applied.
 
+.. mgr_module:: prometheus
+.. confval:: server_addr
+.. confval:: server_port
+.. confval:: scrape_interval
+.. confval:: stale_cache_strategy
+.. confval:: rbd_stats_pools
+.. confval:: rbd_stats_pools_refresh_interval
+
 By default the module will accept HTTP requests on port ``9283`` on all IPv4
 and IPv6 addresses on the host.  The port and listen address are both
 configurable with ``ceph config set``, with keys
@@ -43,11 +51,10 @@ is registered with Prometheus's `registry
 
 .. warning::
 
-    The ``scrape_interval`` of this module should always be set to match
+    The :confval:`mgr/prometheus/scrape_interval` of this module should always be set to match
     Prometheus' scrape interval to work properly and not cause any issues.
     
-The Prometheus manager module is, by default, configured with a scrape interval
-of 15 seconds.  The scrape interval in the module is used for caching purposes
+The scrape interval in the module is used for caching purposes
 and to determine when a cache is stale.
 
 It is not recommended to use a scrape interval below 10 seconds.  It is

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -269,11 +269,15 @@ class MetricCollectionThread(threading.Thread):
 class Module(MgrModule):
     MODULE_OPTIONS = [
         Option(
-            'server_addr'
+            'server_addr',
+            default=get_default_addr(),
+            desc='the IPv4 or IPv6 address on which the module listens for HTTP requests',
         ),
         Option(
             'server_port',
-            type='int'
+            type='int',
+            default=DEFAULT_PORT,
+            desc='the port on which the module listens for HTTP requests'
         ),
         Option(
             'scrape_interval',


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
