### PR TITLE
nautilus: common/buffer: adjust align before calling posix_memalign()

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -108,8 +108,8 @@ static ceph::spinlock debug_lock;
     static raw_combined *create(unsigned len,
 				unsigned align,
 				int mempool = mempool::mempool_buffer_anon) {
-      if (!align)
-	align = sizeof(size_t);
+      // posix_memalign() requires a multiple of sizeof(void *)
+      align = std::max<unsigned>(align, sizeof(void *));
       size_t rawlen = round_up_to(sizeof(buffer::raw_combined),
 				  alignof(buffer::raw_combined));
       size_t datalen = round_up_to(len, alignof(buffer::raw_combined));
@@ -169,8 +169,8 @@ static ceph::spinlock debug_lock;
     MEMPOOL_CLASS_HELPERS();
 
     raw_posix_aligned(unsigned l, unsigned _align) : raw(l) {
-      align = _align;
-      ceph_assert((align >= sizeof(void *)) && (align & (align - 1)) == 0);
+      // posix_memalign() requires a multiple of sizeof(void *)
+      align = std::max<unsigned>(_align, sizeof(void *));
 #ifdef DARWIN
       data = (char *) valloc(len);
 #else

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1152,7 +1152,7 @@ CtPtr ProtocolV2::read_frame_segment() {
   try {
     rx_buffer = buffer::ptr_node::create(buffer::create_aligned(
         onwire_len, align));
-  } catch (std::bad_alloc&) {
+  } catch (const ceph::buffer::bad_alloc&) {
     // Catching because of potential issues with satisfying alignment.
     ldout(cct, 1) << __func__ << " can't allocate aligned rx_buffer"
                   << " len=" << onwire_len


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50700

---

backport of https://github.com/ceph/ceph/pull/41143
parent tracker: https://tracker.ceph.com/issues/50646