### PR TITLE
mgr: Fix orch osd rm stop help message

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -807,7 +807,7 @@ Usage:
 
     @_cli_write_command('orch osd rm stop')
     def _osd_rm_stop(self, svc_id: List[str]) -> HandleCommandResult:
-        """Remove OSD services"""
+        """Cancel ongoing OSD removal operation"""
         completion = self.stop_remove_osds(svc_id)
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())


### PR DESCRIPTION
Corrects help message of `ceph orch osd rm --help`
Doc link - https://docs.ceph.com/en/latest/cephadm/osd/#stopping-osd-removal

Signed-off-by: VasishtaShastry <vipin.indiasmg@gmail.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
 
Not applicable
---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
