### PR TITLE
osd/scrub: separate between PG state flags and internal scrubber operation

### DIFF
--- a/src/osd/PrimaryLogScrub.h
+++ b/src/osd/PrimaryLogScrub.h
@@ -62,14 +62,12 @@ class PrimaryLogScrub : public PgScrubber {
 		   LogChannelRef clog,
 		   const spg_t& pgid,
 		   const char* func,
-		   const char* mode,
 		   bool allow_incomplete_clones);
 
   int process_clones_to(const std::optional<hobject_t>& head,
 			const std::optional<SnapSet>& snapset,
 			LogChannelRef clog,
 			const spg_t& pgid,
-			const char* mode,
 			bool allow_incomplete_clones,
 			std::optional<snapid_t> target,
 			std::vector<snapid_t>::reverse_iterator* curclone,

--- a/src/osd/pg_scrubber.h
+++ b/src/osd/pg_scrubber.h
@@ -559,7 +559,7 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
   /// Maps from objects with errors to missing peers
   HobjToShardSetMapping m_missing;
 
- private:
+ protected:
   /**
    * 'm_is_deep' - is the running scrub a deep one?
    *
@@ -569,6 +569,33 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
    * building the scrub maps.
    */
   bool m_is_deep{false};
+
+  /**
+   * If set: affects the backend & scrubber-backend functions called after all
+   * scrub maps are available.
+   *
+   * Replaces code that directly checks PG_STATE_REPAIR (which was meant to be
+   * a "user facing" status display only).
+   */
+  bool m_is_repair{false};
+
+  /**
+   * User-readable summary of the scrubber's current mode of operation. Used for
+   * both osd.*.log and the cluster log.
+   * One of:
+   *    "repair"
+   *    "deep-scrub",
+   *    "scrub
+   *
+   * Note: based on PG_STATE_REPAIR, and not on m_is_repair. I.e. for
+   * auto_repair will show as "deep-scrub" and not as "repair" (until the first error
+   * is detected).
+   */
+  std::string_view m_mode_desc;
+
+  void update_op_mode_text();
+
+private:
 
   /**
    * initiate a deep-scrub after the current scrub ended with errors.


### PR DESCRIPTION

Modify the scrubber to rely on internal flags for 'should we repair' and
'is this a deep scrub', instead of using PG_STATE_REPAIR & PG_STATE_DEEP_SCRUB.

This enables us to implement the 'fix-as-you-go deepscrub' functionality
of 'osd_scrub_auto_repair', without displaying REPAIR status to the user.

Fixes: https://tracker.ceph.com/issues/50446

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
Co-Authored by: Neha Ojha <nojha@redhat.com>

