### PR TITLE
rgw: deprecate the civetweb frontend

### DIFF
--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -100,6 +100,7 @@ Civetweb
 ========
 
 .. versionadded:: Firefly
+.. deprecated:: Pacific
 
 The ``civetweb`` frontend uses the Civetweb HTTP library, which is a
 fork of Mongoose.

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -560,6 +560,8 @@ int radosgw_Main(int argc, const char **argv)
     RGWFrontend *fe = NULL;
 
     if (framework == "civetweb" || framework == "mongoose") {
+      lderr(cct.get()) << "IMPORTANT: the civetweb frontend is now deprecated "
+          "and will be removed in a future release" << dendl;
       framework = "civetweb";
       std::string uri_prefix;
       config->get_val("prefix", "", &uri_prefix);


### PR DESCRIPTION
for backport to pacific

Fixes: https://tracker.ceph.com/issues/50758

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
