### PR TITLE
doc/cephadm: rewrite "config ssl/tls f. grafana"

### DIFF
--- a/doc/cephadm/monitoring.rst
+++ b/doc/cephadm/monitoring.rst
@@ -108,26 +108,25 @@ completed, you should see something like this from ``ceph orch ls``
 Configuring SSL/TLS for Grafana
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``cephadm`` will deploy Grafana using the certificate defined in the ceph
-key/value store. If a certificate is not specified, ``cephadm`` will generate a
-self-signed certificate during deployment of the Grafana service.
+``cephadm`` deploys Grafana using the certificate defined in the ceph
+key/value store. If no certificate is specified, ``cephadm`` generates a
+self-signed certificate during the deployment of the Grafana service.
 
-A custom certificate can be configured using the following commands.
+A custom certificate can be configured using the following commands:
 
-.. code-block:: bash
+.. prompt:: bash #
 
   ceph config-key set mgr/cephadm/grafana_key -i $PWD/key.pem
   ceph config-key set mgr/cephadm/grafana_crt -i $PWD/certificate.pem
 
-If you already deployed Grafana, you need to ``reconfig`` the service for the
-configuration to be updated.
+If you have already deployed Grafana, run ``reconfig`` on the service to
+update its configuration:
 
-.. code-block:: bash
+.. prompt:: bash #
 
   ceph orch reconfig grafana
 
-The ``reconfig`` command also takes care of setting the right URL for Ceph
-Dashboard.
+The ``reconfig`` command also sets the proper URL for Ceph Dashboard.
 
 Using custom images
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR streamlines the grammar in the subsection
called "Configuring SSL/TLS for Grafana" in the
monitoring.rst file. It also corrects the prompt
rst.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
