### PR TITLE
ceph-volume: Consider /dev/root as mounted

### DIFF
--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -260,6 +260,7 @@ def get_mounts(devices=False, paths=False, realpath=False):
 
     - tmpfs
     - devtmpfs
+    - /dev/root
 
     If ``devices`` is set to ``True`` the mapping will be a device-to-path(s),
     if ``paths`` is set to ``True`` then the mapping will be
@@ -270,7 +271,7 @@ def get_mounts(devices=False, paths=False, realpath=False):
     """
     devices_mounted = {}
     paths_mounted = {}
-    do_not_skip = ['tmpfs', 'devtmpfs']
+    do_not_skip = ['tmpfs', 'devtmpfs', '/dev/root']
     default_to_devices = devices is False and paths is False
 
     with open(PROCDIR + '/mounts', 'rb') as mounts:


### PR DESCRIPTION
This adds `/dev/root` to the list of devices to skip when considering if they
are mounted or not, as sometimes (see related bug) it is not trivial to
discover what device it signifies. But supposing that it always means a device,
it's safe to consider it as mounted.

Fixes: https://tracker.ceph.com/issues/50604

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>