### PR TITLE
rbd: promote rbd-nbd attach and detach at rbd integrated cli

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -268,6 +268,22 @@ Commands
   The --options argument is a comma separated list of device type
   specific options (opt1,opt2=val,...).
 
+:command:`device attach` [-t | --device-type *device-type*] --device *device-path* [--read-only] [--exclusive] [--force] [-o | --options *device-options*] *image-spec* | *snap-spec*
+  Attach the specified image to the specified block device (currently only
+  `nbd` on Linux). This operation is unsafe and should not be normally used.
+  In particular, specifying the wrong image or the wrong block device may
+  lead to data corruption as no validation is performed by `nbd` kernel driver.
+
+  The --options argument is a comma separated list of device type
+  specific options (opt1,opt2=val,...).
+
+:command:`device detach` [-t | --device-type *device-type*] [-o | --options *device-options*] *image-spec* | *snap-spec* | *device-path*
+  Detach the block device that was mapped or attached (currently only `nbd`
+  on Linux). This operation is unsafe and should not be normally used.
+
+  The --options argument is a comma separated list of device type
+  specific options (opt1,opt2=val,...).
+
 :command:`diff` [--from-snap *snap-name*] [--whole-object] *image-spec* | *snap-spec*
   Dump a list of byte extents in the image that have changed since the specified start
   snapshot, or since the image was created.  Each output line includes the starting offset

--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -346,13 +346,14 @@ expect_false grep 'quiesce failed' ${LOG_FILE}
 DEV=`_sudo rbd device --device-type nbd --options try-netlink map ${POOL}/${IMAGE}`
 get_pid ${POOL}
 _sudo mount ${DEV} ${TEMPDIR}/mnt
-_sudo rbd-nbd detach ${POOL}/${IMAGE}
+_sudo rbd device detach ${POOL}/${IMAGE} --device-type nbd
 expect_false get_pid ${POOL}
-_sudo rbd-nbd attach --device ${DEV} ${POOL}/${IMAGE}
+expect_false _sudo rbd device attach --device ${DEV} ${POOL}/${IMAGE} --device-type nbd
+_sudo rbd device attach --device ${DEV} ${POOL}/${IMAGE} --device-type nbd --force
 get_pid ${POOL}
-_sudo rbd-nbd detach ${DEV}
+_sudo rbd device detach ${DEV} --device-type nbd
 expect_false get_pid ${POOL}
-_sudo rbd-nbd attach --device ${DEV} ${POOL}/${IMAGE}
+_sudo rbd device attach --device ${DEV} ${POOL}/${IMAGE} --device-type nbd --force
 get_pid ${POOL}
 ls ${TEMPDIR}/mnt/
 dd if=${TEMPDIR}/mnt/test of=/dev/null bs=1M count=1

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -27,6 +27,8 @@
       copy (cp)                         Copy src image to dest.
       create                            Create an empty image.
       deep copy (deep cp)               Deep copy src image to dest.
+      device attach                     Attach image to device.
+      device detach                     Detach image from device.
       device list (showmapped)          List mapped rbd images.
       device map (map)                  Map an image to a block device.
       device unmap (unmap)              Unmap a rbd device.
@@ -569,6 +571,56 @@
     (*) supports enabling/disabling on existing images
     (-) supports disabling-only on existing images
     (+) enabled by default for new images if features not specified
+  
+  rbd help device attach
+  usage: rbd device attach [--device-type <device-type>] [--pool <pool>] 
+                           [--namespace <namespace>] [--image <image>] 
+                           [--snap <snap>] --device <device> [--read-only] 
+                           [--force] [--exclusive] [--quiesce] 
+                           [--quiesce-hook <quiesce-hook>] [--options <options>] 
+                           <image-or-snap-spec> 
+  
+  Attach image to device.
+  
+  Positional arguments
+    <image-or-snap-spec>     image or snapshot specification
+                             (example:
+                             [<pool-name>/[<namespace>/]]<image-name>[@<snap-name>
+                             ])
+  
+  Optional arguments
+    -t [ --device-type ] arg device type [ggate, krbd (default), nbd]
+    -p [ --pool ] arg        pool name
+    --namespace arg          namespace name
+    --image arg              image name
+    --snap arg               snapshot name
+    --device arg             specify device path
+    --read-only              attach read-only
+    --force                  force attach
+    --exclusive              disable automatic exclusive lock transitions
+    --quiesce                use quiesce hooks
+    --quiesce-hook arg       quiesce hook path
+    -o [ --options ] arg     device specific options
+  
+  rbd help device detach
+  usage: rbd device detach [--device-type <device-type>] [--pool <pool>] 
+                           [--image <image>] [--snap <snap>] 
+                           [--options <options>] 
+                           <image-or-snap-or-device-spec> 
+  
+  Detach image from device.
+  
+  Positional arguments
+    <image-or-snap-or-device-spec>  image, snapshot, or device specification
+                                    [<pool-name>/]<image-name>[@<snap-name>] or
+                                    <device-path>
+  
+  Optional arguments
+    -t [ --device-type ] arg        device type [ggate, krbd (default), nbd]
+    -p [ --pool ] arg               pool name
+    --image arg                     image name
+    --snap arg                      snapshot name
+    -o [ --options ] arg            device specific options
   
   rbd help device list
   usage: rbd device list [--device-type <device-type>] [--format <format>] 

--- a/src/tools/rbd/action/Ggate.cc
+++ b/src/tools/rbd/action/Ggate.cc
@@ -207,6 +207,16 @@ int execute_unmap(const po::variables_map &vm,
   return call_ggate_cmd(vm, args, ceph_global_init_args);
 }
 
+int execute_attach(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
+  return -EOPNOTSUPP;
+}
+
+int execute_detach(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
+  return -EOPNOTSUPP;
+}
+
 } // namespace ggate
 } // namespace action
 } // namespace rbd

--- a/src/tools/rbd/action/Ggate.cc
+++ b/src/tools/rbd/action/Ggate.cc
@@ -25,6 +25,7 @@ namespace ggate {
 namespace at = argument_types;
 namespace po = boost::program_options;
 
+#if defined(__FreeBSD__)
 static int call_ggate_cmd(const po::variables_map &vm,
                           const std::vector<std::string> &args,
                           const std::vector<std::string> &ceph_global_args) {
@@ -103,13 +104,14 @@ int parse_options(const std::vector<std::string> &options,
 
   return 0;
 }
+#endif
 
 int execute_list(const po::variables_map &vm,
                  const std::vector<std::string> &ceph_global_init_args) {
 #if !defined(__FreeBSD__)
   std::cerr << "rbd: ggate is only supported on FreeBSD" << std::endl;
   return -EOPNOTSUPP;
-#endif
+#else
   std::vector<std::string> args;
 
   args.push_back("list");
@@ -123,6 +125,7 @@ int execute_list(const po::variables_map &vm,
   }
 
   return call_ggate_cmd(vm, args, ceph_global_init_args);
+#endif
 }
 
 int execute_map(const po::variables_map &vm,
@@ -130,7 +133,7 @@ int execute_map(const po::variables_map &vm,
 #if !defined(__FreeBSD__)
   std::cerr << "rbd: ggate is only supported on FreeBSD" << std::endl;
   return -EOPNOTSUPP;
-#endif
+#else
   std::vector<std::string> args;
 
   args.push_back("map");
@@ -165,6 +168,7 @@ int execute_map(const po::variables_map &vm,
   }
 
   return call_ggate_cmd(vm, args, ceph_global_init_args);
+#endif
 }
 
 int execute_unmap(const po::variables_map &vm,
@@ -172,7 +176,7 @@ int execute_unmap(const po::variables_map &vm,
 #if !defined(__FreeBSD__)
   std::cerr << "rbd: ggate is only supported on FreeBSD" << std::endl;
   return -EOPNOTSUPP;
-#endif
+#else
   std::string device_name = utils::get_positional_argument(vm, 0);
   if (!boost::starts_with(device_name, "/dev/")) {
     device_name.clear();
@@ -205,15 +209,26 @@ int execute_unmap(const po::variables_map &vm,
   }
 
   return call_ggate_cmd(vm, args, ceph_global_init_args);
+#endif
 }
 
 int execute_attach(const po::variables_map &vm,
                    const std::vector<std::string> &ceph_global_init_args) {
+#if !defined(__FreeBSD__)
+  std::cerr << "rbd: ggate is only supported on FreeBSD" << std::endl;
+#else
+  std::cerr << "rbd: ggate attach command not supported" << std::endl;
+#endif
   return -EOPNOTSUPP;
 }
 
 int execute_detach(const po::variables_map &vm,
                    const std::vector<std::string> &ceph_global_init_args) {
+#if !defined(__FreeBSD__)
+  std::cerr << "rbd: ggate is only supported on FreeBSD" << std::endl;
+#else
+  std::cerr << "rbd: ggate detach command not supported" << std::endl;
+#endif
   return -EOPNOTSUPP;
 }
 

--- a/src/tools/rbd/action/Kernel.cc
+++ b/src/tools/rbd/action/Kernel.cc
@@ -635,11 +635,21 @@ int execute_unmap(const po::variables_map &vm,
 
 int execute_attach(const po::variables_map &vm,
                    const std::vector<std::string> &ceph_global_init_args) {
+#if defined(WITH_KRBD)
+  std::cerr << "rbd: krbd does not support attach" << std::endl;
+#else
+  std::cerr << "rbd: kernel device is not supported" << std::endl;
+#endif
   return -EOPNOTSUPP;
 }
 
 int execute_detach(const po::variables_map &vm,
                    const std::vector<std::string> &ceph_global_init_args) {
+#if defined(WITH_KRBD)
+  std::cerr << "rbd: krbd does not support detach" << std::endl;
+#else
+  std::cerr << "rbd: kernel device is not supported" << std::endl;
+#endif
   return -EOPNOTSUPP;
 }
 

--- a/src/tools/rbd/action/Kernel.cc
+++ b/src/tools/rbd/action/Kernel.cc
@@ -633,6 +633,16 @@ int execute_unmap(const po::variables_map &vm,
   return 0;
 }
 
+int execute_attach(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
+  return -EOPNOTSUPP;
+}
+
+int execute_detach(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
+  return -EOPNOTSUPP;
+}
+
 } // namespace kernel
 } // namespace action
 } // namespace rbd

--- a/src/tools/rbd/action/Nbd.cc
+++ b/src/tools/rbd/action/Nbd.cc
@@ -21,7 +21,7 @@ namespace po = boost::program_options;
 static int call_nbd_cmd(const po::variables_map &vm,
                         const std::vector<std::string> &args,
                         const std::vector<std::string> &ceph_global_init_args) {
-  #ifdef _WIN32
+  #if defined(__FreeBSD__) || defined(_WIN32)
   std::cerr << "rbd: nbd device is not supported" << std::endl;
   return -EOPNOTSUPP;
   #else
@@ -60,6 +60,7 @@ static int call_nbd_cmd(const po::variables_map &vm,
   #endif
 }
 
+#if !defined(__FreeBSD__) && !defined(_WIN32)
 int get_image_or_snap_spec(const po::variables_map &vm, std::string *spec) {
   size_t arg_index = 0;
   std::string pool_name;
@@ -112,13 +113,14 @@ int parse_options(const std::vector<std::string> &options,
 
   return 0;
 }
+#endif
 
 int execute_list(const po::variables_map &vm,
                  const std::vector<std::string> &ceph_global_init_args) {
 #if defined(__FreeBSD__) || defined(_WIN32)
   std::cerr << "rbd: nbd device is not supported" << std::endl;
   return -EOPNOTSUPP;
-#endif
+#else
   std::vector<std::string> args;
 
   args.push_back("list-mapped");
@@ -132,6 +134,7 @@ int execute_list(const po::variables_map &vm,
   }
 
   return call_nbd_cmd(vm, args, ceph_global_init_args);
+#endif
 }
 
 int execute_attach(const po::variables_map &vm,
@@ -139,7 +142,7 @@ int execute_attach(const po::variables_map &vm,
 #if defined(__FreeBSD__) || defined(_WIN32)
   std::cerr << "rbd: nbd device is not supported" << std::endl;
   return -EOPNOTSUPP;
-#endif
+#else
   std::vector<std::string> args;
   std::string device_path;
 
@@ -192,6 +195,7 @@ int execute_attach(const po::variables_map &vm,
   }
 
   return call_nbd_cmd(vm, args, ceph_global_init_args);
+#endif
 }
 
 int execute_detach(const po::variables_map &vm,
@@ -199,7 +203,7 @@ int execute_detach(const po::variables_map &vm,
 #if defined(__FreeBSD__) || defined(_WIN32)
   std::cerr << "rbd: nbd device is not supported" << std::endl;
   return -EOPNOTSUPP;
-#endif
+#else
   std::string device_name = utils::get_positional_argument(vm, 0);
   if (!boost::starts_with(device_name, "/dev/")) {
     device_name.clear();
@@ -232,6 +236,7 @@ int execute_detach(const po::variables_map &vm,
   }
 
   return call_nbd_cmd(vm, args, ceph_global_init_args);
+#endif
 }
 
 int execute_map(const po::variables_map &vm,
@@ -239,7 +244,7 @@ int execute_map(const po::variables_map &vm,
 #if defined(__FreeBSD__) || defined(_WIN32)
   std::cerr << "rbd: nbd device is not supported" << std::endl;
   return -EOPNOTSUPP;
-#endif
+#else
   std::vector<std::string> args;
 
   args.push_back("map");
@@ -275,6 +280,7 @@ int execute_map(const po::variables_map &vm,
   }
 
   return call_nbd_cmd(vm, args, ceph_global_init_args);
+#endif
 }
 
 int execute_unmap(const po::variables_map &vm,
@@ -282,7 +288,7 @@ int execute_unmap(const po::variables_map &vm,
 #if defined(__FreeBSD__) || defined(_WIN32)
   std::cerr << "rbd: nbd device is not supported" << std::endl;
   return -EOPNOTSUPP;
-#endif
+#else
   std::string device_name = utils::get_positional_argument(vm, 0);
   if (!boost::starts_with(device_name, "/dev/")) {
     device_name.clear();
@@ -315,6 +321,7 @@ int execute_unmap(const po::variables_map &vm,
   }
 
   return call_nbd_cmd(vm, args, ceph_global_init_args);
+#endif
 }
 
 void get_list_arguments_deprecated(po::options_description *positional,

--- a/src/tools/rbd/action/Wnbd.cc
+++ b/src/tools/rbd/action/Wnbd.cc
@@ -187,6 +187,16 @@ int execute_unmap(const po::variables_map &vm,
   return call_wnbd_cmd(vm, args, ceph_global_init_args);
 }
 
+int execute_attach(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
+  return -EOPNOTSUPP;
+}
+
+int execute_detach(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
+  return -EOPNOTSUPP;
+}
+
 Shell::SwitchArguments switched_arguments({"read-only", "exclusive"});
 
 } // namespace wnbd

--- a/src/tools/rbd/action/Wnbd.cc
+++ b/src/tools/rbd/action/Wnbd.cc
@@ -18,6 +18,7 @@ namespace wnbd {
 namespace at = argument_types;
 namespace po = boost::program_options;
 
+#if defined(_WIN32)
 static int call_wnbd_cmd(const po::variables_map &vm,
                         const std::vector<std::string> &args,
                         const std::vector<std::string> &ceph_global_init_args) {
@@ -106,9 +107,14 @@ int parse_options(const std::vector<std::string> &options,
 
   return 0;
 }
+#endif
 
 int execute_list(const po::variables_map &vm,
                  const std::vector<std::string> &ceph_global_init_args) {
+#if !defined(_WIN32)
+  std::cerr << "rbd: wnbd is only supported on Windows" << std::endl;
+  return -EOPNOTSUPP;
+#else
   std::vector<std::string> args;
 
   args.push_back("list");
@@ -122,10 +128,15 @@ int execute_list(const po::variables_map &vm,
   }
 
   return call_wnbd_cmd(vm, args, ceph_global_init_args);
+#endif
 }
 
 int execute_map(const po::variables_map &vm,
                 const std::vector<std::string> &ceph_global_init_args) {
+#if !defined(_WIN32)
+  std::cerr << "rbd: wnbd is only supported on Windows" << std::endl;
+  return -EOPNOTSUPP;
+#else
   std::vector<std::string> args;
 
   args.push_back("map");
@@ -152,10 +163,15 @@ int execute_map(const po::variables_map &vm,
   }
 
   return call_wnbd_cmd(vm, args, ceph_global_init_args);
+#endif
 }
 
 int execute_unmap(const po::variables_map &vm,
                   const std::vector<std::string> &ceph_global_init_args) {
+#if !defined(_WIN32)
+  std::cerr << "rbd: wnbd is only supported on Windows" << std::endl;
+  return -EOPNOTSUPP;
+#else
   std::string device_name = utils::get_positional_argument(vm, 0);
 
   std::string image_name;
@@ -185,15 +201,26 @@ int execute_unmap(const po::variables_map &vm,
   }
 
   return call_wnbd_cmd(vm, args, ceph_global_init_args);
+#endif
 }
 
 int execute_attach(const po::variables_map &vm,
                    const std::vector<std::string> &ceph_global_init_args) {
+#if !defined(_WIN32)
+  std::cerr << "rbd: wnbd is only supported on Windows" << std::endl;
+#else
+  std::cerr << "rbd: wnbd attach command not supported" << std::endl;
+#endif
   return -EOPNOTSUPP;
 }
 
 int execute_detach(const po::variables_map &vm,
                    const std::vector<std::string> &ceph_global_init_args) {
+#if !defined(_WIN32)
+  std::cerr << "rbd: wnbd is only supported on Windows" << std::endl;
+#else
+  std::cerr << "rbd: wnbd detach command not supported" << std::endl;
+#endif
   return -EOPNOTSUPP;
 }
 


### PR DESCRIPTION
## Description:

Example:
$ rbd device attach rpool/image --device /dev/nbd0 --device-type nbd --force
$ rbd device detach rpool/image --device-type nbd

for now returning EOPNOTSUPP with krbd, ggate and wnbd

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>