### PR TITLE
[mgr/dashboard] build fails if python3-virtualenv-xx is not installed

### DIFF
--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -14,6 +14,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Library Public License for more details.
 #
+set -e
 
 SCRIPTNAME="$(basename $0)"
 if [ `uname` == FreeBSD ]; then


### PR DESCRIPTION
In particular it fails late, for reasons that are hard to diagnose.

It would probably fail earlier, and be easier to diagnose,
if .../src/tools/setup-virtualenv.sh used `set -e`

Found while trying to build on rhel9-beta which currently does not
have python3-virtualenv-xx available, e.g. in its Code Ready Builder
repo or the BaseOS repo.

(N.B. python3-virtualenv-xx and its dependencies are built in brew
for rhel9, but at the time of this writing aren't in any package repos
for rhel9)

Fixes: https://tracker.ceph.com/issues/50760

Signed-off-by: Kaleb S KEITHLEY <kkeithle@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
