### PR TITLE
octopus: cephfs: client: Fix executeable access check for the root user

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -124,6 +124,10 @@
 
 #define DEBUG_GETATTR_CAPS (CEPH_CAP_XATTR_SHARED)
 
+#ifndef S_IXUGO
+#define S_IXUGO	(S_IXUSR|S_IXGRP|S_IXOTH)
+#endif
+
 using namespace TOPNSPC::common;
 
 void client_flush_set_callback(void *p, ObjectCacher::ObjectSet *oset)
@@ -5424,8 +5428,12 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
 
 int Client::inode_permission(Inode *in, const UserPerm& perms, unsigned want)
 {
-  if (perms.uid() == 0)
+  if (perms.uid() == 0) {
+    // Executable are overridable when there is at least one exec bit set
+    if((want & MAY_EXEC) && !(in->mode & S_IXUGO))
+      return -EACCES;
     return 0;
+  }
   
   if (perms.uid() != in->uid && (in->mode & S_IRWXG)) {
     int ret = _posix_acl_permission(in, perms, want);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50626

---

backport of https://github.com/ceph/ceph/pull/40882
parent tracker: https://tracker.ceph.com/issues/50060

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh