### PR TITLE
pacific: mgr/dashboard: fix HAProxy (now called ingress)

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
@@ -1,0 +1,86 @@
+import { PageHelper } from '../page-helper.po';
+
+const pages = {
+  index: { url: '#/services', id: 'cd-services' },
+  create: { url: '#/services/create', id: 'cd-service-form' }
+};
+
+export class ServicesPageHelper extends PageHelper {
+  pages = pages;
+
+  columnIndex = {
+    service_name: 2,
+    container_image_name: 3,
+    container_image_id: 4,
+    placement: 5,
+    running: 6,
+    size: 7,
+    last_refresh: 8
+  };
+
+  check_for_service() {
+    this.getTableCount('total').should('not.be.eq', 0);
+  }
+
+  private selectServiceType(serviceType: string) {
+    return this.selectOption('service_type', serviceType);
+  }
+
+  @PageHelper.restrictTo(pages.create.url)
+  addService(serviceType: string, exist?: boolean) {
+    cy.get(`${this.pages.create.id}`).within(() => {
+      this.selectServiceType(serviceType);
+      if (serviceType === 'rgw') {
+        cy.get('#service_id').type('rgw.foo');
+        cy.get('#count').type('1');
+      } else if (serviceType === 'ingress') {
+        this.selectOption('backend_service', 'rgw.rgw.foo');
+        cy.get('#service_id').type('rgw.rgw.foo');
+        cy.get('#virtual_ip').type('192.168.20.1/24');
+        cy.get('#frontend_port').type('8081');
+        cy.get('#monitor_port').type('8082');
+      }
+
+      cy.get('cd-submit-button').click();
+    });
+    if (exist) {
+      cy.get('#service_id').should('have.class', 'ng-invalid');
+    } else {
+      // back to service list
+      cy.get(`${this.pages.index.id}`);
+    }
+  }
+
+  @PageHelper.restrictTo(pages.index.url)
+  checkExist(serviceName: string, exist: boolean) {
+    this.getTableCell(this.columnIndex.service_name, serviceName).should(($elements) => {
+      const services = $elements.map((_, el) => el.textContent).get();
+      if (exist) {
+        expect(services).to.include(serviceName);
+      } else {
+        expect(services).to.not.include(serviceName);
+      }
+    });
+  }
+
+  @PageHelper.restrictTo(pages.index.url)
+  deleteService(serviceName: string, wait: number) {
+    const getRow = this.getTableCell.bind(this, this.columnIndex.service_name);
+    getRow(serviceName).click();
+
+    // Clicks on table Delete button
+    this.clickActionButton('delete');
+
+    // Confirms deletion
+    cy.get('cd-modal .custom-control-label').click();
+    cy.contains('cd-modal button', 'Delete').click();
+
+    // Wait for modal to close
+    cy.get('cd-modal').should('not.exist');
+
+    // wait for delete operation to complete: tearing down the service daemons
+    cy.wait(wait);
+
+    this.checkExist(serviceName, false);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/05-services.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/05-services.e2e-spec.ts
@@ -1,0 +1,29 @@
+import { ServicesPageHelper } from '../cluster/services.po';
+
+describe('Services page', () => {
+  const services = new ServicesPageHelper();
+
+  beforeEach(() => {
+    cy.login();
+    Cypress.Cookies.preserveOnce('token');
+    services.navigateTo();
+  });
+
+  describe('when Orchestrator is available', () => {
+    it('should create an rgw service', () => {
+      services.navigateTo('create');
+      services.addService('rgw');
+
+      services.checkExist('rgw.rgw.foo', true);
+    });
+
+    it('should create and delete an ingress service', () => {
+      services.navigateTo('create');
+      services.addService('ingress');
+
+      services.checkExist('ingress.rgw.rgw.foo', true);
+
+      services.deleteService('ingress.rgw.rgw.foo', 5000);
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -14,6 +14,7 @@
                  i18n>Type</label>
           <div class="cd-col-form-input">
             <select id="service_type"
+                    name="service_type"
                     class="form-control custom-select"
                     formControlName="service_type">
               <option i18n

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
 
-import { delay, finalize } from 'rxjs/operators';
+import { delay } from 'rxjs/operators';
 
 import { CephServiceService } from '~/app/shared/api/ceph-service.service';
 import { OrchestratorService } from '~/app/shared/api/orchestrator.service';
@@ -201,15 +201,10 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
           })
           .pipe(
             // Delay closing the dialog, otherwise the datatable still
-            // shows the deleted service after forcing a reload.
+            // shows the deleted service after an auto-reload.
             // Showing the dialog while delaying is done to increase
             // the user experience.
-            delay(2000),
-            finalize(() => {
-              // Force reloading the data table content because it is
-              // auto-reloaded only every 60s.
-              this.table.refreshBtn();
-            })
+            delay(5000)
           )
     });
   }


### PR DESCRIPTION
backport trackers: https://tracker.ceph.com/issues/50543, https://tracker.ceph.com/issues/50764

---

backport of https://github.com/ceph/ceph/pull/40936, https://github.com/ceph/ceph/pull/41196
parent trackers: https://tracker.ceph.com/issues/50319, https://tracker.ceph.com/issues/50567

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh