### PR TITLE
[RFC] osd: fix the op consistent between osds

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -281,7 +281,7 @@ OSDService::OSDService(OSD *osd, ceph::async::io_context_pool& poolctx) :
   poolctx(poolctx),
   objecter(make_unique<Objecter>(osd->client_messenger->cct,
 				 osd->objecter_messenger,
-				 osd->monc, poolctx)),
+				 osd->monc, poolctx, osd->whoami)),
   m_objecter_finishers(cct->_conf->osd_objecter_finishers),
   watch_timer(osd->client_messenger->cct, watch_lock),
   next_notif_id(0),

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2311,6 +2311,13 @@ bool PG::can_discard_op(OpRequestRef& op)
     return true;
   }
 
+  if (m->get_source().is_osd()) {
+    int from = m->get_source().num();
+    if (!get_osdmap()->exists(from) ||
+	m->get_map_epoch() <= get_osdmap()->get_down_at(from)) {
+      return true; 
+    }
+  }
 
   if (m->get_connection()->has_feature(CEPH_FEATURE_RESEND_ON_SPLIT)) {
     // >= luminous client


### PR DESCRIPTION
some major premise:
1. PGs and objecter maintain their own osdmap, and they advance new map epoch independently, so they may had different epoch at some point.
2. Objecter::op send by pg (to local objecter) do not indicate the pg epoch, Objecter::op send by objecter (to other osd) will fill MOSDOp's epoch with objecter's own map epoch.
3. When network partition happen, there may exist two primaries of same pg at same time, the one with connection with the majority of monitors will be the auth; the one can not receive new map will become stray, but it can not aware that it's the stray one.
4. Considering above 1-3, we conclude that op send by tier, may array to base with wrongly epoch, and completed on base unorderly.
5. On some circumstance, internal op of pg generate at diffirent epoch must complete with order. eg. on the writeback tier mode,  proxy write on e1 and promote on e2 must be orderly; when flush object, flush(delete+copy_from) on e1 and flush on e2 must be orderly.

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
