### PR TITLE
crimson/os/seastore: do not capture unused variables

### DIFF
--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -487,15 +487,15 @@ struct interruptible_errorator {
   using future = interruptible_future_detail<InterruptCond,
 	typename Errorator::template future<ValueT>>;
 
-  template <typename ValueT = void, typename A>
+  template <typename ValueT = void, typename... A>
   static interruptible_future_detail<
     InterruptCond,
     typename Errorator::template future<ValueT>>
-  make_ready_future(A&& value) {
+  make_ready_future(A&&... value) {
     return interruptible_future_detail<
       InterruptCond, typename Errorator::template future<ValueT>>(
 	Errorator::template make_ready_future<ValueT>(
-	  std::forward<A>(value)));
+	  std::forward<A>(value)...));
   }
   template <typename ValueT = void>
   static interruptible_future_detail<

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -74,7 +74,7 @@ class SeastoreNodeExtentManager final: public NodeExtentManager {
       Transaction& t, laddr_t addr, extent_len_t len) override {
     TRACET("reading {}B at {:#x} ...", t, len, addr);
     return tm.read_extent<SeastoreNodeExtent>(t, addr, len
-    ).safe_then([addr, len, this, &t](auto&& e) {
+    ).safe_then([addr, len, &t](auto&& e) {
       TRACET("read {}B at {:#x}", t, e->get_length(), e->get_laddr());
       assert(e->get_laddr() == addr);
       assert(e->get_length() == len);
@@ -88,7 +88,7 @@ class SeastoreNodeExtentManager final: public NodeExtentManager {
       Transaction& t, extent_len_t len) override {
     TRACET("allocating {}B ...", t, len);
     return tm.alloc_extent<SeastoreNodeExtent>(t, addr_min, len
-    ).safe_then([len, this, &t](auto extent) {
+    ).safe_then([len, &t](auto extent) {
       DEBUGT("allocated {}B at {:#x}",
              t, extent->get_length(), extent->get_laddr());
       assert(extent->get_length() == len);
@@ -103,7 +103,7 @@ class SeastoreNodeExtentManager final: public NodeExtentManager {
     auto addr = extent->get_laddr();
     auto len = extent->get_length();
     DEBUGT("retiring {}B at {:#x} ...", t, len, addr);
-    return tm.dec_ref(t, extent).safe_then([addr, len, this, &t] (unsigned cnt) {
+    return tm.dec_ref(t, extent).safe_then([addr, len, &t] (unsigned cnt) {
       assert(cnt == 0);
       TRACET("retired {}B at {:#x} ...", t, len, addr);
     });

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -115,7 +115,7 @@ TransactionManager::close_ertr::future<> TransactionManager::close() {
   }).safe_then([this] {
     cache->dump_contents();
     return journal->close();
-  }).safe_then([this, FNAME] {
+  }).safe_then([FNAME] {
     DEBUG("completed");
     return seastar::now();
   });


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
