### PR TITLE
nautilus: mgr/progress: ensure progress stays between [0,1]

### DIFF
--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -265,10 +265,16 @@ class PgRecoveryEvent(Event):
 
         self._pgs = list(set(self._pgs) ^ complete)
         completed_pgs = self._original_pg_count - len(self._pgs)
-        self._progress = (completed_pgs + complete_accumulate)\
-            / self._original_pg_count
-        self._refresh()
+        completed_pgs = max(completed_pgs, 0)
+        try:
+            prog = (completed_pgs + complete_accumulate)\
+                / self._original_pg_count
+        except ZeroDivisionError:
+            prog = 0.0
 
+        self._progress = min(max(prog, 0.0), 1.0)
+
+        self._refresh()
         log.info("Updated progress to {0} ({1})".format(
             self._progress, self._message
         ))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50777

---

backport of https://github.com/ceph/ceph/pull/41094
parent tracker: https://tracker.ceph.com/issues/50591

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh