### PR TITLE
common/options/global.yaml.in: remove osd_command_thread* timeouts

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -419,7 +419,6 @@ Miscellaneous
 
 .. confval:: osd_default_notify_timeout
 .. confval:: osd_check_for_log_corruption
-.. confval:: osd_command_thread_timeout
 .. confval:: osd_delete_sleep
 .. confval:: osd_delete_sleep_hdd
 .. confval:: osd_delete_sleep_ssd

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4859,17 +4859,6 @@ options:
   level: advanced
   default: true
   with_legacy: true
-- name: osd_command_thread_timeout
-  type: int
-  level: advanced
-  default: 10_min
-  fmt_desc: The maximum time in seconds before timing out a command thread.
-  with_legacy: true
-- name: osd_command_thread_suicide_timeout
-  type: int
-  level: advanced
-  default: 15_min
-  with_legacy: true
 - name: osd_heartbeat_interval
   type: int
   level: dev


### PR DESCRIPTION
These are no longer used after 817cca779db24b9ef08138a546ccb339271a3d9c

Signed-off-by: Neha Ojha <nojha@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
