### PR TITLE
pacific: osd: don't assert in-flight backfill is always in recovery list

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -12765,7 +12765,6 @@ void PrimaryLogPG::_clear_recovery_state()
   last_backfill_started = hobject_t();
   set<hobject_t>::iterator i = backfills_in_flight.begin();
   while (i != backfills_in_flight.end()) {
-    ceph_assert(recovering.count(*i));
     backfills_in_flight.erase(i++);
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50794

---

backport of https://github.com/ceph/ceph/pull/41270
parent tracker: https://tracker.ceph.com/issues/50351

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh