### PR TITLE
mgr/cephadm: Fix OSD replacement in hosts with FQDN host name

### DIFF
--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -30,10 +30,10 @@ class OSDService(CephService):
 
     def create_from_spec(self, drive_group: DriveGroupSpec) -> str:
         logger.debug(f"Processing DriveGroup {drive_group}")
-        osd_id_claims = self.find_destroyed_osds()
-        if osd_id_claims:
+        osd_id_claims = OsdIdClaims(self.mgr)
+        if osd_id_claims.get():
             logger.info(
-                f"Found osd claims for drivegroup {drive_group.service_id} -> {osd_id_claims}")
+                f"Found osd claims for drivegroup {drive_group.service_id} -> {osd_id_claims.get()}")
 
         @forall_hosts
         def create_from_spec_one(host: str, drive_selection: DriveSelection) -> Optional[str]:
@@ -46,8 +46,10 @@ class OSDService(CephService):
             if self.mgr.inventory.has_label(host, '_no_schedule'):
                 return None
 
+            osd_id_claims_for_host = osd_id_claims.filtered_by_host(host)
+
             cmd = self.driveselection_to_ceph_volume(drive_selection,
-                                                     osd_id_claims.get(host, []))
+                                                     osd_id_claims_for_host)
             if not cmd:
                 logger.debug("No data_devices, skipping DriveGroup: {}".format(
                     drive_group.service_id))
@@ -60,7 +62,7 @@ class OSDService(CephService):
             env_vars: List[str] = [f"CEPH_VOLUME_OSDSPEC_AFFINITY={drive_group.service_id}"]
             ret_msg = self.create_single_host(
                 drive_group, host, cmd,
-                replace_osd_ids=osd_id_claims.get(host, []), env_vars=env_vars
+                replace_osd_ids=osd_id_claims_for_host, env_vars=env_vars
             )
             self.mgr.cache.update_osdspec_last_applied(
                 host, drive_group.service_name(), start_ts
@@ -94,7 +96,7 @@ class OSDService(CephService):
                                              replace_osd_ids: Optional[List[str]] = None) -> str:
 
         if replace_osd_ids is None:
-            replace_osd_ids = self.find_destroyed_osds().get(host, [])
+            replace_osd_ids = OsdIdClaims(self.mgr).filtered_by_host(host)
             assert replace_osd_ids is not None
         # check result
         osds_elems: dict = CephadmServe(self.mgr)._run_cephadm_json(
@@ -218,7 +220,7 @@ class OSDService(CephService):
         for osdspec in osdspecs:
 
             # populate osd_id_claims
-            osd_id_claims = self.find_destroyed_osds()
+            osd_id_claims = OsdIdClaims(self.mgr)
 
             # prepare driveselection
             for host, ds in self.prepare_drivegroup(osdspec):
@@ -227,7 +229,7 @@ class OSDService(CephService):
 
                 # driveselection for host
                 cmd = self.driveselection_to_ceph_volume(ds,
-                                                         osd_id_claims.get(host, []),
+                                                         osd_id_claims.filtered_by_host(host),
                                                          preview=True)
                 if not cmd:
                     logger.debug("No data_devices, skipping DriveGroup: {}".format(
@@ -302,8 +304,18 @@ class OSDService(CephService):
     def get_osdspec_affinity(self, osd_id: str) -> str:
         return self.mgr.get('osd_metadata').get(osd_id, {}).get('osdspec_affinity', '')
 
-    def find_destroyed_osds(self) -> Dict[str, List[str]]:
-        osd_host_map: Dict[str, List[str]] = dict()
+
+class OsdIdClaims(object):
+    """
+    Retrieve and provide osd ids that can be reused in the cluster
+    """
+
+    def __init__(self, mgr: "CephadmOrchestrator") -> None:
+        self.mgr: "CephadmOrchestrator" = mgr
+        self.osd_host_map: Dict[str, List[str]] = dict()
+        self.refresh()
+
+    def refresh(self) -> None:
         try:
             ret, out, err = self.mgr.check_mon_command({
                 'prefix': 'osd tree',
@@ -317,17 +329,29 @@ class OSDService(CephService):
             tree = json.loads(out)
         except ValueError:
             logger.exception(f'Cannot decode JSON: \'{out}\'')
-            return osd_host_map
+            return
 
         nodes = tree.get('nodes', {})
         for node in nodes:
             if node.get('type') == 'host':
-                osd_host_map.update(
+                self.osd_host_map.update(
                     {node.get('name'): [str(_id) for _id in node.get('children', list())]}
                 )
-        if osd_host_map:
-            self.mgr.log.info(f"Found osd claims -> {osd_host_map}")
-        return osd_host_map
+        if self.osd_host_map:
+            self.mgr.log.info(f"Found osd claims -> {self.osd_host_map}")
+
+    def get(self) -> Dict[str, List[str]]:
+        return self.osd_host_map
+
+    def filtered_by_host(self, host: str) -> List[str]:
+        """
+        Return the list of osd ids that can be reused  in a host
+
+        OSD id claims in CRUSH map are linked to the bare name of
+        the hostname. In case of FQDN hostnames the host is searched by the
+        bare name
+        """
+        return self.osd_host_map.get(host.split(".")[0], [])
 
 
 class RemoveUtil(object):


### PR DESCRIPTION
Resolves: https://tracker.ceph.com/issues/50805

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
