### PR TITLE
mon/OSDMonitor: clear new flag when do destroy

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -9594,6 +9594,11 @@ int OSDMonitor::prepare_command_osd_destroy(
 
   pending_inc.new_state[id] = CEPH_OSD_DESTROYED;
   pending_inc.new_uuid[id] = uuid_d();
+  // better to clear the "new" flag or the next new command may
+  // wrongly flip it to non-new.
+  if (osdmap.is_new(id)) {
+    pending_inc.new_state[id] |= CEPH_OSD_NEW;
+  }
 
   // we can only propose_pending() once per service, otherwise we'll be
   // defying PaxosService and all laws of nature. Therefore, as we may

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -830,6 +830,10 @@ public:
     return osd >= 0 && osd < max_osd && (osd_state[osd] & CEPH_OSD_EXISTS);
   }
 
+  bool is_new(int osd) const {
+    return exists(osd) && (osd_state[osd] & CEPH_OSD_NEW);
+  }
+
   bool is_destroyed(int osd) const {
     return exists(osd) && (osd_state[osd] & CEPH_OSD_DESTROYED);
   }


### PR DESCRIPTION
the new flag in osdmap will affects the osd up according option
mon_osd_auto_mark_new_in. So it is more safe to clear the new flag when
destroy osd. the follow sequence may cause new osd can not up.

1. ceph osd new
2. *do not* start daemon, so the new flag will exist.
3. ceph osd destroy the osd, the destoryed flag add, but new flag
   remain to exist. then the new state is :
   "state": [
      "destroyed",
      "exists",
      "new"
   ]
5. if we new the osd again, the new flag will flip ,and the state will become:
   "state": [
     "exists",
   ]
6. becase the new flag do not exist, so the osd boot and can not up when
   the option mon_osd_auto_mark_new_in is true.

Fixes: https://tracker.ceph.com/issues/50813

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
