### PR TITLE
rgw/multisite: fix bucket shard state init function

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3018,7 +3018,7 @@ class CheckAllBucketShardStatusIsIncremental : public RGWShardCollectCR {
 // and a loop to retry on racing writes
 class InitBucketShardStatusCR : public RGWCoroutine {
   RGWDataSyncCtx* sc;
-  const rgw_bucket_sync_pair_info& pair;
+  rgw_bucket_sync_pair_info pair;
   rgw_bucket_shard_sync_info status;
   RGWObjVersionTracker objv;
   rgw_bucket_index_marker_info& info;
@@ -3099,7 +3099,7 @@ class InitBucketShardStatusCollectCR : public RGWShardCollectCR {
     if (shard >= num_shards || status < 0) { // stop spawning on any errors
       return false;
     }
-    sync_pair.dest_bs.shard_id = shard++;
+    sync_pair.dest_bs.shard_id = sync_pair.source_bs.shard_id = shard++;
     spawn(new InitBucketShardStatusCR(sc, sync_pair, info, marker_mgr), false);
     return true;
   }


### PR DESCRIPTION
* make sure src/dest shard ids are the same in sync pair
* copy sync pair by value in coroutine loop

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
