### PR TITLE
librbd: Repair deprecated use of allocator<void>

### DIFF
--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -202,7 +202,7 @@ namespace librbd {
 
     typedef boost::lockfree::queue<
       io::AioCompletion*,
-      boost::lockfree::allocator<ceph::allocator<void>>> Completions;
+      boost::lockfree::allocator<ceph::allocator<void*>>> Completions;
 
     Completions event_socket_completions;
     EventSocket event_socket;

--- a/src/librbd/crypto/CryptoContextPool.h
+++ b/src/librbd/crypto/CryptoContextPool.h
@@ -46,7 +46,7 @@ public:
 
     typedef boost::lockfree::queue<
             T*,
-            boost::lockfree::allocator<ceph::allocator<void>>> ContextQueue;
+            boost::lockfree::allocator<ceph::allocator<void*>>> ContextQueue;
 
 private:
     DataCryptor<T>* m_data_cryptor;


### PR DESCRIPTION
FreeBsD/Clang/libc++ warns: (ad nauseam)
```
In file included from /home/jenkins/workspace/ceph-pacific/src/librbd/ImageCtx.h:15:
/home/jenkins/workspace/ceph-pacific/src/common/allocator.h:62:1: warning: 'allocator<void>' is deprecated [-Wdeprecated-declarations]
using allocator = std::allocator<T>;
^
/usr/include/c++/v1/memory:725:28: note: 'allocator<void>' has been explicitly marked deprecated here
class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 allocator<void>
                           ^
/usr/include/c++/v1/__config:997:39: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
                                      ^
/usr/include/c++/v1/__config:974:48: note: expanded from macro '_LIBCPP_DEPRECATED'
                                               ^
1 warning generated.
```

So changed <void> to <void*>.
Which will prevent compilation errors once this is promoted to an error.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>