### PR TITLE
crimson/seastore: fix omap manager testcase bug

### DIFF
--- a/src/test/crimson/seastore/test_omap_manager.cc
+++ b/src/test/crimson/seastore/test_omap_manager.cc
@@ -179,6 +179,14 @@ struct omap_manager_test_t :
     check_mappings(omap_root, *t);
   }
 
+  std::vector<std::string> get_mapped_keys() {
+    std::vector<std::string> mkeys;
+    mkeys.reserve(test_omap_mappings.size());
+    for (auto &k: test_omap_mappings) {
+      mkeys.push_back(k.first);
+    }
+    return mkeys;
+  }
   void replay() {
     logger().debug("{}: begin", __func__);
     restart();
@@ -279,11 +287,11 @@ TEST_F(omap_manager_test_t, force_leafnode_split_merge)
         check_mappings(omap_root);
       }
     }
+    auto mkeys = get_mapped_keys();
     auto t = tm->create_transaction();
-    int i = 0;
-    for (auto &e: test_omap_mappings) {
+    for (unsigned i = 0; i < mkeys.size(); i++) {
       if (i % 3 != 0) {
-        rm_key(omap_root, *t, e.first);
+        rm_key(omap_root, *t, mkeys[i]);
       }
 
       if (i % 10 == 0) {
@@ -296,7 +304,6 @@ TEST_F(omap_manager_test_t, force_leafnode_split_merge)
         check_mappings(omap_root, *t);
         check_mappings(omap_root);
       }
-      i++;
     }
     logger().debug("finally submitting transaction ");
     submit_transaction(std::move(t));
@@ -328,27 +335,25 @@ TEST_F(omap_manager_test_t, force_leafnode_split_merge_fullandbalanced)
         check_mappings(omap_root);
       }
     }
+    auto mkeys = get_mapped_keys();
     auto t = tm->create_transaction();
-    int i = 0;
-    for (auto &e: test_omap_mappings) {
+    for (unsigned i = 0; i < mkeys.size(); i++) {
       if (30 < i && i < 100) {
-        auto val = e;
-        rm_key(omap_root, *t, e.first);
+        rm_key(omap_root, *t, mkeys[i]);
       }
 
       if (i % 10 == 0) {
-      logger().debug("submitting transaction i= {}", i);
+        logger().debug("submitting transaction i= {}", i);
         submit_transaction(std::move(t));
         t = tm->create_transaction();
       }
       if (i % 50 == 0) {
-      logger().debug("check_mappings  i= {}", i);
+        logger().debug("check_mappings  i= {}", i);
         check_mappings(omap_root, *t);
         check_mappings(omap_root);
       }
-      i++;
       if (i == 100)
- break;
+        break;
     }
     logger().debug("finally submitting transaction ");
     submit_transaction(std::move(t));
@@ -449,23 +454,21 @@ TEST_F(omap_manager_test_t, internal_force_merge_fullandbalanced)
       logger().debug("submitting transaction");
       submit_transaction(std::move(t));
     }
+    auto mkeys = get_mapped_keys();
     auto t = tm->create_transaction();
-    int i = 0;
-    for (auto &e: test_omap_mappings) {
-        auto val = e;
-        rm_key(omap_root, *t, e.first);
+    for (unsigned i = 0; i < mkeys.size(); i++) {
+      rm_key(omap_root, *t, mkeys[i]);
 
       if (i % 10 == 0) {
-      logger().debug("submitting transaction i= {}", i);
+        logger().debug("submitting transaction i= {}", i);
         submit_transaction(std::move(t));
         t = tm->create_transaction();
       }
       if (i % 50 == 0) {
-      logger().debug("check_mappings  i= {}", i);
+        logger().debug("check_mappings  i= {}", i);
         check_mappings(omap_root, *t);
         check_mappings(omap_root);
       }
-      i++;
     }
     logger().debug("finally submitting transaction ");
     submit_transaction(std::move(t));
@@ -500,20 +503,19 @@ TEST_F(omap_manager_test_t, replay)
     replay();
     check_mappings(omap_root);
 
+    auto mkeys = get_mapped_keys();
     auto t = tm->create_transaction();
-    int i = 0;
-    for (auto &e: test_omap_mappings) {
-        auto val = e;
-        rm_key(omap_root, *t, e.first);
+    for (unsigned i = 0; i < mkeys.size(); i++) {
+      rm_key(omap_root, *t, mkeys[i]);
 
       if (i % 10 == 0) {
-      logger().debug("submitting transaction i= {}", i);
+        logger().debug("submitting transaction i= {}", i);
         submit_transaction(std::move(t));
         replay();
         t = tm->create_transaction();
       }
       if (i % 50 == 0) {
-      logger().debug("check_mappings  i= {}", i);
+        logger().debug("check_mappings  i= {}", i);
         check_mappings(omap_root, *t);
         check_mappings(omap_root);
       }


### PR DESCRIPTION
can't erase map while iterating it.

Signed-off-by: chunmei-liu <chunmei.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
