### PR TITLE
pybind/mgr/CMakeLists.txt: exclude files not used at runtime

### DIFF
--- a/src/pybind/mgr/CMakeLists.txt
+++ b/src/pybind/mgr/CMakeLists.txt
@@ -22,4 +22,12 @@ install(DIRECTORY
   REGEX "rook/rook-client-python.*" EXCLUDE
   REGEX "osd_perf_query/.*" EXCLUDE
   REGEX "tox.ini" EXCLUDE
-  REGEX "requirements.txt" EXCLUDE)
+  REGEX "requirements.*\.txt" EXCLUDE
+  REGEX "constraints.*\.txt" EXCLUDE
+  REGEX "node_modules" EXCLUDE
+  REGEX "cypress.*" EXCLUDE
+  REGEX "\.coveragerc" EXCLUDE
+  REGEX "\.editorconfig" EXCLUDE
+  REGEX "\..*lintrc" EXCLUDE
+  REGEX "\.browserslistrc" EXCLUDE
+  REGEX "\.prettier*" EXCLUDE)


### PR DESCRIPTION
Exclude node_modules so it is not installed with make install
Exclude cypress files and .editorconfig also

Fixes: https://tracker.ceph.com/issues/50827
Signed-off-by: Duncan Bellamy <dunk@denkimushi.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [X] References tracker ticket
- [X] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
