### PR TITLE
cmake: cleanups related to file(GLOB_RECURSE..) call

### DIFF
--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -85,23 +85,11 @@ add_npm_command(
   ${nodeenv}
 )
 
-# Glob some frontend files. With CMake 3.6, this can be simplified
-# to *.ts *.html. Just add:
-# list(FILTER frontend_src INCLUDE REGEX "frontend/src")
+# Glob some frontend files.
 file(
   GLOB_RECURSE frontend_src
   frontend/src/*.ts
-  frontend/src/*.html
-  frontend/src/*/*.ts
-  frontend/src/*/*.html
-  frontend/src/*/*/*.ts
-  frontend/src/*/*/*.html
-  frontend/src/*/*/*/*.ts
-  frontend/src/*/*/*/*.html
-  frontend/src/*/*/*/*/*.ts
-  frontend/src/*/*/*/*/*.html
-  frontend/src/*/*/*/*/*/*.ts
-  frontend/src/*/*/*/*/*/*.html)
+  frontend/src/*.html)
 
 # these files are generated during build
 list(REMOVE_ITEM frontend_src

--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -88,13 +88,14 @@ add_npm_command(
 # Glob some frontend files.
 file(
   GLOB_RECURSE frontend_src
+  RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
   frontend/src/*.ts
   frontend/src/*.html)
 
 # these files are generated during build
 list(REMOVE_ITEM frontend_src
-  ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/src/environments/environment.prod.ts
-  ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/src/environments/environment.ts)
+  frontend/src/environments/environment.prod.ts
+  frontend/src/environments/environment.ts)
 
 execute_process(
     COMMAND bash -c "jq -r .config.locale ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/package.json"


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
