### PR TITLE
crimson/seastore: add string_kv_node_layout diagrams

### DIFF
--- a/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
+++ b/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
@@ -267,6 +267,24 @@ namespace crimson::os::seastore::omap_manager {
  * and related methods.
  *
  * Also included are helpers for doing splits and merges as for a btree.
+ *
+ * layout diagram:
+ *
+ * # <----------------------------- node range --------------------------------------------> #
+ * #                                                         #<~># free space                #
+ * # <------------- left part -----------------------------> # <~# <----- right keys  -----> #
+ * #               # <------------ left keys --------------> #~> #                           #
+ * #               #                         keys [2, n) |<~>#   #<~>| right keys [2, n)     #
+ * #               # <--- key 0 ----> | <--- key 1 ----> |   #   #   | <- k1 -> | <-- k0 --> #
+ * #               #                  |                  |   #   #   |          |            #
+ * #  num_ | meta  # key | key | val  | key | key | val  |   #   #   | key      | key        #
+ * #  keys | depth # off | len | laddr| off | len | laddr|   #   #   | buff     | buff       #
+ * #       |       # 0   | 0   | 0    | 1   | 1   | 1    |...#...#...| key 1    | key 0      #
+ * #                 |                  |                            | <- off --+----------> #
+ * #                 |                  |                                  ^    | <- off --> #
+ *                   |                  |                                  |          ^
+ *                   |                  +----------------------------------+          |
+ *                   +----------------------------------------------------------------+
  */
 class StringKVInnerNodeLayout {
   char *buf = nullptr;
@@ -866,6 +884,27 @@ private:
 
 };
 
+/**
+ * StringKVLeafNodeLayout
+ *
+ * layout diagram:
+ *
+ * # <----------------------------- node range -------------------------------------------------> #
+ * #                                                       #<~># free space                       #
+ * # <------------- left part ---------------------------> # <~# <----- right key-value pairs --> #
+ * #               # <------------ left keys ------------> #~> #                                  #
+ * #               #                       keys [2, n) |<~>#   #<~>| right kvs [2, n)             #
+ * #               # <--- key 0 ---> | <--- key 1 ---> |   #   #   | <-- kv 1 --> | <-- kv 0 -->  #
+ * #               #                 |                 |   #   #   |              |               #
+ * # num_ | meta   # key | key | val | key | key | val |   #   #   | key   | val  | key   | val   #
+ * # keys | depth  # off | len | len | off | len | len |   #   #   | buff  | buff | buff  | buff  #
+ * #               # 0   | 0   | 0   | 1   | 1   | 1   |...#...#...| key 1 | val 1| key 0 | val 0 #
+ * #                 |                 |                           | <--- off ----+-------------> #
+ * #                 |                 |                                   ^      | <--- off ---> #
+ *                   |                 |                                   |             ^
+ *                   |                 +-----------------------------------+             |
+ *                   +-------------------------------------------------------------------+
+ */
 class StringKVLeafNodeLayout {
   char *buf = nullptr;
 


### PR DESCRIPTION
Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
