### PR TITLE
qa: drop verification of tcmalloc.max_total_thread_cache_byte.

### DIFF
--- a/qa/suites/rados/singleton/all/admin-socket.yaml
+++ b/qa/suites/rados/singleton/all/admin-socket.yaml
@@ -21,6 +21,3 @@ tasks:
       config set bluestore_csum_type xxhash64:
       perf dump:
       perf schema:
-      get_heap_property tcmalloc.max_total_thread_cache_byte:
-      set_heap_property tcmalloc.max_total_thread_cache_bytes 67108864:
-      set_heap_property tcmalloc.max_total_thread_cache_bytes 33554432:


### PR DESCRIPTION
The motivation behind the change is that this property
is not a part of the public interface exposed to operators.
We shouldn't assume a concrete memory allocator is used.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
