### PR TITLE
crimson/os: use compile-time validation

### DIFF
--- a/src/crimson/os/seastore/logging.h
+++ b/src/crimson/os/seastore/logging.h
@@ -12,23 +12,23 @@
 
 #ifdef NDEBUG
 
-#define LOG(LEVEL, MSG, ...) LOGGER . LEVEL("{}: " MSG, FNAME __VA_OPT__(,) __VA_ARGS__)
-#define LOGT(LEVEL, MSG, t, ...) LOGGER . LEVEL("{}({}): " MSG, FNAME, (void*)&t __VA_OPT__(,) __VA_ARGS__)
+#define LOG(level_, MSG, ...) LOGGER.log(level_, "{}: " MSG, FNAME __VA_OPT__(,) __VA_ARGS__))
+#define LOGT(level_, MSG, t, ...) LOGGER.log(level_, "{}({}): " MSG, FNAME, (void*)&t __VA_OPT__(,) __VA_ARGS__))
 
-#define TRACE(...) LOG(trace, __VA_ARGS__)
-#define TRACET(...) LOGT(trace, __VA_ARGS__)
+#define TRACE(...) LOG(seastar::log_level::trace, __VA_ARGS__)
+#define TRACET(...) LOGT(seastar::log_level::trace, __VA_ARGS__)
 
-#define DEBUG(...) LOG(debug, __VA_ARGS__)
-#define DEBUGT(...) LOGT(debug, __VA_ARGS__)
+#define DEBUG(...) LOG(seastar::log_level::debug, __VA_ARGS__)
+#define DEBUGT(...) LOGT(seastar::log_level::debug, __VA_ARGS__)
 
-#define INFO(...) LOG(info, __VA_ARGS__)
-#define INFOT(...) LOGT(info, __VA_ARGS__)
+#define INFO(...) LOG(seastar::log_level::info, __VA_ARGS__)
+#define INFOT(...) LOGT(seastar::log_level::info, __VA_ARGS__)
 
-#define WARN(...) LOG(warn, __VA_ARGS__)
-#define WARNT(...) LOGT(warn, __VA_ARGS__)
+#define WARN(...) LOG(seastar::log_level::warn, __VA_ARGS__)
+#define WARNT(...) LOGT(seastar::log_level::warn, __VA_ARGS__)
 
-#define ERROR(...) LOG(error, __VA_ARGS__)
-#define ERRORT(...) LOGT(error, __VA_ARGS__)
+#define ERROR(...) LOG(seastar::log_level::error, __VA_ARGS__)
+#define ERRORT(...) LOGT(seastar::log_level::error, __VA_ARGS__)
 
 #else
 // do compile-time format string validation

--- a/src/crimson/os/seastore/logging.h
+++ b/src/crimson/os/seastore/logging.h
@@ -3,10 +3,14 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include "crimson/common/log.h"
 
 #define LOGGER crimson::get_logger(ceph_subsys_seastore)
 #define LOG_PREFIX(x) constexpr auto FNAME = #x
+
+#ifdef NDEBUG
 
 #define LOG(LEVEL, MSG, ...) LOGGER . LEVEL("{}: " MSG, FNAME __VA_OPT__(,) __VA_ARGS__)
 #define LOGT(LEVEL, MSG, t, ...) LOGGER . LEVEL("{}({}): " MSG, FNAME, (void*)&t __VA_OPT__(,) __VA_ARGS__)
@@ -25,3 +29,26 @@
 
 #define ERROR(...) LOG(error, __VA_ARGS__)
 #define ERRORT(...) LOGT(error, __VA_ARGS__)
+
+#else
+// do compile-time format string validation
+using namespace fmt::literals;
+template<seastar::log_level lv>
+void LOG(std::string_view info) {
+  crimson::get_logger(ceph_subsys_seastore).log(lv, info);
+}
+#define TRACE(MSG_, ...) LOG<seastar::log_level::trace>("{}: " MSG_ ## _format(FNAME __VA_OPT__(,) __VA_ARGS__))
+#define TRACET(MSG_, t_, ...) LOG<seastar::log_level::trace>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ __VA_OPT__(,) __VA_ARGS__))
+
+#define DEBUG(MSG_, ...) LOG<seastar::log_level::debug>("{}: " MSG_ ## _format(FNAME __VA_OPT__(,) __VA_ARGS__))
+#define DEBUGT(MSG_, t_, ...) LOG<seastar::log_level::debug>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ __VA_OPT__(,) __VA_ARGS__))
+
+#define INFO(MSG_, ...) LOG<seastar::log_level::info>("{}: " MSG_ ## _format(FNAME __VA_OPT__(,) __VA_ARGS__))
+#define INFOT(MSG_, t_, ...) LOG<seastar::log_level::info>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ __VA_OPT__(,) __VA_ARGS__))
+
+#define WARN(MSG_, ...) LOG<seastar::log_level::warn>("{}: " MSG_ ## _format(FNAME __VA_OPT__(,) __VA_ARGS__))
+#define WARNT(MSG_, t_, ...) LOG<seastar::log_level::warn>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ __VA_OPT__(,) __VA_ARGS__))
+
+#define ERROR(MSG_, ...) LOG<seastar::log_level::error>("{}: " MSG_ ## _format(FNAME __VA_OPT__(,) __VA_ARGS__))
+#define ERRORT(MSG_, t_, ...) LOG<seastar::log_level::error>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ __VA_OPT__(,) __VA_ARGS__))
+#endif


### PR DESCRIPTION
libfmt does compile-time format argument validation of the format string
and the argument when the the user-defined literal is used. but the
downside is that the formatter materialize the whole formatted string
into a std::string, before printing them argument into seastar's log buffer
inserter. presumably, the inserter would be more efficient in
comparision to the pre-format approach. so this validation is only
enabled for non NDEBUG build. so it is able to help us to identify
errors like

DEBUG("{} {}", 1, 2, 3)

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
