### PR TITLE
rbd: make possible to merge image import file with import diff

### DIFF
--- a/qa/workunits/rbd/diff.sh
+++ b/qa/workunits/rbd/diff.sh
@@ -8,17 +8,50 @@ function cleanup() {
     rbd rm foo.copy || :
     rbd snap purge foo.copy2 || :
     rbd rm foo.copy2 || :
-    rm -f foo.diff foo.out
+    rbd snap purge foo.fv1 || :
+    rbd rm foo.fv1 || :
+    rbd snap purge foo.fv2 || :
+    rbd rm foo.fv2 || :
+    rm -f foo.diff foo.out foo.fv1 foo.fv2
+}
+
+function checksum() {
+    local image=$1
+
+    rbd export $image - | md5sum | awk '{print $1}'
+}
+
+function compare() {
+    local image1=$1
+    local image2=$2
+
+    if [ "$(checksum $image1)" != "$(checksum $image2)" ]; then
+        echo $image2 does not match $image1
+        return 1
+    fi
 }
 
 cleanup
 
 rbd create foo --size 1000
+rbd export --export-format 1 foo foo.fv1
+rbd export --export-format 2 foo foo.fv2
+
 rbd bench --io-type write foo --io-size 4096 --io-threads 5 --io-total 4096000 --io-pattern rand
 
 #rbd cp foo foo.copy
 rbd create foo.copy --size 1000
 rbd export-diff foo - | rbd import-diff - foo.copy
+rbd export-diff foo - | rbd import-diff - --to-file foo.fv1
+rbd export-diff foo - | rbd import-diff - --to-file foo.fv2
+
+rbd import --export-format 2 foo.fv2 foo.fv2
+rbd import --export-format 1 foo.fv1 foo.fv1
+compare foo foo.copy
+compare foo foo.fv1
+compare foo foo.fv2
+rbd rm foo.fv1
+rbd rm foo.fv2
 
 rbd snap create foo --snap=two
 rbd bench --io-type write foo --io-size 4096 --io-threads 5 --io-total 4096000 --io-pattern rand
@@ -30,22 +63,20 @@ rm -f foo.diff
 
 rbd export-diff foo@three --from-snap two foo.diff
 rbd import-diff foo.diff foo.copy
+rbd import-diff foo.diff --to-file foo.fv1
+rbd import-diff foo.diff --to-file foo.fv2
 rbd import-diff foo.diff foo.copy && exit 1 || true   # this should fail with EEXIST on the end snap
 rbd snap ls foo.copy | grep three
 
 rbd create foo.copy2 --size 1000
 rbd import-diff foo.diff foo.copy2 && exit 1 || true   # this should fail bc the start snap dne
 
-rbd export foo foo.out
-orig=`md5sum foo.out | awk '{print $1}'`
-rm foo.out
-rbd export foo.copy foo.out
-copy=`md5sum foo.out | awk '{print $1}'`
-
-if [ "$orig" != "$copy" ]; then
-    echo does not match
-    exit 1
-fi
+rbd import --export-format 1 foo.fv1 foo.fv1
+rbd import --export-format 2 foo.fv2 foo.fv2
+rbd snap ls foo.fv2 | grep three
+compare foo foo.copy
+compare foo foo.fv1
+compare foo foo.fv2
 
 cleanup
 

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -1250,6 +1250,7 @@
   usage: rbd import-diff [--path <path>] [--pool <pool>] 
                          [--namespace <namespace>] [--image <image>] 
                          [--sparse-size <sparse-size>] [--no-progress] 
+                         [--to-file <to-file>] 
                          <path-name> <image-spec> 
   
   Import an incremental diff.
@@ -1266,6 +1267,7 @@
     --image arg          image name
     --sparse-size arg    sparse size in B/K/M [default: 4K]
     --no-progress        disable progress output
+    --to-file arg        destination file
   
   rbd help info
   usage: rbd info [--pool <pool>] [--namespace <namespace>] [--image <image>] 


### PR DESCRIPTION
Sometime it is useful to be able to merge an image file obtained with `rbd export` with a consequent diff file obtained with `rbd export-diff` to produce a single "export" file.

Before this change one would need the access to a Ceph cluster (a rbd pool) to merge the files by importing them to an image and exporting back.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
