### PR TITLE
mon/MonClient: send commands to mon after connected

### DIFF
--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -306,6 +306,7 @@ private:
   void send_log(bool flush = false);
 
   bool ms_dispatch(Message *m) override;
+  void ms_handle_connect(Connection *con) final;
   bool ms_handle_reset(Connection *con) override;
   void ms_handle_remote_reset(Connection *con) override {}
   bool ms_handle_refused(Connection *con) override { return false; }


### PR DESCRIPTION
MonClient sends the pending commands to monitor once it completes the
authentication with the monitor, but the connection is not fully
established by then. it's still in its AUTH_CONNECTING_SIGN phase, and
the server has not sent its server identity to MonClient yet. this does
not happen before the connection enters READY phase.

so if there is any message sent via MonClient before the connection is
"READY", it is encoded with feature of "0", even if connection between
the connected monitor and MonClient has non-zero feature bits. and
that's the case in general.

"fortunately", we are using messenger->ms_can_fast_dispatch(m) to tell
if we can "fast_prepare" a message. and the only "can_fast_dispatch"
message sent to monitor is MMonCommand, whose encoder does not use
features at all. that's why the existing implementation works. but
this is not quite correct though, as the criteria here should be:

- if we can encode the message in the critical path. as send_message()
  is supposed to return immediately. if encoding a message takes lots
  of CPU cycles we should defer this to the messager's worker thread.
- if we can re-encode the message. for instance, if a message encodes
  its data in a destructive way, we are not allowed to re-encode it.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
