### PR TITLE
mgr/dashboard: Fix for query params resetting on change-password

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.ts
@@ -1,7 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
+import * as _ from 'lodash';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
@@ -16,7 +17,8 @@ export class AuthService {
   constructor(
     private authStorageService: AuthStorageService,
     private http: HttpClient,
-    private router: Router
+    private router: Router,
+    private route: ActivatedRoute
   ) {}
 
   check(token: string) {
@@ -40,7 +42,8 @@ export class AuthService {
   logout(callback: Function = null) {
     return this.http.post('api/auth/logout', null).subscribe((resp: any) => {
       this.authStorageService.remove();
-      this.router.navigate(['/login'], { skipLocationChange: true });
+      const url = _.get(this.route.snapshot.queryParams, 'returnUrl', '/login');
+      this.router.navigate([url], { skipLocationChange: true });
       if (callback) {
         callback();
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/change-password-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/change-password-guard.service.spec.ts
@@ -1,6 +1,6 @@
 import { Component, NgZone } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { Router, Routes } from '@angular/router';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { configureTestBed } from '~/testing/unit-test-helper';
@@ -11,6 +11,8 @@ describe('ChangePasswordGuardService', () => {
   let service: ChangePasswordGuardService;
   let authStorageService: AuthStorageService;
   let ngZone: NgZone;
+  let route: ActivatedRouteSnapshot;
+  let state: RouterStateSnapshot;
 
   @Component({ selector: 'cd-login-password-form', template: '' })
   class LoginPasswordFormComponent {}
@@ -35,30 +37,32 @@ describe('ChangePasswordGuardService', () => {
 
   it('should do nothing (not logged in)', () => {
     spyOn(authStorageService, 'isLoggedIn').and.returnValue(false);
-    expect(service.canActivate()).toBeTruthy();
+    expect(service.canActivate(route, state)).toBeTruthy();
   });
 
   it('should do nothing (SSO enabled)', () => {
     spyOn(authStorageService, 'isLoggedIn').and.returnValue(true);
     spyOn(authStorageService, 'isSSO').and.returnValue(true);
-    expect(service.canActivate()).toBeTruthy();
+    expect(service.canActivate(route, state)).toBeTruthy();
   });
 
   it('should do nothing (no update pwd required)', () => {
     spyOn(authStorageService, 'isLoggedIn').and.returnValue(true);
     spyOn(authStorageService, 'getPwdUpdateRequired').and.returnValue(false);
-    expect(service.canActivate()).toBeTruthy();
+    expect(service.canActivate(route, state)).toBeTruthy();
   });
 
-  it('should redirect to change password page', fakeAsync(() => {
+  it('should redirect to change password page by preserving the query params', fakeAsync(() => {
+    route = null;
+    state = { url: '/host', root: null };
     spyOn(authStorageService, 'isLoggedIn').and.returnValue(true);
     spyOn(authStorageService, 'isSSO').and.returnValue(false);
     spyOn(authStorageService, 'getPwdUpdateRequired').and.returnValue(true);
     const router = TestBed.inject(Router);
     ngZone.run(() => {
-      expect(service.canActivate()).toBeFalsy();
+      expect(service.canActivate(route, state)).toBeFalsy();
     });
     tick();
-    expect(router.url).toBe('/login-change-password');
+    expect(router.url).toBe('/login-change-password?returnUrl=%2Fhost');
   }));
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/change-password-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/change-password-guard.service.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, CanActivateChild, Router } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  CanActivateChild,
+  Router,
+  RouterStateSnapshot
+} from '@angular/router';
 
 import { AuthStorageService } from './auth-storage.service';
 
@@ -13,7 +19,7 @@ import { AuthStorageService } from './auth-storage.service';
 export class ChangePasswordGuardService implements CanActivate, CanActivateChild {
   constructor(private router: Router, private authStorageService: AuthStorageService) {}
 
-  canActivate() {
+  canActivate(_route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
     // Redirect to '/login-change-password' when the following constraints
     // are fulfilled:
     // - The user must be logged in.
@@ -24,13 +30,13 @@ export class ChangePasswordGuardService implements CanActivate, CanActivateChild
       !this.authStorageService.isSSO() &&
       this.authStorageService.getPwdUpdateRequired()
     ) {
-      this.router.navigate(['/login-change-password']);
+      this.router.navigate(['/login-change-password'], { queryParams: { returnUrl: state.url } });
       return false;
     }
     return true;
   }
 
-  canActivateChild(): boolean {
-    return this.canActivate();
+  canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    return this.canActivate(childRoute, state);
   }
 }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50857
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
