### PR TITLE
pybind/mgr: generalize CLICheckNonemptyFileInput() error msg

### DIFF
--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -26,6 +26,7 @@ from ..settings import Settings
 logger = logging.getLogger('access_control')
 DEFAULT_FILE_DESC = 'password/secret'
 
+
 # password hashing algorithm
 def password_hash(password, salt_password=None):
     if not password:

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -24,7 +24,7 @@ from ..security import Permission, Scope
 from ..settings import Settings
 
 logger = logging.getLogger('access_control')
-
+DEFAULT_FILE_DESC = 'password/secret'
 
 # password hashing algorithm
 def password_hash(password, salt_password=None):
@@ -549,7 +549,7 @@ def load_access_control_db():
 # CLI dashboard access control scope commands
 
 @CLIWriteCommand('dashboard set-login-credentials')
-@CLICheckNonemptyFileInput
+@CLICheckNonemptyFileInput(desc=DEFAULT_FILE_DESC)
 def set_login_credentials_cmd(_, username: str, inbuf: str):
     '''
     Set the login credentials. Password read from -i <file>
@@ -688,7 +688,7 @@ def ac_user_show_cmd(_, username: Optional[str] = None):
 
 
 @CLIWriteCommand('dashboard ac-user-create')
-@CLICheckNonemptyFileInput
+@CLICheckNonemptyFileInput(desc=DEFAULT_FILE_DESC)
 def ac_user_create_cmd(_, username: str, inbuf: str,
                        rolename: Optional[str] = None,
                        name: Optional[str] = None,
@@ -842,7 +842,7 @@ def ac_user_del_roles_cmd(_, username: str, roles: Sequence[str]):
 
 
 @CLIWriteCommand('dashboard ac-user-set-password')
-@CLICheckNonemptyFileInput
+@CLICheckNonemptyFileInput(desc=DEFAULT_FILE_DESC)
 def ac_user_set_password(_, username: str, inbuf: str,
                          force_password: bool = False):
     '''
@@ -864,7 +864,7 @@ def ac_user_set_password(_, username: str, inbuf: str,
 
 
 @CLIWriteCommand('dashboard ac-user-set-password-hash')
-@CLICheckNonemptyFileInput
+@CLICheckNonemptyFileInput(desc=DEFAULT_FILE_DESC)
 def ac_user_set_password_hash(_, username: str, inbuf: str):
     '''
     Set user password bcrypt hash from -i <file>

--- a/src/pybind/mgr/dashboard/services/iscsi_cli.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_cli.py
@@ -22,7 +22,7 @@ def list_iscsi_gateways(_):
 
 
 @CLIWriteCommand('dashboard iscsi-gateway-add')
-@CLICheckNonemptyFileInput
+@CLICheckNonemptyFileInput(desc='iSCSI gateway configuration')
 def add_iscsi_gateway(_, inbuf, name: Optional[str] = None):
     '''
     Add iSCSI gateway configuration. Gateway URL read from -i <file>

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -252,6 +252,6 @@ def handles_secret(cmd: str) -> bool:
     return bool([cmd for secret_word in ['password', 'key'] if (secret_word in cmd)])
 
 
-@CLICheckNonemptyFileInput
+@CLICheckNonemptyFileInput(desc='password/secret')
 def get_secret(inbuf=None):
     return inbuf, None, None

--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -609,7 +609,7 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
                           force_password=True)
 
         self.assertEqual(ctx.exception.retcode, -errno.EINVAL)
-        self.assertEqual(str(ctx.exception), ERROR_MSG_EMPTY_INPUT_FILE)
+        self.assertIn(ERROR_MSG_EMPTY_INPUT_FILE, str(ctx.exception))
 
     def test_set_user_password_hash(self):
         user_orig = self.test_create_user()

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -50,7 +50,7 @@ class IscsiTestCli(unittest.TestCase, CLICommandTestMixin):
                           inbuf='')
 
         self.assertEqual(ctx.exception.retcode, -errno.EINVAL)
-        self.assertEqual(str(ctx.exception), ERROR_MSG_NO_INPUT_FILE)
+        self.assertIn(ERROR_MSG_NO_INPUT_FILE, str(ctx.exception))
 
     def test_cli_add_gateway(self):
         self.exec_cmd('iscsi-gateway-add', name='node1',

--- a/src/pybind/mgr/dashboard/tests/test_settings.py
+++ b/src/pybind/mgr/dashboard/tests/test_settings.py
@@ -68,7 +68,7 @@ class SettingsTest(unittest.TestCase, KVStoreMockMixin):
         )
         self.assertEqual(r, -errno.EINVAL)
         self.assertEqual(out, '')
-        self.assertEqual(err, ERROR_MSG_EMPTY_INPUT_FILE)
+        self.assertIn(ERROR_MSG_EMPTY_INPUT_FILE, err)
 
     def test_set_secret(self):
         r, out, err = handle_option_command(

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -417,7 +417,7 @@ def CLICheckNonemptyFileInput(func: HandlerFuncType) -> HandlerFuncType:
         if isinstance(kwargs['inbuf'], str):
             # Delete new line separator at EOF (it may have been added by a text editor).
             kwargs['inbuf'] = kwargs['inbuf'].rstrip('\r\n').rstrip('\n')
-        if not kwargs['inbuf']:
+        if not kwargs['inbuf'] or not kwargs['inbuf'].strip():
             return -errno.EINVAL, '', ERROR_MSG_EMPTY_INPUT_FILE
         return func(*args, **kwargs)
     check.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -37,8 +37,8 @@ else:
         return getattr(tp, '__origin__', None)
 
 
-ERROR_MSG_EMPTY_INPUT_FILE = 'Empty content: please add a password/secret to the file.'
-ERROR_MSG_NO_INPUT_FILE = 'Please specify the file containing the password/secret with "-i" option.'
+ERROR_MSG_EMPTY_INPUT_FILE = 'Empty input file'
+ERROR_MSG_NO_INPUT_FILE = 'Input file not specified'
 # Full list of strings in "osd_types.cc:pg_state_string()"
 PG_STATES = [
     "active",
@@ -409,19 +409,23 @@ def CLIWriteCommand(prefix: str, poll: bool = False) -> CLICommand:
     return CLICommand(prefix, "w", poll)
 
 
-def CLICheckNonemptyFileInput(func: HandlerFuncType) -> HandlerFuncType:
-    @functools.wraps(func)
-    def check(*args: Any, **kwargs: Any) -> Tuple[int, str, str]:
-        if 'inbuf' not in kwargs:
-            return -errno.EINVAL, '', ERROR_MSG_NO_INPUT_FILE
-        if isinstance(kwargs['inbuf'], str):
-            # Delete new line separator at EOF (it may have been added by a text editor).
-            kwargs['inbuf'] = kwargs['inbuf'].rstrip('\r\n').rstrip('\n')
-        if not kwargs['inbuf'] or not kwargs['inbuf'].strip():
-            return -errno.EINVAL, '', ERROR_MSG_EMPTY_INPUT_FILE
-        return func(*args, **kwargs)
-    check.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
-    return check
+def CLICheckNonemptyFileInput(desc: str) -> Callable[[HandlerFuncType], HandlerFuncType]:
+    def CheckFileInput(func: HandlerFuncType) -> HandlerFuncType:
+        @functools.wraps(func)
+        def check(*args: Any, **kwargs: Any) -> Tuple[int, str, str]:
+            if 'inbuf' not in kwargs:
+                return -errno.EINVAL, '', f'{ERROR_MSG_NO_INPUT_FILE}: Please specify the file '\
+                                          f'containing {desc} with "-i" option'
+            if isinstance(kwargs['inbuf'], str):
+                # Delete new line separator at EOF (it may have been added by a text editor).
+                kwargs['inbuf'] = kwargs['inbuf'].rstrip('\r\n').rstrip('\n')
+            if not kwargs['inbuf'] or not kwargs['inbuf'].strip():
+                return -errno.EINVAL, '', f'{ERROR_MSG_EMPTY_INPUT_FILE}: Please add {desc} to '\
+                                           'the file'
+            return func(*args, **kwargs)
+        check.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
+        return check
+    return CheckFileInput
 
 
 def _get_localized_key(prefix: str, key: str) -> str:

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -190,8 +190,6 @@ class NFSCluster:
     @cluster_setter
     def set_nfs_cluster_config(self, cluster_id, nfs_config):
         try:
-            if not nfs_config:
-                raise NFSInvalidOperation("Empty Config!!")
             if cluster_id in available_clusters(self.mgr):
                 rados_obj = NFSRados(self.mgr, self.pool_ns)
                 if rados_obj.check_user_config():

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -332,8 +332,6 @@ class ExportMgr:
 
     def update_export(self, export_config):
         try:
-            if not export_config:
-                raise NFSInvalidOperation("Empty Config!!")
             new_export = json.loads(export_config)
             # check export type
             return FSExport(self).update_export(new_export)

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -1,9 +1,8 @@
-import errno
 import logging
 import threading
 from typing import Tuple, Optional, List
 
-from mgr_module import MgrModule, CLICommand, Option
+from mgr_module import MgrModule, CLICommand, Option, CLICheckNonemptyFileInput
 import orchestrator
 
 from .export import ExportMgr
@@ -58,6 +57,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.export_mgr.get_export(cluster_id=clusterid, pseudo_path=binding)
 
     @CLICommand('nfs export update', perm='rw')
+    @CLICheckNonemptyFileInput(desc='CephFS Export configuration')
     def _cmd_nfs_export_update(self, inbuf: str) -> Tuple[int, str, str]:
         """Update an export of a NFS cluster by `-i <json_file>`"""
         # The export <json_file> is passed to -i and it's processing is handled by the Ceph CLI.
@@ -94,6 +94,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.nfs.show_nfs_cluster_info(cluster_id=clusterid)
 
     @CLICommand('nfs cluster config set', perm='rw')
+    @CLICheckNonemptyFileInput(desc='NFS-Ganesha Configuration')
     def _cmd_nfs_cluster_config_set(self, clusterid: str, inbuf: str) -> Tuple[int, str, str]:
         """Set NFS-Ganesha config by `-i <config_file>`"""
         return self.nfs.set_nfs_cluster_config(cluster_id=clusterid, nfs_config=inbuf)


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->

This PR makes the following changes:
* checks if file contains only spaces
* generalize CLICheckNonemptyFileInput() error msg
* use CLICheckNonemptyFileInput decorator in nfs module

Fixes: https://tracker.ceph.com/issues/50858

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
