### PR TITLE
ceph-volume:Supports specifying osd_id that is not exist and is not in destroyed.

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
@@ -33,7 +33,7 @@ class TestOSDIDAvailable(object):
         stdout = ['', json.dumps(stdout)]
         monkeypatch.setattr('ceph_volume.process.call', lambda *a, **kw: (stdout, '', 0))
         result = prepare.osd_id_available(1)
-        assert not result
+        assert result
 
     def test_invalid_osd_id(self, monkeypatch):
         stdout = dict(nodes=[

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -176,7 +176,7 @@ def create_id(fsid, json_secrets, osd_id=None):
 
 def osd_id_available(osd_id):
     """
-    Checks to see if an osd ID exists and if it's available for
+    Checks to see if an osd ID exists or if it's available for
     reuse. Returns True if it is, False if it isn't.
 
     :param osd_id: The osd ID to check
@@ -202,6 +202,8 @@ def osd_id_available(osd_id):
     output = json.loads(''.join(stdout).strip())
     osds = output['nodes']
     osd = [osd for osd in osds if str(osd['id']) == str(osd_id)]
+    if osd is None:
+        return True
     if osd and osd[0].get('status') == "destroyed":
         return True
     return False


### PR DESCRIPTION
if osd_id specified by a does not exist, it should also meet the requirements.

 Is there any other situation that has not been considered.？

Thank you.

Signed-off-by: zhang daolong <zhangdaolong@fiberhome.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
