### PR TITLE
crimson/osd: Refactor PeeringState

### DIFF
--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -131,7 +131,7 @@ seastar::future<> AdminSocket::handle_command(crimson::net::ConnectionRef conn,
   return execute_command(m->cmd, std::move(m->get_data())).then(
     [conn, tid=m->get_tid()](auto result) {
     auto [ret, err, out] = std::move(result);
-    auto reply = crimson::net::make_message<MCommandReply>(ret, err);
+    auto reply = crimson::make_message<MCommandReply>(ret, err);
     reply->set_tid(tid);
     reply->set_data(out);
     return conn->send(std::move(reply));

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -279,7 +279,7 @@ seastar::future<> Heartbeat::handle_ping(crimson::net::ConnectionRef conn,
   auto min_message = static_cast<uint32_t>(
     local_conf()->osd_heartbeat_min_size);
   auto reply =
-    crimson::net::make_message<MOSDPing>(
+    crimson::make_message<MOSDPing>(
       m->fsid,
       service.get_osdmap_service().get_map()->get_epoch(),
       MOSDPing::PING_REPLY,
@@ -613,7 +613,7 @@ void Heartbeat::Peer::do_send_heartbeat(
   for_each_conn([&, this] (auto& conn) {
     auto min_message = static_cast<uint32_t>(
       local_conf()->osd_heartbeat_min_size);
-    auto ping = crimson::net::make_message<MOSDPing>(
+    auto ping = crimson::make_message<MOSDPing>(
       heartbeat.monc.get_fsid(),
       heartbeat.service.get_osdmap_service().get_map()->get_epoch(),
       MOSDPing::PING,
@@ -641,7 +641,7 @@ bool Heartbeat::FailingPeers::add_pending(
       now - failed_since).count();
   auto osdmap = heartbeat.service.get_osdmap_service().get_map();
   auto failure_report =
-      crimson::net::make_message<MOSDFailure>(heartbeat.monc.get_fsid(),
+      crimson::make_message<MOSDFailure>(heartbeat.monc.get_fsid(),
                                 peer,
                                 osdmap->get_addrs(peer),
                                 static_cast<int>(failed_for),
@@ -668,7 +668,7 @@ seastar::future<>
 Heartbeat::FailingPeers::send_still_alive(
     osd_id_t osd, const entity_addrvec_t& addrs)
 {
-  auto still_alive = crimson::net::make_message<MOSDFailure>(
+  auto still_alive = crimson::make_message<MOSDFailure>(
     heartbeat.monc.get_fsid(),
     osd,
     addrs,

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -366,7 +366,7 @@ seastar::future<> OSD::_send_boot()
   logger().info("hb_back_msgr: {}", heartbeat->get_back_addrs());
   logger().info("hb_front_msgr: {}", heartbeat->get_front_addrs());
   logger().info("cluster_msgr: {}", cluster_msgr->get_myaddr());
-  auto m = crimson::net::make_message<MOSDBoot>(superblock,
+  auto m = crimson::make_message<MOSDBoot>(superblock,
                                   osdmap->get_epoch(),
                                   osdmap->get_epoch(),
                                   heartbeat->get_back_addrs(),
@@ -738,7 +738,7 @@ MessageRef OSD::get_stats() const
 {
   // todo: m-to-n: collect stats using map-reduce
   // MPGStats::had_map_for is not used since PGMonitor was removed
-  auto m = make_message<MPGStats>(monc->get_fsid(), osdmap->get_epoch());
+  auto m = ceph::make_message<MPGStats>(monc->get_fsid(), osdmap->get_epoch());
   m->osd_stat = osd_stat;
   for (auto [pgid, pg] : pg_map.get_pgs()) {
     if (pg->is_primary()) {
@@ -1105,7 +1105,7 @@ seastar::future<> OSD::send_incremental_map(crimson::net::ConnectionRef conn,
   if (first >= superblock.oldest_map) {
     return load_map_bls(first, superblock.newest_map)
     .then([this, conn, first](auto&& bls) {
-      auto m = crimson::net::make_message<MOSDMap>(monc->get_fsid(),
+      auto m = crimson::make_message<MOSDMap>(monc->get_fsid(),
 	  osdmap->get_encoding_features());
       m->oldest_map = first;
       m->newest_map = superblock.newest_map;
@@ -1115,7 +1115,7 @@ seastar::future<> OSD::send_incremental_map(crimson::net::ConnectionRef conn,
   } else {
     return load_map_bl(osdmap->get_epoch())
     .then([this, conn](auto&& bl) mutable {
-      auto m = crimson::net::make_message<MOSDMap>(monc->get_fsid(),
+      auto m = crimson::make_message<MOSDMap>(monc->get_fsid(),
 	  osdmap->get_encoding_features());
       m->oldest_map = superblock.oldest_map;
       m->newest_map = superblock.newest_map;
@@ -1240,7 +1240,7 @@ seastar::future<> OSD::send_beacon()
   // FIXME: min lec should be calculated from pg_stat
   //        and should set m->pgs
   epoch_t min_last_epoch_clean = osdmap->get_epoch();
-  auto m = crimson::net::make_message<MOSDBeacon>(osdmap->get_epoch(),
+  auto m = crimson::make_message<MOSDBeacon>(osdmap->get_epoch(),
                                     min_last_epoch_clean,
                                     superblock.last_purged_snaps_scrub,
                                     local_conf()->osd_beacon_report_interval);
@@ -1346,7 +1346,7 @@ seastar::future<> OSD::prepare_to_stop()
     return seastar::with_timeout(
       seastar::timer<>::clock::now() + timeout,
       monc->send_message(
-	  crimson::net::make_message<MOSDMarkMeDown>(
+	  crimson::make_message<MOSDMarkMeDown>(
 	    monc->get_fsid(),
 	    whoami,
 	    osdmap->get_addrs(whoami),

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -157,7 +157,7 @@ ClientRequest::process_op(Ref<PG> &pg)
       [this, pg](bool completed, int ret) mutable
       -> PG::load_obc_iertr::future<> {
       if (completed) {
-        auto reply = crimson::net::make_message<MOSDOpReply>(
+        auto reply = crimson::make_message<MOSDOpReply>(
           m.get(), ret, pg->get_osdmap_epoch(),
           CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK, false);
         return conn->send(std::move(reply));
@@ -196,7 +196,7 @@ ClientRequest::do_process(Ref<PG>& pg, crimson::osd::ObjectContextRef obc)
       return seastar::now();
     } else if (const hobject_t& hoid = m->get_hobj();
                !pg->get_peering_state().can_serve_replica_read(hoid)) {
-      auto reply = crimson::net::make_message<MOSDOpReply>(
+      auto reply = crimson::make_message<MOSDOpReply>(
 	m.get(), -EAGAIN, pg->get_osdmap_epoch(),
 	m->get_flags() & (CEPH_OSD_FLAG_ACK|CEPH_OSD_FLAG_ONDISK),
 	!m->has_flag(CEPH_OSD_FLAG_RETURNVEC));

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -756,7 +756,7 @@ PG::do_osd_ops(
       if (result > 0 && !rvec) {
         result = 0;
       }
-      auto reply = make_message<MOSDOpReply>(m.get(),
+      auto reply = ceph::make_message<MOSDOpReply>(m.get(),
                                              result,
                                              get_osdmap_epoch(),
                                              0,
@@ -770,7 +770,7 @@ PG::do_osd_ops(
         std::move(reply));
     },
     [m, this] (const std::error_code& e) {
-      auto reply = make_message<MOSDOpReply>(
+      auto reply = ceph::make_message<MOSDOpReply>(
         m.get(), -e.value(), get_osdmap_epoch(), 0, false);
       reply->set_enoent_reply_versions(
         peering_state.get_info().last_update,
@@ -812,12 +812,12 @@ PG::interruptible_future<Ref<MOSDOpReply>> PG::do_pg_ops(Ref<MOSDOp> m)
     logger().debug("will be handling pg op {}", ceph_osd_op_name(osd_op.op.op));
     return ox->execute_op(osd_op);
   }).then_interruptible([m, this, ox = std::move(ox)] {
-    auto reply = make_message<MOSDOpReply>(m.get(), 0, get_osdmap_epoch(),
+    auto reply = ceph::make_message<MOSDOpReply>(m.get(), 0, get_osdmap_epoch(),
                                            CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK,
                                            false);
     return seastar::make_ready_future<Ref<MOSDOpReply>>(std::move(reply));
   }).handle_exception_type_interruptible([=](const crimson::osd::error& e) {
-    auto reply = make_message<MOSDOpReply>(
+    auto reply = ceph::make_message<MOSDOpReply>(
       m.get(), -e.code().value(), get_osdmap_epoch(), 0, false);
     reply->set_enoent_reply_versions(peering_state.get_info().last_update,
 				     peering_state.get_info().last_user_version);
@@ -1105,7 +1105,7 @@ PG::interruptible_future<> PG::handle_rep_op(Ref<MOSDRepOp> req)
       [req, lcod=peering_state.get_info().last_complete, this] {
       peering_state.update_last_complete_ondisk(lcod);
       const auto map_epoch = get_osdmap_epoch();
-      auto reply = make_message<MOSDRepOpReply>(
+      auto reply = ceph::make_message<MOSDRepOpReply>(
         req.get(), pg_whoami, 0,
 	map_epoch, req->get_min_epoch(), CEPH_OSD_FLAG_ONDISK);
       reply->set_last_complete_ondisk(lcod);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -164,9 +164,9 @@ public:
   }
 
   void send_cluster_message(
-    int osd, MessageRef m,
+    int osd, MessageURef m,
     epoch_t epoch, bool share_map_update=false) final {
-    (void)shard_services.send_to_osd(osd, m, epoch);
+    (void)shard_services.send_to_osd(osd, std::move(m), epoch);
   }
 
   void send_pg_created(pg_t pgid) final {

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -403,7 +403,7 @@ void PGRecovery::request_replica_scan(
   const hobject_t& end)
 {
   logger().debug("{}: target.osd={}", __func__, target.osd);
-  auto msg = crimson::net::make_message<MOSDPGScan>(
+  auto msg = crimson::make_message<MOSDPGScan>(
     MOSDPGScan::OP_SCAN_GET_DIGEST,
     pg->get_pg_whoami(),
     pg->get_osdmap_epoch(),
@@ -488,7 +488,7 @@ void PGRecovery::update_peers_last_backfill(
     if (const pg_info_t& pinfo = pg->get_peering_state().get_peer_info(bt);
         new_last_backfill > pinfo.last_backfill) {
       pg->get_peering_state().update_peer_last_backfill(bt, new_last_backfill);
-      auto m = crimson::net::make_message<MOSDPGBackfill>(
+      auto m = crimson::make_message<MOSDPGBackfill>(
         pinfo.last_backfill.is_max() ? MOSDPGBackfill::OP_BACKFILL_FINISH
                                      : MOSDPGBackfill::OP_BACKFILL_PROGRESS,
         pg->get_osdmap_epoch(),

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -72,7 +72,7 @@ void RecoveryBackend::handle_backfill_finish(
   logger().debug("{}", __func__);
   ceph_assert(!pg.is_primary());
   ceph_assert(crimson::common::local_conf()->osd_kill_backfill_at != 1);
-  auto reply = crimson::net::make_message<MOSDPGBackfill>(
+  auto reply = crimson::make_message<MOSDPGBackfill>(
     MOSDPGBackfill::OP_BACKFILL_FINISH_ACK,
     pg.get_osdmap_epoch(),
     m.query_epoch,
@@ -232,7 +232,7 @@ RecoveryBackend::handle_scan_get_digest(
   ).then_interruptible([this,
           query_epoch=m.query_epoch,
           conn=m.get_connection()] (auto backfill_interval) {
-    auto reply = crimson::net::make_message<MOSDPGScan>(
+    auto reply = crimson::make_message<MOSDPGScan>(
       MOSDPGScan::OP_SCAN_DIGEST,
       pg.get_pg_whoami(),
       pg.get_osdmap_epoch(),

--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -83,7 +83,7 @@ ReplicatedBackend::_submit_transaction(std::set<pg_shard_t>&& pg_shards,
 
   for (auto pg_shard : pg_shards) {
     if (pg_shard != whoami) {
-      auto m = crimson::net::make_message<MOSDRepOp>(
+      auto m = crimson::make_message<MOSDRepOp>(
 	osd_op_p.req_id,
 	whoami,
 	spg_t{pgid, pg_shard.shard},

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -53,7 +53,7 @@ ReplicatedRecoveryBackend::maybe_push_shards(
   return interruptor::parallel_for_each(get_shards_to_push(soid),
     [this, need, soid](auto shard) {
     return prep_push(soid, need, shard).then_interruptible([this, soid, shard](auto push) {
-      auto msg = crimson::net::make_message<MOSDPGPush>();
+      auto msg = crimson::make_message<MOSDPGPush>();
       msg->from = pg.get_pg_whoami();
       msg->pgid = pg.get_pgid();
       msg->map_epoch = pg.get_osdmap_epoch();
@@ -106,7 +106,7 @@ ReplicatedRecoveryBackend::maybe_pull_missing_obj(
   recovery_waiter.pi = std::make_optional<RecoveryBackend::PullInfo>();
   auto& pi = *recovery_waiter.pi;
   prepare_pull(po, pi, soid, need);
-  auto msg = crimson::net::make_message<MOSDPGPull>();
+  auto msg = crimson::make_message<MOSDPGPull>();
   msg->from = pg.get_pg_whoami();
   msg->set_priority(pg.get_recovery_op_priority());
   msg->pgid = pg.get_pgid();
@@ -144,7 +144,7 @@ ReplicatedRecoveryBackend::push_delete(
       logger().debug("push_delete: will remove {} from {}", soid, shard);
       pg.begin_peer_recover(shard, soid);
       spg_t target_pg(pg.get_info().pgid.pgid, shard.shard);
-      auto msg = crimson::net::make_message<MOSDPGRecoveryDelete>(
+      auto msg = crimson::make_message<MOSDPGRecoveryDelete>(
 	  pg.get_pg_whoami(), target_pg, pg.get_osdmap_epoch(), min_epoch);
       msg->set_priority(pg.get_recovery_op_priority());
       msg->objects.push_back(std::make_pair(soid, need));
@@ -169,7 +169,7 @@ ReplicatedRecoveryBackend::handle_recovery_delete(
   return local_recover_delete(p.first, p.second, pg.get_osdmap_epoch())
   .then_interruptible(
     [this, m] {
-    auto reply = crimson::net::make_message<MOSDPGRecoveryDeleteReply>();
+    auto reply = crimson::make_message<MOSDPGRecoveryDeleteReply>();
     reply->from = pg.get_pg_whoami();
     reply->set_priority(m->get_priority());
     reply->pgid = spg_t(pg.get_info().pgid.pgid, m->from.shard);
@@ -608,7 +608,7 @@ ReplicatedRecoveryBackend::handle_pull(Ref<MOSDPGPull> m)
         }
         return build_push_op(recovery_info, progress, 0);
       }).then_interruptible([this, from](auto pop) {
-        auto msg = crimson::net::make_message<MOSDPGPush>();
+        auto msg = crimson::make_message<MOSDPGPush>();
         msg->from = pg.get_pg_whoami();
         msg->pgid = pg.get_pgid();
         msg->map_epoch = pg.get_osdmap_epoch();
@@ -738,7 +738,7 @@ ReplicatedRecoveryBackend::handle_pull_response(
 	recovering.at(pop.soid).set_pulled();
 	return seastar::make_ready_future<>();
       } else {
-	auto reply = crimson::net::make_message<MOSDPGPull>();
+	auto reply = crimson::make_message<MOSDPGPull>();
 	reply->from = pg.get_pg_whoami();
 	reply->set_priority(m->get_priority());
 	reply->pgid = pg.get_info().pgid;
@@ -813,7 +813,7 @@ ReplicatedRecoveryBackend::handle_push(
 	});
       });
     }).then_interruptible([this, m, &response]() mutable {
-      auto reply = crimson::net::make_message<MOSDPGPushReply>();
+      auto reply = crimson::make_message<MOSDPGPushReply>();
       reply->from = pg.get_pg_whoami();
       reply->set_priority(m->get_priority());
       reply->pgid = pg.get_info().pgid;
@@ -872,7 +872,7 @@ ReplicatedRecoveryBackend::handle_push_reply(
   return _handle_push_reply(from, push_reply).then_interruptible(
     [this, from](std::optional<PushOp> push_op) {
     if (push_op) {
-      auto msg = crimson::net::make_message<MOSDPGPush>();
+      auto msg = crimson::make_message<MOSDPGPush>();
       msg->from = pg.get_pg_whoami();
       msg->pgid = pg.get_pgid();
       msg->map_epoch = pg.get_osdmap_epoch();

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -206,7 +206,7 @@ seastar::future<> ShardServices::send_pg_temp()
   for (auto& [pgid, pg_temp] : pg_temp_wanted) {
     auto& m = ms[pg_temp.forced];
     if (!m) {
-      m = crimson::net::make_message<MOSDPGTemp>(osdmap->get_epoch());
+      m = crimson::make_message<MOSDPGTemp>(osdmap->get_epoch());
       m->forced = pg_temp.forced;
     }
     m->pg_temp.emplace(pgid, pg_temp.acting);
@@ -239,7 +239,7 @@ seastar::future<> ShardServices::send_pg_created(pg_t pgid)
   auto o = get_osdmap();
   ceph_assert(o->require_osd_release >= ceph_release_t::luminous);
   pg_created.insert(pgid);
-  return monc.send_message(crimson::net::make_message<MOSDPGCreated>(pgid));
+  return monc.send_message(crimson::make_message<MOSDPGCreated>(pgid));
 }
 
 seastar::future<> ShardServices::send_pg_created()
@@ -249,7 +249,7 @@ seastar::future<> ShardServices::send_pg_created()
   ceph_assert(o->require_osd_release >= ceph_release_t::luminous);
   return seastar::parallel_for_each(pg_created,
     [this](auto &pgid) {
-      return monc.send_message(crimson::net::make_message<MOSDPGCreated>(pgid));
+      return monc.send_message(crimson::make_message<MOSDPGCreated>(pgid));
     });
 }
 
@@ -312,7 +312,7 @@ seastar::future<> ShardServices::send_alive(const epoch_t want)
         up_thru_wanted > up_thru) {
     logger().debug("{} up_thru_wanted={} up_thru={}", __func__, want, up_thru);
     return monc.send_message(
-      crimson::net::make_message<MOSDAlive>(osdmap->get_epoch(), want));
+      crimson::make_message<MOSDAlive>(osdmap->get_epoch(), want));
   } else {
     logger().debug("{} {} <= {}", __func__, want, osdmap->get_up_thru(whoami));
     return seastar::now();

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -92,7 +92,7 @@ seastar::future<> Watch::connect(crimson::net::ConnectionRef conn, bool)
 seastar::future<> Watch::send_notify_msg(NotifyRef notify)
 {
   logger().info("{} for notify(id={})", __func__, notify->ninfo.notify_id);
-  return conn->send(crimson::net::make_message<MWatchNotify>(
+  return conn->send(crimson::make_message<MWatchNotify>(
     winfo.cookie,
     notify->user_version,
     notify->ninfo.notify_id,
@@ -131,7 +131,7 @@ seastar::future<> Watch::send_disconnect_msg()
     return seastar::now();
   }
   ceph::bufferlist empty;
-  return conn->send(crimson::net::make_message<MWatchNotify>(
+  return conn->send(crimson::make_message<MWatchNotify>(
     winfo.cookie,
     0,
     0,
@@ -259,7 +259,7 @@ seastar::future<> Notify::send_completion(
   logger().debug("{} sending notify replies: {}", __func__, notify_replies);
 
   ceph::bufferlist empty;
-  auto reply = crimson::net::make_message<MWatchNotify>(
+  auto reply = crimson::make_message<MWatchNotify>(
     ninfo.cookie,
     user_version,
     ninfo.notify_id,

--- a/src/messages/MCacheExpire.h
+++ b/src/messages/MCacheExpire.h
@@ -106,7 +106,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 WRITE_CLASS_ENCODER(MCacheExpire::realm)

--- a/src/messages/MClientCapRelease.h
+++ b/src/messages/MClientCapRelease.h
@@ -53,7 +53,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 
   static constexpr int HEAD_VERSION = 2;
   static constexpr int COMPAT_VERSION = 1;

--- a/src/messages/MClientCaps.h
+++ b/src/messages/MClientCaps.h
@@ -343,7 +343,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientLease.h
+++ b/src/messages/MClientLease.h
@@ -91,7 +91,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientMetrics.h
+++ b/src/messages/MClientMetrics.h
@@ -50,7 +50,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif // CEPH_MDS_CLIENT_METRICS_H

--- a/src/messages/MClientQuota.h
+++ b/src/messages/MClientQuota.h
@@ -50,7 +50,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientReclaim.h
+++ b/src/messages/MClientReclaim.h
@@ -62,7 +62,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientReclaimReply.h
+++ b/src/messages/MClientReclaimReply.h
@@ -68,7 +68,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientReconnect.h
+++ b/src/messages/MClientReconnect.h
@@ -171,7 +171,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -401,7 +401,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -323,7 +323,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 WRITE_CLASS_ENCODER(MClientRequest::Release)

--- a/src/messages/MClientRequestForward.h
+++ b/src/messages/MClientRequestForward.h
@@ -68,7 +68,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientSession.h
+++ b/src/messages/MClientSession.h
@@ -95,7 +95,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientSnap.h
+++ b/src/messages/MClientSnap.h
@@ -67,7 +67,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MDentryLink.h
+++ b/src/messages/MDentryLink.h
@@ -76,7 +76,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MDentryUnlink.h
+++ b/src/messages/MDentryUnlink.h
@@ -67,7 +67,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MDirUpdate.h
+++ b/src/messages/MDirUpdate.h
@@ -94,7 +94,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MDiscover.h
+++ b/src/messages/MDiscover.h
@@ -96,7 +96,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MDiscoverReply.h
+++ b/src/messages/MDiscoverReply.h
@@ -211,7 +211,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportCaps.h
+++ b/src/messages/MExportCaps.h
@@ -60,7 +60,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportCapsAck.h
+++ b/src/messages/MExportCapsAck.h
@@ -54,7 +54,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDir.h
+++ b/src/messages/MExportDir.h
@@ -62,7 +62,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirAck.h
+++ b/src/messages/MExportDirAck.h
@@ -54,7 +54,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirCancel.h
+++ b/src/messages/MExportDirCancel.h
@@ -54,7 +54,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirDiscover.h
+++ b/src/messages/MExportDirDiscover.h
@@ -69,7 +69,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirDiscoverAck.h
+++ b/src/messages/MExportDirDiscoverAck.h
@@ -65,7 +65,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirFinish.h
+++ b/src/messages/MExportDirFinish.h
@@ -59,7 +59,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirNotify.h
+++ b/src/messages/MExportDirNotify.h
@@ -86,7 +86,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirNotifyAck.h
+++ b/src/messages/MExportDirNotifyAck.h
@@ -59,7 +59,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirPrep.h
+++ b/src/messages/MExportDirPrep.h
@@ -89,7 +89,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirPrepAck.h
+++ b/src/messages/MExportDirPrepAck.h
@@ -60,7 +60,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MGatherCaps.h
+++ b/src/messages/MGatherCaps.h
@@ -35,7 +35,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MHeartbeat.h
+++ b/src/messages/MHeartbeat.h
@@ -62,7 +62,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MInodeFileCaps.h
+++ b/src/messages/MInodeFileCaps.h
@@ -59,7 +59,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MLock.h
+++ b/src/messages/MLock.h
@@ -102,7 +102,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSBeacon.h
+++ b/src/messages/MMDSBeacon.h
@@ -318,7 +318,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSCacheRejoin.h
+++ b/src/messages/MMDSCacheRejoin.h
@@ -344,7 +344,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 
   static constexpr int HEAD_VERSION = 2;
   static constexpr int COMPAT_VERSION = 1;

--- a/src/messages/MMDSFindIno.h
+++ b/src/messages/MMDSFindIno.h
@@ -51,7 +51,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSFindInoReply.h
+++ b/src/messages/MMDSFindInoReply.h
@@ -51,7 +51,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSFragmentNotify.h
+++ b/src/messages/MMDSFragmentNotify.h
@@ -72,7 +72,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);  
+  friend MURef<T> crimson::make_message(Args&&... args);  
 };
 
 #endif

--- a/src/messages/MMDSFragmentNotifyAck.h
+++ b/src/messages/MMDSFragmentNotifyAck.h
@@ -58,7 +58,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSLoadTargets.h
+++ b/src/messages/MMDSLoadTargets.h
@@ -59,7 +59,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSMap.h
+++ b/src/messages/MMDSMap.h
@@ -85,7 +85,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSMetrics.h
+++ b/src/messages/MMDSMetrics.h
@@ -49,7 +49,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif // CEPH_MDS_METRICS_H

--- a/src/messages/MMDSOpenIno.h
+++ b/src/messages/MMDSOpenIno.h
@@ -55,7 +55,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSOpenInoReply.h
+++ b/src/messages/MMDSOpenInoReply.h
@@ -60,7 +60,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSPeerRequest.h
+++ b/src/messages/MMDSPeerRequest.h
@@ -229,7 +229,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSPing.h
+++ b/src/messages/MMDSPing.h
@@ -46,7 +46,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif // CEPH_MESSAGES_MMDSPING_H

--- a/src/messages/MMDSResolve.h
+++ b/src/messages/MMDSResolve.h
@@ -149,7 +149,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 inline std::ostream& operator<<(std::ostream& out, const MMDSResolve::peer_request&) {

--- a/src/messages/MMDSResolveAck.h
+++ b/src/messages/MMDSResolveAck.h
@@ -61,7 +61,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSScrub.h
+++ b/src/messages/MMDSScrub.h
@@ -123,7 +123,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 
   static constexpr unsigned FLAG_INTERNAL_TAG	= 1<<0;
   static constexpr unsigned FLAG_FORCE		= 1<<1;

--- a/src/messages/MMDSScrubStats.h
+++ b/src/messages/MMDSScrubStats.h
@@ -76,7 +76,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSSnapUpdate.h
+++ b/src/messages/MMDSSnapUpdate.h
@@ -59,7 +59,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSTableRequest.h
+++ b/src/messages/MMDSTableRequest.h
@@ -66,7 +66,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMgrConfigure.h
+++ b/src/messages/MMgrConfigure.h
@@ -82,7 +82,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMgrDigest.h
+++ b/src/messages/MMgrDigest.h
@@ -54,7 +54,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMgrMap.h
+++ b/src/messages/MMgrMap.h
@@ -54,7 +54,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMgrOpen.h
+++ b/src/messages/MMgrOpen.h
@@ -93,7 +93,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMgrReport.h
+++ b/src/messages/MMgrReport.h
@@ -198,7 +198,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MRemoveSnaps.h
+++ b/src/messages/MRemoveSnaps.h
@@ -52,7 +52,7 @@ private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
-  friend MURef<T> crimson::net::make_message(Args&&... args);
+  friend MURef<T> crimson::make_message(Args&&... args);
 };
 
 #endif

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -553,7 +553,7 @@ ceph::ref_t<T> make_message(Args&&... args) {
 }
 }
 
-namespace crimson::net {
+namespace crimson {
 template<class T, typename... Args>
 MURef<T> make_message(Args&&... args) {
   return {new T(std::forward<Args>(args)...), TOPNSPC::common::UniquePtrDeleter{}};

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -257,10 +257,10 @@ void PeeringState::purge_strays()
       psdout(10) << "sending PGRemove to osd." << *p << dendl;
       vector<spg_t> to_remove;
       to_remove.push_back(spg_t(info.pgid.pgid, p->shard));
-      auto m = make_message<MOSDPGRemove>(
+      auto m = TOPNSPC::make_message<MOSDPGRemove>(
 	get_osdmap_epoch(),
 	to_remove);
-      pl->send_cluster_message(p->osd, m, get_osdmap_epoch());
+      pl->send_cluster_message(p->osd, std::move(m), get_osdmap_epoch());
     } else {
       psdout(10) << "not sending PGRemove to down osd." << *p << dendl;
     }
@@ -1134,7 +1134,7 @@ void PeeringState::send_lease()
     }
     pl->send_cluster_message(
       peer.osd,
-      make_message<MOSDPGLease>(epoch,
+      TOPNSPC::make_message<MOSDPGLease>(epoch,
 		      spg_t(spgid.pgid, peer.shard),
 		      get_lease()),
       epoch);
@@ -1423,7 +1423,7 @@ void PeeringState::reject_reservation()
   pl->unreserve_recovery_space();
   pl->send_cluster_message(
     primary.osd,
-    make_message<MBackfillReserve>(
+    TOPNSPC::make_message<MBackfillReserve>(
       MBackfillReserve::REJECT_TOOFULL,
       spg_t(info.pgid.pgid, primary.shard),
       get_osdmap_epoch()),
@@ -2718,7 +2718,11 @@ void PeeringState::activate(
 
       psdout(10) << "activate peer osd." << peer << " " << pi << dendl;
 
+      #if defined(WITH_SEASTAR)
+      MURef<MOSDPGLog> m;
+      #else
       MRef<MOSDPGLog> m;
+      #endif
       ceph_assert(peer_missing.count(peer));
       pg_missing_t& pm = peer_missing[peer];
 
@@ -2745,7 +2749,7 @@ void PeeringState::activate(
 	} else {
 	  psdout(10) << "activate peer osd." << peer
 		     << " is up to date, but sending pg_log anyway" << dendl;
-	  m = make_message<MOSDPGLog>(
+	  m = TOPNSPC::make_message<MOSDPGLog>(
 	    i->shard, pg_whoami.shard,
 	    get_osdmap_epoch(), info,
 	    last_peering_reset);
@@ -2782,7 +2786,7 @@ void PeeringState::activate(
 	// initialize peer with our purged_snaps.
 	pi.purged_snaps = info.purged_snaps;
 
-	m = make_message<MOSDPGLog>(
+	m = TOPNSPC::make_message<MOSDPGLog>(
 	  i->shard, pg_whoami.shard,
 	  get_osdmap_epoch(), pi,
 	  last_peering_reset /* epoch to create pg at */);
@@ -2797,7 +2801,7 @@ void PeeringState::activate(
       } else {
 	// catch up
 	ceph_assert(pg_log.get_tail() <= pi.last_update);
-	m = make_message<MOSDPGLog>(
+	m = TOPNSPC::make_message<MOSDPGLog>(
 	  i->shard, pg_whoami.shard,
 	  get_osdmap_epoch(), info,
 	  last_peering_reset /* epoch to create pg at */);
@@ -2829,7 +2833,7 @@ void PeeringState::activate(
 	dout(10) << "activate peer osd." << peer << " sending " << m->log
 		 << dendl;
 	m->lease = get_lease();
-	pl->send_cluster_message(peer.osd, m, get_osdmap_epoch());
+	pl->send_cluster_message(peer.osd, std::move(m), get_osdmap_epoch());
       }
 
       // peer now has
@@ -2944,13 +2948,13 @@ void PeeringState::share_pg_info()
       peer->second.last_interval_started = info.last_interval_started;
       peer->second.history.merge(info.history);
     }
-    MessageRef m = make_message<MOSDPGInfo2>(spg_t{info.pgid.pgid, pg_shard.shard},
+    auto m = TOPNSPC::make_message<MOSDPGInfo2>(spg_t{info.pgid.pgid, pg_shard.shard},
 			  info,
 			  get_osdmap_epoch(),
 			  get_osdmap_epoch(),
 			  std::optional<pg_lease_t>{get_lease()},
 			  std::nullopt);
-    pl->send_cluster_message(pg_shard.osd, m, get_osdmap_epoch());
+    pl->send_cluster_message(pg_shard.osd, std::move(m), get_osdmap_epoch());
   }
 }
 
@@ -3075,7 +3079,7 @@ void PeeringState::fulfill_log(
   ceph_assert(from == primary);
   ceph_assert(query.type != pg_query_t::INFO);
 
-  auto mlog = make_message<MOSDPGLog>(
+  auto mlog = TOPNSPC::make_message<MOSDPGLog>(
     from.shard, pg_whoami.shard,
     get_osdmap_epoch(),
     info, query_epoch);
@@ -3101,7 +3105,7 @@ void PeeringState::fulfill_log(
 
   psdout(10) << " sending " << mlog->log << " " << mlog->missing << dendl;
 
-  pl->send_cluster_message(from.osd, mlog, get_osdmap_epoch(), true);
+  pl->send_cluster_message(from.osd, std::move(mlog), get_osdmap_epoch(), true);
 }
 
 void PeeringState::fulfill_query(const MQuery& query, PeeringCtxWrapper &rctx)
@@ -4321,7 +4325,7 @@ void PeeringState::recovery_committed_to(eversion_t version)
       // we are fully up to date.  tell the primary!
       pl->send_cluster_message(
 	get_primary().osd,
-	make_message<MOSDPGTrim>(
+	TOPNSPC::make_message<MOSDPGTrim>(
 	  get_osdmap_epoch(),
 	  spg_t(info.pgid.pgid, primary.shard),
 	  last_complete_ondisk),
@@ -4964,7 +4968,7 @@ void PeeringState::Backfilling::backfill_release_reservations()
     ceph_assert(*it != ps->pg_whoami);
     pl->send_cluster_message(
       it->osd,
-      make_message<MBackfillReserve>(
+      TOPNSPC::make_message<MBackfillReserve>(
 	MBackfillReserve::RELEASE,
 	spg_t(ps->info.pgid.pgid, it->shard),
 	ps->get_osdmap_epoch()),
@@ -5088,7 +5092,7 @@ PeeringState::WaitRemoteBackfillReserved::react(const RemoteBackfillReserved &ev
     ceph_assert(*backfill_osd_it != ps->pg_whoami);
     pl->send_cluster_message(
       backfill_osd_it->osd,
-      make_message<MBackfillReserve>(
+      TOPNSPC::make_message<MBackfillReserve>(
 	MBackfillReserve::REQUEST,
 	spg_t(context< PeeringMachine >().spgid.pgid, backfill_osd_it->shard),
 	ps->get_osdmap_epoch(),
@@ -5128,7 +5132,7 @@ void PeeringState::WaitRemoteBackfillReserved::retry()
     ceph_assert(*it != ps->pg_whoami);
     pl->send_cluster_message(
       it->osd,
-      make_message<MBackfillReserve>(
+      TOPNSPC::make_message<MBackfillReserve>(
 	MBackfillReserve::RELEASE,
 	spg_t(context< PeeringMachine >().spgid.pgid, it->shard),
 	ps->get_osdmap_epoch()),
@@ -5301,7 +5305,7 @@ PeeringState::RepWaitRecoveryReserved::react(const RemoteRecoveryReserved &evt)
   DECLARE_LOCALS;
   pl->send_cluster_message(
     ps->primary.osd,
-    make_message<MRecoveryReserve>(
+    TOPNSPC::make_message<MRecoveryReserve>(
       MRecoveryReserve::GRANT,
       spg_t(ps->info.pgid.pgid, ps->primary.shard),
       ps->get_osdmap_epoch()),
@@ -5409,7 +5413,7 @@ PeeringState::RepWaitBackfillReserved::react(const RemoteBackfillReserved &evt)
 
   pl->send_cluster_message(
       ps->primary.osd,
-      make_message<MBackfillReserve>(
+      TOPNSPC::make_message<MBackfillReserve>(
 	MBackfillReserve::GRANT,
 	spg_t(ps->info.pgid.pgid, ps->primary.shard),
 	ps->get_osdmap_epoch()),
@@ -5466,7 +5470,7 @@ PeeringState::RepRecovering::react(const RemoteRecoveryPreempted &)
   pl->unreserve_recovery_space();
   pl->send_cluster_message(
     ps->primary.osd,
-    make_message<MRecoveryReserve>(
+    TOPNSPC::make_message<MRecoveryReserve>(
       MRecoveryReserve::REVOKE,
       spg_t(ps->info.pgid.pgid, ps->primary.shard),
       ps->get_osdmap_epoch()),
@@ -5483,7 +5487,7 @@ PeeringState::RepRecovering::react(const BackfillTooFull &)
   pl->unreserve_recovery_space();
   pl->send_cluster_message(
     ps->primary.osd,
-    make_message<MBackfillReserve>(
+    TOPNSPC::make_message<MBackfillReserve>(
       MBackfillReserve::REVOKE_TOOFULL,
       spg_t(ps->info.pgid.pgid, ps->primary.shard),
       ps->get_osdmap_epoch()),
@@ -5500,7 +5504,7 @@ PeeringState::RepRecovering::react(const RemoteBackfillPreempted &)
   pl->unreserve_recovery_space();
   pl->send_cluster_message(
     ps->primary.osd,
-    make_message<MBackfillReserve>(
+    TOPNSPC::make_message<MBackfillReserve>(
       MBackfillReserve::REVOKE,
       spg_t(ps->info.pgid.pgid, ps->primary.shard),
       ps->get_osdmap_epoch()),
@@ -5604,7 +5608,7 @@ PeeringState::WaitRemoteRecoveryReserved::react(const RemoteRecoveryReserved &ev
     ceph_assert(*remote_recovery_reservation_it != ps->pg_whoami);
     pl->send_cluster_message(
       remote_recovery_reservation_it->osd,
-      make_message<MRecoveryReserve>(
+      TOPNSPC::make_message<MRecoveryReserve>(
 	MRecoveryReserve::REQUEST,
 	spg_t(context< PeeringMachine >().spgid.pgid,
 	      remote_recovery_reservation_it->shard),
@@ -5654,7 +5658,7 @@ void PeeringState::Recovering::release_reservations(bool cancel)
       continue;
     pl->send_cluster_message(
       i->osd,
-      make_message<MRecoveryReserve>(
+      TOPNSPC::make_message<MRecoveryReserve>(
 	MRecoveryReserve::RELEASE,
 	spg_t(ps->info.pgid.pgid, i->shard),
 	ps->get_osdmap_epoch()),
@@ -6352,7 +6356,7 @@ boost::statechart::result PeeringState::ReplicaActive::react(const MLease& l)
   ps->proc_lease(l.lease);
   pl->send_cluster_message(
     ps->get_primary().osd,
-    make_message<MOSDPGLeaseAck>(epoch,
+    TOPNSPC::make_message<MOSDPGLeaseAck>(epoch,
 		       spg_t(spgid.pgid, ps->get_primary().shard),
 		       ps->get_lease_ack()),
     epoch);

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -265,8 +265,13 @@ public:
     virtual uint64_t get_snap_trimq_size() const = 0;
 
     /// Send cluster message to osd
+    #if defined(WITH_SEASTAR)
+    virtual void send_cluster_message(
+      int osd, MessageURef m, epoch_t epoch, bool share_map_update=false) = 0;
+    #else
     virtual void send_cluster_message(
       int osd, MessageRef m, epoch_t epoch, bool share_map_update=false) = 0;
+    #endif
     /// Send pg_created to mon
     virtual void send_pg_created(pg_t pgid) = 0;
 


### PR DESCRIPTION
Follow up PR to #40931 
PeeringState is shared between crimson-osd and ceph-osd and it uses wrapper methods to the underlying conn::send() method which was refactored in the mentioned PR.

Signed-off-by: Amnon Hanuhov <ahanukov@redhat.com>