### PR TITLE
doc/security: Add single GPG key in lieu of existing three GPG keys

### DIFF
--- a/doc/security/index.rst
+++ b/doc/security/index.rst
@@ -25,13 +25,12 @@ To report a vulnerability, please send email to `security@ceph.io
   report.
 
 Although you are not required to, you may encrypt your message using 
-the following GPG keys:
+the following GPG key:
 
-`08B7 3419 AC32 B4E9 66C1  A330 E84A C2C0 460F 3994 <https://keyserver.ubuntu.com/pks/lookup?search=0x08b73419ac32b4e966c1a330e84ac2c0460f3994&fingerprint=on&op=index>`_
+**6EEF26FFD4093B99: Ceph Security Team (security@ceph.io)**
 
-`A72E 2206 BC85 31EE 964B  6FF8 FF69 432F 307A 807F <https://keyserver.ubuntu.com/pks/lookup?search=0xA72E2206BC8531EE964B6FF8FF69432F307A807F&fingerprint=on&op=index>`_
-
-`CD64 14F0 E2A8 3D47 CBCD  2990 9827 12C0 12E8 8B35 <https://keyserver.ubuntu.com/pks/lookup?search=0xcd6414f0e2a83d47cbcd2990982712c012e88b35&fingerprint=on&op=index>`_
+| **Download:** `MIT PGP Public Key Server <https://pgp.mit.edu/pks/lookup?op=vindex&search=0x6EEF26FFD4093B99>`_
+| **Fingerprint:** A527 D019 21F9 7178 C232 66C1 6EEF 26FF D409 3B99
 
 
 Supported versions


### PR DESCRIPTION
Replace existing three GPG keys with new Ceph Security Team GPG key

Signed-off-by: Hardik Vyas <hvyas@redhat.com>