### PR TITLE
common/crc32c_aarch64: fix crc32c unittest failed on aarch64

### DIFF
--- a/src/common/crc32c_aarch64.c
+++ b/src/common/crc32c_aarch64.c
@@ -147,7 +147,7 @@ uint32_t ceph_crc32c_aarch64(uint32_t crc, unsigned char const *buffer, unsigned
 			"mov    x16,            #0x8014         \n\t"
 			"movk   x16,            #0x8f15, lsl 16 \n\t"
 			"mov    v0.2d[0],       x16             \n\t"
-			:::"x16");
+			:::"x16","v0","v1");
 
 		while ((length -= 1024) >= 0) {
 			PREF1KL2(1024*3);
@@ -178,7 +178,8 @@ uint32_t ceph_crc32c_aarch64(uint32_t crc, unsigned char const *buffer, unsigned
 				"crc32cx        %w[c0],         wzr,    %x[c0]  \n\t"
 				"eor            %w[c],          %w[c],  %w[c0]  \n\t"
 				:[c1]"+r"(crc1), [c0]"+r"(crc0), [c2]"+r"(crc2), [c]"+r"(crc)
-				:[v]"r"(*((const uint64_t *)buffer)));
+				:[v]"r"(*((const uint64_t *)buffer))
+				:"v0","v1","v2","v3");
 			buffer += sizeof(uint64_t);
 		}
 #endif /* HAVE_ARMV8_CRC_CRYPTO_INTRINSICS */
@@ -229,7 +230,7 @@ uint32_t ceph_crc32c_aarch64(uint32_t crc, unsigned char const *buffer, unsigned
 		__asm__("mov    x16,            #0xf38a         \n\t"
 			"movk   x16,            #0xe417, lsl 16 \n\t"
 			"mov    v1.2d[0],       x16             \n\t"
-			:::"x16");
+			:::"x16","v1");
 
 		while ((length -= 1024) >= 0) {
 			__asm__("crc32cx %w[c0], %w[c], xzr\n\t"
@@ -247,7 +248,8 @@ uint32_t ceph_crc32c_aarch64(uint32_t crc, unsigned char const *buffer, unsigned
 				"mov            %x[c0],         v3.2d[0]        \n\t"
 				"crc32cx        %w[c],          wzr,    %x[c0]  \n\t"
 				:[c]"=r"(crc)
-				:[c0]"r"(crc0));
+				:[c0]"r"(crc0)
+				:"v1","v3");
 		}
 #endif /* HAVE_ARMV8_CRC_CRYPTO_INTRINSICS */
 


### PR DESCRIPTION
On centos 8.2 for aarch64 with gcc 8.3, the complier will use
register v0 conflicting with the register v0 be usded in inline
asm code. Adding the related registers into clobber list to inform
complier avoiding the confict.

Fixes: https://tracker.ceph.com/issues/50835

Signed-off-by: luo rixin <luorixin@huawei.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
