### PR TITLE
crimson/osd, common: implement the inject{m,}dataerr admin commands

### DIFF
--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -20,6 +20,13 @@
 using crimson::osd::OSD;
 using namespace crimson::common;
 
+namespace {
+seastar::logger& logger()
+{
+  return crimson::get_logger(ceph_subsys_osd);
+}
+}  // namespace
+
 namespace crimson::admin {
 
 using crimson::common::local_conf;
@@ -264,5 +271,106 @@ private:
   }
 };
 template std::unique_ptr<AdminSocketHook> make_asok_hook<SeastarMetricsHook>();
+
+
+static ghobject_t test_ops_get_object_name(
+  const OSDMap& osdmap,
+  const cmdmap_t& cmdmap)
+{
+  auto pool = [&] {
+    auto pool_arg = cmd_getval<std::string>(cmdmap, "pool");
+    if (!pool_arg) {
+      throw std::invalid_argument{"No 'pool' specified"};
+    }
+    int64_t pool = osdmap.lookup_pg_pool_name(*pool_arg);
+    if (pool < 0 && std::isdigit((*pool_arg)[0])) {
+      pool = std::atoll(pool_arg->c_str());
+    }
+    if (pool < 0) {
+      // the return type of `fmt::format` is `std::string`
+      using namespace fmt::literals;
+      throw std::invalid_argument{
+        "Invalid pool '{}'"_format(*pool_arg)
+      };
+    }
+    return pool;
+  }();
+
+  auto [ objname, nspace, raw_pg ] = [&] {
+    auto obj_arg = cmd_getval<std::string>(cmdmap, "objname");
+    if (!obj_arg) {
+      throw std::invalid_argument{"No 'objname' specified"};
+    }
+    std::string objname, nspace;
+    if (std::size_t sep_pos = obj_arg->find_first_of('/');
+        sep_pos != obj_arg->npos) {
+      nspace = obj_arg->substr(0, sep_pos);
+      objname = obj_arg->substr(sep_pos+1);
+    } else {
+      objname = *obj_arg;
+    }
+    pg_t raw_pg;
+    if (object_locator_t oloc(pool, nspace);
+        osdmap.object_locator_to_pg(object_t(objname), oloc,  raw_pg) < 0) {
+      throw std::invalid_argument{"Invalid namespace/objname"};
+    }
+    return std::make_tuple(std::move(objname),
+                           std::move(nspace),
+                           std::move(raw_pg));
+  }();
+
+  auto shard_id = cmd_getval_or<int64_t>(cmdmap,
+					 "shardid",
+					 shard_id_t::NO_SHARD);
+
+  return ghobject_t{
+    hobject_t{
+      object_t{objname}, std::string{}, CEPH_NOSNAP, raw_pg.ps(), pool, nspace
+    },
+    ghobject_t::NO_GEN,
+    shard_id_t{static_cast<int8_t>(shard_id)}
+  };
+}
+
+// Usage:
+//   injectdataerr <pool> [namespace/]<obj-name> [shardid]
+class InjectDataErrorHook : public AdminSocketHook {
+public:
+  InjectDataErrorHook(crimson::osd::ShardServices& shard_services)  :
+   AdminSocketHook("injectdataerr",
+    "name=pool,type=CephString " \
+    "name=objname,type=CephObjectname " \
+    "name=shardid,type=CephInt,req=false,range=0|255",
+    "inject data error to an object"),
+   shard_services(shard_services) {
+  }
+
+  seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
+				      std::string_view format,
+				      ceph::bufferlist&& input) const final
+  {
+    ghobject_t obj;
+    try {
+      obj = test_ops_get_object_name(*shard_services.get_osdmap(), cmdmap);
+    } catch (const std::invalid_argument& e) {
+      logger().info("error during data error injection: {}", e.what());
+      return seastar::make_ready_future<tell_result_t>(-EINVAL,
+	                                               e.what());
+    }
+    return shard_services.get_store().inject_data_error(obj).then([=] {
+      logger().info("successfully injected data error for obj={}", obj);
+      ceph::bufferlist bl;
+      bl.append("ok"sv);
+      return seastar::make_ready_future<tell_result_t>(0,
+						       std::string{}, // no err
+						       std::move(bl));
+    });
+  }
+
+private:
+  crimson::osd::ShardServices& shard_services;
+};
+template std::unique_ptr<AdminSocketHook> make_asok_hook<InjectDataErrorHook>(
+  crimson::osd::ShardServices&);
 
 } // namespace crimson::admin

--- a/src/crimson/admin/osd_admin.h
+++ b/src/crimson/admin/osd_admin.h
@@ -16,6 +16,7 @@ class DumpPGStateHistory;
 class SeastarMetricsHook;
 class DumpPerfCountersHook;
 class InjectDataErrorHook;
+class InjectMDataErrorHook;
 
 template<class Hook, class... Args>
 std::unique_ptr<AdminSocketHook> make_asok_hook(Args&&... args);

--- a/src/crimson/admin/osd_admin.h
+++ b/src/crimson/admin/osd_admin.h
@@ -15,6 +15,7 @@ class SendBeaconHook;
 class DumpPGStateHistory;
 class SeastarMetricsHook;
 class DumpPerfCountersHook;
+class InjectDataErrorHook;
 
 template<class Hook, class... Args>
 std::unique_ptr<AdminSocketHook> make_asok_hook(Args&&... args);

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -400,6 +400,22 @@ seastar::future<> AlienStore::do_transaction(CollectionRef ch,
     });
 }
 
+seastar::future<> AlienStore::inject_data_error(const ghobject_t& o)
+{
+  logger().debug("{}", __func__);
+  return tp->submit([=] {
+    return store->inject_data_error(o);
+  });
+}
+
+seastar::future<> AlienStore::inject_mdata_error(const ghobject_t& o)
+{
+  logger().debug("{}", __func__);
+  return tp->submit([=] {
+    return store->inject_mdata_error(o);
+  });
+}
+
 seastar::future<> AlienStore::write_meta(const std::string& key,
                                          const std::string& value)
 {

--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -90,6 +90,10 @@ public:
   seastar::future<> do_transaction(CollectionRef c,
                                    ceph::os::Transaction&& txn) final;
 
+  // error injection
+  seastar::future<> inject_data_error(const ghobject_t& o) final;
+  seastar::future<> inject_mdata_error(const ghobject_t& o) final;
+
   seastar::future<> write_meta(const std::string& key,
                   const std::string& value) final;
   seastar::future<std::tuple<int, std::string>> read_meta(

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -131,6 +131,14 @@ public:
 
   virtual seastar::future<> do_transaction(CollectionRef ch,
 					   ceph::os::Transaction&& txn) = 0;
+  // error injection
+  virtual seastar::future<> inject_data_error(const ghobject_t& o) {
+    return seastar::now();
+  }
+  virtual seastar::future<> inject_mdata_error(const ghobject_t& o) {
+    return seastar::now();
+  }
+
   virtual seastar::future<OmapIteratorRef> get_omap_iterator(
     CollectionRef ch,
     const ghobject_t& oid) = 0;

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -444,6 +444,7 @@ seastar::future<> OSD::start_asok_admin()
       asok->register_command(make_asok_hook<SeastarMetricsHook>()),
       asok->register_command(make_asok_hook<DumpPerfCountersHook>()),
       asok->register_command(make_asok_hook<InjectDataErrorHook>(get_shard_services())),
+      asok->register_command(make_asok_hook<InjectMDataErrorHook>(get_shard_services())),
       // PG commands
       asok->register_command(make_asok_hook<pg::QueryCommand>(*this)),
       asok->register_command(make_asok_hook<pg::MarkUnfoundLostCommand>(*this)));

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -443,6 +443,7 @@ seastar::future<> OSD::start_asok_admin()
       asok->register_command(make_asok_hook<DumpPGStateHistory>(std::as_const(*this))),
       asok->register_command(make_asok_hook<SeastarMetricsHook>()),
       asok->register_command(make_asok_hook<DumpPerfCountersHook>()),
+      asok->register_command(make_asok_hook<InjectDataErrorHook>(get_shard_services())),
       // PG commands
       asok->register_command(make_asok_hook<pg::QueryCommand>(*this)),
       asok->register_command(make_asok_hook<pg::MarkUnfoundLostCommand>(*this)));


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
