### PR TITLE
test/librbd: add unit tests for rbd update features

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -717,6 +717,8 @@ Context *ImageWatcher<I>::remove_async_request(const AsyncRequestId &id,
                                                ceph::shared_mutex &lock) {
   ceph_assert(ceph_mutex_is_locked(lock));
 
+  ldout(m_image_ctx.cct, 20) << __func__ << ": " << id << dendl;
+
   auto it = m_async_requests.find(id);
   if (it != m_async_requests.end()) {
     Context *on_complete = it->second.first;

--- a/src/librbd/image_watcher/NotifyLockOwner.cc
+++ b/src/librbd/image_watcher/NotifyLockOwner.cc
@@ -80,6 +80,7 @@ void NotifyLockOwner::handle_notify(int r) {
     decode(response_message, iter);
 
     r = response_message.result;
+    ldout(cct, 20) << " client responded with r=" << r << dendl;
   } catch (const buffer::error &err) {
     r = -EINVAL;
   }

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -217,6 +217,13 @@ public:
         *id = payload.async_request_id;
       }
       return true;
+    case NOTIFY_OP_UPDATE_FEATURES:
+      {
+        UpdateFeaturesPayload payload;
+        payload.decode(7, iter);
+        *id = payload.async_request_id;
+      }
+      return true;
     default:
       break;
     }
@@ -431,6 +438,23 @@ struct RebuildObjectMapTask {
   }
 };
 
+struct UpdateFeaturesTask {
+  librbd::ImageCtx *ictx;
+  int result;
+
+  UpdateFeaturesTask(librbd::ImageCtx *ictx)
+    : ictx(ictx), result(0) {}
+
+  void operator()() {
+    std::shared_lock l{ictx->owner_lock};
+    C_SaferCond ctx;
+    uint64_t features = 24;
+    bool enabled = 0;
+    ictx->image_watcher->notify_update_features(0, features, enabled, &ctx);
+    result = ctx.wait();
+  }
+};
+
 TEST_F(TestImageWatcher, NotifyHeaderUpdate) {
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
@@ -550,6 +574,36 @@ TEST_F(TestImageWatcher, NotifyRebuildObjectMap) {
 
   ASSERT_TRUE(thread.timed_join(boost::posix_time::seconds(10)));
   ASSERT_EQ(0, rebuild_task.result);
+}
+
+TEST_F(TestImageWatcher, NotifyUpdateFeatures) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  ASSERT_EQ(0, register_image_watch(*ictx));
+  ASSERT_EQ(0, lock_image(*ictx, ClsLockType::EXCLUSIVE,
+        "auto " + stringify(m_watch_ctx->get_handle())));
+
+  m_notify_acks = {{NOTIFY_OP_UPDATE_FEATURES, create_response_message(0)}};
+
+  UpdateFeaturesTask update_features_task(ictx);
+  boost::thread thread(boost::ref(update_features_task));
+
+  ASSERT_TRUE(wait_for_notifies(*ictx));
+
+  NotifyOps expected_notify_ops;
+  expected_notify_ops += NOTIFY_OP_UPDATE_FEATURES;
+  ASSERT_EQ(expected_notify_ops, m_notifies);
+
+  AsyncRequestId async_request_id;
+  ASSERT_TRUE(extract_async_request_id(NOTIFY_OP_UPDATE_FEATURES,
+					&async_request_id));
+
+  ASSERT_EQ(0, notify_async_complete(ictx, async_request_id, 0));
+  ASSERT_TRUE(thread.timed_join(boost::posix_time::seconds(10)));
+  ASSERT_EQ(0, update_features_task.result);
 }
 
 TEST_F(TestImageWatcher, NotifySnapCreate) {


### PR DESCRIPTION
this additon is just for added coverage which I was using to debug/reproduce
rbd upgrade tests failures.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug




---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
