### PR TITLE
octopus: rgw: fix bucket object listing when marker matches prefix

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -484,6 +484,7 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   bool has_delimiter = !op.delimiter.empty();
 
   if (has_delimiter &&
+      start_after_key > op.filter_prefix &&
       boost::algorithm::ends_with(start_after_key, op.delimiter)) {
     // advance past all subdirectory entries if we start after a
     // subdirectory


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50709

---

backport of https://github.com/ceph/ceph/pull/41141
parent tracker: https://tracker.ceph.com/issues/50621

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh