### PR TITLE
octopus: rgw/rgw_file: Fix the return value of read() and readlink()

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -298,7 +298,7 @@ namespace rgw {
 
     int rc = rgwlib.get_fe()->execute_req(&req);
     if ((rc == 0) &&
-	(req.get_ret() == 0)) {
+        ((rc = req.get_ret()) == 0)) {
       lock_guard guard(rgw_fh->mtx);
       rgw_fh->set_atime(real_clock::to_timespec(real_clock::now()));
       *bytes_read = req.nread;
@@ -322,7 +322,7 @@ namespace rgw {
 
     int rc = rgwlib.get_fe()->execute_req(&req);
     if ((rc == 0) &&
-        (req.get_ret() == 0)) {
+        ((rc = req.get_ret()) == 0)) {
       lock_guard(rgw_fh->mtx);
       rgw_fh->set_atime(real_clock::to_timespec(real_clock::now()));
       *bytes_read = req.nread;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50730

---

backport of https://github.com/ceph/ceph/pull/38729
parent tracker: https://tracker.ceph.com/issues/49189

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh