### PR TITLE
test/crimson/CMakeLists.txt: fix name of unittest-interruptible-future

### DIFF
--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -74,13 +74,13 @@ add_executable(unittest-fixed-kv-node-layout
   test_fixed_kv_node_layout.cc)
 add_ceph_unittest(unittest-fixed-kv-node-layout)
 
-add_executable(unittest_interruptible_future
+add_executable(unittest-interruptible-future
   test_interruptible_future.cc
   gtest_seastar.cc)
-add_ceph_unittest(unittest_interruptible_future
+add_ceph_unittest(unittest-interruptible-future
   --memory 256M --smp 1)
 target_link_libraries(
-  unittest_interruptible_future
+  unittest-interruptible-future
   crimson-common)
 
 add_subdirectory(seastore)


### PR DESCRIPTION
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
