### PR TITLE
pacific: mgr/dashboard: fix ESOCKETTIMEDOUT E2E failure

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress.json
+++ b/src/pybind/mgr/dashboard/frontend/cypress.json
@@ -7,6 +7,7 @@
   "supportFile": "cypress/support/index.ts",
   "video": false,
   "defaultCommandTimeout": 120000,
+  "responseTimeout": 45000,
   "viewportHeight": 1080,
   "viewportWidth": 1920,
   "projectId": "k7ab29",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50882

---

backport of https://github.com/ceph/ceph/pull/41104
parent tracker: https://tracker.ceph.com/issues/49828

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh