### PR TITLE
librbd/cache/pwl: change pmemobj library to libpmem

### DIFF
--- a/doc/rbd/rbd-persistent-write-log-cache.rst
+++ b/doc/rbd/rbd-persistent-write-log-cache.rst
@@ -60,6 +60,11 @@ Here are some cache configuration settings:
 - ``rbd_persistent_cache_size`` The cache size per image. The minimum cache
   size is 1 GB.
 
+- ``rbd_persistent_cache_allow_simulation`` This is a debug option. It is
+  used to allow ``rwl`` mode to run on any device, suggested to be used only
+  when `DAX`_ feature cannot be used on the device. By default the value is
+  false.
+
 The above configurations can be set per-host, per-pool, per-image etc. Eg, to
 set per-host, add the overrides to the appropriate `section`_ in the host's
 ``ceph.conf`` file. To set per-pool, per-image, etc, please refer to the

--- a/qa/suites/rbd/pwl-cache/home/5-cache-mode/rwl.yaml
+++ b/qa/suites/rbd/pwl-cache/home/5-cache-mode/rwl.yaml
@@ -3,3 +3,4 @@ overrides:
     conf:
       client:
         rbd_persistent_cache_mode: rwl
+        rbd_persistent_cache_allow_simulation: true

--- a/qa/suites/rbd/pwl-cache/tmpfs/5-cache-mode/rwl.yaml
+++ b/qa/suites/rbd/pwl-cache/tmpfs/5-cache-mode/rwl.yaml
@@ -3,3 +3,4 @@ overrides:
     conf:
       client:
         rbd_persistent_cache_mode: rwl
+        rbd_persistent_cache_allow_simulation: true

--- a/src/common/options/rbd.yaml.in
+++ b/src/common/options/rbd.yaml.in
@@ -846,6 +846,13 @@ options:
   default: /tmp
   services:
   - rbd
+- name: rbd_persistent_cache_allow_simulation
+  type: bool
+  level: advanced
+  desc: allow rwl to be run on any device, not only pmem
+  default: false
+  services:
+  - rbd
 - name: rbd_quiesce_notification_attempts
   type: uint
   level: dev

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -291,7 +291,8 @@ if(WITH_RBD_RWL OR WITH_RBD_SSD_CACHE)
         cache/pwl/rwl/LogEntry.cc
         cache/pwl/rwl/LogOperation.cc
         cache/pwl/rwl/ReadRequest.cc
-        cache/pwl/rwl/Request.cc)
+        cache/pwl/rwl/Request.cc
+        cache/pwl/rwl/PmemManager.cc)
     endif()
 
   add_library(librbd_plugin_pwl_cache SHARED

--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -1497,8 +1497,8 @@ bool AbstractWriteLog<I>::check_allocation(
     uint32_t num_unpublished_reserves) {
   bool alloc_succeeds = true;
   bool no_space = false;
+  std::lock_guard locker(m_lock);
   {
-    std::lock_guard locker(m_lock);
     if (m_free_lanes < num_lanes) {
       ldout(m_image_ctx.cct, 20) << "not enough free lanes (need "
                                  <<  num_lanes
@@ -1531,26 +1531,18 @@ bool AbstractWriteLog<I>::check_allocation(
   }
 
   if (alloc_succeeds) {
-    std::lock_guard locker(m_lock);
     /* We need one free log entry per extent (each is a separate entry), and
      * one free "lane" for remote replication. */
-    if ((m_free_lanes >= num_lanes) &&
-        (m_free_log_entries >= num_log_entries) &&
-        (m_bytes_allocated_cap >= m_bytes_allocated + bytes_allocated)) {
-      m_free_lanes -= num_lanes;
-      m_free_log_entries -= num_log_entries;
-      m_unpublished_reserves += num_unpublished_reserves;
-      m_bytes_allocated += bytes_allocated;
-      m_bytes_cached += bytes_cached;
-      m_bytes_dirty += bytes_dirtied;
-    } else {
-      alloc_succeeds = false;
-    }
+    m_free_lanes -= num_lanes;
+    m_free_log_entries -= num_log_entries;
+    m_unpublished_reserves += num_unpublished_reserves;
+    m_bytes_allocated += bytes_allocated;
+    m_bytes_cached += bytes_cached;
+    m_bytes_dirty += bytes_dirtied;
   }
 
   if (!alloc_succeeds && no_space) {
     /* Expedite flushing and/or retiring */
-    std::lock_guard locker(m_lock);
     m_alloc_failed_since_retire = true;
     m_last_alloc_fail = ceph_clock_now();
   }

--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -1527,7 +1527,7 @@ bool AbstractWriteLog<I>::check_allocation(
   }
 
   if (alloc_succeeds) {
-    reserve_cache(req, alloc_succeeds, no_space);
+    alloc_cache(req, alloc_succeeds, no_space);
   }
 
   if (alloc_succeeds) {

--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -436,8 +436,8 @@ void AbstractWriteLog<I>::update_sync_points(std::map<uint64_t, bool> &missing_s
           sync_point_entry->bytes += gen_write_entry->ram_entry.write_bytes;
           sync_point_entry->writes_completed++;
           m_blocks_to_log_entries.add_log_entry(gen_write_entry);
-          /* This entry is only dirty if its sync gen number is > the flushed
-           * sync gen number from the root object. */
+          /* This entry is only dirty if its sync gen number > the flushed
+           * sync gen number from the superblock. */
           if (gen_write_entry->ram_entry.sync_gen_number > m_flushed_sync_gen) {
             m_dirty_log_entries.push_back(log_entry);
             m_bytes_dirty += gen_write_entry->bytes_dirty();

--- a/src/librbd/cache/pwl/AbstractWriteLog.h
+++ b/src/librbd/cache/pwl/AbstractWriteLog.h
@@ -321,8 +321,6 @@ protected:
 
   PerfCounters *m_perfcounter = nullptr;
 
-  unsigned int m_unpublished_reserves = 0;
-
   ContextWQ m_work_queue;
 
   void wake_up();
@@ -353,8 +351,7 @@ protected:
 
   bool check_allocation(
       C_BlockIORequestT *req, uint64_t bytes_cached, uint64_t bytes_dirtied,
-      uint64_t bytes_allocated, uint32_t num_log_entries,
-      uint32_t num_unpublished_reserves);
+      uint64_t bytes_allocated, uint32_t num_log_entries);
   void append_scheduled(
       pwl::GenericLogOperations &ops, bool &ops_remain, bool &appending,
       bool isRWL=false);

--- a/src/librbd/cache/pwl/AbstractWriteLog.h
+++ b/src/librbd/cache/pwl/AbstractWriteLog.h
@@ -393,11 +393,7 @@ protected:
   virtual void alloc_cache(C_BlockIORequestT *req, bool &alloc_succeeds,
                              bool &no_space) {}
   virtual void construct_flush_entries(pwl::GenericLogEntries entries_to_flush,
-					DeferredContexts &post_unlock,
-					bool has_write_entry) = 0;
-  virtual uint64_t get_max_extent() {
-    return 0;
-  }
+      DeferredContexts &post_unlock, bool has_write_entry) = 0;
   void update_image_cache_state(void);
 };
 

--- a/src/librbd/cache/pwl/AbstractWriteLog.h
+++ b/src/librbd/cache/pwl/AbstractWriteLog.h
@@ -390,7 +390,7 @@ protected:
   virtual void schedule_flush_and_append(
       pwl::GenericLogOperationsVector &ops) {}
   virtual void persist_last_flushed_sync_gen() {}
-  virtual void reserve_cache(C_BlockIORequestT *req, bool &alloc_succeeds,
+  virtual void alloc_cache(C_BlockIORequestT *req, bool &alloc_succeeds,
                              bool &no_space) {}
   virtual void construct_flush_entries(pwl::GenericLogEntries entries_to_flush,
 					DeferredContexts &post_unlock,

--- a/src/librbd/cache/pwl/LogEntry.cc
+++ b/src/librbd/cache/pwl/LogEntry.cc
@@ -16,7 +16,7 @@ namespace pwl {
 
 std::ostream& GenericLogEntry::format(std::ostream &os) const {
   os << "ram_entry=[" << ram_entry
-     << "], cache_entry=" << (void*)cache_entry
+     << "], cache_entry=" << reinterpret_cast<void *>(cache_entry)
      << ", log_entry_index=" << log_entry_index
      << ", completed=" << completed;
   return os;
@@ -88,7 +88,7 @@ void WriteLogEntry::init(bool has_data,
 std::ostream& WriteLogEntry::format(std::ostream &os) const {
   os << "(Write) ";
   GenericWriteLogEntry::format(os);
-  os << ", cache_buffer=" << (void*)cache_buffer;
+  os << ", cache_buffer=" << reinterpret_cast<void *>(cache_buffer);
   os << ", cache_bp=" << cache_bp;
   os << ", bl_refs=" << bl_refs;
   return os;

--- a/src/librbd/cache/pwl/LogEntry.h
+++ b/src/librbd/cache/pwl/LogEntry.h
@@ -169,7 +169,7 @@ protected:
 
   virtual void init_bl(buffer::ptr &bp, buffer::list &bl) {}
 public:
-  uint8_t *cache_buffer = nullptr;
+  char *cache_buffer = nullptr;   // runtime addr for pmem write
   WriteLogEntry(std::shared_ptr<SyncPointLogEntry> sync_point_entry,
                 uint64_t image_offset_bytes, uint64_t write_bytes)
     : GenericWriteLogEntry(sync_point_entry, image_offset_bytes, write_bytes),

--- a/src/librbd/cache/pwl/LogOperation.cc
+++ b/src/librbd/cache/pwl/LogOperation.cc
@@ -266,7 +266,7 @@ WriteLogOperationSet::~WriteLogOperationSet() { }
 
 std::ostream &operator<<(std::ostream &os,
                          const WriteLogOperationSet &s) {
-  os << "cell=" << (void*)s.cell
+  os << "cell=" << reinterpret_cast<void *>(s.cell)
      << ", extent_ops_appending=" << s.extent_ops_appending
      << ", extent_ops_persist=" << s.extent_ops_persist;
   return os;

--- a/src/librbd/cache/pwl/LogOperation.h
+++ b/src/librbd/cache/pwl/LogOperation.h
@@ -51,7 +51,7 @@ public:
   virtual void appending() = 0;
   virtual void complete(int r) = 0;
   virtual void mark_log_entry_completed() {};
-  virtual bool reserved_allocated() const {
+  virtual bool allocated() const {
     return false;
   }
   virtual bool is_writing_op() const {
@@ -115,7 +115,7 @@ public:
   void mark_log_entry_completed() override{
     sync_point->log_entry->writes_completed++;
   }
-  bool reserved_allocated() const override {
+  bool allocated() const override {
     return true;
   }
   bool is_writing_op() const override {
@@ -209,7 +209,7 @@ public:
   const std::shared_ptr<GenericLogEntry> get_log_entry() override {
     return log_entry;
   }
-  bool reserved_allocated() const override {
+  bool allocated() const override {
     return false;
   }
   std::ostream &format(std::ostream &os) const;

--- a/src/librbd/cache/pwl/Request.cc
+++ b/src/librbd/cache/pwl/Request.cc
@@ -373,8 +373,8 @@ void C_FlushRequest<T>::dispatch() {
 
 template <typename T>
 void C_FlushRequest<T>::setup_buffer_resources(
-    uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-    uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) {
+    uint64_t *bytes_cached, uint64_t *bytes_dirtied,
+    uint64_t *bytes_allocated, uint64_t *number_log_entries) {
   *number_log_entries = 1;
 }
 
@@ -456,8 +456,8 @@ void C_DiscardRequest<T>::dispatch() {
 
 template <typename T>
 void C_DiscardRequest<T>::setup_buffer_resources(
-    uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-    uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) {
+    uint64_t *bytes_cached, uint64_t *bytes_dirtied,
+    uint64_t *bytes_allocated, uint64_t *number_log_entries) {
   *number_log_entries = 1;
   /* No bytes are allocated for a discard, but we count the discarded bytes
    * as dirty.  This means it's possible to have more bytes dirty than

--- a/src/librbd/cache/pwl/Request.cc
+++ b/src/librbd/cache/pwl/Request.cc
@@ -163,7 +163,7 @@ void C_WriteRequest<T>::finish_req(int r) {
     update_req_stats(now);
     return;
   }
-  pwl.release_write_lanes(this);
+  pwl.attempt_to_dispatch_deferred_writes();
   ceph_assert(m_resources.allocated);
   m_resources.allocated = false;
   this->release_cell(); /* TODO: Consider doing this in appending state */
@@ -268,11 +268,8 @@ void C_WriteRequest<T>::schedule_append() {
 
 /**
  * Attempts to allocate log resources for a write. Returns true if successful.
- *
- * Resources include 1 lane per extent, 1 log entry per extent, and the payload
- * data space for each extent.
- *
- * Lanes are released after the write persists via release_write_lanes()
+ * Resources include 1 log entry per extent, and the payload data space for
+ * each extent.
  */
 template <typename T>
 bool C_WriteRequest<T>::alloc_resources() {
@@ -377,8 +374,7 @@ void C_FlushRequest<T>::dispatch() {
 template <typename T>
 void C_FlushRequest<T>::setup_buffer_resources(
     uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-    uint64_t *number_lanes, uint64_t *number_log_entries,
-    uint64_t *number_unpublished_reserves) {
+    uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) {
   *number_log_entries = 1;
 }
 
@@ -461,8 +457,7 @@ void C_DiscardRequest<T>::dispatch() {
 template <typename T>
 void C_DiscardRequest<T>::setup_buffer_resources(
     uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-    uint64_t *number_lanes, uint64_t *number_log_entries,
-    uint64_t *number_unpublished_reserves) {
+    uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) {
   *number_log_entries = 1;
   /* No bytes are allocated for a discard, but we count the discarded bytes
    * as dirty.  This means it's possible to have more bytes dirty than

--- a/src/librbd/cache/pwl/Request.h
+++ b/src/librbd/cache/pwl/Request.h
@@ -87,8 +87,7 @@ public:
 
   virtual void setup_buffer_resources(
       uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-      uint64_t *number_lanes, uint64_t *number_log_entries,
-      uint64_t *number_unpublished_reserves) = 0;
+      uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) = 0;
 
 protected:
   utime_t m_arrived_time;
@@ -211,8 +210,7 @@ public:
 
   void setup_buffer_resources(
       uint64_t *bytes_cached, uint64_t *bytes_dirtied,
-      uint64_t *bytes_allocated, uint64_t *number_lanes,
-      uint64_t *number_log_entries,
+      uint64_t *bytes_allocated, uint64_t *number_log_entries,
       uint64_t *number_unpublished_reserves) override;
 private:
   std::shared_ptr<SyncPointLogOperation> op;
@@ -262,8 +260,7 @@ public:
   }
   void setup_buffer_resources(
       uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-      uint64_t *number_lanes, uint64_t *number_log_entries,
-      uint64_t *number_unpublished_reserves) override;
+      uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) override;
 private:
   uint32_t m_discard_granularity_bytes;
   ceph::mutex &m_lock;

--- a/src/librbd/cache/pwl/Request.h
+++ b/src/librbd/cache/pwl/Request.h
@@ -86,8 +86,8 @@ public:
   }
 
   virtual void setup_buffer_resources(
-      uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-      uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) = 0;
+      uint64_t *bytes_cached, uint64_t *bytes_dirtied,
+      uint64_t *bytes_allocated, uint64_t *number_log_entries) = 0;
 
 protected:
   utime_t m_arrived_time;
@@ -210,8 +210,7 @@ public:
 
   void setup_buffer_resources(
       uint64_t *bytes_cached, uint64_t *bytes_dirtied,
-      uint64_t *bytes_allocated, uint64_t *number_log_entries,
-      uint64_t *number_unpublished_reserves) override;
+      uint64_t *bytes_allocated, uint64_t *number_log_entries) override;
 private:
   std::shared_ptr<SyncPointLogOperation> op;
   ceph::mutex &m_lock;
@@ -259,8 +258,8 @@ public:
     return "C_DiscardRequest";
   }
   void setup_buffer_resources(
-      uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-      uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) override;
+      uint64_t *bytes_cached, uint64_t *bytes_dirtied,
+      uint64_t *bytes_allocated, uint64_t *number_log_entries) override;
 private:
   uint32_t m_discard_granularity_bytes;
   ceph::mutex &m_lock;

--- a/src/librbd/cache/pwl/Types.cc
+++ b/src/librbd/cache/pwl/Types.cc
@@ -67,7 +67,6 @@ void WriteLogCacheEntry::dump(Formatter *f) const {
   f->dump_bool("discard", is_discard());
   f->dump_bool("writesame", is_writesame());
   f->dump_unsigned("ws_datalen", ws_datalen);
-  f->dump_unsigned("entry_index", entry_index);
 }
 
 void WriteLogCacheEntry::generate_test_instances(std::list<WriteLogCacheEntry*>& ls) {
@@ -85,7 +84,6 @@ void WriteLogCacheEntry::generate_test_instances(std::list<WriteLogCacheEntry*>&
   ls.back()->set_discard(true);
   ls.back()->set_writesame(true);
   ls.back()->ws_datalen = 1;
-  ls.back()->entry_index = 1;
 }
 
 void WriteLogSuperblock::dump(Formatter *f) const {
@@ -125,8 +123,7 @@ std::ostream& operator<<(std::ostream& os,
      << ", write_sequence_number=" << entry.write_sequence_number
      << ", image_offset_bytes=" << entry.image_offset_bytes
      << ", write_bytes=" << entry.write_bytes
-     << ", ws_datalen=" << entry.ws_datalen
-     << ", entry_index=" << entry.entry_index;
+     << ", ws_datalen=" << entry.ws_datalen;
   return os;
 }
 

--- a/src/librbd/cache/pwl/Types.cc
+++ b/src/librbd/cache/pwl/Types.cc
@@ -88,7 +88,7 @@ void WriteLogCacheEntry::generate_test_instances(std::list<WriteLogCacheEntry*>&
   ls.back()->entry_index = 1;
 }
 
-void WriteLogPoolRoot::dump(Formatter *f) const {
+void WriteLogSuperblock::dump(Formatter *f) const {
   f->dump_unsigned("layout_version", layout_version);
   f->dump_unsigned("cur_sync_gen", cur_sync_gen);
   f->dump_unsigned("pool_size", pool_size);
@@ -99,9 +99,9 @@ void WriteLogPoolRoot::dump(Formatter *f) const {
   f->dump_unsigned("first_valid_entry", first_valid_entry);
 }
 
-void WriteLogPoolRoot::generate_test_instances(std::list<WriteLogPoolRoot*>& ls) {
-  ls.push_back(new WriteLogPoolRoot());
-  ls.push_back(new WriteLogPoolRoot);
+void WriteLogSuperblock::generate_test_instances(std::list<WriteLogSuperblock*>& ls) {
+  ls.push_back(new WriteLogSuperblock());
+  ls.push_back(new WriteLogSuperblock);
   ls.back()->layout_version = 2;
   ls.back()->cur_sync_gen = 1;
   ls.back()->pool_size = 1024;

--- a/src/librbd/cache/pwl/Types.h
+++ b/src/librbd/cache/pwl/Types.h
@@ -145,7 +145,7 @@ enum {
   WRITE_LOG_CACHE_ENTRY_SYNC_POINT = 1U << 1, /* No data. No write sequence number.
                                                  Marks sync point for this sync gen number */
   WRITE_LOG_CACHE_ENTRY_SEQUENCED = 1U << 2,  /* write sequence number is valid */
-  WRITE_LOG_CACHE_ENTRY_HAS_DATA = 1U << 3,   /* write_data field is valid (else ignore) */
+  WRITE_LOG_CACHE_ENTRY_HAS_DATA = 1U << 3,   /* write_data_pos field is valid (else ignore) */
   WRITE_LOG_CACHE_ENTRY_DISCARD = 1U << 4,    /* has_data will be 0 if this is a discard */
   WRITE_LOG_CACHE_ENTRY_WRITESAME = 1U << 5,  /* ws_datalen indicates length of data at write_bytes */
 };
@@ -210,13 +210,7 @@ struct WriteLogCacheEntry {
   uint64_t write_sequence_number = 0;
   uint64_t image_offset_bytes;
   uint64_t write_bytes;
-  #ifdef WITH_RBD_RWL
-  uint64_t write_data = 0;     /* offset in pmem,
-                                * 1 offset == MIN_WRITE_ALLOC_SIZE Byte */
-  #endif
-  #ifdef WITH_RBD_SSD_CACHE
-  uint64_t write_data_pos = 0; /* SSD data offset */
-  #endif
+  uint64_t write_data_pos = 0;  /* offset in pmem or SSD */
   uint8_t flags = 0;
   uint32_t ws_datalen = 0;  /* Length of data buffer (writesame only) */
   uint32_t entry_index = 0; /* For debug consistency check. Can be removed if

--- a/src/librbd/cache/pwl/Types.h
+++ b/src/librbd/cache/pwl/Types.h
@@ -38,7 +38,6 @@ enum {
   l_librbd_pwl_wr_req,             // write requests
   l_librbd_pwl_wr_bytes,           // bytes written
   l_librbd_pwl_wr_req_def,         // write requests deferred for resources
-  l_librbd_pwl_wr_req_def_lanes,   // write requests deferred for lanes
   l_librbd_pwl_wr_req_def_log,     // write requests deferred for log entries
   l_librbd_pwl_wr_req_def_buf,     // write requests deferred for buffer space
   l_librbd_pwl_wr_req_overlap,     // write requests detained for overlap

--- a/src/librbd/cache/pwl/Types.h
+++ b/src/librbd/cache/pwl/Types.h
@@ -163,8 +163,8 @@ const int IN_FLIGHT_FLUSH_BYTES_LIMIT = (1 * 1024 * 1024);
 const uint64_t MAX_WRITES_PER_SYNC_POINT = 256;
 const uint64_t MAX_BYTES_PER_SYNC_POINT = (1024 * 1024 * 8);
 
-const uint32_t MIN_WRITE_ALLOC_SIZE = 512;
-const uint32_t MIN_WRITE_ALLOC_SSD_SIZE = 4096;
+const uint32_t PMEM_MIN_WRITE_ALLOC_SIZE = 4096;
+const uint32_t SSD_MIN_WRITE_ALLOC_SIZE = 4096;
 const uint32_t LOG_STATS_INTERVAL_SECONDS = 5;
 
 /**** Write log entries ****/

--- a/src/librbd/cache/pwl/Types.h
+++ b/src/librbd/cache/pwl/Types.h
@@ -213,8 +213,6 @@ struct WriteLogCacheEntry {
   uint64_t write_data_pos = 0;  /* offset in pmem or SSD */
   uint8_t flags = 0;
   uint32_t ws_datalen = 0;  /* Length of data buffer (writesame only) */
-  uint32_t entry_index = 0; /* For debug consistency check. Can be removed if
-                             * we need the space */
   WriteLogCacheEntry(uint64_t image_offset_bytes=0, uint64_t write_bytes=0)
       : image_offset_bytes(image_offset_bytes), write_bytes(write_bytes) {}
   BlockExtent block_extent();
@@ -300,7 +298,6 @@ struct WriteLogCacheEntry {
     denc(v.write_data_pos, p);
     denc(v.flags, p);
     denc(v.ws_datalen, p);
-    denc(v.entry_index, p);
     DENC_FINISH(p);
   }
   #endif

--- a/src/librbd/cache/pwl/Types.h
+++ b/src/librbd/cache/pwl/Types.h
@@ -97,12 +97,8 @@ enum {
   l_librbd_pwl_nowait_req_all_to_dis_t,   // Time spent allocating or waiting to allocate resources
   l_librbd_pwl_nowait_wr_latency,         // average req (persist) completion latency
   l_librbd_pwl_nowait_wr_latency_hist,    // Histogram of write req (persist) completion latency vs. bytes written
-  l_librbd_pwl_nowait_wr_caller_latency,  // average req completion (to caller) latency
 
   /* Log operation times */
-  l_librbd_pwl_log_op_alloc_t,      // elapsed time of pmemobj_reserve()
-  l_librbd_pwl_log_op_alloc_t_hist, // Histogram of elapsed time of pmemobj_reserve()
-
   l_librbd_pwl_log_op_dis_to_buf_t, // dispatch to buffer persist elapsed time
   l_librbd_pwl_log_op_dis_to_app_t, // dispatch to log append elapsed time
   l_librbd_pwl_log_op_dis_to_cmp_t, // dispatch to persist completion elapsed time

--- a/src/librbd/cache/pwl/Types.h
+++ b/src/librbd/cache/pwl/Types.h
@@ -176,14 +176,14 @@ const uint32_t LOG_STATS_INTERVAL_SECONDS = 5;
 const unsigned long int MAX_ALLOC_PER_TRANSACTION = 8;
 const unsigned long int MAX_FREE_PER_TRANSACTION = 1;
 const unsigned int MAX_CONCURRENT_WRITES = (1024 * 1024);
-const unsigned int SECOND_ROOT_OFFSET = 1u << 11;
-const unsigned int MAX_ROOT_LEN = 1u << 11;
+const unsigned int SECOND_SUPERBLOCK_OFFSET = 1u << 11;
+const unsigned int MAX_SUPERBLOCK_LEN = 1u << 11;
 const unsigned int FIRST_ENTRY_OFFSET = 1u << 12;
 
 const uint64_t DEFAULT_POOL_SIZE = 1u << 30;
 const uint64_t MIN_POOL_SIZE = DEFAULT_POOL_SIZE;
 const uint64_t POOL_SIZE_ALIGN = 1 << 20;
-/* The unusable spaces include root and entry.
+/* The unusable spaces include superblock and entries.
  * If modification is necessary, please calculate carefully */
 constexpr double USABLE_SIZE = (7.0 / 10);
 const uint64_t BLOCK_ALLOC_OVERHEAD_BYTES = 16;
@@ -319,7 +319,7 @@ struct WriteLogCacheEntry {
   static void generate_test_instances(std::list<WriteLogCacheEntry*>& ls);
 };
 
-struct WriteLogPoolRoot {
+struct WriteLogSuperblock {
   #ifdef WITH_RBD_RWL
   uint32_t crc = 0;
   /* To make superblock update atomic. If one of the superblocks fails to
@@ -348,7 +348,7 @@ struct WriteLogPoolRoot {
   uint64_t first_valid_entry;   /* The oldest valid entry to be retired */
 
   #ifdef WITH_RBD_SSD_CACHE
-  DENC(WriteLogPoolRoot, v, p) {
+  DENC(WriteLogSuperblock, v, p) {
     DENC_START(1, 1, p);
     denc(v.layout_version, p);
     denc(v.cur_sync_gen, p);
@@ -363,7 +363,7 @@ struct WriteLogPoolRoot {
   #endif
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<WriteLogPoolRoot*>& ls);
+  static void generate_test_instances(std::list<WriteLogSuperblock*>& ls);
 };
 
 struct WriteBufferAllocation {
@@ -436,7 +436,7 @@ std::string unique_lock_name(const std::string &name, void *address);
 
 #ifdef WITH_RBD_SSD_CACHE
 WRITE_CLASS_DENC(librbd::cache::pwl::WriteLogCacheEntry)
-WRITE_CLASS_DENC(librbd::cache::pwl::WriteLogPoolRoot)
+WRITE_CLASS_DENC(librbd::cache::pwl::WriteLogSuperblock)
 #endif
 
 #endif // CEPH_LIBRBD_CACHE_PWL_TYPES_H

--- a/src/librbd/cache/pwl/rwl/LogEntry.cc
+++ b/src/librbd/cache/pwl/rwl/LogEntry.cc
@@ -49,9 +49,9 @@ void WriteLogEntry::init_bl(buffer::ptr &bp, buffer::list &bl) {
 
 void WriteLogEntry::init_cache_buffer(
     std::vector<WriteBufferAllocation>::iterator allocation) {
-  this->ram_entry.write_data = allocation->pmem_offset;
-  ceph_assert(this->ram_entry.write_data);
-  cache_buffer = allocation->pmem_head_addr + this->ram_entry.write_data;
+  this->ram_entry.write_data_pos = allocation->pmem_offset;
+  ceph_assert(this->ram_entry.write_data_pos);
+  cache_buffer = allocation->pmem_head_addr + this->ram_entry.write_data_pos;
 }
 
 buffer::list& WriteLogEntry::get_cache_bl() {

--- a/src/librbd/cache/pwl/rwl/LogEntry.cc
+++ b/src/librbd/cache/pwl/rwl/LogEntry.cc
@@ -30,7 +30,7 @@ void WriteLogEntry::writeback(
 void WriteLogEntry::init_cache_bp() {
   ceph_assert(!this->cache_bp.have_raw());
   cache_bp = buffer::ptr(buffer::create_static(this->write_bytes(),
-                                               (char*)this->cache_buffer));
+                                               this->cache_buffer));
 }
 
 void WriteLogEntry::init_bl(buffer::ptr &bp, buffer::list &bl) {
@@ -49,9 +49,9 @@ void WriteLogEntry::init_bl(buffer::ptr &bp, buffer::list &bl) {
 
 void WriteLogEntry::init_cache_buffer(
     std::vector<WriteBufferAllocation>::iterator allocation) {
-  this->ram_entry.write_data = allocation->buffer_oid;
-  ceph_assert(!TOID_IS_NULL(this->ram_entry.write_data));
-  cache_buffer = D_RW(this->ram_entry.write_data);
+  this->ram_entry.write_data = allocation->pmem_offset;
+  ceph_assert(this->ram_entry.write_data);
+  cache_buffer = allocation->pmem_head_addr + this->ram_entry.write_data;
 }
 
 buffer::list& WriteLogEntry::get_cache_bl() {

--- a/src/librbd/cache/pwl/rwl/LogOperation.cc
+++ b/src/librbd/cache/pwl/rwl/LogOperation.cc
@@ -21,7 +21,7 @@ void WriteLogOperation::copy_bl_to_cache_buffer(
   m_perfcounter->inc(l_librbd_pwl_log_op_bytes, log_entry->write_bytes());
   ldout(m_cct, 20) << bl << dendl;
   log_entry->init_cache_buffer(allocation);
-  i.copy((unsigned)log_entry->write_bytes(), (char*)log_entry->cache_buffer);
+  i.copy((unsigned)log_entry->write_bytes(), log_entry->cache_buffer);
 }
 
 void DiscardLogOperation::init_op(

--- a/src/librbd/cache/pwl/rwl/PmemManager.cc
+++ b/src/librbd/cache/pwl/rwl/PmemManager.cc
@@ -18,9 +18,18 @@ PmemDev::PmemDev(const char * path, const uint64_t size, CephContext *cct)
   : m_lock(ceph::make_mutex(pwl::unique_lock_name(
       "librbd::cache::pwl::PmemManager::m_lock", this))),
     m_cct(cct) {
+  bool allow_simulation = cct->_conf.get_val<bool>(
+      "rbd_persistent_cache_allow_simulation");
   m_head_addr = create_dev(path, size);
   if (!m_head_addr) {
     lderr(m_cct) << "failed to create pmem device." << dendl;
+    return;
+  }
+  if (allow_simulation == false && m_is_pmem == false) {
+    close_dev();
+    lderr(m_cct) << "err: the hardware does not support pmem,"
+                 << " and debug simulation is not enabled."
+                 << dendl;
     return;
   }
   m_max_offset = p2align(m_mapped_len, min_write_alloc_size);
@@ -36,9 +45,18 @@ PmemDev::PmemDev(const char * path, CephContext *cct)
   : m_lock(ceph::make_mutex(pwl::unique_lock_name(
       "librbd::cache::pwl::PmemManager::m_lock", this))),
     m_cct(cct) {
+  bool allow_simulation = cct->_conf.get_val<bool>(
+      "rbd_persistent_cache_allow_simulation");
   m_head_addr = open_dev(path);
   if (!m_head_addr) {
     lderr(m_cct) << "failed to create pmem device." << dendl;
+    return;
+  }
+  if (allow_simulation == false && m_is_pmem == false) {
+    close_dev();
+    lderr(m_cct) << "err: the hardware does not support pmem"
+                 << " and debug simulation is not enabled."
+                 << dendl;
     return;
   }
   m_max_offset = p2align(m_mapped_len, min_write_alloc_size);

--- a/src/librbd/cache/pwl/rwl/PmemManager.cc
+++ b/src/librbd/cache/pwl/rwl/PmemManager.cc
@@ -1,0 +1,190 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "PmemManager.h"
+
+#undef dout_subsys
+#define dout_subsys ceph_subsys_rbd_pwl
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::cache::pwl::rwl::PmemManager: " \
+                           << this << " " <<  __func__ << ": "
+
+namespace librbd::cache::pwl::rwl {
+
+/* p2align and p2roundup require uint64_t, keep the same with offset */
+static const uint64_t min_write_alloc_size = MIN_WRITE_ALLOC_SIZE;
+
+PmemDev::PmemDev(const char * path, const uint64_t size, CephContext *cct)
+  : m_lock(ceph::make_mutex(pwl::unique_lock_name(
+      "librbd::cache::pwl::PmemManager::m_lock", this))),
+    m_cct(cct) {
+  m_head_addr = create_dev(path, size);
+  if (!m_head_addr) {
+    lderr(m_cct) << "failed to create pmem device." << dendl;
+    return;
+  }
+  m_max_offset = p2align(m_mapped_len, min_write_alloc_size);
+  ldout(m_cct, 5) << "successfully created pmem Device."
+                  << " m_is_pmem: " << m_is_pmem
+                  << " m_head_addr: " << reinterpret_cast<void *>(m_head_addr)
+                  << " m_mapped_len: " << m_mapped_len
+                  << " m_max_offset: " << m_max_offset
+                  << dendl;
+}
+
+PmemDev::PmemDev(const char * path, CephContext *cct)
+  : m_lock(ceph::make_mutex(pwl::unique_lock_name(
+      "librbd::cache::pwl::PmemManager::m_lock", this))),
+    m_cct(cct) {
+  m_head_addr = open_dev(path);
+  if (!m_head_addr) {
+    lderr(m_cct) << "failed to create pmem device." << dendl;
+    return;
+  }
+  m_max_offset = p2align(m_mapped_len, min_write_alloc_size);
+  ldout(m_cct, 5) << "successfully map existing pmem Device."
+                  << " m_is_pmem: " << m_is_pmem
+                  << " m_head_addr: " << reinterpret_cast<void *>(m_head_addr)
+                  << " m_mapped_len: " << m_mapped_len
+                  << " m_max_offset: " << m_max_offset
+                  << dendl;
+}
+
+PmemDev::~PmemDev() {
+}
+
+std::unique_ptr<PmemDev> PmemDev::pmem_create_dev(const char *path,
+    const uint64_t size, CephContext *cct) {
+  std::unique_ptr<PmemDev> pmem_dev;
+  pmem_dev = std::make_unique<PmemDev>(path, size, cct);
+  if (!pmem_dev->m_head_addr) {
+    return nullptr;
+  }
+  return pmem_dev;
+}
+
+std::unique_ptr<PmemDev> PmemDev::pmem_open_dev(const char *path,
+                                                CephContext *cct) {
+  std::unique_ptr<PmemDev> pmem_dev;
+  pmem_dev = std::make_unique<PmemDev>(path, cct);
+  if (!pmem_dev->m_head_addr) {
+    return nullptr;
+  }
+  return pmem_dev;
+}
+
+char *PmemDev::create_dev(const char *path, const uint64_t size) {
+  int is_pmem = 0;
+  char *head_addr = nullptr;
+
+  /* create a pmem file and memory map it */
+  head_addr = (char *)pmem_map_file(path, size,
+              PMEM_FILE_CREATE | PMEM_FILE_SPARSE,
+              0666, &m_mapped_len, &is_pmem);
+  if (head_addr) {
+    m_is_pmem = is_pmem;
+  } else {
+    lderr(m_cct) << "failed to map new pmem file." << dendl;
+  }
+
+  return head_addr;
+}
+
+char *PmemDev::open_dev(const char *path) {
+  int is_pmem = 0;
+  char *head_addr = nullptr;
+
+  /* Memory map an existing file */
+  head_addr = (char *)pmem_map_file(path, 0, 0, 0, &m_mapped_len, &is_pmem);
+  if (head_addr) {
+    m_is_pmem = is_pmem;
+  } else {
+    lderr(m_cct) << "failed to map existing pmem file." << dendl;
+  }
+
+  return head_addr;
+}
+
+void PmemDev::close_dev() {
+  pmem_unmap(m_head_addr, m_mapped_len);
+  m_head_addr = nullptr;
+}
+
+void PmemDev::init_data_offset(uint64_t metadata_size) {
+  m_first_data_offset = p2roundup(metadata_size, min_write_alloc_size);
+  m_first_valid_offset = m_first_data_offset;
+  m_first_free_offset = m_first_data_offset;
+  ldout(m_cct, 5) << "init pmem space."
+                  << " m_first_data_offset: " << m_first_data_offset
+                  << " m_first_free_offset: " << m_first_free_offset
+                  << " m_first_valid_offset: " << m_first_valid_offset
+                  << dendl;
+}
+
+void PmemDev::set_data_offset(uint64_t metadata_size,
+                              uint64_t first_valid_offset,
+                              uint64_t the_last_valid_entry_end_offset) {
+  m_first_data_offset = p2roundup(metadata_size, min_write_alloc_size);
+  m_first_valid_offset = first_valid_offset;
+  m_first_free_offset = p2roundup(the_last_valid_entry_end_offset,
+                                  min_write_alloc_size);
+  ldout(m_cct, 5) << "successfully recovery pmem data space."
+                  << " m_first_data_offset: " << m_first_data_offset
+                  << " m_first_free_offset: " << m_first_free_offset
+                  << " m_first_valid_offset: " << m_first_valid_offset
+                  << dendl;
+}
+
+uint64_t PmemDev::alloc(uint64_t size) {
+  /* keep m_first_free_offset to m_first_valid_offset at least 1 offset free
+   * to distinguish full allocated space from full free space */
+  uint64_t ret_offset = 0;
+  uint64_t aligned_size = p2roundup(size, min_write_alloc_size);
+
+  std::lock_guard locker(m_lock);
+  if ((m_first_valid_offset <= m_first_free_offset &&
+       m_first_free_offset + aligned_size < m_max_offset) ||
+      (m_first_valid_offset > m_first_free_offset &&
+       m_first_free_offset + aligned_size < m_first_valid_offset)) {
+    m_first_free_offset += aligned_size;
+    ret_offset = m_first_free_offset - aligned_size;
+  } else if (m_first_valid_offset <= m_first_free_offset &&
+             m_first_free_offset + aligned_size >= m_max_offset &&
+             m_first_data_offset + aligned_size < m_first_valid_offset) {
+    m_first_free_offset = m_first_data_offset + aligned_size;
+    ret_offset = m_first_data_offset;
+  } else {
+    ldout(m_cct, 20) << "allocation failed, no space. size: " << size << dendl;
+    return 0;
+  }
+
+  ldout(m_cct, 20) << "allocation succeeded, start offset: " << ret_offset
+                   << " size: " << size
+                   << " new m_first_free_offset: " << m_first_free_offset
+                   << dendl;
+  return ret_offset;
+}
+
+void PmemDev::release(uint64_t the_last_entry_end_offset) {
+  std::lock_guard locker(m_lock);
+  m_first_valid_offset = p2roundup(the_last_entry_end_offset,
+                                   min_write_alloc_size);
+  ldout(m_cct, 20) << "m_first_valid_offset: " << m_first_valid_offset
+                   << " release to entry, end offset: "
+                   << the_last_entry_end_offset
+                   << dendl;
+}
+
+char *PmemDev::get_head_addr() const {
+  return m_head_addr;
+}
+
+uint64_t PmemDev::get_mapped_len() {
+  return m_mapped_len;
+}
+
+bool PmemDev::is_pmem() {
+  return m_is_pmem;
+}
+
+} // namespace librbd::cache::pwl::rwl

--- a/src/librbd/cache/pwl/rwl/PmemManager.cc
+++ b/src/librbd/cache/pwl/rwl/PmemManager.cc
@@ -12,7 +12,7 @@
 namespace librbd::cache::pwl::rwl {
 
 /* p2align and p2roundup require uint64_t, keep the same with offset */
-static const uint64_t min_write_alloc_size = MIN_WRITE_ALLOC_SIZE;
+static const uint64_t min_write_alloc_size = PMEM_MIN_WRITE_ALLOC_SIZE;
 
 PmemDev::PmemDev(const char * path, const uint64_t size, CephContext *cct)
   : m_lock(ceph::make_mutex(pwl::unique_lock_name(

--- a/src/librbd/cache/pwl/rwl/PmemManager.cc
+++ b/src/librbd/cache/pwl/rwl/PmemManager.cc
@@ -96,9 +96,9 @@ char *PmemDev::create_dev(const char *path, const uint64_t size) {
   char *head_addr = nullptr;
 
   /* create a pmem file and memory map it */
-  head_addr = (char *)pmem_map_file(path, size,
+  head_addr = static_cast<char *>(pmem_map_file(path, size,
               PMEM_FILE_CREATE | PMEM_FILE_SPARSE,
-              0666, &m_mapped_len, &is_pmem);
+              0666, &m_mapped_len, &is_pmem));
   if (head_addr) {
     m_is_pmem = is_pmem;
   } else {
@@ -113,7 +113,8 @@ char *PmemDev::open_dev(const char *path) {
   char *head_addr = nullptr;
 
   /* Memory map an existing file */
-  head_addr = (char *)pmem_map_file(path, 0, 0, 0, &m_mapped_len, &is_pmem);
+  head_addr = static_cast<char *>(pmem_map_file(path, 0, 0, 0,
+                                                &m_mapped_len, &is_pmem));
   if (head_addr) {
     m_is_pmem = is_pmem;
   } else {

--- a/src/librbd/cache/pwl/rwl/PmemManager.h
+++ b/src/librbd/cache/pwl/rwl/PmemManager.h
@@ -45,7 +45,7 @@ private:
    *                                   m_first_valid_offset               m_max_offset
    */
 
-  /* offset all align to MIN_WRITE_ALLOC_SIZE */
+  /* offset all align to PMEM_MIN_WRITE_ALLOC_SIZE */
   uint64_t m_max_offset = 0;             /* the max aligned offset */
   uint64_t m_first_data_offset = 0;      /* skip superblock and entry area */
   uint64_t m_first_free_offset = 0;      /* for alloc, data head +1 */

--- a/src/librbd/cache/pwl/rwl/PmemManager.h
+++ b/src/librbd/cache/pwl/rwl/PmemManager.h
@@ -1,0 +1,56 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CACHE_RWL_PMEMMANAGER_H
+#define CEPH_LIBRBD_CACHE_RWL_PMEMMANAGER_H
+
+#include <libpmem.h>
+#include "librbd/cache/pwl/Types.h"
+
+namespace librbd::cache::pwl::rwl {
+
+class PmemDev {
+ public:
+  static std::unique_ptr<PmemDev> pmem_create_dev(const char *path,
+      const uint64_t size, CephContext *cct);
+  static std::unique_ptr<PmemDev> pmem_open_dev(const char *path,
+      CephContext *cct);
+  char *create_dev(const char *path, const uint64_t size);
+  char *open_dev(const char *path);
+  void close_dev();
+  void init_data_offset(uint64_t metadata_size);
+  void set_data_offset(uint64_t metadata_size, uint64_t first_valid_offset,
+                       uint64_t the_last_valid_entry_end_offset);
+  uint64_t alloc(uint64_t size);
+  void release(uint64_t the_last_entry_end_offset);
+  char *get_head_addr() const;
+  uint64_t get_mapped_len();
+  bool is_pmem();
+  PmemDev(const char * path, const uint64_t size, CephContext *cct);
+  PmemDev(const char * path, CephContext *cct);
+  ~PmemDev();
+private:
+  uint64_t m_mapped_len = 0;      /* size of the actual mapping */
+  char *m_head_addr = nullptr;    /* the head addr of pmem device */
+  bool m_is_pmem = false;
+  mutable ceph::mutex m_lock;
+  CephContext *m_cct;
+
+  /* | superblock  | entries |                data area                        |
+   * ---------------------------------------------------------------------------
+   * |superblock1/2| enrties |      free      |   used         |    free       |
+   * ---------------------------------------------------------------------------
+   * |             |         |                |                |               |
+   * 0                m_first_data_offset               m_first_free_offset
+   *                                   m_first_valid_offset               m_max_offset
+   */
+
+  /* offset all align to MIN_WRITE_ALLOC_SIZE */
+  uint64_t m_max_offset = 0;             /* the max aligned offset */
+  uint64_t m_first_data_offset = 0;      /* skip root and entry area */
+  uint64_t m_first_free_offset = 0;      /* for alloc, data head +1 */
+  uint64_t m_first_valid_offset = 0;     /* for free, data tail */
+};
+
+} // namespace librbd::cache::pwl::rwl
+#endif // CEPH_LIBRBD_CACHE_RWL_PMEMMANAGER_H

--- a/src/librbd/cache/pwl/rwl/PmemManager.h
+++ b/src/librbd/cache/pwl/rwl/PmemManager.h
@@ -47,7 +47,7 @@ private:
 
   /* offset all align to MIN_WRITE_ALLOC_SIZE */
   uint64_t m_max_offset = 0;             /* the max aligned offset */
-  uint64_t m_first_data_offset = 0;      /* skip root and entry area */
+  uint64_t m_first_data_offset = 0;      /* skip superblock and entry area */
   uint64_t m_first_free_offset = 0;      /* for alloc, data head +1 */
   uint64_t m_first_valid_offset = 0;     /* for free, data tail */
 };

--- a/src/librbd/cache/pwl/rwl/Request.cc
+++ b/src/librbd/cache/pwl/rwl/Request.cc
@@ -17,8 +17,7 @@ namespace rwl {
 template <typename T>
 void C_WriteRequest<T>::setup_buffer_resources(
     uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-    uint64_t *number_lanes, uint64_t *number_log_entries,
-    uint64_t *number_unpublished_reserves) {
+    uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) {
 
   ceph_assert(!this->m_resources.allocated);
 
@@ -27,7 +26,6 @@ void C_WriteRequest<T>::setup_buffer_resources(
 
   *bytes_cached = 0;
   *bytes_allocated = 0;
-  *number_lanes = image_extents_size;
   *number_log_entries = image_extents_size;
   *number_unpublished_reserves = image_extents_size;
 
@@ -59,8 +57,7 @@ std::ostream &operator<<(std::ostream &os,
 template <typename T>
 void C_WriteSameRequest<T>::setup_buffer_resources(
     uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-    uint64_t *number_lanes, uint64_t *number_log_entries,
-    uint64_t *number_unpublished_reserves) {
+    uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) {
   ceph_assert(this->image_extents.size() == 1);
   *number_log_entries = 1;
   *bytes_dirtied += this->image_extents[0].second;

--- a/src/librbd/cache/pwl/rwl/Request.cc
+++ b/src/librbd/cache/pwl/rwl/Request.cc
@@ -31,7 +31,7 @@ void C_WriteRequest<T>::setup_buffer_resources(
   for (auto &extent : this->image_extents) {
     this->m_resources.buffers.emplace_back();
     struct WriteBufferAllocation &buffer = this->m_resources.buffers.back();
-    buffer.allocation_size = MIN_WRITE_ALLOC_SIZE;
+    buffer.allocation_size = PMEM_MIN_WRITE_ALLOC_SIZE;
     buffer.allocated = false;
     *bytes_cached += extent.second;
     if (extent.second > buffer.allocation_size) {
@@ -63,7 +63,7 @@ void C_WriteSameRequest<T>::setup_buffer_resources(
   auto pattern_length = this->bl.length();
   this->m_resources.buffers.emplace_back();
   struct WriteBufferAllocation &buffer = this->m_resources.buffers.back();
-  buffer.allocation_size = MIN_WRITE_ALLOC_SIZE;
+  buffer.allocation_size = PMEM_MIN_WRITE_ALLOC_SIZE;
   buffer.allocated = false;
   *bytes_cached += pattern_length;
   if (pattern_length > buffer.allocation_size) {

--- a/src/librbd/cache/pwl/rwl/Request.cc
+++ b/src/librbd/cache/pwl/rwl/Request.cc
@@ -16,8 +16,8 @@ namespace rwl {
 
 template <typename T>
 void C_WriteRequest<T>::setup_buffer_resources(
-    uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-    uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) {
+    uint64_t *bytes_cached, uint64_t *bytes_dirtied,
+    uint64_t *bytes_allocated, uint64_t *number_log_entries) {
 
   ceph_assert(!this->m_resources.allocated);
 
@@ -27,7 +27,6 @@ void C_WriteRequest<T>::setup_buffer_resources(
   *bytes_cached = 0;
   *bytes_allocated = 0;
   *number_log_entries = image_extents_size;
-  *number_unpublished_reserves = image_extents_size;
 
   for (auto &extent : this->image_extents) {
     this->m_resources.buffers.emplace_back();
@@ -56,8 +55,8 @@ std::ostream &operator<<(std::ostream &os,
 
 template <typename T>
 void C_WriteSameRequest<T>::setup_buffer_resources(
-    uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-    uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) {
+    uint64_t *bytes_cached, uint64_t *bytes_dirtied,
+    uint64_t *bytes_allocated, uint64_t *number_log_entries) {
   ceph_assert(this->image_extents.size() == 1);
   *number_log_entries = 1;
   *bytes_dirtied += this->image_extents[0].second;

--- a/src/librbd/cache/pwl/rwl/Request.h
+++ b/src/librbd/cache/pwl/rwl/Request.h
@@ -37,8 +37,7 @@ protected:
   //Plain writes will allocate one buffer per request extent
   void setup_buffer_resources(
       uint64_t *bytes_cached, uint64_t *bytes_dirtied,
-      uint64_t *bytes_allocated, uint64_t *number_log_entries,
-      uint64_t *number_unpublished_reserves) override;
+      uint64_t *bytes_allocated, uint64_t *number_log_entries) override;
 };
 
 template <typename T>
@@ -75,8 +74,7 @@ public:
 
   void setup_buffer_resources(
       uint64_t *bytes_cached, uint64_t *bytes_dirtied,
-      uint64_t *bytes_allocated, uint64_t *number_log_entries,
-      uint64_t *number_unpublished_reserves) override;
+      uint64_t *bytes_allocated, uint64_t *number_log_entries) override;
 
 };
 

--- a/src/librbd/cache/pwl/rwl/Request.h
+++ b/src/librbd/cache/pwl/rwl/Request.h
@@ -37,8 +37,7 @@ protected:
   //Plain writes will allocate one buffer per request extent
   void setup_buffer_resources(
       uint64_t *bytes_cached, uint64_t *bytes_dirtied,
-      uint64_t *bytes_allocated, uint64_t *number_lanes,
-      uint64_t *number_log_entries,
+      uint64_t *bytes_allocated, uint64_t *number_log_entries,
       uint64_t *number_unpublished_reserves) override;
 };
 
@@ -76,8 +75,7 @@ public:
 
   void setup_buffer_resources(
       uint64_t *bytes_cached, uint64_t *bytes_dirtied,
-      uint64_t *bytes_allocated, uint64_t *number_lanes,
-      uint64_t *number_log_entries,
+      uint64_t *bytes_allocated, uint64_t *number_log_entries,
       uint64_t *number_unpublished_reserves) override;
 
 };

--- a/src/librbd/cache/pwl/rwl/WriteLog.cc
+++ b/src/librbd/cache/pwl/rwl/WriteLog.cc
@@ -140,7 +140,6 @@ void WriteLog<I>::alloc_op_log_entries(GenericLogOperations &ops)
     this->m_first_free_entry = (this->m_first_free_entry + 1) % this->m_total_log_entries;
     auto &log_entry = operation->get_log_entry();
     log_entry->log_entry_index = entry_index;
-    log_entry->ram_entry.entry_index = entry_index;
     log_entry->cache_entry = &m_pmem_log_entries[entry_index];
     log_entry->ram_entry.set_entry_valid(true);
     m_log_entries.push_back(log_entry);
@@ -472,7 +471,6 @@ void WriteLog<I>::load_existing_entries(DeferredContexts &later) {
   while (entry_index != m_first_free_entry) {
     WriteLogCacheEntry *pmem_entry = &m_pmem_log_entries[entry_index];
     std::shared_ptr<GenericLogEntry> log_entry = nullptr;
-    ceph_assert(pmem_entry->entry_index == entry_index);
 
     this->update_entries(&log_entry, pmem_entry, missing_sync_points,
         sync_point_entries, entry_index);

--- a/src/librbd/cache/pwl/rwl/WriteLog.cc
+++ b/src/librbd/cache/pwl/rwl/WriteLog.cc
@@ -497,8 +497,8 @@ void WriteLog<I>::load_existing_entries(DeferredContexts &later) {
       if ((*entry_iter)->ram_entry.write_bytes != 0) {
         m_log_pool->set_data_offset(FIRST_ENTRY_OFFSET +
             sizeof(struct WriteLogCacheEntry) * this->m_total_log_entries,
-            m_log_entries.front()->ram_entry.write_data,
-            (*entry_iter)->ram_entry.write_data +
+            m_log_entries.front()->ram_entry.write_data_pos,
+            (*entry_iter)->ram_entry.write_data_pos +
             (*entry_iter)->ram_entry.write_bytes);
         break;
       }
@@ -526,7 +526,7 @@ template <typename I>
 void WriteLog<I>::write_data_to_buffer(
     std::shared_ptr<pwl::WriteLogEntry> ws_entry,
     WriteLogCacheEntry *pmem_entry) {
-  ws_entry->cache_buffer = m_pool_head + pmem_entry->write_data;
+  ws_entry->cache_buffer = m_pool_head + pmem_entry->write_data_pos;
 }
 
 /**
@@ -585,7 +585,7 @@ bool WriteLog<I>::retire_entries(const unsigned long int frees_per_tx) {
         for(entry_iter = retiring_entries.rbegin();
             entry_iter != retiring_entries.rend(); ++entry_iter) {
           if ((*entry_iter)->ram_entry.write_bytes != 0) {
-            m_log_pool->release((*entry_iter)->ram_entry.write_data +
+            m_log_pool->release((*entry_iter)->ram_entry.write_data_pos +
                                 (*entry_iter)->ram_entry.write_bytes);
             ldout(cct, 20) << "Retire to entry index: "
                            << (*entry_iter)->log_entry_index << dendl;

--- a/src/librbd/cache/pwl/rwl/WriteLog.cc
+++ b/src/librbd/cache/pwl/rwl/WriteLog.cc
@@ -35,6 +35,43 @@ namespace rwl {
 
 const unsigned long int OPS_APPENDED_TOGETHER = MAX_ALLOC_PER_TRANSACTION;
 
+/* Persist runtime metada to pool_root in pmem All values that may be changed
+ * will be persisted. Constant value won't be persisted, which has been
+ * assigned when initializing the pool. Acquires m_log_append_lock before call.
+ */
+template <typename I>
+void WriteLog<I>::persist_pmem_root() {
+  struct WriteLogPoolRoot *pool_root;
+  pool_root = (struct WriteLogPoolRoot *)m_log_pool->get_head_addr();
+  uint32_t crc = 0;
+  uint64_t flushed_sync_gen;
+
+  ceph_assert(ceph_mutex_is_locked_by_me(this->m_log_append_lock));
+  {
+    std::lock_guard locker(m_lock);
+    flushed_sync_gen = this->m_flushed_sync_gen;
+  }
+  if (m_sequence_num % 2) {
+    pool_root = (struct WriteLogPoolRoot *)((char *)pool_root +
+                SECOND_ROOT_OFFSET);
+  }
+  /* Don't move the flushed sync gen num backwards. */
+  if (pool_root->flushed_sync_gen < flushed_sync_gen) {
+    ldout(m_image_ctx.cct, 20) << "flushed_sync_gen in log updated from "
+                               << pool_root->flushed_sync_gen << " to "
+                               << flushed_sync_gen << dendl;
+    pool_root->flushed_sync_gen = flushed_sync_gen;
+  }
+  pool_root->sequence_num = m_sequence_num;
+  pool_root->first_free_entry = this->m_first_free_entry;
+  pool_root->first_valid_entry = this->m_first_valid_entry;
+  crc = ceph_crc32c(crc, (unsigned char*)&pool_root->sequence_num,
+                    m_super_block_crc_len);
+  pool_root->crc = crc;
+  pmem_persist(pool_root, MAX_ROOT_LEN);
+  ++m_sequence_num;
+}
+
 template <typename I>
 Builder<AbstractWriteLog<I>>* WriteLog<I>::create_builder() {
   m_builderobj = new Builder<This>();
@@ -46,9 +83,8 @@ WriteLog<I>::WriteLog(
     I &image_ctx, librbd::cache::pwl::ImageCacheState<I>* cache_state,
     ImageWritebackInterface& image_writeback,
     plugin::Api<I>& plugin_api)
-: AbstractWriteLog<I>(image_ctx, cache_state, create_builder(), image_writeback,
-                      plugin_api),
-  m_pwl_pool_layout_name(POBJ_LAYOUT_NAME(rbd_pwl))
+: AbstractWriteLog<I>(image_ctx, cache_state, create_builder(),
+                      image_writeback, plugin_api)
 {
 }
 
@@ -97,10 +133,6 @@ void WriteLog<I>::complete_read(
 template <typename I>
 void WriteLog<I>::alloc_op_log_entries(GenericLogOperations &ops)
 {
-  TOID(struct WriteLogPoolRoot) pool_root;
-  pool_root = POBJ_ROOT(m_log_pool, struct WriteLogPoolRoot);
-  struct WriteLogCacheEntry *pmem_log_entries = D_RW(D_RW(pool_root)->log_entries);
-
   ceph_assert(ceph_mutex_is_locked_by_me(this->m_log_append_lock));
 
   /* Allocate the (already reserved) log entries */
@@ -112,7 +144,7 @@ void WriteLog<I>::alloc_op_log_entries(GenericLogOperations &ops)
     auto &log_entry = operation->get_log_entry();
     log_entry->log_entry_index = entry_index;
     log_entry->ram_entry.entry_index = entry_index;
-    log_entry->cache_entry = &pmem_log_entries[entry_index];
+    log_entry->cache_entry = &m_pmem_log_entries[entry_index];
     log_entry->ram_entry.set_entry_valid(true);
     m_log_entries.push_back(log_entry);
     ldout(m_image_ctx.cct, 20) << "operation=[" << *operation << "]" << dendl;
@@ -131,14 +163,10 @@ void WriteLog<I>::alloc_op_log_entries(GenericLogOperations &ops)
 template <typename I>
 int WriteLog<I>::append_op_log_entries(GenericLogOperations &ops)
 {
-  CephContext *cct = m_image_ctx.cct;
   GenericLogOperationsVector entries_to_flush;
-  TOID(struct WriteLogPoolRoot) pool_root;
-  pool_root = POBJ_ROOT(m_log_pool, struct WriteLogPoolRoot);
   int ret = 0;
 
   ceph_assert(ceph_mutex_is_locked_by_me(this->m_log_append_lock));
-
   if (ops.empty()) {
     return 0;
   }
@@ -175,36 +203,18 @@ int WriteLog<I>::append_op_log_entries(GenericLogOperations &ops)
   flush_op_log_entries(entries_to_flush);
 
   /* Drain once for all */
-  pmemobj_drain(m_log_pool);
+  pmem_drain();
 
   /*
    * Atomically advance the log head pointer and publish the
    * allocations for all the data buffers they refer to.
    */
   utime_t tx_start = ceph_clock_now();
-  TX_BEGIN(m_log_pool) {
-    D_RW(pool_root)->first_free_entry = this->m_first_free_entry;
-    for (auto &operation : ops) {
-      if (operation->reserved_allocated()) {
-        auto write_op = (std::shared_ptr<WriteLogOperation>&) operation;
-        pmemobj_tx_publish(&write_op->buffer_alloc->buffer_alloc_action, 1);
-      } else {
-        ldout(m_image_ctx.cct, 20) << "skipping non-write op: " << *operation << dendl;
-      }
-    }
-  } TX_ONCOMMIT {
-  } TX_ONABORT {
-    lderr(cct) << "failed to commit " << ops.size()
-               << " log entries (" << this->m_log_pool_name << ")" << dendl;
-    ceph_assert(false);
-    ret = -EIO;
-  } TX_FINALLY {
-  } TX_END;
-
+  persist_pmem_root();
   utime_t tx_end = ceph_clock_now();
   m_perfcounter->tinc(l_librbd_pwl_append_tx_t, tx_end - tx_start);
-  m_perfcounter->hinc(
-    l_librbd_pwl_append_tx_t_hist, utime_t(tx_end - tx_start).to_nsec(), ops.size());
+  m_perfcounter->hinc(l_librbd_pwl_append_tx_t_hist,
+                      utime_t(tx_end - tx_start).to_nsec(), ops.size());
   for (auto &operation : ops) {
     operation->log_append_comp_time = tx_end;
   }
@@ -233,22 +243,22 @@ void WriteLog<I>::flush_op_log_entries(GenericLogOperationsVector &ops)
                              << " bytes="
                              << ops.size() * sizeof(*(ops.front()->get_log_entry()->cache_entry))
                              << dendl;
-  pmemobj_flush(m_log_pool,
-                ops.front()->get_log_entry()->cache_entry,
-                ops.size() * sizeof(*(ops.front()->get_log_entry()->cache_entry)));
+  pmem_flush(ops.front()->get_log_entry()->cache_entry,
+             ops.size() * sizeof(*(ops.front()->get_log_entry()->cache_entry)));
 }
 
 template <typename I>
 void WriteLog<I>::remove_pool_file() {
   if (m_log_pool) {
     ldout(m_image_ctx.cct, 6) << "closing pmem pool" << dendl;
-    pmemobj_close(m_log_pool);
+    m_log_pool->close_dev();
   }
   if (m_cache_state->clean) {
       ldout(m_image_ctx.cct, 5) << "Removing empty pool file: " << this->m_log_pool_name << dendl;
       if (remove(this->m_log_pool_name.c_str()) != 0) {
-        lderr(m_image_ctx.cct) << "failed to remove empty pool \"" << this->m_log_pool_name << "\": "
-          << pmemobj_errormsg() << dendl;
+        lderr(m_image_ctx.cct) << "failed to remove empty pool: "
+                               << this->m_log_pool_name
+                               << dendl;
       } else {
         m_cache_state->present = false;
       }
@@ -260,17 +270,14 @@ void WriteLog<I>::remove_pool_file() {
 template <typename I>
 bool WriteLog<I>::initialize_pool(Context *on_finish, pwl::DeferredContexts &later) {
   CephContext *cct = m_image_ctx.cct;
+  uint32_t crc = 0;
   int r = -EINVAL;
-  TOID(struct WriteLogPoolRoot) pool_root;
+  struct WriteLogPoolRoot *pool_root = nullptr;
   ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
   if (access(this->m_log_pool_name.c_str(), F_OK) != 0) {
-    if ((m_log_pool =
-         pmemobj_create(this->m_log_pool_name.c_str(),
-                        this->m_pwl_pool_layout_name,
-                        this->m_log_pool_size,
-                        (S_IWUSR | S_IRUSR))) == NULL) {
-      lderr(cct) << "failed to create pool: " << this->m_log_pool_name
-                 << ". error: " << pmemobj_errormsg() << dendl;
+    if (!(m_log_pool = PmemDev::pmem_create_dev(this->m_log_pool_name.c_str(),
+                                                this->m_log_pool_size, cct))) {
+      lderr(cct) << "failed to create pool:" << this->m_log_pool_name << dendl;
       m_cache_state->present = false;
       m_cache_state->clean = true;
       m_cache_state->empty = true;
@@ -281,11 +288,12 @@ bool WriteLog<I>::initialize_pool(Context *on_finish, pwl::DeferredContexts &lat
     m_cache_state->present = true;
     m_cache_state->clean = true;
     m_cache_state->empty = true;
-    pool_root = POBJ_ROOT(m_log_pool, struct WriteLogPoolRoot);
 
     /* new pool, calculate and store metadata */
+    this->m_log_pool_size = m_log_pool->get_mapped_len(); // actual mapped size
     size_t effective_pool_size = (size_t)(this->m_log_pool_size * USABLE_SIZE);
-    size_t small_write_size = MIN_WRITE_ALLOC_SIZE + BLOCK_ALLOC_OVERHEAD_BYTES + sizeof(struct WriteLogCacheEntry);
+    size_t small_write_size = MIN_WRITE_ALLOC_SIZE +
+        BLOCK_ALLOC_OVERHEAD_BYTES + sizeof(struct WriteLogCacheEntry);
     uint64_t num_small_writes = (uint64_t)(effective_pool_size / small_write_size);
     if (num_small_writes > MAX_LOG_ENTRIES) {
       num_small_writes = MAX_LOG_ENTRIES;
@@ -298,69 +306,114 @@ bool WriteLog<I>::initialize_pool(Context *on_finish, pwl::DeferredContexts &lat
     /* Log ring empty */
     m_first_free_entry = 0;
     m_first_valid_entry = 0;
-    TX_BEGIN(m_log_pool) {
-      TX_ADD(pool_root);
-      D_RW(pool_root)->header.layout_version = RWL_LAYOUT_VERSION;
-      D_RW(pool_root)->log_entries =
-        TX_ZALLOC(struct WriteLogCacheEntry,
-                  sizeof(struct WriteLogCacheEntry) * num_small_writes);
-      D_RW(pool_root)->pool_size = this->m_log_pool_size;
-      D_RW(pool_root)->flushed_sync_gen = this->m_flushed_sync_gen;
-      D_RW(pool_root)->block_size = MIN_WRITE_ALLOC_SIZE;
-      D_RW(pool_root)->num_log_entries = num_small_writes;
-      D_RW(pool_root)->first_free_entry = m_first_free_entry;
-      D_RW(pool_root)->first_valid_entry = m_first_valid_entry;
-    } TX_ONCOMMIT {
-      this->m_total_log_entries = D_RO(pool_root)->num_log_entries;
-      this->m_free_log_entries = D_RO(pool_root)->num_log_entries - 1; // leave one free
-    } TX_ONABORT {
-      this->m_total_log_entries = 0;
-      this->m_free_log_entries = 0;
-      lderr(cct) << "failed to initialize pool: " << this->m_log_pool_name
-                 << ". pmemobj TX errno: " << pmemobj_tx_errno() << dendl;
-      r = -pmemobj_tx_errno();
-      goto err_close_pool;
-    } TX_FINALLY {
-    } TX_END;
+    m_sequence_num = 0;
+    m_pmem_log_entries = (struct WriteLogCacheEntry *)((char *)pool_root +
+                         FIRST_ENTRY_OFFSET);
+    {
+      pool_root = (struct WriteLogPoolRoot *)m_log_pool->get_head_addr();
+      pool_root->sequence_num = m_sequence_num;
+      pool_root->header.layout_version = RWL_LAYOUT_VERSION;
+      pool_root->pool_size = this->m_log_pool_size;
+      pool_root->flushed_sync_gen = this->m_flushed_sync_gen;
+      pool_root->block_size = MIN_WRITE_ALLOC_SIZE;
+      pool_root->num_log_entries = num_small_writes;
+      pool_root->first_free_entry = m_first_free_entry;
+      pool_root->first_valid_entry = m_first_valid_entry;
+      m_super_block_crc_len = (char *)&pool_root->first_valid_entry -
+                              (char *)&pool_root->sequence_num +
+                              sizeof(pool_root->first_valid_entry);
+      crc = ceph_crc32c(crc, (unsigned char*)&pool_root->sequence_num,
+                        m_super_block_crc_len);
+      pool_root->crc = crc;
+      pmem_flush(pool_root, MAX_ROOT_LEN);
+      /* copy initialized root1 to root2
+       * Next time, just update the values that might be changed */
+      pmem_memcpy_nodrain((char *)pool_root + SECOND_ROOT_OFFSET,
+                          pool_root, MAX_ROOT_LEN);
+      pmem_memset_nodrain(m_log_pool->get_head_addr() + FIRST_ENTRY_OFFSET, 0,
+          sizeof(struct WriteLogCacheEntry) * num_small_writes);
+      m_log_pool->init_data_offset(FIRST_ENTRY_OFFSET +
+          sizeof(struct WriteLogCacheEntry) * num_small_writes);
+      /* update other run time metadata */
+      this->m_total_log_entries = num_small_writes;
+      this->m_free_log_entries = num_small_writes - 1;
+      ++m_sequence_num;
+      pmem_drain();
+    }
   } else {
     ceph_assert(m_cache_state->present);
     /* Open existing pool */
-    if ((m_log_pool =
-         pmemobj_open(this->m_log_pool_name.c_str(),
-                      this->m_pwl_pool_layout_name)) == NULL) {
-      lderr(cct) << "failed to open pool (" << this->m_log_pool_name << "): "
-                 << pmemobj_errormsg() << dendl;
+    if (!(m_log_pool = PmemDev::pmem_open_dev(this->m_log_pool_name.c_str(),
+                                              cct))) {
+      lderr(cct) << "failed to open pool ("
+                 << this->m_log_pool_name << "): " << dendl;
       on_finish->complete(-errno);
       return false;
     }
-    pool_root = POBJ_ROOT(m_log_pool, struct WriteLogPoolRoot);
-    if (D_RO(pool_root)->header.layout_version != RWL_LAYOUT_VERSION) {
-      // TODO: will handle upgrading version in the future
+    uint32_t second_root_crc = 0;
+    struct WriteLogPoolRoot *second_pool_root = nullptr;
+    pool_root = (struct WriteLogPoolRoot *)m_log_pool->get_head_addr();
+    second_pool_root = (struct WriteLogPoolRoot *)(m_log_pool->get_head_addr() +
+                       SECOND_ROOT_OFFSET);
+    m_super_block_crc_len = (char *)&pool_root->first_valid_entry -
+                            (char *)&pool_root->sequence_num +
+                            sizeof(pool_root->first_valid_entry);
+    crc = ceph_crc32c(crc, (unsigned char*)&pool_root->sequence_num,
+                      m_super_block_crc_len);
+    second_root_crc = ceph_crc32c(second_root_crc,
+                      (unsigned char*)&second_pool_root->sequence_num,
+                      m_super_block_crc_len);
+    if (pool_root->crc != crc && second_pool_root->crc == crc) {
+        pool_root = second_pool_root;
+    } else if (pool_root->crc == crc &&
+               second_pool_root->crc == second_root_crc) {
+      if (pool_root->sequence_num < second_pool_root->sequence_num) {
+        pool_root = second_pool_root;
+      } else {
+        // do nothing
+      }
+    } else if (pool_root->crc != crc &&
+               second_pool_root->crc != second_root_crc) {
+      ldout(cct, 5) << "no valid superblock exist." << dendl;
+      goto err_close_pool;
+    } else {
+      // do nothing
+      // case: pool_root->crc == crc && second_root_crc->crc != crc
+    }
+
+    if (pool_root->header.layout_version != RWL_LAYOUT_VERSION) {
+      /* Different versions are not compatible */
       lderr(cct) << "pool layout version is "
-                 << D_RO(pool_root)->header.layout_version
+                 << pool_root->header.layout_version
                  << " expected " << RWL_LAYOUT_VERSION << dendl;
       goto err_close_pool;
     }
-    if (D_RO(pool_root)->block_size != MIN_WRITE_ALLOC_SIZE) {
-      lderr(cct) << "pool block size is " << D_RO(pool_root)->block_size
+    if (pool_root->block_size != MIN_WRITE_ALLOC_SIZE) {
+      lderr(cct) << "pool block size is " << pool_root->block_size
                  << " expected " << MIN_WRITE_ALLOC_SIZE << dendl;
       goto err_close_pool;
     }
-    this->m_log_pool_size = D_RO(pool_root)->pool_size;
-    this->m_flushed_sync_gen = D_RO(pool_root)->flushed_sync_gen;
-    this->m_total_log_entries = D_RO(pool_root)->num_log_entries;
-    m_first_free_entry = D_RO(pool_root)->first_free_entry;
-    m_first_valid_entry = D_RO(pool_root)->first_valid_entry;
+    this->m_log_pool_size = pool_root->pool_size;
+    this->m_flushed_sync_gen = pool_root->flushed_sync_gen;
+    this->m_total_log_entries = pool_root->num_log_entries;
+    m_first_free_entry = pool_root->first_free_entry;
+    m_first_valid_entry = pool_root->first_valid_entry;
+    /* run time write num is next write operation */
+    m_sequence_num = pool_root->sequence_num + 1;
+    m_pmem_log_entries = (struct WriteLogCacheEntry *)(m_log_pool->get_head_addr() +
+                         FIRST_ENTRY_OFFSET);
     if (m_first_free_entry < m_first_valid_entry) {
       /* Valid entries wrap around the end of the ring, so first_free is lower
        * than first_valid.  If first_valid was == first_free+1, the entry at
        * first_free would be empty. The last entry is never used, so in
        * that case there would be zero free log entries. */
-     this->m_free_log_entries = this->m_total_log_entries - (m_first_valid_entry - m_first_free_entry) -1;
+     this->m_free_log_entries = this->m_total_log_entries -
+                                (m_first_valid_entry - m_first_free_entry) -1;
     } else {
       /* first_valid is <= first_free. If they are == we have zero valid log
        * entries, and n-1 free log entries */
-      this->m_free_log_entries = this->m_total_log_entries - (m_first_free_entry - m_first_valid_entry) -1;
+      this->m_free_log_entries = this->m_total_log_entries -
+                                 (m_first_free_entry - m_first_valid_entry) -1;
     }
     size_t effective_pool_size = (size_t)(this->m_log_pool_size * USABLE_SIZE);
     this->m_bytes_allocated_cap = effective_pool_size;
@@ -371,7 +424,7 @@ bool WriteLog<I>::initialize_pool(Context *on_finish, pwl::DeferredContexts &lat
   return true;
 
 err_close_pool:
-  pmemobj_close(m_log_pool);
+  m_log_pool->close_dev();;
   on_finish->complete(r);
   return false;
 }
@@ -397,9 +450,6 @@ err_close_pool:
 
 template <typename I>
 void WriteLog<I>::load_existing_entries(DeferredContexts &later) {
-  TOID(struct WriteLogPoolRoot) pool_root;
-  pool_root = POBJ_ROOT(m_log_pool, struct WriteLogPoolRoot);
-  struct WriteLogCacheEntry *pmem_log_entries = D_RW(D_RW(pool_root)->log_entries);
   uint64_t entry_index = m_first_valid_entry;
   /* The map below allows us to find sync point log entries by sync
    * gen number, which is necessary so write entries can be linked to
@@ -422,7 +472,7 @@ void WriteLog<I>::load_existing_entries(DeferredContexts &later) {
    * the log.
    */
   while (entry_index != m_first_free_entry) {
-    WriteLogCacheEntry *pmem_entry = &pmem_log_entries[entry_index];
+    WriteLogCacheEntry *pmem_entry = &m_pmem_log_entries[entry_index];
     std::shared_ptr<GenericLogEntry> log_entry = nullptr;
     ceph_assert(pmem_entry->entry_index == entry_index);
 
@@ -439,6 +489,29 @@ void WriteLog<I>::load_existing_entries(DeferredContexts &later) {
     entry_index = (entry_index + 1) % this->m_total_log_entries;
   }
 
+  if (m_log_entries.empty()) {
+    m_log_pool->init_data_offset(FIRST_ENTRY_OFFSET +
+        sizeof(struct WriteLogCacheEntry) * this->m_total_log_entries);
+  } else {
+    pwl::GenericLogEntries::reverse_iterator entry_iter;
+    for(entry_iter = m_log_entries.rbegin();
+        entry_iter != m_log_entries.rend(); ++entry_iter) {
+      if ((*entry_iter)->ram_entry.write_bytes != 0) {
+        m_log_pool->set_data_offset(FIRST_ENTRY_OFFSET +
+            sizeof(struct WriteLogCacheEntry) * this->m_total_log_entries,
+            m_log_entries.front()->ram_entry.write_data,
+            (*entry_iter)->ram_entry.write_data +
+            (*entry_iter)->ram_entry.write_bytes);
+        break;
+      }
+    }
+    // no write log entry in m_log_entries
+    if (entry_iter == m_log_entries.rend()) {
+      m_log_pool->init_data_offset(FIRST_ENTRY_OFFSET +
+          sizeof(struct WriteLogCacheEntry) * this->m_total_log_entries);
+    }
+
+  }
   this->update_sync_points(missing_sync_points, sync_point_entries, later);
 }
 
@@ -455,7 +528,7 @@ template <typename I>
 void WriteLog<I>::write_data_to_buffer(
     std::shared_ptr<pwl::WriteLogEntry> ws_entry,
     WriteLogCacheEntry *pmem_entry) {
-  ws_entry->cache_buffer = D_RW(pmem_entry->write_data);
+  ws_entry->cache_buffer = m_log_pool->get_head_addr() + pmem_entry->write_data;
 }
 
 /**
@@ -502,50 +575,34 @@ bool WriteLog<I>::retire_entries(const unsigned long int frees_per_tx) {
 
   if (retiring_entries.size()) {
     ldout(cct, 20) << "Retiring " << retiring_entries.size() << " entries" << dendl;
-    TOID(struct WriteLogPoolRoot) pool_root;
-    pool_root = POBJ_ROOT(m_log_pool, struct WriteLogPoolRoot);
-
     utime_t tx_start;
     utime_t tx_end;
     /* Advance first valid entry and release buffers */
     {
-      uint64_t flushed_sync_gen;
-      std::lock_guard append_locker(this->m_log_append_lock);
-      {
-        std::lock_guard locker(m_lock);
-        flushed_sync_gen = this->m_flushed_sync_gen;
-      }
-
       tx_start = ceph_clock_now();
-      TX_BEGIN(m_log_pool) {
-        if (D_RO(pool_root)->flushed_sync_gen < flushed_sync_gen) {
-          ldout(m_image_ctx.cct, 20) << "flushed_sync_gen in log updated from "
-                                     << D_RO(pool_root)->flushed_sync_gen << " to "
-                                     << flushed_sync_gen << dendl;
-          D_RW(pool_root)->flushed_sync_gen = flushed_sync_gen;
-        }
-        D_RW(pool_root)->first_valid_entry = first_valid_entry;
-        for (auto &entry: retiring_entries) {
-          if (entry->write_bytes()) {
-            ldout(cct, 20) << "Freeing " << entry->ram_entry.write_data.oid.pool_uuid_lo
-                           << "." << entry->ram_entry.write_data.oid.off << dendl;
-            TX_FREE(entry->ram_entry.write_data);
-          } else {
-            ldout(cct, 20) << "Retiring non-write: " << *entry << dendl;
+      {
+        /* Find the first entry that points to a valid address through
+         * the reverse iterator */
+        GenericLogEntriesVector::reverse_iterator entry_iter;
+        for(entry_iter = retiring_entries.rbegin();
+            entry_iter != retiring_entries.rend(); ++entry_iter) {
+          if ((*entry_iter)->ram_entry.write_bytes != 0) {
+            m_log_pool->release((*entry_iter)->ram_entry.write_data +
+                                (*entry_iter)->ram_entry.write_bytes);
+            ldout(cct, 20) << "Retire to entry index: "
+                           << (*entry_iter)->log_entry_index << dendl;
+            break;
           }
         }
-      } TX_ONCOMMIT {
-      } TX_ONABORT {
-        lderr(cct) << "failed to commit free of" << retiring_entries.size()
-                   << " log entries (" << this->m_log_pool_name << ")" << dendl;
-        ceph_assert(false);
-      } TX_FINALLY {
-      } TX_END;
+        if (entry_iter == retiring_entries.rend()) {
+          ldout(cct, 20) << "Only retiring non-write entries" << dendl;
+        }
+      }
       tx_end = ceph_clock_now();
     }
     m_perfcounter->tinc(l_librbd_pwl_retire_tx_t, tx_end - tx_start);
-    m_perfcounter->hinc(l_librbd_pwl_retire_tx_t_hist, utime_t(tx_end - tx_start).to_nsec(),
-        retiring_entries.size());
+    m_perfcounter->hinc(l_librbd_pwl_retire_tx_t_hist,
+        utime_t(tx_end - tx_start).to_nsec(), retiring_entries.size());
 
     /* Update runtime copy of first_valid, and free entries counts */
     {
@@ -572,6 +629,10 @@ bool WriteLog<I>::retire_entries(const unsigned long int frees_per_tx) {
       }
       this->m_alloc_failed_since_retire = false;
       this->wake_up();
+    }
+    {
+      std::lock_guard append_locker(this->m_log_append_lock);
+      persist_pmem_root();
     }
   } else {
     ldout(cct, 20) << "Nothing to retire" << dendl;
@@ -864,12 +925,12 @@ void WriteLog<I>::flush_pmem_buffer(V& ops)
   for (auto &operation : ops) {
     if(operation->is_writing_op()) {
       auto log_entry = static_pointer_cast<WriteLogEntry>(operation->get_log_entry());
-      pmemobj_flush(m_log_pool, log_entry->cache_buffer, log_entry->write_bytes());
+      pmem_flush(log_entry->cache_buffer, log_entry->write_bytes());
     }
   }
 
   /* Drain once for all */
-  pmemobj_drain(m_log_pool);
+  pmem_drain();
 
   now = ceph_clock_now();
   for (auto &operation : ops) {
@@ -888,60 +949,27 @@ void WriteLog<I>::flush_pmem_buffer(V& ops)
 template <typename I>
 void WriteLog<I>::persist_last_flushed_sync_gen()
 {
-  TOID(struct WriteLogPoolRoot) pool_root;
-  pool_root = POBJ_ROOT(m_log_pool, struct WriteLogPoolRoot);
-  uint64_t flushed_sync_gen;
-
   std::lock_guard append_locker(this->m_log_append_lock);
-  {
-    std::lock_guard locker(m_lock);
-    flushed_sync_gen = this->m_flushed_sync_gen;
-  }
-
-  if (D_RO(pool_root)->flushed_sync_gen < flushed_sync_gen) {
-    ldout(m_image_ctx.cct, 15) << "flushed_sync_gen in log updated from "
-                               << D_RO(pool_root)->flushed_sync_gen << " to "
-                               << flushed_sync_gen << dendl;
-    TX_BEGIN(m_log_pool) {
-      D_RW(pool_root)->flushed_sync_gen = flushed_sync_gen;
-    } TX_ONCOMMIT {
-    } TX_ONABORT {
-      lderr(m_image_ctx.cct) << "failed to commit update of flushed sync point" << dendl;
-      ceph_assert(false);
-    } TX_FINALLY {
-    } TX_END;
-  }
+  persist_pmem_root();
 }
 
 template <typename I>
-void WriteLog<I>::reserve_cache(C_BlockIORequestT *req,
+void WriteLog<I>::alloc_cache(C_BlockIORequestT *req,
                                          bool &alloc_succeeds, bool &no_space) {
   std::vector<WriteBufferAllocation>& buffers = req->get_resources_buffers();
   for (auto &buffer : buffers) {
-    utime_t before_reserve = ceph_clock_now();
-    buffer.buffer_oid = pmemobj_reserve(m_log_pool,
-                                        &buffer.buffer_alloc_action,
-                                        buffer.allocation_size,
-                                        0 /* Object type */);
-    buffer.allocation_lat = ceph_clock_now() - before_reserve;
-    if (TOID_IS_NULL(buffer.buffer_oid)) {
-      ldout(m_image_ctx.cct, 5) << "can't allocate all data buffers: "
-                                << pmemobj_errormsg() << ". "
-                                << *req << dendl;
+    buffer.pmem_offset = m_log_pool->alloc(buffer.allocation_size);
+    buffer.pmem_head_addr = m_log_pool->get_head_addr();
+    if (!buffer.pmem_offset) {
+      ldout(m_image_ctx.cct, 20) << "can't allocate all data buffers: "
+                                << ". " << *req << dendl;
       alloc_succeeds = false;
       no_space = true; /* Entries need to be retired */
-
-      if (this->m_free_log_entries == this->m_total_log_entries - 1) {
-        /* When the cache is empty, there is still no space to allocate.
-         * Defragment. */
-        pmemobj_defrag(m_log_pool, NULL, 0, NULL);
-      }
       break;
     } else {
       buffer.allocated = true;
     }
-    ldout(m_image_ctx.cct, 20) << "Allocated " << buffer.buffer_oid.oid.pool_uuid_lo
-                               << "." << buffer.buffer_oid.oid.off
+    ldout(m_image_ctx.cct, 20) << "Allocated from " << buffer.pmem_offset
                                << ", size=" << buffer.allocation_size << dendl;
   }
 }
@@ -970,20 +998,9 @@ bool WriteLog<I>::alloc_resources(C_BlockIORequestT *req) {
   // Setup buffer, and get all the number of required resources
   req->setup_buffer_resources(&bytes_cached, &bytes_dirtied, &bytes_allocated,
                               &num_lanes, &num_log_entries, &num_unpublished_reserves);
-
   alloc_succeeds = this->check_allocation(req, bytes_cached, bytes_dirtied,
                                           bytes_allocated, num_lanes, num_log_entries,
                                           num_unpublished_reserves);
-
-  std::vector<WriteBufferAllocation>& buffers = req->get_resources_buffers();
-  if (!alloc_succeeds) {
-    /* On alloc failure, free any buffers we did allocate */
-    for (auto &buffer : buffers) {
-      if (buffer.allocated) {
-        pmemobj_cancel(m_log_pool, &buffer.buffer_alloc_action, 1);
-      }
-    }
-  }
 
   req->set_allocated(alloc_succeeds);
   return alloc_succeeds;

--- a/src/librbd/cache/pwl/rwl/WriteLog.cc
+++ b/src/librbd/cache/pwl/rwl/WriteLog.cc
@@ -992,16 +992,15 @@ bool WriteLog<I>::alloc_resources(C_BlockIORequestT *req) {
   uint64_t bytes_allocated = 0;
   uint64_t bytes_cached = 0;
   uint64_t bytes_dirtied = 0;
-  uint64_t num_lanes = 0;
   uint64_t num_unpublished_reserves = 0;
   uint64_t num_log_entries = 0;
 
   ldout(m_image_ctx.cct, 20) << dendl;
   // Setup buffer, and get all the number of required resources
   req->setup_buffer_resources(&bytes_cached, &bytes_dirtied, &bytes_allocated,
-                              &num_lanes, &num_log_entries, &num_unpublished_reserves);
+                              &num_log_entries, &num_unpublished_reserves);
   alloc_succeeds = this->check_allocation(req, bytes_cached, bytes_dirtied,
-                                          bytes_allocated, num_lanes, num_log_entries,
+                                          bytes_allocated, num_log_entries,
                                           num_unpublished_reserves);
 
   req->set_allocated(alloc_succeeds);

--- a/src/librbd/cache/pwl/rwl/WriteLog.h
+++ b/src/librbd/cache/pwl/rwl/WriteLog.h
@@ -56,8 +56,9 @@ private:
   using C_DiscardRequestT = pwl::C_DiscardRequest<This>;
 
   std::unique_ptr<PmemDev> m_log_pool = nullptr;
+  char *m_pool_head = nullptr;
   uint64_t m_sequence_num = 0;
-  unsigned m_super_block_crc_len = 0;
+  unsigned m_superblock_crc_len = 0;
   struct WriteLogCacheEntry *m_pmem_log_entries = nullptr;
   Builder<This> *m_builderobj;
 
@@ -73,7 +74,7 @@ private:
   void flush_pmem_buffer(V& ops);
   void inc_allocated_cached_bytes(
       std::shared_ptr<pwl::GenericLogEntry> log_entry) override;
-  void persist_pmem_root();
+  void persist_pmem_superblock();
 
 protected:
   using AbstractWriteLog<ImageCtxT>::m_lock;

--- a/src/librbd/cache/pwl/rwl/WriteLog.h
+++ b/src/librbd/cache/pwl/rwl/WriteLog.h
@@ -60,7 +60,6 @@ private:
   unsigned m_super_block_crc_len = 0;
   struct WriteLogCacheEntry *m_pmem_log_entries = nullptr;
   Builder<This> *m_builderobj;
-  const uint64_t MAX_EXTENT_SIZE = 1048576;
 
   Builder<This>* create_builder();
   void remove_pool_file();
@@ -113,9 +112,6 @@ protected:
   void write_data_to_buffer(
       std::shared_ptr<pwl::WriteLogEntry> ws_entry,
       pwl::WriteLogCacheEntry *pmem_entry) override;
-  uint64_t get_max_extent() override {
-    return MAX_EXTENT_SIZE;
-  }
 };
 
 } // namespace rwl

--- a/src/librbd/cache/pwl/ssd/LogEntry.cc
+++ b/src/librbd/cache/pwl/ssd/LogEntry.cc
@@ -36,9 +36,9 @@ void WriteLogEntry::remove_cache_bl() {
 
 unsigned int WriteLogEntry::get_aligned_data_size() const {
   if (cache_bl.length()) {
-    return round_up_to(cache_bl.length(), MIN_WRITE_ALLOC_SSD_SIZE);
+    return round_up_to(cache_bl.length(), SSD_MIN_WRITE_ALLOC_SIZE);
   }
-  return round_up_to(write_bytes(), MIN_WRITE_ALLOC_SSD_SIZE);
+  return round_up_to(write_bytes(), SSD_MIN_WRITE_ALLOC_SIZE);
 }
 
 void WriteLogEntry::writeback_bl(

--- a/src/librbd/cache/pwl/ssd/Request.cc
+++ b/src/librbd/cache/pwl/ssd/Request.cc
@@ -16,9 +16,7 @@ namespace ssd {
 template <typename T>
 void C_WriteRequest<T>::setup_buffer_resources(
     uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-    uint64_t *number_lanes, uint64_t *number_log_entries,
-    uint64_t *number_unpublished_reserves) {
-
+    uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) {
   *bytes_cached = 0;
   *bytes_allocated = 0;
   *number_log_entries = this->image_extents.size();
@@ -44,8 +42,7 @@ std::ostream &operator<<(std::ostream &os,
 template <typename T>
 void C_WriteSameRequest<T>::setup_buffer_resources(
     uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-    uint64_t *number_lanes, uint64_t *number_log_entries,
-    uint64_t *number_unpublished_reserves) {
+    uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) {
   ceph_assert(this->image_extents.size() == 1);
   *number_log_entries = 1;
   *bytes_dirtied = this->image_extents[0].second;

--- a/src/librbd/cache/pwl/ssd/Request.cc
+++ b/src/librbd/cache/pwl/ssd/Request.cc
@@ -23,7 +23,7 @@ void C_WriteRequest<T>::setup_buffer_resources(
 
   for (auto &extent : this->image_extents) {
     *bytes_cached += extent.second;
-    *bytes_allocated += round_up_to(extent.second, MIN_WRITE_ALLOC_SSD_SIZE);
+    *bytes_allocated += round_up_to(extent.second, SSD_MIN_WRITE_ALLOC_SIZE);
   }
   *bytes_dirtied = *bytes_cached;
 }
@@ -47,7 +47,7 @@ void C_WriteSameRequest<T>::setup_buffer_resources(
   *number_log_entries = 1;
   *bytes_dirtied = this->image_extents[0].second;
   *bytes_cached = this->bl.length();
-  *bytes_allocated = round_up_to(*bytes_cached, MIN_WRITE_ALLOC_SSD_SIZE);
+  *bytes_allocated = round_up_to(*bytes_cached, SSD_MIN_WRITE_ALLOC_SIZE);
 }
 
 } // namespace ssd

--- a/src/librbd/cache/pwl/ssd/Request.cc
+++ b/src/librbd/cache/pwl/ssd/Request.cc
@@ -15,8 +15,8 @@ namespace ssd {
 
 template <typename T>
 void C_WriteRequest<T>::setup_buffer_resources(
-    uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-    uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) {
+    uint64_t *bytes_cached, uint64_t *bytes_dirtied,
+    uint64_t *bytes_allocated, uint64_t *number_log_entries) {
   *bytes_cached = 0;
   *bytes_allocated = 0;
   *number_log_entries = this->image_extents.size();
@@ -41,8 +41,8 @@ std::ostream &operator<<(std::ostream &os,
 
 template <typename T>
 void C_WriteSameRequest<T>::setup_buffer_resources(
-    uint64_t *bytes_cached, uint64_t *bytes_dirtied, uint64_t *bytes_allocated,
-    uint64_t *number_log_entries, uint64_t *number_unpublished_reserves) {
+    uint64_t *bytes_cached, uint64_t *bytes_dirtied,
+    uint64_t *bytes_allocated, uint64_t *number_log_entries) {
   ceph_assert(this->image_extents.size() == 1);
   *number_log_entries = 1;
   *bytes_dirtied = this->image_extents[0].second;

--- a/src/librbd/cache/pwl/ssd/Request.h
+++ b/src/librbd/cache/pwl/ssd/Request.h
@@ -40,8 +40,7 @@ public:
 protected:
   void setup_buffer_resources(
       uint64_t *bytes_cached, uint64_t *bytes_dirtied,
-      uint64_t *bytes_allocated, uint64_t *number_lanes,
-      uint64_t *number_log_entries,
+      uint64_t *bytes_allocated, uint64_t *number_log_entries,
       uint64_t *number_unpublished_reserves) override;
 };
 
@@ -79,8 +78,7 @@ public:
 
   void setup_buffer_resources(
       uint64_t *bytes_cached, uint64_t *bytes_dirtied,
-      uint64_t *bytes_allocated, uint64_t *number_lanes,
-      uint64_t *number_log_entries,
+      uint64_t *bytes_allocated, uint64_t *number_log_entries,
       uint64_t *number_unpublished_reserves) override;
 };
 

--- a/src/librbd/cache/pwl/ssd/Request.h
+++ b/src/librbd/cache/pwl/ssd/Request.h
@@ -40,8 +40,7 @@ public:
 protected:
   void setup_buffer_resources(
       uint64_t *bytes_cached, uint64_t *bytes_dirtied,
-      uint64_t *bytes_allocated, uint64_t *number_log_entries,
-      uint64_t *number_unpublished_reserves) override;
+      uint64_t *bytes_allocated, uint64_t *number_log_entries) override;
 };
 
 template <typename T>
@@ -78,8 +77,7 @@ public:
 
   void setup_buffer_resources(
       uint64_t *bytes_cached, uint64_t *bytes_dirtied,
-      uint64_t *bytes_allocated, uint64_t *number_log_entries,
-      uint64_t *number_unpublished_reserves) override;
+      uint64_t *bytes_allocated, uint64_t *number_log_entries) override;
 };
 
 } // namespace ssd

--- a/src/librbd/cache/pwl/ssd/Types.h
+++ b/src/librbd/cache/pwl/ssd/Types.h
@@ -14,30 +14,30 @@ namespace cache {
 namespace pwl {
 namespace ssd {
 
-struct SuperBlock{
-  WriteLogPoolRoot root;
+struct SuperBlockWrapper{
+  WriteLogSuperblock superblock;
 
-  DENC(SuperBlock, v, p) {
+  DENC(SuperBlockWrapper, v, p) {
     DENC_START(1, 1, p);
-    denc(v.root, p);
+    denc(v.superblock, p);
     DENC_FINISH(p);
   }
 
   void dump(Formatter *f) const {
-    f->dump_object("super", root);
+    f->dump_object("super", superblock);
   }
 
-  static void generate_test_instances(std::list<SuperBlock*>& ls) {
-    ls.push_back(new SuperBlock());
-    ls.push_back(new SuperBlock);
-    ls.back()->root.layout_version = 3;
-    ls.back()->root.cur_sync_gen = 1;
-    ls.back()->root.pool_size = 10737418240;
-    ls.back()->root.flushed_sync_gen = 1;
-    ls.back()->root.block_size = 4096;
-    ls.back()->root.num_log_entries = 0;
-    ls.back()->root.first_free_entry = 30601;
-    ls.back()->root.first_valid_entry = 2;
+  static void generate_test_instances(std::list<SuperBlockWrapper*>& ls) {
+    ls.push_back(new SuperBlockWrapper());
+    ls.push_back(new SuperBlockWrapper);
+    ls.back()->superblock.layout_version = 3;
+    ls.back()->superblock.cur_sync_gen = 1;
+    ls.back()->superblock.pool_size = 10737418240;
+    ls.back()->superblock.flushed_sync_gen = 1;
+    ls.back()->superblock.block_size = 4096;
+    ls.back()->superblock.num_log_entries = 0;
+    ls.back()->superblock.first_free_entry = 30601;
+    ls.back()->superblock.first_valid_entry = 2;
   }
 };
 
@@ -46,6 +46,6 @@ struct SuperBlock{
 } // namespace cache
 } // namespace librbd
 
-WRITE_CLASS_DENC(librbd::cache::pwl::ssd::SuperBlock)
+WRITE_CLASS_DENC(librbd::cache::pwl::ssd::SuperBlockWrapper)
 
 #endif // CEPH_LIBRBD_CACHE_SSD_TYPES_H

--- a/src/librbd/cache/pwl/ssd/WriteLog.cc
+++ b/src/librbd/cache/pwl/ssd/WriteLog.cc
@@ -341,16 +341,13 @@ bool WriteLog<I>::alloc_resources(C_BlockIORequestT *req) {
   uint64_t bytes_allocated = 0;
   uint64_t bytes_cached = 0;
   uint64_t bytes_dirtied = 0;
-  uint64_t num_lanes = 0;
   uint64_t num_unpublished_reserves = 0;
   uint64_t num_log_entries = 0;
 
   // Setup buffer, and get all the number of required resources
   req->setup_buffer_resources(&bytes_cached, &bytes_dirtied, &bytes_allocated,
-                              &num_lanes, &num_log_entries,
-                              &num_unpublished_reserves);
+                              &num_log_entries, &num_unpublished_reserves);
 
-  ceph_assert(!num_lanes);
   if (num_log_entries) {
     bytes_allocated += num_log_entries * MIN_WRITE_ALLOC_SSD_SIZE;
     num_log_entries = 0;
@@ -358,8 +355,7 @@ bool WriteLog<I>::alloc_resources(C_BlockIORequestT *req) {
   ceph_assert(!num_unpublished_reserves);
 
   alloc_succeeds = this->check_allocation(req, bytes_cached, bytes_dirtied,
-                                          bytes_allocated, num_lanes,
-                                          num_log_entries,
+                                          bytes_allocated, num_log_entries,
                                           num_unpublished_reserves);
   req->set_allocated(alloc_succeeds);
   return alloc_succeeds;

--- a/src/librbd/cache/pwl/ssd/WriteLog.cc
+++ b/src/librbd/cache/pwl/ssd/WriteLog.cc
@@ -341,22 +341,19 @@ bool WriteLog<I>::alloc_resources(C_BlockIORequestT *req) {
   uint64_t bytes_allocated = 0;
   uint64_t bytes_cached = 0;
   uint64_t bytes_dirtied = 0;
-  uint64_t num_unpublished_reserves = 0;
   uint64_t num_log_entries = 0;
 
   // Setup buffer, and get all the number of required resources
-  req->setup_buffer_resources(&bytes_cached, &bytes_dirtied, &bytes_allocated,
-                              &num_log_entries, &num_unpublished_reserves);
+  req->setup_buffer_resources(&bytes_cached, &bytes_dirtied,
+                              &bytes_allocated, &num_log_entries);
 
   if (num_log_entries) {
     bytes_allocated += num_log_entries * MIN_WRITE_ALLOC_SSD_SIZE;
     num_log_entries = 0;
   }
-  ceph_assert(!num_unpublished_reserves);
 
   alloc_succeeds = this->check_allocation(req, bytes_cached, bytes_dirtied,
-                                          bytes_allocated, num_log_entries,
-                                          num_unpublished_reserves);
+                                          bytes_allocated, num_log_entries);
   req->set_allocated(alloc_succeeds);
   return alloc_succeeds;
 }

--- a/src/librbd/cache/pwl/ssd/WriteLog.h
+++ b/src/librbd/cache/pwl/ssd/WriteLog.h
@@ -87,22 +87,22 @@ private:
      }
  }; //class AioTransContext
 
- struct WriteLogPoolRootUpdate {
-    std::shared_ptr<pwl::WriteLogPoolRoot> root;
+ struct WriteLogSuperblockUpdate {
+    std::shared_ptr<pwl::WriteLogSuperblock> superblock;
     Context *ctx;
-    WriteLogPoolRootUpdate(std::shared_ptr<pwl::WriteLogPoolRoot> r,
+    WriteLogSuperblockUpdate(std::shared_ptr<pwl::WriteLogSuperblock> r,
                            Context* c)
-      : root(r), ctx(c) {}
+      : superblock(r), ctx(c) {}
   };
 
-  using WriteLogPoolRootUpdateList = std::list<std::shared_ptr<WriteLogPoolRootUpdate>>;
-  WriteLogPoolRootUpdateList m_poolroot_to_update; /* pool root list to update to SSD */
-  bool m_updating_pool_root = false;
+  using WriteLogSuperblockUpdateList = std::list<std::shared_ptr<WriteLogSuperblockUpdate>>;
+  WriteLogSuperblockUpdateList m_superblock_to_update; /* superblock list to update to SSD */
+  bool m_updating_superblock = false;
 
   std::atomic<int> m_async_update_superblock = {0};
   BlockDevice *bdev = nullptr;
-  pwl::WriteLogPoolRoot pool_root;
-  Builder<This> *m_builderobj;
+  pwl::WriteLogSuperblock m_superblock;
+  Builder<This> *m_builderobj = nullptr;
 
   Builder<This>* create_builder();
   int create_and_open_bdev();
@@ -129,13 +129,13 @@ private:
                   uint64_t* new_first_free_entry);
   void write_log_entries(GenericLogEntriesVector log_entries,
                          AioTransContext *aio, uint64_t *pos);
-  void schedule_update_root(std::shared_ptr<WriteLogPoolRoot> root,
-                            Context *ctx);
-  void enlist_op_update_root();
-  void update_root_scheduled_ops();
-  int update_pool_root_sync(std::shared_ptr<pwl::WriteLogPoolRoot> root);
-  void update_pool_root(std::shared_ptr<WriteLogPoolRoot> root,
-                                          AioTransContext *aio);
+  void schedule_update_superblock(std::shared_ptr<WriteLogSuperblock> superblock,
+                                  Context *ctx);
+  void enlist_op_update_superblock();
+  void update_superblock_scheduled_ops();
+  int update_superblock_sync(std::shared_ptr<pwl::WriteLogSuperblock> superblock);
+  void update_superblock(std::shared_ptr<WriteLogSuperblock> superblock,
+                         AioTransContext *aio);
   void aio_read_data_block(std::shared_ptr<GenericWriteLogEntry> log_entry,
                            bufferlist *bl, Context *ctx);
   void aio_read_data_blocks(std::vector<std::shared_ptr<GenericWriteLogEntry>> &log_entries,

--- a/src/test/librbd/cache/pwl/test_mock_ReplicatedWriteLog.cc
+++ b/src/test/librbd/cache/pwl/test_mock_ReplicatedWriteLog.cc
@@ -161,6 +161,7 @@ TEST_F(TestMockCacheReplicatedWriteLog, init_shutdown) {
   MockReplicatedWriteLog rwl(
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   MockContextRWL finish_ctx1;
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
@@ -186,6 +187,7 @@ TEST_F(TestMockCacheReplicatedWriteLog, write) {
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
 
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   MockContextRWL finish_ctx1;
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
@@ -219,6 +221,7 @@ TEST_F(TestMockCacheReplicatedWriteLog, flush) {
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
 
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
 
@@ -259,7 +262,8 @@ TEST_F(TestMockCacheReplicatedWriteLog, flush_source_shutdown) {
   MockReplicatedWriteLog rwl(
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
-  
+
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
 
@@ -299,6 +303,7 @@ TEST_F(TestMockCacheReplicatedWriteLog, flush_source_internal) {
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
 
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
 
@@ -337,6 +342,7 @@ TEST_F(TestMockCacheReplicatedWriteLog, flush_source_user) {
   MockReplicatedWriteLog rwl(
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
 
@@ -376,6 +382,7 @@ TEST_F(TestMockCacheReplicatedWriteLog, read_hit_rwl_cache) {
   MockReplicatedWriteLog rwl(
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
 
@@ -419,6 +426,7 @@ TEST_F(TestMockCacheReplicatedWriteLog, read_hit_part_rwl_cache) {
   MockReplicatedWriteLog rwl(
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
 
@@ -466,6 +474,7 @@ TEST_F(TestMockCacheReplicatedWriteLog, read_miss_rwl_cache) {
   MockReplicatedWriteLog rwl(
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
 
@@ -508,6 +517,7 @@ TEST_F(TestMockCacheReplicatedWriteLog, discard) {
   MockReplicatedWriteLog rwl(
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
 
@@ -556,6 +566,7 @@ TEST_F(TestMockCacheReplicatedWriteLog, writesame) {
   MockReplicatedWriteLog rwl(
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
 
@@ -598,6 +609,7 @@ TEST_F(TestMockCacheReplicatedWriteLog, invalidate) {
   MockReplicatedWriteLog rwl(
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
 
@@ -638,6 +650,7 @@ TEST_F(TestMockCacheReplicatedWriteLog, compare_and_write_compare_matched) {
   MockReplicatedWriteLog rwl(
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
 
@@ -692,6 +705,7 @@ TEST_F(TestMockCacheReplicatedWriteLog, compare_and_write_compare_failed) {
   MockReplicatedWriteLog rwl(
       mock_image_ctx, get_cache_state(mock_image_ctx, mock_api),
       mock_image_writeback, mock_api);
+  mock_image_ctx.cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
   expect_op_work_queue(mock_image_ctx);
   expect_metadata_set(mock_image_ctx);
 

--- a/src/test/librbd/test_support.cc
+++ b/src/test/librbd/test_support.cc
@@ -130,7 +130,13 @@ bool is_librados_test_stub(librados::Rados &rados) {
 bool is_rbd_pwl_enabled(ceph::common::CephContext *cct) {
 #if defined(WITH_RBD_RWL) || defined(WITH_RBD_SSD_CACHE)
   auto value = cct->_conf.get_val<std::string>("rbd_persistent_cache_mode");
-  return value == "disabled" ? false : true;
+  if (value == "disabled") {
+    return false;
+  } else {
+    // allow rwl to be run on any device, not only pmem
+    cct->_conf.set_val("rbd_persistent_cache_allow_simulation", "true");
+    return true;
+  }
 #else
   return false;
 #endif

--- a/src/tools/ceph-dencoder/rbd_types.h
+++ b/src/tools/ceph-dencoder/rbd_types.h
@@ -23,8 +23,8 @@ TYPE(rbd::mirror::image_map::PolicyData)
 #include "librbd/cache/pwl/Types.h"
 #include "librbd/cache/pwl/ssd/Types.h"
 TYPE(librbd::cache::pwl::WriteLogCacheEntry)
-TYPE(librbd::cache::pwl::WriteLogPoolRoot)
-TYPE(librbd::cache::pwl::ssd::SuperBlock)
+TYPE(librbd::cache::pwl::WriteLogSuperblock)
+TYPE(librbd::cache::pwl::ssd::SuperBlockWrapper)
 #endif
 
 #ifdef WITH_RBD


### PR DESCRIPTION
RWL needs to implement replica in the future, so it needs its own space allocator or manager to copy data directly to the remote client address space during RDMA connection. After the pmem is mapped to the memory, the cache of the local client and the remote client(replica) is only the difference of the head address, and the others are replication. In this way, the remote can reuse the current code. If the remote server uses a allocator similar to `libpmemobj` to manage another set of processes, the program will be very complex and the performance will be low. So we decide abandon `libpmemobj` and use `libpmem` to manage the address space.
  
At the same time, using libpmem can also bring many benefits, such as:

- Performance improvement, because the IO path is shorter and the latency is reduced. `libpmemobj` is a high-level package based on libpmem.
- Simplify the data structure, no longer use the complex data structure customized by `libpmemobj` like `TOID()`, but use simple address and offset.
- After simplifying the data structure,  can remove the `#ifdef` in the data structure and change the persistence method of RWL to `encode/decode` mode more conveniently.

  
The new pmem manager provides the functions of device creation and destruction, space allocation and release. Because pmem can be written overlay, space allocation and release are only coordinate movement. In terms of transaction, because pmem can only guarantee the atomicity of 8 bytes. double root and CRC are used to ensure that there is an valid root in case of unexpected crash or downtime.

After change libpmemobj to libpmem, cleaned some code:

- remove the operation of split extents;
- rename root to superblock;
- remove lanes from pwl;
- remove published_reserves ;
- combine write_data & write_data_pos into one filed;
- remove entry_index rename MIN_WRITE_ALLOC_SIZE and reset value.

Finally, to avoid low performance caused by users using cache with no dax feature for memory mapping. Require cache files with dax feature on pmem in rwl mode  Add debug configuration to allow users to use any cache files to simulate files with dax feature on pmem for memory mapping.

Signed-off-by: Yin Congmin <congmin.yin@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
