### PR TITLE
os/bluestore/bluestore_tool: compare retval stat() with -1

### DIFF
--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -106,6 +106,11 @@ if(WITH_BLUESTORE)
     bluestore/bluestore_tool.cc)
   target_link_libraries(ceph-bluestore-tool
     os global)
+  # TODO: drop this linkage once we don't need to build on bionic
+  if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
+    target_link_libraries(ceph-bluestore-tool
+      Boost::filesystem)
+  endif()
   install(TARGETS ceph-bluestore-tool
     DESTINATION bin)
 endif()

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -790,9 +790,12 @@ int main(int argc, char **argv)
 
     // Attach either DB or WAL volume, create if needed
     struct stat st;
-    int r = ::stat(rlpath, &st);
+    int r = -1;
+    if (rlpath != nullptr) {
+      r = ::stat(rlpath, &st);
+    }
     // check if we need additional size specification
-    if (r == ENOENT || (r == 0 && S_ISREG(st.st_mode) && st.st_size == 0)) {
+    if (r == -1 || (r == 0 && S_ISREG(st.st_mode) && st.st_size == 0)) {
       r = 0;
       if (need_db && cct->_conf->bluestore_block_db_size == 0) {
 	cerr << "Might need DB size specification, "

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -9,9 +9,9 @@
 #if __has_include(<filesystem>)
 #include <filesystem>
 namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
+#else
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
 #endif
 #include <iostream>
 #include <fstream>
@@ -249,8 +249,8 @@ static void bluefs_import(
 
   BlueFS::FileWriter *h;
   fs::path file_path(dest_file);
-  const string dir = file_path.parent_path();
-  const string file_name = file_path.filename();
+  const string dir = file_path.parent_path().native();
+  const string file_name = file_path.filename().native();
   bs->open_for_write(dir, file_name, &h, false);
   uint64_t max_block = 4096;
   char buf[max_block];


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50891

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
