### PR TITLE
common/cmdparse: use string_view for the key and return val by retval

### DIFF
--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -638,7 +638,7 @@ bool validate_cmd(CephContext* cct,
 }
 
 bool cmd_getval(const cmdmap_t& cmdmap,
-		const std::string& k, bool& val)
+		std::string_view k, bool& val)
 {
   /*
    * Specialized getval for booleans.  CephBool didn't exist before Nautilus,
@@ -651,7 +651,8 @@ bool cmd_getval(const cmdmap_t& cmdmap,
       return true;
     } catch (boost::bad_get&) {
       try {
-        std::string expected = "--" + k;
+        std::string expected{"--"};
+	expected += k;
         std::replace(expected.begin(), expected.end(), '_', '-');
 
         std::string v_str = boost::get<std::string>(cmdmap.find(k)->second);

--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -645,29 +645,30 @@ bool cmd_getval(const cmdmap_t& cmdmap,
    * so earlier clients are sent a CephChoices argdesc instead, and will
    * send us a "--foo-bar" value string for boolean arguments.
    */
-  if (cmdmap.count(k)) {
+  auto found = cmdmap.find(k);
+  if (found == cmdmap.end()) {
+    return false;
+  }
+  try {
+    val = boost::get<bool>(found->second);
+    return true;
+  } catch (boost::bad_get&) {
     try {
-      val = boost::get<bool>(cmdmap.find(k)->second);
-      return true;
-    } catch (boost::bad_get&) {
-      try {
-        std::string expected{"--"};
-	expected += k;
-        std::replace(expected.begin(), expected.end(), '_', '-');
+      std::string expected{"--"};
+      expected += k;
+      std::replace(expected.begin(), expected.end(), '_', '-');
 
-        std::string v_str = boost::get<std::string>(cmdmap.find(k)->second);
-        if (v_str == expected) {
-          val = true;
-          return true;
-        } else {
-          throw bad_cmd_get(k, cmdmap);
-        }
-      } catch (boost::bad_get&) {
-        throw bad_cmd_get(k, cmdmap);
+      std::string v_str = boost::get<std::string>(found->second);
+      if (v_str == expected) {
+	val = true;
+	return true;
+      } else {
+	throw bad_cmd_get(k, cmdmap);
       }
+    } catch (boost::bad_get&) {
+      throw bad_cmd_get(k, cmdmap);
     }
   }
-  return false;
 }
 
 }

--- a/src/common/cmdparse.h
+++ b/src/common/cmdparse.h
@@ -65,15 +65,16 @@ template <typename T>
 bool cmd_getval(const cmdmap_t& cmdmap,
 		std::string_view k, T& val)
 {
-  if (cmdmap.count(k)) {
-    try {
-      val = boost::get<T>(cmdmap.find(k)->second);
-      return true;
-    } catch (boost::bad_get&) {
-      throw bad_cmd_get(k, cmdmap);
-    }
+  auto found = cmdmap.find(k);
+  if (found == cmdmap.end()) {
+    return false;
   }
-  return false;
+  try {
+    val = boost::get<T>(found->second);
+    return true;
+  } catch (boost::bad_get&) {
+    throw bad_cmd_get(k, cmdmap);
+  }
 }
 
 // with default
@@ -83,16 +84,16 @@ bool cmd_getval(
   const cmdmap_t& cmdmap, std::string_view k,
   T& val, const T& defval)
 {
-  if (cmdmap.count(k)) {
-    try {
-      val = boost::get<T>(cmdmap.find(k)->second);
-      return true;
-    } catch (boost::bad_get&) {
-      throw bad_cmd_get(k, cmdmap);
-    }
-  } else {
+  auto found = cmdmap.find(k);
+  if (found == cmdmap.end()) {
     val = defval;
     return true;
+  }
+  try {
+    val = boost::get<T>(cmdmap.find(k)->second);
+    return true;
+  } catch (boost::bad_get&) {
+    throw bad_cmd_get(k, cmdmap);
   }
 }
 

--- a/src/common/cmdparse.h
+++ b/src/common/cmdparse.h
@@ -5,6 +5,7 @@
 
 #include <vector>
 #include <stdexcept>
+#include <optional>
 #include <ostream>
 #include <boost/variant.hpp>
 #include "include/ceph_assert.h"	// boost clobbers this
@@ -74,6 +75,18 @@ bool cmd_getval(const cmdmap_t& cmdmap,
     return true;
   } catch (boost::bad_get&) {
     throw bad_cmd_get(k, cmdmap);
+  }
+}
+
+template <typename T>
+std::optional<T> cmd_getval(const cmdmap_t& cmdmap,
+			    std::string_view k)
+{
+  T ret;
+  if (const bool found = cmd_getval(cmdmap, k, ret); found) {
+    return std::make_optional(std::move(ret));
+  } else {
+    return std::nullopt;
   }
 }
 

--- a/src/common/cmdparse.h
+++ b/src/common/cmdparse.h
@@ -48,8 +48,10 @@ std::string cmd_vartype_stringify(const cmd_vartype& v);
 
 struct bad_cmd_get : public std::exception {
   std::string desc;
-  bad_cmd_get(const std::string& f, const cmdmap_t& cmdmap) {
-    desc = "bad or missing field '" + f + "'";
+  bad_cmd_get(std::string_view f, const cmdmap_t& cmdmap) {
+    desc += "bad or missing field '";
+    desc += f;
+    desc += "'";
   }
   const char *what() const throw() override {
     return desc.c_str();
@@ -57,11 +59,11 @@ struct bad_cmd_get : public std::exception {
 };
 
 bool cmd_getval(const cmdmap_t& cmdmap,
-		const std::string& k, bool& val);
+		std::string_view k, bool& val);
 
 template <typename T>
 bool cmd_getval(const cmdmap_t& cmdmap,
-		const std::string& k, T& val)
+		std::string_view k, T& val)
 {
   if (cmdmap.count(k)) {
     try {
@@ -78,7 +80,7 @@ bool cmd_getval(const cmdmap_t& cmdmap,
 
 template <typename T>
 bool cmd_getval(
-  const cmdmap_t& cmdmap, const std::string& k,
+  const cmdmap_t& cmdmap, std::string_view k,
   T& val, const T& defval)
 {
   if (cmdmap.count(k)) {
@@ -96,9 +98,9 @@ bool cmd_getval(
 
 template <typename T>
 void
-cmd_putval(CephContext *cct, cmdmap_t& cmdmap, const std::string& k, const T& val)
+cmd_putval(CephContext *cct, cmdmap_t& cmdmap, std::string_view k, const T& val)
 {
-  cmdmap[k] = val;
+  cmdmap.insert_or_assign(std::string{k}, val);
 }
 
 bool validate_cmd(CephContext* cct,

--- a/src/common/cmdparse.h
+++ b/src/common/cmdparse.h
@@ -79,19 +79,16 @@ bool cmd_getval(const cmdmap_t& cmdmap,
 
 // with default
 
-template <typename T>
-bool cmd_getval(
-  const cmdmap_t& cmdmap, std::string_view k,
-  T& val, const T& defval)
+template <typename T, typename V>
+T cmd_getval_or(const cmdmap_t& cmdmap, std::string_view k,
+		const V& defval)
 {
   auto found = cmdmap.find(k);
   if (found == cmdmap.end()) {
-    val = defval;
-    return true;
+    return T(defval);
   }
   try {
-    val = boost::get<T>(cmdmap.find(k)->second);
-    return true;
+    return boost::get<T>(cmdmap.find(k)->second);
   } catch (boost::bad_get&) {
     throw bad_cmd_get(k, cmdmap);
   }

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1046,7 +1046,7 @@ bool DaemonServer::_handle_command(
     if (boost::algorithm::ends_with(prefix, "_json")) {
       format = "json";
     } else {
-      cmd_getval(cmdctx->cmdmap, "format", format, string("plain"));
+      format = cmd_getval_or<string>(cmdctx->cmdmap, "format", "plain");
     }
     f.reset(Formatter::create(format));
   }
@@ -1408,8 +1408,7 @@ bool DaemonServer::_handle_command(
     bool dry_run =
       prefix == "osd test-reweight-by-pg" ||
       prefix == "osd test-reweight-by-utilization";
-    int64_t oload;
-    cmd_getval(cmdctx->cmdmap, "oload", oload, int64_t(120));
+    int64_t oload = cmd_getval_or<int64_t>(cmdctx->cmdmap, "oload", 120);
     set<int64_t> pools;
     vector<string> poolnames;
     cmd_getval(cmdctx->cmdmap, "pools", poolnames);

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -829,8 +829,7 @@ bool AuthMonitor::preprocess_command(MonOpRequestRef op)
     return true;
   }
 
-  string format;
-  cmd_getval(cmdmap, "format", format, string("plain"));
+  string format = cmd_getval_or<string>(cmdmap, "format", "plain");
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   if (prefix == "auth export") {
@@ -1345,8 +1344,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
 
   cmd_getval(cmdmap, "prefix", prefix);
 
-  string format;
-  cmd_getval(cmdmap, "format", format, string("plain"));
+  string format = cmd_getval_or<string>(cmdmap, "format", "plain");
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   MonSession *session = op->get_session();

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -180,8 +180,7 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
     mon.reply_command(op, -EINVAL, rs, get_last_committed());
     return true;
   }
-  string format;
-  cmd_getval(cmdmap, "format", format, string("plain"));
+  string format = cmd_getval_or<string>(cmdmap, "format", "plain");
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   string prefix;

--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -280,8 +280,7 @@ bool HealthMonitor::prepare_command(MonOpRequestRef op)
     return true;
   }
 
-  string format;
-  cmd_getval(cmdmap, "format", format, string("plain"));
+  string format = cmd_getval_or<string>(cmdmap, "format", "plain");
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   string prefix;

--- a/src/mon/KVMonitor.cc
+++ b/src/mon/KVMonitor.cc
@@ -146,8 +146,7 @@ bool KVMonitor::preprocess_command(MonOpRequestRef op)
     mon.reply_command(op, -EINVAL, rs, get_last_committed());
     return true;
   }
-  string format;
-  cmd_getval(cmdmap, "format", format, string("plain"));
+  string format = cmd_getval_or<string>(cmdmap, "format", "plain");
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   string prefix;

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -579,8 +579,7 @@ bool LogMonitor::preprocess_command(MonOpRequestRef op)
   string prefix;
   cmd_getval(cmdmap, "prefix", prefix);
 
-  string format;
-  cmd_getval(cmdmap, "format", format, string("plain"));
+  string format = cmd_getval_or<string>(cmdmap, "format", "plain");
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   if (prefix == "log last") {
@@ -736,7 +735,6 @@ bool LogMonitor::prepare_command(MonOpRequestRef op)
 
   if (prefix == "log") {
     vector<string> logtext;
-    string level_str;
     cmd_getval(cmdmap, "logtext", logtext);
     LogEntry le;
     le.rank = m->get_orig_source();
@@ -744,7 +742,7 @@ bool LogMonitor::prepare_command(MonOpRequestRef op)
     le.name = session->entity_name;
     le.stamp = m->get_recv_stamp();
     le.seq = 0;
-    cmd_getval(cmdmap, "level", level_str, string("info"));
+    string level_str = cmd_getval_or<string>(cmdmap, "level", "info");
     le.prio = LogEntry::str_to_level(level_str);
     le.channel = CLOG_CHANNEL_DEFAULT;
     le.msg = str_join(logtext, " ");

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -951,8 +951,7 @@ bool MDSMonitor::preprocess_command(MonOpRequestRef op)
 
   string prefix;
   cmd_getval(cmdmap, "prefix", prefix);
-  string format;
-  cmd_getval(cmdmap, "format", format, string("plain"));
+  string format = cmd_getval_or<string>(cmdmap, "format", "plain");
   std::unique_ptr<Formatter> f(Formatter::create(format));
 
   MonSession *session = op->get_session();

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -86,19 +86,19 @@ static const string MDS_HEALTH_PREFIX("mds_health");
  */
 namespace TOPNSPC::common {
 template<> bool cmd_getval(const cmdmap_t& cmdmap,
-			   const std::string& k, mds_gid_t &val)
+			   std::string_view k, mds_gid_t &val)
 {
   return cmd_getval(cmdmap, k, (int64_t&)val);
 }
 
 template<> bool cmd_getval(const cmdmap_t& cmdmap,
-			   const std::string& k, mds_rank_t &val)
+			   std::string_view k, mds_rank_t &val)
 {
   return cmd_getval(cmdmap, k, (int64_t&)val);
 }
 
 template<> bool cmd_getval(const cmdmap_t& cmdmap,
-			   const std::string& k, MDSMap::DaemonState &val)
+			   std::string_view k, MDSMap::DaemonState &val)
 {
   return cmd_getval(cmdmap, k, (int64_t&)val);
 }

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -976,8 +976,7 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
     f->close_section();
     f->flush(rdata);
   } else if (prefix == "mgr dump") {
-    int64_t epoch = 0;
-    cmd_getval(cmdmap, "epoch", epoch, (int64_t)map.get_epoch());
+    int64_t epoch = cmd_getval_or<int64_t>(cmdmap, "epoch", map.get_epoch());
     if (epoch == (int64_t)map.get_epoch()) {
       f->dump_object("mgrmap", map);
     } else {
@@ -1110,8 +1109,7 @@ bool MgrMonitor::prepare_command(MonOpRequestRef op)
     return true;
   }
 
-  string format;
-  cmd_getval(cmdmap, "format", format, string("plain"));
+  string format = cmd_getval_or<string>(cmdmap, "format", "plain");
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   string prefix;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3340,8 +3340,7 @@ void Monitor::handle_command(MonOpRequestRef op)
 
   dout(0) << "handle_command " << *m << dendl;
 
-  string format;
-  cmd_getval(cmdmap, "format", format, string("plain"));
+  string format = cmd_getval_or<string>(cmdmap, "format", "plain");
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   get_str_vec(prefix, fullcmd);

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -308,8 +308,7 @@ bool MonmapMonitor::preprocess_command(MonOpRequestRef op)
     return true;
   }
 
-  string format;
-  cmd_getval(cmdmap, "format", format, string("plain"));
+  string format = cmd_getval_or<string>(cmdmap, "format", "plain");
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   if (prefix == "mon stat") {
@@ -344,8 +343,7 @@ bool MonmapMonitor::preprocess_command(MonOpRequestRef op)
              prefix == "mon dump") {
 
     epoch_t epoch;
-    int64_t epochnum;
-    cmd_getval(cmdmap, "epoch", epochnum, (int64_t)0);
+    int64_t epochnum = cmd_getval_or<int64_t>(cmdmap, "epoch", 0);
     epoch = epochnum;
 
     MonMap *p = mon.monmap;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5423,8 +5423,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
   string prefix;
   cmd_getval(cmdmap, "prefix", prefix);
 
-  string format;
-  cmd_getval(cmdmap, "format", format, string("plain"));
+  string format = cmd_getval_or<string>(cmdmap, "format", "plain");
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   if (prefix == "osd stat") {
@@ -5447,11 +5446,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	   prefix == "osd ls-tree" ||
 	   prefix == "osd info") {
 
-    epoch_t epoch = 0;
-    int64_t epochnum;
-    cmd_getval(cmdmap, "epoch", epochnum, (int64_t)osdmap.get_epoch());
-    epoch = epochnum;
-    
+    epoch_t epoch = cmd_getval_or<int64_t>(cmdmap, "epoch", osdmap.get_epoch());
     bufferlist osdmap_bl;
     int err = get_version_full(epoch, osdmap_bl);
     if (err == -ENOENT) {
@@ -9691,8 +9686,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
   bufferlist rdata;
   int err = 0;
 
-  string format;
-  cmd_getval(cmdmap, "format", format, string("plain"));
+  string format = cmd_getval_or<string>(cmdmap, "format", "plain");
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   string prefix;
@@ -12519,9 +12513,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       }
       if (blocklistop == "add") {
 	utime_t expires = ceph_clock_now();
-	double d;
 	// default one hour
-	cmd_getval(cmdmap, "expire", d,
+	double d = cmd_getval_or<double>(cmdmap, "expire",
           g_conf()->mon_osd_blocklist_default_expire);
 	expires += d;
 
@@ -12643,12 +12636,9 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 					      get_last_committed() + 1));
     return true;
   } else if (prefix == "osd pool create") {
-    int64_t pg_num, pg_num_min;
-    int64_t pgp_num;
-    cmd_getval(cmdmap, "pg_num", pg_num, int64_t(0));
-    cmd_getval(cmdmap, "pgp_num", pgp_num, pg_num);
-    cmd_getval(cmdmap, "pg_num_min", pg_num_min, int64_t(0));
-
+    int64_t pg_num = cmd_getval_or<int64_t>(cmdmap, "pg_num", 0);
+    int64_t pg_num_min = cmd_getval_or<int64_t>(cmdmap, "pg_num_min", 0);
+    int64_t pgp_num = cmd_getval_or<int64_t>(cmdmap, "pgp_num", pg_num);
     string pool_type_str;
     cmd_getval(cmdmap, "pool_type", pool_type_str);
     if (pool_type_str.empty())
@@ -12719,8 +12709,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 	  rule_name = poolstr;
 	}
       }
-      cmd_getval(cmdmap, "expected_num_objects",
-                 expected_num_objects, int64_t(0));
+      expected_num_objects =
+	cmd_getval_or<int64_t>(cmdmap, "expected_num_objects", 0);
     } else {
       //NOTE:for replicated pool,cmd_map will put rule_name to erasure_code_profile field
       //     and put expected_num_objects to rule field
@@ -12736,8 +12726,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
         }
         rule_name = erasure_code_profile;
       } else { // cmd is well-formed
-        cmd_getval(cmdmap, "expected_num_objects",
-                   expected_num_objects, int64_t(0));
+        expected_num_objects =
+	  cmd_getval_or<int64_t>(cmdmap, "expected_num_objects", 0);
       }
     }
 
@@ -12793,8 +12783,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       }
     }
 
-    int64_t fast_read_param;
-    cmd_getval(cmdmap, "fast_read", fast_read_param, int64_t(-1));
+    int64_t fast_read_param = cmd_getval_or<int64_t>(cmdmap, "fast_read", -1);
     FastReadType fast_read = FAST_READ_DEFAULT;
     if (fast_read_param == 0)
       fast_read = FAST_READ_OFF;

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -35,6 +35,7 @@ using ceph::bufferlist;
 using ceph::fixed_u_to_string;
 
 using TOPNSPC::common::cmd_getval;
+using TOPNSPC::common::cmd_getval_or;
 
 MEMPOOL_DEFINE_OBJECT_FACTORY(PGMapDigest, pgmap_digest, pgmap);
 MEMPOOL_DEFINE_OBJECT_FACTORY(PGMap, pgmap, pgmap);
@@ -3657,9 +3658,9 @@ int process_pg_map_command(
     cmd_getval(cmdmap, "stuckops", stuckop_vec);
     if (stuckop_vec.empty())
       stuckop_vec.push_back("unclean");
-    int64_t threshold;
-    cmd_getval(cmdmap, "threshold", threshold,
-               g_conf().get_val<int64_t>("mon_pg_stuck_threshold"));
+    const int64_t threshold = cmd_getval_or<int64_t>(
+      cmdmap, "threshold",
+      g_conf().get_val<int64_t>("mon_pg_stuck_threshold"));
 
     if (pg_map.dump_stuck_pg_stats(ds, f, (int)threshold, stuckop_vec) < 0) {
       *ss << "failed";
@@ -3671,9 +3672,9 @@ int process_pg_map_command(
   }
 
   if (prefix == "pg debug") {
-    string debugop;
-    cmd_getval(cmdmap, "debugop", debugop,
-	       string("unfound_objects_exist"));
+    const string debugop = cmd_getval_or<string>(
+      cmdmap, "debugop",
+      "unfound_objects_exist");
     if (debugop == "unfound_objects_exist") {
       bool unfound_objects_exist = false;
       for (const auto& p : pg_map.pg_stat) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -104,6 +104,7 @@ using ceph::encode_destructively;
 
 using namespace ceph::osd::scheduler;
 using TOPNSPC::common::cmd_getval;
+using TOPNSPC::common::cmd_getval_or;
 
 template <typename T>
 static ostream& _prefix(std::ostream *_dout, T *pg) {
@@ -1145,8 +1146,7 @@ void PrimaryLogPG::do_command(
   else if (prefix == "scrub" ||
 	   prefix == "deep_scrub") {
     bool deep = (prefix == "deep_scrub");
-    int64_t time;
-    cmd_getval(cmdmap, "time", time, (int64_t)0);
+    int64_t time = cmd_getval_or<int64_t>(cmdmap, "time", 0);
 
     if (is_primary()) {
       const pg_pool_t *p = &pool.info;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
