### PR TITLE
rgw: add 'rgw_suggested_removal_wait_time' option when deleting object key.

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2928,3 +2928,10 @@ options:
   - rgw
   flags:
   - startup
+- name: rgw_suggested_removal_wait_time
+  type: int
+  level: basic
+  desc: The waiting time for removing bucket_dir_key when doing pending-state object
+  default: 5
+  services:
+  - rgw


### PR DESCRIPTION
rgw: add 'rgw_suggested_removal_wait_time' option when deleting object key.

In a multi-site synchronization environment, the bucket full sync process will send a bucket list request to the remote, but the remote execution of the bucket list operation is likely to delete the object key.  This parameter is added to delay deleting the object key.

Fixes: https://tracker.ceph.com/issues/50892
Signed-off-by: WeiGuo Ren weiguo.ren@xtaotech.com
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
