### PR TITLE
mon/auth: trigger_propose not active cause mon leader update rotate r…

### DIFF
--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -195,8 +195,8 @@ class KeyServer : public KeyStore {
   KeyServerData data;
   mutable ceph::mutex lock;
 
-  int _rotate_secret(uint32_t service_id);
-  bool _check_rotating_secrets();
+  int _rotate_secret(uint32_t service_id, int auth_done);
+  bool _check_rotating_secrets(int auth_done = 0);
   void _dump_rotating_secrets();
   int _build_session_auth_info(uint32_t service_id, 
 			       const AuthTicket& parent_ticket,
@@ -297,7 +297,7 @@ public:
     }
   }
 
-  bool updated_rotating(ceph::buffer::list& rotating_bl, version_t& rotating_ver);
+  bool updated_rotating(ceph::buffer::list& rotating_bl, version_t& rotating_ver, int auth_done = 0);
 
   bool get_rotating_encrypted(const EntityName& name, ceph::buffer::list& enc_bl) const;
 

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -29,9 +29,12 @@ class KeyRing;
 class Monitor;
 
 #define MIN_GLOBAL_ID 0x1000
+#define MAX_AUTH_RETRY 3
+#define CHECK_AUTH_DONE 1
 
 class AuthMonitor : public PaxosService {
 public:
+  int auth_propose_retry = 0;
   enum IncType {
     GLOBAL_ID,
     AUTH_DATA,
@@ -165,7 +168,7 @@ private:
   bool preprocess_command(MonOpRequestRef op);
   bool prepare_command(MonOpRequestRef op);
 
-  bool check_rotate();
+  bool check_rotate(int check = 0);
 
   bool entity_is_pending(EntityName& entity);
   int exists_and_matches_entity(

--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -32,6 +32,14 @@ class PaxosService {
    */
  public:
   /**
+  *rotate_secret update state
+  */
+  enum propose_auth {
+    NO_AUTH_PROPOSE,
+    AUTH_PROPOSE_START,
+    AUTH_PROPOSE_DONE,
+  };
+  /**
    * The Monitor to which this class is associated with
    */
   Monitor &mon;
@@ -63,6 +71,7 @@ protected:
   version_t service_version;
 
  private:
+  int auth_propose_done = 0;//1:start trigger_propose  2:propose succeed
   /**
    * Event callback responsible for proposing our pending value once a timer 
    * runs out and fires.
@@ -171,7 +180,12 @@ public:
   virtual void get_store_prefixes(std::set<std::string>& s) const {
     s.insert(service_name);
   }
-  
+  virtual void set_auth_done(int num) {
+    auth_propose_done = num;
+  }
+  virtual int get_auth_done() {
+    return auth_propose_done;
+  }
   // i implement and you ignore
   /**
    * Informs this instance that it should consider itself restarted.
@@ -230,7 +244,7 @@ public:
    * @note This function depends on the implementation of encode_pending on
    *	   the class that is implementing PaxosService
    */
-  void propose_pending();
+  void propose_pending(int auth = 0);
 
   /**
    * Let others request us to propose.


### PR DESCRIPTION
When Paxos in the update state, mon leader need update rotate secret just right. It cause trigger_propose not active and return false. update rotate secret is not timely. For this case，just retry propose . retry three times at most,if retry three times still failed just give up retransmission。

Fixes: https://tracker.ceph.com/issues/50775

Signed-off-by: wenge.song <wenge.song@lenovonetapp.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
