### PR TITLE
cephadm: add daemon_name in daemon descriptiono

### DIFF
--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -943,6 +943,7 @@ class DaemonDescription(object):
         out: Dict[str, Any] = OrderedDict()
         out['daemon_type'] = self.daemon_type
         out['daemon_id'] = self.daemon_id
+        out['daemon_name'] = '{}.{}'.format(self.daemon_type, self.daemon_id)
         out['hostname'] = self.hostname
         out['container_id'] = self.container_id
         out['container_image_id'] = self.container_image_id
@@ -977,6 +978,7 @@ class DaemonDescription(object):
         out: Dict[str, Any] = OrderedDict()
         out['daemon_type'] = self.daemon_type
         out['daemon_id'] = self.daemon_id
+        out['daemon_name'] = '{}.{}'.format(self.daemon_type, self.daemon_id)
         out['hostname'] = self.hostname
         out['container_id'] = self.container_id
         out['container_image_id'] = self.container_image_id


### PR DESCRIPTION
This adds the daemon_name in json output when asking for daemon
description.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
