### PR TITLE
cephadm: allow /etc/hosts with podman

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -291,6 +291,7 @@ names etc. When cephadm initiates an ssh connection to a remote host,
 the host name  can be resolved in four different ways:
 
 -  a custom ssh config resolving the name to an IP
+-  via an externally maintained ``/etc/hosts`` (not recommended)
 -  via explicitly providing an IP address to cephadm: ``ceph orch host add <hostname> <IP>``
 -  automatic name resolution via DNS.
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3134,10 +3134,13 @@ class CephContainer:
         ]
 
         if isinstance(self.ctx.container_engine, Podman):
-            # podman adds the container *name* to /etc/hosts (for 127.0.1.1)
-            # by default, which makes python's socket.getfqdn() return that
-            # instead of a valid hostname.
-            cmd_args.append('--no-hosts')
+            # podman adds the container *name* to /etc/hosts (for
+            # 127.0.1.1) by default, which makes python's
+            # socket.getfqdn() return that instead of a valid
+            # hostname.  explicitly add an entry for the host.  this
+            # leads to a duplicate, but our --add-host item comes
+            # first, and that is the one that is used.
+            cmd_args.extend(['--add-host', f'{get_hostname()}:127.0.1.1'])
             if os.path.exists('/etc/ceph/podman-auth.json'):
                 cmd_args.append('--authfile=/etc/ceph/podman-auth.json')
 

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1289,7 +1289,10 @@ To add the cephadm SSH key to the host:
 > ceph cephadm get-pub-key > ~/ceph.pub
 > ssh-copy-id -f -i ~/ceph.pub {user}@{addr}
 
-To check that the host is reachable open a new shell with the --no-hosts flag:
+To check that the host is reachable:
+> cephadm shell
+
+To check that the host is reachable *without* /etc/hosts (which may vary):
 > cephadm shell --no-hosts
 
 Then run the following:


### PR DESCRIPTION
We were disabling /etc/hosts with podman.  This reverts that behavior so that it is now allowed.

Note that docker does not pass through /etc/hosts by default (unlike podman).

So, new/final behavior: docker containers do not respect /etc/hosts; podman does pass through /etc/hosts.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>