### PR TITLE
qa/suites/rados: include rook test in rados

### DIFF
--- a/qa/suites/rados/rook
+++ b/qa/suites/rados/rook
@@ -1,0 +1,1 @@
+../orch/rook


### PR DESCRIPTION
This just to make sure we don't break mgr/orchestrator.

Note that we already symlink ../orch/cephadm, so this makes rados
include all of orch/.

Signed-off-by: Sage Weil <sage@newdream.net>