### PR TITLE
rgw multisite: teach 'bucket sync checkpoint' about log generations

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2310,8 +2310,10 @@ static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::Ra
 
   out << indented{width} << "incremental sync on " << total_shards << " shards\n";
 
+  rgw_bucket_index_marker_info remote_info;
   BucketIndexShardsManager remote_markers;
-  r = rgw_read_remote_bilog_info(dpp, conn, source_bucket->get_key(), remote_markers, null_yield);
+  r = rgw_read_remote_bilog_info(dpp, conn, source_bucket->get_key(),
+                                 remote_info, remote_markers, null_yield);
   if (r < 0) {
     ldpp_dout(dpp, -1) << "failed to read remote log: " << cpp_strerror(r) << dendl;
     return r;

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -5510,6 +5510,7 @@ string RGWBucketPipeSyncStatusManager::obj_status_oid(const rgw_bucket_sync_pipe
 int rgw_read_remote_bilog_info(const DoutPrefixProvider *dpp,
                                RGWRESTConn* conn,
                                const rgw_bucket& bucket,
+                               rgw_bucket_index_marker_info& info,
                                BucketIndexShardsManager& markers,
                                optional_yield y)
 {
@@ -5520,15 +5521,15 @@ int rgw_read_remote_bilog_info(const DoutPrefixProvider *dpp,
     { "info" , nullptr },
     { nullptr, nullptr }
   };
-  rgw_bucket_index_marker_info result;
-  int r = conn->get_json_resource(dpp, "/admin/log/", params, y, result);
+  int r = conn->get_json_resource(dpp, "/admin/log/", params, y, info);
   if (r < 0) {
     ldpp_dout(dpp, -1) << "failed to fetch remote log markers: " << cpp_strerror(r) << dendl;
     return r;
   }
-  r = markers.from_string(result.max_marker, -1);
+  // parse shard markers
+  r = markers.from_string(info.max_marker, -1);
   if (r < 0) {
-    lderr(conn->get_ctx()) << "failed to decode remote log markers" << dendl;
+    ldpp_dout(dpp, -1) << "failed to decode remote log markers" << dendl;
     return r;
   }
   return 0;

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -698,6 +698,7 @@ class BucketIndexShardsManager;
 int rgw_read_remote_bilog_info(const DoutPrefixProvider *dpp,
                                RGWRESTConn* conn,
                                const rgw_bucket& bucket,
+                               rgw_bucket_index_marker_info& info,
                                BucketIndexShardsManager& markers,
                                optional_yield y);
 

--- a/src/rgw/rgw_sync_checkpoint.cc
+++ b/src/rgw/rgw_sync_checkpoint.cc
@@ -145,11 +145,12 @@ int bucket_source_sync_checkpoint(const DoutPrefixProvider* dpp,
   return 0;
 }
 
-int source_bilog_markers(const DoutPrefixProvider *dpp,
-                         RGWSI_Zone* zone_svc,
-                         const rgw_sync_bucket_pipe& pipe,
-                         BucketIndexShardsManager& remote_markers,
-                         optional_yield y)
+int source_bilog_info(const DoutPrefixProvider *dpp,
+                      RGWSI_Zone* zone_svc,
+                      const rgw_sync_bucket_pipe& pipe,
+                      rgw_bucket_index_marker_info& info,
+                      BucketIndexShardsManager& markers,
+                      optional_yield y)
 {
   ceph_assert(pipe.source.zone);
 
@@ -160,7 +161,7 @@ int source_bilog_markers(const DoutPrefixProvider *dpp,
   }
 
   return rgw_read_remote_bilog_info(dpp, conn->second, *pipe.source.bucket,
-                                    remote_markers, y);
+                                    info, markers, y);
 }
 
 } // anonymous namespace
@@ -198,8 +199,9 @@ int rgw_bucket_sync_checkpoint(const DoutPrefixProvider* dpp,
     // fetch remote markers
     spawn::spawn(ioctx, [&] (spawn::yield_context yield) {
       auto y = optional_yield{ioctx, yield};
-      int r = source_bilog_markers(dpp, store->svc()->zone, entry.pipe,
-                                   entry.remote_markers, y);
+      rgw_bucket_index_marker_info info;
+      int r = source_bilog_info(dpp, store->svc()->zone, entry.pipe,
+                                info, entry.remote_markers, y);
       if (r < 0) {
         ldpp_dout(dpp, 0) << "failed to fetch remote bilog markers: "
             << cpp_strerror(r) << dendl;

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -163,23 +163,23 @@ static void get_bucket_index_objects(const string& bucket_oid_base,
 }
 
 static void get_bucket_instance_ids(const RGWBucketInfo& bucket_info,
-                                    int shard_id,
+                                    int num_shards, int shard_id,
                                     map<int, string> *result)
 {
   const rgw_bucket& bucket = bucket_info.bucket;
   string plain_id = bucket.name + ":" + bucket.bucket_id;
 
-  if (!bucket_info.layout.current_index.layout.normal.num_shards) {
+  if (!num_shards) {
     (*result)[0] = plain_id;
   } else {
     char buf[16];
     if (shard_id < 0) {
-      for (uint32_t i = 0; i < bucket_info.layout.current_index.layout.normal.num_shards; ++i) {
+      for (int i = 0; i < num_shards; ++i) {
         snprintf(buf, sizeof(buf), ":%d", i);
         (*result)[i] = plain_id + buf;
       }
     } else {
-      if (static_cast<uint32_t>(shard_id) > bucket_info.layout.current_index.layout.normal.num_shards) {
+      if (shard_id > num_shards) {
         return;
       }
       snprintf(buf, sizeof(buf), ":%d", shard_id);
@@ -208,8 +208,8 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const DoutPrefixProvider *dpp,
   get_bucket_index_objects(bucket_oid_base, idx_layout.layout.normal.num_shards,
                            idx_layout.gen, bucket_objs, shard_id);
   if (bucket_instance_ids) {
-    // TODO: generation need to be passed here
-    get_bucket_instance_ids(bucket_info, shard_id, bucket_instance_ids);
+    get_bucket_instance_ids(bucket_info, idx_layout.layout.normal.num_shards,
+                            shard_id, bucket_instance_ids);
   }
   return 0;
 }


### PR DESCRIPTION
`radosgw-admin bucket sync checkpoint` is used by multisite tests to wait for a bucket sync to catch up with a source zone. sync on a resharded bucket is not caught up until the sync status' generation matches the source zone's latest_gen

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
