### PR TITLE
mgr/dashboard: remove id from pool-overview.json

### DIFF
--- a/monitoring/grafana/dashboards/pool-overview.json
+++ b/monitoring/grafana/dashboards/pool-overview.json
@@ -15,7 +15,6 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 15,
   "iteration": 1617656284287,
   "links": [],
   "panels": [


### PR DESCRIPTION
This id shouldn't be there because it prevents from dashboard creation
when it doesn't exist.

see: https://grafana.com/docs/grafana/latest/http_api/dashboard/#create--update-dashboard

Fixes: https://tracker.ceph.com/issues/50912

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
