### PR TITLE
common/blkdev: remove double _'s from device_id

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -429,6 +429,14 @@ std::string _decode_model_enc(const std::string& in)
     v.erase(found + 1);
   }
   std::replace(v.begin(), v.end(), ' ', '_');
+
+  // remove "__", which seems to come up on by ubuntu box for some reason.
+  while (true) {
+    auto p = v.find("__");
+    if (p == std::string::npos) break;
+    v.replace(p, 2, "_");
+  }
+
   return v;
 }
 
@@ -497,6 +505,12 @@ std::string get_device_id(const std::string& devname,
   }
   udev_device_unref(dev);
   udev_unref(udev);
+
+  cout << " vendor '" << id_vendor << "'" << std::endl;
+  cout << " model '" << id_model << "'" << std::endl;
+  cout << " serial_short '" << id_serial_short << "'" << std::endl;
+  cout << " scsi_serial '" << id_scsi_serial << "'" << std::endl;
+  cout << " serial '" << id_serial << "'" << std::endl;
 
   // ID_SERIAL is usually $vendor_$model_$serial, but not always
   // ID_SERIAL_SHORT is mostly always just the serial

--- a/src/test/common/test_blkdev.cc
+++ b/src/test/common/test_blkdev.cc
@@ -99,3 +99,16 @@ TEST(blkdev, _decode_model_enc)
     ASSERT_EQ(std::string(foo[i][1]), d);
   }
 }
+
+TEST(blkdev, get_device_id)
+{
+  // this doesn't really test anything; it's just a way to exercise the
+  // get_device_id() code.
+  for (char c = 'a'; c < 'z'; ++c) {
+    char devname[4] = {'s', 'd', c, 0};
+    std::string err;
+    auto i = get_device_id(devname, &err);
+    cout << "devname " << devname << " -> '" << i
+	 << "' (" << err << ")" << std::endl;
+  }
+}


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>