### PR TITLE
pacific: qa/tests: replaced ubuntu_latest.yaml with ubuntu 20.04

### DIFF
--- a/qa/distros/supported-all-distro/ubuntu_latest.yaml
+++ b/qa/distros/supported-all-distro/ubuntu_latest.yaml
@@ -1,1 +1,1 @@
-../all/ubuntu_18.04.yaml
+../all/ubuntu_20.04.yaml

--- a/qa/distros/supported-random-distro$/ubuntu_latest.yaml
+++ b/qa/distros/supported-random-distro$/ubuntu_latest.yaml
@@ -1,1 +1,1 @@
-../all/ubuntu_18.04.yaml
+../all/ubuntu_20.04.yaml

--- a/qa/suites/fs/shell/tasks/cephfs-shell.yaml
+++ b/qa/suites/fs/shell/tasks/cephfs-shell.yaml
@@ -1,7 +1,7 @@
 # Right now, cephfs-shell is only available as a package on Ubuntu
 # This overrides the random distribution that's chosen in the other yaml fragments.
 os_type: ubuntu
-os_version: "18.04"
+os_version: "20.04"
 tasks:
   - cephfs_test_runner:
       modules:


### PR DESCRIPTION
Currently on pacific:
```
$ find qa/distros -name '*ubuntu_latest*' | xargs file
qa/distros/supported/ubuntu_latest.yaml:                symbolic link to ../all/ubuntu_20.04.yaml
qa/distros/supported-all-distro/ubuntu_latest.yaml:     symbolic link to ../all/ubuntu_18.04.yaml
qa/distros/supported-random-distro$/ubuntu_latest.yaml: symbolic link to ../all/ubuntu_18.04.yaml
```

Looking at the history, pacific was supposed to be tested on 20.04 all along, but that change was reverted in May 2020 (#35110).  `supported` facet was resurrected and backported to pacific for cephadm suite in January (#39040), but `supported-all-distro` and `supported-random-distro$` facets that matter for other suites remained reverted until April (#40475).  Let's make pacific consistent with master.