### PR TITLE
rgw: auth v4 client: don't convert '+' to space

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -578,16 +578,8 @@ static void add_v4_canonical_params_from_map(const map<string, string>& m,
     if (key.empty()) {
       continue;
     }
-    const string *pval = &(entry.second);
-    string _val;
 
-    if (pval->find_first_of('+') != std::string::npos) {
-      _val = *pval;
-      boost::replace_all(_val, "+", " ");
-      pval = &_val;
-    }
-
-    (*result)[aws4_uri_recode(key, true)] = aws4_uri_recode(*pval, true);
+    (*result)[aws4_uri_recode(key, true)] = aws4_uri_recode(entry.second, true);
   }
 }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50920

The plus sign can be used to represent space after conversion, but this
pre conversion string representation will be hex encoded as plus.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
