### PR TITLE
script/build-integration-branch: always generate merge commits

### DIFF
--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -94,7 +94,7 @@ for pr in prs:
     pr_ref = pr['head']['ref']
     print(f'--- pr {pr_number} --- pulling {pr_url} branch {pr_ref}')
     while True:
-        r = call(['git', 'pull', '--no-edit', pr_url, pr_ref])
+        r = call(['git', 'pull', '--no-ff', '--no-edit', pr_url, pr_ref])
         if r == 0:
             break
         elif r == 1:


### PR DESCRIPTION
This guarantees we'll always get a new sha1, so shaman will generate a
new build even if the same PRs are pushed to more than one branch.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>

