### PR TITLE
include/cephfs: add cephfs headers to CMakeLists.txt

### DIFF
--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -36,3 +36,10 @@ if(WITH_RADOSGW)
     rados/rgw_file.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rados)
 endif()
+
+if(WITH_LIBCEPHFS)
+  install(FILES
+    cephfs/libcephfs.h
+    cephfs/ceph_ll_client.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cephfs)
+endif()


### PR DESCRIPTION
If WITH_LIBCEPHFS is set, the cephfs headers are installed as well by
the install target.

Signed-off-by: Sven Anderson <sven@redhat.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
