### PR TITLE
crimson/onode-staged-tree: tolerate eagain and add proper errorhandling

### DIFF
--- a/src/crimson/os/seastore/onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager.h
@@ -13,17 +13,19 @@
 #include "include/ceph_assert.h"
 #include "common/hobject.h"
 
+#include "crimson/common/errorator.h"
 #include "crimson/os/seastore/onode.h"
 #include "crimson/os/seastore/seastore_types.h"
-#include "crimson/os/seastore/transaction_manager.h"
 #include "crimson/osd/exceptions.h"
 
 namespace crimson::os::seastore {
 
 class OnodeManager {
-  using base_ertr = TransactionManager::base_ertr;
+  using base_ertr = crimson::errorator<
+    crimson::ct_error::eagain>;
+
 public:
-  using mkfs_ertr = TransactionManager::mkfs_ertr;
+  using mkfs_ertr = base_ertr;
   using mkfs_ret = mkfs_ertr::future<>;
   virtual mkfs_ret mkfs(Transaction &t) = 0;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
@@ -12,14 +12,7 @@ FLTreeOnodeManager::contains_onode_ret FLTreeOnodeManager::contains_onode(
   Transaction &trans,
   const ghobject_t &hoid)
 {
-  return tree.contains(
-    trans, hoid
-  ).handle_error(
-    contains_onode_ertr::pass_further{},
-    crimson::ct_error::assert_all{
-      "Invalid error in FLTreeOnodeManager::contains_onode"
-    }
-  );
+  return tree.contains(trans, hoid);
 }
 
 FLTreeOnodeManager::get_onode_ret FLTreeOnodeManager::get_onode(
@@ -39,12 +32,7 @@ FLTreeOnodeManager::get_onode_ret FLTreeOnodeManager::get_onode(
     return seastar::make_ready_future<OnodeRef>(
       val
     );
-  }).handle_error(
-    get_onode_ertr::pass_further{},
-    crimson::ct_error::assert_all{
-      "Invalid error in FLTreeOnodeManager::get_onode"
-    }
-  );
+  });
 }
 
 FLTreeOnodeManager::get_or_create_onode_ret
@@ -71,12 +59,7 @@ FLTreeOnodeManager::get_or_create_onode(
     return seastar::make_ready_future<OnodeRef>(
       val
     );
-  }).handle_error(
-    get_or_create_onode_ertr::pass_further{},
-    crimson::ct_error::assert_all{
-      "Invalid error in FLTreeOnodeManager::get_or_create_onode"
-    }
-  );
+  });
 }
 
 FLTreeOnodeManager::get_or_create_onodes_ret
@@ -123,12 +106,7 @@ FLTreeOnodeManager::write_dirty_ret FLTreeOnodeManager::write_dirty(
       default:
         __builtin_unreachable();
       }
-    }).handle_error(
-      write_dirty_ertr::pass_further{},
-      crimson::ct_error::assert_all{
-        "Invalid error in FLTreeOnodeManager::write_dirty"
-      }
-    );
+    });
 }
 
 FLTreeOnodeManager::erase_onode_ret FLTreeOnodeManager::erase_onode(
@@ -180,12 +158,7 @@ FLTreeOnodeManager::list_onodes_ret FLTreeOnodeManager::list_onodes(
             std::move(ret));
       });
     });
-  }).handle_error(
-    list_onodes_ertr::pass_further{},
-    crimson::ct_error::assert_all{
-      "Invalid error in FLTreeOnodeManager::list_onodes"
-    }
-  );
+  });
 }
 
 FLTreeOnodeManager::~FLTreeOnodeManager() {}

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
@@ -107,7 +107,7 @@ FLTreeOnodeManager::write_dirty_ret FLTreeOnodeManager::write_dirty(
 {
   return crimson::do_for_each(
     onodes,
-    [this, &trans](auto &onode) -> OnodeTree::btree_future<> {
+    [this, &trans](auto &onode) -> eagain_future<> {
       auto &flonode = static_cast<FLTreeOnode&>(*onode);
       switch (flonode.status) {
       case FLTreeOnode::status_t::MUTATED: {
@@ -154,10 +154,9 @@ FLTreeOnodeManager::list_onodes_ret FLTreeOnodeManager::list_onodes(
         std::move(cursor),
         list_onodes_bare_ret(),
         [this, &trans, end] (auto& to_list, auto& current_cursor, auto& ret) {
-      using get_next_ertr = typename OnodeTree::btree_ertr;
       return crimson::do_until(
           [this, &trans, end, &to_list, &current_cursor, &ret] () mutable
-          -> get_next_ertr::future<bool> {
+          -> eagain_future<bool> {
         if (current_cursor.is_end() ||
             current_cursor.get_ghobj() >= end) {
           std::get<1>(ret) = end;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "crimson/os/seastore/onode_manager.h"
-#include "crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h"
 #include "crimson/os/seastore/onode_manager/staged-fltree/value.h"
 #include "crimson/os/seastore/onode_manager/staged-fltree/tree.h"
 
@@ -95,8 +94,7 @@ class FLTreeOnodeManager : public crimson::os::seastore::OnodeManager {
 
 public:
   FLTreeOnodeManager(TransactionManager &tm) :
-    tree(std::make_unique<SeastoreNodeExtentManager>(
-           tm, laddr_t{})) {}
+    tree(NodeExtentManager::create_seastore(tm)) {}
 
   mkfs_ret mkfs(Transaction &t) {
     return tree.mkfs(t);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -99,13 +99,7 @@ public:
            tm, laddr_t{})) {}
 
   mkfs_ret mkfs(Transaction &t) {
-    return tree.mkfs(t
-    ).handle_error(
-      mkfs_ertr::pass_further{},
-      crimson::ct_error::assert_all{
-        "Invalid error in FLTreeOnodeManager::mkfs"
-      }
-    );
+    return tree.mkfs(t);
   }
 
   contains_onode_ret contains_onode(

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
@@ -19,6 +19,8 @@ namespace crimson::os::seastore::onode {
 
 using eagain_ertr = crimson::errorator<
   crimson::ct_error::eagain>;
+template <class ValueT=void>
+using eagain_future = eagain_ertr::future<ValueT>;
 
 using crimson::os::seastore::Transaction;
 using crimson::os::seastore::TransactionRef;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
@@ -17,6 +17,9 @@
 
 namespace crimson::os::seastore::onode {
 
+using eagain_ertr = crimson::errorator<
+  crimson::ct_error::eagain>;
+
 using crimson::os::seastore::Transaction;
 using crimson::os::seastore::TransactionRef;
 using crimson::os::seastore::laddr_t;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -2062,6 +2062,10 @@ void LeafNode::validate_cursor(const tree_cursor_t& cursor) const
   assert(this == cursor.get_leaf_node().get());
   assert(cursor.is_tracked());
   assert(!impl->is_extent_retired());
+
+  // We need to make sure user has freed all the cursors before submitting the
+  // according transaction. Otherwise the below checks will have undefined
+  // behaviors.
   auto [key, p_value_header] = get_kv(cursor.get_position());
   auto magic = p_value_header->magic;
   assert(key.compare_to(cursor.get_key_view(magic)) == MatchKindCMP::EQ);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -284,13 +284,13 @@ Node::~Node()
     // 2. unlink parent/super --ptr-> me
     // 3. unlink me --ref-> parent/super
     // 4. extent is retired
-    assert(!impl->is_extent_valid());
+    assert(impl->is_extent_retired());
 
     // TODO: maybe its possible when eagain happens internally, we should
     // revisit to make sure tree operations can be aborted normally,
     // without resource leak or hitting unexpected asserts.
   } else {
-    assert(impl->is_extent_valid());
+    assert(!impl->is_extent_retired());
     if (is_root()) {
       super->do_untrack_root(*this);
     } else {
@@ -2058,6 +2058,7 @@ void LeafNode::validate_cursor(const tree_cursor_t& cursor) const
 #ifndef NDEBUG
   assert(this == cursor.get_leaf_node().get());
   assert(cursor.is_tracked());
+  assert(!impl->is_extent_retired());
   auto [key, p_value_header] = get_kv(cursor.get_position());
   auto magic = p_value_header->magic;
   assert(key.compare_to(cursor.get_key_view(magic)) == MatchKindCMP::EQ);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -383,9 +383,14 @@ class Node
 
  protected:
   Node(NodeImplURef&&);
+
+  bool is_tracked() const {
+    assert(!(super && _parent_info.has_value()));
+    return (super || _parent_info.has_value());
+  }
+
   bool is_root() const {
-    assert((super && !_parent_info.has_value()) ||
-           (!super && _parent_info.has_value()));
+    assert(is_tracked());
     return !_parent_info.has_value();
   }
 
@@ -402,6 +407,8 @@ class Node
   void as_root(Super::URef&& _super);
   eagain_future<> upgrade_root(context_t);
 
+  Super::URef deref_super();
+
   // as child/non-root
   template <bool VALIDATE = true>
   void as_child(const search_position_t&, Ref<InternalNode>);
@@ -411,6 +418,8 @@ class Node
     Ref<InternalNode> ptr;
   };
   const parent_info_t& parent_info() const { return *_parent_info; }
+
+  Ref<InternalNode> deref_parent();
 
   eagain_future<> apply_split_to_parent(context_t, Ref<Node>&&, Ref<Node>&&, bool);
   eagain_future<Ref<tree_cursor_t>> get_next_cursor_from_parent(context_t);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -74,15 +74,6 @@ class tree_cursor_t final
   : public boost::intrusive_ref_counter<
            tree_cursor_t, boost::thread_unsafe_counter> {
  public:
-  using ertr = crimson::errorator<
-    crimson::ct_error::input_output_error,
-    crimson::ct_error::invarg,
-    crimson::ct_error::enoent,
-    crimson::ct_error::erange,
-    crimson::ct_error::eagain>;
-  template <class ValueT=void>
-  using future = ertr::future<ValueT>;
-
   ~tree_cursor_t();
   tree_cursor_t(const tree_cursor_t&) = delete;
   tree_cursor_t(tree_cursor_t&&) = delete;
@@ -123,14 +114,14 @@ class tree_cursor_t final
   }
 
   /// Returns the next tree_cursor_t in tree, can be end if there's no next.
-  future<Ref<tree_cursor_t>> get_next(context_t);
+  eagain_future<Ref<tree_cursor_t>> get_next(context_t);
 
   /// Check that this is next to prv
   void assert_next_to(const tree_cursor_t&, value_magic_t) const;
 
   /// Erases the key-value pair from tree.
   template <bool FORCE_MERGE = false>
-  future<Ref<tree_cursor_t>> erase(context_t, bool get_next);
+  eagain_future<Ref<tree_cursor_t>> erase(context_t, bool get_next);
 
   MatchKindCMP compare_to(const tree_cursor_t&, value_magic_t) const;
 
@@ -150,10 +141,10 @@ class tree_cursor_t final
   }
 
   /// Extends the size of value payload.
-  future<> extend_value(context_t, value_size_t);
+  eagain_future<> extend_value(context_t, value_size_t);
 
   /// Trim and shrink the value payload.
-  future<> trim_value(context_t, value_size_t);
+  eagain_future<> trim_value(context_t, value_size_t);
 
   static Ref<tree_cursor_t> get_invalid() {
     static Ref<tree_cursor_t> INVALID = new tree_cursor_t();
@@ -259,15 +250,6 @@ class Node
            Node, boost::thread_unsafe_counter> {
  public:
   // public to Btree
-  using node_ertr = crimson::errorator<
-    crimson::ct_error::input_output_error,
-    crimson::ct_error::invarg,
-    crimson::ct_error::enoent,
-    crimson::ct_error::erange,
-    crimson::ct_error::eagain>;
-  template <class ValueT=void>
-  using node_future = node_ertr::future<ValueT>;
-
   struct search_result_t {
     bool is_end() const { return p_cursor->is_end(); }
     Ref<tree_cursor_t> p_cursor;
@@ -319,7 +301,7 @@ class Node
    *
    * Returns an end cursor if it is an empty root node.
    */
-  virtual node_future<Ref<tree_cursor_t>> lookup_smallest(context_t) = 0;
+  virtual eagain_future<Ref<tree_cursor_t>> lookup_smallest(context_t) = 0;
 
   /**
    * lookup_largest
@@ -329,7 +311,7 @@ class Node
    *
    * Returns an end cursor if it is an empty root node.
    */
-  virtual node_future<Ref<tree_cursor_t>> lookup_largest(context_t) = 0;
+  virtual eagain_future<Ref<tree_cursor_t>> lookup_largest(context_t) = 0;
 
   /**
    * lower_bound
@@ -342,7 +324,7 @@ class Node
    * - It is an empty root node;
    * - Or the input key is larger than all the keys in the sub-tree;
    */
-  node_future<search_result_t> lower_bound(context_t c, const key_hobj_t& key);
+  eagain_future<search_result_t> lower_bound(context_t c, const key_hobj_t& key);
 
   /**
    * insert
@@ -353,7 +335,7 @@ class Node
    * - If true, the returned cursor points to the inserted element in tree;
    * - If false, the returned cursor points to the conflicting element in tree;
    */
-  node_future<std::pair<Ref<tree_cursor_t>, bool>> insert(
+  eagain_future<std::pair<Ref<tree_cursor_t>, bool>> insert(
       context_t, const key_hobj_t&, value_config_t);
 
   /**
@@ -363,10 +345,10 @@ class Node
    *
    * Returns the number of erased key-value pairs (0 or 1).
    */
-  node_future<std::size_t> erase(context_t, const key_hobj_t&);
+  eagain_future<std::size_t> erase(context_t, const key_hobj_t&);
 
   /// Recursively collects the statistics of the sub-tree formed by this node
-  node_future<tree_stats_t> get_tree_stats(context_t);
+  eagain_future<tree_stats_t> get_tree_stats(context_t);
 
   /// Returns an ostream containing a dump of all the elements in the node.
   std::ostream& dump(std::ostream&) const;
@@ -378,22 +360,22 @@ class Node
   const std::string& get_name() const;
 
   /// Initializes the tree by allocating an empty root node.
-  static node_future<> mkfs(context_t, RootNodeTracker&);
+  static eagain_future<> mkfs(context_t, RootNodeTracker&);
 
   /// Loads the tree root. The tree must be initialized.
-  static node_future<Ref<Node>> load_root(context_t, RootNodeTracker&);
+  static eagain_future<Ref<Node>> load_root(context_t, RootNodeTracker&);
 
   // Only for unit test purposes.
   void test_make_destructable(context_t, NodeExtentMutable&, Super::URef&&);
-  virtual node_future<> test_clone_root(context_t, RootNodeTracker&) const = 0;
+  virtual eagain_future<> test_clone_root(context_t, RootNodeTracker&) const = 0;
 
  protected:
-  virtual node_future<> test_clone_non_root(context_t, Ref<InternalNode>) const {
+  virtual eagain_future<> test_clone_non_root(context_t, Ref<InternalNode>) const {
     ceph_abort("impossible path");
   }
-  virtual node_future<search_result_t> lower_bound_tracked(
+  virtual eagain_future<search_result_t> lower_bound_tracked(
       context_t, const key_hobj_t&, MatchHistory&) = 0;
-  virtual node_future<> do_get_tree_stats(context_t, tree_stats_t&) = 0;
+  virtual eagain_future<> do_get_tree_stats(context_t, tree_stats_t&) = 0;
 
   virtual bool is_tracking() const = 0;
 
@@ -418,7 +400,7 @@ class Node
     make_root(c, std::move(_super));
   }
   void as_root(Super::URef&& _super);
-  node_future<> upgrade_root(context_t);
+  eagain_future<> upgrade_root(context_t);
 
   // as child/non-root
   template <bool VALIDATE = true>
@@ -430,15 +412,15 @@ class Node
   };
   const parent_info_t& parent_info() const { return *_parent_info; }
 
-  node_future<> apply_split_to_parent(context_t, Ref<Node>&&, Ref<Node>&&, bool);
-  node_future<Ref<tree_cursor_t>> get_next_cursor_from_parent(context_t);
+  eagain_future<> apply_split_to_parent(context_t, Ref<Node>&&, Ref<Node>&&, bool);
+  eagain_future<Ref<tree_cursor_t>> get_next_cursor_from_parent(context_t);
   template <bool FORCE_MERGE = false>
-  node_future<> try_merge_adjacent(context_t, bool, Ref<Node>&&);
-  node_future<> erase_node(context_t, Ref<Node>&&);
+  eagain_future<> try_merge_adjacent(context_t, bool, Ref<Node>&&);
+  eagain_future<> erase_node(context_t, Ref<Node>&&);
   template <bool FORCE_MERGE = false>
-  node_future<> fix_parent_index(context_t, Ref<Node>&&, bool);
-  node_future<NodeExtentMutable> rebuild_extent(context_t);
-  node_future<> retire(context_t, Ref<Node>&&);
+  eagain_future<> fix_parent_index(context_t, Ref<Node>&&, bool);
+  eagain_future<NodeExtentMutable> rebuild_extent(context_t);
+  eagain_future<> retire(context_t, Ref<Node>&&);
   void make_tail(context_t);
 
  private:
@@ -457,7 +439,7 @@ class Node
   std::optional<parent_info_t> _parent_info;
 
  private:
-  static node_future<Ref<Node>> load(context_t, laddr_t, bool expect_is_level_tail);
+  static eagain_future<Ref<Node>> load(context_t, laddr_t, bool expect_is_level_tail);
 
   NodeImplURef impl;
   friend class InternalNode;
@@ -483,9 +465,9 @@ class InternalNode final : public Node {
   InternalNode& operator=(const InternalNode&) = delete;
   InternalNode& operator=(InternalNode&&) = delete;
 
-  node_future<Ref<tree_cursor_t>> get_next_cursor(context_t, const search_position_t&);
+  eagain_future<Ref<tree_cursor_t>> get_next_cursor(context_t, const search_position_t&);
 
-  node_future<> apply_child_split(context_t, Ref<Node>&& left, Ref<Node>&& right, bool);
+  eagain_future<> apply_child_split(context_t, Ref<Node>&& left, Ref<Node>&& right, bool);
 
   template <bool VALIDATE>
   void do_track_child(Node& child) {
@@ -514,16 +496,16 @@ class InternalNode final : public Node {
     }
   }
 
-  node_future<std::pair<Ref<Node>, Ref<Node>>> get_child_peers(
+  eagain_future<std::pair<Ref<Node>, Ref<Node>>> get_child_peers(
       context_t, const search_position_t&);
 
-  node_future<> erase_child(context_t, Ref<Node>&&);
+  eagain_future<> erase_child(context_t, Ref<Node>&&);
 
   template <bool FORCE_MERGE = false>
-  node_future<> fix_index(context_t, Ref<Node>&&, bool);
+  eagain_future<> fix_index(context_t, Ref<Node>&&, bool);
 
   template <bool FORCE_MERGE = false>
-  node_future<> apply_children_merge(
+  eagain_future<> apply_children_merge(
       context_t, Ref<Node>&& left, laddr_t, Ref<Node>&& right, bool update_index);
 
   void validate_child_tracked(const Node& child) const {
@@ -546,32 +528,32 @@ class InternalNode final : public Node {
 
   void track_make_tail(const search_position_t&);
 
-  static node_future<Ref<InternalNode>> allocate_root(
+  static eagain_future<Ref<InternalNode>> allocate_root(
       context_t, level_t, laddr_t, Super::URef&&);
 
  protected:
-  node_future<Ref<tree_cursor_t>> lookup_smallest(context_t) override;
-  node_future<Ref<tree_cursor_t>> lookup_largest(context_t) override;
-  node_future<search_result_t> lower_bound_tracked(
+  eagain_future<Ref<tree_cursor_t>> lookup_smallest(context_t) override;
+  eagain_future<Ref<tree_cursor_t>> lookup_largest(context_t) override;
+  eagain_future<search_result_t> lower_bound_tracked(
       context_t, const key_hobj_t&, MatchHistory&) override;
-  node_future<> do_get_tree_stats(context_t, tree_stats_t&) override;
+  eagain_future<> do_get_tree_stats(context_t, tree_stats_t&) override;
   bool is_tracking() const override {
      return !tracked_child_nodes.empty();
   }
   void track_merge(Ref<Node>, match_stage_t, search_position_t&) override;
 
-  node_future<> test_clone_root(context_t, RootNodeTracker&) const override;
+  eagain_future<> test_clone_root(context_t, RootNodeTracker&) const override;
 
  private:
-  node_future<> try_downgrade_root(context_t, Ref<Node>&&);
+  eagain_future<> try_downgrade_root(context_t, Ref<Node>&&);
 
-  node_future<Ref<InternalNode>> insert_or_split(
+  eagain_future<Ref<InternalNode>> insert_or_split(
       context_t, const search_position_t&, const key_view_t&, Ref<Node>,
       Ref<Node> outdated_child=nullptr);
 
   // XXX: extract a common tracker for InternalNode to track Node,
   // and LeafNode to track tree_cursor_t.
-  node_future<Ref<Node>> get_or_track_child(context_t, const search_position_t&, laddr_t);
+  eagain_future<Ref<Node>> get_or_track_child(context_t, const search_position_t&, laddr_t);
   template <bool VALIDATE = true>
   void track_insert(
       const search_position_t&, match_stage_t, Ref<Node>, Ref<Node> nxt_child = nullptr);
@@ -588,7 +570,7 @@ class InternalNode final : public Node {
       return std::make_pair(Ref<Node>(node), mut);
     }
   };
-  static node_future<fresh_node_t> allocate(context_t, field_type_t, bool, level_t);
+  static eagain_future<fresh_node_t> allocate(context_t, field_type_t, bool, level_t);
 
  private:
   /**
@@ -622,7 +604,7 @@ class LeafNode final : public Node {
   node_version_t get_version() const;
   const char* read() const;
   std::tuple<key_view_t, const value_header_t*> get_kv(const search_position_t&) const;
-  node_future<Ref<tree_cursor_t>> get_next_cursor(context_t, const search_position_t&);
+  eagain_future<Ref<tree_cursor_t>> get_next_cursor(context_t, const search_position_t&);
 
   /**
    * erase
@@ -633,7 +615,7 @@ class LeafNode final : public Node {
    * pair that followed the erased element, which can be nullptr if is end.
    */
   template <bool FORCE_MERGE>
-  node_future<Ref<tree_cursor_t>> erase(
+  eagain_future<Ref<tree_cursor_t>> erase(
       context_t, const search_position_t&, bool get_next);
 
   template <bool VALIDATE>
@@ -662,32 +644,32 @@ class LeafNode final : public Node {
     }
   }
 
-  node_future<> extend_value(context_t, const search_position_t&, value_size_t);
-  node_future<> trim_value(context_t, const search_position_t&, value_size_t);
+  eagain_future<> extend_value(context_t, const search_position_t&, value_size_t);
+  eagain_future<> trim_value(context_t, const search_position_t&, value_size_t);
 
   std::pair<NodeExtentMutable&, ValueDeltaRecorder*>
   prepare_mutate_value_payload(context_t);
 
  protected:
-  node_future<Ref<tree_cursor_t>> lookup_smallest(context_t) override;
-  node_future<Ref<tree_cursor_t>> lookup_largest(context_t) override;
-  node_future<search_result_t> lower_bound_tracked(
+  eagain_future<Ref<tree_cursor_t>> lookup_smallest(context_t) override;
+  eagain_future<Ref<tree_cursor_t>> lookup_largest(context_t) override;
+  eagain_future<search_result_t> lower_bound_tracked(
       context_t, const key_hobj_t&, MatchHistory&) override;
-  node_future<> do_get_tree_stats(context_t, tree_stats_t&) override;
+  eagain_future<> do_get_tree_stats(context_t, tree_stats_t&) override;
   bool is_tracking() const override {
     return !tracked_cursors.empty();
   }
   void track_merge(Ref<Node>, match_stage_t, search_position_t&) override;
 
-  node_future<> test_clone_root(context_t, RootNodeTracker&) const override;
+  eagain_future<> test_clone_root(context_t, RootNodeTracker&) const override;
 
  private:
   LeafNode(LeafNodeImpl*, NodeImplURef&&);
-  node_future<Ref<tree_cursor_t>> insert_value(
+  eagain_future<Ref<tree_cursor_t>> insert_value(
       context_t, const key_hobj_t&, value_config_t,
       const search_position_t&, const MatchHistory&,
       match_stat_t mstat);
-  static node_future<Ref<LeafNode>> allocate_root(context_t, RootNodeTracker&);
+  static eagain_future<Ref<LeafNode>> allocate_root(context_t, RootNodeTracker&);
   friend class Node;
 
  private:
@@ -718,7 +700,7 @@ class LeafNode final : public Node {
       return std::make_pair(Ref<Node>(node), mut);
     }
   };
-  static node_future<fresh_node_t> allocate(context_t, field_type_t, bool);
+  static eagain_future<fresh_node_t> allocate(context_t, field_type_t, bool);
 
  private:
   /**

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -499,6 +499,7 @@ class InternalNode final : public Node {
     auto& child_pos = child.parent_info().position;
     auto found = tracked_child_nodes.find(child_pos);
     if (found != tracked_child_nodes.end() && found->second == &child) {
+      assert(child.parent_info().ptr == this);
       return true;
     } else {
       return false;
@@ -647,6 +648,7 @@ class LeafNode final : public Node {
     auto& cursor_pos = cursor.get_position();
     auto found = tracked_cursors.find(cursor_pos);
     if (found != tracked_cursors.end() && found->second == &cursor) {
+      assert(cursor.ref_leaf_node == this);
       return true;
     } else {
       return false;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -492,14 +492,13 @@ class NodeExtentAccessorT {
     std::memcpy(to.get_write(), extent->get_read(), extent->get_length());
   }
 
-  using ertr = NodeExtentManager::tm_ertr;
-  ertr::future<NodeExtentMutable> rebuild(context_t c) {
+  eagain_future<NodeExtentMutable> rebuild(context_t c) {
     LOG_PREFIX(OTree::Extent::rebuild);
     assert(extent->is_valid());
     if (state == nextent_state_t::FRESH) {
       assert(extent->is_initial_pending());
       // already fresh and no need to record
-      return ertr::make_ready_future<NodeExtentMutable>(*mut);
+      return eagain_ertr::make_ready_future<NodeExtentMutable>(*mut);
     }
     assert(!extent->is_initial_pending());
     return c.nm.alloc_extent(c.t, node_stage_t::EXTENT_SIZE
@@ -551,7 +550,7 @@ class NodeExtentAccessorT {
     });
   }
 
-  ertr::future<> retire(context_t c) {
+  eagain_future<> retire(context_t c) {
     LOG_PREFIX(OTree::Extent::retire);
     assert(extent->is_valid());
     auto addr = extent->get_laddr();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.cc
@@ -30,9 +30,15 @@ NodeExtentManagerURef NodeExtentManager::create_dummy(bool is_sync)
 }
 
 NodeExtentManagerURef NodeExtentManager::create_seastore(
-    TransactionManager& tm, laddr_t min_laddr)
+    TransactionManager& tm, laddr_t min_laddr, double p_eagain)
 {
-  return NodeExtentManagerURef(new SeastoreNodeExtentManager(tm, min_laddr));
+  if (p_eagain == 0.0) {
+    return NodeExtentManagerURef(
+        new SeastoreNodeExtentManager<false>(tm, min_laddr, p_eagain));
+  } else {
+    return NodeExtentManagerURef(
+        new SeastoreNodeExtentManager<true>(tm, min_laddr, p_eagain));
+  }
 }
 
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
@@ -61,14 +61,6 @@ class NodeExtentManager {
  public:
   virtual ~NodeExtentManager() = default;
 
-  // TODO: remove the coarse-grained errorator
-  using tm_ertr = crimson::errorator<
-    crimson::ct_error::input_output_error,
-    crimson::ct_error::invarg,
-    crimson::ct_error::enoent,
-    crimson::ct_error::erange,
-    crimson::ct_error::eagain>;
-
   virtual bool is_read_isolated() const = 0;
 
   using read_ertr = base_ertr::extend<

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
@@ -87,7 +87,7 @@ class NodeExtentManager {
 
   static NodeExtentManagerURef create_dummy(bool is_sync);
   static NodeExtentManagerURef create_seastore(
-      TransactionManager& tm, laddr_t min_laddr = L_ADDR_MIN);
+      TransactionManager& tm, laddr_t min_laddr = L_ADDR_MIN, double p_eagain = 0.0);
 };
 inline std::ostream& operator<<(std::ostream& os, const NodeExtentManager& nm) {
   return nm.print(os);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
@@ -55,23 +55,42 @@ class NodeExtent : public LogicalCachedExtent {
 
 using crimson::os::seastore::TransactionManager;
 class NodeExtentManager {
+  using base_ertr = eagain_ertr::extend<
+    crimson::ct_error::input_output_error>;
+
  public:
   virtual ~NodeExtentManager() = default;
+
+  // TODO: remove the coarse-grained errorator
   using tm_ertr = crimson::errorator<
     crimson::ct_error::input_output_error,
     crimson::ct_error::invarg,
     crimson::ct_error::enoent,
     crimson::ct_error::erange,
     crimson::ct_error::eagain>;
-  template <class ValueT=void>
-  using tm_future = tm_ertr::future<ValueT>;
 
   virtual bool is_read_isolated() const = 0;
-  virtual tm_future<NodeExtentRef> read_extent(
+
+  using read_ertr = base_ertr::extend<
+    crimson::ct_error::invarg,
+    crimson::ct_error::enoent,
+    crimson::ct_error::erange>;
+  virtual read_ertr::future<NodeExtentRef> read_extent(
       Transaction&, laddr_t, extent_len_t) = 0;
-  virtual tm_future<NodeExtentRef> alloc_extent(Transaction&, extent_len_t) = 0;
-  virtual tm_future<> retire_extent(Transaction&, NodeExtentRef) = 0;
-  virtual tm_future<Super::URef> get_super(Transaction&, RootNodeTracker&) = 0;
+
+  using alloc_ertr = base_ertr;
+  virtual alloc_ertr::future<NodeExtentRef> alloc_extent(
+      Transaction&, extent_len_t) = 0;
+
+  using retire_ertr = base_ertr::extend<
+    crimson::ct_error::enoent>;
+  virtual retire_ertr::future<> retire_extent(
+      Transaction&, NodeExtentRef) = 0;
+
+  using getsuper_ertr = base_ertr;
+  virtual getsuper_ertr::future<Super::URef> get_super(
+      Transaction&, RootNodeTracker&) = 0;
+
   virtual std::ostream& print(std::ostream& os) const = 0;
 
   static NodeExtentManagerURef create_dummy(bool is_sync);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
@@ -44,14 +44,6 @@ static DeltaRecorderURef create_replay_recorder(
   }
 }
 
-void SeastoreSuper::write_root_laddr(context_t c, laddr_t addr)
-{
-  DEBUGT("update root {:#x} ...", c.t, addr);
-  root_addr = addr;
-  auto nm = static_cast<SeastoreNodeExtentManager*>(&c.nm);
-  nm->get_tm().write_onode_root(c.t, addr);
-}
-
 NodeExtentRef SeastoreNodeExtent::mutate(
     context_t c, DeltaRecorderURef&& _recorder)
 {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
@@ -48,8 +48,8 @@ NodeExtentRef SeastoreNodeExtent::mutate(
     context_t c, DeltaRecorderURef&& _recorder)
 {
   DEBUGT("mutate {:#x} ...", c.t, get_laddr());
-  auto nm = static_cast<SeastoreNodeExtentManager*>(&c.nm);
-  auto extent = nm->get_tm().get_mutable_extent(c.t, this);
+  auto p_handle = static_cast<TransactionManagerHandle*>(&c.nm);
+  auto extent = p_handle->tm.get_mutable_extent(c.t, this);
   auto ret = extent->cast<SeastoreNodeExtent>();
   // A replayed extent may already have an empty recorder, we discard it for
   // simplicity.

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -26,7 +26,12 @@ class SeastoreSuper final: public Super {
   laddr_t get_root_laddr() const override {
     return root_addr;
   }
-  void write_root_laddr(context_t c, laddr_t addr) override;
+  void write_root_laddr(context_t c, laddr_t addr) override {
+    LOG_PREFIX(OTree::Seastore);
+    DEBUGT("update root {:#x} ...", c.t, addr);
+    root_addr = addr;
+    tm.write_onode_root(c.t, addr);
+  }
  private:
   laddr_t root_addr;
   TransactionManager& tm;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -70,7 +70,7 @@ class SeastoreNodeExtentManager final: public NodeExtentManager {
  protected:
   bool is_read_isolated() const override { return true; }
 
-  tm_future<NodeExtentRef> read_extent(
+  read_ertr::future<NodeExtentRef> read_extent(
       Transaction& t, laddr_t addr, extent_len_t len) override {
     TRACET("reading {}B at {:#x} ...", t, len, addr);
     return tm.read_extent<SeastoreNodeExtent>(t, addr, len
@@ -84,7 +84,7 @@ class SeastoreNodeExtentManager final: public NodeExtentManager {
     });
   }
 
-  tm_future<NodeExtentRef> alloc_extent(
+  alloc_ertr::future<NodeExtentRef> alloc_extent(
       Transaction& t, extent_len_t len) override {
     TRACET("allocating {}B ...", t, len);
     return tm.alloc_extent<SeastoreNodeExtent>(t, addr_min, len
@@ -97,7 +97,7 @@ class SeastoreNodeExtentManager final: public NodeExtentManager {
     });
   }
 
-  tm_future<> retire_extent(
+  retire_ertr::future<> retire_extent(
       Transaction& t, NodeExtentRef _extent) override {
     LogicalCachedExtentRef extent = _extent;
     auto addr = extent->get_laddr();
@@ -109,7 +109,7 @@ class SeastoreNodeExtentManager final: public NodeExtentManager {
     });
   }
 
-  tm_future<Super::URef> get_super(
+  getsuper_ertr::future<Super::URef> get_super(
       Transaction& t, RootNodeTracker& tracker) override {
     TRACET("get root ...", t);
     return tm.read_onode_root(t).safe_then([this, &t, &tracker](auto root_addr) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.cc
@@ -11,7 +11,7 @@ last_split_info_t last_split = {};
 #endif
 
 // XXX: branchless allocation
-InternalNodeImpl::ertr::future<InternalNodeImpl::fresh_impl_t>
+eagain_future<InternalNodeImpl::fresh_impl_t>
 InternalNodeImpl::allocate(
     context_t c, field_type_t type, bool is_level_tail, level_t level)
 {
@@ -28,7 +28,7 @@ InternalNodeImpl::allocate(
   }
 }
 
-LeafNodeImpl::ertr::future<LeafNodeImpl::fresh_impl_t>
+eagain_future<LeafNodeImpl::fresh_impl_t>
 LeafNodeImpl::allocate(
     context_t c, field_type_t type, bool is_level_tail)
 {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -82,7 +82,7 @@ class NodeImpl {
   virtual level_t level() const = 0;
   virtual node_offset_t free_size() const = 0;
   virtual node_offset_t total_size() const = 0;
-  virtual bool is_extent_valid() const = 0;
+  virtual bool is_extent_retired() const = 0;
   virtual std::optional<key_view_t> get_pivot_index() const = 0;
   virtual bool is_size_underflow() const = 0;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -58,13 +58,6 @@ class NodeExtentMutable;
  */
 class NodeImpl {
  public:
-  using ertr = crimson::errorator<
-    crimson::ct_error::input_output_error,
-    crimson::ct_error::invarg,
-    crimson::ct_error::enoent,
-    crimson::ct_error::erange,
-    crimson::ct_error::eagain
-   >;
   virtual ~NodeImpl() = default;
 
   virtual node_type_t node_type() const = 0;
@@ -96,8 +89,8 @@ class NodeImpl {
   virtual std::tuple<match_stage_t, search_position_t> erase(const search_position_t&) = 0;
   virtual std::tuple<match_stage_t, std::size_t> evaluate_merge(NodeImpl&) = 0;
   virtual search_position_t merge(NodeExtentMutable&, NodeImpl&, match_stage_t, node_offset_t) = 0;
-  virtual ertr::future<NodeExtentMutable> rebuild_extent(context_t) = 0;
-  virtual ertr::future<> retire_extent(context_t) = 0;
+  virtual eagain_future<NodeExtentMutable> rebuild_extent(context_t) = 0;
+  virtual eagain_future<> retire_extent(context_t) = 0;
   virtual search_position_t make_tail() = 0;
 
   virtual node_stats_t get_stats() const = 0;
@@ -185,7 +178,7 @@ class InternalNodeImpl : public NodeImpl {
       return {std::move(impl), mut};
     }
   };
-  static ertr::future<fresh_impl_t> allocate(context_t, field_type_t, bool, level_t);
+  static eagain_future<fresh_impl_t> allocate(context_t, field_type_t, bool, level_t);
 
   static InternalNodeImplURef load(NodeExtentRef, field_type_t, bool);
 
@@ -265,7 +258,7 @@ class LeafNodeImpl : public NodeImpl {
       return {std::move(impl), mut};
     }
   };
-  static ertr::future<fresh_impl_t> allocate(context_t, field_type_t, bool);
+  static eagain_future<fresh_impl_t> allocate(context_t, field_type_t, bool);
 
   static LeafNodeImplURef load(NodeExtentRef, field_type_t, bool);
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -120,7 +120,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   level_t level() const override { return extent.read().level(); }
   node_offset_t free_size() const override { return extent.read().free_size(); }
   node_offset_t total_size() const override { return extent.read().total_size(); }
-  bool is_extent_valid() const override { return extent.is_valid(); }
+  bool is_extent_retired() const override { return extent.is_retired(); }
 
   std::optional<key_view_t> get_pivot_index() const override {
     if (is_level_tail()) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -66,7 +66,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     return ret;
   }
 
-  static ertr::future<typename parent_t::fresh_impl_t> allocate(
+  static eagain_future<typename parent_t::fresh_impl_t> allocate(
       context_t c, bool is_level_tail, level_t level) {
     LOG_PREFIX(OTree::Layout::allocate);
     // NOTE: Currently, all the node types have the same size for simplicity.
@@ -267,7 +267,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     return normalize(std::move(left_last_pos));
   }
 
-  ertr::future<NodeExtentMutable>
+  eagain_future<NodeExtentMutable>
   rebuild_extent(context_t c) override {
     return extent.rebuild(c).safe_then([this] (auto mut) {
       // addr may change
@@ -276,7 +276,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     });
   }
 
-  ertr::future<> retire_extent(context_t c) override {
+  eagain_future<> retire_extent(context_t c) override {
     return extent.retire(c);
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
@@ -33,15 +33,6 @@ class tree_cursor_t;
 template <typename ValueImpl>
 class Btree {
  public:
-  using btree_ertr = crimson::errorator<
-    crimson::ct_error::input_output_error,
-    crimson::ct_error::invarg,
-    crimson::ct_error::enoent,
-    crimson::ct_error::erange,
-    crimson::ct_error::eagain>;
-  template <class ValueT=void>
-  using btree_future = btree_ertr::future<ValueT>;
-
   Btree(NodeExtentManagerURef&& _nm)
     : nm{std::move(_nm)},
       root_tracker{RootNodeTracker::create(nm->is_read_isolated())} {}
@@ -52,7 +43,7 @@ class Btree {
   Btree& operator=(const Btree&) = delete;
   Btree& operator=(Btree&&) = delete;
 
-  btree_future<> mkfs(Transaction& t) {
+  eagain_future<> mkfs(Transaction& t) {
     return Node::mkfs(get_context(t), *root_tracker);
   }
 
@@ -97,7 +88,7 @@ class Btree {
     bool operator==(const Cursor& o) const { return (int)compare_to(o) == 0; }
     bool operator!=(const Cursor& o) const { return (int)compare_to(o) != 0; }
 
-    btree_future<Cursor> get_next(Transaction& t) {
+    eagain_future<Cursor> get_next(Transaction& t) {
       assert(!is_end());
       auto this_obj = *this;
       return p_cursor->get_next(p_tree->get_context(t)
@@ -111,7 +102,7 @@ class Btree {
     }
 
     template <bool FORCE_MERGE = false>
-    btree_future<Cursor> erase(Transaction& t) {
+    eagain_future<Cursor> erase(Transaction& t) {
       assert(!is_end());
       auto this_obj = *this;
       return p_cursor->erase<FORCE_MERGE>(p_tree->get_context(t), true
@@ -161,7 +152,7 @@ class Btree {
    * lookup
    */
 
-  btree_future<Cursor> begin(Transaction& t) {
+  eagain_future<Cursor> begin(Transaction& t) {
     return get_root(t).safe_then([this, &t](auto root) {
       return root->lookup_smallest(get_context(t));
     }).safe_then([this](auto cursor) {
@@ -169,7 +160,7 @@ class Btree {
     });
   }
 
-  btree_future<Cursor> last(Transaction& t) {
+  eagain_future<Cursor> last(Transaction& t) {
     return get_root(t).safe_then([this, &t](auto root) {
       return root->lookup_largest(get_context(t));
     }).safe_then([this](auto cursor) {
@@ -181,10 +172,10 @@ class Btree {
     return Cursor::make_end(this);
   }
 
-  btree_future<bool> contains(Transaction& t, const ghobject_t& obj) {
+  eagain_future<bool> contains(Transaction& t, const ghobject_t& obj) {
     return seastar::do_with(
       full_key_t<KeyT::HOBJ>(obj),
-      [this, &t](auto& key) -> btree_future<bool> {
+      [this, &t](auto& key) -> eagain_future<bool> {
         return get_root(t).safe_then([this, &t, &key](auto root) {
           // TODO: improve lower_bound()
           return root->lower_bound(get_context(t), key);
@@ -195,10 +186,10 @@ class Btree {
     );
   }
 
-  btree_future<Cursor> find(Transaction& t, const ghobject_t& obj) {
+  eagain_future<Cursor> find(Transaction& t, const ghobject_t& obj) {
     return seastar::do_with(
       full_key_t<KeyT::HOBJ>(obj),
-      [this, &t](auto& key) -> btree_future<Cursor> {
+      [this, &t](auto& key) -> eagain_future<Cursor> {
         return get_root(t).safe_then([this, &t, &key](auto root) {
           // TODO: improve lower_bound()
           return root->lower_bound(get_context(t), key);
@@ -213,10 +204,10 @@ class Btree {
     );
   }
 
-  btree_future<Cursor> lower_bound(Transaction& t, const ghobject_t& obj) {
+  eagain_future<Cursor> lower_bound(Transaction& t, const ghobject_t& obj) {
     return seastar::do_with(
       full_key_t<KeyT::HOBJ>(obj),
-      [this, &t](auto& key) -> btree_future<Cursor> {
+      [this, &t](auto& key) -> eagain_future<Cursor> {
         return get_root(t).safe_then([this, &t, &key](auto root) {
           return root->lower_bound(get_context(t), key);
         }).safe_then([this](auto result) {
@@ -226,7 +217,7 @@ class Btree {
     );
   }
 
-  btree_future<Cursor> get_next(Transaction& t, Cursor& cursor) {
+  eagain_future<Cursor> get_next(Transaction& t, Cursor& cursor) {
     return cursor.get_next(t);
   }
 
@@ -237,12 +228,12 @@ class Btree {
   struct tree_value_config_t {
     value_size_t payload_size = 256;
   };
-  btree_future<std::pair<Cursor, bool>>
+  eagain_future<std::pair<Cursor, bool>>
   insert(Transaction& t, const ghobject_t& obj, tree_value_config_t _vconf) {
     value_config_t vconf{value_builder.get_header_magic(), _vconf.payload_size};
     return seastar::do_with(
       full_key_t<KeyT::HOBJ>(obj),
-      [this, &t, vconf](auto& key) -> btree_future<std::pair<Cursor, bool>> {
+      [this, &t, vconf](auto& key) -> eagain_future<std::pair<Cursor, bool>> {
         ceph_assert(key.is_valid());
         return get_root(t).safe_then([this, &t, &key, vconf](auto root) {
           return root->insert(get_context(t), key, vconf);
@@ -254,10 +245,10 @@ class Btree {
     );
   }
 
-  btree_future<std::size_t> erase(Transaction& t, const ghobject_t& obj) {
+  eagain_future<std::size_t> erase(Transaction& t, const ghobject_t& obj) {
     return seastar::do_with(
       full_key_t<KeyT::HOBJ>(obj),
-      [this, &t](auto& key) -> btree_future<std::size_t> {
+      [this, &t](auto& key) -> eagain_future<std::size_t> {
         return get_root(t).safe_then([this, &t, &key](auto root) {
           return root->erase(get_context(t), key);
         });
@@ -265,11 +256,11 @@ class Btree {
     );
   }
 
-  btree_future<Cursor> erase(Transaction& t, Cursor& pos) {
+  eagain_future<Cursor> erase(Transaction& t, Cursor& pos) {
     return pos.erase(t);
   }
 
-  btree_future<> erase(Transaction& t, Value& value) {
+  eagain_future<> erase(Transaction& t, Value& value) {
     assert(value.is_tracked());
     auto ref_cursor = value.p_cursor;
     return ref_cursor->erase(get_context(t), false
@@ -283,19 +274,19 @@ class Btree {
    * stats
    */
 
-  btree_future<size_t> height(Transaction& t) {
+  eagain_future<size_t> height(Transaction& t) {
     return get_root(t).safe_then([](auto root) {
       return size_t(root->level() + 1);
     });
   }
 
-  btree_future<tree_stats_t> get_stats_slow(Transaction& t) {
+  eagain_future<tree_stats_t> get_stats_slow(Transaction& t) {
     return get_root(t).safe_then([this, &t](auto root) {
       unsigned height = root->level() + 1;
       return root->get_tree_stats(get_context(t)
       ).safe_then([height](auto stats) {
         stats.height = height;
-        return btree_ertr::make_ready_future<tree_stats_t>(stats);
+        return seastar::make_ready_future<tree_stats_t>(stats);
       });
     });
   }
@@ -322,7 +313,7 @@ class Btree {
     return root_tracker->is_clean();
   }
 
-  btree_future<> test_clone_from(
+  eagain_future<> test_clone_from(
       Transaction& t, Transaction& t_from, Btree& from) {
     // Note: assume the tree to clone is tracked correctly in memory.
     // In some unit tests, parts of the tree are stubbed out that they
@@ -338,10 +329,10 @@ class Btree {
     return {*nm, value_builder, t};
   }
 
-  btree_future<Ref<Node>> get_root(Transaction& t) {
+  eagain_future<Ref<Node>> get_root(Transaction& t) {
     auto root = root_tracker->get_root(t);
     if (root) {
-      return btree_ertr::make_ready_future<Ref<Node>>(root);
+      return seastar::make_ready_future<Ref<Node>>(root);
     } else {
       return Node::load_root(get_context(t), *root_tracker);
     }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
@@ -23,6 +23,9 @@
  * - Runs above seastore block and transaction layer;
  * - Specially optimized for onode key structures and seastore
  *   delta/transaction semantics;
+ *
+ * Note: User should not hold any Cursor/Value when call
+ * submit_transaction() because of validations implemented in ~tree_cursor_t().
  */
 
 namespace crimson::os::seastore::onode {
@@ -66,6 +69,11 @@ class Btree {
         assert(p_cursor->is_end());
         ceph_abort("impossible");
       }
+    }
+
+    /// Invalidate the Cursor before submitting transaction.
+    void invalidate() {
+      p_cursor.reset();
     }
 
     // XXX: return key_view_t to avoid unecessary ghobject_t constructions

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -290,6 +290,34 @@ class TreeBuilder {
     return tree->mkfs(t);
   }
 
+  eagain_future<BtreeCursor> insert_one(
+      Transaction& t, const iterator_t& iter_rd) {
+    auto p_kv = *iter_rd;
+    logger().debug("[{}] insert {} -> {}",
+                   iter_rd - kvs.random_begin(),
+                   key_hobj_t{p_kv->key},
+                   p_kv->value);
+    return tree->insert(
+        t, p_kv->key, {p_kv->value.get_payload_size()}
+    ).safe_then([&t, this, p_kv](auto ret) {
+      auto& [cursor, success] = ret;
+      initialize_cursor_from_item(t, p_kv->key, p_kv->value, cursor, success);
+#ifndef NDEBUG
+      validate_cursor_from_item(p_kv->key, p_kv->value, cursor);
+      return tree->find(t, p_kv->key
+      ).safe_then([this, cursor, p_kv](auto cursor_) mutable {
+        assert(!cursor_.is_end());
+        ceph_assert(cursor_.get_ghobj() == p_kv->key);
+        ceph_assert(cursor_.value() == cursor.value());
+        validate_cursor_from_item(p_kv->key, p_kv->value, cursor_);
+        return cursor;
+      });
+#else
+      return eagain_ertr::make_ready_future<BtreeCrusor>(cursor);
+#endif
+    });
+  }
+
   eagain_future<> insert(Transaction& t) {
     auto ref_kv_iter = seastar::make_lw_shared<iterator_t>();
     *ref_kv_iter = kvs.random_begin();
@@ -302,38 +330,16 @@ class TreeBuilder {
         std::chrono::duration<double> duration = mono_clock::now() - start_time;
         logger().warn("Insert done! {}s", duration.count());
         return seastar::make_ready_future<bool>(true);
-      }
-      auto p_kv = **ref_kv_iter;
-      logger().debug("[{}] insert {} -> {}",
-                     (*ref_kv_iter) - kvs.random_begin(),
-                     key_hobj_t{p_kv->key},
-                     p_kv->value);
-      return tree->insert(
-          t, p_kv->key, {p_kv->value.get_payload_size()}
-      ).safe_then([&t, this, cursors, ref_kv_iter](auto ret) {
-        auto p_kv = **ref_kv_iter;
-        auto& [cursor, success] = ret;
-        initialize_cursor_from_item(t, p_kv->key, p_kv->value, cursor, success);
-        if constexpr (TRACK) {
-          cursors->emplace_back(cursor);
-        }
-#ifndef NDEBUG
-        validate_cursor_from_item(p_kv->key, p_kv->value, cursor);
-        return tree->find(t, p_kv->key
-        ).safe_then([this, cursor, ref_kv_iter](auto cursor_) mutable {
-          assert(!cursor_.is_end());
-          auto p_kv = **ref_kv_iter;
-          ceph_assert(cursor_.get_ghobj() == p_kv->key);
-          ceph_assert(cursor_.value() == cursor.value());
-          validate_cursor_from_item(p_kv->key, p_kv->value, cursor_);
+      } else {
+        return insert_one(t, *ref_kv_iter
+        ).safe_then([cursors, ref_kv_iter] (auto cursor) {
+          if constexpr (TRACK) {
+            cursors->emplace_back(cursor);
+          }
           ++(*ref_kv_iter);
           return seastar::make_ready_future<bool>(false);
         });
-#else
-        ++(*ref_kv_iter);
-        return seastar::make_ready_future<bool>(false);
-#endif
-      });
+      }
     }).safe_then([&t, this, cursors, ref_kv_iter] {
       if (!cursors->empty()) {
         logger().info("Verifing tracked cursors ...");
@@ -367,11 +373,31 @@ class TreeBuilder {
     });
   }
 
+  eagain_future<> erase_one(
+      Transaction& t, const iterator_t& iter_rd) {
+    auto p_kv = *iter_rd;
+    logger().debug("[{}] erase {} -> {}",
+                   iter_rd - kvs.random_begin(),
+                   key_hobj_t{p_kv->key},
+                   p_kv->value);
+    return tree->erase(t, p_kv->key
+    ).safe_then([&t, this, p_kv] (auto size) {
+      ceph_assert(size == 1);
+#ifndef NDEBUG
+      return tree->contains(t, p_kv->key
+      ).safe_then([] (bool ret) {
+        ceph_assert(ret == false);
+      });
+#else
+      return eagain_ertr::now();
+#endif
+    });
+  }
+
   eagain_future<> erase(Transaction& t, std::size_t erase_size) {
     assert(erase_size <= kvs.size());
     kvs.shuffle();
-    auto begin = kvs.random_begin();
-    auto end = begin + erase_size;
+    auto erase_end = kvs.random_begin() + erase_size;
     auto ref_kv_iter = seastar::make_lw_shared<iterator_t>();
     auto cursors = seastar::make_lw_shared<std::map<ghobject_t, BtreeCursor>>();
     return seastar::now().then([&t, this, cursors, ref_kv_iter] {
@@ -398,42 +424,30 @@ class TreeBuilder {
       } else {
         return eagain_ertr::now();
       }
-    }).safe_then([&t, this, ref_kv_iter, begin, end] {
-      *ref_kv_iter = begin;
-      logger().warn("start erasing {}/{} kvs ...", end - begin, kvs.size());
+    }).safe_then([&t, this, ref_kv_iter, erase_end] {
+      *ref_kv_iter = kvs.random_begin();
+      logger().warn("start erasing {}/{} kvs ...",
+                    erase_end - kvs.random_begin(), kvs.size());
       auto start_time = mono_clock::now();
       return crimson::do_until([&t, this, ref_kv_iter,
-                                start_time, begin, end] () -> eagain_future<bool> {
-        if (*ref_kv_iter == end) {
+                                start_time, erase_end] () -> eagain_future<bool> {
+        if (*ref_kv_iter == erase_end) {
           std::chrono::duration<double> duration = mono_clock::now() - start_time;
           logger().warn("Erase done! {}s", duration.count());
           return seastar::make_ready_future<bool>(true);
-        }
-        auto p_kv = **ref_kv_iter;
-        logger().debug("[{}] erase {} -> {}",
-                       (*ref_kv_iter) - begin,
-                       key_hobj_t{p_kv->key},
-                       p_kv->value);
-        return tree->erase(t, p_kv->key).safe_then([&t, this, ref_kv_iter] (auto size) {
-          ceph_assert(size == 1);
-#ifndef NDEBUG
-          auto p_kv = **ref_kv_iter;
-          return tree->contains(t, p_kv->key).safe_then([ref_kv_iter] (bool ret) {
-            ceph_assert(ret == false);
+        } else {
+          return erase_one(t, *ref_kv_iter
+          ).safe_then([ref_kv_iter] {
             ++(*ref_kv_iter);
             return seastar::make_ready_future<bool>(false);
           });
-#else
-          ++(*ref_kv_iter);
-          return seastar::make_ready_future<bool>(false);
-#endif
-        });
+        }
       });
-    }).safe_then([this, cursors, ref_kv_iter, begin, end] {
+    }).safe_then([this, cursors, ref_kv_iter, erase_end] {
       if constexpr (TRACK) {
         logger().info("Verifing tracked cursors ...");
-        *ref_kv_iter = begin;
-        while (*ref_kv_iter != end) {
+        *ref_kv_iter = kvs.random_begin();
+        while (*ref_kv_iter != erase_end) {
           auto p_kv = **ref_kv_iter;
           auto c_it = cursors->find(p_kv->key);
           ceph_assert(c_it != cursors->end());
@@ -442,7 +456,7 @@ class TreeBuilder {
           ++(*ref_kv_iter);
         }
       }
-      kvs.erase_from_random(begin, end);
+      kvs.erase_from_random(kvs.random_begin(), erase_end);
       if constexpr (TRACK) {
         *ref_kv_iter = kvs.begin();
         for (auto& [k, c] : *cursors) {
@@ -471,23 +485,33 @@ class TreeBuilder {
     tree.emplace(std::move(nm));
   }
 
+  eagain_future<> validate_one(
+      Transaction& t, const iterator_t& iter_seq) {
+    assert(iter_seq != kvs.end());
+    auto next_iter = iter_seq + 1;
+    auto p_kv = *iter_seq;
+    return tree->find(t, p_kv->key
+    ).safe_then([p_kv, &t] (auto cursor) {
+      validate_cursor_from_item(p_kv->key, p_kv->value, cursor);
+      return cursor.get_next(t);
+    }).safe_then([next_iter, this] (auto cursor) {
+      if (next_iter == kvs.end()) {
+        ceph_assert(cursor.is_end());
+      } else {
+        auto p_kv = *next_iter;
+        validate_cursor_from_item(p_kv->key, p_kv->value, cursor);
+      }
+    });
+  }
+
   eagain_future<> validate(Transaction& t) {
     return seastar::async([this, &t] {
       logger().info("Verifing inserted ...");
-      for (auto& p_kv : kvs) {
-        auto cursor = tree->find(t, p_kv->key).unsafe_get0();
-        validate_cursor_from_item(p_kv->key, p_kv->value, cursor);
+      auto iter = kvs.begin();
+      while (iter != kvs.end()) {
+        validate_one(t, iter).unsafe_get0();
+        ++iter;
       }
-
-      logger().info("Verifing range query ...");
-      auto cursor = tree->begin(t).unsafe_get0();
-      for (auto& p_kv : kvs) {
-        assert(!cursor.is_end());
-        validate_cursor_from_item(p_kv->key, p_kv->value, cursor);
-        cursor = cursor.get_next(t).unsafe_get0();
-      }
-      assert(cursor.is_end());
-
       logger().info("Verify done!");
     });
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -36,6 +36,11 @@ bool Value::is_tracked() const
   return p_cursor->is_tracked();
 }
 
+void Value::invalidate()
+{
+  p_cursor.reset();
+}
+
 eagain_future<> Value::extend(Transaction& t, value_size_t extend_size)
 {
   assert(is_tracked());

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -12,10 +12,6 @@
 
 namespace crimson::os::seastore::onode {
 
-using ertr = Value::ertr;
-template <class ValueT=void>
-using future = Value::future<ValueT>;
-
 ceph::bufferlist&
 ValueDeltaRecorder::get_encoded(NodeExtentMutable& payload_mut)
 {
@@ -40,7 +36,7 @@ bool Value::is_tracked() const
   return p_cursor->is_tracked();
 }
 
-future<> Value::extend(Transaction& t, value_size_t extend_size)
+eagain_future<> Value::extend(Transaction& t, value_size_t extend_size)
 {
   assert(is_tracked());
   [[maybe_unused]] auto target_size = get_payload_size() + extend_size;
@@ -53,7 +49,7 @@ future<> Value::extend(Transaction& t, value_size_t extend_size)
   ;
 }
 
-future<> Value::trim(Transaction& t, value_size_t trim_size)
+eagain_future<> Value::trim(Transaction& t, value_size_t trim_size)
 {
   assert(is_tracked());
   assert(get_payload_size() > trim_size);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -171,6 +171,9 @@ class Value {
   /// Returns whether the Value is still tracked in tree.
   bool is_tracked() const;
 
+  /// Invalidate the Value before submitting transaction.
+  void invalidate();
+
   /// Returns the value payload size.
   value_size_t get_payload_size() const {
     assert(is_tracked());

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -162,15 +162,6 @@ class tree_cursor_t;
  */
 class Value {
  public:
-  using ertr = crimson::errorator<
-    crimson::ct_error::input_output_error,
-    crimson::ct_error::invarg,
-    crimson::ct_error::enoent,
-    crimson::ct_error::erange,
-    crimson::ct_error::eagain>;
-  template <class ValueT=void>
-  using future = ertr::future<ValueT>;
-
   virtual ~Value();
   Value(const Value&) = default;
   Value(Value&&) = default;
@@ -193,10 +184,10 @@ class Value {
   Value(NodeExtentManager&, const ValueBuilder&, Ref<tree_cursor_t>&);
 
   /// Extends the payload size.
-  future<> extend(Transaction&, value_size_t extend_size);
+  eagain_future<> extend(Transaction&, value_size_t extend_size);
 
   /// Trim and shrink the payload.
-  future<> trim(Transaction&, value_size_t trim_size);
+  eagain_future<> trim(Transaction&, value_size_t trim_size);
 
   /// Get the permission to mutate the payload with the optional value recorder.
   template <typename PayloadT, typename ValueDeltaRecorderT>

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -605,6 +605,10 @@ seastar::future<> SeaStore::do_transaction(
       }).safe_then([this, &ctx] {
 	return onode_manager->write_dirty(*ctx.transaction, ctx.onodes);
       }).safe_then([this, &ctx] {
+        // There are some validations in onode tree during onode value
+        // destruction in debug mode, which need to be done before calling
+        // submit_transaction().
+        ctx.onodes.clear();
 	return transaction_manager->submit_transaction(std::move(ctx.transaction));
       }).safe_then([&ctx]() {
 	for (auto i : {

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -120,7 +120,7 @@ SeaStore::list_objects(CollectionRef ch,
   return seastar::do_with(
       RetType(),
       [this, start, end, limit] (auto& ret) {
-    return repeat_eagain([this, start, end, limit, &ret] {
+    return repeat_eagain2([this, start, end, limit, &ret] {
       return seastar::do_with(
           transaction_manager->create_transaction(),
           [this, start, end, limit, &ret] (auto& t) {
@@ -129,14 +129,10 @@ SeaStore::list_objects(CollectionRef ch,
           ret = std::move(_ret);
         });
       });
-    }).safe_then([&ret] {
+    }).then([&ret] {
       return std::move(ret);
     });
-  }).handle_error(
-    crimson::ct_error::assert_all{
-      "Invalid error in SeaStore::list_objects"
-    }
-  );
+  });
 }
 
 seastar::future<CollectionRef> SeaStore::create_new_collection(const coll_t& cid)

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1017,6 +1017,9 @@ class DummyChildPool {
         DummyChildPool& pool, RootNodeTracker& root_tracker) {
       auto initial = create_new(keys, true, pool);
       return c.nm.get_super(c.t, root_tracker
+      ).handle_error(
+        eagain_ertr::pass_further{},
+        crimson::ct_error::assert_all{"Invalid error during create_initial()"}
       ).safe_then([c, &pool, initial](auto super) {
         initial->make_root_new(c, std::move(super));
         return initial->upgrade_root(c).safe_then([initial] {

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -828,7 +828,7 @@ class DummyChildPool {
     laddr_t laddr() const override { return _laddr; }
     bool is_level_tail() const override { return _is_level_tail; }
     std::optional<key_view_t> get_pivot_index() const override { return {key_view}; }
-    bool is_extent_valid() const override { return _is_extent_valid; }
+    bool is_extent_retired() const override { return _is_extent_retired; }
     const std::string& get_name() const override { return name; }
     search_position_t make_tail() override {
       _is_level_tail = true;
@@ -836,7 +836,8 @@ class DummyChildPool {
       return search_position_t::end();
     }
     eagain_future<> retire_extent(context_t) override {
-      _is_extent_valid = false;
+      assert(!_is_extent_retired);
+      _is_extent_retired = true;
       return seastar::now();
     }
 
@@ -898,7 +899,7 @@ class DummyChildPool {
     bool _is_level_tail;
     laddr_t _laddr;
     std::string name;
-    bool _is_extent_valid = true;
+    bool _is_extent_retired = false;
 
     key_view_t key_view;
     void* p_mem_key_view;

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1521,7 +1521,7 @@ TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
     auto kvs = KVPool<test_item_t>::create_raw_range(
         {8, 11, 64, 256, 301, 320},
         {8, 16, 128, 512, 576, 640},
-        {0, 32}, {0, 10}, {0, 4});
+        {0, 16}, {0, 10}, {0, 4});
     auto moved_nm = (TEST_SEASTORE ? NodeExtentManager::create_seastore(*tm)
                                    : NodeExtentManager::create_dummy(IS_DUMMY_SYNC));
     auto p_nm = moved_nm.get();


### PR DESCRIPTION
## Current vstart status after fixing OTree with eagain
Mkfs and pool create operations are successful now.
But during test write:
```
$ ./bin/rados bench -p test-pool 5 write -b 4096 --no-cleanup
```
Got unexpected behavior from SeaStore as BTree can read invalid extent from TransactionManager:
https://github.com/ceph/ceph/blob/dd9de9db9f8d7be5fe1a526aa2271862dc62c475/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h#L108-L115
```
osd.0.stdout:
...
TRACE 2021-05-21 13:59:27,559 [shard 0] seastore - OTree::Seastore(0x61200007a440): reading 4096B at 0x1002000 ...
DEBUG 2021-05-21 13:59:27,559 [shard 0] seastore - Cache::get_root(0x61200007a440): root already on transaction CachedExtent(addr=0x61a000009080, type=ROOT, version=2, dirty_from_or_retired_at=journal_seq_t(segment_seq=3, offset=paddr_t<3, 12288>), paddr=paddr_t<NULL_SEG, NULL_OFF>, state=DIRTY, last_committed_crc=0, refcount=15)
...
DEBUG 2021-05-21 13:59:27,562 [shard 0] seastore - TransactionManager::pin_to_extent(0x61200007a440): getting extent LBAPin(16785408~4096->paddr_t<3, 20480>
DEBUG 2021-05-21 13:59:27,562 [shard 0] seastore - TransactionManager::pin_to_extent(0x61200007a440): got extent CachedExtent(addr=0x61100004b540, type=ONODE_BLOCK_STAGED, version=4, dirty_from_or_retired_at=journal_seq_t(segment_seq=3, offset=paddr_t<3, 57344>), paddr=paddr_t<3, 20480>, state=DIRTY, last_committed_crc=1740309759, refcount=12, laddr=16785408, pin=LBAPin(16785408~4096->paddr_t<3, 20480>)
...
TRACE 2021-05-21 13:59:27,564 [shard 0] seastore - OTree::Seastore(0x61200007a440): read 4096B at 0x1002000 -- CachedExtent(addr=0x61100004b540, type=ONODE_BLOCK_STAGED, version=4, dirty_from_or_retired_at=journal_seq_t(segment_seq=3, offset=paddr_t<3, 57344>), paddr=paddr_t<3, 20480>, state=INVALID, last_committed_crc=1740309759, refcount=11, laddr=16785408, pin=LBAPin(16785408~4096->paddr_t<3, 20480>)
ERROR 2021-05-21 13:59:27,564 [shard 0] seastore - OTree::Seastore(0x61200007a440): read invalid extent: CachedExtent(addr=0x61100004b540, type=ONODE_BLOCK_STAGED, version=4, dirty_from_or_retired_at=journal_seq_t(segment_seq=3, offset=paddr_t<3, 57344>), paddr=paddr_t<3, 20480>, state=INVALID, last_committed_crc=1740309759, refcount=11, laddr=16785408, pin=LBAPin(16785408~4096->paddr_t<3, 20480>)
<aborted>
```
After OSD restart, SeaStore got contaminated extents during replay:
```
osd.0.stdout:
...
DEBUG 2021-05-21 13:59:37,964 [shard 0] filestore - Journal::scan_valid_records: read complete paddr_t<3, 45056>
DEBUG 2021-05-21 13:59:37,964 [shard 0] filestore - Journal::scan_valid_records: valid record read at paddr_t<3, 45056>
DEBUG 2021-05-21 13:59:37,964 [shard 0] filestore - Journal::scan_valid_records: valid record read, processing queue
DEBUG 2021-05-21 13:59:37,964 [shard 0] filestore - try_decode_deltas: decoding 3 deltas
DEBUG 2021-05-21 13:59:37,964 [shard 0] seastore - Cache::replay_delta: replaying CachedExtent(addr=0x611000018dc0, type=ONODE_BLOCK_STAGED, version=1, dirty_from_or_retired_at=journal_seq_t(segment_seq=2, offset=paddr_t<2, 4096>), paddr=paddr_t<1, 8192>, state=DIRTY, last_committed_crc=3279673991, refcount=2,  laddr=0, pin=empty) on delta_info_t(type: ONODE_BLOCK_STAGED, paddr: paddr_t<1, 8192>, laddr: 0, prev_crc: 3279673991, final_crc: 1606285838, length: 4096, pversion: 1)
DEBUG 2021-05-21 13:59:37,964 [shard 0] seastore - OTree::Seastore: replay 0x0 ...
DEBUG 2021-05-21 13:59:37,964 [shard 0] seastore - OTree::Extent::Replay: decoding INSERT ...
DEBUG 2021-05-21 13:59:37,965 [shard 0] seastore - OTree::Extent::Replay: apply key_hobj(-1,-1,4251863473; "","osdmap.1"; 0,18446744073709551615), ValueConf(ONODE, 1200B), insert_pos(END, END, END), insert_stage=2, insert_size=1251B ...
DEBUG 2021-05-21 13:59:37,965 [shard 0] seastore - OTree::Extent::Replay: decoding INSERT ...
DEBUG 2021-05-21 13:59:37,965 [shard 0] seastore - OTree::Extent::Replay: apply key_hobj(-1,-1,4251863361; "","osdmap.2"; 0,18446744073709551615), ValueConf(ONODE, 1200B), insert_pos(1, 0, 0), insert_stage=2, insert_size=1251B ...
DEBUG 2021-05-21 13:59:37,965 [shard 0] seastore - OTree::Extent::Replay: decoding SPLIT ...
DEBUG 2021-05-21 13:59:37,965 [shard 0] seastore - OTree::Extent::Replay: apply split_at=2, 0!, 0! ...
DEBUG 2021-05-21 13:59:37,965 [shard 0] seastore - OTree::Extent::Replay: decoding SUBOP_UPDATE_VALUE ...
DEBUG 2021-05-21 13:59:37,965 [shard 0] seastore - OTree::Extent::Replay: update Value(ONODE, 1200B) at 0x652 ...
DEBUG 2021-05-21 13:59:37,965 [shard 0] seastore - OTree::Extent::Replay: decoding SUBOP_UPDATE_VALUE ...
DEBUG 2021-05-21 13:59:37,965 [shard 0] seastore - OTree::Extent::Replay: update Value(ONODE, 1200B) at 0xb26 ...
crimson-osd: /root/ceph/src/crimson/os/seastore/cache.cc:488: crimson::os::seastore::Cache::replay_delta(crimson::os::seastore::journal_seq_t, crimson::os::seastore::paddr_t, const crimson::os::seastore::delta_info_t&)::<lambda(auto:110)> [with auto:110 = boost::intrusive_ptr<crimson::os::seastore::CachedExtent>]: Assertion `extent->last_committed_crc == delta.final_crc' failed.
<aborted>
```

@tchaikov seems vstart is broken if crimson is compiled with `-DWITH_ASAN=ON` in my local environment, not sure what's wrong yet.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
