### PR TITLE
mgr/dashboard: remove non-null id in Grafana dashboard

### DIFF
--- a/monitoring/grafana/dashboards/pool-overview.json
+++ b/monitoring/grafana/dashboards/pool-overview.json
@@ -15,7 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 15,
+  "id": null,
   "iteration": 1617656284287,
   "links": [],
   "panels": [

--- a/src/pybind/mgr/dashboard/ci/check_grafana_uids.py
+++ b/src/pybind/mgr/dashboard/ci/check_grafana_uids.py
@@ -72,28 +72,34 @@ def get_grafana_dashboards(base_dir):
     json_files = get_files(base_dir, 'json')
     dashboards = {}
     for json_file in json_files:
-        with open(json_file) as f:
-            dashboard_config = json.load(f)
-            uid = dashboard_config.get('uid')
+        try:
+            with open(json_file) as f:
+                dashboard_config = json.load(f)
+                uid = dashboard_config.get('uid')
+                assert dashboard_config['id'] is None, \
+                    "'id' not null: '{}'".format(dashboard_config['id'])
 
-            # Grafana dashboard checks
-            title = dashboard_config['title']
-            assert len(title) > 0, \
-                "Title not found in '{}'".format(json_file)
-            assert len(dashboard_config.get('links', [])) == 0, \
-                "Links found in '{}'".format(json_file)
-            if not uid:
-                continue
-            if uid in dashboards:
-                # duplicated uids
-                error_msg = 'Duplicated UID {} found, already defined in {}'.\
-                    format(uid, dashboards[uid]['file'])
-                exit(error_msg)
+                # Grafana dashboard checks
+                title = dashboard_config['title']
+                assert len(title) > 0, \
+                    "Title not found in '{}'".format(json_file)
+                assert len(dashboard_config.get('links', [])) == 0, \
+                    "Links found in '{}'".format(json_file)
+                if not uid:
+                    continue
+                if uid in dashboards:
+                    # duplicated uids
+                    error_msg = 'Duplicated UID {} found, already defined in {}'.\
+                        format(uid, dashboards[uid]['file'])
+                    exit(error_msg)
 
-            dashboards[uid] = {
-                'file': json_file,
-                'title': title
-            }
+                dashboards[uid] = {
+                    'file': json_file,
+                    'title': title
+                }
+        except Exception as e:
+            print(f"Error in file {json_file}")
+            raise e
     return dashboards
 
 


### PR DESCRIPTION
Testing added to prevent this situation.

Fixes: https://tracker.ceph.com/issues/50918
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
