### PR TITLE
mgr/cephadm: Fix Errors calculating OSD services size

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -636,10 +636,10 @@ class CephadmServe:
         self._apply_service_config(spec)
 
         if service_type == 'osd':
-            self.mgr.osd_service.create_from_spec(cast(DriveGroupSpec, spec))
-            # TODO: return True would result in a busy loop
-            # can't know if daemon count changed; create_from_spec doesn't
-            # return a solid indication
+            osd_svc_spec = cast(DriveGroupSpec, spec)
+            osd_distribution = self.mgr.osd_service.create_from_spec(osd_svc_spec)
+            osd_svc_spec.update_daemon_distribution(osd_distribution)
+            self.mgr.spec_store.save(osd_svc_spec, update_create=False)
             return False
 
         svc = self.mgr.cephadm_services[service_type]

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -678,7 +678,7 @@ spec:
                                 data_devices=DeviceSelection(paths=['']))
             c = cephadm_module.create_osds(dg)
             out = wait(cephadm_module, c)
-            assert out == "Created no osd(s) on host test; already created?"
+            assert out == 'Number of OSDs summary: {"test": 0}'
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_create_noncollocated_osd(self, cephadm_module):
@@ -687,7 +687,7 @@ spec:
                                 data_devices=DeviceSelection(paths=['']))
             c = cephadm_module.create_osds(dg)
             out = wait(cephadm_module, c)
-            assert out == "Created no osd(s) on host test; already created?"
+            assert out == 'Number of OSDs summary: {"test": 0}'
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_prepare_drivegroup(self, cephadm_module):
@@ -1340,7 +1340,7 @@ Traceback (most recent call last):
             _run_cephadm.return_value = (json.dumps(ceph_volume_lvm_list), '', 0)
             _run_cephadm.reset_mock()
             assert cephadm_module._osd_activate(
-                ['test']).stdout == "Created osd(s) 1 on host 'test'"
+                ['test']).stdout == "Created 1 OSD on host 'test'"
             assert _run_cephadm.mock_calls == [
                 mock.call('test', 'osd', 'ceph-volume',
                           ['--', 'lvm', 'list', '--format', 'json'], no_fsid=False, image=''),
@@ -1382,7 +1382,7 @@ Traceback (most recent call last):
             _run_cephadm.return_value = (json.dumps(ceph_volume_lvm_list), '', 0)
             _run_cephadm.reset_mock()
             assert cephadm_module._osd_activate(
-                ['test']).stdout == "Created osd(s) 1 on host 'test'"
+                ['test']).stdout == "Created 1 OSD on host 'test'"
             assert _run_cephadm.mock_calls == [
                 mock.call('test', 'osd', 'ceph-volume',
                           ['--', 'lvm', 'list', '--format', 'json'], no_fsid=False, image=''),

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -772,6 +772,10 @@ class CephadmUpgrade:
                 'who': name_to_config_section(daemon_type),
             })
 
+        # Force an update of OSD Services status
+        for host in self.mgr.cache.get_hosts():
+            self.mgr.cache.invalidate_host_devices(host)
+
         logger.info('Upgrade: Complete!')
         if self.upgrade_state.progress_id:
             self.mgr.remote('progress', 'complete',

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -803,8 +803,9 @@ Usage:
             host_name, block_device = svc_arg.split(":")
             block_devices = block_device.split(',')
             devs = DeviceSelection(paths=block_devices)
-            drive_group = DriveGroupSpec(placement=PlacementSpec(
-                host_pattern=host_name), data_devices=devs)
+            drive_group = DriveGroupSpec(service_id='unmanaged',
+                                         placement=PlacementSpec(host_pattern=host_name),
+                                         data_devices=devs)
         except (TypeError, KeyError, ValueError):
             msg = "Invalid host:device spec: '{}'".format(svc_arg) + usage
             return HandleCommandResult(-errno.EINVAL, stderr=msg)


### PR DESCRIPTION
Resolves: https://tracker.ceph.com/issues/50928

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
