### PR TITLE
nautilus: qa: vstart_runner: TypeError: lstat: path should be string, bytes or os.PathLike, not NoneType

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -918,7 +918,9 @@ class LocalContext(object):
                     self.daemons.daemons[prefixed_type][svc_id] = LocalDaemon(svc_type, svc_id)
 
     def __del__(self):
-        shutil.rmtree(self.teuthology_config['test_path'])
+        path = self.teuthology_config['test_path']
+        if path is not None:
+            shutil.rmtree(path)
 
 def exec_test():
     # Parse arguments


### PR DESCRIPTION
https://tracker.ceph.com/issues/50933