### PR TITLE
doc/rbd: add missing snapshot in command line examples

### DIFF
--- a/doc/rbd/rbd-mirroring.rst
+++ b/doc/rbd/rbd-mirroring.rst
@@ -353,7 +353,7 @@ an optional pool or image name. Additionally, the ``--recursive`` option can
 be specified to list all schedules at the specified level and below. For
 example::
 
-        $ rbd --cluster site-a mirror schedule ls --pool image-pool --recursive
+        $ rbd --cluster site-a mirror snapshot schedule ls --pool image-pool --recursive
         POOL        NAMESPACE IMAGE  SCHEDULE                            
         image-pool  -         -      every 1d starting at 14:00:00-05:00 
         image-pool            image1 every 6h                            
@@ -367,7 +367,7 @@ image name::
 
 For example::
 
-        $ rbd --cluster site-a mirror schedule status
+        $ rbd --cluster site-a mirror snapshot schedule status
         SCHEDULE TIME       IMAGE             
         2020-02-26 18:00:00 image-pool/image1 
 


### PR DESCRIPTION
This fixes examples in documentation page: https://docs.ceph.com/en/latest/rbd/rbd-mirroring/

There are missing `snapshot` in examples:
`rbd --cluster site-a mirror schedule ls --pool image-pool --recursive`
`rbd --cluster site-a mirror schedule status`

It should be:
`rbd --cluster site-a mirror snapshot schedule ls --pool image-pool --recursive`
`rbd --cluster site-a mirror snapshot schedule status`

Signed-off-by: Grzegorz Wieczorek <grzegorz.wieczorek@onito.pl>

## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
