### PR TITLE
pybind: do not import from "__future__" anymore

### DIFF
--- a/doc/dev/developer_guide/dash-devel.rst
+++ b/doc/dev/developer_guide/dash-devel.rst
@@ -1630,8 +1630,6 @@ log viewer page:
 
 .. code-block:: python
 
-  from __future__ import absolute_import
-
   import collections
 
   import cherrypy
@@ -2022,7 +2020,6 @@ updates its progress:
 
 .. code-block:: python
 
-  from __future__ import absolute_import
   import random
   import time
   import cherrypy

--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import pkgutil
 import shutil

--- a/src/pybind/mgr/dashboard/__init__.py
+++ b/src/pybind/mgr/dashboard/__init__.py
@@ -3,7 +3,6 @@
 """
 ceph dashboard module
 """
-from __future__ import absolute_import
 
 import os
 

--- a/src/pybind/mgr/dashboard/api/__init__.py
+++ b/src/pybind/mgr/dashboard/api/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import absolute_import

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=protected-access,too-many-branches,too-many-lines
-from __future__ import absolute_import
 
 import collections
 import importlib

--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import http.cookies
 import logging

--- a/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
+++ b/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import cherrypy
 

--- a/src/pybind/mgr/dashboard/controllers/crush_rule.py
+++ b/src/pybind/mgr/dashboard/controllers/crush_rule.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from cherrypy import NotFound
 

--- a/src/pybind/mgr/dashboard/controllers/docs.py
+++ b/src/pybind/mgr/dashboard/controllers/docs.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 import logging
 from typing import Any, Dict, List, Union
 

--- a/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
+++ b/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from cherrypy import NotFound
 

--- a/src/pybind/mgr/dashboard/controllers/frontend_logging.py
+++ b/src/pybind/mgr/dashboard/controllers/frontend_logging.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 
 from . import BaseController, Endpoint, UiApiController

--- a/src/pybind/mgr/dashboard/controllers/grafana.py
+++ b/src/pybind/mgr/dashboard/controllers/grafana.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 from .. import mgr
 from ..exceptions import DashboardException
 from ..grafana import GrafanaRestClient, push_local_dashboards

--- a/src/pybind/mgr/dashboard/controllers/health.py
+++ b/src/pybind/mgr/dashboard/controllers/health.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 

--- a/src/pybind/mgr/dashboard/controllers/home.py
+++ b/src/pybind/mgr/dashboard/controllers/home.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 import logging

--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import copy
 import os

--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -2,7 +2,6 @@
 # pylint: disable=C0302
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-lines
-from __future__ import absolute_import
 
 import json
 import re

--- a/src/pybind/mgr/dashboard/controllers/logs.py
+++ b/src/pybind/mgr/dashboard/controllers/logs.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import collections
 

--- a/src/pybind/mgr/dashboard/controllers/mgr_modules.py
+++ b/src/pybind/mgr/dashboard/controllers/mgr_modules.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from .. import mgr
 from ..security import Scope

--- a/src/pybind/mgr/dashboard/controllers/monitor.py
+++ b/src/pybind/mgr/dashboard/controllers/monitor.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 

--- a/src/pybind/mgr/dashboard/controllers/nfsganesha.py
+++ b/src/pybind/mgr/dashboard/controllers/nfsganesha.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import logging
 import os

--- a/src/pybind/mgr/dashboard/controllers/orchestrator.py
+++ b/src/pybind/mgr/dashboard/controllers/orchestrator.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from functools import wraps
 

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 import logging

--- a/src/pybind/mgr/dashboard/controllers/perf_counters.py
+++ b/src/pybind/mgr/dashboard/controllers/perf_counters.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from typing import Any, Dict
 

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import time
 from typing import Any, Dict, Iterable, List, Optional, Union, cast

--- a/src/pybind/mgr/dashboard/controllers/prometheus.py
+++ b/src/pybind/mgr/dashboard/controllers/prometheus.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 from datetime import datetime

--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unused-argument
 # pylint: disable=too-many-statements,too-many-branches
-from __future__ import absolute_import
 
 import logging
 import math

--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 import logging

--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 import logging

--- a/src/pybind/mgr/dashboard/controllers/role.py
+++ b/src/pybind/mgr/dashboard/controllers/role.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import cherrypy
 

--- a/src/pybind/mgr/dashboard/controllers/saml2.py
+++ b/src/pybind/mgr/dashboard/controllers/saml2.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import cherrypy
 

--- a/src/pybind/mgr/dashboard/controllers/settings.py
+++ b/src/pybind/mgr/dashboard/controllers/settings.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 from contextlib import contextmanager
 
 import cherrypy

--- a/src/pybind/mgr/dashboard/controllers/summary.py
+++ b/src/pybind/mgr/dashboard/controllers/summary.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 

--- a/src/pybind/mgr/dashboard/controllers/task.py
+++ b/src/pybind/mgr/dashboard/controllers/task.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from ..services import progress
 from ..tools import TaskManager

--- a/src/pybind/mgr/dashboard/controllers/telemetry.py
+++ b/src/pybind/mgr/dashboard/controllers/telemetry.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from .. import mgr
 from ..exceptions import DashboardException

--- a/src/pybind/mgr/dashboard/controllers/user.py
+++ b/src/pybind/mgr/dashboard/controllers/user.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import time
 from datetime import datetime

--- a/src/pybind/mgr/dashboard/exceptions.py
+++ b/src/pybind/mgr/dashboard/exceptions.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 
 class ViewCacheNoDataException(Exception):

--- a/src/pybind/mgr/dashboard/grafana.py
+++ b/src/pybind/mgr/dashboard/grafana.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 import logging

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -2,8 +2,6 @@
 """
 ceph dashboard mgr plugin (based on CherryPy)
 """
-from __future__ import absolute_import
-
 import collections
 import errno
 import logging

--- a/src/pybind/mgr/dashboard/plugins/__init__.py
+++ b/src/pybind/mgr/dashboard/plugins/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import abc
 

--- a/src/pybind/mgr/dashboard/plugins/debug.py
+++ b/src/pybind/mgr/dashboard/plugins/debug.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
 
 import json
 from enum import Enum

--- a/src/pybind/mgr/dashboard/plugins/feature_toggles.py
+++ b/src/pybind/mgr/dashboard/plugins/feature_toggles.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from enum import Enum
 from typing import List, Optional

--- a/src/pybind/mgr/dashboard/plugins/interfaces.py
+++ b/src/pybind/mgr/dashboard/plugins/interfaces.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from . import PLUGIN_MANAGER as PM  # pylint: disable=cyclic-import
 from . import Interface, Mixin

--- a/src/pybind/mgr/dashboard/plugins/lru_cache.py
+++ b/src/pybind/mgr/dashboard/plugins/lru_cache.py
@@ -4,7 +4,6 @@ This is a minimal implementation of lru_cache function.
 
 Based on Python 3 functools and backports.functools_lru_cache.
 """
-from __future__ import absolute_import
 
 from collections import OrderedDict
 from functools import wraps

--- a/src/pybind/mgr/dashboard/plugins/ttl_cache.py
+++ b/src/pybind/mgr/dashboard/plugins/ttl_cache.py
@@ -3,7 +3,6 @@ This is a minimal implementation of TTL-ed lru_cache function.
 
 Based on Python 3 functools and backports.functools_lru_cache.
 """
-from __future__ import absolute_import
 
 from collections import OrderedDict
 from functools import wraps

--- a/src/pybind/mgr/dashboard/rest_client.py
+++ b/src/pybind/mgr/dashboard/rest_client.py
@@ -11,7 +11,6 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
 """
-from __future__ import absolute_import
 
 import inspect
 import logging

--- a/src/pybind/mgr/dashboard/security.py
+++ b/src/pybind/mgr/dashboard/security.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import inspect
 

--- a/src/pybind/mgr/dashboard/services/__init__.py
+++ b/src/pybind/mgr/dashboard/services/__init__.py
@@ -1,2 +1,1 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-arguments,too-many-return-statements
 # pylint: disable=too-many-branches, too-many-locals, too-many-statements
-from __future__ import absolute_import
 
 import errno
 import json

--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 import logging

--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 import logging

--- a/src/pybind/mgr/dashboard/services/cephfs.py
+++ b/src/pybind/mgr/dashboard/services/cephfs.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import datetime
 import logging

--- a/src/pybind/mgr/dashboard/services/cephx.py
+++ b/src/pybind/mgr/dashboard/services/cephx.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from .ceph_service import CephService
 

--- a/src/pybind/mgr/dashboard/services/exception.py
+++ b/src/pybind/mgr/dashboard/services/exception.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 import logging

--- a/src/pybind/mgr/dashboard/services/ganesha.py
+++ b/src/pybind/mgr/dashboard/services/ganesha.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-lines
-from __future__ import absolute_import
 
 import logging
 import os

--- a/src/pybind/mgr/dashboard/services/iscsi_cli.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_cli.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import errno
 import json

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-public-methods
-from __future__ import absolute_import
 
 import json
 import logging

--- a/src/pybind/mgr/dashboard/services/iscsi_config.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_config.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import logging
 from functools import wraps

--- a/src/pybind/mgr/dashboard/services/progress.py
+++ b/src/pybind/mgr/dashboard/services/progress.py
@@ -7,7 +7,6 @@ executing and completed tasks tacked by the progress mgr module
 using the same structure of dashboard tasks
 '''
 
-from __future__ import absolute_import
 
 import logging
 from datetime import datetime

--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unused-argument
-from __future__ import absolute_import
 
 import cherrypy
 import rbd

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import ipaddress
 import logging

--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-return-statements,too-many-branches
-from __future__ import absolute_import
 
 import errno
 import json

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 import errno
 import inspect
 from ast import literal_eval

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-arguments
-from __future__ import absolute_import
 
 import json
 import logging

--- a/src/pybind/mgr/dashboard/tests/helper.py
+++ b/src/pybind/mgr/dashboard/tests/helper.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 try:
     from typing import Any, Dict

--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=dangerous-default-value,too-many-public-methods
-from __future__ import absolute_import
 
 import errno
 import json

--- a/src/pybind/mgr/dashboard/tests/test_api_auditing.py
+++ b/src/pybind/mgr/dashboard/tests/test_api_auditing.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 import re

--- a/src/pybind/mgr/dashboard/tests/test_ceph_service.py
+++ b/src/pybind/mgr/dashboard/tests/test_ceph_service.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=dangerous-default-value,too-many-public-methods
-from __future__ import absolute_import
 
 import logging
 import unittest

--- a/src/pybind/mgr/dashboard/tests/test_controllers.py
+++ b/src/pybind/mgr/dashboard/tests/test_controllers.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from ..controllers import ApiController, BaseController, Controller, Endpoint, RESTController
 from . import ControllerTestCase  # pylint: disable=no-name-in-module

--- a/src/pybind/mgr/dashboard/tests/test_docs.py
+++ b/src/pybind/mgr/dashboard/tests/test_docs.py
@@ -1,5 +1,4 @@
 # # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import unittest
 

--- a/src/pybind/mgr/dashboard/tests/test_exceptions.py
+++ b/src/pybind/mgr/dashboard/tests/test_exceptions.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import time
 

--- a/src/pybind/mgr/dashboard/tests/test_feature_toggles.py
+++ b/src/pybind/mgr/dashboard/tests/test_feature_toggles.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import unittest
 

--- a/src/pybind/mgr/dashboard/tests/test_ganesha.py
+++ b/src/pybind/mgr/dashboard/tests/test_ganesha.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-lines
-from __future__ import absolute_import
 
 import unittest
 from unittest.mock import MagicMock, Mock, patch

--- a/src/pybind/mgr/dashboard/tests/test_home.py
+++ b/src/pybind/mgr/dashboard/tests/test_home.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import logging
 import os

--- a/src/pybind/mgr/dashboard/tests/test_notification.py
+++ b/src/pybind/mgr/dashboard/tests/test_notification.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import random
 import time

--- a/src/pybind/mgr/dashboard/tests/test_plugin_debug.py
+++ b/src/pybind/mgr/dashboard/tests/test_plugin_debug.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from . import CLICommandTestMixin, ControllerTestCase  # pylint: disable=no-name-in-module
 

--- a/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import json
 import unittest

--- a/src/pybind/mgr/dashboard/tests/test_rbd_service.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_service.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=dangerous-default-value,too-many-public-methods
-from __future__ import absolute_import
 
 import unittest
 

--- a/src/pybind/mgr/dashboard/tests/test_settings.py
+++ b/src/pybind/mgr/dashboard/tests/test_settings.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import errno
 import unittest

--- a/src/pybind/mgr/dashboard/tests/test_sso.py
+++ b/src/pybind/mgr/dashboard/tests/test_sso.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=dangerous-default-value,too-many-public-methods
-from __future__ import absolute_import
 
 import errno
 import tempfile

--- a/src/pybind/mgr/dashboard/tests/test_task.py
+++ b/src/pybind/mgr/dashboard/tests/test_task.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import json
 import threading

--- a/src/pybind/mgr/dashboard/tests/test_tools.py
+++ b/src/pybind/mgr/dashboard/tests/test_tools.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import unittest
 

--- a/src/pybind/mgr/dashboard/tests/test_versioning.py
+++ b/src/pybind/mgr/dashboard/tests/test_versioning.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import unittest
 

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import collections
 import fnmatch

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import json
 

--- a/src/pybind/mgr/restful/decorators.py
+++ b/src/pybind/mgr/restful/decorators.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from pecan import request, response
 from base64 import b64decode

--- a/src/pybind/mgr/restful/hooks.py
+++ b/src/pybind/mgr/restful/hooks.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from pecan.hooks import PecanHook
 

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -1,7 +1,6 @@
 """
 A RESTful API for Ceph
 """
-from __future__ import absolute_import
 
 import os
 import json

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -1,5 +1,4 @@
 # type: ignore
-from __future__ import absolute_import
 
 import json
 import logging

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import pkgutil
 if not pkgutil.find_loader('setuptools'):
     from distutils.core import setup

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import pkgutil
 import shutil

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import pkgutil
 if not pkgutil.find_loader('setuptools'):
     from distutils.core import setup


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
