### PR TITLE
cmake/modules/FindSanitizers: prefer libasan.6

### DIFF
--- a/cmake/modules/FindSanitizers.cmake
+++ b/cmake/modules/FindSanitizers.cmake
@@ -34,6 +34,7 @@ if(Sanitizers_address_COMPILE_OPTIONS OR Sanitizers_leak_COMPILE_OPTIONS)
   # ASAN_LIBRARY will be read by ceph.in to preload the asan library
   find_library(ASAN_LIBRARY
     NAMES
+      libasan.so.6
       libasan.so.5
       libasan.so.4
       libasan.so.3)

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -77,24 +77,22 @@ def add_to_ld_path(path_name, path):
 
 
 def respawn_in_path(lib_path, pybind_path, pythonlib_path, asan_lib_path):
-    execv_cmd = []
-    if 'CEPH_DBG' in os.environ:
-        execv_cmd += ['@Python3_EXECUTABLE@', '-mpdb']
-
     if platform.system() == "Darwin":
         lib_path_var = "DYLD_LIBRARY_PATH"
     else:
         lib_path_var = "LD_LIBRARY_PATH"
 
-    execv_cmd += sys.argv
     ld_paths_changed = 0
     if asan_lib_path:
         ld_paths_changed += add_to_ld_path('LD_PRELOAD', asan_lib_path)
-    if add_to_ld_path(lib_path_var, lib_path) > 0:
+    ld_paths_changed += add_to_ld_path(lib_path_var, lib_path)
+    if ld_paths_changed > 0:
         if "CEPH_DEV" not in os.environ:
             print(DEVMODEMSG, file=sys.stderr)
-        ld_paths_changed += 1
-    if ld_paths_changed > 0:
+        execv_cmd = []
+        if 'CEPH_DBG' in os.environ:
+            execv_cmd += ['@Python3_EXECUTABLE@', '-mpdb']
+        execv_cmd += sys.argv
         os.execvp(execv_cmd[0], execv_cmd)
     else:
         sys.path.insert(0, pybind_path)

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -23,6 +23,7 @@ from time import sleep
 import grp
 import os
 import pwd
+import re
 import shutil
 import stat
 import sys
@@ -65,6 +66,16 @@ MYPDIR = os.path.dirname(MYDIR)
 DEVMODEMSG = '*** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***'
 
 
+def add_to_ld_path(path_name, path):
+    paths = re.split('[ :]', os.environ.get(path_name, ''))
+    if path in paths:
+        return 0
+    else:
+        paths.insert(0, path)
+        os.environ[path_name] = ':'.join(paths)
+        return 1
+
+
 def respawn_in_path(lib_path, pybind_path, pythonlib_path, asan_lib_path):
     execv_cmd = []
     if 'CEPH_DBG' in os.environ:
@@ -76,21 +87,18 @@ def respawn_in_path(lib_path, pybind_path, pythonlib_path, asan_lib_path):
         lib_path_var = "LD_LIBRARY_PATH"
 
     execv_cmd += sys.argv
+    ld_paths_changed = 0
     if asan_lib_path:
-        os.environ['LD_PRELOAD'] = asan_lib_path
-    if lib_path_var in os.environ:
-        if lib_path not in os.environ[lib_path_var]:
-            os.environ[lib_path_var] += ':' + lib_path
-            if "CEPH_DEV" not in os.environ:
-                print(DEVMODEMSG, file=sys.stderr)
-            os.execvp(execv_cmd[0], execv_cmd)
-    else:
-        os.environ[lib_path_var] = lib_path
+        ld_paths_changed += add_to_ld_path('LD_PRELOAD', asan_lib_path)
+    if add_to_ld_path(lib_path_var, lib_path) > 0:
         if "CEPH_DEV" not in os.environ:
             print(DEVMODEMSG, file=sys.stderr)
+        ld_paths_changed += 1
+    if ld_paths_changed > 0:
         os.execvp(execv_cmd[0], execv_cmd)
-    sys.path.insert(0, pybind_path)
-    sys.path.insert(0, pythonlib_path)
+    else:
+        sys.path.insert(0, pybind_path)
+        sys.path.insert(0, pythonlib_path)
 
 
 def get_pythonlib_dir():

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -83,6 +83,9 @@ def respawn_in_path(lib_path, pybind_path, pythonlib_path, asan_lib_path):
         lib_path_var = "LD_LIBRARY_PATH"
 
     ld_paths_changed = 0
+    preload_libcxx = os.environ.get('CEPH_PRELOAD_LIBCXX')
+    if preload_libcxx:
+        ld_paths_changed += add_to_ld_path('LD_PRELOAD', preload_libcxx)
     if asan_lib_path:
         ld_paths_changed += add_to_ld_path('LD_PRELOAD', asan_lib_path)
     ld_paths_changed += add_to_ld_path(lib_path_var, lib_path)


### PR DESCRIPTION
libasan.6 is shipped as part of GCC-11, so prefer it over older versions

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
