### PR TITLE
pacific: rbd-mirror: fix segfault in snapshot replayer shutdown

### DIFF
--- a/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.h
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.h
@@ -211,7 +211,7 @@ private:
   int m_error_code = 0;
   std::string m_error_description;
 
-  C_UpdateWatchCtx* m_update_watch_ctx;
+  C_UpdateWatchCtx* m_update_watch_ctx = nullptr;
   uint64_t m_local_update_watcher_handle = 0;
   uint64_t m_remote_update_watcher_handle = 0;
   bool m_image_updated = false;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50942

---

backport of https://github.com/ceph/ceph/pull/41480
parent tracker: https://tracker.ceph.com/issues/50931