### PR TITLE
pacific: mgr/dashboard: drop container image name and id from services list

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
@@ -10,12 +10,10 @@ export class ServicesPageHelper extends PageHelper {
 
   columnIndex = {
     service_name: 2,
-    container_image_name: 3,
-    container_image_id: 4,
-    placement: 5,
-    running: 6,
-    size: 7,
-    last_refresh: 8
+    placement: 3,
+    running: 4,
+    size: 5,
+    last_refresh: 6
   };
 
   check_for_service() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
@@ -32,8 +32,6 @@ describe('ServicesComponent', () => {
       service_type: 'osd',
       service_name: 'osd',
       status: {
-        container_image_id: 'e70344c77bcbf3ee389b9bf5128f635cf95f3d59e005c5d8e67fc19bcc74ed23',
-        container_image_name: 'docker.io/ceph/daemon-base:latest-master-devel',
         size: 3,
         running: 3,
         last_refresh: '2020-02-25T04:33:26.465699'
@@ -43,8 +41,6 @@ describe('ServicesComponent', () => {
       service_type: 'crash',
       service_name: 'crash',
       status: {
-        container_image_id: 'e70344c77bcbf3ee389b9bf5128f635cf95f3d59e005c5d8e67fc19bcc74ed23',
-        container_image_name: 'docker.io/ceph/daemon-base:latest-master-devel',
         size: 1,
         running: 1,
         last_refresh: '2020-02-25T04:33:26.465766'

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -8,7 +8,6 @@ import { ListWithDetails } from '~/app/shared/classes/list-with-details.class';
 import { CriticalConfirmationModalComponent } from '~/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { TableComponent } from '~/app/shared/datatable/table/table.component';
-import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
 import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
@@ -95,20 +94,6 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
         name: $localize`Service`,
         prop: 'service_name',
         flexGrow: 1
-      },
-      {
-        name: $localize`Container image name`,
-        prop: 'status.container_image_name',
-        flexGrow: 3
-      },
-      {
-        name: $localize`Container image ID`,
-        prop: 'status.container_image_id',
-        flexGrow: 1.5,
-        cellTransformation: CellTemplate.truncate,
-        customTemplateConfig: {
-          length: 12
-        }
       },
       {
         name: $localize`Placement`,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50959

---

backport of https://github.com/ceph/ceph/pull/41426
parent tracker: https://tracker.ceph.com/issues/50889

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh