### PR TITLE
ceph: allow for non-positional optional CLI arguments

### DIFF
--- a/doc/_ext/ceph_commands.py
+++ b/doc/_ext/ceph_commands.py
@@ -82,7 +82,7 @@ class CmdParam(object):
 
     def __init__(self, type, name,
                  who=None, n=None, req=True, range=None, strings=None,
-                 goodchars=None):
+                 goodchars=None, positional=True):
         self.type = type
         self.name = name
         self.who = who
@@ -91,6 +91,7 @@ class CmdParam(object):
         self.range = range.split('|') if range else []
         self.strings = strings.split('|') if strings else []
         self.goodchars = goodchars
+        self.positional = positional != 'false'
 
         assert who == None
 
@@ -200,7 +201,7 @@ TEMPLATE = '''
 
 {%- if command.params %}
 :Parameters:{% for param in command.params -%}
-{{" -" | indent(12, not loop.first) }} **{{param.name}}**: {{ param.help() }}
+{{" -" | indent(12, not loop.first) }} **{% if param.positional %}{{param.name}}{% else %}--{{param.name}}{% endif %}**: {{ param.help() }}
 {% endfor %}
 {% endif %}
 :Ceph Module: {{ command.module }}

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -348,7 +348,8 @@ class TestNFS(MgrTestCase):
         # Export-3 for subvolume with r only
         self._cmd('fs', 'subvolume', 'create', self.fs_name, 'sub_vol')
         fs_path = self._cmd('fs', 'subvolume', 'getpath', self.fs_name, 'sub_vol').strip()
-        self._create_export(export_id='3', extra_cmd=[self.pseudo_path+'2', '--readonly', fs_path])
+        self._create_export(export_id='3', extra_cmd=[self.pseudo_path+'2', '--readonly',
+                                                      '--path', fs_path])
         # Export-4 for subvolume
         self._create_export(export_id='4', extra_cmd=[self.pseudo_path+'3', fs_path])
         # Check if exports gets listed

--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -179,10 +179,16 @@ dump_cmd_to_json(Formatter *f, uint64_t features, const string& cmd)
       desckv["positional"] = "false";
     }
     for (auto [key, value] : desckv) {
-      if (key == "positional" && !HAVE_FEATURE(features, SERVER_QUINCY)) {
-	continue;
+      if (key == "positional") {
+	if (!HAVE_FEATURE(features, SERVER_QUINCY)) {
+	  continue;
+	}
+	f->dump_bool(key, value == "true" || value == "True");
+      } else if (key == "req" && HAVE_FEATURE(features, SERVER_QUINCY)) {
+	f->dump_bool(key, value == "true" || value == "True");
+      } else {
+	f->dump_string(key, value);
       }
-      f->dump_string(key, value);
     }
     f->close_section(); // attribute object for individual desc
   }

--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -138,13 +138,20 @@ dump_cmd_to_json(Formatter *f, uint64_t features, const string& cmd)
 
   stringstream ss(cmd);
   std::string word;
+  bool positional = true;
 
   while (std::getline(ss, word, ' ')) {
+    if (word == "--") {
+      positional = false;
+      continue;
+    }
+
     // if no , or =, must be a plain word to put out
     if (word.find_first_of(",=") == string::npos) {
       f->dump_string("arg", word);
       continue;
     }
+
     // accumulate descriptor keywords in desckv
     auto desckv = cmddesc_get_args(word);
     // name the individual desc object based on the name key
@@ -168,7 +175,13 @@ dump_cmd_to_json(Formatter *f, uint64_t features, const string& cmd)
     }
 
     // dump all the keys including name into the array
+    if (!positional) {
+      desckv["positional"] = "false";
+    }
     for (auto [key, value] : desckv) {
+      if (key == "positional" && !HAVE_FEATURE(features, SERVER_QUINCY)) {
+	continue;
+      }
       f->dump_string(key, value);
     }
     f->close_section(); // attribute object for individual desc

--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -682,4 +682,23 @@ bool cmd_getval(const cmdmap_t& cmdmap,
   return false;
 }
 
+bool cmd_getval_compat_cephbool(
+  const cmdmap_t& cmdmap,
+  const std::string& k, bool& val)
+{
+  try {
+    return cmd_getval(cmdmap, k, val);
+  } catch (bad_cmd_get& e) {
+    // try as legacy/compat CephChoices
+    std::string t;
+    if (!cmd_getval(cmdmap, k, t)) {
+      return false;
+    }
+    std::string expected = "--"s + k;
+    std::replace(expected.begin(), expected.end(), '_', '-');
+    val = (t == expected);
+    return true;
+  }
+}
+
 }

--- a/src/common/cmdparse.h
+++ b/src/common/cmdparse.h
@@ -59,6 +59,10 @@ struct bad_cmd_get : public std::exception {
 bool cmd_getval(const cmdmap_t& cmdmap,
 		const std::string& k, bool& val);
 
+bool cmd_getval_compat_cephbool(
+  const cmdmap_t& cmdmap,
+  const std::string& k, bool& val);
+
 template <typename T>
 bool cmd_getval(const cmdmap_t& cmdmap,
 		const std::string& k, T& val)

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1443,7 +1443,7 @@ bool DaemonServer::_handle_command(
       return true;
     }
     bool no_increasing = false;
-    cmd_getval(cmdctx->cmdmap, "no_increasing", no_increasing);
+    cmd_getval_compat_cephbool(cmdctx->cmdmap, "no_increasing", no_increasing);
     string out_str;
     mempool::osdmap::map<int32_t, uint32_t> new_weights;
     r = cluster_state.with_osdmap_and_pgmap([&](const OSDMap &osdmap, const PGMap& pgmap) {

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -181,7 +181,7 @@ COMMAND("service status",
         "dump service state", "service", "r")
 
 COMMAND("config show " \
-	"name=who,type=CephString name=key,type=CephString,req=False",
+	"name=who,type=CephString name=key,type=CephString,req=false",
 	"Show running configuration",
 	"mgr", "r")
 COMMAND("config show-with-defaults " \
@@ -203,7 +203,7 @@ COMMAND("device ls-by-host name=host,type=CephString",
 	"mgr", "r")
 COMMAND("device set-life-expectancy name=devid,type=CephString "\
 	"name=from,type=CephString "\
-	"name=to,type=CephString,req=False",
+	"name=to,type=CephString,req=false",
 	"Set predicted device life expectancy",
 	"mgr", "rw")
 COMMAND("device rm-life-expectancy name=devid,type=CephString",

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -111,7 +111,7 @@ COMMAND("osd reweight-by-utilization " \
 	"name=oload,type=CephInt,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
 	"name=max_osds,type=CephInt,req=false "			\
-	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false",\
+	"name=no_increasing,type=CephBool,req=false",\
 	"reweight OSDs by utilization [overload-percentage-for-consideration, default 120]", \
 	"osd", "rw")
 COMMAND("osd test-reweight-by-utilization " \

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -12,6 +12,7 @@
  */
 
 #include <Python.h>
+#include <boost/algorithm/string/replace.hpp>
 
 #include "common/errno.h"
 #include "common/signal.h"
@@ -258,6 +259,12 @@ void MgrStandby::send_beacon()
       std::vector<MonCommand> commands = mgr_commands;
       std::vector<MonCommand> py_commands = py_module_registry.get_commands();
       commands.insert(commands.end(), py_commands.begin(), py_commands.end());
+      if (monc.monmap.min_mon_release < ceph_release_t::quincy) {
+	dout(10) << " stripping out positional=false quincy-ism" << dendl;
+	for (auto& i : commands) {
+	  boost::replace_all(i.cmdstring, ",positional=false", "");
+	}
+      }
       m->set_command_descs(commands);
       dout(4) << "going active, including " << m->get_command_descs().size()
               << " commands in beacon" << dendl;

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -1186,10 +1186,10 @@ bool MgrMonitor::prepare_command(MonOpRequestRef op)
       ss << "module '" << module << "' is already enabled (always-on)";
       goto out;
     }
-    string force;
-    cmd_getval(cmdmap, "force", force);
+    bool force = false;
+    cmd_getval_compat_cephbool(cmdmap, "force", force);
     if (!pending_map.all_support_module(module) &&
-	force != "--force") {
+	!force) {
       ss << "all mgr daemons do not support module '" << module << "', pass "
 	 << "--force to force enablement";
       r = -ENOENT;
@@ -1197,7 +1197,7 @@ bool MgrMonitor::prepare_command(MonOpRequestRef op)
     }
 
     std::string can_run_error;
-    if (force != "--force" && !pending_map.can_run_module(module, &can_run_error)) {
+    if (!force && !pending_map.can_run_module(module, &can_run_error)) {
       ss << "module '" << module << "' reports that it cannot run on the active "
             "manager daemon: " << can_run_error << " (pass --force to force "
             "enablement)";

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -474,7 +474,7 @@ COMMAND_WITH_FLAG("mon remove "
 	"remove monitor named <name>", "mon", "rw",
     FLAG(DEPRECATED))
 COMMAND("mon feature ls "
-        "name=with_value,type=CephChoices,strings=--with-value,req=false",
+        "name=with_value,type=CephBool,req=false",
         "list available mon map features to be set/unset",
         "mon", "r")
 COMMAND("mon feature set "
@@ -750,7 +750,7 @@ COMMAND("osd crush rule rename "
         "rename crush rule <srcname> to <dstname>",
         "osd", "rw")
 COMMAND("osd crush tree "
-        "name=shadow,type=CephChoices,strings=--show-shadow,req=false",
+        "name=show_shadow,type=CephBool,req=false",
 	"dump crush buckets and items in a tree view",
 	"osd", "r")
 COMMAND("osd crush ls name=node,type=CephString,goodchars=[A-Za-z0-9-_.]",
@@ -1166,7 +1166,7 @@ COMMAND("osd force_recovery_stretch_mode " \
 COMMAND("osd tier add "
 	"name=pool,type=CephPoolname "
 	"name=tierpool,type=CephPoolname "
-	"name=force_nonempty,type=CephChoices,strings=--force-nonempty,req=false",
+	"name=force_nonempty,type=CephBool,req=false",
 	"add the tier <tierpool> (the second one) to base pool <pool> (the first one)",
 	"osd", "rw")
 COMMAND("osd tier rm "
@@ -1256,7 +1256,7 @@ COMMAND("mgr services",
         "mgr", "r")
 COMMAND("mgr module enable "
 	"name=module,type=CephString "
-	"name=force,type=CephChoices,strings=--force,req=false",
+	"name=force,type=CephBool,req=false",
 	"enable mgr module", "mgr", "rw")
 COMMAND("mgr module disable "
 	"name=module,type=CephString",
@@ -1352,7 +1352,7 @@ COMMAND_WITH_FLAG("connection scores reset",
 		  "mon", "rwx",
 		  FLAG(TELL))
 COMMAND_WITH_FLAG("sync_force "
-            "name=validate,type=CephChoices,strings=--yes-i-really-mean-it,req=false",
+            "name=yes_i_really_mean_it,type=CephBool,req=false",
             "force sync of and clear monitor store",
             "mon", "rw",
             FLAG(TELL))

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -77,7 +77,9 @@
  *
  * COMMAND("auth add "
  *   	   "name=entity,type=CephString "
- *   	   "name=caps,type=CephString,n=N,req=false",
+ *   	   "name=caps,type=CephString,n=N,req=false "
+ *         "-- "
+ *         "name=some_option,type=CephString,req=false",
  *   	   "add auth info for <name> from input file, or random key "
  *   	   "if no input given, and/or any caps specified in the command")
  *
@@ -88,6 +90,12 @@
  * enters auth add client.admin 'mon rwx' 'osd *'.  The result will be a
  * JSON object like {"prefix":"auth add", "entity":"client.admin",
  * "caps":["mon rwx", "osd *"]}.
+ *
+ * The -- separates positional from non-positional (and, by implication,
+ * optional) arguments.  Note that CephBool is assumed to be non-positional
+ * and will also implicitly mark that any following arguments are
+ * non-positional.
+ *
  * Note that
  * 	- string literals are accumulated into 'prefix'
  * 	- n=1 descriptors are given normal string or int object values

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1294,7 +1294,7 @@ COMMAND("config rm"
 	"config", "rw")
 COMMAND("config get "
 	"name=who,type=CephString "
-	"name=key,type=CephString,req=False",
+	"name=key,type=CephString,req=false",
 	"Show configuration option(s) for an entity",
 	"config", "r")
 COMMAND("config dump",
@@ -1310,7 +1310,7 @@ COMMAND("config ls",
 COMMAND("config assimilate-conf",
 	"Assimilate options from a conf, and return a new, minimal conf file",
 	"config", "rw")
-COMMAND("config log name=num,type=CephInt,req=False",
+COMMAND("config log name=num,type=CephInt,req=false",
 	"Show recent history of config changes",
 	"config", "r")
 COMMAND("config reset "

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -337,9 +337,15 @@ int Monitor::do_admin_command(
   } else if (command == "quorum_status") {
     _quorum_status(f, out);
   } else if (command == "sync_force") {
-    string validate;
-    if ((!cmd_getval(cmdmap, "validate", validate)) ||
-	(validate != "--yes-i-really-mean-it")) {
+    bool validate = false;
+    if (!cmd_getval(cmdmap, "yes_i_really_mean_it", validate)) {
+      std::string v;
+      if (cmd_getval(cmdmap, "validate", v) &&
+	  v == "--yes-i-really-mean-it") {
+	validate = true;
+      }
+    }
+    if (!validate) {
       err << "are you SURE? this will mean the monitor store will be erased "
 	"the next time the monitor is restarted.  pass "
 	"'--yes-i-really-mean-it' if you really do.";

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -397,11 +397,7 @@ bool MonmapMonitor::preprocess_command(MonOpRequestRef op)
   } else if (prefix == "mon feature ls") {
    
     bool list_with_value = false;
-    string with_value;
-    if (cmd_getval(cmdmap, "with_value", with_value) &&
-        with_value == "--with-value") {
-      list_with_value = true;
-    }
+    cmd_getval_compat_cephbool(cmdmap, "with_value", list_with_value);
 
     MonMap *p = mon.monmap;
 

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -836,34 +836,61 @@ class argdesc(object):
         like str(), but omit parameter names (except for CephString,
         which really needs them)
         """
-        if self.t == CephBool:
-            chunk = "--{0}".format(self.name.replace("_", "-"))
-        elif self.t == CephPrefix:
-            chunk = str(self.instance)
-        elif self.t == CephChoices:
-            if self.name == 'format':
-                chunk = f'--{self.name} {{{str(self.instance)}}}'
-            else:
+        if self.positional:
+            if self.t == CephBool:
+                chunk = "--{0}".format(self.name.replace("_", "-"))
+            elif self.t == CephPrefix:
                 chunk = str(self.instance)
-        elif self.t == CephOsdName:
-            # it just so happens all CephOsdName commands are named 'id' anyway,
-            # so <id|osd.id> is perfect.
-            chunk = '<id|osd.id>'
-        elif self.t == CephName:
-            # CephName commands similarly only have one arg of the
-            # type, so <type.id> is good.
-            chunk = '<type.id>'
-        elif self.t == CephInt:
-            chunk = '<{0}:int>'.format(self.name)
-        elif self.t == CephFloat:
-            chunk = '<{0}:float>'.format(self.name)
+            elif self.t == CephChoices:
+                if self.name == 'format':
+                    # this is for talking to legacy clusters only; new clusters
+                    # should properly mark format args as non-positional.
+                    chunk = f'--{self.name} {{{str(self.instance)}}}'
+                else:
+                    chunk = f'<{self.name}:{self.instance}>'
+            elif self.t == CephOsdName:
+                # it just so happens all CephOsdName commands are named 'id' anyway,
+                # so <id|osd.id> is perfect.
+                chunk = '<id|osd.id>'
+            elif self.t == CephName:
+                # CephName commands similarly only have one arg of the
+                # type, so <type.id> is good.
+                chunk = '<type.id>'
+            elif self.t == CephInt:
+                chunk = '<{0}:int>'.format(self.name)
+            elif self.t == CephFloat:
+                chunk = '<{0}:float>'.format(self.name)
+            else:
+                chunk = '<{0}>'.format(self.name)
+            s = chunk
+            if self.N:
+                s += '...'
+            if not self.req:
+                s = '[' + s + ']'
         else:
-            chunk = '<{0}>'.format(self.name)
-        s = chunk
-        if self.N:
-            s += '...'
-        if not self.req:
-            s = '[' + s + ']'
+            # non-positional
+            if self.t == CephBool:
+                chunk = "--{0}".format(self.name.replace("_", "-"))
+            elif self.t == CephPrefix:
+                chunk = str(self.instance)
+            elif self.t == CephChoices:
+                chunk = f'--{self.name} {{{str(self.instance)}}}'
+            elif self.t == CephOsdName:
+                chunk = f'--{self.name} <id|osd.id>'
+            elif self.t == CephName:
+                chunk = f'--{self.name} <type.id>'
+            elif self.t == CephInt:
+                chunk = f'--{self.name} <int>'
+            elif self.t == CephFloat:
+                chunk = f'--{self.name} <float>'
+            else:
+                chunk = f'--{self.name} <value>'
+            s = chunk
+            if self.N:
+                s += '...'
+            if not self.req:  # req should *always* be false
+                s = '[' + s + ']'
+
         return s
 
     def complete(self, s):

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1159,10 +1159,6 @@ def validate(args: List[str],
                 # argdesc for the keyword argument, if we find one
                 kwarg_desc = None
 
-                # Track whether we need to push value back onto
-                # myargs in the case that this isn't a valid k=v
-                consumed_next = False
-
                 # Try both styles of keyword argument
                 kwarg_match = re.match(KWARG_EQUALS, myarg)
                 if kwarg_match:

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1196,6 +1196,10 @@ def validate(args: List[str],
                     store_arg(kwarg_desc, d)
                     continue
 
+            if not desc.positional:
+                # No more positional args!
+                raise ArgumentValid(f"Unexpected argument '{myarg}'")
+
             # Don't handle something as a positional argument if it
             # has a leading "--" unless it's a CephChoices (used for
             # "--yes-i-really-mean-it")

--- a/src/pybind/mgr/k8sevents/module.py
+++ b/src/pybind/mgr/k8sevents/module.py
@@ -1026,12 +1026,12 @@ class Module(MgrModule):
         },
         {
             "cmd": "k8sevents set-access name=key,type=CephString",
-            "desc": "Set kubernetes access credentials. <key> must be cacrt or token and use -i <filename> syntax.\ne.g. ceph k8sevents set-access cacrt -i /root/ca.crt",
+            "desc": "Set kubernetes access credentials. <key> must be cacrt or token and use -i <filename> syntax (e.g., ceph k8sevents set-access cacrt -i /root/ca.crt).",
             "perm": "rw"
         },
         {
             "cmd": "k8sevents set-config name=key,type=CephString name=value,type=CephString",
-            "desc": "Set kubernetes config paramters. <key> must be server or namespace.\ne.g. ceph k8sevents set-config server https://localhost:30433",
+            "desc": "Set kubernetes config paramters. <key> must be server or namespace (e.g., ceph k8sevents set-config server https://localhost:30433).",
             "perm": "rw"
         },
         {

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -331,6 +331,14 @@ class CLICommand(object):
             if arg == '_end_positional_':
                 positional = False
                 continue
+            if (
+                arg == 'format'
+                or arg_spec[arg] is Optional[bool]
+                or arg_spec[arg] is bool
+            ):
+                # implicit switch to non-positional on any
+                # Optional[bool] or the --format option
+                positional = False
             assert arg in arg_spec, \
                 f"'{arg}' is not annotated for {f}: {full_argspec}"
             has_default = index >= first_default

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -317,7 +317,7 @@ class CLICommand(object):
 
     @staticmethod
     def load_func_metadata(f: HandlerFuncType) -> Tuple[str, Dict[str, Any], int, str]:
-        desc = inspect.getdoc(f) or ''
+        desc = (inspect.getdoc(f) or '').replace('\n', ' ')
         full_argspec = inspect.getfullargspec(f)
         arg_spec = full_argspec.annotations
         first_default = len(arg_spec)

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -324,15 +324,20 @@ class CLICommand(object):
         if full_argspec.defaults:
             first_default -= len(full_argspec.defaults)
         args = []
+        positional = True
         for index, arg in enumerate(full_argspec.args):
             if arg in CLICommand.KNOWN_ARGS:
+                continue
+            if arg == '_end_positional_':
+                positional = False
                 continue
             assert arg in arg_spec, \
                 f"'{arg}' is not annotated for {f}: {full_argspec}"
             has_default = index >= first_default
             args.append(CephArgtype.to_argdesc(arg_spec[arg],
                                                dict(name=arg),
-                                               has_default))
+                                               has_default,
+                                               positional))
         return desc, arg_spec, first_default, ' '.join(args)
 
     def store_func_metadata(self, f: HandlerFuncType) -> None:

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -28,8 +28,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                       fsname: str,
                                       clusterid: str,
                                       binding: str,
-                                      readonly: bool = False,
-                                      path: str = '/') -> Tuple[int, str, str]:
+                                      path: str = '/',
+                                      readonly: bool = False) -> Tuple[int, str, str]:
         """Create a cephfs export"""
         # TODO Extend export creation for rgw.
         return self.export_mgr.create_export(fsal_type='cephfs', fs_name=fsname,

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -611,6 +611,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
     @_cli_read_command('orch ps')
     def _list_daemons(self,
                       hostname: Optional[str] = None,
+                      _end_positional_: int = 0,
                       service_name: Optional[str] = None,
                       daemon_type: Optional[str] = None,
                       daemon_id: Optional[str] = None,
@@ -1342,6 +1343,7 @@ Usage:
     @_cli_write_command('orch upgrade start')
     def _upgrade_start(self,
                        image: Optional[str] = None,
+                       _end_positional_: int = 0,
                        ceph_version: Optional[str] = None) -> HandleCommandResult:
         """Initiate upgrade"""
         self._upgrade_check_image_name(image, ceph_version)

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -901,9 +901,10 @@ Usage:
     @_cli_write_command('orch daemon add rgw')
     def _rgw_add(self,
                  svc_id: str,
+                 placement: Optional[str] = None,
+                 _end_positional_: int = 0,
                  port: Optional[int] = None,
                  ssl: bool = False,
-                 placement: Optional[str] = None,
                  inbuf: Optional[str] = None) -> HandleCommandResult:
         """Start RGW daemon(s)"""
         if inbuf:
@@ -1091,11 +1092,12 @@ Usage:
     @_cli_write_command('orch apply rgw')
     def _apply_rgw(self,
                    svc_id: str,
+                   placement: Optional[str] = None,
+                   _end_positional_: int = 0,
                    realm: Optional[str] = None,
                    zone: Optional[str] = None,
                    port: Optional[int] = None,
                    ssl: bool = False,
-                   placement: Optional[str] = None,
                    dry_run: bool = False,
                    format: Format = Format.plain,
                    unmanaged: bool = False,

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -329,7 +329,11 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return cast(str, self.get_module_option("orchestrator"))
 
     @_cli_write_command('orch host add')
-    def _add_host(self, hostname: str, addr: Optional[str] = None, labels: Optional[List[str]] = None, maintenance: Optional[bool] = False) -> HandleCommandResult:
+    def _add_host(self,
+                  hostname: str,
+                  addr: Optional[str] = None,
+                  labels: Optional[List[str]] = None,
+                  maintenance: Optional[bool] = False) -> HandleCommandResult:
         """Add a host"""
         _status = 'maintenance' if maintenance else ''
 
@@ -970,7 +974,9 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch daemon redeploy')
-    def _daemon_action_redeploy(self, name: str, image: Optional[str] = None) -> HandleCommandResult:
+    def _daemon_action_redeploy(self,
+                                name: str,
+                                image: Optional[str] = None) -> HandleCommandResult:
         """Redeploy a daemon (with a specifc image)"""
         if '.' not in name:
             raise OrchestratorError('%s is not a valid daemon name' % name)


### PR DESCRIPTION
Currently any optional argument may be specified as a flag (--arg val) or positionally.  The ability to specify flags positionally is confusing, and not something that other CLIs allow.  This PR makes it possible to mark the end of positional (and possibly optinoal) arguments and the beginning of optional flags (that *must* use the '--flagname value' syntax).

Also,
- fix a few remaining CephChoices args that were never converted to CephBool
- fix some CLI helptext strings
- fix orch rgw commands to rearrange positional args and make more args flags
- misc other CLI cleanup





<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>