### PR TITLE
doc/cephfs/nfs: remove documented limitation

### DIFF
--- a/doc/cephfs/nfs.rst
+++ b/doc/cephfs/nfs.rst
@@ -74,12 +74,6 @@ following conventions work on Linux and some Unix platforms:
 
     mount -t nfs -o nfsvers=4.1,proto=tcp <ganesha-host-name>:<ganesha-pseudo-path> <mount-point>
 
-Current limitations
-===================
-
-- Per running ganesha daemon, FSAL_CEPH_ can only export one Ceph file system
-  although multiple directories in a Ceph file system may be exported.
-
 
 .. _FSAL_CEPH: https://github.com/nfs-ganesha/nfs-ganesha/tree/next/src/FSAL/FSAL_CEPH
 .. _NFS-Ganesha NFS server: https://github.com/nfs-ganesha/nfs-ganesha/wiki


### PR DESCRIPTION
At the time NFS support was added, this limitation applied.
However, in
 https://github.com/nfs-ganesha/nfs-ganesha/commit/b3d97f8157a131f55d848ff57e46af91b746b944
and
 https://github.com/nfs-ganesha/nfs-ganesha/commit/1cfe7e2df96f9785367ba94d41559140f584a875
we added support for multiple filesystems and started mixing
the fscid into the filehandle.

Signed-off-by: Sage Weil <sage@newdream.net>