### PR TITLE
octopus: qa/upgrade: disable update_features test_notify with older client as lockowner

### DIFF
--- a/qa/suites/upgrade-clients/client-upgrade-octopus-pacific/octopus-client-x/rbd/3-workload/rbd_notification_tests.yaml
+++ b/qa/suites/upgrade-clients/client-upgrade-octopus-pacific/octopus-client-x/rbd/3-workload/rbd_notification_tests.yaml
@@ -8,25 +8,23 @@ tasks:
       env:
         RBD_FEATURES: "61"
   - workunit:
-      #The line below to change to 'pacific'
-      branch: master
+      branch: pacific
       clients:
         client.1:
           - rbd/notify_slave.sh
       env:
         RBD_FEATURES: "61"
+        RBD_DISABLE_UPDATE_FEATURES: "1"
 - print: "**** done rbd: old librbd -> new librbd"
 - parallel:
   - workunit:
-      #The line below to change to 'pacific'
-      branch: master
+      branch: octopus
       clients:
         client.0:
           - rbd/notify_slave.sh
       env:
         RBD_FEATURES: "61"
   - workunit:
-      #The line below to change to 'pacific'
       branch: pacific
       clients:
         client.1:


### PR DESCRIPTION
with the recent support for async rbd operations from pacific+ when an
older client(non async support) goes on upgrade, and simultaneously
interacts with a newer client which expects the requests to be async,
experiences hang; considering the return code for request completion to
be acknowledgement for async request, which then keeps waiting for
another acknowledgement of request completion.

this if happens should be a rare only when lockowner is an old client
and should be deferred if compatibility issues arises.

tests including DISABLE_UPDATE_FEATURES: "1" environment variable should skip update_features test_notify check

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
