### PR TITLE
qa/upgrade: conditionally disable update_features tests

### DIFF
--- a/src/test/librbd/test_notify.py
+++ b/src/test/librbd/test_notify.py
@@ -140,20 +140,21 @@ def slave(ioctx):
         assert(not image.is_exclusive_lock_owner())
         assert(list(image.list_snaps()) == [])
 
-        print("update_features")
-        assert((image.features() & RBD_FEATURE_OBJECT_MAP) != 0)
-        image.update_features(RBD_FEATURE_OBJECT_MAP, False)
-        assert(not image.is_exclusive_lock_owner())
-        assert((image.features() & RBD_FEATURE_OBJECT_MAP) == 0)
-        image.update_features(RBD_FEATURE_OBJECT_MAP, True)
-        assert(not image.is_exclusive_lock_owner())
-        assert((image.features() & RBD_FEATURE_OBJECT_MAP) != 0)
-        assert((image.flags() & RBD_FLAG_OBJECT_MAP_INVALID) != 0)
-
         print("rebuild object map")
         image.rebuild_object_map()
         assert(not image.is_exclusive_lock_owner())
         assert((image.flags() & RBD_FLAG_OBJECT_MAP_INVALID) == 0)
+
+        if 'RBD_DISABLE_UPDATE_FEATURES' not in os.environ:
+            print("update_features")
+            assert((image.features() & RBD_FEATURE_OBJECT_MAP) != 0)
+            image.update_features(RBD_FEATURE_OBJECT_MAP, False)
+            assert(not image.is_exclusive_lock_owner())
+            assert((image.features() & RBD_FEATURE_OBJECT_MAP) == 0)
+            image.update_features(RBD_FEATURE_OBJECT_MAP, True)
+            assert(not image.is_exclusive_lock_owner())
+            assert((image.features() & RBD_FEATURE_OBJECT_MAP) != 0)
+            assert((image.flags() & RBD_FLAG_OBJECT_MAP_INVALID) != 0)
 
         print("write")
         data = os.urandom(512)


### PR DESCRIPTION
with the recent support for async rbd operations from pacific+ when an
    older client(non async support) goes on upgrade, and simultaneously
    interacts with a newer client which expects the requests to be async,
    experiences hang; considering the return code for request completion to
    be acknowledgement for async request, which then keeps waiting for
    another acknowledgement of request completion.

    this if happens should be a rare only when lockowner is an old client
    and should be deferred if compatibility issues arises.

see also: 541230475d3b25ab18c4eb9bc5011060462594a6(octopus)

Signed-off-by: Deepika <dupadhya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
