### PR TITLE
crimson/onode-staged-tree: fix an use-after-free issue in test

### DIFF
--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1076,8 +1076,9 @@ class DummyChildPool {
         p_keys = &left->impl->get_keys();
       }
       left->impl->reset(*p_keys, left_is_tail);
+      auto left_addr = left->impl->laddr();
       return left->parent_info().ptr->apply_children_merge<true>(
-          c, std::move(left), left->impl->laddr(), std::move(right), !stole_key);
+          c, std::move(left), left_addr, std::move(right), !stole_key);
     }
 
     DummyChildImpl* impl;


### PR DESCRIPTION
This should fix the following test failure:
```
...
ERASE-MERGE DummyNode@0x1aLv0(key_view(3,3,3; "ns4","oid4..__/254B"; 5,5)):
unittest-staged-fltree: boost/include/boost/smart_ptr/intrusive_ptr.hpp:199: T* boost::intrusive_ptr<T>::operator->() const [with T = crimson::os::seastore::onode::DummyChildPool::DummyChild]: Assertion `px != 0' failed.
Aborting on shard 0.
Backtrace:
...
```


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
