### PR TITLE
rgw: Get the correct initial value(pos) in raw_obj_to_obj function when zoneid contains ‘_ ’character.

### DIFF
--- a/src/rgw/services/svc_tier_rados.h
+++ b/src/rgw/services/svc_tier_rados.h
@@ -129,7 +129,7 @@ public:
   }
 
   static inline bool raw_obj_to_obj(const rgw_bucket& bucket, const rgw_raw_obj& raw_obj, rgw_obj *obj) {
-    ssize_t pos = raw_obj.oid.find('_');
+    ssize_t pos = raw_obj.oid.find('_', bucket.marker.length());
     if (pos < 0) {
       return false;
     }


### PR DESCRIPTION
rgw:  Get the correct initial value(pos) in raw_obj_to_obj function when zoneid contains ‘_ ’character.

Fixes: https://tracker.ceph.com/issues/50967
Signed-off-by: WeiGuo Ren weiguo.ren@xtaotech.com
