### PR TITLE
rgw/sts: enhancements and improvements to JWT validation

### DIFF
--- a/src/rgw/jwt-cpp/jwt.h
+++ b/src/rgw/jwt-cpp/jwt.h
@@ -240,7 +240,7 @@ namespace jwt {
 			rsa(const EVP_MD*(*md)(), const std::string& name) : md(md), alg_name(name)
 			{}
 
-			void setModulusExponentCalcPublicKey(const string& n, const string& exponent)
+			void setModulusExponentCalcPublicKey(const string& modulus, const string& exponent)
 			{
 				this->modulus = modulus;
 				this->exponent = exponent;

--- a/src/rgw/jwt-cpp/jwt.h
+++ b/src/rgw/jwt-cpp/jwt.h
@@ -14,7 +14,7 @@
 #include <openssl/bn.h>
 #include <openssl/rsa.h>
 
-#include "../rgw_b64.h"
+#include "rgw/rgw_b64.h"
 
 //If openssl version less than 1.1
 #if OPENSSL_VERSION_NUMBER < 269484032
@@ -312,9 +312,9 @@ namespace jwt {
 			std::shared_ptr<EVP_PKEY> pkey;
 			/// Hash generator
 			const EVP_MD*(*md)();
-			// Modulus
+			/// Modulus
 			std::string modulus;
-			// Exponent
+			/// Exponent
 			std::string exponent;
 			/// Algorithmname
 			const std::string alg_name;

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -189,11 +189,11 @@ WebTokenEngine::get_from_jwt(const DoutPrefixProvider* dpp, const std::string& t
     if (error == -EACCES) {
       throw -EACCES;
     }
-    ldpp_dout(dpp, 5) << "Invalid JWT" << dendl;
+    ldpp_dout(dpp, 5) << "Invalid JWT: " << error << dendl;
     return boost::none;
   }
-  catch (...) {
-    ldpp_dout(dpp, 5) << "Invalid JWT" << dendl;
+  catch (const std::exception& e) {
+    ldpp_dout(dpp, 5) << "Invalid JWT: " << e.what() << dendl;
     return boost::none;
   }
   return t;
@@ -335,7 +335,7 @@ WebTokenEngine::validate_signature_using_cert(const DoutPrefixProvider* dpp, con
 
       verifier.verify(decoded);
     }
-  } catch (std::runtime_error& e) {
+  } catch (const std::exception& e) {
     ldpp_dout(dpp, 0) << "Signature validation using x5c failed: " << e.what() << dendl;
     throw;
   }
@@ -363,7 +363,7 @@ WebTokenEngine::validate_signature_using_n_e(const DoutPrefixProvider* dpp, cons
                   .allow_algorithm(jwt::algorithm::rs512().setModulusAndExponent(n,e));
       verifier.verify(decoded);
     }
-  } catch (std::runtime_error& e) {
+  } catch (const std::exception& e) {
     ldpp_dout(dpp, 0) << "Signature validation using n, e failed: " << e.what() << dendl;
     throw;
   }

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -347,7 +347,7 @@ WebTokenEngine::validate_signature_using_cert(const DoutPrefixProvider* dpp, con
 }
 
 void
-WebTokenEngine::validate_signature_using_n_e(const DoutPrefixProvider* dpp, const jwt::decoded_jwt& decoded, const string& n, const string& e, const string &algorithm) const
+WebTokenEngine::validate_signature_using_n_e(const DoutPrefixProvider* dpp, const jwt::decoded_jwt& decoded, const string &algorithm, const string& n, const string& e) const
 {
   try {
     if (algorithm == "RS256") {
@@ -362,6 +362,9 @@ WebTokenEngine::validate_signature_using_n_e(const DoutPrefixProvider* dpp, cons
       auto verifier = jwt::verify()
                   .allow_algorithm(jwt::algorithm::rs512().setModulusAndExponent(n,e));
       verifier.verify(decoded);
+    } else {
+      ldpp_dout(dpp, 0) << "Invalid algorithm: " << algorithm << dendl;
+      throw std::runtime_error("Invalid algorithm: " + algorithm);
     }
   } catch (const std::exception& e) {
     ldpp_dout(dpp, 0) << "Signature validation using n, e failed: " << e.what() << dendl;
@@ -369,6 +372,7 @@ WebTokenEngine::validate_signature_using_n_e(const DoutPrefixProvider* dpp, cons
   }
   catch (...) {
     ldpp_dout(dpp, 0) << "Signature validation n, e failed" << dendl;
+    throw;
   }
   ldpp_dout(dpp, 10) << "Verified signature using n and e"<< dendl;
   return;

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -33,10 +33,19 @@ class WebTokenEngine : public rgw::auth::Engine {
 
   std::string get_role_tenant(const string& role_arn) const;
 
-  std::string get_cert_url(const string& iss, const DoutPrefixProvider *dpp,optional_yield y) const;
+  std::string get_jwks_url(const string& iss, const DoutPrefixProvider *dpp,optional_yield y) const;
 
   boost::optional<WebTokenEngine::token_t>
   get_from_jwt(const DoutPrefixProvider* dpp, const std::string& token, const req_state* const s, optional_yield y) const;
+
+  vector<string>
+  get_x5c_certs_from_x5u_url(const DoutPrefixProvider* dpp, const string& x5u_url, optional_yield y) const;
+
+  void
+  validate_signature_using_cert(const DoutPrefixProvider* dpp, const jwt::decoded_jwt& decoded, const string& algorithm, const vector<string>& certs, const vector<string>& thumbprints, bool add_pem_str=true) const;
+
+  void
+  validate_signature_using_n_e(const DoutPrefixProvider* dpp, const jwt::decoded_jwt& decoded, const string& n, const string& e, const string &algorithm) const;
 
   void validate_signature (const DoutPrefixProvider* dpp, const jwt::decoded_jwt& decoded, const string& algorithm, const string& iss, const vector<string>& thumbprints, optional_yield y) const;
 

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -45,7 +45,7 @@ class WebTokenEngine : public rgw::auth::Engine {
   validate_signature_using_cert(const DoutPrefixProvider* dpp, const jwt::decoded_jwt& decoded, const string& algorithm, const vector<string>& certs, const vector<string>& thumbprints, bool add_pem_str=true) const;
 
   void
-  validate_signature_using_n_e(const DoutPrefixProvider* dpp, const jwt::decoded_jwt& decoded, const string& n, const string& e, const string &algorithm) const;
+  validate_signature_using_n_e(const DoutPrefixProvider* dpp, const jwt::decoded_jwt& decoded, const string &algorithm, const string& n, const string& e) const;
 
   void validate_signature (const DoutPrefixProvider* dpp, const jwt::decoded_jwt& decoded, const string& algorithm, const string& iss, const vector<string>& thumbprints, optional_yield y) const;
 


### PR DESCRIPTION
in AssumeRoleWithWebIdentity.

added code for token validation using x5c, x5u, x5t, x5t#S256, kid
in header and x5u and modulus, exponent (for RSA group of algos)
in JWKS (JSON Web Key Set).

Fixes: https://tracker.ceph.com/issues/51018
Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
