### PR TITLE
osd/PeeringState: cleanup dead code in PeeringState::init

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -940,7 +940,6 @@ seastar::future<Ref<PG>> OSD::handle_pg_create_info(
           acting_primary,
           info->history,
           info->past_intervals,
-          false,
           rctx.transaction);
 
         return shard_services.start_operation<PGAdvanceMap>(

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -405,12 +405,11 @@ void PG::init(
   const vector<int>& newacting, int new_acting_primary,
   const pg_history_t& history,
   const PastIntervals& pi,
-  bool backfill,
   ObjectStore::Transaction &t)
 {
   peering_state.init(
     role, newup, new_up_primary, newacting,
-    new_acting_primary, history, pi, backfill, t);
+    new_acting_primary, history, pi, t);
 }
 
 seastar::future<> PG::read_state(crimson::os::FuturizedStore* store)

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -465,7 +465,6 @@ public:
     int acting_primary,
     const pg_history_t& history,
     const PastIntervals& pim,
-    bool backfill,
     ceph::os::Transaction &t);
 
   seastar::future<> read_state(crimson::os::FuturizedStore* store);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4953,7 +4953,6 @@ PGRef OSD::handle_pg_create_info(const OSDMapRef& osdmap,
     acting_primary,
     info->history,
     info->past_intervals,
-    false,
     rctx.transaction);
 
   pg->init_collection_pool_opts();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -859,12 +859,11 @@ void PG::init(
   const vector<int>& newacting, int new_acting_primary,
   const pg_history_t& history,
   const PastIntervals& pi,
-  bool backfill,
   ObjectStore::Transaction &t)
 {
   recovery_state.init(
     role, newup, new_up_primary, newacting,
-    new_acting_primary, history, pi, backfill, t);
+    new_acting_primary, history, pi, t);
 }
 
 void PG::shutdown()

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -337,7 +337,6 @@ public:
     int acting_primary,
     const pg_history_t& history,
     const PastIntervals& pim,
-    bool backfill,
     ObjectStore::Transaction &t);
 
   /// read existing pg state off disk

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3862,7 +3862,6 @@ void PeeringState::init(
   const vector<int>& newacting, int new_acting_primary,
   const pg_history_t& history,
   const PastIntervals& pi,
-  bool backfill,
   ObjectStore::Transaction &t)
 {
   psdout(10) << "init role " << role << " up "
@@ -3889,13 +3888,6 @@ void PeeringState::init(
 
   if (!perform_deletes_during_peering()) {
     pg_log.set_missing_may_contain_deletes();
-  }
-
-  if (backfill) {
-    psdout(10) << __func__ << ": Setting backfill" << dendl;
-    info.set_last_backfill(hobject_t());
-    info.last_complete = info.last_update;
-    pg_log.mark_log_for_rewrite();
   }
 
   on_new_interval();

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1719,7 +1719,6 @@ public:
     const std::vector<int>& newacting, int new_acting_primary,
     const pg_history_t& history,
     const PastIntervals& pi,
-    bool backfill,
     ObjectStore::Transaction &t);
 
   /// Init pg instance from disk state


### PR DESCRIPTION
Argument 'backfill' in PeeringState::init is always set to
false. Commit log shows this is originally for _create_lock_pg
which is removed in d9dcaa79b779. So, just remove dead code.

Signed-off-by: Misono Tomohiro <misono.tomohiro@jp.fujitsu.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
