### PR TITLE
pacific: mgr/dashboard: show RGW tenant user id correctly in 'NFS create export' form 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -58,7 +58,9 @@ describe('NfsFormComponent', () => {
     httpTesting.expectOne('ui-api/nfs-ganesha/fsals').flush(['CEPH', 'RGW']);
     httpTesting.expectOne('ui-api/nfs-ganesha/cephx/clients').flush(['admin', 'fs', 'rgw']);
     httpTesting.expectOne('ui-api/nfs-ganesha/cephfs/filesystems').flush([{ id: 1, name: 'a' }]);
-    httpTesting.expectOne(`api/rgw/user?${RgwHelper.DAEMON_QUERY_PARAM}`).flush(['test', 'dev']);
+    httpTesting
+      .expectOne(`api/rgw/user?${RgwHelper.DAEMON_QUERY_PARAM}`)
+      .flush(['test', 'dev', 'tenant$user']);
     const user_dev = {
       suspended: 0,
       user_id: 'dev',
@@ -71,6 +73,15 @@ describe('NfsFormComponent', () => {
       keys: ['a']
     };
     httpTesting.expectOne(`api/rgw/user/test?${RgwHelper.DAEMON_QUERY_PARAM}`).flush(user_test);
+    const tenantUser = {
+      suspended: 0,
+      tenant: 'tenant',
+      user_id: 'user',
+      keys: ['a']
+    };
+    httpTesting
+      .expectOne(`api/rgw/user/tenant%24user?${RgwHelper.DAEMON_QUERY_PARAM}`)
+      .flush(tenantUser);
     httpTesting.verify();
   });
 
@@ -87,7 +98,7 @@ describe('NfsFormComponent', () => {
     ]);
     expect(component.allCephxClients).toEqual(['admin', 'fs', 'rgw']);
     expect(component.allFsNames).toEqual([{ id: 1, name: 'a' }]);
-    expect(component.allRgwUsers).toEqual(['dev']);
+    expect(component.allRgwUsers).toEqual(['dev', 'tenant$user']);
   });
 
   it('should create the form', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -301,7 +301,8 @@ export class NfsFormComponent extends CdForm implements OnInit {
           this.rgwUserService.list().subscribe((result: any) => {
             result.forEach((user: Record<string, any>) => {
               if (user.suspended === 0 && user.keys.length > 0) {
-                this.allRgwUsers.push(user.user_id);
+                const userId = user.tenant ? `${user.tenant}$${user.user_id}` : user.user_id;
+                this.allRgwUsers.push(userId);
               }
             });
           });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50968

---

backport of https://github.com/ceph/ceph/pull/41447
parent tracker: https://tracker.ceph.com/issues/50909

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh