### PR TITLE
rgw/multisite: track shard sync status objects per generation

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2300,7 +2300,7 @@ static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::Ra
   }
 
   std::vector<rgw_bucket_shard_sync_info> status;
-  r = rgw_read_bucket_inc_sync_status(dpp, store, pipe, bucket_info, &source_bucket->get_info(), &status);
+  r = rgw_read_bucket_inc_sync_status(dpp, store, pipe, bucket_info, &source_bucket->get_info(), full_status.incremental_gen,  &status);
   if (r < 0) {
     lderr(store->ctx()) << "failed to read bucket incremental sync status: " << cpp_strerror(r) << dendl;
     return r;
@@ -8108,6 +8108,7 @@ next:
       cerr << "ERROR: sync.init() returned ret=" << ret << std::endl;
       return -ret;
     }
+
     ret = sync.read_sync_status(dpp());
     if (ret < 0) {
       cerr << "ERROR: sync.read_sync_status() returned ret=" << ret << std::endl;

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -754,7 +754,8 @@ public:
                                 const rgw_bucket& source_bucket,
                                 const rgw_bucket& dest_bucket);
   static string inc_status_oid(const rgw_zone_id& source_zone,
-                               const rgw_bucket_sync_pair_info& bs);
+                               const rgw_bucket_sync_pair_info& bs,
+                               uint64_t gen);
   // specific source obj sync status, can be used by sync modules
   static string obj_status_oid(const rgw_bucket_sync_pipe& sync_pipe,
                                const rgw_zone_id& source_zone, const rgw::sal::Object* obj); /* specific source obj sync status,
@@ -782,6 +783,7 @@ int rgw_read_bucket_inc_sync_status(const DoutPrefixProvider *dpp,
                                     const rgw_sync_bucket_pipe& pipe,
                                     const RGWBucketInfo& dest_bucket_info,
                                     const RGWBucketInfo *psource_bucket_info,
+                                    uint64_t gen,
                                     std::vector<rgw_bucket_shard_sync_info> *status);
 
 class RGWDefaultSyncModule : public RGWSyncModule {

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -1013,6 +1013,7 @@ void RGWOp_BILog_Status::execute(optional_yield y)
       pipe,
       bucket->get_info(),
       nullptr,
+      status.sync_status.incremental_gen,
       &status.inc_status);
     if (op_ret < 0) {
       ldpp_dout(this, -1) << "ERROR: rgw_read_bucket_inc_sync_status() on pipe=" << pipe << " returned ret=" << op_ret << dendl;
@@ -1074,7 +1075,7 @@ void RGWOp_BILog_Status::execute(optional_yield y)
       }
     }
     int r = rgw_read_bucket_inc_sync_status(this, static_cast<rgw::sal::RadosStore*>(store),
-					    pipe, *pinfo, &bucket->get_info(), &current_status);
+					    pipe, *pinfo, &bucket->get_info(), status.sync_status.incremental_gen, &current_status);
     if (r < 0) {
       ldpp_dout(this, -1) << "ERROR: rgw_read_bucket_inc_sync_status() on pipe=" << pipe << " returned ret=" << r << dendl;
       op_ret = r;

--- a/src/rgw/rgw_sync_checkpoint.cc
+++ b/src/rgw/rgw_sync_checkpoint.cc
@@ -145,7 +145,7 @@ int bucket_source_sync_checkpoint(const DoutPrefixProvider* dpp,
   std::vector<rgw_bucket_shard_sync_info> status;
   status.resize(std::max<size_t>(1, num_shards));
   r = rgw_read_bucket_inc_sync_status(dpp, store, pipe, bucket_info,
-                                      &source_bucket_info, &status);
+                                      &source_bucket_info, full_status.incremental_gen, &status);
   if (r < 0) {
     return r;
   }
@@ -161,7 +161,7 @@ int bucket_source_sync_checkpoint(const DoutPrefixProvider* dpp,
         << "    remote markers: " << remote_markers << dendl;
     std::this_thread::sleep_until(delay_until);
     r = rgw_read_bucket_inc_sync_status(dpp, store, pipe, bucket_info,
-                                        &source_bucket_info, &status);
+                                        &source_bucket_info, full_status.incremental_gen, &status);
     if (r < 0) {
       return r;
     }


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
