### PR TITLE
crush/crush: ensure alignof(crush_work_bucket) is 1

### DIFF
--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -540,7 +540,7 @@ struct crush_work_bucket {
 	__u32 perm_x; /* @x for which *perm is defined */
 	__u32 perm_n; /* num elements of *perm that are permuted/defined */
 	__u32 *perm;  /* Permutation of the bucket's items */
-};
+} __attribute__ ((packed));
 
 struct crush_work {
 	struct crush_work_bucket **work; /* Per-bucket working store */


### PR DESCRIPTION
in do_rule(), we allocate the space for crush_work_bucket using

char work[crush_work_size(crush, maxout)];

where crush_work_size() calculate the size like:

map->working_size + result_max * 3 * sizeof(__u32);

so work is allocated on stack, but the alignment of the
crush_work_bucket struct is not taken into consideration, so in
crush_init_workspace(), point could point to an address which is not
aligned to 8 bytes, which is the alignment of crush_work_bucket by
default. so is its member variables, all of them are uint32_t, and hence
are also 8-bytes aligned.

to ensure the compiler generate the correct assembly for accessing
the member variables without assuming that the struct is 8-byte
aligned, we should specify the alignment explicitly.

in this change, `__attribute__ ((packed))` is specified for
crush_work_bucket, so that its alignment is 1.

this issue is spotted by ASan, it complains like:
```
../src/crush/mapper.c:881:22: runtime error: member access within misaligned address 0x7ffe051f90dc for type 'struct crush_work_bucket', which requires 8 byte alignment
0x7ffe051f90dc: note: pointer points here
  1d e5 77 3d 68 55 00 00  00 00 00 00 00 00 00 00  20 93 1f 05 fe 7f 00 00  10 91 1f 05 fe 7f 00 00
              ^
../src/crush/mapper.c:882:22: runtime error: member access within misaligned address 0x7ffe051f90dc for type 'struct crush_work_bucket', which requires 8 byte alignment
0x7ffe051f90dc: note: pointer points here
  1d e5 77 3d 00 00 00 00  00 00 00 00 00 00 00 00  20 93 1f 05 fe 7f 00 00  10 91 1f 05 fe 7f 00 00
              ^
../src/crush/mapper.c:883:20: runtime error: member access within misaligned address 0x7ffe051f90dc for type 'struct crush_work_bucket', which requires 8 byte alignment
0x7ffe051f90dc: note: pointer points here
  1d e5 77 3d 00 00 00 00  00 00 00 00 00 00 00 00  20 93 1f 05 fe 7f 00 00  10 91 1f 05 fe 7f 00 00
              ^
```

FIxes: https://tracker.ceph.com/issues/50978
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
