### PR TITLE
cephadm: add bootstrap unit tests

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -8160,18 +8160,15 @@ def _parse_args(av):
     return args
 
 
-def cephadm_init_ctx(args: List[str]) -> Optional[CephadmContext]:
-
+def cephadm_init_ctx(args: List[str]) -> CephadmContext:
     ctx = CephadmContext()
     ctx.set_args(_parse_args(args))
     return ctx
 
 
-def cephadm_init(args: List[str]) -> Optional[CephadmContext]:
-
+def cephadm_init(args: List[str]) -> CephadmContext:
     global logger
     ctx = cephadm_init_ctx(args)
-    assert ctx is not None
 
     # Logger configuration
     if not os.path.exists(LOG_DIR):
@@ -8196,10 +8193,6 @@ def cephadm_init(args: List[str]) -> Optional[CephadmContext]:
             if handler.name == 'console':
                 handler.setLevel(logging.DEBUG)
 
-    if not ctx.has_function():
-        sys.stderr.write('No command specified; pass -h or --help for usage\n')
-        return None
-
     return ctx
 
 
@@ -8214,7 +8207,8 @@ def main():
     av = sys.argv[1:]
 
     ctx = cephadm_init(av)
-    if not ctx:  # error, exit
+    if not ctx.has_function():
+        sys.stderr.write('No command specified; pass -h or --help for usage\n')
         sys.exit(1)
 
     try:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1474,6 +1474,16 @@ def call_timeout(ctx, command, timeout):
 ##################################
 
 
+def json_loads_retry(cli_func):
+    for sleep_secs in [1, 4, 4]:
+        try:
+            return json.loads(cli_func())
+        except json.JSONDecodeError:
+            logger.debug('Invalid JSON. Retrying in %s seconds...' % sleep_secs)
+            time.sleep(sleep_secs)
+    return json.loads(cli_func())
+
+
 def is_available(ctx, what, func):
     # type: (CephadmContext, str, Callable[[], bool]) -> None
     """
@@ -4117,15 +4127,6 @@ def command_bootstrap(ctx):
             cli(['config', 'assimilate-conf',
                  '-i', '/var/lib/ceph/user.conf'],
                 {tmp.name: '/var/lib/ceph/user.conf:z'})
-
-    def json_loads_retry(cli_func):
-        for sleep_secs in [1, 4, 4]:
-            try:
-                return json.loads(cli_func())
-            except json.JSONDecodeError:
-                logger.debug('Invalid JSON. Retrying in %s seconds...' % sleep_secs)
-                time.sleep(sleep_secs)
-        return json.loads(cli_func())
 
     # wait for mgr to restart (after enabling a module)
     def wait_for_mgr_restart():

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4048,14 +4048,15 @@ def command_bootstrap(ctx):
 
     image_ver = CephContainer(ctx, ctx.image, 'ceph', ['--version']).run().strip()
     logger.info(f'Ceph version: {image_ver}')
-    image_release = image_ver.split()[4]
-    if (
-        not ctx.allow_mismatched_release
-        and image_release not in [DEFAULT_IMAGE_RELEASE, LATEST_STABLE_RELEASE]
-    ):
-        raise Error(
-            f'Container release {image_release} != cephadm release {DEFAULT_IMAGE_RELEASE}; please use matching version of cephadm (pass --allow-mismatched-release to continue anyway)'
-        )
+
+    if not ctx.allow_mismatched_release:
+        image_release = image_ver.split()[4]
+        if image_release not in \
+                [DEFAULT_IMAGE_RELEASE, LATEST_STABLE_RELEASE]:
+            raise Error(
+                f'Container release {image_release} != cephadm release {DEFAULT_IMAGE_RELEASE};'
+                ' please use matching version of cephadm (pass --allow-mismatched-release to continue anyway)'
+            )
 
     logger.info('Extracting ceph user uid/gid from container image...')
     (uid, gid) = extract_uid_gid(ctx)

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -84,15 +84,19 @@ def cephadm_fs(
 def with_cephadm_ctx(
     cmd: List[str],
     container_engine: Callable = mock_podman(),
-    list_networks: Optional[Dict[str,Dict[str,List[str]]]] = None
+    list_networks: Optional[Dict[str,Dict[str,List[str]]]] = None,
+    hostname: Optional[str] = None,
 ):
     """
     :param cmd: cephadm command argv
     :param container_engine: container engine mock (podman or docker)
     :param list_networks: mock 'list-networks' return
+    :param hostname: mock 'socket.gethostname' return
     """
     if not list_networks:
         list_networks = {}
+    if not hostname:
+        hostname = 'host1'
 
     with mock.patch('cephadm.get_parm'), \
          mock.patch('cephadm.attempt_bind'), \
@@ -100,7 +104,8 @@ def with_cephadm_ctx(
          mock.patch('cephadm.find_executable', return_value='foo'), \
          mock.patch('cephadm.is_available', return_value=True), \
          mock.patch('cephadm.json_loads_retry', return_value={'epoch' : 1}), \
-         mock.patch('cephadm.list_networks', return_value=list_networks):
+         mock.patch('cephadm.list_networks', return_value=list_networks), \
+         mock.patch('socket.gethostname', return_value=hostname):
              ctx: cd.CephadmContext = cd.cephadm_init_ctx(cmd)
              ctx.container_engine = container_engine
              yield ctx

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -3,6 +3,8 @@ import os
 import pytest
 import time
 
+from pyfakefs import fake_filesystem
+
 
 with mock.patch('builtins.open', create=True):
     from importlib.machinery import SourceFileLoader
@@ -38,3 +40,25 @@ def exporter():
         exporter = cd.CephadmDaemon(ctx, fsid='foobar', daemon_id='test')
         assert exporter.token == 'MyAccessToken' 
         yield exporter
+
+
+@pytest.fixture()
+def cephadm_fs(
+    fs: fake_filesystem.FakeFilesystem,
+):
+    """
+    use pyfakefs to stub filesystem calls
+    """
+    uid = os.getuid()
+    gid = os.getgid()
+
+    with mock.patch('os.fchown'), \
+         mock.patch('cephadm.extract_uid_gid', return_value=(uid, gid)):
+
+            fs.create_dir(cd.DATA_DIR)
+            fs.create_dir(cd.LOG_DIR)
+            fs.create_dir(cd.LOCK_DIR)
+            fs.create_dir(cd.LOGROTATE_DIR)
+            fs.create_dir(cd.UNIT_DIR)
+
+            yield fs

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -1,12 +1,10 @@
-
 import mock
-from mock import patch
-import pytest
-
 import os
+import pytest
 import time
 
-with patch('builtins.open', create=True):
+
+with mock.patch('builtins.open', create=True):
     from importlib.machinery import SourceFileLoader
     cd = SourceFileLoader('cephadm', 'cephadm').load_module()
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1042,3 +1042,16 @@ class TestBootstrap(TestCephAdm):
             msg = r'must specify --mon-ip or --mon-addrv'
             with pytest.raises(cd.Error, match=msg):
                 cd.command_bootstrap(ctx)
+
+    def test_skip_mon_network(self, cephadm_fs):
+        cmd = self._get_cmd('--mon-ip', '192.168.1.1')
+
+        with with_cephadm_ctx(cmd, list_networks={}) as ctx:
+            msg = r'Failed to infer CIDR network'
+            with pytest.raises(cd.Error, match=msg):
+                cd.command_bootstrap(ctx)
+
+        cmd += ['--skip-mon-network']
+        with with_cephadm_ctx(cmd, list_networks={}) as ctx:
+            retval = cd.command_bootstrap(ctx)
+            assert retval == 0

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1140,3 +1140,20 @@ class TestBootstrap(TestCephAdm):
             with with_cephadm_ctx(cmd, list_networks=list_networks) as ctx:
                 retval = cd.command_bootstrap(ctx)
                 assert retval == 0
+
+    def test_allow_fqdn_hostname(self, cephadm_fs):
+        hostname = 'foo.bar'
+        cmd = self._get_cmd(
+            '--mon-ip', '192.168.1.1',
+            '--skip-mon-network',
+        )
+
+        with with_cephadm_ctx(cmd, hostname=hostname) as ctx:
+            msg = r'--allow-fqdn-hostname'
+            with pytest.raises(cd.Error, match=msg):
+                cd.command_bootstrap(ctx)
+
+        cmd += ['--allow-fqdn-hostname']
+        with with_cephadm_ctx(cmd, hostname=hostname) as ctx:
+            retval = cd.command_bootstrap(ctx)
+            assert retval == 0

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -410,19 +410,17 @@ default proto ra metric 100
 
         # test normal valid login with url, username and password specified
         call_throws.return_value = '', '', 0
-        ctx: Optional[cd.CephadmContext] = cd.cephadm_init_ctx(
+        ctx: cd.CephadmContext = cd.cephadm_init_ctx(
             ['registry-login', '--registry-url', 'sample-url',
             '--registry-username', 'sample-user', '--registry-password',
             'sample-pass'])
         ctx.container_engine = self.mock_docker()
-        assert ctx
         retval = cd.command_registry_login(ctx)
         assert retval == 0
 
         # test bad login attempt with invalid arguments given
-        ctx: Optional[cd.CephadmContext] = cd.cephadm_init_ctx(
+        ctx: cd.CephadmContext = cd.cephadm_init_ctx(
             ['registry-login', '--registry-url', 'bad-args-url'])
-        assert ctx
         with pytest.raises(Exception) as e:
             assert cd.command_registry_login(ctx)
         assert str(e.value) == ('Invalid custom registry arguments received. To login to a custom registry include '
@@ -430,18 +428,16 @@ default proto ra metric 100
 
         # test normal valid login with json file
         get_parm.return_value = {"url": "sample-url", "username": "sample-username", "password": "sample-password"}
-        ctx: Optional[cd.CephadmContext] = cd.cephadm_init_ctx(
+        ctx: cd.CephadmContext = cd.cephadm_init_ctx(
             ['registry-login', '--registry-json', 'sample-json'])
         ctx.container_engine = self.mock_docker()
-        assert ctx
         retval = cd.command_registry_login(ctx)
         assert retval == 0
 
         # test bad login attempt with bad json file
         get_parm.return_value = {"bad-json": "bad-json"}
-        ctx: Optional[cd.CephadmContext] =  cd.cephadm_init_ctx(
+        ctx: cd.CephadmContext =  cd.cephadm_init_ctx(
             ['registry-login', '--registry-json', 'sample-json'])
-        assert ctx
         with pytest.raises(Exception) as e:
             assert cd.command_registry_login(ctx)
         assert str(e.value) == ("json provided for custom registry login did not include all necessary fields. "
@@ -454,11 +450,10 @@ default proto ra metric 100
 
         # test login attempt with valid arguments where login command fails
         call_throws.side_effect = Exception
-        ctx: Optional[cd.CephadmContext] = cd.cephadm_init_ctx(
+        ctx: cd.CephadmContext = cd.cephadm_init_ctx(
             ['registry-login', '--registry-url', 'sample-url',
             '--registry-username', 'sample-user', '--registry-password',
             'sample-pass'])
-        assert ctx
         with pytest.raises(Exception) as e:
             cd.command_registry_login(ctx)
         assert str(e.value) == "Failed to login to custom registry @ sample-url as sample-user with given password"

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1,25 +1,27 @@
 # type: ignore
-from typing import List, Optional
-import mock
-from mock import patch, call
-import os
-import sys
-import unittest
-import threading
-import time
+
 import errno
+import mock
+import os
+import pytest
 import socket
+import sys
+import time
+import threading
+import unittest
+
 from http.server import HTTPServer
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError
 
-import pytest
-
+from typing import List, Optional
 from .fixtures import exporter
 
-with patch('builtins.open', create=True):
+
+with mock.patch('builtins.open', create=True):
     from importlib.machinery import SourceFileLoader
     cd = SourceFileLoader('cephadm', 'cephadm').load_module()
+
 
 class TestCephAdm(object):
 
@@ -107,7 +109,7 @@ class TestCephAdm(object):
             except:
                 assert False
             else:
-                assert _socket.call_args == call(address_family, socket.SOCK_STREAM)
+                assert _socket.call_args == mock.call(address_family, socket.SOCK_STREAM)
 
     @mock.patch('socket.socket')
     @mock.patch('cephadm.logger')
@@ -1019,10 +1021,10 @@ class TestMonitoring(object):
             daemon_id=daemon_id
         )
         assert _open.call_args_list == [
-            call('{}/etc/prometheus/prometheus.yml'.format(prefix), 'w',
+            mock.call('{}/etc/prometheus/prometheus.yml'.format(prefix), 'w',
                  encoding='utf-8'),
-            call('{}/etc/prometheus/alerting/ceph_alerts.yml'.format(prefix), 'w',
+            mock.call('{}/etc/prometheus/alerting/ceph_alerts.yml'.format(prefix), 'w',
                  encoding='utf-8'),
         ]
-        assert call().__enter__().write('foo') in _open.mock_calls
-        assert call().__enter__().write('bar') in _open.mock_calls
+        assert mock.call().__enter__().write('foo') in _open.mock_calls
+        assert mock.call().__enter__().write('bar') in _open.mock_calls

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -15,7 +15,7 @@ from urllib.request import Request, urlopen
 from urllib.error import HTTPError
 
 from typing import List, Optional
-from .fixtures import exporter
+from .fixtures import exporter, mock_docker, mock_podman
 
 
 with mock.patch('builtins.open', create=True):
@@ -25,25 +25,12 @@ with mock.patch('builtins.open', create=True):
 
 class TestCephAdm(object):
 
-    @staticmethod
-    def mock_docker():
-        docker = mock.Mock(cd.Docker)
-        docker.path = '/usr/bin/docker'
-        return docker
-
-    @staticmethod
-    def mock_podman():
-        podman = mock.Mock(cd.Podman)
-        podman.path = '/usr/bin/podman'
-        podman.version = (2, 1, 0)
-        return podman
-
     def test_docker_unit_file(self):
         ctx = mock.Mock()
-        ctx.container_engine = self.mock_docker()
+        ctx.container_engine = mock_docker()
         r = cd.get_unit_file(ctx, '9b9d7609-f4d5-4aba-94c8-effa764d96c9')
         assert 'Requires=docker.service' in r
-        ctx.container_engine = self.mock_podman()
+        ctx.container_engine = mock_podman()
         r = cd.get_unit_file(ctx, '9b9d7609-f4d5-4aba-94c8-effa764d96c9')
         assert 'Requires=docker.service' not in r
 
@@ -416,7 +403,7 @@ default proto ra metric 100
             ['registry-login', '--registry-url', 'sample-url',
             '--registry-username', 'sample-user', '--registry-password',
             'sample-pass'])
-        ctx.container_engine = self.mock_docker()
+        ctx.container_engine = mock_docker()
         retval = cd.command_registry_login(ctx)
         assert retval == 0
 
@@ -432,7 +419,7 @@ default proto ra metric 100
         get_parm.return_value = {"url": "sample-url", "username": "sample-username", "password": "sample-password"}
         ctx: cd.CephadmContext = cd.cephadm_init_ctx(
             ['registry-login', '--registry-json', 'sample-json'])
-        ctx.container_engine = self.mock_docker()
+        ctx.container_engine = mock_docker()
         retval = cd.command_registry_login(ctx)
         assert retval == 0
 
@@ -529,7 +516,7 @@ docker.io/ceph/daemon-base:octopus
 
         ctx.log_to_journald = None
         # enable if podman support --cgroup=split
-        ctx.container_engine = self.mock_podman()
+        ctx.container_engine = mock_podman()
         ctx.container_engine.version = (2, 1, 0)
         assert cd.should_log_to_journald(ctx)
 
@@ -538,7 +525,7 @@ docker.io/ceph/daemon-base:octopus
         assert not cd.should_log_to_journald(ctx)
 
         # disable on docker
-        ctx.container_engine = self.mock_docker()
+        ctx.container_engine = mock_docker()
         assert not cd.should_log_to_journald(ctx)
 
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1036,6 +1036,24 @@ class TestBootstrap(TestCephAdm):
             *args,
         ]
 
+    def test_config(self, cephadm_fs):
+        conf_file = 'foo'
+        cmd = self._get_cmd(
+            '--mon-ip', '192.168.1.1',
+            '--skip-mon-network',
+            '--config', conf_file,
+        )
+
+        with with_cephadm_ctx(cmd) as ctx:
+            msg = r'No such file or directory'
+            with pytest.raises(cd.Error, match=msg):
+                cd.command_bootstrap(ctx)
+
+        cephadm_fs.create_file(conf_file)
+        with with_cephadm_ctx(cmd) as ctx:
+            retval = cd.command_bootstrap(ctx)
+            assert retval == 0
+
     def test_no_mon_addr(self, cephadm_fs):
         cmd = self._get_cmd()
         with with_cephadm_ctx(cmd) as ctx:

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -34,8 +34,9 @@ addopts =
 [testenv]
 skip_install=true
 deps =
-  pytest
+  pyfakefs
   mock
+  pytest
 commands=pytest {posargs}
 
 [testenv:mypy]


### PR DESCRIPTION
unit tests for `cephadm bootstrap ..`

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
