### PR TITLE
os/bluestore: improve usability for bluestore/bluefs perf counters

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -276,19 +276,28 @@ void BlueFS::_init_logger()
 		    "random read requests processed");
   b.add_u64_counter(l_bluefs_read_random_bytes, "read_random_bytes",
 		    "Bytes requested in random read mode",
-		    "rrdb",
-		    PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+		    NULL,
+		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_random_disk_count, "read_random_disk_count",
 		    "random reads requests going to disk");
   b.add_u64_counter(l_bluefs_read_random_disk_bytes, "read_random_disk_bytes",
-		    "Bytes read from disk in random read mode", NULL,
-		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
+		    "Bytes read from disk in random read mode",
+		    "rrd",
+		    PerfCountersBuilder::PRIO_INTERESTING,
+		    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_random_disk_bytes_wal, "read_random_disk_bytes_wal",
-    "random reads requests going to WAL disk");
+		    "random reads requests going to WAL disk",
+		    NULL,
+		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_random_disk_bytes_db, "read_random_disk_bytes_db",
-    "random reads requests going to DB disk");
+		    "random reads requests going to DB disk",
+		    NULL,
+		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_random_disk_bytes_slow, "read_random_disk_bytes_slow",
-    "random reads requests going to main disk");
+		    "random reads requests going to main disk",
+		    "rrds",
+		    PerfCountersBuilder::PRIO_INTERESTING,
+		    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_random_buffer_count, "read_random_buffer_count",
 		    "random read requests processed using prefetch buffer");
   b.add_u64_counter(l_bluefs_read_random_buffer_bytes, "read_random_buffer_bytes",
@@ -299,21 +308,27 @@ void BlueFS::_init_logger()
 		    "buffered read requests processed");
   b.add_u64_counter(l_bluefs_read_bytes, "read_bytes",
 		    "Bytes requested in buffered read mode",
-		    "read",
-		    PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+		    NULL,
+		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
   b.add_u64_counter(l_bluefs_read_disk_count, "read_disk_count",
-    "buffered reads requests going to disk");
+		    "buffered reads requests going to disk");
   b.add_u64_counter(l_bluefs_read_disk_bytes, "read_disk_bytes",
-    "Bytes read in buffered mode from disk", NULL,
-    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
+		    "Bytes read in buffered mode from disk",
+		    "rd",
+		    PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_disk_bytes_wal, "read_disk_bytes_wal",
-    "reads requests going to WAL disk");
+		    "reads requests going to WAL disk",
+		    NULL,
+		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_disk_bytes_db, "read_disk_bytes_db",
-    "reads requests going to DB disk");
+		    "reads requests going to DB disk",
+		    NULL,
+		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_disk_bytes_slow, "read_disk_bytes_slow",
-    "reads requests going to main disk");
-
+		    "reads requests going to main disk",
+		    "rds",
+		    PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_prefetch_count, "read_prefetch_count",
 		    "prefetch read requests processed");
   b.add_u64_counter(l_bluefs_read_prefetch_bytes, "read_prefetch_bytes",

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -246,21 +246,25 @@ void BlueFS::_init_logger()
   b.add_u64_counter(l_bluefs_log_compactions, "log_compactions",
 		    "Compactions of the metadata log");
   b.add_u64_counter(l_bluefs_logged_bytes, "logged_bytes",
-		    "Bytes written to the metadata log", "j",
+		    "Bytes written to the metadata log",
+		    "j",
 		    PerfCountersBuilder::PRIO_CRITICAL, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_files_written_wal, "files_written_wal",
 		    "Files written to WAL");
   b.add_u64_counter(l_bluefs_files_written_sst, "files_written_sst",
 		    "Files written to SSTs");
   b.add_u64_counter(l_bluefs_bytes_written_wal, "bytes_written_wal",
-		    "Bytes written to WAL", "wal",
+		    "Bytes written to WAL",
+		    "walb",
 		    PerfCountersBuilder::PRIO_CRITICAL);
   b.add_u64_counter(l_bluefs_bytes_written_sst, "bytes_written_sst",
-		    "Bytes written to SSTs", "sst",
+		    "Bytes written to SSTs",
+		    "sstb",
 		    PerfCountersBuilder::PRIO_CRITICAL, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_bytes_written_slow, "bytes_written_slow",
-		    "Bytes written to WAL/SSTs at slow device", NULL,
-		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
+		    "Bytes written to WAL/SSTs at slow device",
+		    "slwb",
+		    PerfCountersBuilder::PRIO_CRITICAL, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_max_bytes_wal, "max_bytes_wal",
 		    "Maximum bytes allocated from WAL");
   b.add_u64_counter(l_bluefs_max_bytes_db, "max_bytes_db",
@@ -271,8 +275,9 @@ void BlueFS::_init_logger()
   b.add_u64_counter(l_bluefs_read_random_count, "read_random_count",
 		    "random read requests processed");
   b.add_u64_counter(l_bluefs_read_random_bytes, "read_random_bytes",
-		    "Bytes requested in random read mode", NULL,
-		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
+		    "Bytes requested in random read mode",
+		    "rrdb",
+		    PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_random_disk_count, "read_random_disk_count",
 		    "random reads requests going to disk");
   b.add_u64_counter(l_bluefs_read_random_disk_bytes, "read_random_disk_bytes",
@@ -287,8 +292,9 @@ void BlueFS::_init_logger()
   b.add_u64_counter(l_bluefs_read_count, "read_count",
 		    "buffered read requests processed");
   b.add_u64_counter(l_bluefs_read_bytes, "read_bytes",
-		    "Bytes requested in buffered read mode", NULL,
-		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
+		    "Bytes requested in buffered read mode",
+		    "read",
+		    PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
 
   b.add_u64_counter(l_bluefs_read_prefetch_count, "read_prefetch_count",
 		    "prefetch read requests processed");

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -266,20 +266,32 @@ void BlueFS::_init_logger()
 		    "slwb",
 		    PerfCountersBuilder::PRIO_CRITICAL, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_max_bytes_wal, "max_bytes_wal",
-		    "Maximum bytes allocated from WAL");
+		    "Maximum bytes allocated from WAL",
+		    "mxwb",
+		    PerfCountersBuilder::PRIO_INTERESTING,
+		    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_max_bytes_db, "max_bytes_db",
-		    "Maximum bytes allocated from DB");
+		    "Maximum bytes allocated from DB",
+		    "mxdb",
+		    PerfCountersBuilder::PRIO_INTERESTING,
+		    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_max_bytes_slow, "max_bytes_slow",
-		    "Maximum bytes allocated from SLOW");
-
+		    "Maximum bytes allocated from SLOW",
+		    "mxwb",
+		    PerfCountersBuilder::PRIO_INTERESTING,
+		    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_random_count, "read_random_count",
-		    "random read requests processed");
+		    "random read requests processed",
+		    NULL,
+		    PerfCountersBuilder::PRIO_USEFUL);
   b.add_u64_counter(l_bluefs_read_random_bytes, "read_random_bytes",
 		    "Bytes requested in random read mode",
 		    NULL,
 		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_random_disk_count, "read_random_disk_count",
-		    "random reads requests going to disk");
+		    "random reads requests going to disk",
+		    NULL,
+		    PerfCountersBuilder::PRIO_USEFUL);
   b.add_u64_counter(l_bluefs_read_random_disk_bytes, "read_random_disk_bytes",
 		    "Bytes read from disk in random read mode",
 		    "rrb",
@@ -299,20 +311,25 @@ void BlueFS::_init_logger()
 		    PerfCountersBuilder::PRIO_INTERESTING,
 		    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_random_buffer_count, "read_random_buffer_count",
-		    "random read requests processed using prefetch buffer");
+		    "random read requests processed using prefetch buffer",
+		    NULL,
+		    PerfCountersBuilder::PRIO_USEFUL);
   b.add_u64_counter(l_bluefs_read_random_buffer_bytes, "read_random_buffer_bytes",
-		    "Bytes read from prefetch buffer in random read mode", NULL,
+		    "Bytes read from prefetch buffer in random read mode",
+		    NULL,
 		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
-
   b.add_u64_counter(l_bluefs_read_count, "read_count",
-		    "buffered read requests processed");
+		    "buffered read requests processed",
+		    NULL,
+		    PerfCountersBuilder::PRIO_USEFUL);
   b.add_u64_counter(l_bluefs_read_bytes, "read_bytes",
 		    "Bytes requested in buffered read mode",
 		    NULL,
 		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
-
   b.add_u64_counter(l_bluefs_read_disk_count, "read_disk_count",
-		    "buffered reads requests going to disk");
+		    "buffered reads requests going to disk",
+		    NULL,
+		    PerfCountersBuilder::PRIO_USEFUL);
   b.add_u64_counter(l_bluefs_read_disk_bytes, "read_disk_bytes",
 		    "Bytes read in buffered mode from disk",
 		    "rb",
@@ -330,9 +347,12 @@ void BlueFS::_init_logger()
 		    "rsb",
 		    PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_prefetch_count, "read_prefetch_count",
-		    "prefetch read requests processed");
+		    "prefetch read requests processed",
+		     NULL,
+		    PerfCountersBuilder::PRIO_USEFUL);
   b.add_u64_counter(l_bluefs_read_prefetch_bytes, "read_prefetch_bytes",
-		    "Bytes requested in prefetch read mode", NULL,
+		    "Bytes requested in prefetch read mode",
+		     NULL,
 		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
   b.add_u64(l_bluefs_read_zeros_candidate, "read_zeros_candidate",
 	    "How many times bluefs read found page with all 0s");

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -282,7 +282,7 @@ void BlueFS::_init_logger()
 		    "random reads requests going to disk");
   b.add_u64_counter(l_bluefs_read_random_disk_bytes, "read_random_disk_bytes",
 		    "Bytes read from disk in random read mode",
-		    "rrd",
+		    "rrb",
 		    PerfCountersBuilder::PRIO_INTERESTING,
 		    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_random_disk_bytes_wal, "read_random_disk_bytes_wal",
@@ -295,7 +295,7 @@ void BlueFS::_init_logger()
 		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_random_disk_bytes_slow, "read_random_disk_bytes_slow",
 		    "random reads requests going to main disk",
-		    "rrds",
+		    "rrsb",
 		    PerfCountersBuilder::PRIO_INTERESTING,
 		    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_random_buffer_count, "read_random_buffer_count",
@@ -315,7 +315,7 @@ void BlueFS::_init_logger()
 		    "buffered reads requests going to disk");
   b.add_u64_counter(l_bluefs_read_disk_bytes, "read_disk_bytes",
 		    "Bytes read in buffered mode from disk",
-		    "rd",
+		    "rb",
 		    PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_disk_bytes_wal, "read_disk_bytes_wal",
 		    "reads requests going to WAL disk",
@@ -327,7 +327,7 @@ void BlueFS::_init_logger()
 		    PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_disk_bytes_slow, "read_disk_bytes_slow",
 		    "reads requests going to main disk",
-		    "rds",
+		    "rsb",
 		    PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluefs_read_prefetch_count, "read_prefetch_count",
 		    "prefetch read requests processed");

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -44,10 +44,18 @@ enum {
   l_bluefs_read_random_bytes,
   l_bluefs_read_random_disk_count,
   l_bluefs_read_random_disk_bytes,
+  l_bluefs_read_random_disk_bytes_wal,
+  l_bluefs_read_random_disk_bytes_db,
+  l_bluefs_read_random_disk_bytes_slow,
   l_bluefs_read_random_buffer_count,
   l_bluefs_read_random_buffer_bytes,
   l_bluefs_read_count,
   l_bluefs_read_bytes,
+  l_bluefs_read_disk_count,
+  l_bluefs_read_disk_bytes,
+  l_bluefs_read_disk_bytes_wal,
+  l_bluefs_read_disk_bytes_db,
+  l_bluefs_read_disk_bytes_slow,
   l_bluefs_read_prefetch_count,
   l_bluefs_read_prefetch_bytes,
   l_bluefs_read_zeros_candidate,
@@ -656,9 +664,13 @@ public:
 private:
   // Wrappers for BlockDevice::read(...) and BlockDevice::read_random(...)
   // They are used for checking if read values are all 0, and reread if so.
-  int read(uint8_t ndev, uint64_t off, uint64_t len,
+  int _read_and_check(uint8_t ndev, uint64_t off, uint64_t len,
 	   ceph::buffer::list *pbl, IOContext *ioc, bool buffered);
-  int read_random(uint8_t ndev, uint64_t off, uint64_t len, char *buf, bool buffered);
+  int _read_random_and_check(uint8_t ndev, uint64_t off, uint64_t len, char *buf, bool buffered);
+
+  int _bdev_read(uint8_t ndev, uint64_t off, uint64_t len,
+    ceph::buffer::list* pbl, IOContext* ioc, bool buffered);
+  int _bdev_read_random(uint8_t ndev, uint64_t off, uint64_t len, char* buf, bool buffered);
 };
 
 class OriginalVolumeSelector : public BlueFSVolumeSelector {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4931,9 +4931,15 @@ void BlueStore::_init_logger()
   // space utilization stats
   //****************************************
   b.add_u64(l_bluestore_allocated, "allocated",
-	    "Sum for allocated bytes");
+	    "Sum for allocated bytes",
+	    "al_b",
+	    PerfCountersBuilder::PRIO_CRITICAL,
+	    unit_t(UNIT_BYTES));
   b.add_u64(l_bluestore_stored, "stored",
-	    "Sum for stored bytes");
+	    "Sum for stored bytes",
+	    "st_b",
+	    PerfCountersBuilder::PRIO_CRITICAL,
+	    unit_t(UNIT_BYTES));
   b.add_u64(l_bluestore_fragmentation, "fragmentation_micros",
             "How fragmented bluestore free space is (free extents / max possible number of free extents) * 1000");
   //****************************************
@@ -5031,7 +5037,10 @@ void BlueStore::_init_logger()
   b.add_u64_counter(l_bluestore_write_big, "write_big",
 		    "Large aligned writes into fresh blobs");
   b.add_u64_counter(l_bluestore_write_big_bytes, "write_big_bytes",
-		    "Large aligned writes into fresh blobs (bytes)", NULL, 0, unit_t(UNIT_BYTES));
+		    "Large aligned writes into fresh blobs (bytes)",
+		    NULL,
+		    PerfCountersBuilder::PRIO_DEBUGONLY,
+		    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluestore_write_big_blobs, "write_big_blobs",
 		    "Large aligned writes into fresh blobs (blobs)");
   b.add_u64_counter(l_bluestore_write_big_deferred,
@@ -5041,7 +5050,10 @@ void BlueStore::_init_logger()
   b.add_u64_counter(l_bluestore_write_small, "write_small",
 		    "Small writes into existing or sparse small blobs");
   b.add_u64_counter(l_bluestore_write_small_bytes, "write_small_bytes",
-		    "Small writes into existing or sparse small blobs (bytes)", NULL, 0, unit_t(UNIT_BYTES));
+		    "Small writes into existing or sparse small blobs (bytes)",
+		    NULL,
+		    PerfCountersBuilder::PRIO_DEBUGONLY,
+		    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluestore_write_small_unused,
 		    "write_small_unused",
 		    "Small writes into unused portion of existing blob");
@@ -5051,24 +5063,33 @@ void BlueStore::_init_logger()
 		    "cached) to fill out the block");
 
   b.add_u64_counter(l_bluestore_write_pad_bytes, "write_pad_bytes",
-    "Sum for write-op padded bytes", NULL, 0, unit_t(UNIT_BYTES));
+		    "Sum for write-op padded bytes",
+		    NULL,
+		    PerfCountersBuilder::PRIO_DEBUGONLY,
+		    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluestore_write_penalty_read_ops, "write_penalty_read_ops",
-    "Sum for write penalty read ops");
+		    "Sum for write penalty read ops");
   b.add_u64_counter(l_bluestore_write_new, "write_new",
-    "Write into new blob");
+		    "Write into new blob");
 
   b.add_u64_counter(l_bluestore_issued_deferred_writes,
 		    "issued_deferred_writes",
 		    "Total deferred writes issued");
   b.add_u64_counter(l_bluestore_issued_deferred_write_bytes,
 		    "issued_deferred_write_bytes",
-		    "Total bytes in issued deferred writes");
+		    "Total bytes in issued deferred writes",
+		    NULL,
+		    PerfCountersBuilder::PRIO_DEBUGONLY,
+		    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluestore_submitted_deferred_writes,
 		    "submitted_deferred_writes",
 		    "Total deferred writes submitted to disk");
   b.add_u64_counter(l_bluestore_submitted_deferred_write_bytes,
 		    "submitted_deferred_write_bytes",
-		    "Total bytes submitted to disk by deferred writes");
+		    "Total bytes submitted to disk by deferred writes",
+		    NULL,
+		    PerfCountersBuilder::PRIO_DEBUGONLY,
+		    unit_t(UNIT_BYTES));
   //****************************************
 
   // compressions stats
@@ -5122,11 +5143,20 @@ void BlueStore::_init_logger()
   b.add_u64(l_bluestore_buffers, "buffers",
 	    "Number of buffers in cache");
   b.add_u64(l_bluestore_buffer_bytes, "buffer_bytes",
-	    "Number of buffer bytes in cache", NULL, 0, unit_t(UNIT_BYTES));
+	    "Number of buffer bytes in cache",
+	     NULL,
+	     PerfCountersBuilder::PRIO_DEBUGONLY,
+	     unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluestore_buffer_hit_bytes, "buffer_hit_bytes",
-	    "Sum for bytes of read hit in the cache", NULL, 0, unit_t(UNIT_BYTES));
+	    "Sum for bytes of read hit in the cache",
+	    NULL,
+	    PerfCountersBuilder::PRIO_DEBUGONLY,
+	    unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluestore_buffer_miss_bytes, "buffer_miss_bytes",
-	    "Sum for bytes of read missed in the cache", NULL, 0, unit_t(UNIT_BYTES));
+	    "Sum for bytes of read missed in the cache",
+	    NULL,
+	    PerfCountersBuilder::PRIO_DEBUGONLY,
+	    unit_t(UNIT_BYTES));
   //****************************************
 
   // internal stats

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4927,9 +4927,94 @@ void BlueStore::_init_logger()
 {
   PerfCountersBuilder b(cct, "bluestore",
                         l_bluestore_first, l_bluestore_last);
+
+  // space utilization stats
+  //****************************************
+  b.add_u64(l_bluestore_allocated, "allocated",
+	    "Sum for allocated bytes");
+  b.add_u64(l_bluestore_stored, "stored",
+	    "Sum for stored bytes");
+  b.add_u64(l_bluestore_fragmentation, "fragmentation_micros",
+            "How fragmented bluestore free space is (free extents / max possible number of free extents) * 1000");
+  //****************************************
+
+  // Update op processing state latencies
+  //****************************************
+  b.add_time_avg(l_bluestore_state_prepare_lat, "state_prepare_lat",
+		 "Average prepare state latency",
+		 "sprl", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_state_aio_wait_lat, "state_aio_wait_lat",
+		 "Average aio_wait state latency",
+		 "sawl", PerfCountersBuilder::PRIO_INTERESTING);
+  b.add_time_avg(l_bluestore_state_io_done_lat, "state_io_done_lat",
+		 "Average io_done state latency",
+		 "sidl", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_state_kv_queued_lat, "state_kv_queued_lat",
+		"Average kv_queued state latency",
+		"skql", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_state_kv_committing_lat, "state_kv_commiting_lat",
+		 "Average kv_commiting state latency",
+		 "skcl", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_state_kv_done_lat, "state_kv_done_lat",
+		 "Average kv_done state latency",
+		 "skdl", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_state_finishing_lat, "state_finishing_lat",
+		 "Average finishing state latency",
+		 "sfnl", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_state_done_lat, "state_done_lat",
+		 "Average done state latency",
+		 "sdnl", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_state_deferred_queued_lat, "state_deferred_queued_lat",
+		 "Average deferred_queued state latency",
+		 "sdql", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_state_deferred_aio_wait_lat, "state_deferred_aio_wait_lat",
+		 "Average aio_wait state latency",
+		 "sdal", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_state_deferred_cleanup_lat, "state_deferred_cleanup_lat",
+		 "Average cleanup state latency",
+		 "sdcl", PerfCountersBuilder::PRIO_USEFUL);
+  //****************************************
+
+  // Update Transaction stats
+  //****************************************
+  b.add_time_avg(l_bluestore_throttle_lat, "txc_throttle_lat",
+		 "Average submit throttle latency",
+		 "th_l", PerfCountersBuilder::PRIO_CRITICAL);
+  b.add_time_avg(l_bluestore_submit_lat, "txc_submit_lat",
+		 "Average submit latency",
+		 "s_l", PerfCountersBuilder::PRIO_CRITICAL);
+  b.add_time_avg(l_bluestore_commit_lat, "txc_commit_lat",
+		 "Average commit latency",
+		 "c_l", PerfCountersBuilder::PRIO_CRITICAL);
+  b.add_u64_counter(l_bluestore_txc, "txc_count", "Transactions committed");
+  //****************************************
+
+  // Read op stats
+  //****************************************
+  b.add_time_avg(l_bluestore_read_onode_meta_lat, "read_onode_meta_lat",
+		 "Average read onode metadata latency",
+		 "roml", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_read_wait_aio_lat, "read_wait_aio_lat",
+		 "Average read I/O waiting latency",
+		 "rwal", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_csum_lat, "csum_lat",
+		 "Average checksum latency",
+		 "csml", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_u64_counter(l_bluestore_read_eio, "read_eio",
+                    "Read EIO errors propagated to high level callers");
+  b.add_u64_counter(l_bluestore_reads_with_retries, "reads_with_retries",
+                    "Read operations that required at least one retry due to failed checksum validation",
+		    "rd_r", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_read_lat, "read_lat",
+		 "Average read latency",
+		 "r_l", PerfCountersBuilder::PRIO_CRITICAL);
+  //****************************************
+
+  // kv_thread latencies
+  //****************************************
   b.add_time_avg(l_bluestore_kv_flush_lat, "kv_flush_lat",
 		 "Average kv_thread flush latency",
-		 "kfll", PerfCountersBuilder::PRIO_INTERESTING);
+		 "kfsl", PerfCountersBuilder::PRIO_INTERESTING);
   b.add_time_avg(l_bluestore_kv_commit_lat, "kv_commit_lat",
 		 "Average kv_thread commit latency",
 		 "kcol", PerfCountersBuilder::PRIO_USEFUL);
@@ -4939,94 +5024,79 @@ void BlueStore::_init_logger()
   b.add_time_avg(l_bluestore_kv_final_lat, "kv_final_lat",
 		 "Average kv_finalize thread latency",
 		 "kfll", PerfCountersBuilder::PRIO_INTERESTING);
-  b.add_time_avg(l_bluestore_state_prepare_lat, "state_prepare_lat",
-    "Average prepare state latency",
-    "sprl", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_state_aio_wait_lat, "state_aio_wait_lat",
-		 "Average aio_wait state latency",
-		 "sawl", PerfCountersBuilder::PRIO_INTERESTING);
-  b.add_time_avg(l_bluestore_state_io_done_lat, "state_io_done_lat",
-    "Average io_done state latency",
-    "sidl", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_state_kv_queued_lat, "state_kv_queued_lat",
-    "Average kv_queued state latency",
-    "skql", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_state_kv_committing_lat, "state_kv_commiting_lat",
-    "Average kv_commiting state latency",
-    "skcl", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_state_kv_done_lat, "state_kv_done_lat",
-    "Average kv_done state latency",
-    "skdl", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_state_deferred_queued_lat, "state_deferred_queued_lat",
-    "Average deferred_queued state latency",
-    "sdql", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_state_deferred_aio_wait_lat, "state_deferred_aio_wait_lat",
-    "Average aio_wait state latency",
-    "sdal", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_state_deferred_cleanup_lat, "state_deferred_cleanup_lat",
-    "Average cleanup state latency",
-    "sdcl", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_state_finishing_lat, "state_finishing_lat",
-    "Average finishing state latency",
-    "sfnl", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_state_done_lat, "state_done_lat",
-    "Average done state latency",
-    "sdnl", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_throttle_lat, "throttle_lat",
-		 "Average submit throttle latency",
-		 "th_l", PerfCountersBuilder::PRIO_CRITICAL);
-  b.add_time_avg(l_bluestore_submit_lat, "submit_lat",
-		 "Average submit latency",
-		 "s_l", PerfCountersBuilder::PRIO_CRITICAL);
-  b.add_time_avg(l_bluestore_commit_lat, "commit_lat",
-		 "Average commit latency",
-		 "c_l", PerfCountersBuilder::PRIO_CRITICAL);
-  b.add_time_avg(l_bluestore_read_lat, "read_lat",
-		 "Average read latency",
-		 "r_l", PerfCountersBuilder::PRIO_CRITICAL);
-  b.add_time_avg(l_bluestore_read_onode_meta_lat, "read_onode_meta_lat",
-    "Average read onode metadata latency",
-    "roml", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_read_wait_aio_lat, "read_wait_aio_lat",
-    "Average read latency",
-    "rwal", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_compress_lat, "compress_lat",
-    "Average compress latency",
-    "_cpl", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_decompress_lat, "decompress_lat",
-    "Average decompress latency",
-    "dcpl", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_time_avg(l_bluestore_csum_lat, "csum_lat",
-    "Average checksum latency",
-    "csml", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_u64_counter(l_bluestore_compress_success_count, "compress_success_count",
-    "Sum for beneficial compress ops");
-  b.add_u64_counter(l_bluestore_compress_rejected_count, "compress_rejected_count",
-    "Sum for compress ops rejected due to low net gain of space");
+  //****************************************
+
+  // write op stats
+  //****************************************
+  b.add_u64_counter(l_bluestore_write_big, "write_big",
+		    "Large aligned writes into fresh blobs");
+  b.add_u64_counter(l_bluestore_write_big_bytes, "write_big_bytes",
+		    "Large aligned writes into fresh blobs (bytes)", NULL, 0, unit_t(UNIT_BYTES));
+  b.add_u64_counter(l_bluestore_write_big_blobs, "write_big_blobs",
+		    "Large aligned writes into fresh blobs (blobs)");
+  b.add_u64_counter(l_bluestore_write_big_deferred,
+		    "write_big_deferred",
+		    "Big overwrites using deferred");
+
+  b.add_u64_counter(l_bluestore_write_small, "write_small",
+		    "Small writes into existing or sparse small blobs");
+  b.add_u64_counter(l_bluestore_write_small_bytes, "write_small_bytes",
+		    "Small writes into existing or sparse small blobs (bytes)", NULL, 0, unit_t(UNIT_BYTES));
+  b.add_u64_counter(l_bluestore_write_small_unused,
+		    "write_small_unused",
+		    "Small writes into unused portion of existing blob");
+  b.add_u64_counter(l_bluestore_write_small_pre_read,
+		    "write_small_pre_read",
+		    "Small writes that required we read some data (possibly "
+		    "cached) to fill out the block");
+
   b.add_u64_counter(l_bluestore_write_pad_bytes, "write_pad_bytes",
-		    "Sum for write-op padded bytes", NULL, 0, unit_t(UNIT_BYTES));
-  b.add_u64_counter(l_bluestore_deferred_write_ops, "deferred_write_ops",
-		    "Sum for deferred write op");
-  b.add_u64_counter(l_bluestore_deferred_write_bytes, "deferred_write_bytes",
-		    "Sum for deferred write bytes", "def", 0, unit_t(UNIT_BYTES));
+    "Sum for write-op padded bytes", NULL, 0, unit_t(UNIT_BYTES));
   b.add_u64_counter(l_bluestore_write_penalty_read_ops, "write_penalty_read_ops",
-		    "Sum for write penalty read ops");
-  b.add_u64(l_bluestore_allocated, "bluestore_allocated",
-    "Sum for allocated bytes");
-  b.add_u64(l_bluestore_stored, "bluestore_stored",
-    "Sum for stored bytes");
-  b.add_u64(l_bluestore_compressed, "bluestore_compressed",
-    "Sum for stored compressed bytes",
-    "c", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
-  b.add_u64(l_bluestore_compressed_allocated, "bluestore_compressed_allocated",
-    "Sum for bytes allocated for compressed data",
-    "c_a", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
-  b.add_u64(l_bluestore_compressed_original, "bluestore_compressed_original",
-    "Sum for original bytes that were compressed",
-    "c_o", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
-  b.add_u64(l_bluestore_onodes, "bluestore_onodes",
+    "Sum for write penalty read ops");
+  b.add_u64_counter(l_bluestore_write_new, "write_new",
+    "Write into new blob");
+
+  b.add_u64_counter(l_bluestore_write_deferred,
+		    "write_deferred",
+		    "Total deferred writes submitted");
+  b.add_u64_counter(l_bluestore_write_deferred_bytes,
+		    "write_deferred_bytes",
+		    "Total bytes submitted as deferred writes");
+  b.add_u64_counter(l_bluestore_deferred_write_ops, "write_deferred_ops",
+		    "Sum for deferred write op");
+  b.add_u64_counter(l_bluestore_deferred_write_bytes, "write_deferred_bytes",
+		    "Sum for deferred write bytes", "def", 0, unit_t(UNIT_BYTES));
+  //****************************************
+
+  // compressions stats
+  //****************************************
+  b.add_u64(l_bluestore_compressed, "compressed",
+	    "Sum for stored compressed bytes",
+	    "c", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
+  b.add_u64(l_bluestore_compressed_allocated, "compressed_allocated",
+	    "Sum for bytes allocated for compressed data",
+	    "c_a", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
+  b.add_u64(l_bluestore_compressed_original, "compressed_original",
+	    "Sum for original bytes that were compressed",
+	    "c_o", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
+  b.add_time_avg(l_bluestore_compress_lat, "compress_lat",
+	    "Average compress latency",
+	    "_cpl", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_time_avg(l_bluestore_decompress_lat, "decompress_lat",
+	    "Average decompress latency",
+	    "dcpl", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_u64_counter(l_bluestore_compress_success_count, "compress_success_count",
+	    "Sum for beneficial compress ops");
+  b.add_u64_counter(l_bluestore_compress_rejected_count, "compress_rejected_count",
+	    "Sum for compress ops rejected due to low net gain of space");
+  //****************************************
+
+  // onode cache stats
+  //****************************************
+  b.add_u64(l_bluestore_onodes, "onodes",
 	    "Number of onodes in cache");
-  b.add_u64(l_bluestore_pinned_onodes, "bluestore_pinned_onodes",
+  b.add_u64(l_bluestore_pinned_onodes, "onodes_pinned",
             "Number of pinned onodes in cache");
   b.add_u64_counter(l_bluestore_onode_hits, "bluestore_onode_hits",
 		    "Count of onode cache lookup hits",
@@ -5035,69 +5105,43 @@ void BlueStore::_init_logger()
 		    "Count of onode cache lookup misses",
 		    "o_ms", PerfCountersBuilder::PRIO_USEFUL);
   b.add_u64_counter(l_bluestore_onode_shard_hits, "bluestore_onode_shard_hits",
-		    "Sum for onode-shard lookups hit in the cache");
+		    "Count of onode shard cache lookups hits");
   b.add_u64_counter(l_bluestore_onode_shard_misses,
-		    "bluestore_onode_shard_misses",
-		    "Sum for onode-shard lookups missed in the cache");
-  b.add_u64(l_bluestore_extents, "bluestore_extents",
+		    "onode_shard_misses",
+		    "Count of onode shard cache lookups misses");
+  b.add_u64(l_bluestore_extents, "onode_extents",
 	    "Number of extents in cache");
-  b.add_u64(l_bluestore_blobs, "bluestore_blobs",
+  b.add_u64(l_bluestore_blobs, "onode_blobs",
 	    "Number of blobs in cache");
-  b.add_u64(l_bluestore_buffers, "bluestore_buffers",
+  //****************************************
+
+  // buffer cache stats
+  //****************************************
+  b.add_u64(l_bluestore_buffers, "buffers",
 	    "Number of buffers in cache");
-  b.add_u64(l_bluestore_buffer_bytes, "bluestore_buffer_bytes",
+  b.add_u64(l_bluestore_buffer_bytes, "buffer_bytes",
 	    "Number of buffer bytes in cache", NULL, 0, unit_t(UNIT_BYTES));
-  b.add_u64_counter(l_bluestore_buffer_hit_bytes, "bluestore_buffer_hit_bytes",
+  b.add_u64_counter(l_bluestore_buffer_hit_bytes, "buffer_hit_bytes",
 	    "Sum for bytes of read hit in the cache", NULL, 0, unit_t(UNIT_BYTES));
-  b.add_u64_counter(l_bluestore_buffer_miss_bytes, "bluestore_buffer_miss_bytes",
+  b.add_u64_counter(l_bluestore_buffer_miss_bytes, "buffer_miss_bytes",
 	    "Sum for bytes of read missed in the cache", NULL, 0, unit_t(UNIT_BYTES));
+  //****************************************
 
-  b.add_u64_counter(l_bluestore_write_big, "bluestore_write_big",
-		    "Large aligned writes into fresh blobs");
-  b.add_u64_counter(l_bluestore_write_big_bytes, "bluestore_write_big_bytes",
-		    "Large aligned writes into fresh blobs (bytes)", NULL, 0, unit_t(UNIT_BYTES));
-  b.add_u64_counter(l_bluestore_write_big_blobs, "bluestore_write_big_blobs",
-		    "Large aligned writes into fresh blobs (blobs)");
-  b.add_u64_counter(l_bluestore_write_big_deferred,
-		    "bluestore_write_big_deferred",
-		    "Big overwrites using deferred");
-  b.add_u64_counter(l_bluestore_write_small, "bluestore_write_small",
-		    "Small writes into existing or sparse small blobs");
-  b.add_u64_counter(l_bluestore_write_small_bytes, "bluestore_write_small_bytes",
-		    "Small writes into existing or sparse small blobs (bytes)", NULL, 0, unit_t(UNIT_BYTES));
-  b.add_u64_counter(l_bluestore_write_small_unused,
-		    "bluestore_write_small_unused",
-		    "Small writes into unused portion of existing blob");
-  b.add_u64_counter(l_bluestore_write_deferred,
-		    "bluestore_write_deferred",
-		    "Total deferred writes submitted");
-  b.add_u64_counter(l_bluestore_write_deferred_bytes,
-		    "bluestore_write_deferred_bytes",
-		    "Total bytes submitted as deferred writes");
-  b.add_u64_counter(l_bluestore_write_small_pre_read,
-		    "bluestore_write_small_pre_read",
-		    "Small writes that required we read some data (possibly "
-		    "cached) to fill out the block");
-  b.add_u64_counter(l_bluestore_write_new, "bluestore_write_new",
-		    "Write into new blob");
-
-  b.add_u64_counter(l_bluestore_txc, "bluestore_txc", "Transactions committed");
-  b.add_u64_counter(l_bluestore_onode_reshard, "bluestore_onode_reshard",
+  // internal stats
+  //****************************************
+  b.add_u64_counter(l_bluestore_onode_reshard, "onode_reshard",
 		    "Onode extent map reshard events");
-  b.add_u64_counter(l_bluestore_blob_split, "bluestore_blob_split",
+  b.add_u64_counter(l_bluestore_blob_split, "blob_split",
 		    "Sum for blob splitting due to resharding");
-  b.add_u64_counter(l_bluestore_extent_compress, "bluestore_extent_compress",
+  b.add_u64_counter(l_bluestore_extent_compress, "extent_compress",
 		    "Sum for extents that have been removed due to compression");
-  b.add_u64_counter(l_bluestore_gc_merged, "bluestore_gc_merged",
+  b.add_u64_counter(l_bluestore_gc_merged, "gc_merged",
 		    "Sum for extents that have been merged due to garbage "
 		    "collection");
-  b.add_u64_counter(l_bluestore_read_eio, "bluestore_read_eio",
-                    "Read EIO errors propagated to high level callers");
-  b.add_u64_counter(l_bluestore_reads_with_retries, "bluestore_reads_with_retries",
-                    "Read operations that required at least one retry due to failed checksum validation",
-		    "rd_r", PerfCountersBuilder::PRIO_USEFUL);
-  b.add_u64(l_bluestore_fragmentation, "bluestore_fragmentation_micros",
-            "How fragmented bluestore free space is (free extents / max possible number of free extents) * 1000");
+  //****************************************
+
+  // other client ops latencies
+  //****************************************
   b.add_time_avg(l_bluestore_omap_seek_to_first_lat, "omap_seek_to_first_lat",
     "Average omap iterator seek_to_first call latency",
     "osfl", PerfCountersBuilder::PRIO_USEFUL);
@@ -5122,6 +5166,7 @@ void BlueStore::_init_logger()
   b.add_time_avg(l_bluestore_remove_lat, "remove_lat",
     "Average removal latency",
     "rm_l", PerfCountersBuilder::PRIO_USEFUL);
+  //****************************************
 
   // Resulting size axis configuration for op histograms, values are in bytes
   PerfHistogramCommon::axis_config_d alloc_hist_x_axis_config{

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -136,10 +136,10 @@ enum {
   l_bluestore_write_penalty_read_ops,
   l_bluestore_write_new,
 
-  l_bluestore_write_deferred,
-  l_bluestore_write_deferred_bytes,
-  l_bluestore_deferred_write_ops,
-  l_bluestore_deferred_write_bytes,
+  l_bluestore_issued_deferred_writes,
+  l_bluestore_issued_deferred_write_bytes,
+  l_bluestore_submitted_deferred_writes,
+  l_bluestore_submitted_deferred_write_bytes,
   //****************************************
 
   // compressions stats

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -70,41 +70,91 @@ class BlueStoreRepairer;
 
 enum {
   l_bluestore_first = 732430,
-  l_bluestore_kv_flush_lat,
-  l_bluestore_kv_commit_lat,
-  l_bluestore_kv_sync_lat,
-  l_bluestore_kv_final_lat,
+  // space utilization stats
+  //****************************************
+  l_bluestore_allocated,
+  l_bluestore_stored,
+  l_bluestore_fragmentation,
+  //****************************************
+
+  // Update op processing state latencies
+  //****************************************
   l_bluestore_state_prepare_lat,
   l_bluestore_state_aio_wait_lat,
   l_bluestore_state_io_done_lat,
   l_bluestore_state_kv_queued_lat,
   l_bluestore_state_kv_committing_lat,
   l_bluestore_state_kv_done_lat,
+  l_bluestore_state_finishing_lat,
+  l_bluestore_state_done_lat,
+
   l_bluestore_state_deferred_queued_lat,
   l_bluestore_state_deferred_aio_wait_lat,
   l_bluestore_state_deferred_cleanup_lat,
-  l_bluestore_state_finishing_lat,
-  l_bluestore_state_done_lat,
+
+  l_bluestore_commit_lat,
+  //****************************************
+
+  // Update Transaction stats
+  //****************************************
   l_bluestore_throttle_lat,
   l_bluestore_submit_lat,
-  l_bluestore_commit_lat,
-  l_bluestore_read_lat,
+  l_bluestore_txc,
+  //****************************************
+
+  // Read op stats
+  //****************************************
   l_bluestore_read_onode_meta_lat,
   l_bluestore_read_wait_aio_lat,
-  l_bluestore_compress_lat,
-  l_bluestore_decompress_lat,
   l_bluestore_csum_lat,
-  l_bluestore_compress_success_count,
-  l_bluestore_compress_rejected_count,
+  l_bluestore_read_eio,
+  l_bluestore_reads_with_retries,
+  l_bluestore_read_lat,
+  //****************************************
+
+  // kv_thread latencies
+  //****************************************
+  l_bluestore_kv_flush_lat,
+  l_bluestore_kv_commit_lat,
+  l_bluestore_kv_sync_lat,
+  l_bluestore_kv_final_lat,
+  //****************************************
+
+  // write op stats
+  //****************************************
+  l_bluestore_write_big,
+  l_bluestore_write_big_bytes,
+  l_bluestore_write_big_blobs,
+  l_bluestore_write_big_deferred,
+
+  l_bluestore_write_small,
+  l_bluestore_write_small_bytes,
+  l_bluestore_write_small_unused,
+  l_bluestore_write_small_pre_read,
+
   l_bluestore_write_pad_bytes,
+  l_bluestore_write_penalty_read_ops,
+  l_bluestore_write_new,
+
+  l_bluestore_write_deferred,
+  l_bluestore_write_deferred_bytes,
   l_bluestore_deferred_write_ops,
   l_bluestore_deferred_write_bytes,
-  l_bluestore_write_penalty_read_ops,
-  l_bluestore_allocated,
-  l_bluestore_stored,
+  //****************************************
+
+  // compressions stats
+  //****************************************
   l_bluestore_compressed,
   l_bluestore_compressed_allocated,
   l_bluestore_compressed_original,
+  l_bluestore_compress_lat,
+  l_bluestore_decompress_lat,
+  l_bluestore_compress_success_count,
+  l_bluestore_compress_rejected_count,
+  //****************************************
+
+  // onode cache stats
+  //****************************************
   l_bluestore_onodes,
   l_bluestore_pinned_onodes,
   l_bluestore_onode_hits,
@@ -113,29 +163,26 @@ enum {
   l_bluestore_onode_shard_misses,
   l_bluestore_extents,
   l_bluestore_blobs,
+  //****************************************
+
+  // buffer cache stats
+  //****************************************
   l_bluestore_buffers,
   l_bluestore_buffer_bytes,
   l_bluestore_buffer_hit_bytes,
   l_bluestore_buffer_miss_bytes,
-  l_bluestore_write_big,
-  l_bluestore_write_big_bytes,
-  l_bluestore_write_big_blobs,
-  l_bluestore_write_big_deferred,
-  l_bluestore_write_small,
-  l_bluestore_write_small_bytes,
-  l_bluestore_write_small_unused,
-  l_bluestore_write_deferred,
-  l_bluestore_write_deferred_bytes,
-  l_bluestore_write_small_pre_read,
-  l_bluestore_write_new,
-  l_bluestore_txc,
+  //****************************************
+
+  // internal stats
+  //****************************************
   l_bluestore_onode_reshard,
   l_bluestore_blob_split,
   l_bluestore_extent_compress,
   l_bluestore_gc_merged,
-  l_bluestore_read_eio,
-  l_bluestore_reads_with_retries,
-  l_bluestore_fragmentation,
+  //****************************************
+
+  // other client ops latencies
+  //****************************************
   l_bluestore_omap_seek_to_first_lat,
   l_bluestore_omap_upper_bound_lat,
   l_bluestore_omap_lower_bound_lat,
@@ -144,7 +191,12 @@ enum {
   l_bluestore_omap_get_values_lat,
   l_bluestore_clist_lat,
   l_bluestore_remove_lat,
+  //****************************************
+
+  // allocation stats
+  //****************************************
   l_bluestore_allocate_hist,
+  //****************************************
   l_bluestore_last
 };
 

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -7510,8 +7510,8 @@ TEST_P(StoreTestSpecificAUSize, DeferredOnBigOverwrite) {
   sleep(2);
   ASSERT_EQ(logger->get(l_bluestore_write_big), 1u);
   ASSERT_EQ(logger->get(l_bluestore_write_big_deferred), 1u);
-  ASSERT_EQ(logger->get(l_bluestore_write_deferred), 1u);
-  ASSERT_EQ(logger->get(l_bluestore_write_deferred_bytes), block_size);
+  ASSERT_EQ(logger->get(l_bluestore_issued_deferred_writes), 1u);
+  ASSERT_EQ(logger->get(l_bluestore_issued_deferred_write_bytes), block_size);
 
   {
     struct store_statfs_t statfs;
@@ -7574,8 +7574,8 @@ TEST_P(StoreTestSpecificAUSize, DeferredOnBigOverwrite2) {
     ASSERT_EQ(logger->get(l_bluestore_write_big_bytes), bl.length());
     ASSERT_EQ(logger->get(l_bluestore_write_big_blobs), 3u);
     ASSERT_EQ(logger->get(l_bluestore_write_big_deferred), 0u);
-    ASSERT_EQ(logger->get(l_bluestore_write_deferred), 0u);
-    ASSERT_EQ(logger->get(l_bluestore_write_deferred_bytes), 0);
+    ASSERT_EQ(logger->get(l_bluestore_issued_deferred_writes), 0u);
+    ASSERT_EQ(logger->get(l_bluestore_issued_deferred_write_bytes), 0);
   }
 
   logger->reset();
@@ -7593,8 +7593,8 @@ TEST_P(StoreTestSpecificAUSize, DeferredOnBigOverwrite2) {
     ASSERT_EQ(logger->get(l_bluestore_write_big_bytes), bl.length());
     ASSERT_EQ(logger->get(l_bluestore_write_big_blobs), 3u);
     ASSERT_EQ(logger->get(l_bluestore_write_big_deferred), 1u);
-    ASSERT_EQ(logger->get(l_bluestore_write_deferred), 1u);
-    ASSERT_EQ(logger->get(l_bluestore_write_deferred_bytes), 57344);
+    ASSERT_EQ(logger->get(l_bluestore_issued_deferred_writes), 1u);
+    ASSERT_EQ(logger->get(l_bluestore_issued_deferred_write_bytes), 57344);
   }
 
   {
@@ -7653,8 +7653,8 @@ TEST_P(StoreTestSpecificAUSize, DeferredOnBigOverwrite3) {
     ASSERT_EQ(logger->get(l_bluestore_write_big_bytes), bl.length());
     ASSERT_EQ(logger->get(l_bluestore_write_big_blobs), 64u);
     ASSERT_EQ(logger->get(l_bluestore_write_big_deferred), 0u);
-    ASSERT_EQ(logger->get(l_bluestore_write_deferred), 0u);
-    ASSERT_EQ(logger->get(l_bluestore_write_deferred_bytes), 0u);
+    ASSERT_EQ(logger->get(l_bluestore_issued_deferred_writes), 0u);
+    ASSERT_EQ(logger->get(l_bluestore_issued_deferred_write_bytes), 0u);
   }
   logger->reset();
   {
@@ -7671,8 +7671,8 @@ TEST_P(StoreTestSpecificAUSize, DeferredOnBigOverwrite3) {
     ASSERT_EQ(logger->get(l_bluestore_write_big_bytes), bl.length());
     ASSERT_EQ(logger->get(l_bluestore_write_big_blobs), 65u);
     ASSERT_EQ(logger->get(l_bluestore_write_big_deferred), 1u);
-    ASSERT_EQ(logger->get(l_bluestore_write_deferred), 1u);
-    ASSERT_EQ(logger->get(l_bluestore_write_deferred_bytes), 61440);
+    ASSERT_EQ(logger->get(l_bluestore_issued_deferred_writes), 1u);
+    ASSERT_EQ(logger->get(l_bluestore_issued_deferred_write_bytes), 61440);
   }
   {
     ObjectStore::Transaction t;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
