### PR TITLE
crimson/os/seastore: resolve clang build problems, misc cleanups

### DIFF
--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -104,7 +104,7 @@ public:
     CollectionRef c,
     const ghobject_t& oid) = 0;
 
-  using omap_values_t = std::map<std::string, bufferlist, std::less<>>;
+  using omap_values_t = std::map<std::string, ceph::bufferlist, std::less<>>;
   using omap_keys_t = std::set<std::string>;
   virtual read_errorator::future<omap_values_t> omap_get_values(
     CollectionRef c,

--- a/src/crimson/os/seastore/logging.h
+++ b/src/crimson/os/seastore/logging.h
@@ -12,8 +12,8 @@
 
 #ifdef NDEBUG
 
-#define LOG(level_, MSG, ...) LOGGER.log(level_, "{}: " MSG, FNAME __VA_OPT__(,) __VA_ARGS__)
-#define LOGT(level_, MSG, t, ...) LOGGER.log(level_, "{}({}): " MSG, FNAME, (void*)&t __VA_OPT__(,) __VA_ARGS__)
+#define LOG(level_, MSG, ...) LOGGER.log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
+#define LOGT(level_, MSG, t, ...) LOGGER.log(level_, "{}({}): " MSG, FNAME, (void*)&t , ##__VA_ARGS__)
 
 #define TRACE(...) LOG(seastar::log_level::trace, __VA_ARGS__)
 #define TRACET(...) LOGT(seastar::log_level::trace, __VA_ARGS__)
@@ -37,18 +37,18 @@ template<seastar::log_level lv>
 void LOG(std::string_view info) {
   crimson::get_logger(ceph_subsys_seastore).log(lv, info.data());
 }
-#define TRACE(MSG_, ...) LOG<seastar::log_level::trace>("{}: " MSG_ ## _format(FNAME __VA_OPT__(,) __VA_ARGS__))
-#define TRACET(MSG_, t_, ...) LOG<seastar::log_level::trace>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ __VA_OPT__(,) __VA_ARGS__))
+#define TRACE(MSG_, ...) LOG<seastar::log_level::trace>("{}: " MSG_ ## _format(FNAME , ##__VA_ARGS__))
+#define TRACET(MSG_, t_, ...) LOG<seastar::log_level::trace>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ , ##__VA_ARGS__))
 
-#define DEBUG(MSG_, ...) LOG<seastar::log_level::debug>("{}: " MSG_ ## _format(FNAME __VA_OPT__(,) __VA_ARGS__))
-#define DEBUGT(MSG_, t_, ...) LOG<seastar::log_level::debug>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ __VA_OPT__(,) __VA_ARGS__))
+#define DEBUG(MSG_, ...) LOG<seastar::log_level::debug>("{}: " MSG_ ## _format(FNAME , ##__VA_ARGS__))
+#define DEBUGT(MSG_, t_, ...) LOG<seastar::log_level::debug>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ , ##__VA_ARGS__))
 
-#define INFO(MSG_, ...) LOG<seastar::log_level::info>("{}: " MSG_ ## _format(FNAME __VA_OPT__(,) __VA_ARGS__))
-#define INFOT(MSG_, t_, ...) LOG<seastar::log_level::info>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ __VA_OPT__(,) __VA_ARGS__))
+#define INFO(MSG_, ...) LOG<seastar::log_level::info>("{}: " MSG_ ## _format(FNAME , ##__VA_ARGS__))
+#define INFOT(MSG_, t_, ...) LOG<seastar::log_level::info>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ , ##__VA_ARGS__))
 
-#define WARN(MSG_, ...) LOG<seastar::log_level::warn>("{}: " MSG_ ## _format(FNAME __VA_OPT__(,) __VA_ARGS__))
-#define WARNT(MSG_, t_, ...) LOG<seastar::log_level::warn>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ __VA_OPT__(,) __VA_ARGS__))
+#define WARN(MSG_, ...) LOG<seastar::log_level::warn>("{}: " MSG_ ## _format(FNAME , ##__VA_ARGS__))
+#define WARNT(MSG_, t_, ...) LOG<seastar::log_level::warn>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ , ##__VA_ARGS__))
 
-#define ERROR(MSG_, ...) LOG<seastar::log_level::error>("{}: " MSG_ ## _format(FNAME __VA_OPT__(,) __VA_ARGS__))
-#define ERRORT(MSG_, t_, ...) LOG<seastar::log_level::error>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ __VA_OPT__(,) __VA_ARGS__))
+#define ERROR(MSG_, ...) LOG<seastar::log_level::error>("{}: " MSG_ ## _format(FNAME , ##__VA_ARGS__))
+#define ERRORT(MSG_, t_, ...) LOG<seastar::log_level::error>("{}({}): " MSG_ ## _format(FNAME, (void*)&t_ , ##__VA_ARGS__))
 #endif

--- a/src/crimson/os/seastore/omap_manager.h
+++ b/src/crimson/os/seastore/omap_manager.h
@@ -143,7 +143,7 @@ public:
     }
   };
   using omap_list_ertr = base_ertr;
-  using omap_list_bare_ret = std::pair<
+  using omap_list_bare_ret = std::tuple<
     bool,
     std::map<std::string, bufferlist, std::less<>>>;
   using omap_list_ret = omap_list_ertr::future<omap_list_bare_ret>;

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -207,8 +207,8 @@ OMapInnerNode::list(
     iter_cend(),
     list_bare_ret(false, {}),
     [=, &start](auto &biter, auto &eiter, auto &ret) {
-      auto &complete = ret.first;
-      auto &result = ret.second;
+      auto &complete = std::get<0>(ret);
+      auto &result = std::get<1>(ret);
       return crimson::do_until(
 	[&, config, oc, this]() -> list_ertr::future<bool> {
 	  if (biter == eiter  || result.size() == config.max_result_size) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -300,7 +300,8 @@ class TreeBuilder {
     return tree->insert(
         t, p_kv->key, {p_kv->value.get_payload_size()}
     ).safe_then([&t, this, p_kv](auto ret) {
-      auto& [cursor, success] = ret;
+      auto success = ret.second;
+      auto cursor = std::move(ret.first);
       initialize_cursor_from_item(t, p_kv->key, p_kv->value, cursor, success);
 #ifndef NDEBUG
       validate_cursor_from_item(p_kv->key, p_kv->value, cursor);

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -195,6 +195,22 @@ private:
       });
   }
 
+  using _omap_get_value_ertr = OMapManager::base_ertr::extend<
+    crimson::ct_error::enodata
+    >;
+  using _omap_get_value_ret = _omap_get_value_ertr::future<ceph::bufferlist>;
+  _omap_get_value_ret _omap_get_value(
+    Transaction &t,
+    omap_root_t &&root,
+    std::string_view key) const;
+
+  using _omap_get_values_ertr = OMapManager::base_ertr;
+  using _omap_get_values_ret = _omap_get_values_ertr::future<omap_values_t>;
+  _omap_get_values_ret _omap_get_values(
+    Transaction &t,
+    omap_root_t &&root,
+    const omap_keys_t &keys) const;
+
   using _omap_list_bare_ret = OMapManager::omap_list_bare_ret;
   using _omap_list_ret = OMapManager::omap_list_ret;
   _omap_list_ret _omap_list(

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -195,16 +195,19 @@ private:
       });
   }
 
+  using _omap_list_bare_ret = OMapManager::omap_list_bare_ret;
+  using _omap_list_ret = OMapManager::omap_list_ret;
+  _omap_list_ret _omap_list(
+    const omap_root_le_t& omap_root,
+    Transaction& t,
+    const std::optional<std::string>& start,
+    OMapManager::omap_list_config_t config) const;
+
   friend class SeaStoreOmapIterator;
   omap_get_values_ret_t omap_list(
     CollectionRef ch,
     const ghobject_t &oid,
     const std::optional<string> &_start,
-    OMapManager::omap_list_config_t config);
-  OMapManager::omap_list_ret _omap_list(
-    const omap_root_le_t& omap_root,
-    Transaction& t,
-    const std::optional<std::string>& start,
     OMapManager::omap_list_config_t config);
 
   SegmentManagerRef segment_manager;

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -195,7 +195,6 @@ private:
       });
   }
 
-
   friend class SeaStoreOmapIterator;
   omap_get_values_ret_t omap_list(
     CollectionRef ch,

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -171,35 +171,6 @@ private:
   auto repeat_with_onode(
     CollectionRef ch,
     const ghobject_t &oid,
-    F &&f) {
-    return seastar::do_with(
-      oid,
-      Ret{},
-      TransactionRef(),
-      OnodeRef(),
-      std::forward<F>(f),
-      [=](auto &oid, auto &ret, auto &t, auto &onode, auto &f) {
-	return repeat_eagain([&, this] {
-	  t = transaction_manager->create_transaction();
-	  return onode_manager->get_onode(
-	    *t, oid
-	  ).safe_then([&](auto onode_ret) {
-	    onode = std::move(onode_ret);
-	    return f(*t, *onode);
-	  }).safe_then([&ret](auto _ret) {
-	    ret = _ret;
-	  });
-	}).safe_then([&ret] {
-	  return seastar::make_ready_future<Ret>(ret);
-	});
-      });
-  }
-
-
-  template <typename Ret, typename F>
-  auto repeat_with_onode(
-    CollectionRef ch,
-    const ghobject_t &oid,
     F &&f) const {
     return seastar::do_with(
       oid,

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -146,7 +146,7 @@ protected:
   }
 };
 
-class TestSegmentManagerWrapper : public SegmentManager {
+class TestSegmentManagerWrapper final : public SegmentManager {
   SegmentManager &sm;
 public:
   TestSegmentManagerWrapper(SegmentManager &sm) : sm(sm) {}

--- a/src/test/crimson/test_backfill.cc
+++ b/src/test/crimson/test_backfill.cc
@@ -448,7 +448,8 @@ namespace StoreRandomizer {
   FakeStore mutate(const FakeStore& source_store) {
     FakeStore mutated_store;
     source_store.list(hobject_t{}, [&] (const auto& kv) {
-      const auto& [ oid, version ] = kv;
+      const auto &oid = kv.first;
+      const auto &version = kv.second;
       execute_random(
         []  { /* just drop the entry */ },
         [&] { mutated_store.push(oid, version); },


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
