### PR TITLE
doc/radosgw: modernize reference to rgw_max_chunk_size

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -52,6 +52,7 @@ instances or all radosgw-admin options can be put into the ``[global]`` or the
 .. confval:: rgw_user_default_quota_max_objects
 .. confval:: rgw_user_default_quota_max_size
 .. confval:: rgw_verify_ssl
+.. confval:: rgw_max_chunk_size
 
 Lifecycle Settings
 ==================

--- a/doc/radosgw/layout.rst
+++ b/doc/radosgw/layout.rst
@@ -103,7 +103,7 @@ is controlled by a 'policy' setting.[3]
 An RGW object may consist of several RADOS objects, the first of which
 is the head that contains the metadata, such as manifest, ACLs, content type,
 ETag, and user-defined metadata. The metadata is stored in xattrs.
-The head may also contain up to 512 kilobytes of object data, for efficiency
+The head may also contain up to :confval:`rgw_max_chunk_size` of object data, for efficiency
 and atomicity. The manifest describes how each object is laid out in RADOS
 objects.
 


### PR DESCRIPTION
The value changed from 512KB to 4MB in Kraken.

Signed-off-by: Anthony D'Atri anthony.datri@gmail.com

