### PR TITLE
[mgr/dashboard]: cephfs MDS Workload to use rate for counter type metric

### DIFF
--- a/monitoring/grafana/dashboards/cephfs-overview.json
+++ b/monitoring/grafana/dashboards/cephfs-overview.json
@@ -89,14 +89,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(ceph_objecter_op_r{ceph_daemon=~\"($mds_servers).*\"})",
+          "expr": "sum(rate(ceph_objecter_op_r{ceph_daemon=~\"($mds_servers).*\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Read Ops",
           "refId": "A"
         },
         {
-          "expr": "sum(ceph_objecter_op_w{ceph_daemon=~\"($mds_servers).*\"})",
+          "expr": "sum(rate(ceph_objecter_op_w{ceph_daemon=~\"($mds_servers).*\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Write Ops",


### PR DESCRIPTION
current MDS Workload dashboard graph still increases, because the metric is of type counter, but the prometheus query
does not use `rate(...[1m])`

after this modification, increased could could be seen as spike/mountain and not only increasing line.

no related bug/issue was found for this

