### PR TITLE
mgr/volumes: Re-introduce subvolumegroup snapshots

### DIFF
--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -110,8 +110,12 @@ List subvolume groups using::
 
     $ ceph fs subvolumegroup ls <vol_name>
 
-.. note:: Subvolume group snapshot feature is no longer supported in mainline CephFS (existing group
-          snapshots can still be listed and deleted)
+Create a snapshot (see :doc:`/cephfs/experimental-features`) of a
+subvolume group using::
+
+    $ ceph fs subvolumegroup snapshot create <vol_name> <group_name> <snap_name>
+
+This implicitly snapshots all the subvolumes under the subvolume group.
 
 Remove a snapshot of a subvolume group using::
 

--- a/src/pybind/mgr/volumes/fs/operations/group.py
+++ b/src/pybind/mgr/volumes/fs/operations/group.py
@@ -8,7 +8,7 @@ import cephfs
 from .snapshot_util import mksnap, rmsnap
 from .pin_util import pin
 from .template import GroupTemplate
-from ..fs_util import listdir, listsnaps, get_ancestor_xattr
+from ..fs_util import listdir, listsnaps, get_ancestor_xattr, list_subvolgroup_snapshot_subvols
 from ..exception import VolumeException
 
 log = logging.getLogger(__name__)
@@ -82,6 +82,17 @@ class Group(GroupTemplate):
             dirpath = os.path.join(self.path,
                                    self.vol_spec.snapshot_dir_prefix.encode('utf-8'))
             return listsnaps(self.fs, self.vol_spec, dirpath, filter_inherited_snaps=True)
+        except VolumeException as ve:
+            if ve.errno == -errno.ENOENT:
+                return []
+            raise
+
+    def list_snapshot_subvolumes(self, snapname):
+        try:
+            snappath = os.path.join(self.path,
+                                    self.vol_spec.snapshot_dir_prefix.encode('utf-8'),
+                                    snapname.encode('utf-8'))
+            return list_subvolgroup_snapshot_subvols(self.fs, self.vol_spec, snappath)
         except VolumeException as ve:
             if ve.errno == -errno.ENOENT:
                 return []

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -681,6 +681,21 @@ class VolumeClient(CephfsClient["Module"]):
                 ret = self.volume_exception_to_retval(ve)
         return ret
 
+    def subvolume_group_snapshot_subvolume_list(self, **kwargs):
+        ret       = 0, "", ""
+        volname   = kwargs['vol_name']
+        groupname = kwargs['group_name']
+        snapname  = kwargs['snap_name']
+
+        try:
+            with open_volume(self, volname) as fs_handle:
+                with open_group(fs_handle, self.volspec, groupname) as group:
+                    subvolumes = group.list_snapshot_subvolumes(snapname)
+                    ret = 0, name_to_json(subvolumes), ""
+        except VolumeException as ve:
+            ret = self.volume_exception_to_retval(ve)
+        return ret
+
     def list_subvolume_group_snapshots(self, **kwargs):
         ret       = 0, "", ""
         volname   = kwargs['vol_name']

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -652,18 +652,15 @@ class VolumeClient(CephfsClient["Module"]):
     ### group snapshot
 
     def create_subvolume_group_snapshot(self, **kwargs):
-        ret       = -errno.ENOSYS, "", "subvolume group snapshots are not supported"
+        ret       = 0, "", ""
         volname   = kwargs['vol_name']
         groupname = kwargs['group_name']
-        # snapname  = kwargs['snap_name']
+        snapname  = kwargs['snap_name']
 
         try:
             with open_volume(self, volname) as fs_handle:
                 with open_group(fs_handle, self.volspec, groupname) as group:
-                    # as subvolumes are marked with the vxattr ceph.dir.subvolume deny snapshots
-                    # at the subvolume group (see: https://tracker.ceph.com/issues/46074)
-                    # group.create_snapshot(snapname)
-                    pass
+                    group.create_snapshot(snapname)
         except VolumeException as ve:
             ret = self.volume_exception_to_retval(ve)
         return ret

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -214,6 +214,14 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'perm': 'rw'
         },
         {
+            'cmd': 'fs subvolumegroup snapshot subvolume_list '
+                   'name=vol_name,type=CephString '
+                   'name=group_name,type=CephString '
+                   'name=snap_name,type=CephString ',
+            'desc': "List subvolumes in CephFS subvolume group snapshot",
+            'perm': 'r'
+        },
+        {
             'cmd': 'fs subvolume snapshot ls '
                    'name=vol_name,type=CephString '
                    'name=sub_name,type=CephString '
@@ -542,6 +550,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                                        group_name=cmd['group_name'],
                                                        snap_name=cmd['snap_name'],
                                                        force=cmd.get('force', False))
+
+    @mgr_cmd_wrap
+    def _cmd_fs_subvolumegroup_snapshot_subvolume_list(self, inbuf, cmd):
+        return self.vc.subvolume_group_snapshot_subvolume_list(vol_name=cmd['vol_name'],
+                                                               group_name=cmd['group_name'],
+                                                               snap_name=cmd['snap_name'])
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_snapshot_ls(self, inbuf, cmd):


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/48577
Signed-off-by: Kotresh HR <khiremat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
