### PR TITLE
os/bluestore: pass string_view to ctor of Allocator

### DIFF
--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -25,8 +25,7 @@ class Allocator::SocketHook : public AdminSocketHook {
   friend class Allocator;
   std::string name;
 public:
-  explicit SocketHook(Allocator *alloc,
-                      const std::string& _name) :
+  SocketHook(Allocator *alloc, std::string_view _name) :
     alloc(alloc), name(_name)
   {
     AdminSocket *admin_socket = g_ceph_context->get_admin_socket();
@@ -106,7 +105,7 @@ public:
   }
 
 };
-Allocator::Allocator(const std::string& name,
+Allocator::Allocator(std::string_view name,
                      int64_t _capacity,
                      int64_t _block_size)
   : device_size(_capacity), block_size(_block_size)
@@ -124,8 +123,8 @@ const string& Allocator::get_name() const {
   return asok_hook->name;
 }
 
-Allocator *Allocator::create(CephContext* cct, string type,
-                             int64_t size, int64_t block_size, const std::string& name)
+Allocator *Allocator::create(CephContext* cct, std::string_view type,
+                             int64_t size, int64_t block_size, std::string_view name)
 {
   Allocator* alloc = nullptr;
   if (type == "stupid") {

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -19,9 +19,9 @@
 
 class Allocator {
 public:
-  explicit Allocator(const std::string& name,
-                     int64_t _capacity,
-                     int64_t _block_size);
+  Allocator(std::string_view name,
+	    int64_t _capacity,
+	    int64_t _block_size);
   virtual ~Allocator();
 
   /*
@@ -66,8 +66,8 @@ public:
   virtual double get_fragmentation_score();
   virtual void shutdown() = 0;
 
-  static Allocator *create(CephContext* cct, std::string type, int64_t size,
-			   int64_t block_size, const std::string& name = "");
+  static Allocator *create(CephContext* cct, std::string_view type, int64_t size,
+			   int64_t block_size, const std::string_view name = "");
 
 
   const string& get_name() const;

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -301,7 +301,7 @@ AvlAllocator::AvlAllocator(CephContext* cct,
                            int64_t device_size,
                            int64_t block_size,
                            uint64_t max_mem,
-                           const std::string& name) :
+                           std::string_view name) :
   Allocator(name, device_size, block_size),
   range_size_alloc_threshold(
     cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_threshold")),
@@ -314,7 +314,7 @@ AvlAllocator::AvlAllocator(CephContext* cct,
 AvlAllocator::AvlAllocator(CephContext* cct,
 			   int64_t device_size,
 			   int64_t block_size,
-			   const std::string& name) :
+			   std::string_view name) :
   Allocator(name, device_size, block_size),
   range_size_alloc_threshold(
     cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_threshold")),

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -65,11 +65,11 @@ protected:
   */
   AvlAllocator(CephContext* cct, int64_t device_size, int64_t block_size,
     uint64_t max_mem,
-    const std::string& name);
+    std::string_view name);
 
 public:
   AvlAllocator(CephContext* cct, int64_t device_size, int64_t block_size,
-	       const std::string& name);
+	       std::string_view name);
   ~AvlAllocator();
   const char* get_type() const override
   {

--- a/src/os/bluestore/BitmapAllocator.cc
+++ b/src/os/bluestore/BitmapAllocator.cc
@@ -11,7 +11,7 @@
 BitmapAllocator::BitmapAllocator(CephContext* _cct,
 					 int64_t capacity,
 					 int64_t alloc_unit,
-					 const std::string& name) :
+					 std::string_view name) :
     Allocator(name, capacity, alloc_unit),
     cct(_cct)
 {

--- a/src/os/bluestore/BitmapAllocator.h
+++ b/src/os/bluestore/BitmapAllocator.h
@@ -16,7 +16,8 @@ class BitmapAllocator : public Allocator,
   public AllocatorLevel02<AllocatorLevel01Loose> {
   CephContext* cct;
 public:
-  BitmapAllocator(CephContext* _cct, int64_t capacity, int64_t alloc_unit, const std::string& name);
+  BitmapAllocator(CephContext* _cct, int64_t capacity, int64_t alloc_unit,
+		  std::string_view name);
   ~BitmapAllocator() override
   {
   }

--- a/src/os/bluestore/HybridAllocator.h
+++ b/src/os/bluestore/HybridAllocator.h
@@ -13,7 +13,7 @@ class HybridAllocator : public AvlAllocator {
 public:
   HybridAllocator(CephContext* cct, int64_t device_size, int64_t _block_size,
                   uint64_t max_mem,
-	          const std::string& name) :
+	          std::string_view name) :
       AvlAllocator(cct, device_size, _block_size, max_mem, name) {
   }
   const char* get_type() const override

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -13,7 +13,7 @@
 StupidAllocator::StupidAllocator(CephContext* cct,
                                  int64_t capacity,
                                  int64_t _block_size,
-                                 const std::string& name)
+                                 std::string_view name)
   : Allocator(name, capacity, _block_size),
     cct(cct), num_free(0),
     free(10)

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -39,7 +39,7 @@ public:
   StupidAllocator(CephContext* cct,
                   int64_t size,
                   int64_t block_size,
-		  const std::string& name);
+		  std::string_view name);
   ~StupidAllocator() override;
   const char* get_type() const override
   {

--- a/src/os/bluestore/ZonedAllocator.cc
+++ b/src/os/bluestore/ZonedAllocator.cc
@@ -21,7 +21,7 @@
 ZonedAllocator::ZonedAllocator(CephContext* cct,
 			       int64_t size,
 			       int64_t blk_size,
-			       const std::string& name)
+			       std::string_view name)
     : Allocator(name, size, blk_size),
       cct(cct),
       num_free(0),

--- a/src/os/bluestore/ZonedAllocator.h
+++ b/src/os/bluestore/ZonedAllocator.h
@@ -70,7 +70,7 @@ class ZonedAllocator : public Allocator {
 
 public:
   ZonedAllocator(CephContext* cct, int64_t size, int64_t block_size,
-                 const std::string& name);
+                 std::string_view name);
   ~ZonedAllocator() override;
 
   const char *get_type() const override {

--- a/src/test/objectstore/Allocator_bench.cc
+++ b/src/test/objectstore/Allocator_bench.cc
@@ -28,7 +28,7 @@ public:
   AllocTest(): alloc(0) { }
   void init_alloc(int64_t size, uint64_t min_alloc_size) {
     std::cout << "Creating alloc type " << string(GetParam()) << " \n";
-    alloc.reset(Allocator::create(g_ceph_context, string(GetParam()), size,
+    alloc.reset(Allocator::create(g_ceph_context, GetParam(), size,
 				  min_alloc_size));
   }
 
@@ -333,7 +333,7 @@ TEST_P(AllocTest, mempoolAccounting)
 
   uint64_t alloc_size = 4 * 1024;
   uint64_t capacity = 512ll * 1024 * 1024 * 1024;
-  Allocator* alloc = Allocator::create(g_ceph_context, string(GetParam()),
+  Allocator* alloc = Allocator::create(g_ceph_context, GetParam(),
 				       capacity, alloc_size);
   ASSERT_NE(alloc, nullptr);
   alloc->init_add_free(0, capacity);

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -23,7 +23,7 @@ public:
   AllocTest(): alloc(0) { }
   void init_alloc(int64_t size, uint64_t min_alloc_size) {
     std::cout << "Creating alloc type " << string(GetParam()) << " \n";
-    alloc.reset(Allocator::create(g_ceph_context, string(GetParam()), size,
+    alloc.reset(Allocator::create(g_ceph_context, GetParam(), size,
 				  min_alloc_size));
   }
 

--- a/src/test/objectstore/allocator_replay_test.cc
+++ b/src/test/objectstore/allocator_replay_test.cc
@@ -202,7 +202,7 @@ int replay_and_check_for_duplicate(char* fname)
 	std::cerr << "error: invalid init: " << s << std::endl;
       return -1;
       }
-      alloc.reset(Allocator::create(g_ceph_context, string("bitmap"), total,
+      alloc.reset(Allocator::create(g_ceph_context, "bitmap", total,
 				    alloc_unit));
       owned_by_app.insert(0, total);
 


### PR DESCRIPTION
just for the sake of correctness, as they don't need a full-blown
std::string, what they need is but a string like object. and they always
create a std::string instance as a member variable if they want to have
a copy of it.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
