### PR TITLE
common/PriorityCache: low perf counters priorities for submodules.

### DIFF
--- a/src/common/PriorityCache.cc
+++ b/src/common/PriorityCache.cc
@@ -176,59 +176,59 @@ namespace PriorityCache
 
     b.add_u64(cur_index + Priority::PRI0, "pri0_bytes",
               "bytes allocated to pri0", "p0",
-              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     b.add_u64(cur_index + Priority::PRI1, "pri1_bytes",
               "bytes allocated to pri1", "p1",
-              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     b.add_u64(cur_index + Priority::PRI2, "pri2_bytes",
               "bytes allocated to pri2", "p2",
-              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     b.add_u64(cur_index + Priority::PRI3, "pri3_bytes",
               "bytes allocated to pri3", "p3",
-              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     b.add_u64(cur_index + Priority::PRI4, "pri4_bytes",
               "bytes allocated to pri4", "p4",
-              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     b.add_u64(cur_index + Priority::PRI5, "pri5_bytes",
               "bytes allocated to pri5", "p5",
-              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     b.add_u64(cur_index + Priority::PRI6, "pri6_bytes",
               "bytes allocated to pri6", "p6",
-              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     b.add_u64(cur_index + Priority::PRI7, "pri7_bytes",
               "bytes allocated to pri7", "p7",
-              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     b.add_u64(cur_index + Priority::PRI8, "pri8_bytes",
               "bytes allocated to pri8", "p8",
-              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     b.add_u64(cur_index + Priority::PRI9, "pri9_bytes",
               "bytes allocated to pri9", "p9",
-              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     b.add_u64(cur_index + Priority::PRI10, "pri10_bytes",
               "bytes allocated to pri10", "p10",
-              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     b.add_u64(cur_index + Priority::PRI11, "pri11_bytes",
               "bytes allocated to pri11", "p11",
-              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     b.add_u64(cur_index + Extra::E_RESERVED, "reserved_bytes",
               "bytes reserved for future growth.", "r",
-              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     b.add_u64(cur_index + Extra::E_COMMITTED, "committed_bytes",
               "total bytes committed,", "c",
-              PerfCountersBuilder::PRIO_CRITICAL, unit_t(UNIT_BYTES));
+              PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
 
     for (int i = 0; i < Extra::E_LAST+1; i++) {
       indexes[name][i] = cur_index + i;


### PR DESCRIPTION
Having too many perf counters with nicknames and priorities >= PRIO_INTERESTING spoils daemonperf output and causes no "osd" section there due to presumably too many columns.

Dropping priorities for some priority cache counters which look less important.

Fixes: https://tracker.ceph.com/issues/51002

Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
