### PR TITLE
rgw: Simplify log shard probing and err on the side of omap

### DIFF
--- a/src/rgw/rgw_log_backing.h
+++ b/src/rgw/rgw_log_backing.h
@@ -115,6 +115,10 @@ struct logback_generation {
   }
 };
 WRITE_CLASS_ENCODER(logback_generation)
+inline std::ostream& operator <<(std::ostream& m, const logback_generation& g) {
+  return m << "[" << g.gen_id << "," << g.type << ","
+	   << (g.pruned ? "PRUNED" : "NOT PRUNED") << "]";
+}
 
 class logback_generations : public librados::WatchCtx2 {
 public:

--- a/src/test/rgw/test_log_backing.cc
+++ b/src/test/rgw/test_log_backing.cc
@@ -249,7 +249,6 @@ TEST_F(LogBacking, GenerationSingle)
   auto ec = lg->empty_to(&dp, 0, null_yield);
   ASSERT_TRUE(ec);
 
-
   lg.reset();
 
   lg = *logback_generations::init<generations>(
@@ -305,18 +304,6 @@ TEST_F(LogBacking, GenerationSingle)
   ASSERT_EQ(1, lg->got_entries[1].gen_id);
   ASSERT_EQ(log_type::omap, lg->got_entries[1].type);
   ASSERT_FALSE(lg->got_entries[1].pruned);
-
-  ec = lg->remove_empty(&dp, null_yield);
-  ASSERT_FALSE(ec);
-
-  auto entries = lg->entries();
-  ASSERT_EQ(1, entries.size());
-
-  ASSERT_EQ(1, entries[1].gen_id);
-  ASSERT_EQ(log_type::omap, entries[1].type);
-  ASSERT_FALSE(entries[1].pruned);
-
-  lg.reset();
 }
 
 TEST_F(LogBacking, GenerationWN)


### PR DESCRIPTION
In the multigeneration version we no longer care whether entries
exist, since we never delete and recreate empty logs. Remove logic
that marked entirely empty shards as DNE under the assumption that
they would be deleted if so.

Backport: https://tracker.ceph.com/issues/50982