### PR TITLE
crimson/seastore: introduce and adopt LBAManager::get_mapping(t, offset)

### DIFF
--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -42,22 +42,32 @@ public:
    *
    * Future will not resolve until all pins have resolved (set_paddr called)
    */
-  using get_mapping_ertr = base_ertr;
-  using get_mapping_ret = get_mapping_ertr::future<lba_pin_list_t>;
-  virtual get_mapping_ret get_mapping(
+  using get_mappings_ertr = base_ertr;
+  using get_mappings_ret = get_mappings_ertr::future<lba_pin_list_t>;
+  virtual get_mappings_ret get_mappings(
     Transaction &t,
     laddr_t offset, extent_len_t length) = 0;
 
   /**
-   * Fetches mappings for laddr_t in range [offset, offset + len)
+   * Fetches mappings for a list of laddr_t in range [offset, offset + len)
    *
-   * Future will not result until all pins have resolved (set_paddr called)
+   * Future will not resolve until all pins have resolved (set_paddr called)
    */
-  using get_mappings_ertr = base_ertr;
-  using get_mappings_ret = get_mapping_ertr::future<lba_pin_list_t>;
   virtual get_mappings_ret get_mappings(
     Transaction &t,
     laddr_list_t &&extent_lisk) = 0;
+
+  /**
+   * Fetches the mapping for laddr_t
+   *
+   * Future will not resolve until the pin has resolved (set_paddr called)
+   */
+  using get_mapping_ertr = base_ertr::extend<
+    crimson::ct_error::enoent>;
+  using get_mapping_ret = get_mapping_ertr::future<LBAPinRef>;
+  virtual get_mapping_ret get_mapping(
+    Transaction &t,
+    laddr_t offset) = 0;
 
   /**
    * Finds unmapped laddr extent of len len

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -107,7 +107,16 @@ BtreeLBAManager::get_mapping(
   Transaction &t,
   laddr_t offset)
 {
-  ceph_abort("not implemented");
+  logger().debug("BtreeLBAManager::get_mapping: {}", offset);
+  return get_root(t
+  ).safe_then([this, &t, offset] (auto extent) {
+    return extent->lookup_pin(get_context(t), offset);
+  }).safe_then([] (auto &&e) {
+    logger().debug("BtreeLBAManager::get_mapping: got mapping {}", *e);
+    return get_mapping_ret(
+      get_mapping_ertr::ready_future_marker{},
+      std::move(e));
+  });
 }
 
 BtreeLBAManager::find_hole_ret

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -59,12 +59,12 @@ BtreeLBAManager::get_root(Transaction &t)
   });
 }
 
-BtreeLBAManager::get_mapping_ret
-BtreeLBAManager::get_mapping(
+BtreeLBAManager::get_mappings_ret
+BtreeLBAManager::get_mappings(
   Transaction &t,
   laddr_t offset, extent_len_t length)
 {
-  logger().debug("BtreeLBAManager::get_mapping: {}, {}", offset, length);
+  logger().debug("BtreeLBAManager::get_mappings: {}, {}", offset, length);
   return get_root(
     t).safe_then([this, &t, offset, length](auto extent) {
       return extent->lookup_range(
@@ -72,9 +72,9 @@ BtreeLBAManager::get_mapping(
 	offset, length
       ).safe_then([extent](auto ret) { return ret; });
     }).safe_then([](auto &&e) {
-      logger().debug("BtreeLBAManager::get_mapping: got mapping {}", e);
-      return get_mapping_ret(
-	get_mapping_ertr::ready_future_marker{},
+      logger().debug("BtreeLBAManager::get_mappings: got mappings {}", e);
+      return get_mappings_ret(
+	get_mappings_ertr::ready_future_marker{},
 	std::move(e));
     });
 }
@@ -93,13 +93,21 @@ BtreeLBAManager::get_mappings(
     l->begin(),
     l->end(),
     [this, &t, &ret](const auto &p) {
-      return get_mapping(t, p.first, p.second).safe_then(
+      return get_mappings(t, p.first, p.second).safe_then(
 	[&ret](auto res) {
 	  ret.splice(ret.end(), res, res.begin(), res.end());
 	});
     }).safe_then([l=std::move(l), retptr=std::move(retptr)]() mutable {
       return std::move(*retptr);
     });
+}
+
+BtreeLBAManager::get_mapping_ret
+BtreeLBAManager::get_mapping(
+  Transaction &t,
+  laddr_t offset)
+{
+  ceph_abort("not implemented");
 }
 
 BtreeLBAManager::find_hole_ret

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -50,13 +50,17 @@ public:
   mkfs_ret mkfs(
     Transaction &t) final;
 
-  get_mapping_ret get_mapping(
+  get_mappings_ret get_mappings(
     Transaction &t,
     laddr_t offset, extent_len_t length) final;
 
   get_mappings_ret get_mappings(
     Transaction &t,
     laddr_list_t &&list) final;
+
+  get_mapping_ret get_mapping(
+    Transaction &t,
+    laddr_t offset) final;
 
   find_hole_ret find_hole(
     Transaction &t,

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -50,8 +50,6 @@ using BtreeLBAPinRef = std::unique_ptr<BtreeLBAPin>;
  */
 struct LBANode : CachedExtent {
   using LBANodeRef = TCachedExtentRef<LBANode>;
-  using lookup_range_ertr = LBAManager::get_mappings_ertr;
-  using lookup_range_ret = LBAManager::get_mappings_ret;
 
   btree_range_pin_t pin;
 
@@ -79,10 +77,23 @@ struct LBANode : CachedExtent {
    *
    * Returns mappings within range [addr, addr+len)
    */
+  using lookup_range_ertr = LBAManager::get_mappings_ertr;
+  using lookup_range_ret = LBAManager::get_mappings_ret;
   virtual lookup_range_ret lookup_range(
     op_context_t c,
     laddr_t addr,
     extent_len_t len) = 0;
+
+  /**
+   * lookup_pin
+   *
+   * Returns the mapping at addr
+   */
+  using lookup_pin_ertr = LBAManager::get_mapping_ertr;
+  using lookup_pin_ret = LBAManager::get_mapping_ret;
+  virtual lookup_pin_ret lookup_pin(
+    op_context_t c,
+    laddr_t addr) = 0;
 
   /**
    * insert

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -50,8 +50,8 @@ using BtreeLBAPinRef = std::unique_ptr<BtreeLBAPin>;
  */
 struct LBANode : CachedExtent {
   using LBANodeRef = TCachedExtentRef<LBANode>;
-  using lookup_range_ertr = LBAManager::get_mapping_ertr;
-  using lookup_range_ret = LBAManager::get_mapping_ret;
+  using lookup_range_ertr = LBAManager::get_mappings_ertr;
+  using lookup_range_ret = LBAManager::get_mappings_ret;
 
   btree_range_pin_t pin;
 

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
@@ -87,6 +87,22 @@ LBAInternalNode::lookup_range_ret LBAInternalNode::lookup_range(
     });
 }
 
+LBAInternalNode::lookup_pin_ret LBAInternalNode::lookup_pin(
+  op_context_t c,
+  laddr_t addr)
+{
+  auto iter = get_containing_child(addr);
+  return get_lba_btree_extent(
+    c,
+    this,
+    get_meta().depth - 1,
+    iter->get_val(),
+    get_paddr()
+  ).safe_then([c, addr] (LBANodeRef extent) {
+    return extent->lookup_pin(c, addr);
+  }).finally([ref=LBANodeRef(this)] {});
+}
+
 LBAInternalNode::insert_ret LBAInternalNode::insert(
   op_context_t c,
   laddr_t laddr,
@@ -484,6 +500,25 @@ LBALeafNode::lookup_range_ret LBALeafNode::lookup_range(
   }
   return lookup_range_ertr::make_ready_future<lba_pin_list_t>(
     std::move(ret));
+}
+
+LBALeafNode::lookup_pin_ret LBALeafNode::lookup_pin(
+  op_context_t c,
+  laddr_t addr)
+{
+  logger().debug("LBALeafNode::lookup_pin {}", addr);
+  auto iter = find(addr);
+  if (iter == end()) {
+    return crimson::ct_error::enoent::make();
+  }
+  auto val = iter->get_val();
+  auto begin = iter->get_key();
+  return lookup_pin_ret(
+    lookup_pin_ertr::ready_future_marker{},
+    std::make_unique<BtreeLBAPin>(
+      this,
+      val.paddr.maybe_relative_to(get_paddr()),
+      lba_node_meta_t{ begin, begin + val.len, 0}));
 }
 
 LBALeafNode::insert_ret LBALeafNode::insert(

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.h
@@ -99,6 +99,10 @@ struct LBAInternalNode
     laddr_t addr,
     extent_len_t len) final;
 
+  lookup_pin_ret lookup_pin(
+    op_context_t c,
+    laddr_t addr) final;
+
   insert_ret insert(
     op_context_t c,
     laddr_t laddr,
@@ -373,6 +377,10 @@ struct LBALeafNode
     op_context_t c,
     laddr_t addr,
     extent_len_t len) final;
+
+  lookup_pin_ret lookup_pin(
+    op_context_t c,
+    laddr_t addr) final;
 
   insert_ret insert(
     op_context_t c,

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -321,7 +321,8 @@ TransactionManager::get_extent_if_live_ret TransactionManager::get_extent_if_liv
     }
 
     if (is_logical_type(type)) {
-      return lba_manager->get_mapping(
+      // TODO: switch to get_mapping()
+      return lba_manager->get_mappings(
 	t,
 	laddr,
 	len).safe_then([=, &t](lba_pin_list_t pins) {

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -321,20 +321,9 @@ TransactionManager::get_extent_if_live_ret TransactionManager::get_extent_if_liv
     }
 
     if (is_logical_type(type)) {
-      // TODO: switch to get_mapping()
-      return lba_manager->get_mappings(
+      return lba_manager->get_mapping(
 	t,
-	laddr,
-	len).safe_then([=, &t](lba_pin_list_t pins) {
-	  ceph_assert(pins.size() <= 1);
-	  if (pins.empty()) {
-	    return get_extent_if_live_ret(
-	      get_extent_if_live_ertr::ready_future_marker{},
-	      CachedExtentRef());
-	  }
-
-	  auto pin = std::move(pins.front());
-	  pins.pop_front();
+	laddr).safe_then([=, &t] (LBAPinRef pin) {
 	  ceph_assert(pin->get_laddr() == laddr);
 	  ceph_assert(pin->get_length() == (extent_len_t)len);
 	  if (pin->get_paddr() == addr) {
@@ -365,7 +354,11 @@ TransactionManager::get_extent_if_live_ret TransactionManager::get_extent_if_liv
 	      get_extent_if_live_ertr::ready_future_marker{},
 	      CachedExtentRef());
 	  }
-	});
+	}).handle_error(crimson::ct_error::enoent::handle([] {
+	  return get_extent_if_live_ret(
+	    get_extent_if_live_ertr::ready_future_marker{},
+	    CachedExtentRef());
+	}), crimson::ct_error::pass_further_all{});
     } else {
       DEBUGT("non-logical extent {}", t, addr);
       return lba_manager->get_physical_extent_if_live(

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -126,13 +126,13 @@ public:
    *
    * Get logical pins overlapping offset~length
    */
-  using get_pins_ertr = LBAManager::get_mapping_ertr;
+  using get_pins_ertr = LBAManager::get_mappings_ertr;
   using get_pins_ret = get_pins_ertr::future<lba_pin_list_t>;
   get_pins_ret get_pins(
     Transaction &t,
     laddr_t offset,
     extent_len_t length) {
-    return lba_manager->get_mapping(
+    return lba_manager->get_mappings(
       t, offset, length);
   }
 

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -272,7 +272,7 @@ struct btree_lba_manager_test :
 
   void check_mappings(test_transaction_t &t) {
     for (auto &&i: t.mappings) {
-      auto ret_list = lba_manager->get_mapping(
+      auto ret_list = lba_manager->get_mappings(
 	*t.t, i.first, i.second.len
       ).unsafe_get0();
       EXPECT_EQ(ret_list.size(), 1);
@@ -280,6 +280,7 @@ struct btree_lba_manager_test :
       EXPECT_EQ(i.second.addr, ret->get_paddr());
       EXPECT_EQ(i.first, ret->get_laddr());
       EXPECT_EQ(i.second.len, ret->get_length());
+      // TODO: test get_mapping()
     }
     lba_manager->scan_mappings(
       *t.t,

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -272,15 +272,23 @@ struct btree_lba_manager_test :
 
   void check_mappings(test_transaction_t &t) {
     for (auto &&i: t.mappings) {
+      auto laddr = i.first;
+      auto len = i.second.len;
+
       auto ret_list = lba_manager->get_mappings(
-	*t.t, i.first, i.second.len
+	*t.t, laddr, len
       ).unsafe_get0();
       EXPECT_EQ(ret_list.size(), 1);
       auto &ret = *ret_list.begin();
       EXPECT_EQ(i.second.addr, ret->get_paddr());
-      EXPECT_EQ(i.first, ret->get_laddr());
-      EXPECT_EQ(i.second.len, ret->get_length());
-      // TODO: test get_mapping()
+      EXPECT_EQ(laddr, ret->get_laddr());
+      EXPECT_EQ(len, ret->get_length());
+
+      auto ret_pin = lba_manager->get_mapping(
+        *t.t, laddr).unsafe_get0();
+      EXPECT_EQ(i.second.addr, ret_pin->get_paddr());
+      EXPECT_EQ(laddr, ret_pin->get_laddr());
+      EXPECT_EQ(len, ret_pin->get_length());
     }
     lba_manager->scan_mappings(
       *t.t,


### PR DESCRIPTION
Should be no impact to existing users.

This is a prerequisite PR that allows us to read an extent without knowing its length first, using the new `get_mapping()` method.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
