### PR TITLE
octopus: ceph: ignore BrokenPipeError when printing help

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -386,8 +386,11 @@ daemonperf {type.id | path} list|ls [stat-pats] [priority]
 
 def do_extended_help(parser, args, target, partial):
     def help_for_sigs(sigs, partial=None):
-        sys.stdout.write(format_help(parse_json_funcsigs(sigs, 'cli'),
-                         partial=partial))
+        try:
+            sys.stdout.write(format_help(parse_json_funcsigs(sigs, 'cli'),
+                             partial=partial))
+        except BrokenPipeError:
+            pass
 
     def help_for_target(target, partial=None):
         # wait for osdmap because we know this is sent after the mgrmap


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50661

---

backport of https://github.com/ceph/ceph/pull/37100
parent tracker: https://tracker.ceph.com/issues/47400

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh