### PR TITLE
mgr/cephadm: automatically configure dashboard <-> RGW connection

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -466,6 +466,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self.template = TemplateMgr(self)
 
         self.requires_post_actions: Set[str] = set()
+        self.need_connect_dashboard_rgw = False
 
         self.config_checker = CephadmConfigChecks(self)
 
@@ -2546,3 +2547,7 @@ Then run the following:
         The CLI call to retrieve an osd removal report
         """
         return self.to_remove_osds.all_osds()
+
+    def trigger_connect_dashboard_rgw(self) -> None:
+        self.need_connect_dashboard_rgw = True
+        self.event.set()

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -22,7 +22,7 @@ from ceph.utils import str_to_datetime, datetime_now
 import orchestrator
 from orchestrator import OrchestratorError, set_exception_subject, OrchestratorEvent, \
     DaemonDescriptionStatus, daemon_type_to_service
-from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, RgwService
 from cephadm.schedule import HostAssignment
 from cephadm.autotune import MemoryAutotuner
 from cephadm.utils import forall_hosts, cephadmNoImage, is_repo_digest, \
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
     from remoto.backends import BaseConnection
 
 logger = logging.getLogger(__name__)
+
+REQUIRES_POST_ACTIONS = ['grafana', 'iscsi', 'prometheus', 'alertmanager', 'rgw']
 
 
 class CephadmServe:
@@ -78,6 +80,11 @@ class CephadmServe:
                 self._check_for_strays()
 
                 self._update_paused_health()
+
+                if self.mgr.need_connect_dashboard_rgw and self.mgr.config_dashboard:
+                    self.mgr.need_connect_dashboard_rgw = False
+                    if 'dashboard' in self.mgr.get('mgr_map')['modules']:
+                        cast(RgwService, self.mgr.cephadm_services['rgw']).connect_dashboard_rgw()
 
                 if not self.mgr.paused:
                     self.mgr.to_remove_osds.process_removal_queue()
@@ -878,7 +885,7 @@ class CephadmServe:
                 continue
 
             # These daemon types require additional configs after creation
-            if dd.daemon_type in ['grafana', 'iscsi', 'prometheus', 'alertmanager', 'nfs']:
+            if dd.daemon_type in REQUIRES_POST_ACTIONS:
                 daemons_post[dd.daemon_type].append(dd)
 
             if self.mgr.cephadm_services[daemon_type_to_service(dd.daemon_type)].get_active_daemon(
@@ -1055,9 +1062,7 @@ class CephadmServe:
                         sd = daemon_spec.to_daemon_description(
                             DaemonDescriptionStatus.running, 'starting')
                         self.mgr.cache.add_daemon(daemon_spec.host, sd)
-                        if daemon_spec.daemon_type in [
-                            'grafana', 'iscsi', 'prometheus', 'alertmanager'
-                        ]:
+                        if daemon_spec.daemon_type in REQUIRES_POST_ACTIONS:
                             self.mgr.requires_post_actions.add(daemon_spec.daemon_type)
                     self.mgr.cache.invalidate_host_daemons(daemon_spec.host)
 


### PR DESCRIPTION
Automatically configure the credential(s) for dashboard to talk to RGW. 

We do not provide any endpoint information--we assume that dashboard can figure that out on its own.

Note that this path is triggered any time we add or remove an rgw daemon, which isn't quite right--what we really want is to trigger this change when teh first or last rgw daemon is deployed, and/or when the realm configuration is modified.  Once a mgr/rgw module exists, we should probably migrate this code there.

- [x] configure credentials per-realm if multisite is enabled
- [ ] trigger this update on upgrade

Fixes: https://tracker.ceph.com/issues/51302