### PR TITLE
pybind/mgr/selftest: add "mgr self-test eval" command

### DIFF
--- a/src/pybind/ceph_mgr_repl.py
+++ b/src/pybind/ceph_mgr_repl.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python3
+# -*- mode:python -*-
+# vim: ts=4 sw=4 smarttab expandtab
+
+__all__ = ['ConsoleOptions', 'MgrModuleInterpreter']
+
+import readline
+import sys
+from code import InteractiveConsole
+from collections import namedtuple
+from pathlib import Path
+
+from ceph_argparse import json_command
+
+
+ConsoleOptions = namedtuple('ConsoleOptions',
+                            ['name', 'conffile', 'prefix', 'timeout'])
+
+
+class MgrModuleInteractiveConsole(InteractiveConsole):
+    def __init__(self, rados, opt, filename="<console>"):
+        super().__init__(filename)
+        self.cmd_prefix = opt.prefix
+        self.timeout = opt.timeout
+        self.cluster = rados.Rados(name=opt.name,
+                                   conffile=opt.conffile)
+        self.cluster.connect(timeout=opt.timeout)
+
+    def _do_runsource(self, source):
+        ret, buf, s = json_command(self.cluster,
+                                   prefix=self.cmd_prefix,
+                                   target=('mon-mgr',),
+                                   inbuf=source.encode(),
+                                   timeout=self.timeout)
+        if ret == 0:
+            # TODO: better way to encode the outputs
+            sys.stdout.write(buf.decode())
+            sys.stderr.write(s)
+        else:
+            # needs more
+            self.write("the input is not complete")
+
+    def runsource(self, source, filename='<input>', symbol='single'):
+        try:
+            # just validate the syntax
+            code = self.compile(source, filename, symbol)
+        except (OverflowError, SyntaxError, ValueError):
+            # Case 1
+            self.showsyntaxerror(filename)
+            return False
+
+        if code is None:
+            # Case 2
+            return True
+
+        # Case 3
+        self._do_runsource(source)
+        return False
+
+    def runcode(self, code):
+        # code object cannot be pickled
+        raise NotImplementedError()
+
+
+def show_env():
+    prog = Path(__file__).resolve()
+    ceph_dir = prog.parents[2]
+    python_path = ':'.join([f'{ceph_dir}/src/pybind',
+                            f'{ceph_dir}/build/lib/cython_modules/lib.3',
+                            f'{ceph_dir}/src/python-common',
+                            '$PYTHONPATH'])
+    ld_library_path = ':'.join([f'{ceph_dir}/build/lib',
+                                '$LD_LIBRARY_PATH'])
+    return f'''
+    $ export PYTHONPATH={python_path}
+    $ export LD_LIBRARY_PATH={ld_library_path}'''.strip('\n')
+
+
+def main():
+    import argparse
+    try:
+        import rados
+    except ImportError:
+        print(f'''Unable to import rados python binding.
+Please set the environment variables first:
+{show_env()}''',
+              file=sys.stderr)
+        exit(1)
+
+    prog = Path(__file__).name
+    epilog = f'''Usage:
+    {prog} -c "print(mgr.release_name)"'''
+    parser = argparse.ArgumentParser(epilog=epilog)
+    parser.add_argument('--name', action='store',
+                        default='client.admin',
+                        help='user name for connecting to cluster')
+    parser.add_argument('--conffile', action='store',
+                        default=rados.Rados.DEFAULT_CONF_FILES,
+                        help='path to ceph.conf')
+    parser.add_argument('--prefix', action='store',
+                        default='mgr self-test eval',
+                        help='command prefix for eval the source')
+    parser.add_argument('--timeout', action='store',
+                        default=10,
+                        help='timeout in seconds')
+    parser.add_argument('--show-env', action='store_true',
+                        help='show instructions to set environment variables')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-c', action='store',
+                       help='optional statement',
+                       dest='command')
+    group.add_argument('script', nargs='?', type=argparse.FileType('r'))
+    args = parser.parse_args()
+    options = ConsoleOptions(name=args.name,
+                             conffile=args.conffile,
+                             prefix=args.prefix,
+                             timeout=args.timeout)
+    console = MgrModuleInteractiveConsole(rados, options)
+    if args.show_env:
+        print(show_env())
+    elif args.command:
+        console.runsource(args.command)
+    elif args.script:
+        console.runsource(args.script.read())
+    else:
+        sys.ps1 = f'[{args.prefix}] >>> '
+        console.interact()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -1,10 +1,13 @@
 
-from mgr_module import MgrModule, CommandResult, CLICommand, Option
+from mgr_module import MgrModule, CommandResult, HandleCommandResult, CLICommand, Option
 import enum
 import json
 import random
 import sys
 import threading
+from code import InteractiveInterpreter
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 from typing import Any, Dict, List, Optional, Tuple
 
 
@@ -60,6 +63,7 @@ class Module(MgrModule):
         self._event = threading.Event()
         self._workload: Optional[Workload] = None
         self._health: Dict[str, Dict[str, Any]] = {}
+        self._repl = InteractiveInterpreter(dict(mgr=self))
 
     @CLICommand('mgr self-test python-version', perm='r')
     def python_version(self) -> Tuple[int, str, str]:
@@ -463,6 +467,31 @@ class Module(MgrModule):
 
         self._event.clear()
         self.log.info("Ended command_spam workload...")
+
+    @CLICommand('mgr self-test eval')
+    def eval(self,
+             s: Optional[str] = None,
+             inbuf: Optional[str] = None) -> HandleCommandResult:
+        '''
+        eval given source
+        '''
+        source = s or inbuf
+        if source is None:
+            return HandleCommandResult(-1, '', 'source is not specified')
+
+        err = StringIO()
+        out = StringIO()
+        with redirect_stderr(err), redirect_stdout(out):
+            needs_more = self._repl.runsource(source)
+            if needs_more:
+                retval = 2
+                stdout = ''
+                stderr = ''
+            else:
+                retval = 0
+                stdout = out.getvalue()
+                stderr = err.getvalue()
+            return HandleCommandResult(retval, stdout, stderr)
 
     def serve(self) -> None:
         while True:


### PR DESCRIPTION
and a simple REPL client allowing developer to peek and poke the
selftest module. if this turns out to be useful, we can promote this
method into a dedicated mix-in class, so other module can use it if
developer wants to test it manually.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
