### PR TITLE
mgr/dashboard: pass Grafana datasource in URL

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.spec.ts
@@ -18,6 +18,8 @@ import { GrafanaComponent } from './grafana.component';
 describe('GrafanaComponent', () => {
   let component: GrafanaComponent;
   let fixture: ComponentFixture<GrafanaComponent>;
+  const expected_url =
+    'http:localhost:3000/d/foo/somePath&refresh=2s&var-datasource=Dashboard1&kiosk&from=now-1h&to=now';
 
   configureTestBed({
     declarations: [GrafanaComponent, AlertPanelComponent, LoadingPanelComponent, DocComponent],
@@ -56,24 +58,18 @@ describe('GrafanaComponent', () => {
       expect(component.grafanaExist).toBe(true);
       expect(component.baseUrl).toBe('http:localhost:3000/d/');
       expect(component.loading).toBe(false);
-      expect(component.url).toBe(
-        'http:localhost:3000/d/foo/somePath&refresh=2s&kiosk&from=now-1h&to=now'
-      );
+      expect(component.url).toBe(expected_url);
       expect(component.grafanaSrc).toEqual({
-        changingThisBreaksApplicationSecurity:
-          'http:localhost:3000/d/foo/somePath&refresh=2s&kiosk&from=now-1h&to=now'
+        changingThisBreaksApplicationSecurity: expected_url
       });
     });
 
     it('should reset the values', () => {
       component.reset();
       expect(component.time).toBe('from=now-1h&to=now');
-      expect(component.url).toBe(
-        'http:localhost:3000/d/foo/somePath&refresh=2s&kiosk&from=now-1h&to=now'
-      );
+      expect(component.url).toBe(expected_url);
       expect(component.grafanaSrc).toEqual({
-        changingThisBreaksApplicationSecurity:
-          'http:localhost:3000/d/foo/somePath&refresh=2s&kiosk&from=now-1h&to=now'
+        changingThisBreaksApplicationSecurity: expected_url
       });
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
@@ -19,6 +19,7 @@ export class GrafanaComponent implements OnInit, OnChanges {
   panelStyle: any;
   grafanaExist = false;
   mode = '&kiosk';
+  datasource = 'Dashboard1';
   loading = true;
   styles: Record<string, string> = {};
   dashboardExist = true;
@@ -171,6 +172,7 @@ export class GrafanaComponent implements OnInit, OnChanges {
       '/' +
       this.grafanaPath +
       '&refresh=2s' +
+      `&var-datasource=${this.datasource}` +
       this.mode +
       '&' +
       this.time;


### PR DESCRIPTION
PR https://github.com/ceph/ceph/pull/24314 added support for
specifying the Grafana datasource via $datasource template variable, but
this hadn't been used from the Dashboard side so far.

As per https://grafana.com/docs/grafana/latest/variables/#templates, by
adding `var-datasource=Dashboard1`, Dashboard can specify the
datasource.

![image](https://user-images.githubusercontent.com/37327689/120190868-76eac380-c219-11eb-9908-f41c301f504a.png)

Fixes: https://tracker.ceph.com/issues/51026
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
