### PR TITLE
osd/ECBackend: Fix null pointer dereference when enabling jaeger tracing

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -941,7 +941,7 @@ void ECBackend::handle_sub_write(
     msg->mark_event("sub_op_started");
   trace.event("handle_sub_write");
 #ifdef HAVE_JAEGER
-  if (msg->osd_parent_span) {
+  if (msg && msg->osd_parent_span) {
     auto ec_sub_trans = jaeger_tracing::child_span(__func__, msg->osd_parent_span);
   }
 #endif
@@ -1544,7 +1544,7 @@ void ECBackend::submit_transaction(
     op->trace = client_op->pg_trace;
 
 #ifdef HAVE_JAEGER
-  if (client_op->osd_parent_span) {
+  if (client_op && client_op->osd_parent_span) {
     auto ec_sub_trans = jaeger_tracing::child_span("ECBackend::submit_transaction", client_op->osd_parent_span);
   }
 #endif
@@ -2118,7 +2118,7 @@ bool ECBackend::try_reads_to_commit()
   }
 
 #ifdef HAVE_JAEGER
-   if (op->client_op->osd_parent_span) {
+   if (op->client_op && op->client_op->osd_parent_span) {
       auto sub_write_span = jaeger_tracing::child_span("EC sub write", op->client_op->osd_parent_span);
     }
 #endif


### PR DESCRIPTION
As comment in header says client_op might be null, we need to check it
first before accessing client_op->osd_parent_span.

Fixes: #51030
Signed-off-by: Misono Tomohiro <misono.tomohiro@jp.fujitsu.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
