### PR TITLE
doc/cephadm: enriching "Service Specification"

### DIFF
--- a/doc/cephadm/service-management.rst
+++ b/doc/cephadm/service-management.rst
@@ -62,8 +62,8 @@ name:
 Service Specification
 =====================
 
-A *Service Specification* is a data structure
-to specify the deployment of services.  For example in YAML:
+A *Service Specification* is a data structure that is used to specify the
+deployment of services.  Here is an example of a service specification in YAML:
 
 .. code-block:: yaml
 
@@ -77,7 +77,7 @@ to specify the deployment of services.  For example in YAML:
     unmanaged: false
     ...
 
-where the properties of a service specification are:
+In this example, the the properties this service specification are:
 
 * ``service_type``
     The type of the service. Needs to be either a Ceph
@@ -89,21 +89,20 @@ where the properties of a service specification are:
     The name of the service.
 * ``placement``
     See :ref:`orchestrator-cli-placement-spec`.
-* ``unmanaged``
-    If set to ``true``, the orchestrator will not deploy nor
-    remove any daemon associated with this service. Placement and all other
-    properties will be ignored. This is useful, if this service should not
-    be managed temporarily. For cephadm, See :ref:`cephadm-spec-unmanaged`
+* ``unmanaged`` If set to ``true``, the orchestrator will not deploy nor remove
+    any daemon associated with this service. Placement and all other properties
+    will be ignored. This is useful, if you do not want this service to be
+    managed temporarily. For cephadm, See :ref:`cephadm-spec-unmanaged`
 
-Each service type can have additional service specific properties.
+Each service type can have additional service-specific properties.
 
 Service specifications of type ``mon``, ``mgr``, and the monitoring
 types do not require a ``service_id``.
 
 A service of type ``osd`` is described in :ref:`drivegroups`
 
-Many service specifications can be applied at once using
-``ceph orch apply -i`` by submitting a multi-document YAML file::
+Many service specifications can be applied at once using ``ceph orch apply -i``
+by submitting a multi-document YAML file::
 
     cat <<EOF | ceph orch apply -i -
     service_type: mon


### PR DESCRIPTION
This PR adds parallel construction to the "Service
Specification" section of the "Service Managment"
chapter of the cephadm documentation.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
