### PR TITLE
octopus: os/bluestore: tolerate zero length for allocators' init_[add/rm]_free()

### DIFF
--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -405,6 +405,8 @@ void AvlAllocator::dump(std::function<void(uint64_t offset, uint64_t length)> no
 
 void AvlAllocator::init_add_free(uint64_t offset, uint64_t length)
 {
+  if (!length)
+    return;
   std::lock_guard l(lock);
   ldout(cct, 10) << __func__ << std::hex
                  << " offset 0x" << offset
@@ -415,6 +417,8 @@ void AvlAllocator::init_add_free(uint64_t offset, uint64_t length)
 
 void AvlAllocator::init_rm_free(uint64_t offset, uint64_t length)
 {
+  if (!length)
+    return;
   std::lock_guard l(lock);
   ldout(cct, 10) << __func__ << std::hex
                  << " offset 0x" << offset

--- a/src/os/bluestore/HybridAllocator.cc
+++ b/src/os/bluestore/HybridAllocator.cc
@@ -155,6 +155,8 @@ void HybridAllocator::dump(std::function<void(uint64_t offset, uint64_t length)>
 
 void HybridAllocator::init_rm_free(uint64_t offset, uint64_t length)
 {
+  if (!length)
+    return;
   std::lock_guard l(lock);
   ldout(cct, 10) << __func__ << std::hex
                  << " offset 0x" << offset

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -307,6 +307,8 @@ void StupidAllocator::dump(std::function<void(uint64_t offset, uint64_t length)>
 
 void StupidAllocator::init_add_free(uint64_t offset, uint64_t length)
 {
+  if (!length)
+    return;
   std::lock_guard l(lock);
   ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << length
 		 << std::dec << dendl;
@@ -316,6 +318,8 @@ void StupidAllocator::init_add_free(uint64_t offset, uint64_t length)
 
 void StupidAllocator::init_rm_free(uint64_t offset, uint64_t length)
 {
+  if (!length)
+    return;
   std::lock_guard l(lock);
   ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << length
 	   	 << std::dec << dendl;

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -47,6 +47,23 @@ TEST_P(AllocTest, test_alloc_init)
   ASSERT_EQ(alloc->get_free(), (uint64_t) 0);
 }
 
+TEST_P(AllocTest, test_init_add_free)
+{
+  int64_t block_size = 1024;
+  int64_t capacity = 4 * 1024 * block_size;
+
+  {
+    init_alloc(capacity, block_size);
+
+    auto free = alloc->get_free();
+    alloc->init_add_free(block_size, 0);
+    ASSERT_EQ(free, alloc->get_free());
+
+    alloc->init_rm_free(block_size, 0);
+    ASSERT_EQ(free, alloc->get_free());
+  }
+}
+
 TEST_P(AllocTest, test_alloc_min_alloc)
 {
   int64_t block_size = 1024;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50781

---

backport of https://github.com/ceph/ceph/pull/41092
parent tracker: https://tracker.ceph.com/issues/50555

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh