### PR TITLE
octopus: mgr: do not load disabled modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,11 @@ if(WITH_MGR)
   set(MGR_PYTHON_LIBRARIES ${Python3_LIBRARIES})
   set(MGR_PYTHON_VERSION_MAJOR ${Python3_VERSION_MAJOR})
   set(MGR_PYTHON_VERSION_MINOR ${Python3_VERSION_MINOR})
+  # https://tracker.ceph.com/issues/45147
+  if(Python3_VERSION VERSION_GREATER_EQUAL 3.8)
+    set(MGR_DISABLED_MODULES "diskprediction_local")
+    message(STATUS "mgr module disabled for ${Python3_VERSION}: ${MGR_DISABLED_MODULES}")
+  endif()
   # Boost dependency check deferred to Boost section
 endif(WITH_MGR)
 

--- a/qa/suites/rados/mgr/tasks/module_selftest.yaml
+++ b/qa/suites/rados/mgr/tasks/module_selftest.yaml
@@ -23,3 +23,4 @@ tasks:
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_module_selftest
+      fail_on_skip: false

--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -3,6 +3,7 @@ import time
 import requests
 import errno
 import logging
+
 from teuthology.exceptions import CommandFailedError
 
 from tasks.mgr.mgr_test_case import MgrTestCase
@@ -49,6 +50,13 @@ class TestModuleSelftest(MgrTestCase):
         self._selftest_plugin("influx")
 
     def test_diskprediction_local(self):
+        self._load_module("selftest")
+        python_version = self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            "mgr", "self-test", "python-version")
+        if tuple(int(v) for v in python_version.split('.')) >= (3, 8):
+            # https://tracker.ceph.com/issues/45147
+            self.skipTest(f'python {python_version} not compatible with '
+                          'diskprediction_local')
         self._selftest_plugin("diskprediction_local")
 
     # Not included in qa/packages/packages.yaml

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5256,6 +5256,20 @@ std::vector<Option> get_global_options() {
     .add_service("mgr")
     .set_description("Filesystem path to manager modules."),
 
+    Option("mgr_disabled_modules", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+#ifdef MGR_DISABLED_MODULES
+    .set_default(MGR_DISABLED_MODULES)
+#endif
+    .set_flag(Option::FLAG_STARTUP)
+    .add_service("mgr")
+    .set_description("List of manager modules never get loaded")
+    .set_long_description("A comma delimited list of module names. This list "
+        "is read by manager when it starts. By default, manager loads all "
+        "modules found in specified 'mgr_module_path', and it starts the "
+        "enabled ones as instructed. The modules in this list will not be "
+        "loaded at all.")
+    .add_see_also("mgr_module_path"),
+
     Option("mgr_initial_modules", Option::TYPE_STR, Option::LEVEL_BASIC)
     .set_default("restful iostat")
     .set_flag(Option::FLAG_NO_MON_UPDATE)

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -318,6 +318,9 @@
 
 #cmakedefine MGR_PYTHON_EXECUTABLE "@MGR_PYTHON_EXECUTABLE@"
 
+/* the default value of "mgr_disabled_module" option */
+#cmakedefine MGR_DISABLED_MODULES "@MGR_DISABLED_MODULES@"
+
 /* Define to 1 if you have the `getprogname' function. */
 #cmakedefine HAVE_GETPROGNAME 1
 

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -25,6 +25,7 @@ namespace fs = std::experimental::filesystem;
 
 #include "include/stringify.h"
 #include "common/errno.h"
+#include "common/split.h"
 
 #include "BaseMgrModule.h"
 #include "PyOSDMap.h"
@@ -269,14 +270,22 @@ void PyModuleRegistry::shutdown()
 
 std::set<std::string> PyModuleRegistry::probe_modules(const std::string &path) const
 {
+  const auto opt = g_conf().get_val<std::string>("mgr_disabled_modules");
+  const auto disabled_modules = ceph::split(opt);
+
   std::set<std::string> modules;
   for (const auto& entry: fs::directory_iterator(path)) {
     if (!fs::is_directory(entry)) {
       continue;
     }
+    const std::string name = entry.path().filename();
+    if (std::count(disabled_modules.begin(), disabled_modules.end(), name)) {
+      dout(10) << "ignoring disabled module " << name << dendl;
+      continue;
+    }
     auto module_path = entry.path() / "module.py";
     if (fs::exists(module_path)) {
-      modules.emplace(entry.path().filename());
+      modules.emplace(name);
     }
   }
   return modules;

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -11,6 +11,17 @@
  * Foundation.  See file COPYING.
  */
 
+#include "PyModuleRegistry.h"
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error std::filesystem not available!
+#endif
 
 #include "include/stringify.h"
 #include "common/errno.h"
@@ -23,8 +34,6 @@
 #include "mgr/mgr_commands.h"
 
 #include "ActivePyModules.h"
-
-#include "PyModuleRegistry.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
@@ -260,29 +269,17 @@ void PyModuleRegistry::shutdown()
 
 std::set<std::string> PyModuleRegistry::probe_modules(const std::string &path) const
 {
-  DIR *dir = opendir(path.c_str());
-  if (!dir) {
-    return {};
-  }
-
-  std::set<std::string> modules_out;
-  struct dirent *entry = NULL;
-  while ((entry = readdir(dir)) != NULL) {
-    string n(entry->d_name);
-    string fn = path + "/" + n;
-    struct stat st;
-    int r = ::stat(fn.c_str(), &st);
-    if (r == 0 && S_ISDIR(st.st_mode)) {
-      string initfn = fn + "/module.py";
-      r = ::stat(initfn.c_str(), &st);
-      if (r == 0) {
-	modules_out.insert(n);
-      }
+  std::set<std::string> modules;
+  for (const auto& entry: fs::directory_iterator(path)) {
+    if (!fs::is_directory(entry)) {
+      continue;
+    }
+    auto module_path = entry.path() / "module.py";
+    if (fs::exists(module_path)) {
+      modules.emplace(entry.path().filename());
     }
   }
-  closedir(dir);
-
-  return modules_out;
+  return modules;
 }
 
 int PyModuleRegistry::handle_command(

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -1,10 +1,11 @@
 
 from mgr_module import MgrModule, CommandResult
-import threading
-import random
-import json
 import errno
 import six
+import json
+import random
+import sys
+import threading
 
 
 class Module(MgrModule):
@@ -101,6 +102,11 @@ class Module(MgrModule):
                 "desc": "Create an audit log record.",
                 "perm": "rw"
             },
+            {
+                "cmd": "mgr self-test python-version",
+                "desc": "Query the version of the embedded Python runtime",
+                "perm": "r"
+            },
             ]
 
     def __init__(self, *args, **kwargs):
@@ -110,7 +116,13 @@ class Module(MgrModule):
         self._health = {}
 
     def handle_command(self, inbuf, command):
-        if command['prefix'] == 'mgr self-test run':
+        if command['prefix'] == 'mgr self-test python-version':
+            major = sys.version_info.major
+            minor = sys.version_info.minor
+            micro = sys.version_info.micro
+            return 0, f'{major}.{minor}.{micro}', ''
+
+        elif command['prefix'] == 'mgr self-test run':
             self._self_test()
             return 0, '', 'Self-test succeeded'
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50167

---

backport of https://github.com/ceph/ceph/pull/34846
parent tracker: https://tracker.ceph.com/issues/45147

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh