### PR TITLE
octopus: test: bump DecayCounter.steady acceptable error

### DIFF
--- a/src/test/common/test_counter.cc
+++ b/src/test/common/test_counter.cc
@@ -36,5 +36,5 @@ TEST(DecayCounter, steady)
    */
   double expected = -1*std::log(0.5)/rate*max*duration;
   std::cerr << "t " << total << " e " << expected << std::endl;
-  ASSERT_LT(std::abs(total-expected)/expected, 0.01);
+  ASSERT_LT(std::abs(total-expected)/expected, 0.05);
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50383

---

backport of https://github.com/ceph/ceph/pull/40875
parent tracker: https://tracker.ceph.com/issues/50378

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh