### PR TITLE
octopus: osd/PG.cc: handle removal of pgmeta object

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3872,9 +3872,15 @@ ghobject_t PG::do_delete_work(ObjectStore::Transaction &t,
       &olist,
       &next);
     if (!olist.empty()) {
-      dout(0) << __func__ << " additional unexpected onode list"
-              <<" (new onodes has appeared since PG removal started"
-              << olist << dendl;
+      for (auto& oid : olist) {
+        if (oid == pgmeta_oid) {
+          dout(20) << __func__ << " removing pgmeta object " << oid << dendl;
+        } else {
+          dout(0) << __func__ << " additional unexpected onode"
+                  <<" new onode has appeared since PG removal started"
+                  << oid << dendl;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50705

---

backport of https://github.com/ceph/ceph/pull/40993
parent tracker: https://tracker.ceph.com/issues/50466

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh