### PR TITLE
octopus: doc/rados/operations: s/max_misplaced/target_max_misplaced_ratio/

### DIFF
--- a/doc/rados/operations/balancer.rst
+++ b/doc/rados/operations/balancer.rst
@@ -42,9 +42,9 @@ healed itself).
 When the cluster is healthy, the balancer will throttle its changes
 such that the percentage of PGs that are misplaced (i.e., that need to
 be moved) is below a threshold of (by default) 5%.  The
-``max_misplaced`` threshold can be adjusted with::
+``target_max_misplaced_ratio`` threshold can be adjusted with::
 
-  ceph config set mgr mgr/balancer/max_misplaced .07   # 7%
+  ceph config set mgr target_max_misplaced_ratio .07   # 7%
 
 
 Modes


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50750

---

backport of https://github.com/ceph/ceph/pull/41269
parent tracker: https://tracker.ceph.com/issues/50745

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh