### PR TITLE
octopus: mds: completed_requests -> num_completed_requests and dump num_completed_flushes

### DIFF
--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -591,6 +591,7 @@ void Session::dump(Formatter *f, bool cap_dump) const
   f->dump_float("uptime", get_session_uptime());
   f->dump_unsigned("requests_in_flight", get_request_count());
   f->dump_unsigned("num_completed_requests", get_num_completed_requests());
+  f->dump_unsigned("num_completed_flushes", get_num_completed_flushes());
   f->dump_bool("reconnecting", reconnecting);
   f->dump_object("recall_caps", recall_caps);
   f->dump_object("release_caps", release_caps);

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -590,7 +590,7 @@ void Session::dump(Formatter *f, bool cap_dump) const
   }
   f->dump_float("uptime", get_session_uptime());
   f->dump_unsigned("requests_in_flight", get_request_count());
-  f->dump_unsigned("completed_requests", get_num_completed_requests());
+  f->dump_unsigned("num_completed_requests", get_num_completed_requests());
   f->dump_bool("reconnecting", reconnecting);
   f->dump_object("recall_caps", recall_caps);
   f->dump_object("release_caps", release_caps);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50635

---

backport of https://github.com/ceph/ceph/pull/41066
parent tracker: https://tracker.ceph.com/issues/50559

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh