### PR TITLE
mgr/dashboard: fix bucket objects and size calculations

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.spec.ts
@@ -98,7 +98,7 @@ describe('RgwBucketListComponent', () => {
               size_actual: 4,
               num_objects: 2
             },
-            'rgw.another': {
+            'rgw.none': {
               size_actual: 6,
               num_objects: 6
             }
@@ -119,17 +119,17 @@ describe('RgwBucketListComponent', () => {
         owner: 'testid',
         usage: {
           'rgw.main': { size_actual: 4, num_objects: 2 },
-          'rgw.another': { size_actual: 6, num_objects: 6 }
+          'rgw.none': { size_actual: 6, num_objects: 6 }
         },
         bucket_quota: {
           max_size: 20,
           max_objects: 10,
           enabled: true
         },
-        bucket_size: 10,
-        num_objects: 8,
-        size_usage: 0.5,
-        object_usage: 0.8
+        bucket_size: 4,
+        num_objects: 2,
+        size_usage: 0.2,
+        object_usage: 0.2
       }
     ]);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
@@ -125,20 +125,18 @@ export class RgwBucketListComponent extends ListWithDetails implements OnInit {
 
   transformBucketData() {
     _.forEach(this.buckets, (bucketKey) => {
-      const usageList = bucketKey['usage'];
       const maxBucketSize = bucketKey['bucket_quota']['max_size'];
       const maxBucketObjects = bucketKey['bucket_quota']['max_objects'];
-      let totalBucketSize = 0;
-      let numOfObjects = 0;
-      _.forEach(usageList, (usageKey) => {
-        totalBucketSize = totalBucketSize + usageKey.size_actual;
-        numOfObjects = numOfObjects + usageKey.num_objects;
-      });
-      bucketKey['bucket_size'] = totalBucketSize;
-      bucketKey['num_objects'] = numOfObjects;
-      bucketKey['size_usage'] = maxBucketSize > 0 ? totalBucketSize / maxBucketSize : undefined;
+      bucketKey['bucket_size'] = 0;
+      bucketKey['num_objects'] = 0;
+      if (!_.isEmpty(bucketKey['usage'])) {
+        bucketKey['bucket_size'] = bucketKey['usage']['rgw.main']['size_actual'];
+        bucketKey['num_objects'] = bucketKey['usage']['rgw.main']['num_objects'];
+      }
+      bucketKey['size_usage'] =
+        maxBucketSize > 0 ? bucketKey['bucket_size'] / maxBucketSize : undefined;
       bucketKey['object_usage'] =
-        maxBucketObjects > 0 ? numOfObjects / maxBucketObjects : undefined;
+        maxBucketObjects > 0 ? bucketKey['num_objects'] / maxBucketObjects : undefined;
     });
   }
 


### PR DESCRIPTION
This PR fixes the number of objects and bucket size calculation.

Fixes: https://tracker.ceph.com/issues/51035
Signed-off-by: Avan Thakkar <athakkar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
