### PR TITLE
auth/KeyRing: always decode keying as plaintext

### DIFF
--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -201,17 +201,10 @@ void KeyRing::decode_plaintext(bufferlist::const_iterator& bli)
   }
 }
 
-void KeyRing::decode(bufferlist::const_iterator& bl) {
-  __u8 struct_v;
+void KeyRing::decode(bufferlist::const_iterator& bl)
+{
   auto start_pos = bl;
-  try {
-    using ceph::decode;
-    decode(struct_v, bl);
-    decode(keys, bl);
-  } catch (ceph::buffer::error& err) {
-    keys.clear();
-    decode_plaintext(start_pos);
-  }
+  decode_plaintext(start_pos);
 }
 
 int KeyRing::load(CephContext *cct, const std::string &filename)

--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -203,8 +203,7 @@ void KeyRing::decode_plaintext(bufferlist::const_iterator& bli)
 
 void KeyRing::decode(bufferlist::const_iterator& bl)
 {
-  auto start_pos = bl;
-  decode_plaintext(start_pos);
+  decode_plaintext(bl);
 }
 
 int KeyRing::load(CephContext *cct, const std::string &filename)

--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -162,7 +162,7 @@ void KeyRing::encode_formatted(string label, Formatter *f, bufferlist& bl)
   f->flush(bl);
 }
 
-void KeyRing::decode_plaintext(bufferlist::const_iterator& bli)
+void KeyRing::decode(bufferlist::const_iterator& bli)
 {
   int ret;
   bufferlist bl;
@@ -199,11 +199,6 @@ void KeyRing::decode_plaintext(bufferlist::const_iterator& bli)
       }
     }
   }
-}
-
-void KeyRing::decode(bufferlist::const_iterator& bl)
-{
-  decode_plaintext(bl);
 }
 
 int KeyRing::load(CephContext *cct, const std::string &filename)

--- a/src/auth/KeyRing.h
+++ b/src/auth/KeyRing.h
@@ -91,7 +91,7 @@ public:
   }
   void import(CephContext *cct, KeyRing& other);
 
-  // encoders
+  // decode as plaintext
   void decode(ceph::buffer::list::const_iterator& bl);
 
   void encode_plaintext(ceph::buffer::list& bl);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -6028,7 +6028,7 @@ int Monitor::mkfs(bufferlist& osdmapbl)
 	bl.append(keyring_plaintext);
 	try {
 	  auto i = bl.cbegin();
-	  keyring.decode_plaintext(i);
+	  keyring.decode(i);
 	}
 	catch (const ceph::buffer::error& e) {
 	  derr << "error decoding keyring " << keyring_plaintext


### PR DESCRIPTION
 auth/KeyRing: always decode keying as plaintext

for three reasons:

* we don't encode binary KeyRing since v0.48: the binary encoder for
  KeyRing was dropped in eaea7aa9b28849be612b22ce84971db671319806,
  which was included since v0.48 (argonaut). and we don't encode
  KeyRing in binary manually elsewhere since then.
* we should not use exception in the normal code path. in C++,
   exception is not designed to be efficient or semantically a
   language facility to be part of the normal code path. so, from
  the readability perspective, we should not use exception here.
  as all encoded KeyRings are in plaintext.
* simpler this way.