### PR TITLE
mgr/cephadm: fix errors in command <ceph orch osd> help and documentation

### DIFF
--- a/doc/cephadm/osd.rst
+++ b/doc/cephadm/osd.rst
@@ -268,7 +268,7 @@ It is possible to stop queued OSD removals by using the following command:
 
 .. prompt:: bash #
 
-  ceph orch osd rm stop <svc_id(s)>
+  ceph orch osd rm stop <osd_id(s)>
 
 Example:
 
@@ -288,7 +288,7 @@ Replacing an OSD
 
 .. prompt:: bash #
 
-  orch osd rm <svc_id(s)> --replace [--force]
+  orch osd rm <osd_id(s)> --replace [--force]
 
 Example:
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -814,24 +814,24 @@ Usage:
 
     @_cli_write_command('orch osd rm')
     def _osd_rm_start(self,
-                      svc_id: List[str],
+                      osd_id: List[str],
                       replace: bool = False,
                       force: bool = False) -> HandleCommandResult:
-        """Remove OSD services"""
-        completion = self.remove_osds(svc_id, replace=replace, force=force)
+        """Remove OSD daemons"""
+        completion = self.remove_osds(osd_id, replace=replace, force=force)
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch osd rm stop')
-    def _osd_rm_stop(self, svc_id: List[str]) -> HandleCommandResult:
+    def _osd_rm_stop(self, osd_id: List[str]) -> HandleCommandResult:
         """Cancel ongoing OSD removal operation"""
-        completion = self.stop_remove_osds(svc_id)
+        completion = self.stop_remove_osds(osd_id)
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch osd rm status')
     def _osd_rm_status(self, format: Format = Format.plain) -> HandleCommandResult:
-        """status of OSD removal operation"""
+        """Status of OSD removal operation"""
         completion = self.remove_osds_status()
         raise_if_exception(completion)
         report = completion.result


### PR DESCRIPTION
`ceph orch rm --help` --->   Now it looks like:

```
 Monitor commands: 
 =================
orch osd rm <osd_id>... [--replace] [--force]                                                              Remove OSD daemons
orch osd rm status [--format {plain|json|json-pretty|yaml}]                                                Status of OSD removal operation
orch osd rm stop <osd_id>...                                                                               Cancel ongoing OSD removal operation
```


Resolves: https://tracker.ceph.com/issues/51043

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst



-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
