### PR TITLE
pacific: mgr/dashboard: pass Grafana datasource in URL

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.spec.ts
@@ -18,6 +18,8 @@ import { GrafanaComponent } from './grafana.component';
 describe('GrafanaComponent', () => {
   let component: GrafanaComponent;
   let fixture: ComponentFixture<GrafanaComponent>;
+  const expected_url =
+    'http:localhost:3000/d/foo/somePath&refresh=2s&var-datasource=Dashboard1&kiosk&from=now-1h&to=now';
 
   configureTestBed({
     declarations: [GrafanaComponent, AlertPanelComponent, LoadingPanelComponent, DocComponent],
@@ -56,24 +58,18 @@ describe('GrafanaComponent', () => {
       expect(component.grafanaExist).toBe(true);
       expect(component.baseUrl).toBe('http:localhost:3000/d/');
       expect(component.loading).toBe(false);
-      expect(component.url).toBe(
-        'http:localhost:3000/d/foo/somePath&refresh=2s&kiosk&from=now-1h&to=now'
-      );
+      expect(component.url).toBe(expected_url);
       expect(component.grafanaSrc).toEqual({
-        changingThisBreaksApplicationSecurity:
-          'http:localhost:3000/d/foo/somePath&refresh=2s&kiosk&from=now-1h&to=now'
+        changingThisBreaksApplicationSecurity: expected_url
       });
     });
 
     it('should reset the values', () => {
       component.reset();
       expect(component.time).toBe('from=now-1h&to=now');
-      expect(component.url).toBe(
-        'http:localhost:3000/d/foo/somePath&refresh=2s&kiosk&from=now-1h&to=now'
-      );
+      expect(component.url).toBe(expected_url);
       expect(component.grafanaSrc).toEqual({
-        changingThisBreaksApplicationSecurity:
-          'http:localhost:3000/d/foo/somePath&refresh=2s&kiosk&from=now-1h&to=now'
+        changingThisBreaksApplicationSecurity: expected_url
       });
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
@@ -19,6 +19,7 @@ export class GrafanaComponent implements OnInit, OnChanges {
   panelStyle: any;
   grafanaExist = false;
   mode = '&kiosk';
+  datasource = 'Dashboard1';
   loading = true;
   styles: Record<string, string> = {};
   dashboardExist = true;
@@ -171,6 +172,7 @@ export class GrafanaComponent implements OnInit, OnChanges {
       '/' +
       this.grafanaPath +
       '&refresh=2s' +
+      `&var-datasource=${this.datasource}` +
       this.mode +
       '&' +
       this.time;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51036

---

backport of https://github.com/ceph/ceph/pull/41598
parent tracker: https://tracker.ceph.com/issues/51026

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh