### PR TITLE
doc/cephadm: enriching "setting a limit"

### DIFF
--- a/doc/cephadm/service-management.rst
+++ b/doc/cephadm/service-management.rst
@@ -243,13 +243,13 @@ Or in YAML:
 Setting a limit
 ---------------
 
-By specifying ``count``, only that number of daemons will be created:
+By specifying ``count``, only the number of daemons specified will be created:
 
    .. prompt:: bash #
 
     orch apply prometheus --placement=3
 
-To deploy *daemons* on a subset of hosts, also specify the count:
+To deploy *daemons* on a subset of hosts, specify the count:
 
    .. prompt:: bash #
 
@@ -261,9 +261,9 @@ If the count is bigger than the amount of hosts, cephadm deploys one per host:
 
     orch apply prometheus --placement="3 host1 host2"
 
-results in two Prometheus daemons.
+The command immediately above results in two Prometheus daemons.
 
-Or in YAML:
+YAML can also be used to specify limits, in the following way:
 
 .. code-block:: yaml
 
@@ -271,7 +271,7 @@ Or in YAML:
     placement:
       count: 3
 
-Or with hosts:
+YAML can also be used to specify limits on hosts:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
This PR improves the flow and syntax of the
sentences in the "Setting a Limit" section of the
"Service Management" chapter of the cephadm documentation.
(This section is about setting limits to the number of
daemons created, and about limiting the creation of daemons
to a specified number of hosts.)

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
