### PR TITLE
octopus:  os/bluestore: fix unexpected ENOSPC in Avl/Hybrid allocators.

### DIFF
--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -498,6 +498,47 @@ TEST_P(AllocTest, test_alloc_47883)
   EXPECT_EQ(got, 0x630000);
 }
 
+TEST_P(AllocTest, test_alloc_50656_best_fit)
+{
+  uint64_t block = 0x1000;
+  uint64_t size = 0x3b9e400000;
+
+  init_alloc(size, block);
+
+  // too few free extents - causes best fit mode for avls
+  for (size_t i = 0; i < 0x10; i++) {
+    alloc->init_add_free(i * 2 * 0x100000, 0x100000);
+  }
+
+  alloc->init_add_free(0x1e1bd13000, 0x404000);
+
+  PExtentVector extents;
+  auto need = 0x400000;
+  auto got = alloc->allocate(need, 0x10000, 0, (int64_t)0, &extents);
+  EXPECT_GT(got, 0);
+  EXPECT_EQ(got, 0x400000);
+}
+
+TEST_P(AllocTest, test_alloc_50656_first_fit)
+{
+  uint64_t block = 0x1000;
+  uint64_t size = 0x3b9e400000;
+
+  init_alloc(size, block);
+
+  for (size_t i = 0; i < 0x10000; i += 2) {
+    alloc->init_add_free(i * 0x100000, 0x100000);
+  }
+
+  alloc->init_add_free(0x1e1bd13000, 0x404000);
+
+  PExtentVector extents;
+  auto need = 0x400000;
+  auto got = alloc->allocate(need, 0x10000, 0, (int64_t)0, &extents);
+  EXPECT_GT(got, 0);
+  EXPECT_EQ(got, 0x400000);
+}
+
 INSTANTIATE_TEST_SUITE_P(
   Allocator,
   AllocTest,

--- a/src/test/objectstore/bmap_allocator_replay_test.cc
+++ b/src/test/objectstore/bmap_allocator_replay_test.cc
@@ -137,7 +137,20 @@ int replay_and_check_for_duplicate(char* fname)
       continue;
     }
 
+    string alloc_type = "bitmap";
     sp = strstr(s, "BitmapAllocator");
+    if (!sp) {
+      alloc_type = "avl";
+      sp = strstr(s, "AvlAllocator");
+    }
+    if (!sp) {
+      alloc_type = "hybrid";
+      sp = strstr(s, "HybridAllocator");
+    }
+    if (!sp) {
+      alloc_type = "stupid";
+      sp = strstr(s, "StupidAllocator");
+    }
     if (sp) {
       // 2019-05-30 03:23:43.460 7f889a5edf00 10 fbmap_alloc 0x5642ed36e900 BitmapAllocator 0x15940000000/100000
       if (init_done) { 
@@ -156,7 +169,7 @@ int replay_and_check_for_duplicate(char* fname)
 	std::cerr << "error: invalid init: " << s << std::endl;
       return -1;
       }
-      alloc.reset(Allocator::create(g_ceph_context, string("bitmap"), total,
+      alloc.reset(Allocator::create(g_ceph_context, alloc_type, total,
 				    alloc_unit));
 
       init_done = true;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51041

---

backport of https://github.com/ceph/ceph/pull/41369
parent tracker: https://tracker.ceph.com/issues/50656

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh