### PR TITLE
crimson/osd: wait for SIGINT and SIGTERM before stopping

### DIFF
--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(crimson-osd
   pg_meta.cc
   replicated_backend.cc
   shard_services.cc
+  stop_signal.cc
   object_context.cc
   ops_executer.cc
   osd_operation.cc

--- a/src/crimson/osd/stop_signal.cc
+++ b/src/crimson/osd/stop_signal.cc
@@ -1,0 +1,33 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "stop_signal.h"
+
+#include <csignal>
+#include <seastar/core/reactor.hh>
+
+StopSignal::StopSignal()
+{
+  seastar::engine().handle_signal(SIGINT, [this] { signaled(); });
+  seastar::engine().handle_signal(SIGTERM, [this] { signaled(); });
+}
+
+StopSignal::~StopSignal()
+{
+  seastar::engine().handle_signal(SIGINT, [] {});
+  seastar::engine().handle_signal(SIGTERM, [] {});
+}
+
+seastar::future<> StopSignal::wait()
+{
+  return should_stop.wait([this] { return caught; });
+}
+
+void StopSignal::signaled()
+{
+  if (caught) {
+    return;
+  }
+  caught = true;
+  should_stop.signal();
+}

--- a/src/crimson/osd/stop_signal.h
+++ b/src/crimson/osd/stop_signal.h
@@ -1,0 +1,21 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/sharded.hh>
+
+class StopSignal {
+public:
+  StopSignal();
+  ~StopSignal();
+  seastar::future<> wait();
+
+private:
+  void signaled();
+
+private:
+  bool caught;
+  seastar::condition_variable should_stop;
+};


### PR DESCRIPTION
this change addresses an ingression introduced by
37b83f4ed7ca69f105b93bf482cb2289cbaf9a4d. as we should not stop
services without being asked to do so.

in this change, signal handler for SIGINT and SIGTERM is registered to
handle these signals, and in the seastar thread, we wait until any of
these two signals is caught.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
