### PR TITLE
crimson, common: improve const-correctness of Operation::dump()s.

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -251,8 +251,9 @@ bool OpTracker::dump_ops_in_flight(Formatter *f, bool print_only_blocked, set<st
   if (print_only_blocked) {
     f->dump_float("complaint_time", complaint_time);
     f->dump_int("num_blocked_ops", total_ops_in_flight);
-  } else
+  } else {
     f->dump_int("num_ops", total_ops_in_flight);
+  }
   f->close_section(); // overall dump
   return true;
 }

--- a/src/crimson/common/operation.cc
+++ b/src/crimson/common/operation.cc
@@ -6,7 +6,7 @@
 
 namespace crimson {
 
-void Operation::dump(ceph::Formatter* f)
+void Operation::dump(ceph::Formatter* f) const
 {
   f->open_object_section("operation");
   f->dump_string("type", get_type_name());
@@ -24,7 +24,7 @@ void Operation::dump(ceph::Formatter* f)
   f->close_section();
 }
 
-void Operation::dump_brief(ceph::Formatter* f)
+void Operation::dump_brief(ceph::Formatter* f) const
 {
   f->open_object_section("operation");
   f->dump_string("type", get_type_name());

--- a/src/crimson/common/operation.h
+++ b/src/crimson/common/operation.h
@@ -276,8 +276,8 @@ class Operation : public boost::intrusive_ref_counter<
     });
   }
 
-  void dump(ceph::Formatter *f);
-  void dump_brief(ceph::Formatter *f);
+  void dump(ceph::Formatter *f) const;
+  void dump_brief(ceph::Formatter *f) const;
   virtual ~Operation() = default;
 
  private:


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
