### PR TITLE
vstart.sh: disable restful by default

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -174,7 +174,7 @@ if [[ "$(get_cmake_variable WITH_MGR_DASHBOARD_FRONTEND)" != "ON" ]] ||
     debug echo "ceph-mgr dashboard not built - disabling."
     with_mgr_dashboard=false
 fi
-with_mgr_restful=true
+with_mgr_restful=false
 
 filestore_path=
 kstore_path=
@@ -451,8 +451,8 @@ case $1 in
     --without-dashboard)
         with_mgr_dashboard=false
         ;;
-    --without-restful)
-        with_mgr_restful=false
+    --with-restful)
+        with_mgr_restful=true
         ;;
     --seastore-devs)
         parse_block_devs --seastore-devs "$2"


### PR DESCRIPTION
since we are going to deprecate restful in favor of dashboard's RESTful
API. see
https://lists.ceph.io/hyperkitty/list/dev@ceph.io/message/LBKLNXH7UQL7TLFU5G52Y2SYVME4RS6P/
and https://tracker.ceph.com/issues/47066, let's disable this module
by default. and change the option of --without-restful to
--with-restful.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
