### PR TITLE
pybind/ceph_daemon: add missing type annotations

### DIFF
--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -18,6 +18,9 @@ ignore_missing_imports = True
 # This would require a cephfs.pyi file
 ignore_missing_imports = True
 
+[mypy-ceph_daemon]
+disallow_untyped_defs = True
+
 # python-common
 [mypy-ceph.*]
 disallow_untyped_defs = True

--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -19,9 +19,10 @@ from collections import OrderedDict
 from fcntl import ioctl
 from fnmatch import fnmatch
 from prettytable import PrettyTable, HEADER
-from signal import signal, SIGWINCH
+from signal import signal, Signals, SIGWINCH
 from termios import TIOCGWINSZ
-from typing import Any, Dict, Optional, Sequence, TextIO, Tuple
+from types import FrameType
+from typing import Any, Callable, Dict, Optional, Sequence, TextIO, Tuple
 
 from ceph_argparse import parse_json_funcsigs, validate_command
 
@@ -40,7 +41,7 @@ def admin_socket(asok_path: str,
     (daemon commands don't support 'plain' output).
     """
 
-    def do_sockio(path, cmd_bytes):
+    def do_sockio(path: str, cmd_bytes: bytes) -> bytes:
         """ helper: do all the actual low-level stream I/O """
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.connect(path)
@@ -180,7 +181,7 @@ class DaemonWatcher(object):
         return (self.COLOR_DARK_SEQ if dark else self.COLOR_SEQ) % (30 + color) \
                + msg + self.RESET_SEQ
 
-    def bold(self, msg) -> str:
+    def bold(self, msg: str) -> str:
         """
         Decorate `msg` with escape sequences to make it appear bold
         """
@@ -365,7 +366,9 @@ class DaemonWatcher(object):
         if not len(self._stats):
             raise RuntimeError("no stats selected by filters")
 
-    def _handle_sigwinch(self, signo, frame) -> None:
+    def _handle_sigwinch(self,
+                         signo: Signals,
+                         frame: FrameType) -> None:
         self.termsize.update()
 
     def run(self,

--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -117,8 +117,8 @@ class Termsize(object):
                                           self.rows, self.cols, self.changed)
 
     def __repr__(self) -> str:
-        return 'Termsize(%d,%d,%s)' % (self.__class__,
-                                       self.rows, self.cols, self.changed)
+        return '%s(%d,%d,%s)' % (self.__class__,
+                                 self.rows, self.cols, self.changed)
 
 
 class DaemonWatcher(object):

--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -71,9 +71,6 @@ def admin_socket(asok_path: str,
     except Exception as e:
         raise RuntimeError('exception getting command descriptions: ' + str(e))
 
-    if cmd == 'get_command_descriptions':
-        return cmd_json
-
     sigdict = parse_json_funcsigs(cmd_json.decode('utf-8'), 'cli')
     valid_dict = validate_command(sigdict, cmd)
     if not valid_dict:

--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -31,7 +31,7 @@ READ_CHUNK_SIZE = 4096
 
 
 def admin_socket(asok_path: str,
-                 cmd: str,
+                 cmd: Sequence[str],
                  format: Optional[str] = '') -> bytes:
     """
     Send a daemon (--admin-daemon) command 'cmd'.  asok_path is the

--- a/src/pybind/tox.ini
+++ b/src/pybind/tox.ini
@@ -1,2 +1,17 @@
+[tox]
+minversion = 3.6
+envlist =
+    mypy
+skipsdist = true
+
+[testenv]
+
+[testenv:mypy]
+deps = mypy
+commands =
+  python -m mypy --config-file ../mypy.ini \
+    -m ceph_daemon \
+    -m ceph_argparse
+
 [pep8]
 ignore = E123,E203


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
