### PR TITLE
cephadm: improve is_container_running()

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2051,10 +2051,11 @@ def check_units(ctx, units, enabler=None):
 
 
 def is_container_running(ctx: CephadmContext, name: str) -> bool:
-    out, err, ret = call_throws(ctx, [
-        ctx.container_engine.path, 'ps',
-        '--format', '{{.Names}}'])
-    return name in out
+    out, err, ret = call(ctx, [
+        ctx.container_engine.path, 'container', 'inspect',
+        '--format', '{{.State.Status}}', name
+    ])
+    return out == 'running'
 
 
 def get_legacy_config_fsid(cluster, legacy_dir=None):


### PR DESCRIPTION
The 'podman ps' command sporatically exits with 125, I suspect due
to some race/bug in podman itself.

However, our goal here is just to check if a specific container
is running.  Use inspect for that instead--it's even (a bit) faster.

Fixes: https://tracker.ceph.com/issues/51109
Signed-off-by: Sage Weil <sage@newdream.net>