### PR TITLE
nautilus: ceph-volume: fix batch report and respect ceph.conf config values

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -106,7 +106,7 @@ def get_physical_fast_allocs(devices, type_, fast_slots_per_device, new_osds, ar
         requested_slots = fast_slots_per_device
 
     requested_size = getattr(args, '{}_size'.format(type_), 0)
-    if requested_size == 0:
+    if not requested_size or requested_size == 0:
         # no size argument was specified, check ceph.conf
         get_size_fct = getattr(prepare, 'get_{}_size'.format(type_))
         requested_size = get_size_fct(lv_format=False)

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -126,6 +126,7 @@ def get_physical_fast_allocs(devices, type_, fast_slots_per_device, new_osds, ar
         if requested_size:
             if requested_size <= abs_size:
                 abs_size = requested_size
+                relative_size = int(abs_size) / dev_size
             else:
                 mlogger.error(
                     '{} was requested for {}, but only {} can be fulfilled'.format(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51104

---

backport of https://github.com/ceph/ceph/pull/41506
parent tracker: https://tracker.ceph.com/issues/50958

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh