### PR TITLE
mgr/dashboard: telemetry activate: show ident fields when checked

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -126,12 +126,14 @@
                   <input type="checkbox"
                          class="custom-control-input"
                          id="channel_ident"
-                         formControlName="channel_ident">
+                         formControlName="channel_ident"
+                         (click)="toggleIdent()">
                   <label class="custom-control-label"
                          for="channel_ident"></label>
                 </div>
               </div>
             </div>
+            <ng-container *ngIf="showContactInfo">
             <legend>
               <ng-container i18n>Contact Information</ng-container>
               <cd-helper i18n>Submitting any contact information is completely optional and disabled by default.</cd-helper>
@@ -161,6 +163,7 @@
                        i18n-placeholder>
               </div>
             </div>
+          </ng-container>
             <legend i18n>Advanced Settings</legend>
             <div class="form-group row">
               <label class="cd-col-form-label"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -80,6 +80,29 @@ describe('TelemetryComponent', () => {
       expect(component).toBeTruthy();
     });
 
+    it('should show/hide ident fields on checking/unchecking', () => {
+      const getContactField = () =>
+        fixture.debugElement.nativeElement.querySelector('input[id=contact]');
+      const getDescriptionField = () =>
+        fixture.debugElement.nativeElement.querySelector('input[id=description]');
+
+      // Initially hidden.
+      expect(getContactField()).toBeFalsy();
+      expect(getDescriptionField()).toBeFalsy();
+
+      // Show fields.
+      component.toggleIdent();
+      fixture.detectChanges();
+      expect(getContactField()).toBeTruthy();
+      expect(getDescriptionField()).toBeTruthy();
+
+      // Hide fields.
+      component.toggleIdent();
+      fixture.detectChanges();
+      expect(getContactField()).toBeFalsy();
+      expect(getDescriptionField()).toBeFalsy();
+    });
+
     it('should set module enability to true correctly', () => {
       expect(component.moduleEnabled).toBeTruthy();
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -42,6 +42,7 @@ export class TelemetryComponent extends CdForm implements OnInit {
   sendToUrl = '';
   sendToDeviceUrl = '';
   step = 1;
+  showContactInfo = false;
 
   constructor(
     public actionLabels: ActionLabelsI18n,
@@ -135,6 +136,10 @@ export class TelemetryComponent extends CdForm implements OnInit {
         this.loadingError();
       }
     );
+  }
+
+  toggleIdent() {
+    this.showContactInfo = !this.showContactInfo;
   }
 
   updateConfig() {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/51020
Before (checking the ident checkbox wasn't doing anything):

![image](https://user-images.githubusercontent.com/54525904/121157501-3e756600-c867-11eb-9228-860bed37c992.png)


After (checking ident box shows contact info form):

![identChecked](https://user-images.githubusercontent.com/54525904/121156856-b1caa800-c866-11eb-8e61-7db68a7022b5.gif)


Signed-off-by: Aaryan Porwal <aaryanporwal2233@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
