### PR TITLE
cmake: do not print warning in each cmake run

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -606,6 +606,10 @@ add_ceph_test(run-cli-tests ${CMAKE_CURRENT_SOURCE_DIR}/run-cli-tests)
 
 add_ceph_test(smoke.sh ${CMAKE_CURRENT_SOURCE_DIR}/smoke.sh)
 
+if(DEFINED PROMTOOL_EXECUTABLE)
+  set(promtool_executable_checked TRUE)
+endif()
+
 find_program(PROMTOOL_EXECUTABLE promtool)
 if(PROMTOOL_EXECUTABLE)
   execute_process(
@@ -615,11 +619,11 @@ if(PROMTOOL_EXECUTABLE)
   if(NOT rc)
     add_ceph_test(run-promtool-unittests
       ${PROMTOOL_EXECUTABLE} test rules ${CMAKE_SOURCE_DIR}/monitoring/prometheus/alerts/test_alerts.yml)
-  else()
+  elseif(NOT promtool_executable_checked)
     message(WARNING "'${PROMTOOL_EXECUTABLE} test rules' does not work, "
       "please use a newer prometheus")
   endif()
-else()
+elseif(NOT promtool_executable_checked)
   message(WARNING "run-promtool-unittests is skipped due to missing promtool")
 endif()
 


### PR DESCRIPTION
cmake prints the warning of

> run-promtool-unittests is skipped due to missing promtool

everytime if the test is skipped per the test. but we only need to
get this message the first time cmake is executed. more importantly,
the value of `PROMTOOL_EXECUTABLE` is cached. so the new error message
does not provide updated information, so just stop doing so if the
cached variable is found.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
