### PR TITLE
*: stop using <experimental/filesystem> as an alternative

### DIFF
--- a/cmake/modules/CephChecks.cmake
+++ b/cmake/modules/CephChecks.cmake
@@ -1,6 +1,6 @@
-if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7)
-    message(FATAL_ERROR "GCC 7+ required due to C++17 requirements")
+if(CMAKE_COMPILER_IS_GNUCXX)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.1)
+    message(FATAL_ERROR "GCC 8.1+ required due to C++17 requirements")
   endif()
 endif()
 

--- a/cmake/modules/FindStdFilesystem.cmake
+++ b/cmake/modules/FindStdFilesystem.cmake
@@ -28,7 +28,6 @@ set(_std_filesystem_already_included FALSE)
 foreach(library
     ""
     "stdc++fs"
-    "c++experimental"
     "c++fs")
   try_std_filesystem_library("${library}" StdFilesystem_LIBRARY _std_filesystem_already_included)
   if(_std_filesystem_already_included)

--- a/cmake/modules/FindStdFilesystem_test.cc
+++ b/cmake/modules/FindStdFilesystem_test.cc
@@ -1,12 +1,6 @@
-#if __has_include(<filesystem>)
 #include <filesystem>
+
 namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-#error std::filesystem not available!
-#endif
 
 int main() {
     fs::create_directory("sandbox");

--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -16,21 +16,12 @@
 #include <algorithm>
 #include <cctype>
 #include <experimental/iterator>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <iterator>
 #include <map>
 #include <sstream>
-
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-#error std::filesystem not available!
-#endif
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/trim_all.hpp>
@@ -42,6 +33,8 @@ namespace fs = std::experimental::filesystem;
 #include "common/errno.h"
 #include "common/utf8.h"
 #include "common/ConfUtils.h"
+
+namespace fs = std::filesystem;
 
 using std::ostringstream;
 using std::string;

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -12,14 +12,9 @@
  *
  */
 
-#include <boost/type_traits.hpp>
-#if __has_include(<filesystem>)
 #include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
+#include <boost/type_traits.hpp>
+
 #include "common/ceph_argparse.h"
 #include "common/common_init.h"
 #include "common/config.h"
@@ -42,6 +37,8 @@ namespace fs = std::experimental::filesystem;
 
 // set set_mon_vals()
 #define dout_subsys ceph_subsys_monc
+
+namespace fs = std::filesystem;
 
 using std::cerr;
 using std::cout;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -12,14 +12,7 @@
  *
  */
 
-#if __has_include(<filesystem>)
 #include <filesystem>
-namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
-
 #include "common/async/context_pool.h"
 #include "common/ceph_argparse.h"
 #include "common/code_environment.h"
@@ -49,6 +42,8 @@ namespace fs = std::experimental::filesystem;
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_
+
+namespace fs = std::filesystem;
 
 using std::cerr;
 using std::string;

--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -6,17 +6,11 @@
  */
 
 #include "include/compat.h"
+#include <filesystem>
 #include <set>
 #include <map>
 #include <string>
 #include <memory>
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 #include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -43,6 +37,8 @@ namespace fs = std::experimental::filesystem;
 #define dtrace dout(30)
 #define dwarn dout(0)
 #define dinfo dout(0)
+
+namespace fs = std::filesystem;
 
 using std::cerr;
 using std::ostream;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1,17 +1,11 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include <set>
-#include <map>
-#include <string>
-#include <memory>
-#if __has_include(<filesystem>)
 #include <filesystem>
-namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
 #include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -42,6 +36,8 @@ namespace fs = std::experimental::filesystem;
 #define dout_subsys ceph_subsys_rocksdb
 #undef dout_prefix
 #define dout_prefix *_dout << "rocksdb: "
+
+namespace fs = std::filesystem;
 
 using std::function;
 using std::list;

--- a/src/librbd/cache/pwl/DiscardRequest.cc
+++ b/src/librbd/cache/pwl/DiscardRequest.cc
@@ -1,19 +1,13 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <filesystem>
+
 #include "common/dout.h"
 #include "common/errno.h"
 #include "common/hostname.h"
 #include "librbd/asio/ContextWQ.h"
 #include "librbd/cache/pwl/DiscardRequest.h"
-
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 
 #include "librbd/cache/pwl/ImageCacheState.h"
 
@@ -27,6 +21,8 @@ namespace fs = std::experimental::filesystem;
 #undef dout_prefix
 #define dout_prefix *_dout << "librbd::cache::pwl:DiscardRequest: " \
                            << this << " " << __func__ << ": "
+
+namespace fs = std::filesystem;
 
 namespace librbd {
 namespace cache {

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -13,15 +13,7 @@
 
 #include "PyModuleRegistry.h"
 
-#if __has_include(<filesystem>)
 #include <filesystem>
-namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-#error std::filesystem not available!
-#endif
 
 #include "include/stringify.h"
 #include "common/errno.h"
@@ -41,6 +33,8 @@ namespace fs = std::experimental::filesystem;
 
 #undef dout_prefix
 #define dout_prefix *_dout << "mgr[py] "
+
+namespace fs = std::filesystem;
 
 std::set<std::string> obsolete_modules = {
   "orchestrator_cli",

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -106,11 +106,6 @@ if(WITH_BLUESTORE)
     bluestore/bluestore_tool.cc)
   target_link_libraries(ceph-bluestore-tool
     os global)
-  # TODO: drop this linkage once we don't need to build on bionic
-  if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
-    target_link_libraries(ceph-bluestore-tool
-      Boost::filesystem)
-  endif()
   install(TARGETS ceph-bluestore-tool
     DESTINATION bin)
 endif()

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -6,15 +6,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#if __has_include(<filesystem>)
 #include <filesystem>
-namespace fs = std::filesystem;
-using sys_error_code = std::error_code;
-#else
-#include <boost/filesystem.hpp>
-namespace fs = boost::filesystem;
-using sys_error_code = boost::system::error_code;
-#endif
 #include <iostream>
 #include <fstream>
 #include <time.h>
@@ -31,6 +23,7 @@ using sys_error_code = boost::system::error_code;
 #include "common/admin_socket.h"
 #include "kv/RocksDBStore.h"
 
+namespace fs = std::filesystem;
 namespace po = boost::program_options;
 
 void usage(po::options_description &desc)
@@ -787,7 +780,7 @@ int main(int argc, char **argv)
       if (dev_target.empty()) {
 	return {"", false};
       }
-      sys_error_code ec;
+      std::error_code ec;
       fs::path target_path = fs::weakly_canonical(fs::path{dev_target}, ec);
       if (ec) {
 	cerr << "failed to retrieve absolute path for " << dev_target

--- a/src/test/admin_socket_output.h
+++ b/src/test/admin_socket_output.h
@@ -15,17 +15,13 @@
 #ifndef CEPH_ADMIN_SOCKET_OUTPUT_H
 #define CEPH_ADMIN_SOCKET_OUTPUT_H
 
+#include <filesystem>
 #include <string>
 #include <map>
 #include <set>
 #include <vector>
-#if __has_include(<filesystem>)	 // For extension
-#include <filesystem>
+
 namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 
 using socket_results = std::map<std::string, std::string>;
 using test_functions =

--- a/src/test/common/test_util.cc
+++ b/src/test/common/test_util.cc
@@ -12,17 +12,13 @@
  *
  */
 
+#include <filesystem>
+
+#include "gtest/gtest.h"
 #include "common/ceph_context.h"
 #include "include/util.h"
-#include "gtest/gtest.h"
 
-#if __has_include(<filesystem>)
-#include <filesystem>
 namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 
 #if defined(__linux__)
 TEST(util, collect_sys_info)

--- a/src/test/confutils.cc
+++ b/src/test/confutils.cc
@@ -17,21 +17,17 @@
 #include "gtest/gtest.h"
 #include "include/buffer.h"
 
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
-
 #include <errno.h>
+#include <filesystem>
 #include <iostream>
-#include <stdlib.h>
 #include <sstream>
+
+#include <stdlib.h>
 #include <stdint.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+namespace fs = std::filesystem;
 
 using ceph::bufferlist;
 using std::cerr;

--- a/src/test/immutable_object_cache/test_object_store.cc
+++ b/src/test/immutable_object_cache/test_object_store.cc
@@ -1,16 +1,10 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <filesystem>
 #include <iostream>
 #include <unistd.h>
 
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 
 #include "gtest/gtest.h"
 #include "include/Context.h"
@@ -23,6 +17,8 @@ namespace fs = std::experimental::filesystem;
 #include "test/librados/test_cxx.h"
 
 #include "tools/immutable_object_cache/ObjectCacheStore.h"
+
+namespace fs = std::filesystem;
 
 using namespace ceph::immutable_obj_cache;
 

--- a/src/test/librbd/migration/test_mock_FileStream.cc
+++ b/src/test/librbd/migration/test_mock_FileStream.cc
@@ -9,13 +9,9 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "json_spirit/json_spirit.h"
-#if __has_include(<filesystem>)
 #include <filesystem>
+
 namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 
 namespace librbd {
 namespace {

--- a/src/tools/ceph-dencoder/ceph_dencoder.cc
+++ b/src/tools/ceph-dencoder/ceph_dencoder.cc
@@ -16,13 +16,7 @@
 #include <dlfcn.h>
 #include <errno.h>
 
-#if __has_include(<filesystem>)
 #include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 #include <iomanip>
 
 #include "ceph_ver.h"
@@ -33,6 +27,8 @@ namespace fs = std::experimental::filesystem;
 #include "denc_registry.h"
 
 #define MB(m) ((m) * 1024 * 1024)
+
+namespace fs = std::filesystem;
 
 void usage(ostream &out)
 {

--- a/src/tools/immutable_object_cache/ObjectCacheStore.cc
+++ b/src/tools/immutable_object_cache/ObjectCacheStore.cc
@@ -3,13 +3,7 @@
 
 #include "ObjectCacheStore.h"
 #include "Utils.h"
-#if __has_include(<filesystem>)
 #include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_immutable_obj_cache
@@ -17,6 +11,7 @@ namespace fs = std::experimental::filesystem;
 #define dout_prefix *_dout << "ceph::cache::ObjectCacheStore: " << this << " " \
                            << __func__ << ": "
 
+namespace fs = std::filesystem;
 
 namespace ceph {
 namespace immutable_obj_cache {

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -44,13 +44,7 @@
 #include <libnl3/netlink/genl/ctrl.h>
 #include <libnl3/netlink/genl/mngt.h>
 
-#if __has_include(<filesystem>)
 #include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -85,6 +79,8 @@ namespace fs = std::experimental::filesystem;
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd-nbd: "
+
+namespace fs = std::filesystem;
 
 using boost::endian::big_to_native;
 using boost::endian::native_to_big;


### PR DESCRIPTION
since we stopped building on ubuntu bionic, we can assume the availability of GCC-8.4.1 (ubuntu focal) and GCC 9.3.0 (RHEL/CentOS 8). there is no need to be backward compatible with GCC-7 anymore. GCC-7 was shipped along with ubuntu bionic.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
