### PR TITLE
pacific: osd: Run osd bench test to override default max osd capacity for mclock

### DIFF
--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -7,11 +7,12 @@
 Mclock profiles mask the low level details from users, making it
 easier for them to configure mclock.
 
-To use mclock, you must provide the following input parameters:
+The following input parameters are required for a mclock profile to configure
+the QoS related parameters:
 
-* total capacity of each OSD
+* total capacity (IOPS) of each OSD (determined automatically)
 
-* an mclock profile to enable
+* an mclock profile type to enable
 
 Using the settings in the specified profile, the OSD determines and applies the
 lower-level mclock and Ceph parameters. The parameters applied by the mclock
@@ -31,11 +32,11 @@ Ceph cluster enables the throttling of the operations(IOPS) belonging to
 different client classes (background recovery, scrub, snaptrim, client op,
 osd subop)”*.
 
-The mclock profile uses the capacity limits and the mclock profile selected by
-the user to determine the low-level mclock resource control parameters.
+The mclock profile uses the capacity limits and the mclock profile type selected
+by the user to determine the low-level mclock resource control parameters.
 
-Depending on the profile, lower-level mclock resource-control parameters and
-some Ceph-configuration parameters are transparently applied.
+Depending on the profile type, lower-level mclock resource-control parameters
+and some Ceph-configuration parameters are transparently applied.
 
 The low-level mclock resource control parameters are the *reservation*,
 *limit*, and *weight* that provide control of the resource shares, as
@@ -56,7 +57,7 @@ mclock profiles can be broadly classified into two types,
     as compared to background recoveries and other internal clients within
     Ceph. This profile is enabled by default.
   - **high_recovery_ops**:
-    This profile allocates more reservation to background recoveries as 
+    This profile allocates more reservation to background recoveries as
     compared to external clients and other internal clients within Ceph. For
     example, an admin may enable this profile temporarily to speed-up background
     recoveries during non-peak hours.
@@ -109,7 +110,8 @@ chunk of the bandwidth allocation goes to client ops. Background recovery ops
 are given lower allocation (and therefore take a longer time to complete). But
 there might be instances that necessitate giving higher allocations to either
 client ops or recovery ops. In order to deal with such a situation, you can
-enable one of the alternate built-in profiles mentioned above.
+enable one of the alternate built-in profiles by following the steps mentioned
+in the next section.
 
 If any mClock profile (including "custom") is active, the following Ceph config
 sleep options will be disabled,
@@ -139,20 +141,64 @@ all its clients.
 Steps to Enable mClock Profile
 ==============================
 
-The following sections outline the steps required to enable a mclock profile.
+As already mentioned, the default mclock profile is set to *high_client_ops*.
+The other values for the built-in profiles include *balanced* and
+*high_recovery_ops*.
 
-Determining OSD Capacity Using Benchmark Tests
-----------------------------------------------
+If there is a requirement to change the default profile, then the option
+``osd_mclock_profile`` may be set during runtime by using the following
+command:
 
-To allow mclock to fulfill its QoS goals across its clients, it is most
-important to have a good understanding of each OSD's capacity in terms of its
-baseline throughputs (IOPS) across the Ceph nodes. To determine this capacity,
-you must perform appropriate benchmarking tests. The steps for performing these
-benchmarking tests are broadly outlined below.
+  .. prompt:: bash #
 
-Any existing benchmarking tool can be used for this purpose. The following
-steps use the *Ceph Benchmarking Tool* (cbt_). Regardless of the tool
-used, the steps described below remain the same.
+    ceph config set [global,osd] osd_mclock_profile <value>
+
+For example, to change the profile to allow faster recoveries, the following
+command can be used to switch to the *high_recovery_ops* profile:
+
+  .. prompt:: bash #
+
+    ceph config set osd osd_mclock_profile high_recovery_ops
+
+.. note:: The *custom* profile is not recommended unless you are an advanced
+          user.
+
+And that's it! You are ready to run workloads on the cluster and check if the
+QoS requirements are being met.
+
+
+OSD Capacity Determination (Automated)
+======================================
+
+The OSD capacity in terms of total IOPS is determined automatically during OSD
+initialization. This is achieved by running the OSD bench tool and overriding
+the default value of ``osd_mclock_max_capacity_iops_[hdd, ssd]`` option
+depending on the device type. No other action/input is expected from the user
+to set the OSD capacity. You may verify the capacity of an OSD after the
+cluster is brought up by using the following command:
+
+  .. prompt:: bash #
+
+    ceph config show osd.x osd_mclock_max_capacity_iops_[hdd, ssd]
+
+For example, the following command shows the max capacity for osd.0 on a Ceph
+node whose underlying device type is SSD:
+
+  .. prompt:: bash #
+
+    ceph config show osd.0 osd_mclock_max_capacity_iops_ssd
+
+
+Steps to Manually Benchmark an OSD (Optional)
+=============================================
+
+.. note:: These steps are only necessary if you want to override the OSD
+          capacity already determined automatically during OSD initialization.
+          Otherwise, you may skip this section entirely.
+
+Any existing benchmarking tool can be used for this purpose. In this case, the
+steps use the *Ceph OSD Bench* command described in the next section. Regardless
+of the tool/command used, the steps outlined further below remain the same.
 
 As already described in the :ref:`dmclock-qos` section, the number of
 shards and the bluestore's throttle parameters have an impact on the mclock op
@@ -171,64 +217,82 @@ maximize the impact of the mclock scheduler.
   these parameters may also be determined during the benchmarking phase as
   described below.
 
-Benchmarking Test Steps Using CBT
-`````````````````````````````````
 
-The steps below use the default shards and detail the steps used to determine the
-correct bluestore throttle values.
+OSD Bench Command Syntax
+````````````````````````
 
-.. note:: These steps, although manual in April 2021, will be automated in the future.
+The :ref:`osd-subsystem` section describes the OSD bench command. The syntax
+used for benchmarking is shown below :
 
-1. On the Ceph node hosting the OSDs, download cbt_ from git.
-2. Install cbt and all the dependencies mentioned on the cbt github page.
-3. Construct the Ceph configuration file and the cbt yaml file.
-4. Ensure that the bluestore throttle options ( i.e.
-   ``bluestore_throttle_bytes`` and ``bluestore_throttle_deferred_bytes``) are
-   set to the default values.
-5. Ensure that the test is performed on similar device types to get reliable
-   OSD capacity data.
-6. The OSDs can be grouped together with the desired replication factor for the
-   test to ensure reliability of OSD capacity data.
-7. After ensuring that the OSDs nodes are in the desired configuration, run a
-   simple 4KiB random write workload on the OSD(s) for 300 secs.
-8. Note the overall throughput(IOPS) obtained from the cbt output file. This
-   value is the baseline throughput(IOPS) when the default bluestore
-   throttle options are in effect.
-9. If the intent is to determine the bluestore throttle values for your
-   environment, then set the two options, ``bluestore_throttle_bytes`` and
-   ``bluestore_throttle_deferred_bytes`` to 32 KiB(32768 Bytes) each to begin
-   with. Otherwise, you may skip to the next section.
-10. Run the 4KiB random write workload as before on the OSD(s) for 300 secs.
-11. Note the overall throughput from the cbt log files and compare the value
-    against the baseline throughput in step 8.
-12. If the throughput doesn't match with the baseline, increment the bluestore
-    throttle options by 2x and repeat steps 9 through 11 until the obtained
-    throughput is very close to the baseline value.
+.. prompt:: bash #
 
-For example, during benchmarking on a machine with NVMe SSDs, a value of 256 KiB for
-both bluestore throttle and deferred bytes was determined to maximize the impact
-of mclock. For HDDs, the corresponding value was 40 MiB, where the overall
-throughput was roughly equal to the baseline throughput. Note that in general
-for HDDs, the bluestore throttle values are expected to be higher when compared
-to SSDs.
+  ceph tell osd.N bench [TOTAL_BYTES] [BYTES_PER_WRITE] [OBJ_SIZE] [NUM_OBJS]
 
-.. _cbt: https://github.com/ceph/cbt
+where,
+
+* ``TOTAL_BYTES``: Total number of bytes to write
+* ``BYTES_PER_WRITE``: Block size per write
+* ``OBJ_SIZE``: Bytes per object
+* ``NUM_OBJS``: Number of objects to write
+
+Benchmarking Test Steps Using OSD Bench
+```````````````````````````````````````
+
+The steps below use the default shards and detail the steps used to determine
+the correct bluestore throttle values (optional).
+
+#. Bring up your Ceph cluster and login to the Ceph node hosting the OSDs that
+   you wish to benchmark.
+#. Run a simple 4KiB random write workload on an OSD using the following
+   commands:
+
+   .. note:: Note that before running the test, caches must be cleared to get an
+             accurate measurement.
+
+   For example, if you are running the benchmark test on osd.0, run the following
+   commands:
+
+   .. prompt:: bash #
+
+     ceph tell osd.0 cache drop
+
+   .. prompt:: bash #
+
+     ceph tell osd.0 bench 12288000 4096 4194304 100
+
+#. Note the overall throughput(IOPS) obtained from the output of the osd bench
+   command. This value is the baseline throughput(IOPS) when the default
+   bluestore throttle options are in effect.
+#. If the intent is to determine the bluestore throttle values for your
+   environment, then set the two options, ``bluestore_throttle_bytes``
+   and ``bluestore_throttle_deferred_bytes`` to 32 KiB(32768 Bytes) each
+   to begin with. Otherwise, you may skip to the next section.
+#. Run the 4KiB random write test as before using OSD bench.
+#. Note the overall throughput from the output and compare the value
+   against the baseline throughput recorded in step 3.
+#. If the throughput doesn't match with the baseline, increment the bluestore
+   throttle options by 2x and repeat steps 5 through 7 until the obtained
+   throughput is very close to the baseline value.
+
+For example, during benchmarking on a machine with NVMe SSDs, a value of 256 KiB
+for both bluestore throttle and deferred bytes was determined to maximize the
+impact of mclock. For HDDs, the corresponding value was 40 MiB, where the
+overall throughput was roughly equal to the baseline throughput. Note that in
+general for HDDs, the bluestore throttle values are expected to be higher when
+compared to SSDs.
 
 
 Specifying  Max OSD Capacity
-----------------------------
+````````````````````````````
 
-The steps in this section may be performed only if the max osd capacity is
-different from the default values (SSDs: 21500 IOPS and HDDs: 315 IOPS). The
-option ``osd_mclock_max_capacity_iops_[hdd, ssd]`` can be set by specifying it
-in either the **[global]** section or in a specific OSD section (**[osd.x]** of
-your Ceph configuration file).
-
-Alternatively, commands of the following form may be used:
+The steps in this section may be performed only if you want to override the
+max osd capacity automatically determined during OSD initialization. The option
+``osd_mclock_max_capacity_iops_[hdd, ssd]`` can be set by running the
+following command:
 
   .. prompt:: bash #
 
-     ceph config set [global, osd] osd_mclock_max_capacity_iops_[hdd,ssd] <value>
+     ceph config set [global,osd] osd_mclock_max_capacity_iops_[hdd,ssd] <value>
 
 For example, the following command sets the max capacity for all the OSDs in a
 Ceph node whose underlying device type is SSDs:
@@ -243,36 +307,6 @@ device type is HDD, use a command like this:
   .. prompt:: bash #
 
     ceph config set osd.0 osd_mclock_max_capacity_iops_hdd 350
-
-
-Specifying Which mClock Profile to Enable
------------------------------------------
-
-As already mentioned, the default mclock profile is set to *high_client_ops*.
-The other values for the built-in profiles include *balanced* and
-*high_recovery_ops*.
-
-If there is a requirement to change the default profile, then the option
-``osd_mclock_profile`` may be set in the **[global]** or **[osd]** section of
-your Ceph configuration file before bringing up your cluster.
-
-Alternatively, to change the profile during runtime, use the following command:
-
-  .. prompt:: bash #
-
-    ceph config set [global,osd] osd_mclock_profile <value>
-
-For example, to change the profile to allow faster recoveries, the following
-command can be used to switch to the *high_recovery_ops* profile:
-
-  .. prompt:: bash #
-
-    ceph config set osd osd_mclock_profile high_recovery_ops
-
-.. note:: The *custom* profile is not recommended unless you are an advanced user.
-
-And that's it! You are ready to run workloads on the cluster and check if the
-QoS requirements are being met.
 
 
 .. index:: mclock; config settings
@@ -293,14 +327,6 @@ mClock Config Options
 :Type: String
 :Valid Choices: high_client_ops, high_recovery_ops, balanced, custom
 :Default: ``high_client_ops``
-
-``osd_mclock_max_capacity_iops``
-
-:Description: Max IOPS capacity (at 4KiB block size) to consider per OSD
-              (overrides _ssd and _hdd if non-zero)
-
-:Type: Float
-:Default: ``0.0``
 
 ``osd_mclock_max_capacity_iops_hdd``
 
@@ -365,4 +391,3 @@ mClock Config Options
 
 :Type: Float
 :Default: ``0.011``
-

--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -151,14 +151,14 @@ command:
 
   .. prompt:: bash #
 
-    ceph config set [global,osd] osd_mclock_profile <value>
+    ceph config set osd.N osd_mclock_profile <value>
 
-For example, to change the profile to allow faster recoveries, the following
-command can be used to switch to the *high_recovery_ops* profile:
+For example, to change the profile to allow faster recoveries on "osd.0", the
+following command can be used to switch to the *high_recovery_ops* profile:
 
   .. prompt:: bash #
 
-    ceph config set osd osd_mclock_profile high_recovery_ops
+    ceph config set osd.0 osd_mclock_profile high_recovery_ops
 
 .. note:: The *custom* profile is not recommended unless you are an advanced
           user.
@@ -179,9 +179,9 @@ cluster is brought up by using the following command:
 
   .. prompt:: bash #
 
-    ceph config show osd.x osd_mclock_max_capacity_iops_[hdd, ssd]
+    ceph config show osd.N osd_mclock_max_capacity_iops_[hdd, ssd]
 
-For example, the following command shows the max capacity for osd.0 on a Ceph
+For example, the following command shows the max capacity for "osd.0" on a Ceph
 node whose underlying device type is SSD:
 
   .. prompt:: bash #
@@ -195,6 +195,11 @@ Steps to Manually Benchmark an OSD (Optional)
 .. note:: These steps are only necessary if you want to override the OSD
           capacity already determined automatically during OSD initialization.
           Otherwise, you may skip this section entirely.
+
+.. tip:: If you have already determined the benchmark data and wish to manually
+         override the max osd capacity for an OSD, you may skip to section
+         `Specifying  Max OSD Capacity`_.
+
 
 Any existing benchmarking tool can be used for this purpose. In this case, the
 steps use the *Ceph OSD Bench* command described in the next section. Regardless
@@ -286,27 +291,24 @@ Specifying  Max OSD Capacity
 ````````````````````````````
 
 The steps in this section may be performed only if you want to override the
-max osd capacity automatically determined during OSD initialization. The option
-``osd_mclock_max_capacity_iops_[hdd, ssd]`` can be set by running the
+max osd capacity automatically set during OSD initialization. The option
+``osd_mclock_max_capacity_iops_[hdd, ssd]`` for an OSD can be set by running the
 following command:
 
   .. prompt:: bash #
 
-     ceph config set [global,osd] osd_mclock_max_capacity_iops_[hdd,ssd] <value>
+     ceph config set osd.N osd_mclock_max_capacity_iops_[hdd,ssd] <value>
 
-For example, the following command sets the max capacity for all the OSDs in a
-Ceph node whose underlying device type is SSDs:
-
-  .. prompt:: bash #
-
-    ceph config set osd osd_mclock_max_capacity_iops_ssd 25000
-
-To set the capacity for a specific OSD (for example "osd.0") whose underlying
-device type is HDD, use a command like this:
+For example, the following command sets the max capacity for a specific OSD
+(say "osd.0") whose underlying device type is HDD to 350 IOPS:
 
   .. prompt:: bash #
 
     ceph config set osd.0 osd_mclock_max_capacity_iops_hdd 350
+
+Alternatively, you may specify the max capacity for OSDs within the Ceph
+configuration file under the respective [osd.N] section. See
+:ref:`ceph-conf-settings` for more details.
 
 
 .. index:: mclock; config settings

--- a/doc/rados/operations/control.rst
+++ b/doc/rados/operations/control.rst
@@ -95,6 +95,8 @@ or delete them if they were just created. ::
 	ceph pg {pgid} mark_unfound_lost revert|delete
 
 
+.. _osd-subsystem:
+
 OSD Subsystem
 =============
 

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -46,8 +46,8 @@ def generate_caps(type_):
     """
     defaults = dict(
         osd=dict(
-            mon='allow *',
-            mgr='allow *',
+            mon='allow profile osd',
+            mgr='allow profile osd',
             osd='allow *',
         ),
         mgr=dict(

--- a/qa/tasks/ceph_test_case.py
+++ b/qa/tasks/ceph_test_case.py
@@ -189,16 +189,22 @@ class CephTestCase(unittest.TestCase):
         log.debug("wait_until_equal: success")
 
     @classmethod
-    def wait_until_true(cls, condition, timeout, period=5):
+    def wait_until_true(cls, condition, timeout, check_fn=None, period=5):
         elapsed = 0
+        retry_count = 0
         while True:
             if condition():
-                log.debug("wait_until_true: success in {0}s".format(elapsed))
+                log.debug("wait_until_true: success in {0}s and {1} retries".format(elapsed, retry_count))
                 return
             else:
                 if elapsed >= timeout:
-                    raise TestTimeoutError("Timed out after {0}s".format(elapsed))
+                    if check_fn and check_fn() and retry_count < 5:
+                        elapsed = 0
+                        retry_count += 1
+                        log.debug("wait_until_true: making progress, waiting (timeout={0} retry_count={1})...".format(timeout, retry_count))
+                    else:
+                        raise TestTimeoutError("Timed out after {0}s and {1} retries".format(elapsed, retry_count))
                 else:
-                    log.debug("wait_until_true: waiting (timeout={0})...".format(timeout))
+                    log.debug("wait_until_true: waiting (timeout={0} retry_count={1})...".format(timeout, retry_count))
                 time.sleep(period)
                 elapsed += period

--- a/qa/tasks/mgr/test_progress.py
+++ b/qa/tasks/mgr/test_progress.py
@@ -243,6 +243,13 @@ class TestProgress(MgrTestCase):
             assert ev_id in live_ids
             return False
 
+    def _is_inprogress_or_complete(self, ev_id):
+        for ev in self._events_in_progress():
+            if ev['id'] == ev_id:
+                return ev['progress'] > 0
+        # check if the event completed
+        return self._is_complete(ev_id)
+
     def tearDown(self):
         if self.POOL in self.mgr_cluster.mon_manager.pools:
             self.mgr_cluster.mon_manager.remove_pool(self.POOL)
@@ -396,5 +403,6 @@ class TestProgress(MgrTestCase):
         log.info(json.dumps(ev1, indent=1))
 
         self.wait_until_true(lambda: self._is_complete(ev1['id']),
+                             check_fn=lambda: self._is_inprogress_or_complete(ev1['id']),
                              timeout=self.RECOVERY_PERIOD)
         self.assertTrue(self._is_quiet())

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1029,6 +1029,16 @@ void md_config_t::get_config_bl(
   }
 }
 
+std::optional<std::string> md_config_t::get_val_default(std::string_view key)
+{
+  std::string val;
+  const Option *opt = find_option(key);
+  if (opt && (conf_stringify(_get_val_default(*opt), &val) == 0)) {
+    return std::make_optional(std::move(val));
+  }
+  return std::nullopt;
+}
+
 int md_config_t::get_val(const ConfigValues& values,
 			 const std::string_view key, char **buf, int len) const
 {

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -191,6 +191,9 @@ public:
   /// get encoded map<string,string> of compiled-in defaults
   void get_defaults_bl(const ConfigValues& values, ceph::buffer::list *bl);
 
+  /// Get the default value of a configuration option
+  std::optional<std::string> get_val_default(std::string_view key);
+
   // Get a configuration value.
   // No metavariables will be returned (they will have already been expanded)
   int get_val(const ConfigValues& values, const std::string_view key, char **buf, int len) const;

--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -344,6 +344,9 @@ public:
   const std::string& get_conf_path() const {
     return config.get_conf_path();
   }
+  std::optional<std::string> get_val_default(std::string_view key) {
+    return config.get_val_default(key);
+  }
 };
 
 }

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3118,12 +3118,6 @@ std::vector<Option> get_global_options() {
     .set_long_description("This option specifies the cost per byte to consider in microseconds per OSD for solid state device type. This is considered by the mclock_scheduler to set an additional cost factor in QoS calculations. Only considered for osd_op_queue = mclock_scheduler")
     .set_flag(Option::FLAG_RUNTIME),
 
-    Option("osd_mclock_max_capacity_iops", Option::TYPE_FLOAT, Option::LEVEL_BASIC)
-    .set_default(0.0)
-    .set_description("Max IOPs capacity (at 4KiB block size) to consider per OSD (overrides _ssd and _hdd if non-zero)")
-    .set_long_description("This option specifies the max osd capacity in iops per OSD. Helps in QoS calculations when enabling a dmclock profile. Only considered for osd_op_queue = mclock_scheduler")
-    .set_flag(Option::FLAG_RUNTIME),
-
     Option("osd_mclock_max_capacity_iops_hdd", Option::TYPE_FLOAT, Option::LEVEL_BASIC)
     .set_default(315.0)
     .set_description("Max IOPs capacity (at 4KiB block size) to consider per OSD (for rotational media)")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3138,6 +3138,14 @@ std::vector<Option> get_global_options() {
     .add_see_also("osd_mclock_max_capacity_iops_hdd")
     .add_see_also("osd_mclock_max_capacity_iops_ssd"),
 
+    Option("osd_mclock_skip_benchmark", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description("Skip the OSD benchmark on OSD initialization/boot-up")
+    .set_long_description("This option specifies whether the OSD benchmark must be skipped during the OSD boot-up sequence. Only considered for osd_op_queue = mclock_scheduler.")
+    .set_flag(Option::FLAG_RUNTIME)
+    .add_see_also("osd_mclock_max_capacity_iops_hdd")
+    .add_see_also("osd_mclock_max_capacity_iops_ssd"),
+
     Option("osd_mclock_profile", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("high_client_ops")
     .set_enum_allowed( { "balanced", "high_recovery_ops", "high_client_ops", "custom" } )

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3130,6 +3130,14 @@ std::vector<Option> get_global_options() {
     .set_long_description("This option specifies the max OSD capacity in iops per OSD. Helps in QoS calculations when enabling a dmclock profile. Only considered for osd_op_queue = mclock_scheduler")
     .set_flag(Option::FLAG_RUNTIME),
 
+    Option("osd_mclock_force_run_benchmark_on_init", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Force run the OSD benchmark on OSD initialization/boot-up")
+    .set_long_description("This option specifies whether the OSD benchmark must be run during the OSD boot-up sequence even if historical data about the OSD iops capacity is available in the MON config store. Enable this to refresh the OSD iops capacity if the underlying device's performance characteristics have changed significantly. Only considered for osd_op_queue = mclock_scheduler.")
+    .set_flag(Option::FLAG_STARTUP)
+    .add_see_also("osd_mclock_max_capacity_iops_hdd")
+    .add_see_also("osd_mclock_max_capacity_iops_ssd"),
+
     Option("osd_mclock_profile", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("high_client_ops")
     .set_enum_allowed( { "balanced", "high_recovery_ops", "high_client_ops", "custom" } )

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -183,6 +183,9 @@ void MonCapGrant::expand_profile(const EntityName& name) const
     profile_grants.push_back(MonCapGrant("mon", MON_CAP_R));
     profile_grants.push_back(MonCapGrant("pg", MON_CAP_R | MON_CAP_W));
     profile_grants.push_back(MonCapGrant("log", MON_CAP_W));
+    StringConstraint constraint(StringConstraint::MATCH_TYPE_REGEX,
+                                string("osd_mclock_max_capacity_iops_(hdd|ssd)"));
+    profile_grants.push_back(MonCapGrant("config set", "name", constraint));
   }
   if (profile == "mds") {
     profile_grants.push_back(MonCapGrant("mds", MON_CAP_ALL));

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10200,6 +10200,32 @@ bool OSD::maybe_override_options_for_qos()
   return false;
 }
 
+int OSD::mon_cmd_set_config(const std::string &key, const std::string &val)
+{
+  std::string cmd =
+    "{"
+      "\"prefix\": \"config set\", "
+      "\"who\": \"osd." + std::to_string(whoami) + "\", "
+      "\"name\": \"" + key + "\", "
+      "\"value\": \"" + val + "\""
+    "}";
+
+  vector<std::string> vcmd{cmd};
+  bufferlist inbl;
+  std::string outs;
+  C_SaferCond cond;
+  monc->start_mon_command(vcmd, inbl, nullptr, &outs, &cond);
+  int r = cond.wait();
+  if (r < 0) {
+    derr << __func__ << " Failed to set config key " << key
+         << " err: " << cpp_strerror(r)
+         << " errstr: " << outs << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
 void OSD::update_log_config()
 {
   map<string,string> log_to_monitors;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10111,12 +10111,50 @@ void OSD::maybe_override_max_osd_capacity_for_qos()
   // osd capacity with the value obtained from running the
   // osd bench test. This is later used to setup mclock.
   if (cct->_conf.get_val<std::string>("osd_op_queue") == "mclock_scheduler") {
-    // Write 200 4MiB objects with blocksize 4KiB
+    std::string max_capacity_iops_config;
+    bool force_run_benchmark = false;
+
+    if (store_is_rotational) {
+      max_capacity_iops_config = "osd_mclock_max_capacity_iops_hdd";
+    } else {
+      max_capacity_iops_config = "osd_mclock_max_capacity_iops_ssd";
+    }
+
+    if (!force_run_benchmark) {
+      double default_iops = 0.0;
+
+      // Get the current osd iops capacity
+      double cur_iops = cct->_conf.get_val<double>(max_capacity_iops_config);
+
+      // Get the default max iops capacity
+      auto val = cct->_conf.get_val_default(max_capacity_iops_config);
+      if (!val.has_value()) {
+        derr << __func__ << " Unable to determine default value of "
+            << max_capacity_iops_config << dendl;
+        // Cannot determine default iops. Force a run of the OSD benchmark.
+        force_run_benchmark = true;
+      } else {
+        // Default iops
+        default_iops = std::stod(val.value());
+      }
+
+      // Determine if we really need to run the osd benchmark
+      if (!force_run_benchmark && (default_iops != cur_iops)) {
+        dout(1) << __func__ << std::fixed << std::setprecision(2)
+                << " default_iops: " << default_iops
+                << " cur_iops: " << cur_iops
+                << ". Skip OSD benchmark test." << dendl;
+        return;
+      }
+    }
+
+    // Run osd bench: write 100 4MiB objects with blocksize 4KiB
     int64_t count = 12288000; // Count of bytes to write
     int64_t bsize = 4096;     // Block size
     int64_t osize = 4194304;  // Object size
     int64_t onum = 100;       // Count of objects to write
     double elapsed = 0.0;     // Time taken to complete the test
+    double iops = 0.0;
     stringstream ss;
     int ret = run_osd_bench_test(count, bsize, osize, onum, &elapsed, ss);
     if (ret != 0) {
@@ -10124,30 +10162,29 @@ void OSD::maybe_override_max_osd_capacity_for_qos()
            << " osd bench err: " << ret
            << " osd bench errstr: " << ss.str()
            << dendl;
-    } else {
-      double rate = count / elapsed;
-      double iops = rate / bsize;
-      dout(1) << __func__
-              << " osd bench result -"
-              << std::fixed << std::setprecision(3)
-              << " bandwidth (MiB/sec): " << rate / (1024 * 1024)
-              << " iops: " << iops
-              << " elapsed_sec: " << elapsed
-              << dendl;
+      return;
+    }
 
-      // Override the appropriate config option
-      if (store_is_rotational) {
-        cct->_conf.set_val(
-          "osd_mclock_max_capacity_iops_hdd", std::to_string(iops));
-      } else {
-        cct->_conf.set_val(
-          "osd_mclock_max_capacity_iops_ssd", std::to_string(iops));
-      }
+    double rate = count / elapsed;
+    iops = rate / bsize;
+    dout(1) << __func__
+            << " osd bench result -"
+            << std::fixed << std::setprecision(3)
+            << " bandwidth (MiB/sec): " << rate / (1024 * 1024)
+            << " iops: " << iops
+            << " elapsed_sec: " << elapsed
+            << dendl;
 
-      // Override the max osd capacity for all shards
-      for (auto& shard : shards) {
-        shard->update_scheduler_config();
-      }
+    // Persist iops to the MON store
+    ret = mon_cmd_set_config(max_capacity_iops_config, std::to_string(iops));
+    if (ret < 0) {
+      // Fallback to setting the config within the in-memory "values" map.
+      cct->_conf.set_val(max_capacity_iops_config, std::to_string(iops));
+    }
+
+    // Override the max osd capacity for all shards
+    for (auto& shard : shards) {
+      shard->update_scheduler_config();
     }
   }
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10110,7 +10110,8 @@ void OSD::maybe_override_max_osd_capacity_for_qos()
   // If the scheduler enabled is mclock, override the default
   // osd capacity with the value obtained from running the
   // osd bench test. This is later used to setup mclock.
-  if (cct->_conf.get_val<std::string>("osd_op_queue") == "mclock_scheduler") {
+  if ((cct->_conf.get_val<std::string>("osd_op_queue") == "mclock_scheduler") &&
+      (cct->_conf.get_val<bool>("osd_mclock_skip_benchmark") == false)) {
     std::string max_capacity_iops_config;
     bool force_run_benchmark =
       cct->_conf.get_val<bool>("osd_mclock_force_run_benchmark_on_init");

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10112,7 +10112,8 @@ void OSD::maybe_override_max_osd_capacity_for_qos()
   // osd bench test. This is later used to setup mclock.
   if (cct->_conf.get_val<std::string>("osd_op_queue") == "mclock_scheduler") {
     std::string max_capacity_iops_config;
-    bool force_run_benchmark = false;
+    bool force_run_benchmark =
+      cct->_conf.get_val<bool>("osd_mclock_force_run_benchmark_on_init");
 
     if (store_is_rotational) {
       max_capacity_iops_config = "osd_mclock_max_capacity_iops_hdd";

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2071,6 +2071,7 @@ private:
                          int64_t onum,
                          double *elapsed,
                          std::ostream& ss);
+  int mon_cmd_set_config(const std::string &key, const std::string &val);
 
   void scrub_purged_snaps();
   void probe_smart(const std::string& devid, std::ostream& ss);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1079,6 +1079,7 @@ struct OSDShard {
 		    std::set<std::pair<spg_t,epoch_t>> *merge_pgs);
   void register_and_wake_split_child(PG *pg);
   void unprime_split_children(spg_t parent, unsigned old_pg_num);
+  void update_scheduler_config();
 
   OSDShard(
     int id,
@@ -2062,7 +2063,14 @@ private:
   float get_osd_snap_trim_sleep();
 
   int get_recovery_max_active();
+  void maybe_override_max_osd_capacity_for_qos();
   bool maybe_override_options_for_qos();
+  int run_osd_bench_test(int64_t count,
+                         int64_t bsize,
+                         int64_t osize,
+                         int64_t onum,
+                         double *elapsed,
+                         std::ostream& ss);
 
   void scrub_purged_snaps();
   void probe_smart(const std::string& devid, std::ostream& ss);

--- a/src/osd/scheduler/OpScheduler.h
+++ b/src/osd/scheduler/OpScheduler.h
@@ -50,6 +50,9 @@ public:
   // Print human readable brief description with relevant parameters
   virtual void print(std::ostream &out) const = 0;
 
+  // Apply config changes to the scheduler (if any)
+  virtual void update_configuration() = 0;
+
   // Destructor
   virtual ~OpScheduler() {};
 };
@@ -132,6 +135,10 @@ public:
     out << "ClassedOpQueueScheduler(queue=";
     queue.print(out);
     out << ", cutoff=" << cutoff << ")";
+  }
+
+  void update_configuration() final {
+    // no-op
   }
 
   ~ClassedOpQueueScheduler() final {};

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -109,7 +109,9 @@ void mClockScheduler::set_max_osd_capacity()
   // Set per op-shard iops limit
   max_osd_capacity /= num_shards;
   dout(1) << __func__ << " #op shards: " << num_shards
-          << " max osd capacity(iops) per shard: " << max_osd_capacity << dendl;
+          << std::fixed << std::setprecision(2)
+          << " max osd capacity(iops) per shard: " << max_osd_capacity
+          << dendl;
 }
 
 void mClockScheduler::set_osd_mclock_cost_per_io()
@@ -132,7 +134,8 @@ void mClockScheduler::set_osd_mclock_cost_per_io()
     }
   }
   dout(1) << __func__ << " osd_mclock_cost_per_io: "
-          << std::fixed << osd_mclock_cost_per_io << dendl;
+          << std::fixed << std::setprecision(7) << osd_mclock_cost_per_io
+          << dendl;
 }
 
 void mClockScheduler::set_osd_mclock_cost_per_byte()
@@ -155,7 +158,8 @@ void mClockScheduler::set_osd_mclock_cost_per_byte()
     }
   }
   dout(1) << __func__ << " osd_mclock_cost_per_byte: "
-          << std::fixed << osd_mclock_cost_per_byte << dendl;
+          << std::fixed << std::setprecision(7) << osd_mclock_cost_per_byte
+          << dendl;
 }
 
 void mClockScheduler::set_mclock_profile()
@@ -371,6 +375,14 @@ int mClockScheduler::calc_scaled_cost(int item_cost)
   int scaled_cost =
     std::round(osd_mclock_cost_per_io + (osd_mclock_cost_per_byte * item_cost));
   return std::max(scaled_cost, 1);
+}
+
+void mClockScheduler::update_configuration()
+{
+  // Apply configuration change. The expectation is that
+  // at least one of the tracked mclock config option keys
+  // is modified before calling this method.
+  cct->_conf.apply_changes(nullptr);
 }
 
 void mClockScheduler::dump(ceph::Formatter &f) const

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -99,17 +99,12 @@ const dmc::ClientInfo *mClockScheduler::ClientRegistry::get_info(
 
 void mClockScheduler::set_max_osd_capacity()
 {
-  if (cct->_conf.get_val<double>("osd_mclock_max_capacity_iops")) {
+  if (is_rotational) {
     max_osd_capacity =
-      cct->_conf.get_val<double>("osd_mclock_max_capacity_iops");
+      cct->_conf.get_val<double>("osd_mclock_max_capacity_iops_hdd");
   } else {
-    if (is_rotational) {
-      max_osd_capacity =
-        cct->_conf.get_val<double>("osd_mclock_max_capacity_iops_hdd");
-    } else {
-      max_osd_capacity =
-        cct->_conf.get_val<double>("osd_mclock_max_capacity_iops_ssd");
-    }
+    max_osd_capacity =
+      cct->_conf.get_val<double>("osd_mclock_max_capacity_iops_ssd");
   }
   // Set per op-shard iops limit
   max_osd_capacity /= num_shards;
@@ -447,7 +442,6 @@ const char** mClockScheduler::get_tracked_conf_keys() const
     "osd_mclock_cost_per_byte_usec",
     "osd_mclock_cost_per_byte_usec_hdd",
     "osd_mclock_cost_per_byte_usec_ssd",
-    "osd_mclock_max_capacity_iops",
     "osd_mclock_max_capacity_iops_hdd",
     "osd_mclock_max_capacity_iops_ssd",
     "osd_mclock_profile",
@@ -470,8 +464,7 @@ void mClockScheduler::handle_conf_change(
       changed.count("osd_mclock_cost_per_byte_usec_ssd")) {
     set_osd_mclock_cost_per_byte();
   }
-  if (changed.count("osd_mclock_max_capacity_iops") ||
-      changed.count("osd_mclock_max_capacity_iops_hdd") ||
+  if (changed.count("osd_mclock_max_capacity_iops_hdd") ||
       changed.count("osd_mclock_max_capacity_iops_ssd")) {
     set_max_osd_capacity();
     if (mclock_profile != "custom") {

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -193,6 +193,9 @@ public:
     ostream << "mClockScheduler";
   }
 
+  // Update data associated with the modified mclock config key(s)
+  void update_configuration() final;
+
   const char** get_tracked_conf_keys() const final;
   void handle_conf_change(const ConfigProxy& conf,
 			  const std::set<std::string> &changed) final;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51117

---

backport of https://github.com/ceph/ceph/pull/41308
parent tracker: https://tracker.ceph.com/issues/51116

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh

Note: The initial backport was created using the backport script. The latest commits (i.e. from commit 0a5f87cc8a52febd98c4115e7ba78743a2636eb2) added to the PR were cherry-picked.