### PR TITLE
rgw/sts: adding role name and role session to ops log.

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -829,6 +829,8 @@ void rgw::auth::RoleApplier::modify_request_state(const DoutPrefixProvider *dpp,
   s->env.emplace("aws:TokenIssueTime", token_issued_at);
 
   s->token_claims.emplace_back("sts");
+  s->token_claims.emplace_back("role_name:" + role.tenant + "$" + role.name);
+  s->token_claims.emplace_back("role_session:" + role_session_name);
   for (auto& it : token_claims) {
     s->token_claims.emplace_back(it);
   }

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -38,9 +38,10 @@ struct rgw_log_entry {
   headers_map x_headers;
   string trans_id;
   std::vector<string> token_claims;
+  uint32_t identity_type;
 
   void encode(bufferlist &bl) const {
-    ENCODE_START(11, 5, bl);
+    ENCODE_START(12, 5, bl);
     encode(object_owner.id, bl);
     encode(bucket_owner.id, bl);
     encode(bucket, bl);
@@ -65,10 +66,11 @@ struct rgw_log_entry {
     encode(x_headers, bl);
     encode(trans_id, bl);
     encode(token_claims, bl);
+    encode(identity_type,bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &p) {
-    DECODE_START_LEGACY_COMPAT_LEN(11, 5, 5, p);
+    DECODE_START_LEGACY_COMPAT_LEN(12, 5, 5, p);
     decode(object_owner.id, p);
     if (struct_v > 3)
       decode(bucket_owner.id, p);
@@ -119,6 +121,9 @@ struct rgw_log_entry {
     }
     if (struct_v >= 11) {
       decode(token_claims, p);
+    }
+    if (struct_v >= 12) {
+      decode(identity_type, p);
     }
     DECODE_FINISH(p);
   }


### PR DESCRIPTION
Also adding authentication type for all ops.

Fixes: https://tracker.ceph.com/issues/51152

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
