### PR TITLE
mgr/nfs: do not depend on cephadm.utils

### DIFF
--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -5,7 +5,6 @@ import re
 from typing import cast, Dict, List, Any, Union, Optional
 
 from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec, IngressSpec
-from cephadm.utils import resolve_ip
 
 import orchestrator
 
@@ -14,6 +13,19 @@ from .utils import POOL_NAME, available_clusters, restart_nfs_service
 from .export import NFSRados, exception_handler
 
 log = logging.getLogger(__name__)
+
+
+def resolve_ip(hostname: str) -> str:
+    try:
+        r = socket.getaddrinfo(hostname, None, flags=socket.AI_CANONNAME,
+                               type=socket.SOCK_STREAM)
+        # pick first v4 IP, if present
+        for a in r:
+            if a[0] == socket.AF_INET:
+                return a[4][0]
+        return r[0][4][0]
+    except socket.gaierror as e:
+        raise NFSInvalidOperation(f"Cannot resolve IP for host {hostname}: {e}")
 
 
 def cluster_setter(func):


### PR DESCRIPTION
The cephadm package may not be installed (it is a separate rpm/deb).

While we are here, adjust the exception to be an NFS-specific one.

This was breaking upgrade tests which do not explicitly install the cephadm mgr package.