### PR TITLE
rgw/rgw_lua_utils: return error using luaL_error()

### DIFF
--- a/src/rgw/rgw_lua_request.cc
+++ b/src/rgw/rgw_lua_request.cc
@@ -58,7 +58,7 @@ struct ResponseMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "Message") == 0) {
       pushstring(L, err->message);
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }
@@ -77,7 +77,7 @@ struct ResponseMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "Message") == 0) {
       err->message.assign(luaL_checkstring(L, 3));
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return NO_RETURNVAL;
   }
@@ -101,7 +101,7 @@ struct QuotaMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "Rounded") == 0) {
       lua_pushboolean(L, !info->check_on_raw);
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }
@@ -121,7 +121,7 @@ struct PlacementRuleMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "StorageClass") == 0) {
       pushstring(L, rule->storage_class);
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }
@@ -141,7 +141,7 @@ struct UserMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "Id") == 0) {
       pushstring(L, user->id);
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }
@@ -161,7 +161,7 @@ struct OwnerMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "User") == 0) {
       create_metatable<UserMetaTable>(L, false, &(owner->get_id()));
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }
@@ -203,7 +203,7 @@ struct BucketMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "User") == 0) {
       create_metatable<UserMetaTable>(L, false, &(bucket->get_info().owner));
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }
@@ -231,7 +231,7 @@ struct ObjectMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "MTime") == 0) {
       pushtime(L, obj->get_mtime());
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }
@@ -346,7 +346,7 @@ struct GrantMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "Referer") == 0) {
       pushstring(L, grant->get_referer());
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }
@@ -446,7 +446,7 @@ struct ACLMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "Grants") == 0) {
       create_metatable<GrantsMetaTable>(L, false, &(acl->get_acl().get_grant_map()));
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }
@@ -543,7 +543,7 @@ struct PolicyMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "Statements") == 0) {
       create_metatable<StatementsMetaTable>(L, &(policy->statements));
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }
@@ -641,7 +641,7 @@ struct HTTPMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "Domain") == 0) {
       pushstring(L, info->domain);
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }
@@ -663,7 +663,7 @@ struct CopyFromMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "Object") == 0) {
       create_metatable<ObjectMetaTable>(L, false, s->src_object);
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }
@@ -683,7 +683,7 @@ struct ZoneGroupMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "Endpoint") == 0) {
       pushstring(L, s->zonegroup_endpoint);
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }
@@ -762,7 +762,7 @@ struct RequestMetaTable : public EmptyMetaTable {
     } else if (strcasecmp(index, "Tags") == 0) {
       create_metatable<StringMapMetaTable<RGWObjTags::tag_map_t>>(L, false, &(s->tagset.get_tags()));
     } else {
-      throw_unknown_field(index, TableName());
+      return error_unknown_field(L, index, TableName());
     }
     return ONE_RETURNVAL;
   }

--- a/src/rgw/rgw_lua_utils.h
+++ b/src/rgw/rgw_lua_utils.h
@@ -164,8 +164,9 @@ struct EmptyMetaTable {
     return luaL_error(L, "trying to get length of non-iterable field");
   }
 
-  static void throw_unknown_field(const std::string& index, const std::string& table) {
-    throw std::runtime_error("unknown field name: " + index + " provided to: " + table);
+  static int error_unknown_field(lua_State* L, const std::string& index, const std::string& table) {
+    return luaL_error(L, "unknown field name: %s provided to: %s",
+                      index.c_str(), table.c_str());
   }
 };
 

--- a/src/rgw/rgw_lua_utils.h
+++ b/src/rgw/rgw_lua_utils.h
@@ -149,22 +149,19 @@ struct EmptyMetaTable {
   // by default everythinmg is "readonly"
   // to change, overload this function in the derived
   static int NewIndexClosure(lua_State* L) {
-    throw std::runtime_error("trying to write to readonly field");
-    return NO_RETURNVAL;
+    return luaL_error(L, "trying to write to readonly field");
   }
   
   // by default nothing is iterable
   // to change, overload this function in the derived
   static int PairsClosure(lua_State* L) {
-    throw std::runtime_error("trying to iterate over non-iterable field");
-    return ONE_RETURNVAL;
+    return luaL_error(L, "trying to iterate over non-iterable field");
   }
   
   // by default nothing is iterable
   // to change, overload this function in the derived
   static int LenClosure(lua_State* L) {
-    throw std::runtime_error("trying to get length of non-iterable field");
-    return ONE_RETURNVAL;
+    return luaL_error(L, "trying to get length of non-iterable field");
   }
 
   static void throw_unknown_field(const std::string& index, const std::string& table) {


### PR DESCRIPTION
it's found on aarch64, the exception is not caught even if we do
catch exactly the same type of thrown exception, and the uncaught
exception ends up with a std::terminate() call. it could be the ABI
mismatch in aarch64, so the C++ runtime failed to find the catch block.

in this change, luaL_error() is used to populate the error to the
caller instead to workaround this issue.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
