### PR TITLE
mgr/cephadm: When create osd which include db, _create_daemon will be…

### DIFF
--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -112,6 +112,8 @@ class OSDService(CephService):
         created = []
         for osd_id, osds in osds_elems.items():
             for osd in osds:
+                if osd['type'] == 'db':
+                    continue
                 if osd['tags']['ceph.cluster_fsid'] != fsid:
                     logger.debug('mismatched fsid, skipping %s' % osd)
                     continue

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1244,8 +1244,17 @@ Traceback (most recent call last):
                 }]
             }
             _run_cephadm.return_value = (json.dumps(ceph_volume_lvm_list), '', 0)
+            _run_cephadm.reset_mock()
             assert cephadm_module._osd_activate(
                 ['test']).stdout == "Created osd(s) 1 on host 'test'"
+            assert _run_cephadm.mock_calls == [
+                mock.call('test', 'osd', 'ceph-volume',
+                          ['--', 'lvm', 'list', '--format', 'json'], no_fsid=False, image=''),
+                mock.call('test', 'osd.1', 'deploy',
+                          ['--name', 'osd.1', '--meta-json', mock.ANY,
+                              '--config-json', '-', '--osd-fsid', 'uuid'],
+                          stdin=mock.ANY, image=''),
+            ]
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
     def test_osd_activate_datadevice_dbdevice(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
@@ -1277,5 +1286,14 @@ Traceback (most recent call last):
                 }]
             }
             _run_cephadm.return_value = (json.dumps(ceph_volume_lvm_list), '', 0)
+            _run_cephadm.reset_mock()
             assert cephadm_module._osd_activate(
                 ['test']).stdout == "Created osd(s) 1 on host 'test'"
+            assert _run_cephadm.mock_calls == [
+                mock.call('test', 'osd', 'ceph-volume',
+                          ['--', 'lvm', 'list', '--format', 'json'], no_fsid=False, image=''),
+                mock.call('test', 'osd.1', 'deploy',
+                          ['--name', 'osd.1', '--meta-json', mock.ANY,
+                              '--config-json', '-', '--osd-fsid', 'uuid'],
+                          stdin=mock.ANY, image=''),
+            ]

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1221,7 +1221,7 @@ Traceback (most recent call last):
             ]
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
-    def test_osd_activate(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+    def test_osd_activate_datadevice(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.return_value = ('{}', '', 0)
         with with_host(cephadm_module, 'test', refresh_hosts=False):
             cephadm_module.mock_store_set('_ceph_get', 'osd_map', {
@@ -1239,7 +1239,41 @@ Traceback (most recent call last):
                     'tags': {
                         'ceph.cluster_fsid': cephadm_module._cluster_fsid,
                         'ceph.osd_fsid': 'uuid'
+                    },
+                    'type': 'data'
+                }]
+            }
+            _run_cephadm.return_value = (json.dumps(ceph_volume_lvm_list), '', 0)
+            assert cephadm_module._osd_activate(
+                ['test']).stdout == "Created osd(s) 1 on host 'test'"
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_osd_activate_datadevice_dbdevice(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.return_value = ('{}', '', 0)
+        with with_host(cephadm_module, 'test', refresh_hosts=False):
+            cephadm_module.mock_store_set('_ceph_get', 'osd_map', {
+                'osds': [
+                    {
+                        'osd': 1,
+                        'up_from': 0,
+                        'uuid': 'uuid'
                     }
+                ]
+            })
+
+            ceph_volume_lvm_list = {
+                '1': [{
+                    'tags': {
+                        'ceph.cluster_fsid': cephadm_module._cluster_fsid,
+                        'ceph.osd_fsid': 'uuid'
+                    },
+                    'type': 'data'
+                }, {
+                    'tags': {
+                        'ceph.cluster_fsid': cephadm_module._cluster_fsid,
+                        'ceph.osd_fsid': 'uuid'
+                    },
+                    'type': 'db'
                 }]
             }
             _run_cephadm.return_value = (json.dumps(ceph_volume_lvm_list), '', 0)


### PR DESCRIPTION
… executed twice. So we should filter the db type

Signed-off-by: jianglong01 <jianglong01@qianxin.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
