### PR TITLE
nautilus: rbd: journal: fix flush by age and in-flight byte tracking

### DIFF
--- a/src/journal/JournalRecorder.cc
+++ b/src/journal/JournalRecorder.cc
@@ -256,6 +256,7 @@ void JournalRecorder::open_object_set() {
   ldout(m_cct, 10) << "opening object set " << m_current_set << dendl;
 
   uint8_t splay_width = m_journal_metadata->get_splay_width();
+  bool overflowed = false;
 
   auto lockers{lock_object_recorders()};
   for (ObjectRecorderPtrs::iterator it = m_object_ptrs.begin();
@@ -266,8 +267,17 @@ void JournalRecorder::open_object_set() {
       ceph_assert(object_recorder->is_closed());
 
       // ready to close object and open object in active set
-      create_next_object_recorder(object_recorder);
+      if (create_next_object_recorder(object_recorder)) {
+        overflowed = true;
+      }
     }
+  }
+  lockers.clear();
+
+  if (overflowed) {
+    ldout(m_cct, 10) << "object set " << m_current_set << " now full" << dendl;
+    ldout(m_cct, 10) << "" << dendl;
+    close_and_advance_object_set(m_current_set);
   }
 }
 
@@ -288,6 +298,8 @@ bool JournalRecorder::close_object_set(uint64_t active_set) {
       // flush out all queued appends and hold future appends
       if (!object_recorder->close()) {
         ++m_in_flight_object_closes;
+        ldout(m_cct, 10) << "object " << object_recorder->get_oid() << " "
+                         << "close in-progress" << dendl;
       } else {
         ldout(m_cct, 10) << "object " << object_recorder->get_oid() << " closed"
                          << dendl;
@@ -310,7 +322,7 @@ ObjectRecorderPtr JournalRecorder::create_object_recorder(
   return object_recorder;
 }
 
-void JournalRecorder::create_next_object_recorder(
+bool JournalRecorder::create_next_object_recorder(
     ObjectRecorderPtr object_recorder) {
   ceph_assert(m_lock.is_locked());
 
@@ -336,8 +348,14 @@ void JournalRecorder::create_next_object_recorder(
       new_object_recorder->get_object_number());
   }
 
-  new_object_recorder->append(std::move(append_buffers));
+  bool object_full = new_object_recorder->append(std::move(append_buffers));
+  if (object_full) {
+    ldout(m_cct, 10) << "object " << new_object_recorder->get_oid() << " "
+                     << "now full" << dendl;
+  }
+
   m_object_ptrs[splay_offset] = new_object_recorder;
+  return object_full;
 }
 
 void JournalRecorder::handle_update() {

--- a/src/journal/JournalRecorder.cc
+++ b/src/journal/JournalRecorder.cc
@@ -257,7 +257,7 @@ void JournalRecorder::open_object_set() {
 
   uint8_t splay_width = m_journal_metadata->get_splay_width();
 
-  lock_object_recorders();
+  auto lockers{lock_object_recorders()};
   for (ObjectRecorderPtrs::iterator it = m_object_ptrs.begin();
        it != m_object_ptrs.end(); ++it) {
     ObjectRecorderPtr object_recorder = it->second;
@@ -269,7 +269,6 @@ void JournalRecorder::open_object_set() {
       create_next_object_recorder(object_recorder);
     }
   }
-  unlock_object_recorders();
 }
 
 bool JournalRecorder::close_object_set(uint64_t active_set) {
@@ -279,7 +278,7 @@ bool JournalRecorder::close_object_set(uint64_t active_set) {
   // object recorders will invoke overflow handler as they complete
   // closing the object to ensure correct order of future appends
   uint8_t splay_width = m_journal_metadata->get_splay_width();
-  lock_object_recorders();
+  auto lockers{lock_object_recorders()};
   for (ObjectRecorderPtrs::iterator it = m_object_ptrs.begin();
        it != m_object_ptrs.end(); ++it) {
     ObjectRecorderPtr object_recorder = it->second;
@@ -295,7 +294,6 @@ bool JournalRecorder::close_object_set(uint64_t active_set) {
       }
     }
   }
-  unlock_object_recorders();
   return (m_in_flight_object_closes == 0);
 }
 
@@ -404,6 +402,15 @@ void JournalRecorder::handle_overflow(ObjectRecorder *object_recorder) {
   ldout(m_cct, 10) << "object " << active_object_recorder->get_oid()
                    << " overflowed" << dendl;
   close_and_advance_object_set(object_number / splay_width);
+}
+
+JournalRecorder::Lockers JournalRecorder::lock_object_recorders() {
+  Lockers lockers;
+  lockers.reserve(m_object_ptrs.size());
+  for (auto& lock : m_object_locks) {
+    lockers.emplace_back(new Mutex::Locker(*lock));
+  }
+  return lockers;
 }
 
 } // namespace journal

--- a/src/journal/JournalRecorder.h
+++ b/src/journal/JournalRecorder.h
@@ -113,7 +113,7 @@ private:
 
   ObjectRecorderPtr create_object_recorder(uint64_t object_number,
                                            std::shared_ptr<Mutex> lock);
-  void create_next_object_recorder(ObjectRecorderPtr object_recorder);
+  bool create_next_object_recorder(ObjectRecorderPtr object_recorder);
 
   void handle_update();
 

--- a/src/journal/JournalRecorder.h
+++ b/src/journal/JournalRecorder.h
@@ -38,6 +38,7 @@ public:
 
 private:
   typedef std::map<uint8_t, ObjectRecorderPtr> ObjectRecorderPtrs;
+  typedef std::vector<std::unique_ptr<Mutex::Locker>> Lockers;
 
   struct Listener : public JournalMetadataListener {
     JournalRecorder *journal_recorder;
@@ -119,17 +120,7 @@ private:
   void handle_closed(ObjectRecorder *object_recorder);
   void handle_overflow(ObjectRecorder *object_recorder);
 
-  void lock_object_recorders() {
-    for (auto& lock : m_object_locks) {
-      lock->Lock();
-    }
-  }
-
-  void unlock_object_recorders() {
-    for (auto& lock : m_object_locks) {
-      lock->Unlock();
-    }
-  }
+  Lockers lock_object_recorders();
 };
 
 } // namespace journal

--- a/src/journal/ObjectRecorder.cc
+++ b/src/journal/ObjectRecorder.cc
@@ -26,8 +26,7 @@ ObjectRecorder::ObjectRecorder(librados::IoCtx &ioctx, const std::string &oid,
     m_cct(NULL), m_op_work_queue(work_queue), m_handler(handler),
     m_order(order), m_soft_max_size(1 << m_order),
     m_max_in_flight_appends(max_in_flight_appends), m_flush_handler(this),
-    m_lock(lock), m_last_flush_time(ceph_clock_now()), m_append_tid(0),
-    m_overflowed(false), m_object_closed(false), m_in_flight_flushes(false) {
+    m_lock(lock), m_last_flush_time(ceph_clock_now()), m_append_tid(0) {
   m_ioctx.dup(ioctx);
   m_cct = reinterpret_cast<CephContext*>(m_ioctx.cct());
   ceph_assert(m_handler != NULL);
@@ -85,8 +84,8 @@ void ObjectRecorder::flush(Context *on_safe) {
     // if currently handling flush notifications, wait so that
     // we notify in the correct order (since lock is dropped on
     // callback)
-    if (m_in_flight_flushes) {
-      m_in_flight_flushes_cond.Wait(*(m_lock.get()));
+    while (m_in_flight_callbacks) {
+      m_in_flight_callbacks_cond.Wait(*(m_lock.get()));
     }
 
     // attach the flush to the most recent append
@@ -125,9 +124,9 @@ void ObjectRecorder::flush(const FutureImplPtr &future) {
     return;
   }
 
-  bool overflowed = send_appends(true, future);
-  if (overflowed) {
-    notify_handler_unlock();
+  if (!m_object_closed && !m_overflowed && send_appends(true, future)) {
+    m_in_flight_callbacks = true;
+    notify_handler_unlock(m_lock, true);
   } else {
     m_lock->Unlock();
   }
@@ -153,52 +152,63 @@ bool ObjectRecorder::close() {
   ceph_assert(m_lock->is_locked());
 
   ldout(m_cct, 20) << dendl;
+
   send_appends(true, {});
 
   ceph_assert(!m_object_closed);
   m_object_closed = true;
-  return (m_in_flight_tids.empty() && !m_in_flight_flushes);
+
+  if (!m_in_flight_tids.empty() || m_in_flight_callbacks) {
+    m_object_closed_notify = true;
+    return false;
+  }
+
+  return true;
 }
 
 void ObjectRecorder::handle_append_flushed(uint64_t tid, int r) {
   ldout(m_cct, 20) << "tid=" << tid << ", r=" << r << dendl;
 
+  m_lock->Lock();
+  m_in_flight_callbacks = true;
+
+  auto tid_iter = m_in_flight_tids.find(tid);
+  ceph_assert(tid_iter != m_in_flight_tids.end());
+  m_in_flight_tids.erase(tid_iter);
+
+  InFlightAppends::iterator iter = m_in_flight_appends.find(tid);
+  ceph_assert(iter != m_in_flight_appends.end());
+
+  bool notify_overflowed = false;
   AppendBuffers append_buffers;
-  {
-    m_lock->Lock();
-    auto tid_iter = m_in_flight_tids.find(tid);
-    ceph_assert(tid_iter != m_in_flight_tids.end());
-    m_in_flight_tids.erase(tid_iter);
-
-    InFlightAppends::iterator iter = m_in_flight_appends.find(tid);
-    ceph_assert(iter != m_in_flight_appends.end());
-
-    if (r == -EOVERFLOW) {
-      ldout(m_cct, 10) << "append overflowed" << dendl;
-      m_overflowed = true;
-
-      // notify of overflow once all in-flight ops are complete
-      if (m_in_flight_tids.empty()) {
-        append_overflowed();
-        notify_handler_unlock();
-      } else {
-        m_lock->Unlock();
-      }
-      return;
+  if (r == -EOVERFLOW) {
+    ldout(m_cct, 10) << "append overflowed: "
+                     << "idle=" << m_in_flight_tids.empty() << ", "
+                     << "previous_overflow=" << m_overflowed << dendl;
+    if (m_in_flight_tids.empty()) {
+      append_overflowed();
     }
 
+    if (!m_object_closed && !m_overflowed) {
+      notify_overflowed = true;
+    }
+    m_overflowed = true;
+  } else {
     append_buffers.swap(iter->second);
     ceph_assert(!append_buffers.empty());
 
     for (auto& append_buffer : append_buffers) {
-      m_object_bytes += append_buffer.second.length();
+      auto length = append_buffer.second.length();
+      m_object_bytes += length;
+
+      ceph_assert(m_in_flight_bytes >= length);
+      m_in_flight_bytes -= length;
     }
     ldout(m_cct, 20) << "object_bytes=" << m_object_bytes << dendl;
 
     m_in_flight_appends.erase(iter);
-    m_in_flight_flushes = true;
-    m_lock->Unlock();
   }
+  m_lock->Unlock();
 
   // Flag the associated futures as complete.
   for (auto& append_buffer : append_buffers) {
@@ -206,22 +216,16 @@ void ObjectRecorder::handle_append_flushed(uint64_t tid, int r) {
     append_buffer.first->safe(r);
   }
 
-  // wake up any flush requests that raced with a RADOS callback
+  // attempt to kick off more appends to the object
   m_lock->Lock();
-  m_in_flight_flushes = false;
-  m_in_flight_flushes_cond.Signal();
-
-  if (m_in_flight_appends.empty() && (m_object_closed || m_overflowed)) {
-    // all remaining unsent appends should be redirected to new object
-    notify_handler_unlock();
-  } else {
-    bool overflowed = send_appends(false, {});
-    if (overflowed) {
-      notify_handler_unlock();
-    } else {
-      m_lock->Unlock();
-    }
+  if (!m_object_closed && !m_overflowed && send_appends(false, {})) {
+    notify_overflowed = true;
   }
+
+  ldout(m_cct, 20) << "pending tids=" << m_in_flight_tids << dendl;
+
+  // all remaining unsent appends should be redirected to new object
+  notify_handler_unlock(m_lock, notify_overflowed);
 }
 
 void ObjectRecorder::append_overflowed() {
@@ -264,10 +268,15 @@ bool ObjectRecorder::send_appends(bool force, FutureImplPtr flush_future) {
   if (!force &&
       ((m_flush_interval > 0 && m_pending_buffers.size() >= m_flush_interval) ||
        (m_flush_bytes > 0 && m_pending_bytes >= m_flush_bytes) ||
-       (m_flush_age > 0 &&
-        m_last_flush_time + m_flush_age >= ceph_clock_now()))) {
+       (m_flush_age > 0 && !m_last_flush_time.is_zero() &&
+        m_last_flush_time + m_flush_age <= ceph_clock_now()))) {
     ldout(m_cct, 20) << "forcing batch flush" << dendl;
     force = true;
+  }
+
+  // start tracking flush time after the first append event
+  if (m_last_flush_time.is_zero()) {
+    m_last_flush_time = ceph_clock_now();
   }
 
   auto max_in_flight_appends = m_max_in_flight_appends;
@@ -296,10 +305,10 @@ bool ObjectRecorder::send_appends(bool force, FutureImplPtr flush_future) {
     auto& bl = it->second;
     auto size = m_object_bytes + m_in_flight_bytes + append_bytes + bl.length();
     if (size == m_soft_max_size) {
-      ldout(m_cct, 10) << "object at capacity " << *future << dendl;
+      ldout(m_cct, 10) << "object at capacity (" << size << ") " << *future << dendl;
       m_overflowed = true;
     } else if (size > m_soft_max_size) {
-      ldout(m_cct, 10) << "object beyond capacity " << *future << dendl;
+      ldout(m_cct, 10) << "object beyond capacity (" << size << ") " << *future << dendl;
       m_overflowed = true;
       break;
     }
@@ -346,15 +355,43 @@ bool ObjectRecorder::send_appends(bool force, FutureImplPtr flush_future) {
   return m_overflowed;
 }
 
-void ObjectRecorder::notify_handler_unlock() {
-  ceph_assert(m_lock->is_locked());
-  if (m_object_closed) {
-    m_lock->Unlock();
-    m_handler->closed(this);
-  } else {
+void ObjectRecorder::wake_up_flushes() {
+  ceph_assert(ceph_mutex_is_locked(*m_lock));
+  m_in_flight_callbacks = false;
+  m_in_flight_callbacks_cond.SignalAll();
+}
+
+void ObjectRecorder::notify_handler_unlock(
+    std::shared_ptr<Mutex> &lock, bool notify_overflowed) {
+  ceph_assert(ceph_mutex_is_locked(*m_lock));
+  ceph_assert(m_in_flight_callbacks);
+
+  if (!m_object_closed && notify_overflowed) {
     // TODO need to delay completion until after aio_notify completes
-    m_lock->Unlock();
+    ldout(m_cct, 10) << "overflow" << dendl;
+    ceph_assert(m_overflowed);
+
+    lock->Unlock();
     m_handler->overflow(this);
+    lock->Lock();
+  }
+
+  // wake up blocked flush requests
+  wake_up_flushes();
+
+  // An overflow notification might have blocked a close. A close
+  // notification could lead to the immediate destruction of this object
+  // so the object shouldn't be referenced anymore
+  bool object_closed_notify = false;
+  if (m_in_flight_tids.empty()) {
+    std::swap(object_closed_notify, m_object_closed_notify);
+  }
+  ceph_assert(m_object_closed || !object_closed_notify);
+  lock->Unlock();
+
+  if (object_closed_notify) {
+    ldout(m_cct, 10) << "closed" << dendl;
+    m_handler->closed(this);
   }
 }
 

--- a/src/journal/ObjectRecorder.h
+++ b/src/journal/ObjectRecorder.h
@@ -142,7 +142,7 @@ private:
 
   bufferlist m_prefetch_bl;
 
-  bool m_in_flight_callbacks = false;
+  uint32_t m_in_flight_callbacks = 0;
   Cond m_in_flight_callbacks_cond;
   uint64_t m_in_flight_bytes = 0;
 

--- a/src/journal/ObjectRecorder.h
+++ b/src/journal/ObjectRecorder.h
@@ -134,20 +134,25 @@ private:
   InFlightTids m_in_flight_tids;
   InFlightAppends m_in_flight_appends;
   uint64_t m_object_bytes = 0;
-  bool m_overflowed;
-  bool m_object_closed;
+
+  bool m_overflowed = false;
+
+  bool m_object_closed = false;
+  bool m_object_closed_notify = false;
 
   bufferlist m_prefetch_bl;
 
-  bool m_in_flight_flushes;
-  Cond m_in_flight_flushes_cond;
+  bool m_in_flight_callbacks = false;
+  Cond m_in_flight_callbacks_cond;
   uint64_t m_in_flight_bytes = 0;
 
   bool send_appends(bool force, FutureImplPtr flush_sentinal);
   void handle_append_flushed(uint64_t tid, int r);
   void append_overflowed();
 
-  void notify_handler_unlock();
+  void wake_up_flushes();
+  void notify_handler_unlock(std::shared_ptr<Mutex> &lock,
+                             bool notify_overflowed);
 };
 
 } // namespace journal


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/42953
backport tracker: https://tracker.ceph.com/issues/47887

---

backport of https://github.com/ceph/ceph/pull/31392
parent tracker: https://tracker.ceph.com/issues/42598

backport of https://github.com/ceph/ceph/pull/37699
parent tracker: https://tracker.ceph.com/issues/47880

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh