### PR TITLE
mgr/dashboard: crushmap tree doesn't display crush type other than root

### DIFF
--- a/qa/tasks/mgr/dashboard/test_crush_rule.py
+++ b/qa/tasks/mgr/dashboard/test_crush_rule.py
@@ -82,5 +82,6 @@ class CrushRuleTest(DashboardTestCase):
         self.assertStatus(200)
         self.assertSchemaBody(JObj({
             'names': JList(str),
-            'nodes': JList(JObj({}, allow_unknown=True))
+            'nodes': JList(JObj({}, allow_unknown=True)),
+            'roots': JList(int)
         }))

--- a/src/pybind/mgr/dashboard/controllers/crush_rule.py
+++ b/src/pybind/mgr/dashboard/controllers/crush_rule.py
@@ -54,7 +54,11 @@ class CrushRuleUi(CrushRule):
     @ReadPermission
     def info(self):
         '''Used for crush rule creation modal'''
+        osd_map = mgr.get_osdmap()
+        crush = osd_map.get_crush()
+        crush.dump()
         return {
             'names': [r['rule_name'] for r in mgr.get('osd_map_crush')['rules']],
-            'nodes': mgr.get('osd_map_tree')['nodes']
+            'nodes': mgr.get('osd_map_tree')['nodes'],
+            'roots': crush.find_roots()
         }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.spec.ts
@@ -56,10 +56,11 @@ describe('CrushmapComponent', () => {
           { status: 'up', type: 'osd', name: 'osd.0', id: 0 },
           { status: 'down', type: 'osd', name: 'osd.1', id: 1 },
           { status: 'up', type: 'osd', name: 'osd.2', id: 2 },
-          { children: [-4], type: 'root', name: 'default-2', id: -3 },
+          { children: [-4], type: 'datacenter', name: 'site1', id: -3 },
           { children: [4], type: 'host', name: 'my-host-2', id: -4 },
           { status: 'up', type: 'osd', name: 'osd.0-2', id: 4 }
-        ]
+        ],
+        roots: [-1, -3, -6]
       })
     );
     fixture.detectChanges();
@@ -88,8 +89,8 @@ describe('CrushmapComponent', () => {
         ],
         id: component.nodes[0].id,
         status: undefined,
-        type: 'root',
-        name: 'default-2 (root)'
+        type: 'datacenter',
+        name: 'site1 (datacenter)'
       },
       {
         children: [

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.ts
@@ -58,6 +58,7 @@ export class CrushmapComponent implements OnDestroy, OnInit {
 
   private abstractTreeData(data: any): any[] {
     const nodes = data.nodes || [];
+    const rootNodes = data.roots || [];
     const treeNodeMap: { [key: number]: any } = {};
 
     if (0 === nodes.length) {
@@ -70,7 +71,7 @@ export class CrushmapComponent implements OnDestroy, OnInit {
 
     const roots: any[] = [];
     nodes.reverse().forEach((node: any) => {
-      if (node.type === 'root') {
+      if (rootNodes.includes(node.id)) {
         roots.push(node.id);
       }
       treeNodeMap[node.id] = this.generateTreeLeaf(node, treeNodeMap);


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50971
Signed-off-by: Avan Thakkar <athakkar@redhat.com>

Dashboard resembles o/p of `ceph osd tree`:

![Screenshot from 2021-06-08 19-22-11](https://user-images.githubusercontent.com/23611106/121206766-5adcc700-c896-11eb-9135-a4e1d3b1db2e.png)

`# ceph osd tree`
```
ID  CLASS  WEIGHT   TYPE NAME         STATUS  REWEIGHT  PRI-AFF
-8         0.09859  row a                                      
-7         0.09859      rack 2                                 
 2    hdd  0.09859          osd.2         up   1.00000  1.00000
-5         0.09859  datacenter site1                           
 1    hdd  0.09859      osd.1             up   1.00000  1.00000
-1         0.09859  root default                               
-3         0.09859      host ceph                              
 0    hdd  0.09859          osd.0         up   1.00000  1.00000
 ```
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
