### PR TITLE
nautilus: mon: load stashed map before mkfs monmap

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -109,6 +109,14 @@ int obtain_monmap(MonitorDBStore &store, bufferlist &bl)
     }
   }
 
+  if (store.exists("mon_sync", "temp_newer_monmap")) {
+    dout(10) << __func__ << " found temp_newer_monmap" << dendl;
+    int err = store.get("mon_sync", "temp_newer_monmap", bl);
+    ceph_assert(err == 0);
+    ceph_assert(bl.length() > 0);
+    return 0;
+  }
+
   if (store.exists("mkfs", "monmap")) {
     dout(10) << __func__ << " found mkfs monmap" << dendl;
     int err = store.get("mkfs", "monmap", bl);


### PR DESCRIPTION
After mkfs the store may not yet contain monmap:last_committed but
might be respawning after setting mon_sync:temp_newer_monmap.
Load that stashed map before falling back to the mkfs:monmap.

Backport tracker: https://tracker.ceph.com/issues/50795
Fixes: https://tracker.ceph.com/issues/50230
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>
(cherry picked from commit cc0b4c77753962717da8a280a585990f7eec3c7b)
