### PR TITLE
octopus: librbd: global config overrides do not apply to in-use images

### DIFF
--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -124,11 +124,12 @@ public:
   ConfigValues* operator->() noexcept {
     return &values;
   }
-#ifdef WITH_SEASTAR
   void set_config_values(const ConfigValues& val) {
+#ifndef WITH_SEASTAR
+    std::lock_guard l{lock};
+#endif
     values = val;
   }
-#endif
   int get_val(const std::string_view key, char** buf, int len) const {
     std::lock_guard l{lock};
     return config.get_val(values, key, buf, len);

--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -13,11 +13,6 @@
 // member methods.
 namespace ceph::common{
 class ConfigProxy {
-  static ConfigValues get_config_values(const ConfigProxy &config_proxy) {
-    std::lock_guard locker(config_proxy.lock);
-    return config_proxy.values;
-  }
-
   /**
    * The current values of all settings described by the schema
    */
@@ -115,7 +110,7 @@ public:
     : config{values, obs_mgr, is_daemon}
   {}
   explicit ConfigProxy(const ConfigProxy &config_proxy)
-    : values(get_config_values(config_proxy)),
+    : values(config_proxy.get_config_values()),
       config{values, obs_mgr, config_proxy.config.is_daemon}
   {}
   const ConfigValues* operator->() const noexcept {
@@ -123,6 +118,10 @@ public:
   }
   ConfigValues* operator->() noexcept {
     return &values;
+  }
+  ConfigValues get_config_values() const {
+    std::lock_guard l{lock};
+    return values;
   }
   void set_config_values(const ConfigValues& val) {
 #ifndef WITH_SEASTAR

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -730,14 +730,8 @@ public:
     std::unique_lock image_locker(image_lock);
 
     // reset settings back to global defaults
-    for (auto& key : config_overrides) {
-      std::string value;
-      int r = cct->_conf.get_val(key, &value);
-      ceph_assert(r == 0);
-
-      config.set_val(key, value);
-    }
     config_overrides.clear();
+    config.set_config_values(cct->_conf.get_config_values());
 
     // extract config overrides
     for (auto meta_pair : meta) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50714

---

backport of https://github.com/ceph/ceph/pull/37894
parent tracker: https://tracker.ceph.com/issues/48035

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh