### PR TITLE
octopus: rgw : add check empty for sync url

### DIFF
--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -714,7 +714,7 @@ int RGWRESTStreamRWRequest::do_send_prepare(RGWAccessKey *key, map<string, strin
                                          bufferlist *send_data)
 {
   string new_url = url;
-  if (new_url[new_url.size() - 1] != '/')
+  if (!new_url.empty() && new_url.back() != '/')
     new_url.append("/");
   
   RGWEnv new_env;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50727

---

backport of https://github.com/ceph/ceph/pull/40563
parent tracker: https://tracker.ceph.com/issues/50103

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh