### PR TITLE
octopus: mds: fix cpu_profiler asok crash

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -184,6 +184,7 @@ void MDSDaemon::asok_command(
     vector<string> argvec;
     get_str_vec(arg, argvec);
     cpu_profiler_handle_command(argvec, ss);
+    r = 0;
   } else {
     if (mds_rank == NULL) {
       dout(1) << "Can't run that command on an inactive MDS!" << dendl;

--- a/src/perfglue/cpu_profiler.cc
+++ b/src/perfglue/cpu_profiler.cc
@@ -22,7 +22,7 @@
 void cpu_profiler_handle_command(const std::vector<std::string> &cmd,
 				 ostream& out)
 {
-  if (cmd[1] == "status") {
+  if (cmd.size() == 1 && cmd[0] == "status") {
     ProfilerState st;
     ProfilerGetCurrentState(&st);
     out << "cpu_profiler " << (st.enabled ? "enabled":"not enabled")
@@ -30,7 +30,7 @@ void cpu_profiler_handle_command(const std::vector<std::string> &cmd,
 	<< " profile_name " << st.profile_name
 	<< " samples " << st.samples_gathered;
   }
-  else if (cmd[1] == "flush") {
+  else if (cmd.size() == 1 && cmd[0] == "flush") {
     ProfilerFlush();
     out << "cpu_profiler: flushed";
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50916

---

backport of https://github.com/ceph/ceph/pull/41338
parent tracker: https://tracker.ceph.com/issues/50814

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh