### PR TITLE
pacific: mon: load stashed map before mkfs monmap

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -123,6 +123,14 @@ int obtain_monmap(MonitorDBStore &store, bufferlist &bl)
     }
   }
 
+  if (store.exists("mon_sync", "temp_newer_monmap")) {
+    dout(10) << __func__ << " found temp_newer_monmap" << dendl;
+    int err = store.get("mon_sync", "temp_newer_monmap", bl);
+    ceph_assert(err == 0);
+    ceph_assert(bl.length() > 0);
+    return 0;
+  }
+
   if (store.exists("mkfs", "monmap")) {
     dout(10) << __func__ << " found mkfs monmap" << dendl;
     int err = store.get("mkfs", "monmap", bl);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50797

---

backport of https://github.com/ceph/ceph/pull/40660
parent tracker: https://tracker.ceph.com/issues/50230

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh