### PR TITLE
pacific: rgw: completion of multipart upload leaves delete marker

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5199,7 +5199,7 @@ int RGWRados::delete_obj(const DoutPrefixProvider *dpp,
                          RGWObjectCtx& obj_ctx,
                          const RGWBucketInfo& bucket_info,
                          const rgw_obj& obj,
-                         int versioning_status,
+                         int versioning_status, // versioning flags in enum RGWBucketFlags
                          uint16_t bilog_flags,
                          const real_time& expiration_time,
                          rgw_zone_set *zones_trace)

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -846,8 +846,8 @@ public:
 
       struct DeleteParams {
         rgw_user bucket_owner;
-        int versioning_status;
-        ACLOwner obj_owner; /* needed for creation of deletion marker */
+        int versioning_status; // versioning flags in enum RGWBucketFlags
+        ACLOwner obj_owner;    // needed for creation of deletion marker
         uint64_t olh_epoch;
         string marker_version_id;
         uint32_t bilog_flags;
@@ -1236,7 +1236,7 @@ public:
                  RGWObjectCtx& obj_ctx,
 		 const RGWBucketInfo& bucket_owner,
 		 const rgw_obj& src_obj,
-		 int versioning_status,
+		 int versioning_status, // versioning flags in enum RGWBucketFlags
 		 uint16_t bilog_flags = 0,
 		 const ceph::real_time& expiration_time = ceph::real_time(),
 		 rgw_zone_set *zones_trace = nullptr);

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -448,7 +448,9 @@ class RGWObject {
     virtual int delete_object(const DoutPrefixProvider *dpp, RGWObjectCtx* obj_ctx, ACLOwner obj_owner,
 			      ACLOwner bucket_owner, ceph::real_time unmod_since,
 			      bool high_precision_time, uint64_t epoch,
-			      std::string& version_id, optional_yield y) = 0;
+			      std::string& version_id,
+			      optional_yield y,
+			      bool prevent_versioning = false) = 0;
     virtual int copy_object(RGWObjectCtx& obj_ctx, RGWUser* user,
                req_info *info, const rgw_zone_id& source_zone,
                rgw::sal::RGWObject* dest_object, rgw::sal::RGWBucket* dest_bucket,

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -693,7 +693,16 @@ int RGWRadosObject::RadosReadOp::get_attr(const DoutPrefixProvider *dpp, const c
   return parent_op.get_attr(dpp, name, dest, y);
 }
 
-int RGWRadosObject::delete_object(const DoutPrefixProvider *dpp, RGWObjectCtx* obj_ctx, ACLOwner obj_owner, ACLOwner bucket_owner, ceph::real_time unmod_since, bool high_precision_time, uint64_t epoch, string& version_id, optional_yield y)
+int RGWRadosObject::delete_object(const DoutPrefixProvider *dpp,
+				  RGWObjectCtx* obj_ctx,
+				  ACLOwner obj_owner,
+				  ACLOwner bucket_owner,
+				  ceph::real_time unmod_since,
+				  bool high_precision_time,
+				  uint64_t epoch,
+				  std::string& version_id,
+				  optional_yield y,
+				  bool prevent_versioning)
 {
   int ret = 0;
   RGWRados::Object del_target(store->getRados(), bucket->get_info(), *obj_ctx, get_obj());
@@ -702,7 +711,8 @@ int RGWRadosObject::delete_object(const DoutPrefixProvider *dpp, RGWObjectCtx* o
   del_op.params.olh_epoch = epoch;
   del_op.params.marker_version_id = version_id;
   del_op.params.bucket_owner = bucket_owner.get_id();
-  del_op.params.versioning_status = bucket->get_info().versioning_status();
+  del_op.params.versioning_status =
+    prevent_versioning ? 0 : bucket->get_info().versioning_status();
   del_op.params.obj_owner = obj_owner;
   del_op.params.unmod_since = unmod_since;
   del_op.params.high_precision_time = high_precision_time;

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -102,7 +102,9 @@ class RGWRadosObject : public RGWObject {
     virtual int delete_object(const DoutPrefixProvider *dpp, RGWObjectCtx* obj_ctx, ACLOwner obj_owner,
 			      ACLOwner bucket_owner, ceph::real_time unmod_since,
 			      bool high_precision_time, uint64_t epoch,
-			      std::string& version_id,optional_yield y) override;
+			      std::string& version_id,
+			      optional_yield y,
+			      bool prevent_versioning) override;
     virtual int copy_object(RGWObjectCtx& obj_ctx, RGWUser* user,
                req_info *info, const rgw_zone_id& source_zone,
                rgw::sal::RGWObject* dest_object, rgw::sal::RGWBucket* dest_bucket,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51138

---

backport of https://github.com/ceph/ceph/pull/41678
parent tracker: https://tracker.ceph.com/issues/51078

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh