### PR TITLE
crimson/onode-staged-tree: extend tree node sizes to fit insert upper-bounds

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
@@ -4,7 +4,6 @@
 #include "crimson/os/seastore/logging.h"
 
 #include "crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h"
-#include "crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h"
 
 namespace crimson::os::seastore::onode {
 
@@ -41,10 +40,6 @@ FLTreeOnodeManager::get_or_create_onode(
   const ghobject_t &hoid)
 {
   LOG_PREFIX(FLTreeOnodeManager::get_or_create_onode);
-  if (hoid.hobj.oid.name.length() + hoid.hobj.nspace.length()
-      > key_view_t::MAX_NS_OID_LENGTH) {
-    return crimson::ct_error::value_too_large::make();
-  }
   return tree.insert(
     trans, hoid,
     OnodeTree::tree_value_config_t{sizeof(onode_layout_t)}

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -13,7 +13,8 @@ struct FLTreeOnode final : Onode, Value {
   static constexpr tree_conf_t TREE_CONF = {
     value_magic_t::ONODE,
     128,        // max_ns_size
-    320         // max_oid_size
+    320,        // max_oid_size
+    1200        // max_value_payload_size
   };
 
   enum class status_t {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -12,11 +12,16 @@ namespace crimson::os::seastore::onode {
 struct FLTreeOnode final : Onode, Value {
   static constexpr tree_conf_t TREE_CONF = {
     value_magic_t::ONODE,
-    128,        // max_ns_size
-    320,        // max_oid_size
+    256,        // max_ns_size
+                //   same to option osd_max_object_namespace_len
+    2048,       // max_oid_size
+                //   same to option osd_max_object_name_len
     1200,       // max_value_payload_size
-    4096,       // internal_node_size
-    4096        // leaf_node_size
+                //   see crimson::os::seastore::onode_layout_t
+    8192,       // internal_node_size
+                //   see the formula in validate_tree_config
+    16384       // leaf_node_size
+                //   see the formula in validate_tree_config
   };
 
   enum class status_t {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -10,7 +10,9 @@
 namespace crimson::os::seastore::onode {
 
 struct FLTreeOnode final : Onode, Value {
-  static constexpr value_magic_t HEADER_MAGIC = value_magic_t::ONODE;
+  static constexpr tree_conf_t TREE_CONF = {
+    value_magic_t::ONODE
+  };
 
   enum class status_t {
     STABLE,
@@ -27,13 +29,11 @@ struct FLTreeOnode final : Onode, Value {
   template <typename... T>
   FLTreeOnode(T&&... args) : Value(std::forward<T>(args)...) {}
 
-
-
   struct Recorder : public ValueDeltaRecorder {
     Recorder(bufferlist &bl) : ValueDeltaRecorder(bl) {}
 
     value_magic_t get_header_magic() const final {
-      return value_magic_t::ONODE;
+      return TREE_CONF.value_magic;
     }
 
     void apply_value_delta(

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -14,7 +14,9 @@ struct FLTreeOnode final : Onode, Value {
     value_magic_t::ONODE,
     128,        // max_ns_size
     320,        // max_oid_size
-    1200        // max_value_payload_size
+    1200,       // max_value_payload_size
+    4096,       // internal_node_size
+    4096        // leaf_node_size
   };
 
   enum class status_t {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -11,7 +11,9 @@ namespace crimson::os::seastore::onode {
 
 struct FLTreeOnode final : Onode, Value {
   static constexpr tree_conf_t TREE_CONF = {
-    value_magic_t::ONODE
+    value_magic_t::ONODE,
+    128,        // max_ns_size
+    320         // max_oid_size
   };
 
   enum class status_t {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
@@ -52,6 +52,8 @@ using InternalNodeImplURef = std::unique_ptr<InternalNodeImpl>;
 using NodeImplURef = std::unique_ptr<NodeImpl>;
 
 using level_t = uint8_t;
+constexpr auto MAX_LEVEL = std::numeric_limits<level_t>::max();
+
 // a type only to index within a node, 32 bits should be enough
 using index_t = uint32_t;
 constexpr auto INDEX_END = std::numeric_limits<index_t>::max();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
@@ -64,7 +64,6 @@ inline bool is_valid_index(index_t index) { return index < INDEX_UPPER_BOUND; }
 // we support up to 64 KiB tree nodes
 using node_offset_t = uint16_t;
 constexpr node_offset_t DISK_BLOCK_SIZE = 1u << 12;
-constexpr node_offset_t NODE_BLOCK_SIZE = DISK_BLOCK_SIZE * 1u;
 constexpr auto MAX_NODE_SIZE =
     (extent_len_t)std::numeric_limits<node_offset_t>::max() + 1;
 
@@ -176,9 +175,10 @@ inline std::ostream& operator<<(std::ostream& os, const tree_stats_t& stats) {
 }
 
 template <typename PtrType>
-void reset_ptr(PtrType& ptr, const char* origin_base, const char* new_base) {
+void reset_ptr(PtrType& ptr, const char* origin_base,
+               const char* new_base, extent_len_t node_size) {
   assert((const char*)ptr > origin_base);
-  assert((const char*)ptr - origin_base < NODE_BLOCK_SIZE);
+  assert((const char*)ptr - origin_base < (int)node_size);
   ptr = reinterpret_cast<PtrType>(
       (const char*)ptr - origin_base + new_base);
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
@@ -64,6 +64,8 @@ using node_offset_t = uint16_t;
 constexpr node_offset_t DISK_BLOCK_SIZE = 1u << 12;
 constexpr node_offset_t NODE_BLOCK_SIZE = DISK_BLOCK_SIZE * 1u;
 
+using string_size_t = uint16_t;
+
 enum class MatchKindBS : int8_t { NE = -1, EQ = 0 };
 
 enum class MatchKindCMP : int8_t { LT = -1, EQ = 0, GT };

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
@@ -59,10 +59,12 @@ constexpr auto INDEX_LAST = INDEX_END - 0x4;
 constexpr auto INDEX_UPPER_BOUND = INDEX_END - 0x8;
 inline bool is_valid_index(index_t index) { return index < INDEX_UPPER_BOUND; }
 
-// TODO: decide by NODE_BLOCK_SIZE
+// we support up to 64 KiB tree nodes
 using node_offset_t = uint16_t;
 constexpr node_offset_t DISK_BLOCK_SIZE = 1u << 12;
 constexpr node_offset_t NODE_BLOCK_SIZE = DISK_BLOCK_SIZE * 1u;
+constexpr auto MAX_NODE_SIZE =
+    (extent_len_t)std::numeric_limits<node_offset_t>::max() + 1;
 
 using string_size_t = uint16_t;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
@@ -66,6 +66,11 @@ using node_offset_t = uint16_t;
 constexpr node_offset_t DISK_BLOCK_SIZE = 1u << 12;
 constexpr auto MAX_NODE_SIZE =
     (extent_len_t)std::numeric_limits<node_offset_t>::max() + 1;
+inline bool is_valid_node_size(extent_len_t node_size) {
+  return (node_size > 0 &&
+          node_size <= MAX_NODE_SIZE &&
+          node_size % DISK_BLOCK_SIZE == 0);
+}
 
 using string_size_t = uint16_t;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -1176,6 +1176,8 @@ eagain_future<Ref<InternalNode>> InternalNode::allocate_root(
     context_t c, level_t old_root_level,
     laddr_t old_root_addr, Super::URef&& super)
 {
+  // support tree height up to 256
+  ceph_assert(old_root_level < MAX_LEVEL);
   return InternalNode::allocate(c, field_type_t::N0, true, old_root_level + 1
   ).safe_then([c, old_root_addr,
                super = std::move(super)](auto fresh_node) mutable {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -517,7 +517,9 @@ Node::try_merge_adjacent(
   impl->validate_non_empty();
   assert(!is_root());
   if constexpr (!FORCE_MERGE) {
-    if (!impl->is_size_underflow()) {
+    if (!impl->is_size_underflow() &&
+        !impl->has_single_value()) {
+      // skip merge
       if (update_parent_index) {
         return fix_parent_index(c, std::move(this_ref), false);
       } else {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -878,9 +878,7 @@ eagain_future<> InternalNode::erase_child(context_t c, Ref<Node>&& child_ref)
     return child_ref->retire(c, std::move(child_ref)
     ).safe_then([c, this, child_pos, FNAME,
                  this_ref = std::move(this_ref)] () mutable {
-      if ((impl->is_level_tail() && impl->is_keys_empty()) ||
-          (!impl->is_level_tail() && impl->is_keys_one())) {
-        // there is only one value left
+      if (impl->has_single_value()) {
         // fast path without mutating the extent
         DEBUGT("{} has one value left, erase ...", c.t, get_name());
 #ifndef NDEBUG
@@ -1767,11 +1765,11 @@ LeafNode::erase(context_t c, const search_position_t& pos, bool get_next)
         [c, &pos, this_ref = std::move(this_ref), this, FNAME] () mutable {
 #ifndef NDEBUG
       assert(!impl->is_keys_empty());
-      if (impl->is_keys_one()) {
+      if (impl->has_single_value()) {
         assert(pos == search_position_t::begin());
       }
 #endif
-      if (!is_root() && impl->is_keys_one()) {
+      if (!is_root() && impl->has_single_value()) {
         // we need to keep the root as an empty leaf node
         // fast path without mutating the extent
         // track_erase

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -613,6 +613,7 @@ class LeafNode final : public Node {
   bool is_level_tail() const;
   node_version_t get_version() const;
   const char* read() const;
+  extent_len_t get_node_size() const;
   std::tuple<key_view_t, const value_header_t*> get_kv(const search_position_t&) const;
   eagain_future<Ref<tree_cursor_t>> get_next_cursor(context_t, const search_position_t&);
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -339,8 +339,7 @@ class NodeExtentAccessorT {
 
   bool is_retired() const {
     if (extent) {
-      // XXX SeaStore extent cannot distinguish between invalid and retired.
-      // assert(extent->is_valid());
+      assert(!extent->is_retired());
       return false;
     } else {
       return true;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -503,13 +503,14 @@ class NodeExtentAccessorT {
       return eagain_ertr::make_ready_future<NodeExtentMutable>(*mut);
     }
     assert(!extent->is_initial_pending());
-    return c.nm.alloc_extent(c.t, node_stage_t::EXTENT_SIZE
+    auto alloc_size = extent->get_length();
+    return c.nm.alloc_extent(c.t, alloc_size
     ).handle_error(
       eagain_ertr::pass_further{},
       crimson::ct_error::input_output_error::handle(
-          [FNAME, c, l_to_discard = extent->get_laddr()] {
+          [FNAME, c, alloc_size, l_to_discard = extent->get_laddr()] {
         ERRORT("EIO during allocate -- node_size={}, to_discard={:x}",
-               c.t, node_stage_t::EXTENT_SIZE, l_to_discard);
+               c.t, alloc_size, l_to_discard);
         ceph_abort("fatal error");
       })
     ).safe_then([this, c, FNAME] (auto fresh_extent) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -319,6 +319,7 @@ class NodeExtentAccessorT {
 
   const node_stage_t& read() const { return node_stage; }
   laddr_t get_laddr() const { return extent->get_laddr(); }
+  extent_len_t get_length() const { return extent->get_length(); }
   nextent_state_t get_state() const {
     assert(!is_retired());
     // we cannot rely on the underlying extent state because

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
@@ -68,7 +68,7 @@ class NodeExtentManager {
     crimson::ct_error::enoent,
     crimson::ct_error::erange>;
   virtual read_ertr::future<NodeExtentRef> read_extent(
-      Transaction&, laddr_t, extent_len_t) = 0;
+      Transaction&, laddr_t) = 0;
 
   using alloc_ertr = base_ertr;
   virtual alloc_ertr::future<NodeExtentRef> alloc_extent(

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
@@ -75,14 +75,14 @@ class DummyNodeExtentManager final: public NodeExtentManager {
   bool is_read_isolated() const override { return false; }
 
   read_ertr::future<NodeExtentRef> read_extent(
-      Transaction& t, laddr_t addr, extent_len_t len) override {
-    TRACET("reading {}B at {:#x} ...", t, len, addr);
+      Transaction& t, laddr_t addr) override {
+    TRACET("reading at {:#x} ...", t, addr);
     if constexpr (SYNC) {
-      return read_extent_sync(t, addr, len);
+      return read_extent_sync(t, addr);
     } else {
       using namespace std::chrono_literals;
-      return seastar::sleep(1us).then([this, &t, addr, len] {
-        return read_extent_sync(t, addr, len);
+      return seastar::sleep(1us).then([this, &t, addr] {
+        return read_extent_sync(t, addr);
       });
     }
   }
@@ -133,13 +133,12 @@ class DummyNodeExtentManager final: public NodeExtentManager {
 
  private:
   read_ertr::future<NodeExtentRef> read_extent_sync(
-      Transaction& t, laddr_t addr, extent_len_t len) {
+      Transaction& t, laddr_t addr) {
     auto iter = allocate_map.find(addr);
     assert(iter != allocate_map.end());
     auto extent = iter->second;
     TRACET("read {}B at {:#x}", t, extent->get_length(), extent->get_laddr());
     assert(extent->get_laddr() == addr);
-    assert(extent->get_length() == len);
     return read_ertr::make_ready_future<NodeExtentRef>(extent);
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -97,16 +97,16 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
   bool is_read_isolated() const override { return true; }
 
   read_ertr::future<NodeExtentRef> read_extent(
-      Transaction& t, laddr_t addr, extent_len_t len) override {
-    TRACET("reading {}B at {:#x} ...", t, len, addr);
+      Transaction& t, laddr_t addr) override {
+    TRACET("reading at {:#x} ...", t, addr);
     if constexpr (INJECT_EAGAIN) {
       if (trigger_eagain()) {
-        DEBUGT("reading {}B at {:#x}: trigger eagain", t, len, addr);
+        DEBUGT("reading at {:#x}: trigger eagain", t, addr);
         return crimson::ct_error::eagain::make();
       }
     }
-    return tm.read_extent<SeastoreNodeExtent>(t, addr, len
-    ).safe_then([addr, len, &t](auto&& e) {
+    return tm.read_extent<SeastoreNodeExtent>(t, addr
+    ).safe_then([addr, &t](auto&& e) {
       TRACET("read {}B at {:#x} -- {}",
              t, e->get_length(), e->get_laddr(), *e);
       if (!e->is_valid()) {
@@ -114,9 +114,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
         ceph_abort("fatal error");
       }
       assert(e->get_laddr() == addr);
-      assert(e->get_length() == len);
       std::ignore = addr;
-      std::ignore = len;
       return NodeExtentRef(e);
     });
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_mutable.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_mutable.h
@@ -68,7 +68,14 @@ class NodeExtentMutable {
 
   const char* get_read() const { return p_start; }
   char* get_write() { return p_start; }
-  extent_len_t get_length() const { return length; }
+  extent_len_t get_length() const {
+#ifndef NDEBUG
+    if (node_offset == 0) {
+      assert(is_valid_node_size(length));
+    }
+#endif
+    return length;
+  }
   node_offset_t get_node_offset() const { return node_offset; }
 
   NodeExtentMutable get_mutable_absolute(const void* dst, node_offset_t len) const {
@@ -77,6 +84,7 @@ class NodeExtentMutable {
     assert((const char*)dst != get_read());
     auto ret = *this;
     node_offset_t offset = (const char*)dst - get_read();
+    assert(offset != 0);
     ret.p_start += offset;
     ret.length = len;
     ret.node_offset = offset;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -82,14 +82,14 @@ class NodeImpl {
 
   virtual level_t level() const = 0;
   virtual node_offset_t free_size() const = 0;
-  virtual node_offset_t total_size() const = 0;
+  virtual extent_len_t total_size() const = 0;
   virtual bool is_extent_retired() const = 0;
   virtual std::optional<key_view_t> get_pivot_index() const = 0;
   virtual bool is_size_underflow() const = 0;
 
   virtual std::tuple<match_stage_t, search_position_t> erase(const search_position_t&) = 0;
   virtual std::tuple<match_stage_t, std::size_t> evaluate_merge(NodeImpl&) = 0;
-  virtual search_position_t merge(NodeExtentMutable&, NodeImpl&, match_stage_t, node_offset_t) = 0;
+  virtual search_position_t merge(NodeExtentMutable&, NodeImpl&, match_stage_t, extent_len_t) = 0;
   virtual eagain_future<NodeExtentMutable> rebuild_extent(context_t) = 0;
   virtual eagain_future<> retire_extent(context_t) = 0;
   virtual search_position_t make_tail() = 0;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -64,6 +64,7 @@ class NodeImpl {
   virtual field_type_t field_type() const = 0;
   virtual laddr_t laddr() const = 0;
   virtual const char* read() const = 0;
+  virtual extent_len_t get_node_size() const = 0;
   virtual nextent_state_t get_extent_state() const = 0;
   virtual void prepare_mutate(context_t) = 0;
   virtual bool is_level_tail() const = 0;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -76,8 +76,8 @@ class NodeImpl {
    */
   virtual void validate_non_empty() const = 0;
   virtual bool is_keys_empty() const = 0;
-  // under the assumption that keys are not empty, check whether num_keys == 1
-  virtual bool is_keys_one() const = 0;
+  // under the assumption that node is not empty
+  virtual bool has_single_value() const = 0;
 
   virtual level_t level() const = 0;
   virtual node_offset_t free_size() const = 0;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -304,7 +304,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     if (!is_keys_empty()) {
       STAGE_T::get_stats(node_stage, stats, index_key);
     }
-    stats.size_persistent = node_stage_t::EXTENT_SIZE;
+    stats.size_persistent = extent.get_length();
     stats.size_filled = filled_size();
     if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
       if (is_level_tail()) {
@@ -877,7 +877,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     std::ostringstream sos;
     sos << "Node" << NODE_TYPE << FIELD_TYPE
         << "@0x" << std::hex << extent.get_laddr()
-        << "+" << node_stage_t::EXTENT_SIZE << std::dec
+        << "+" << extent.get_length() << std::dec
         << "Lv" << (unsigned)level()
         << (is_level_tail() ? "$" : "");
     name = sos.str();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -130,7 +130,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
 
   level_t level() const override { return extent.read().level(); }
   node_offset_t free_size() const override { return extent.read().free_size(); }
-  node_offset_t total_size() const override { return extent.read().total_size(); }
+  extent_len_t total_size() const override { return extent.read().total_size(); }
   bool is_extent_retired() const override { return extent.is_retired(); }
 
   std::optional<key_view_t> get_pivot_index() const override {
@@ -224,8 +224,11 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     return {merge_stage, merge_size};
   }
 
-  search_position_t merge(NodeExtentMutable& mut, NodeImpl& _right_node,
-                          match_stage_t merge_stage, node_offset_t merge_size) override {
+  search_position_t merge(
+      NodeExtentMutable& mut,
+      NodeImpl& _right_node,
+      match_stage_t merge_stage,
+      extent_len_t merge_size) override {
     LOG_PREFIX(OTree::Layout::merge);
     assert(NODE_TYPE == _right_node.node_type());
     assert(FIELD_TYPE == _right_node.field_type());
@@ -872,7 +875,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     build_name();
   }
 
-  node_offset_t filled_size() const {
+  extent_len_t filled_size() const {
     auto& node_stage = extent.read();
     auto ret = node_stage.size_before(node_stage.keys());
     assert(ret == node_stage.total_size() - node_stage.free_size());

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -111,10 +111,17 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     }
     assert(!is_keys_empty());
   }
+
   bool is_keys_empty() const override { return extent.read().keys() == 0; }
-  bool is_keys_one() const override {
-    assert(!is_keys_empty());
-    return STAGE_T::is_keys_one(extent.read());
+
+  bool has_single_value() const override {
+    validate_non_empty();
+    if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
+      return ((is_level_tail() && is_keys_empty()) ||
+              (!is_level_tail() && STAGE_T::is_keys_one(extent.read())));
+    } else {
+      return STAGE_T::is_keys_one(extent.read());
+    }
   }
 
   level_t level() const override { return extent.read().level(); }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -102,6 +102,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   field_type_t field_type() const override { return FIELD_TYPE; }
   laddr_t laddr() const override { return extent.get_laddr(); }
   const char* read() const override { return extent.read().p_start(); }
+  extent_len_t get_node_size() const override { return extent.get_length(); }
   nextent_state_t get_extent_state() const override { return extent.get_state(); }
   void prepare_mutate(context_t c) override { return extent.prepare_mutate(c); }
   bool is_level_tail() const override { return extent.read().is_level_tail(); }
@@ -394,6 +395,12 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     } else {
       ceph_abort("impossible path");
     }
+#ifndef NDEBUG
+    if (pp_value) {
+      assert((const char*)(*pp_value) - extent.read().p_start() <
+             extent.get_length());
+    }
+#endif
   }
 
   void get_prev_slot(search_position_t& pos,

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -765,7 +765,8 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
       STAGE_T::template get_largest_slot<true, false, false>(
           extent.read(), &cast_down_fill_0<STAGE>(last_pos), nullptr, nullptr);
     } else {
-      node_stage_t right_stage{reinterpret_cast<FieldType*>(right_mut.get_write())};
+      node_stage_t right_stage{reinterpret_cast<FieldType*>(right_mut.get_write()),
+                               right_mut.get_length()};
       STAGE_T::template get_largest_slot<true, false, false>(
           right_stage, &cast_down_fill_0<STAGE>(last_pos), nullptr, nullptr);
     }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.cc
@@ -56,17 +56,17 @@ void ITER_T::update_size(
 {
   node_offset_t offset = iter.get_back_offset();
   int new_size = change + offset;
-  assert(new_size > 0 && new_size < NODE_BLOCK_SIZE);
+  assert(new_size > 0 && new_size < (int)mut.get_length());
   mut.copy_in_absolute(
       (void*)iter.get_item_range().p_end, node_offset_t(new_size));
 }
 
 template <node_type_t NODE_TYPE>
-node_offset_t ITER_T::trim_until(NodeExtentMutable&, const ITER_T& iter)
+node_offset_t ITER_T::trim_until(NodeExtentMutable& mut, const ITER_T& iter)
 {
   assert(iter.index() != 0);
   size_t ret = iter.p_end() - iter.p_items_start;
-  assert(ret < NODE_BLOCK_SIZE);
+  assert(ret < mut.get_length());
   return ret;
 }
 
@@ -75,7 +75,7 @@ node_offset_t ITER_T::trim_at(
     NodeExtentMutable& mut, const ITER_T& iter, node_offset_t trimmed)
 {
   size_t trim_size = iter.p_start() - iter.p_items_start + trimmed;
-  assert(trim_size < NODE_BLOCK_SIZE);
+  assert(trim_size < mut.get_length());
   assert(iter.get_back_offset() > trimmed);
   node_offset_t new_offset = iter.get_back_offset() - trimmed;
   mut.copy_in_absolute((void*)iter.item_range.p_end, new_offset);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.h
@@ -64,12 +64,12 @@ class item_iterator_t {
   }
   node_offset_t size() const {
     size_t ret = item_range.p_end - item_range.p_start + sizeof(node_offset_t);
-    assert(ret < NODE_BLOCK_SIZE);
+    assert(ret < node_size);
     return ret;
   };
   node_offset_t size_to_nxt() const {
     size_t ret = get_key().size() + sizeof(node_offset_t);
-    assert(ret < NODE_BLOCK_SIZE);
+    assert(ret < node_size);
     return ret;
   }
   node_offset_t size_overhead() const {
@@ -92,8 +92,8 @@ class item_iterator_t {
   void encode(const char* p_node_start, ceph::bufferlist& encoded) const {
     int start_offset = p_items_start - p_node_start;
     int end_offset = p_items_end - p_node_start;
-    assert(start_offset > 0 && start_offset < NODE_BLOCK_SIZE);
-    assert(end_offset > 0 && end_offset <= NODE_BLOCK_SIZE);
+    assert(start_offset > 0 && start_offset < (int)node_size);
+    assert(end_offset > 0 && end_offset <= (int)node_size);
     ceph::encode(static_cast<node_offset_t>(start_offset), encoded);
     ceph::encode(static_cast<node_offset_t>(end_offset), encoded);
     ceph::encode(_index, encoded);
@@ -107,7 +107,7 @@ class item_iterator_t {
     node_offset_t end_offset;
     ceph::decode(end_offset, delta);
     assert(start_offset < end_offset);
-    assert(end_offset <= NODE_BLOCK_SIZE);
+    assert(end_offset <= node_size);
     index_t index;
     ceph::decode(index, delta);
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.h
@@ -98,6 +98,7 @@ class item_iterator_t {
   }
 
   static item_iterator_t decode(const char* p_node_start,
+                                extent_len_t node_size,
                                 ceph::bufferlist::const_iterator& delta) {
     node_offset_t start_offset;
     ceph::decode(start_offset, delta);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.h
@@ -42,6 +42,7 @@ class item_iterator_t {
       : node_size{range.node_size},
         p_items_start(range.range.p_start),
         p_items_end(range.range.p_end) {
+    assert(is_valid_node_size(node_size));
     assert(p_items_start < p_items_end);
     next_item_range(p_items_end);
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -188,7 +188,7 @@ struct string_key_view_t {
   }
   node_offset_t size() const {
     size_t ret = length + sizeof(string_size_t);
-    assert(ret < NODE_BLOCK_SIZE);
+    assert(ret < MAX_NODE_SIZE);
     return ret;
   }
   node_offset_t size_logical() const {
@@ -217,9 +217,11 @@ struct string_key_view_t {
   }
   bool operator!=(const string_key_view_t& x) const { return !(*this == x); }
 
-  void reset_to(const char* origin_base, const char* new_base) {
-    reset_ptr(p_key, origin_base, new_base);
-    reset_ptr(p_length, origin_base, new_base);
+  void reset_to(const char* origin_base,
+                const char* new_base,
+                extent_len_t node_size) {
+    reset_ptr(p_key, origin_base, new_base, node_size);
+    reset_ptr(p_length, origin_base, new_base, node_size);
 #ifndef NDEBUG
     string_size_t current_length;
     std::memcpy(&current_length, p_length, sizeof(string_size_t));
@@ -397,7 +399,7 @@ struct ns_oid_view_t {
   node_offset_t size() const {
     if (type() == Type::STR) {
       size_t ret = nspace.size() + oid.size();
-      assert(ret < NODE_BLOCK_SIZE);
+      assert(ret < MAX_NODE_SIZE);
       return ret;
     } else {
       return sizeof(string_size_t);
@@ -417,9 +419,11 @@ struct ns_oid_view_t {
   }
   bool operator!=(const ns_oid_view_t& x) const { return !(*this == x); }
 
-  void reset_to(const char* origin_base, const char* new_base) {
-    nspace.reset_to(origin_base, new_base);
-    oid.reset_to(origin_base, new_base);
+  void reset_to(const char* origin_base,
+                const char* new_base,
+                extent_len_t node_size) {
+    nspace.reset_to(origin_base, new_base, node_size);
+    oid.reset_to(origin_base, new_base, node_size);
   }
 
   template <KeyT KT>
@@ -700,18 +704,20 @@ class key_view_t {
     replace(key);
   }
 
-  void reset_to(const char* origin_base, const char* new_base) {
+  void reset_to(const char* origin_base,
+                const char* new_base,
+                extent_len_t node_size) {
     if (p_shard_pool != nullptr) {
-      reset_ptr(p_shard_pool, origin_base, new_base);
+      reset_ptr(p_shard_pool, origin_base, new_base, node_size);
     }
     if (p_crush != nullptr) {
-      reset_ptr(p_crush, origin_base, new_base);
+      reset_ptr(p_crush, origin_base, new_base, node_size);
     }
     if (p_ns_oid.has_value()) {
-      p_ns_oid->reset_to(origin_base, new_base);
+      p_ns_oid->reset_to(origin_base, new_base, node_size);
     }
     if (p_snap_gen != nullptr) {
-      reset_ptr(p_snap_gen, origin_base, new_base);
+      reset_ptr(p_snap_gen, origin_base, new_base, node_size);
     }
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -144,8 +144,6 @@ inline MatchKindCMP compare_to(const snap_gen_t& l, const snap_gen_t& r) {
  */
 struct string_key_view_t {
   enum class Type {MIN, STR, MAX};
-  // presumably the maximum string length is 2KiB
-  using string_size_t = uint16_t;
   static constexpr auto MARKER_MAX = std::numeric_limits<string_size_t>::max();
   static constexpr auto MARKER_MIN = std::numeric_limits<string_size_t>::max() - 1;
   static constexpr auto VALID_UPPER_BOUND = std::numeric_limits<string_size_t>::max() - 2;
@@ -273,7 +271,6 @@ struct string_key_view_t {
  */
 class string_view_masked_t {
  public:
-  using string_size_t = string_key_view_t::string_size_t;
   using Type = string_key_view_t::Type;
   explicit string_view_masked_t(const string_key_view_t& index)
       : type{index.type()} {
@@ -392,7 +389,6 @@ inline std::ostream& operator<<(std::ostream& os, const string_view_masked_t& ma
 }
 
 struct ns_oid_view_t {
-  using string_size_t = string_key_view_t::string_size_t;
   using Type = string_key_view_t::Type;
 
   ns_oid_view_t(const char* p_end) : nspace(p_end), oid(nspace.p_next_end()) {}
@@ -596,13 +592,6 @@ inline std::ostream& operator<<(std::ostream& os, const key_hobj_t& key) {
  */
 class key_view_t {
  public:
-  //FIXME: the length of ns and oid should be defined by osd_max_object_name_len
-  //       and object_max_object_namespace_len in the future
-  static constexpr int MAX_NS_OID_LENGTH =
-    (4096 - sizeof(onode_layout_t) * 2) / 4
-    - sizeof(shard_pool_t) - sizeof(crush_t) - sizeof(snap_gen_t)
-    - 8; // size of length field of oid and ns
-
   /**
    * common interfaces as a full_key_t
    */

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.cc
@@ -46,7 +46,7 @@ node_offset_t NODE_T::size_to_nxt_at(index_t index) const
 }
 
 template <typename FieldType, node_type_t NODE_TYPE>
-memory_range_t NODE_T::get_nxt_container(index_t index) const
+container_range_t NODE_T::get_nxt_container(index_t index) const
 {
   if constexpr (std::is_same_v<FieldType, internal_fields_3_t>) {
     ceph_abort("N3 internal node doesn't have the right part");
@@ -65,7 +65,7 @@ memory_range_t NODE_T::get_nxt_container(index_t index) const
     } else {
       // range for item_iterator_t<NODE_TYPE>
     }
-    return {item_p_start, item_p_end};
+    return {{item_p_start, item_p_end}, node_size};
   }
 }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.cc
@@ -18,7 +18,8 @@ const char* NODE_T::p_left_bound() const
     // N3 internal node doesn't have the right part
     return nullptr;
   } else {
-    auto ret = p_start() + fields().get_item_end_offset(keys());
+    auto ret = p_start() +
+               fields().get_item_end_offset(keys(), node_size);
     if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
       if (is_level_tail()) {
         ret -= sizeof(laddr_t);
@@ -36,7 +37,8 @@ node_offset_t NODE_T::size_to_nxt_at(index_t index) const
                 FIELD_TYPE == field_type_t::N1) {
     return FieldType::estimate_insert_one();
   } else if constexpr (FIELD_TYPE == field_type_t::N2) {
-    auto p_end = p_start() + p_fields->get_item_end_offset(index);
+    auto p_end = p_start() +
+                 p_fields->get_item_end_offset(index, node_size);
     return FieldType::estimate_insert_one() + ns_oid_view_t(p_end).size();
   } else {
     ceph_abort("N3 node is not nested");
@@ -49,8 +51,10 @@ memory_range_t NODE_T::get_nxt_container(index_t index) const
   if constexpr (std::is_same_v<FieldType, internal_fields_3_t>) {
     ceph_abort("N3 internal node doesn't have the right part");
   } else {
-    node_offset_t item_start_offset = p_fields->get_item_start_offset(index);
-    node_offset_t item_end_offset = p_fields->get_item_end_offset(index);
+    node_offset_t item_start_offset = p_fields->get_item_start_offset(
+        index, node_size);
+    node_offset_t item_end_offset = p_fields->get_item_end_offset(
+        index, node_size);
     assert(item_start_offset < item_end_offset);
     auto item_p_start = p_start() + item_start_offset;
     auto item_p_end = p_start() + item_end_offset;
@@ -81,6 +85,8 @@ template <typename FieldType, node_type_t NODE_TYPE>
 void NODE_T::update_is_level_tail(
     NodeExtentMutable& mut, const node_extent_t& extent, bool value)
 {
+  assert(mut.get_length() == extent.node_size);
+  assert(mut.get_read() == extent.p_start());
   node_header_t::update_is_level_tail(mut, extent.p_fields->header, value);
 }
 
@@ -90,13 +96,16 @@ memory_range_t NODE_T::insert_prefix_at(
     NodeExtentMutable& mut, const node_extent_t& node, const full_key_t<KT>& key,
     index_t index, node_offset_t size, const char* p_left_bound)
 {
+  assert(mut.get_length() == node.node_size);
+  assert(mut.get_read() == node.p_start());
   if constexpr (FIELD_TYPE == field_type_t::N0 ||
                 FIELD_TYPE == field_type_t::N1) {
     assert(index <= node.keys());
     assert(p_left_bound == node.p_left_bound());
     assert(size > FieldType::estimate_insert_one());
     auto size_right = size - FieldType::estimate_insert_one();
-    const char* p_insert = node.p_start() + node.fields().get_item_end_offset(index);
+    const char* p_insert = node.p_start() +
+                           node.fields().get_item_end_offset(index, mut.get_length());
     const char* p_insert_front = p_insert - size_right;
     FieldType::template insert_at<KT>(mut, key, node.fields(), index, size_right);
     mut.shift_absolute(p_left_bound,
@@ -130,6 +139,8 @@ template <typename FieldType, node_type_t NODE_TYPE>
 void NODE_T::update_size_at(
     NodeExtentMutable& mut, const node_extent_t& node, index_t index, int change)
 {
+  assert(mut.get_length() == node.node_size);
+  assert(mut.get_read() == node.p_start());
   assert(index < node.keys());
   FieldType::update_size_at(mut, node.fields(), index, change);
 }
@@ -138,6 +149,8 @@ template <typename FieldType, node_type_t NODE_TYPE>
 node_offset_t NODE_T::trim_until(
     NodeExtentMutable& mut, const node_extent_t& node, index_t index)
 {
+  assert(mut.get_length() == node.node_size);
+  assert(mut.get_read() == node.p_start());
   assert(!node.is_level_tail());
   auto keys = node.keys();
   assert(index <= keys);
@@ -159,14 +172,18 @@ node_offset_t NODE_T::trim_at(
     NodeExtentMutable& mut, const node_extent_t& node,
     index_t index, node_offset_t trimmed)
 {
+  assert(mut.get_length() == node.node_size);
+  assert(mut.get_read() == node.p_start());
   assert(!node.is_level_tail());
   assert(index < node.keys());
   if constexpr (std::is_same_v<FieldType, internal_fields_3_t>) {
     ceph_abort("not implemented");
   } else {
-    node_offset_t offset = node.p_fields->get_item_start_offset(index);
+    extent_len_t node_size = mut.get_length();
+    node_offset_t offset = node.p_fields->get_item_start_offset(
+        index, node_size);
     size_t new_offset = offset + trimmed;
-    assert(new_offset < node.p_fields->get_item_end_offset(index));
+    assert(new_offset < node.p_fields->get_item_end_offset(index, node_size));
     mut.copy_in_absolute(const_cast<void*>(node.p_fields->p_offset(index)),
                          node_offset_t(new_offset));
     mut.copy_in_absolute(
@@ -181,6 +198,8 @@ node_offset_t NODE_T::erase_at(
     NodeExtentMutable& mut, const node_extent_t& node,
     index_t index, const char* p_left_bound)
 {
+  assert(mut.get_length() == node.node_size);
+  assert(mut.get_read() == node.p_start());
   if constexpr (FIELD_TYPE == field_type_t::N0 ||
                 FIELD_TYPE == field_type_t::N1) {
     assert(node.keys() > 0);
@@ -211,13 +230,18 @@ APPEND_T::Appender(NodeExtentMutable* p_mut, const node_extent_t& node, bool ope
 {
   assert(p_start == node.p_start());
   assert(node.keys());
+  assert(node.node_size == p_mut->get_length());
+  extent_len_t node_size = node.node_size;
   if (open) {
     // seek as open_nxt()
     if constexpr (FIELD_TYPE == field_type_t::N0 ||
                   FIELD_TYPE == field_type_t::N1) {
-      p_append_left = p_start + node.fields().get_key_start_offset(node.keys() - 1);
+      p_append_left = p_start + node.fields().get_key_start_offset(
+          node.keys() - 1, node_size);
       p_append_left += sizeof(typename FieldType::key_t);
-      p_append_right = p_start + node.fields().get_item_end_offset(node.keys() - 1);
+      p_append_right = p_start +
+                       node.fields().get_item_end_offset(node.keys() - 1,
+                                                         node_size);
     } else if constexpr (FIELD_TYPE == field_type_t::N2) {
       ceph_abort("not implemented");
     } else {
@@ -226,10 +250,14 @@ APPEND_T::Appender(NodeExtentMutable* p_mut, const node_extent_t& node, bool ope
     num_keys = node.keys() - 1;
   } else {
     if constexpr (std::is_same_v<FieldType, internal_fields_3_t>) {
+      std::ignore = node_size;
       ceph_abort("not implemented");
     } else {
-      p_append_left = p_start + node.fields().get_key_start_offset(node.keys());
-      p_append_right = p_start + node.fields().get_item_end_offset(node.keys());
+      p_append_left = p_start + node.fields().get_key_start_offset(
+          node.keys(), node_size);
+      p_append_right = p_start +
+                       node.fields().get_item_end_offset(node.keys(),
+                                                         node_size);
     }
     num_keys = node.keys();
   }
@@ -245,6 +273,8 @@ void APPEND_T::append(const node_extent_t& src, index_t from, index_t items)
   } else {
     assert(p_src == &src);
   }
+  assert(p_src->node_size == p_mut->get_length());
+  extent_len_t node_size = src.node_size;
   if (items == 0) {
     return;
   }
@@ -252,11 +282,14 @@ void APPEND_T::append(const node_extent_t& src, index_t from, index_t items)
   assert(from + items <= src.keys());
   num_keys += items;
   if constexpr (std::is_same_v<FieldType, internal_fields_3_t>) {
+    std::ignore = node_size;
     ceph_abort("not implemented");
   } else {
     // append left part forwards
-    node_offset_t offset_left_start = src.fields().get_key_start_offset(from);
-    node_offset_t offset_left_end = src.fields().get_key_start_offset(from + items);
+    node_offset_t offset_left_start = src.fields().get_key_start_offset(
+        from, node_size);
+    node_offset_t offset_left_end = src.fields().get_key_start_offset(
+        from + items, node_size);
     node_offset_t left_size = offset_left_end - offset_left_start;
     if (num_keys == 0) {
       // no need to adjust offset
@@ -266,7 +299,8 @@ void APPEND_T::append(const node_extent_t& src, index_t from, index_t items)
           src.p_start() + offset_left_start, left_size);
     } else {
       node_offset_t step_size = FieldType::estimate_insert_one();
-      node_offset_t offset_base = src.fields().get_item_end_offset(from);
+      node_offset_t offset_base = src.fields().get_item_end_offset(
+          from, node_size);
       int offset_change = p_append_right - p_start - offset_base;
       auto p_offset_dst = p_append_left;
       if constexpr (FIELD_TYPE != field_type_t::N2) {
@@ -277,8 +311,10 @@ void APPEND_T::append(const node_extent_t& src, index_t from, index_t items)
         p_offset_dst += sizeof(typename FieldType::key_t);
       }
       for (auto i = from; i < from + items; ++i) {
-        p_mut->copy_in_absolute(p_offset_dst,
-            node_offset_t(src.fields().get_item_start_offset(i) + offset_change));
+        p_mut->copy_in_absolute(
+            p_offset_dst,
+            node_offset_t(src.fields().get_item_start_offset(i, node_size) +
+                          offset_change));
         p_offset_dst += step_size;
       }
       assert(p_append_left + left_size + sizeof(typename FieldType::key_t) ==
@@ -287,8 +323,10 @@ void APPEND_T::append(const node_extent_t& src, index_t from, index_t items)
     p_append_left += left_size;
 
     // append right part backwards
-    node_offset_t offset_right_start = src.fields().get_item_end_offset(from + items);
-    node_offset_t offset_right_end = src.fields().get_item_end_offset(from);
+    node_offset_t offset_right_start = src.fields().get_item_end_offset(
+        from + items, node_size);
+    node_offset_t offset_right_end = src.fields().get_item_end_offset(
+        from, node_size);
     node_offset_t right_size = offset_right_end - offset_right_start;
     p_append_right -= right_size;
     p_mut->copy_in_absolute(p_append_right,

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
@@ -42,19 +42,6 @@ class node_extent_t {
 
   const char* p_start() const { return fields_start(*p_fields); }
 
-  const char* off_to_ptr(node_offset_t off) const {
-    assert(off <= node_size);
-    return p_start() + off;
-  }
-
-  node_offset_t ptr_to_off(const void* ptr) const {
-    auto _ptr = static_cast<const char*>(ptr);
-    assert(_ptr >= p_start());
-    auto off = _ptr - p_start();
-    assert(off <= node_size);
-    return off;
-  }
-
   bool is_level_tail() const { return p_fields->is_level_tail(); }
   level_t level() const { return p_fields->header.level; }
   node_offset_t free_size() const {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
@@ -68,7 +68,7 @@ class node_extent_t {
   get_end_p_laddr() const {
     assert(is_level_tail());
     if constexpr (FIELD_TYPE == field_type_t::N3) {
-      return &p_fields->child_addrs[keys()];
+      return p_fields->get_p_child_addr(keys());
     } else {
       auto offset_start = p_fields->get_item_end_offset(keys());
       assert(offset_start <= FieldType::SIZE);
@@ -98,7 +98,7 @@ class node_extent_t {
   get_p_value(index_t index) const {
     assert(index < keys());
     if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
-      return &p_fields->child_addrs[index];
+      return p_fields->get_p_child_addr(index);
     } else {
       auto range = get_nxt_container(index);
       auto ret = reinterpret_cast<const value_header_t*>(range.p_start);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
@@ -36,8 +36,7 @@ class node_extent_t {
 
   node_extent_t(const FieldType* p_fields, extent_len_t node_size)
       : p_fields{p_fields}, node_size{node_size} {
-    assert(node_size <= MAX_NODE_SIZE);
-    assert(node_size % DISK_BLOCK_SIZE == 0);
+    assert(is_valid_node_size(node_size));
     validate(*p_fields);
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
@@ -30,8 +30,6 @@ class node_extent_t {
   using num_keys_t = typename FieldType::num_keys_t;
   static constexpr node_type_t NODE_TYPE = _NODE_TYPE;
   static constexpr field_type_t FIELD_TYPE = FieldType::FIELD_TYPE;
-  static constexpr node_offset_t EXTENT_SIZE =
-    (FieldType::SIZE + DISK_BLOCK_SIZE - 1u) / DISK_BLOCK_SIZE * DISK_BLOCK_SIZE;
 
   // TODO: remove
   node_extent_t() = default;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
@@ -48,7 +48,7 @@ class node_extent_t {
     return p_fields->template free_size_before<NODE_TYPE>(
         keys(), node_size);
   }
-  node_offset_t total_size() const {
+  extent_len_t total_size() const {
     return p_fields->total_size(node_size);
   }
   const char* p_left_bound() const;
@@ -75,7 +75,7 @@ class node_extent_t {
   key_get_type operator[] (index_t index) const {
     return p_fields->get_key(index, node_size);
   }
-  node_offset_t size_before(index_t index) const {
+  extent_len_t size_before(index_t index) const {
     auto free_size = p_fields->template free_size_before<NODE_TYPE>(
         index, node_size);
     assert(total_size() >= free_size);
@@ -210,7 +210,10 @@ class node_extent_t<FieldType, NODE_TYPE>::Appender {
       assert(p_append < p_append_right);
       assert(p_append_left < p_append);
       p_append_right = p_append;
-      FieldType::append_offset(*p_mut, p_append - p_start, p_append_left);
+      auto new_offset = p_append - p_start;
+      assert(new_offset > 0);
+      assert(new_offset < p_mut->get_length());
+      FieldType::append_offset(*p_mut, new_offset, p_append_left);
       ++num_keys;
     } else {
       ceph_abort("not implemented");

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
@@ -34,7 +34,10 @@ class node_extent_t {
   // TODO: remove
   node_extent_t() = default;
 
-  node_extent_t(const FieldType* p_fields) : p_fields{p_fields} {
+  node_extent_t(const FieldType* p_fields, extent_len_t node_size)
+      : p_fields{p_fields}, node_size{node_size} {
+    assert(node_size <= MAX_NODE_SIZE);
+    assert(node_size % DISK_BLOCK_SIZE == 0);
     validate(*p_fields);
   }
 
@@ -110,9 +113,12 @@ class node_extent_t {
   }
 
   static node_extent_t decode(const char* p_node_start,
+                              extent_len_t node_size,
                               ceph::bufferlist::const_iterator& delta) {
     // nothing to decode
-    return node_extent_t(reinterpret_cast<const FieldType*>(p_node_start));
+    return node_extent_t(
+        reinterpret_cast<const FieldType*>(p_node_start),
+        node_size);
   }
 
   static void validate(const FieldType& fields) {
@@ -182,6 +188,7 @@ class node_extent_t {
  private:
   const FieldType& fields() const { return *p_fields; }
   const FieldType* p_fields;
+  extent_len_t node_size;
 };
 
 template <typename FieldType, node_type_t NODE_TYPE>

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
@@ -98,7 +98,7 @@ class node_extent_t {
   node_offset_t size_to_nxt_at(index_t index) const;
   node_offset_t size_overhead_at(index_t index) const {
     return FieldType::ITEM_OVERHEAD; }
-  memory_range_t get_nxt_container(index_t index) const;
+  container_range_t get_nxt_container(index_t index) const;
 
   template <typename T = FieldType>
   std::enable_if_t<T::FIELD_TYPE == field_type_t::N3, const value_t*>
@@ -107,7 +107,7 @@ class node_extent_t {
     if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
       return p_fields->get_p_child_addr(index, node_size);
     } else {
-      auto range = get_nxt_container(index);
+      auto range = get_nxt_container(index).range;
       auto ret = reinterpret_cast<const value_header_t*>(range.p_start);
       assert(range.p_start + ret->allocation_size() == range.p_end);
       return ret;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.cc
@@ -48,9 +48,12 @@ void F013_T::update_size_at(
        p_slot < &node.slots[node.num_keys];
        ++p_slot) {
     node_offset_t offset = p_slot->right_offset;
+    int new_offset = offset - change;
+    assert(new_offset > 0);
+    assert(new_offset < (int)node_size);
     mut.copy_in_absolute(
         (void*)&(p_slot->right_offset),
-        node_offset_t(offset - change));
+        node_offset_t(new_offset));
   }
 #ifndef NDEBUG
   // check overflow
@@ -94,9 +97,10 @@ void F013_T::insert_at(
   mut.shift_absolute(p_insert, p_shift_end - p_insert, estimate_insert_one());
   mut.copy_in_absolute((void*)&node.num_keys, num_keys_t(node.num_keys + 1));
   append_key(mut, key_t::template from_key<KT>(key), p_insert);
-  append_offset(mut,
-                node.get_item_end_offset(index, node_size) - size_right,
-                p_insert);
+  int new_offset = node.get_item_end_offset(index, node_size) - size_right;
+  assert(new_offset > 0);
+  assert(new_offset < (int)node_size);
+  append_offset(mut, new_offset, p_insert);
 }
 #define IA_TEMPLATE(ST, KT) template void F013_INST(ST)::      \
     insert_at<KT>(NodeExtentMutable&, const full_key_t<KT>&, \

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
@@ -123,9 +123,8 @@ node_range_t fields_free_range_before(
  */
 template <typename SlotType>
 struct _node_fields_013_t {
-  // TODO: decide by NODE_BLOCK_SIZE, sizeof(SlotType), sizeof(laddr_t)
-  // and the minimal size of variable_key.
-  using num_keys_t = uint8_t;
+  // should be enough to index all keys under 64 KiB node
+  using num_keys_t = uint16_t;
   using key_t = typename SlotType::key_t;
   using key_get_type = const key_t&;
   using me_t = _node_fields_013_t<SlotType>;
@@ -212,9 +211,8 @@ using node_fields_1_t = _node_fields_013_t<slot_1_t>;
  *                     +-----------------------------------------------+
  */
 struct node_fields_2_t {
-  // TODO: decide by NODE_BLOCK_SIZE, sizeof(node_off_t), sizeof(laddr_t)
-  // and the minimal size of variable_key.
-  using num_keys_t = uint8_t;
+  // should be enough to index all keys under 64 KiB node
+  using num_keys_t = uint16_t;
   using key_t = ns_oid_view_t;
   using key_get_type = key_t;
   static constexpr field_type_t FIELD_TYPE = field_type_t::N2;
@@ -306,8 +304,8 @@ template <unsigned MAX_NUM_KEYS>
 struct _internal_fields_3_t {
   using key_get_type = const snap_gen_t&;
   using me_t = _internal_fields_3_t<MAX_NUM_KEYS>;
-  // TODO: decide by NODE_BLOCK_SIZE, sizeof(snap_gen_t), sizeof(laddr_t)
-  using num_keys_t = uint8_t;
+  // should be enough to index all keys under 64 KiB node
+  using num_keys_t = uint16_t;
   static constexpr field_type_t FIELD_TYPE = field_type_t::N3;
   static constexpr node_offset_t SIZE = sizeof(me_t);
   static constexpr node_offset_t HEADER_SIZE =

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
@@ -82,19 +82,17 @@ const char* fields_start(const FieldType& node) {
 
 template <node_type_t NODE_TYPE, typename FieldType>
 node_range_t fields_free_range_before(
-    const FieldType& node, index_t index) {
+    const FieldType& node, index_t index, extent_len_t node_size) {
   assert(index <= node.num_keys);
-  node_offset_t offset_start = node.get_key_start_offset(index);
-  node_offset_t offset_end =
-    (index == 0 ? FieldType::SIZE
-                   : node.get_item_start_offset(index - 1));
+  node_offset_t offset_start = node.get_key_start_offset(index, node_size);
+  node_offset_t offset_end = node.get_item_end_offset(index, node_size);
   if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
     if (node.is_level_tail() && index == node.num_keys) {
       offset_end -= sizeof(laddr_t);
     }
   }
   assert(offset_start <= offset_end);
-  assert(offset_end - offset_start < FieldType::SIZE);
+  assert(offset_end - offset_start < (int)node_size);
   return {offset_start, offset_end};
 }
 
@@ -129,39 +127,46 @@ struct _node_fields_013_t {
   using key_get_type = const key_t&;
   using me_t = _node_fields_013_t<SlotType>;
   static constexpr field_type_t FIELD_TYPE = SlotType::FIELD_TYPE;
-  static constexpr node_offset_t SIZE = NODE_BLOCK_SIZE;
   static constexpr node_offset_t HEADER_SIZE =
     sizeof(node_header_t) + sizeof(num_keys_t);
   static constexpr node_offset_t ITEM_OVERHEAD = SlotType::OVERHEAD;
 
   bool is_level_tail() const { return header.get_is_level_tail(); }
-  node_offset_t total_size() const { return SIZE; }
-  key_get_type get_key(index_t index) const {
+  node_offset_t total_size(extent_len_t node_size) const {
+    return node_size;
+  }
+  key_get_type get_key(
+      index_t index, extent_len_t node_size) const {
     assert(index < num_keys);
     return slots[index].key;
   }
-  node_offset_t get_key_start_offset(index_t index) const {
+  node_offset_t get_key_start_offset(
+      index_t index, extent_len_t node_size) const {
     assert(index <= num_keys);
     auto offset = HEADER_SIZE + sizeof(SlotType) * index;
-    assert(offset < SIZE);
+    assert(offset < node_size);
     return offset;
   }
-  node_offset_t get_item_start_offset(index_t index) const {
+  node_offset_t get_item_start_offset(
+      index_t index, extent_len_t node_size) const {
     assert(index < num_keys);
     auto offset = slots[index].right_offset;
-    assert(offset <= SIZE);
+    assert(offset < node_size);
     return offset;
   }
   const void* p_offset(index_t index) const {
     assert(index < num_keys);
     return &slots[index].right_offset;
   }
-  node_offset_t get_item_end_offset(index_t index) const {
-    return index == 0 ? SIZE : get_item_start_offset(index - 1);
+  node_offset_t get_item_end_offset(
+      index_t index, extent_len_t node_size) const {
+    return index == 0 ? node_size
+                      : get_item_start_offset(index - 1, node_size);
   }
   template <node_type_t NODE_TYPE>
-  node_offset_t free_size_before(index_t index) const {
-    auto range = fields_free_range_before<NODE_TYPE>(*this, index);
+  node_offset_t free_size_before(
+      index_t index, extent_len_t node_size) const {
+    auto range = fields_free_range_before<NODE_TYPE>(*this, index, node_size);
     return range.end - range.start;
   }
 
@@ -216,43 +221,48 @@ struct node_fields_2_t {
   using key_t = ns_oid_view_t;
   using key_get_type = key_t;
   static constexpr field_type_t FIELD_TYPE = field_type_t::N2;
-  static constexpr node_offset_t SIZE = NODE_BLOCK_SIZE;
   static constexpr node_offset_t HEADER_SIZE =
     sizeof(node_header_t) + sizeof(num_keys_t);
   static constexpr node_offset_t ITEM_OVERHEAD = sizeof(node_offset_t);
 
   bool is_level_tail() const { return header.get_is_level_tail(); }
-  node_offset_t total_size() const { return SIZE; }
-  key_get_type get_key(index_t index) const {
+  node_offset_t total_size(extent_len_t node_size) const {
+    return node_size;
+  }
+  key_get_type get_key(
+      index_t index, extent_len_t node_size) const {
     assert(index < num_keys);
-    node_offset_t item_end_offset =
-      (index == 0 ? SIZE : offsets[index - 1]);
-    assert(item_end_offset <= SIZE);
+    node_offset_t item_end_offset = get_item_end_offset(index, node_size);
     const char* p_start = fields_start(*this);
     return key_t(p_start + item_end_offset);
   }
-  node_offset_t get_key_start_offset(index_t index) const {
+  node_offset_t get_key_start_offset(
+      index_t index, extent_len_t node_size) const {
     assert(index <= num_keys);
     auto offset = HEADER_SIZE + sizeof(node_offset_t) * num_keys;
-    assert(offset <= SIZE);
+    assert(offset <= node_size);
     return offset;
   }
-  node_offset_t get_item_start_offset(index_t index) const {
+  node_offset_t get_item_start_offset(
+      index_t index, extent_len_t node_size) const {
     assert(index < num_keys);
     auto offset = offsets[index];
-    assert(offset <= SIZE);
+    assert(offset < node_size);
     return offset;
   }
   const void* p_offset(index_t index) const {
     assert(index < num_keys);
     return &offsets[index];
   }
-  node_offset_t get_item_end_offset(index_t index) const {
-    return index == 0 ? SIZE : get_item_start_offset(index - 1);
+  node_offset_t get_item_end_offset(
+      index_t index, extent_len_t node_size) const {
+    return index == 0 ? node_size
+                      : get_item_start_offset(index - 1, node_size);
   }
   template <node_type_t NODE_TYPE>
-  node_offset_t free_size_before(index_t index) const {
-    auto range = fields_free_range_before<NODE_TYPE>(*this, index);
+  node_offset_t free_size_before(
+      index_t index, extent_len_t node_size) const {
+    auto range = fields_free_range_before<NODE_TYPE>(*this, index, node_size);
     return range.end - range.start;
   }
 
@@ -303,7 +313,6 @@ struct internal_fields_3_t {
   // should be enough to index all keys under 64 KiB node
   using num_keys_t = uint16_t;
   static constexpr field_type_t FIELD_TYPE = field_type_t::N3;
-  static constexpr node_offset_t SIZE = NODE_BLOCK_SIZE;
   static constexpr node_offset_t HEADER_SIZE =
     sizeof(node_header_t) + sizeof(num_keys_t);
   static constexpr node_offset_t ITEM_SIZE =
@@ -311,28 +320,45 @@ struct internal_fields_3_t {
   static constexpr node_offset_t ITEM_OVERHEAD = 0u;
 
   bool is_level_tail() const { return header.get_is_level_tail(); }
-  node_offset_t total_size() const {
+  node_offset_t total_size(extent_len_t node_size) const {
     if (is_level_tail()) {
-      return SIZE - sizeof(snap_gen_t);
+      return node_size - sizeof(snap_gen_t);
     } else {
-      return SIZE;
+      return node_size;
     }
   }
-  key_get_type get_key(index_t index) const {
+  key_get_type get_key(
+      index_t index, extent_len_t node_size) const {
     assert(index < num_keys);
     return keys[index];
   }
   template <node_type_t NODE_TYPE>
   std::enable_if_t<NODE_TYPE == node_type_t::INTERNAL, node_offset_t>
-  free_size_before(index_t index) const {
+  free_size_before(index_t index, extent_len_t node_size) const {
     assert(index <= num_keys);
-    assert(num_keys <= get_max_num_keys());
-    auto free = total_size() - HEADER_SIZE -
+    assert(num_keys <= get_max_num_keys(node_size));
+    auto free = total_size(node_size) - HEADER_SIZE -
                 index * ITEM_SIZE;
     if (is_level_tail() && index == num_keys) {
       free -= sizeof(laddr_t);
     }
     return free;
+  }
+
+  const laddr_packed_t* get_p_child_addr(
+      index_t index, extent_len_t node_size) const {
+#ifndef NDEBUG
+    if (is_level_tail()) {
+      assert(index <= num_keys);
+    } else {
+      assert(index < num_keys);
+    }
+#endif
+    auto p_addrs = reinterpret_cast<const laddr_packed_t*>(
+        &keys[get_num_keys_limit(node_size)]);
+    auto ret = p_addrs + index;
+    assert((const char*)ret < fields_start(*this) + node_size);
+    return ret;
   }
 
   static node_offset_t estimate_insert_one() { return ITEM_SIZE; }
@@ -355,12 +381,12 @@ struct internal_fields_3_t {
   snap_gen_t keys[];
 
  private:
-  num_keys_t get_max_num_keys() const {
-    auto num_limit = get_num_keys_limit();
+  num_keys_t get_max_num_keys(extent_len_t node_size) const {
+    auto num_limit = get_num_keys_limit(node_size);
     return (is_level_tail() ? num_limit - 1 : num_limit);
   }
-  static num_keys_t get_num_keys_limit() {
-    return (SIZE - HEADER_SIZE) / ITEM_SIZE;
+  static num_keys_t get_num_keys_limit(extent_len_t node_size) {
+    return (node_size - HEADER_SIZE) / ITEM_SIZE;
   }
 } __attribute__((packed));
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
@@ -859,7 +859,7 @@ struct staged {
    *   size() -> node_offset_t
    *   size_overhead() -> node_offset_t
    *   (IS_BOTTOM) get_p_value() -> const value_t*
-   *   (!IS_BOTTOM) get_nxt_container() -> nxt_stage::container_t
+   *   (!IS_BOTTOM) get_nxt_container() -> container_range_t
    *   (!IS_BOTTOM) size_to_nxt() -> node_offset_t
    * seek:
    *   operator++() -> iterator_t&

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
@@ -208,7 +208,7 @@ struct staged {
     *   CONTAINER_TYPE = ContainerType::INDEXABLE
     *   keys() const -> index_t
     *   operator[](index_t) const -> key_get_type
-    *   size_before(index_t) const -> node_offset_t
+    *   size_before(index_t) const -> extent_len_t
     *   size_overhead_at(index_t) const -> node_offset_t
     *   (IS_BOTTOM) get_p_value(index_t) const -> const value_t*
     *   (!IS_BOTTOM) size_to_nxt_at(index_t) const -> node_offset_t

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
@@ -214,7 +214,7 @@ struct staged {
     *   (!IS_BOTTOM) size_to_nxt_at(index_t) const -> node_offset_t
     *   (!IS_BOTTOM) get_nxt_container(index_t) const
     *   encode(p_node_start, encoded)
-    *   decode(p_node_start, delta) -> container_t
+    *   decode(p_node_start, node_size, delta) -> container_t
     * static:
     *   header_size() -> node_offset_t
     *   estimate_insert(key, value) -> node_offset_t
@@ -480,8 +480,10 @@ struct staged {
     }
 
     static me_t decode(const char* p_node_start,
+                       extent_len_t node_size,
                        ceph::bufferlist::const_iterator& delta) {
-      auto container = container_t::decode(p_node_start, delta);
+      auto container = container_t::decode(
+          p_node_start, node_size, delta);
       auto ret = me_t(container);
       index_t index;
       ceph::decode(index, delta);
@@ -517,7 +519,7 @@ struct staged {
      *   get_nxt_container() const
      *   has_next() const -> bool
      *   encode(p_node_start, encoded)
-     *   decode(p_node_start, delta) -> container_t
+     *   decode(p_node_start, node_length, delta) -> container_t
      *   operator++()
      * static:
      *   header_size() -> node_offset_t
@@ -817,8 +819,10 @@ struct staged {
     }
 
     static me_t decode(const char* p_node_start,
+                       extent_len_t node_size,
                        ceph::bufferlist::const_iterator& delta) {
-      auto container = container_t::decode(p_node_start, delta);
+      auto container = container_t::decode(
+          p_node_start, node_size, delta);
       auto ret = me_t(container);
       uint8_t is_end;
       ceph::decode(is_end, delta);
@@ -886,7 +890,7 @@ struct staged {
    *   (!IS_BOTTOM)get_appender_opened(p_mut) -> Appender
    * denc:
    *   encode(p_node_start, encoded)
-   *   decode(p_node_start, delta) -> iterator_t
+   *   decode(p_node_start, node_size, delta) -> iterator_t
    * static:
    *   header_size() -> node_offset_t
    *   estimate_insert(key, value) -> node_offset_t
@@ -1707,14 +1711,17 @@ struct staged {
       }
     }
     static StagedIterator decode(const char* p_node_start,
+                                 extent_len_t node_size,
                                  ceph::bufferlist::const_iterator& delta) {
       StagedIterator ret;
       uint8_t present;
       ceph::decode(present, delta);
       if (present) {
-        ret.iter = iterator_t::decode(p_node_start, delta);
+        ret.iter = iterator_t::decode(
+            p_node_start, node_size, delta);
         if constexpr (!IS_BOTTOM) {
-          ret._nxt = NXT_STAGE_T::StagedIterator::decode(p_node_start, delta);
+          ret._nxt = NXT_STAGE_T::StagedIterator::decode(
+              p_node_start, node_size, delta);
         }
       }
       return ret;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
@@ -395,6 +395,11 @@ struct memory_range_t {
   const char* p_end;
 };
 
+struct container_range_t {
+  memory_range_t range;
+  extent_len_t node_size;
+};
+
 enum class ContainerType { ITERATIVE, INDEXABLE };
 
 // the input type to construct the value during insert.

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.cc
@@ -34,13 +34,13 @@ IA_TEMPLATE(KeyT::VIEW);
 IA_TEMPLATE(KeyT::HOBJ);
 
 node_offset_t internal_sub_items_t::trim_until(
-    NodeExtentMutable&, internal_sub_items_t& items, index_t index)
+    NodeExtentMutable& mut, internal_sub_items_t& items, index_t index)
 {
   assert(index != 0);
   auto keys = items.keys();
   assert(index <= keys);
   size_t ret = sizeof(internal_sub_item_t) * (keys - index);
-  assert(ret < NODE_BLOCK_SIZE);
+  assert(ret < mut.get_length());
   return ret;
 }
 
@@ -152,7 +152,7 @@ node_offset_t leaf_sub_items_t::trim_until(
                      size_trim_offsets);
   mut.copy_in_absolute((void*)items.p_num_keys, num_keys_t(index));
   size_t ret = size_trim_offsets + (p_shift_start - p_items_start);
-  assert(ret < NODE_BLOCK_SIZE);
+  assert(ret < mut.get_length());
   return ret;
 }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
@@ -63,7 +63,7 @@ class internal_sub_items_t {
   }
   node_offset_t size_before(index_t index) const {
     size_t ret = index * sizeof(internal_sub_item_t);
-    assert(ret < NODE_BLOCK_SIZE);
+    assert(ret < node_size);
     return ret;
   }
   const laddr_packed_t* get_p_value(index_t index) const {
@@ -79,7 +79,7 @@ class internal_sub_items_t {
     int end_offset = p_end - p_node_start;
     assert(start_offset > 0 &&
            start_offset < end_offset &&
-           end_offset < NODE_BLOCK_SIZE);
+           end_offset < (int)node_size);
     ceph::encode(static_cast<node_offset_t>(start_offset), encoded);
     ceph::encode(static_cast<node_offset_t>(end_offset), encoded);
   }
@@ -93,7 +93,7 @@ class internal_sub_items_t {
     node_offset_t end_offset;
     ceph::decode(end_offset, delta);
     assert(start_offset < end_offset);
-    assert(end_offset <= NODE_BLOCK_SIZE);
+    assert(end_offset <= node_size);
     return internal_sub_items_t({{p_node_start + start_offset,
                                   p_node_start + end_offset},
                                  node_size});
@@ -233,7 +233,7 @@ class leaf_sub_items_t {
             (index + 1) * sizeof(node_offset_t) +
             get_offset(index).value;
     }
-    assert(ret < NODE_BLOCK_SIZE);
+    assert(ret < node_size);
     return ret;
   }
   node_offset_t size_overhead_at(index_t index) const { return sizeof(node_offset_t); }
@@ -252,7 +252,7 @@ class leaf_sub_items_t {
     int end_offset = p_end - p_node_start;
     assert(start_offset > 0 &&
            start_offset < end_offset &&
-           end_offset < NODE_BLOCK_SIZE);
+           end_offset < (int)node_size);
     ceph::encode(static_cast<node_offset_t>(start_offset), encoded);
     ceph::encode(static_cast<node_offset_t>(end_offset), encoded);
   }
@@ -266,7 +266,7 @@ class leaf_sub_items_t {
     node_offset_t end_offset;
     ceph::decode(end_offset, delta);
     assert(start_offset < end_offset);
-    assert(end_offset <= NODE_BLOCK_SIZE);
+    assert(end_offset < node_size);
     return leaf_sub_items_t({{p_node_start + start_offset,
                               p_node_start + end_offset},
                              node_size});

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
@@ -83,7 +83,9 @@ class internal_sub_items_t {
   }
 
   static internal_sub_items_t decode(
-      const char* p_node_start, ceph::bufferlist::const_iterator& delta) {
+      const char* p_node_start,
+      extent_len_t node_size,
+      ceph::bufferlist::const_iterator& delta) {
     node_offset_t start_offset;
     ceph::decode(start_offset, delta);
     node_offset_t end_offset;
@@ -250,7 +252,9 @@ class leaf_sub_items_t {
   }
 
   static leaf_sub_items_t decode(
-      const char* p_node_start, ceph::bufferlist::const_iterator& delta) {
+      const char* p_node_start,
+      extent_len_t node_size,
+      ceph::bufferlist::const_iterator& delta) {
     node_offset_t start_offset;
     ceph::decode(start_offset, delta);
     node_offset_t end_offset;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
@@ -77,12 +77,12 @@ class internal_sub_items_t {
                  sizeof(internal_sub_item_t);
     auto p_start = p_end - num_items * sizeof(internal_sub_item_t);
     int start_offset = p_start - p_node_start;
-    int end_offset = p_end - p_node_start;
-    assert(start_offset > 0 &&
-           start_offset < end_offset &&
-           end_offset < (int)node_size);
+    int stage_size = p_end - p_start;
+    assert(start_offset > 0);
+    assert(stage_size > 0);
+    assert(start_offset + stage_size < (int)node_size);
     ceph::encode(static_cast<node_offset_t>(start_offset), encoded);
-    ceph::encode(static_cast<node_offset_t>(end_offset), encoded);
+    ceph::encode(static_cast<node_offset_t>(stage_size), encoded);
   }
 
   static internal_sub_items_t decode(
@@ -91,12 +91,13 @@ class internal_sub_items_t {
       ceph::bufferlist::const_iterator& delta) {
     node_offset_t start_offset;
     ceph::decode(start_offset, delta);
-    node_offset_t end_offset;
-    ceph::decode(end_offset, delta);
-    assert(start_offset < end_offset);
-    assert(end_offset <= node_size);
+    node_offset_t stage_size;
+    ceph::decode(stage_size, delta);
+    assert(start_offset > 0);
+    assert(stage_size > 0);
+    assert((unsigned)start_offset + stage_size < node_size);
     return internal_sub_items_t({{p_node_start + start_offset,
-                                  p_node_start + end_offset},
+                                  p_node_start + start_offset + stage_size},
                                  node_size});
   }
 
@@ -251,12 +252,12 @@ class leaf_sub_items_t {
     auto p_end = reinterpret_cast<const char*>(p_num_keys) +
                   sizeof(num_keys_t);
     int start_offset = p_start() - p_node_start;
-    int end_offset = p_end - p_node_start;
-    assert(start_offset > 0 &&
-           start_offset < end_offset &&
-           end_offset < (int)node_size);
+    int stage_size = p_end - p_start();
+    assert(start_offset > 0);
+    assert(stage_size > 0);
+    assert(start_offset + stage_size < (int)node_size);
     ceph::encode(static_cast<node_offset_t>(start_offset), encoded);
-    ceph::encode(static_cast<node_offset_t>(end_offset), encoded);
+    ceph::encode(static_cast<node_offset_t>(stage_size), encoded);
   }
 
   static leaf_sub_items_t decode(
@@ -265,12 +266,13 @@ class leaf_sub_items_t {
       ceph::bufferlist::const_iterator& delta) {
     node_offset_t start_offset;
     ceph::decode(start_offset, delta);
-    node_offset_t end_offset;
-    ceph::decode(end_offset, delta);
-    assert(start_offset < end_offset);
-    assert(end_offset < node_size);
+    node_offset_t stage_size;
+    ceph::decode(stage_size, delta);
+    assert(start_offset > 0);
+    assert(stage_size > 0);
+    assert((unsigned)start_offset + stage_size < node_size);
     return leaf_sub_items_t({{p_node_start + start_offset,
-                              p_node_start + end_offset},
+                              p_node_start + start_offset + stage_size},
                              node_size});
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
@@ -159,9 +159,8 @@ class internal_sub_items_t::Appender {
  */
 class leaf_sub_items_t {
  public:
-  // TODO: decide by NODE_BLOCK_SIZE, sizeof(snap_gen_t),
-  //       and the minimal size of value
-  using num_keys_t = uint8_t;
+  // should be enough to index all keys under 64 KiB node
+  using num_keys_t = uint16_t;
 
   leaf_sub_items_t(const memory_range_t& range) {
     assert(range.p_start < range.p_end);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
@@ -44,6 +44,7 @@ class internal_sub_items_t {
 
   internal_sub_items_t(const container_range_t& _range)
       : node_size{_range.node_size} {
+    assert(is_valid_node_size(node_size));
     auto& range = _range.range;
     assert(range.p_start < range.p_end);
     assert((range.p_end - range.p_start) % sizeof(internal_sub_item_t) == 0);
@@ -170,6 +171,7 @@ class leaf_sub_items_t {
 
   leaf_sub_items_t(const container_range_t& _range)
       : node_size{_range.node_size} {
+    assert(is_valid_node_size(node_size));
     auto& range = _range.range;
     assert(range.p_start < range.p_end);
     auto _p_num_keys = range.p_end - sizeof(num_keys_t);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
@@ -7,6 +7,7 @@
 
 #include "common/hobject.h"
 #include "crimson/common/type_helpers.h"
+#include "crimson/os/seastore/logging.h"
 
 #include "fwd.h"
 #include "node.h"
@@ -79,8 +80,13 @@ class Btree {
     // XXX: return key_view_t to avoid unecessary ghobject_t constructions
     ghobject_t get_ghobj() const {
       assert(!is_end());
-      return p_cursor->get_key_view(
-          p_tree->value_builder.get_header_magic()).to_ghobj();
+      auto view = p_cursor->get_key_view(
+          p_tree->value_builder.get_header_magic());
+      assert(view.nspace().size() <=
+             p_tree->value_builder.get_max_ns_size());
+      assert(view.oid().size() <=
+             p_tree->value_builder.get_max_oid_size());
+      return view.to_ghobj();
     }
 
     ValueImpl value() {
@@ -236,8 +242,20 @@ class Btree {
   struct tree_value_config_t {
     value_size_t payload_size = 256;
   };
-  eagain_future<std::pair<Cursor, bool>>
+  using insert_ertr = eagain_ertr::extend<
+    crimson::ct_error::value_too_large>;
+  insert_ertr::future<std::pair<Cursor, bool>>
   insert(Transaction& t, const ghobject_t& obj, tree_value_config_t _vconf) {
+    if (obj.hobj.nspace.size() > value_builder.get_max_ns_size()) {
+      ERRORT("namespace size {} too large to insert {}",
+             t, obj.hobj.nspace.size(), key_hobj_t{obj});
+      return crimson::ct_error::value_too_large::make();
+    }
+    if (obj.hobj.oid.name.size() > value_builder.get_max_oid_size()) {
+      ERRORT("oid size {} too large to insert {}",
+             t, obj.hobj.oid.name.size(), key_hobj_t{obj});
+      return crimson::ct_error::value_too_large::make();
+    }
     value_config_t vconf{value_builder.get_header_magic(), _vconf.payload_size};
     return seastar::do_with(
       full_key_t<KeyT::HOBJ>(obj),

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
@@ -246,6 +246,12 @@ class Btree {
     crimson::ct_error::value_too_large>;
   insert_ertr::future<std::pair<Cursor, bool>>
   insert(Transaction& t, const ghobject_t& obj, tree_value_config_t _vconf) {
+    LOG_PREFIX(OTree::insert);
+    if (_vconf.payload_size > value_builder.get_max_value_payload_size()) {
+      ERRORT("value payload size {} too large to insert {}",
+             t, _vconf.payload_size, key_hobj_t{obj});
+      return crimson::ct_error::value_too_large::make();
+    }
     if (obj.hobj.nspace.size() > value_builder.get_max_ns_size()) {
       ERRORT("namespace size {} too large to insert {}",
              t, obj.hobj.nspace.size(), key_hobj_t{obj});

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -323,7 +323,12 @@ class TreeBuilder {
 #else
       return eagain_ertr::make_ready_future<BtreeCursor>(cursor);
 #endif
-    });
+    }).handle_error(
+      [] (const crimson::ct_error::value_too_large& e) {
+        ceph_abort("impossible path");
+      },
+      crimson::ct_error::pass_further_all{}
+    );
   }
 
   eagain_future<> insert(Transaction& t) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -155,7 +155,8 @@ class KVPool {
   }
 
   static KVPool create_raw_range(
-      const std::vector<size_t>& str_sizes,
+      const std::vector<size_t>& ns_sizes,
+      const std::vector<size_t>& oid_sizes,
       const std::vector<size_t>& value_sizes,
       const std::pair<index_t, index_t>& range2,
       const std::pair<index_t, index_t>& range1,
@@ -179,8 +180,8 @@ class KVPool {
           ns_size = 0;
           oid_size = 0;
         } else {
-          ns_size = str_sizes[rd() % str_sizes.size()];
-          oid_size = str_sizes[rd() % str_sizes.size()];
+          ns_size = ns_sizes[rd() % ns_sizes.size()];
+          oid_size = oid_sizes[rd() % oid_sizes.size()];
           assert(ns_size && oid_size);
         }
         for (index_t k = range0.first; k < range0.second; ++k) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -85,11 +85,11 @@ build_value_recorder_by_type(ceph::bufferlist& encoded,
 {
   std::unique_ptr<ValueDeltaRecorder> ret;
   switch (magic) {
-  case value_magic_t::TEST:
-    ret = std::make_unique<TestValue::Recorder>(encoded);
-    break;
   case value_magic_t::ONODE:
     ret = std::make_unique<FLTreeOnode::Recorder>(encoded);
+    break;
+  case value_magic_t::TEST:
+    ret = std::make_unique<TestValue::Recorder>(encoded);
     break;
   default:
     ret = nullptr;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -111,6 +111,10 @@ void validate_tree_config(const tree_conf_t& conf)
               string_key_view_t::VALID_UPPER_BOUND);
   ceph_assert(conf.max_oid_size <
               string_key_view_t::VALID_UPPER_BOUND);
+  ceph_assert(conf.internal_node_size <= MAX_NODE_SIZE);
+  ceph_assert(conf.internal_node_size % DISK_BLOCK_SIZE == 0);
+  ceph_assert(conf.leaf_node_size <= MAX_NODE_SIZE);
+  ceph_assert(conf.leaf_node_size % DISK_BLOCK_SIZE == 0);
 }
 
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -5,6 +5,7 @@
 
 #include "node.h"
 #include "node_delta_recorder.h"
+#include "node_layout.h"
 
 // value implementations
 #include "test/crimson/seastore/onode_tree/test_value.h"
@@ -88,8 +89,11 @@ build_value_recorder_by_type(ceph::bufferlist& encoded,
   case value_magic_t::ONODE:
     ret = std::make_unique<FLTreeOnode::Recorder>(encoded);
     break;
-  case value_magic_t::TEST:
-    ret = std::make_unique<TestValue::Recorder>(encoded);
+  case value_magic_t::TEST_UNBOUND:
+    ret = std::make_unique<UnboundedValue::Recorder>(encoded);
+    break;
+  case value_magic_t::TEST_BOUNDED:
+    ret = std::make_unique<BoundedValue::Recorder>(encoded);
     break;
   default:
     ret = nullptr;
@@ -97,6 +101,14 @@ build_value_recorder_by_type(ceph::bufferlist& encoded,
   }
   assert(!ret || ret->get_header_magic() == magic);
   return ret;
+}
+
+void validate_tree_config(const tree_conf_t& conf)
+{
+  ceph_assert(conf.max_ns_size <
+              string_key_view_t::VALID_UPPER_BOUND);
+  ceph_assert(conf.max_oid_size <
+              string_key_view_t::VALID_UPPER_BOUND);
 }
 
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -97,6 +97,9 @@ build_value_recorder_by_type(ceph::bufferlist& encoded,
   case value_magic_t::TEST_BOUNDED:
     ret = std::make_unique<BoundedValue::Recorder>(encoded);
     break;
+  case value_magic_t::TEST_EXTENDED:
+    ret = std::make_unique<ExtendedValue::Recorder>(encoded);
+    break;
   default:
     ret = nullptr;
     break;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -111,10 +111,8 @@ void validate_tree_config(const tree_conf_t& conf)
               string_key_view_t::VALID_UPPER_BOUND);
   ceph_assert(conf.max_oid_size <
               string_key_view_t::VALID_UPPER_BOUND);
-  ceph_assert(conf.internal_node_size <= MAX_NODE_SIZE);
-  ceph_assert(conf.internal_node_size % DISK_BLOCK_SIZE == 0);
-  ceph_assert(conf.leaf_node_size <= MAX_NODE_SIZE);
-  ceph_assert(conf.leaf_node_size % DISK_BLOCK_SIZE == 0);
+  ceph_assert(is_valid_node_size(conf.internal_node_size));
+  ceph_assert(is_valid_node_size(conf.leaf_node_size));
 
   if (conf.do_split_check) {
     // In hope to comply with 3 * (oid + ns) + 2 * value < node

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -71,7 +71,9 @@ eagain_future<> Value::trim(Transaction& t, value_size_t trim_size)
 
 const value_header_t* Value::read_value_header() const
 {
-  return p_cursor->read_value_header(vb.get_header_magic());
+  auto ret = p_cursor->read_value_header(vb.get_header_magic());
+  assert(ret->payload_size <= vb.get_max_value_payload_size());
+  return ret;
 }
 
 std::pair<NodeExtentMutable&, ValueDeltaRecorder*>

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -162,6 +162,7 @@ struct tree_conf_t {
   value_size_t max_value_payload_size;
   extent_len_t internal_node_size;
   extent_len_t leaf_node_size;
+  bool do_split_check = true;
 };
 
 class tree_cursor_t;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -160,6 +160,8 @@ struct tree_conf_t {
   string_size_t max_ns_size;
   string_size_t max_oid_size;
   value_size_t max_value_payload_size;
+  extent_len_t internal_node_size;
+  extent_len_t leaf_node_size;
 };
 
 class tree_cursor_t;
@@ -258,6 +260,8 @@ struct ValueBuilder {
   virtual string_size_t get_max_ns_size() const = 0;
   virtual string_size_t get_max_oid_size() const = 0;
   virtual value_size_t get_max_value_payload_size() const = 0;
+  virtual extent_len_t get_internal_node_size() const = 0;
+  virtual extent_len_t get_leaf_node_size() const = 0;
   virtual std::unique_ptr<ValueDeltaRecorder>
   build_value_recorder(ceph::bufferlist&) const = 0;
 };
@@ -284,6 +288,12 @@ struct ValueBuilderImpl final : public ValueBuilder {
   }
   value_size_t get_max_value_payload_size() const override {
     return ValueImpl::TREE_CONF.max_value_payload_size;
+  }
+  extent_len_t get_internal_node_size() const override {
+    return ValueImpl::TREE_CONF.internal_node_size;
+  }
+  extent_len_t get_leaf_node_size() const override {
+    return ValueImpl::TREE_CONF.leaf_node_size;
   }
 
   std::unique_ptr<ValueDeltaRecorder>

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -16,15 +16,15 @@ namespace crimson::os::seastore::onode {
 // value size up to 64 KiB
 using value_size_t = uint16_t;
 enum class value_magic_t : uint8_t {
-  TEST = 0x52,
-  ONODE,
+  ONODE = 0x52,
+  TEST,
 };
 inline std::ostream& operator<<(std::ostream& os, const value_magic_t& magic) {
   switch (magic) {
-  case value_magic_t::TEST:
-    return os << "TEST";
   case value_magic_t::ONODE:
     return os << "ONODE";
+  case value_magic_t::TEST:
+    return os << "TEST";
   default:
     return os << "UNKNOWN(" << magic << ")";
   }
@@ -147,6 +147,15 @@ class ValueDeltaRecorder {
   ceph::bufferlist& encoded;
 };
 
+/**
+ * tree_conf_t
+ *
+ * Hard limits and compile-time configurations.
+ */
+struct tree_conf_t {
+  value_magic_t value_magic;
+};
+
 class tree_cursor_t;
 /**
  * Value
@@ -252,7 +261,7 @@ struct ValueBuilder {
 template <typename ValueImpl>
 struct ValueBuilderImpl final : public ValueBuilder {
   value_magic_t get_header_magic() const {
-    return ValueImpl::HEADER_MAGIC;
+    return ValueImpl::TREE_CONF.value_magic;
   }
 
   std::unique_ptr<ValueDeltaRecorder>

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -159,6 +159,7 @@ struct tree_conf_t {
   value_magic_t value_magic;
   string_size_t max_ns_size;
   string_size_t max_oid_size;
+  value_size_t max_value_payload_size;
 };
 
 class tree_cursor_t;
@@ -256,6 +257,7 @@ struct ValueBuilder {
   virtual value_magic_t get_header_magic() const = 0;
   virtual string_size_t get_max_ns_size() const = 0;
   virtual string_size_t get_max_oid_size() const = 0;
+  virtual value_size_t get_max_value_payload_size() const = 0;
   virtual std::unique_ptr<ValueDeltaRecorder>
   build_value_recorder(ceph::bufferlist&) const = 0;
 };
@@ -279,6 +281,9 @@ struct ValueBuilderImpl final : public ValueBuilder {
   }
   string_size_t get_max_oid_size() const override {
     return ValueImpl::TREE_CONF.max_oid_size;
+  }
+  value_size_t get_max_value_payload_size() const override {
+    return ValueImpl::TREE_CONF.max_value_payload_size;
   }
 
   std::unique_ptr<ValueDeltaRecorder>

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -19,6 +19,7 @@ enum class value_magic_t : uint8_t {
   ONODE = 0x52,
   TEST_UNBOUND,
   TEST_BOUNDED,
+  TEST_EXTENDED,
 };
 inline std::ostream& operator<<(std::ostream& os, const value_magic_t& magic) {
   switch (magic) {
@@ -28,6 +29,8 @@ inline std::ostream& operator<<(std::ostream& os, const value_magic_t& magic) {
     return os << "TEST_UNBOUND";
   case value_magic_t::TEST_BOUNDED:
     return os << "TEST_BOUNDED";
+  case value_magic_t::TEST_EXTENDED:
+    return os << "TEST_EXTENDED";
   default:
     return os << "UNKNOWN(" << magic << ")";
   }

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -214,6 +214,28 @@ public:
     });
   }
 
+  /**
+   * read_extent
+   *
+   * Read extent of type T at offset
+   */
+  template <typename T>
+  read_extent_ret<T> read_extent(
+    Transaction &t,
+    laddr_t offset) {
+    LOG_PREFIX(TransactionManager::read_extent);
+    return get_pin(
+      t, offset
+    ).safe_then([this, FNAME, &t, offset] (auto pin) {
+      if (!pin->get_paddr().is_real()) {
+        ERRORT("offset {} got wrong pin {}",
+               t, offset, *pin);
+        ceph_assert(0 == "Should be impossible");
+      }
+      return this->pin_to_extent<T>(t, std::move(pin));
+    });
+  }
+
   /// Obtain mutable copy of extent
   LogicalCachedExtentRef get_mutable_extent(Transaction &t, LogicalCachedExtentRef ref) {
     LOG_PREFIX(TransactionManager::get_mutable_extent);

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1271,7 +1271,7 @@ TEST_F(c_dummy_test_t, 5_split_merge_internal_node)
       keys.insert(make_ghobj(2, 2, 2, "ns2", "oid2" + padding_s, 2, 2));
       keys.insert(make_ghobj(2, 2, 2, "ns2", "oid2" + padding_s, 3, 3));
       keys.insert(make_ghobj(2, 2, 2, "ns2", "oid2" + padding_s, 4, 4));
-      auto padding_e = std::string(248, '_');
+      auto padding_e = std::string(247, '_');
       keys.insert(make_ghobj(5, 5, 5, "ns4", "oid4" + padding_e, 2, 2));
       keys.insert(make_ghobj(5, 5, 5, "ns4", "oid4" + padding_e, 3, 3));
       keys.insert(make_ghobj(5, 5, 5, "ns4", "oid4" + padding_e, 4, 4));
@@ -1386,7 +1386,7 @@ TEST_F(c_dummy_test_t, 5_split_merge_internal_node)
     {
       logger().info("\n---------------------------------------------"
                     "\nbefore internal node insert (3):\n");
-      auto padding = std::string(420, '_');
+      auto padding = std::string(419, '_');
       auto keys = build_key_set({2, 5}, {2, 5}, {2, 5}, padding, true);
       keys.erase(make_ghobj(4, 4, 4, "ns4", "oid4" + padding, 2, 2));
       keys.erase(make_ghobj(4, 4, 4, "ns4", "oid4" + padding, 3, 3));
@@ -1411,7 +1411,7 @@ TEST_F(c_dummy_test_t, 5_split_merge_internal_node)
       keys.erase(make_ghobj(2, 2, 2, "ns2", "oid2" + padding, 2, 2));
       keys.erase(make_ghobj(2, 2, 2, "ns2", "oid2" + padding, 3, 3));
       keys.erase(make_ghobj(2, 2, 2, "ns2", "oid2" + padding, 4, 4));
-      auto padding_s = std::string(387, '_');
+      auto padding_s = std::string(386, '_');
       keys.insert(make_ghobj(2, 2, 2, "ns2", "oid2" + padding_s, 2, 2));
       keys.insert(make_ghobj(2, 2, 2, "ns2", "oid2" + padding_s, 3, 3));
       keys.insert(make_ghobj(2, 2, 2, "ns2", "oid2" + padding_s, 4, 4));
@@ -1459,7 +1459,7 @@ TEST_F(c_dummy_test_t, 5_split_merge_internal_node)
                     "\nbefore internal node insert (6):\n");
       auto padding = std::string(328, '_');
       auto keys = build_key_set({2, 5}, {2, 5}, {2, 5}, padding);
-      keys.insert(make_ghobj(5, 5, 5, "ns3", "oid3" + std::string(271, '_'), 3, 3));
+      keys.insert(make_ghobj(5, 5, 5, "ns3", "oid3" + std::string(270, '_'), 3, 3));
       keys.insert(make_ghobj(9, 9, 9, "ns~last", "oid~last", 9, 9));
       pool.build_tree(keys).unsafe_get0();
 

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1526,7 +1526,7 @@ TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
     auto moved_nm = (TEST_SEASTORE ? NodeExtentManager::create_seastore(*tm)
                                    : NodeExtentManager::create_dummy(IS_DUMMY_SYNC));
     auto p_nm = moved_nm.get();
-    auto tree = std::make_unique<TreeBuilder<TRACK_CURSORS, test_item_t>>(
+    auto tree = std::make_unique<TreeBuilder<TRACK_CURSORS, TestValue>>(
         kvs, std::move(moved_nm));
     {
       auto t = tm->create_transaction();
@@ -1623,7 +1623,7 @@ TEST_F(d_seastore_tm_test_t, 7_tree_insert_erase_eagain)
     auto moved_nm = NodeExtentManager::create_seastore(
         *tm, L_ADDR_MIN, EAGAIN_PROBABILITY);
     auto p_nm = static_cast<SeastoreNodeExtentManager<true>*>(moved_nm.get());
-    auto tree = std::make_unique<TreeBuilder<TRACK_CURSORS, test_item_t>>(
+    auto tree = std::make_unique<TreeBuilder<TRACK_CURSORS, TestValue>>(
         kvs, std::move(moved_nm));
     unsigned num_ops = 0;
     unsigned num_ops_eagain = 0;

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -861,7 +861,7 @@ class DummyChildPool {
       ceph_abort("impossible path"); }
     node_offset_t free_size() const override {
       ceph_abort("impossible path"); }
-    node_offset_t total_size() const override {
+    extent_len_t total_size() const override {
       ceph_abort("impossible path"); }
     bool is_size_underflow() const override {
       ceph_abort("impossible path"); }
@@ -869,7 +869,7 @@ class DummyChildPool {
       ceph_abort("impossible path"); }
     std::tuple<match_stage_t, std::size_t> evaluate_merge(NodeImpl&) override {
       ceph_abort("impossible path"); }
-    search_position_t merge(NodeExtentMutable&, NodeImpl&, match_stage_t, node_offset_t) override {
+    search_position_t merge(NodeExtentMutable&, NodeImpl&, match_stage_t, extent_len_t) override {
       ceph_abort("impossible path"); }
     eagain_future<NodeExtentMutable> rebuild_extent(context_t) override {
       ceph_abort("impossible path"); }

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -855,7 +855,7 @@ class DummyChildPool {
       ceph_abort("impossible path"); }
     bool is_keys_empty() const override {
       ceph_abort("impossible path"); }
-    bool is_keys_one() const override {
+    bool has_single_value() const override {
       ceph_abort("impossible path"); }
     node_offset_t free_size() const override {
       ceph_abort("impossible path"); }

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -846,6 +846,8 @@ class DummyChildPool {
     field_type_t field_type() const override { return field_type_t::N0; }
     const char* read() const override {
       ceph_abort("impossible path"); }
+    extent_len_t get_node_size() const override {
+      ceph_abort("impossible path"); }
     nextent_state_t get_extent_state() const override {
       ceph_abort("impossible path"); }
     level_t level() const override { return 0u; }

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1182,7 +1182,7 @@ class DummyChildPool {
 
       // fix back
       logger().info("\n\nFIX pos({}) from {} back to {}:",
-                    pos, node_to_fix->get_name(), old_key);
+                    pos, node_to_fix->get_name(), key_hobj_t(old_key));
       node_to_fix->fix_key(pool_clone.get_context(), old_key).unsafe_get0();
       EXPECT_EQ(pool_clone.p_btree->height(pool_clone.t()).unsafe_get0(), 2);
       EXPECT_EQ(pool_clone.p_dummy->size(), 1);

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1522,7 +1522,8 @@ TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
     constexpr bool TEST_SEASTORE = true;
     constexpr bool TRACK_CURSORS = true;
     auto kvs = KVPool<test_item_t>::create_raw_range(
-        {8, 11, 64, 256, 301, 320},
+        {8, 11,  64, 256, 301, 320},
+        {8, 11,  64, 256, 301, 320},
         {8, 16, 128, 512, 576, 640},
         {0, 16}, {0, 10}, {0, 4});
     auto moved_nm = (TEST_SEASTORE ? NodeExtentManager::create_seastore(*tm)
@@ -1619,13 +1620,14 @@ TEST_F(d_seastore_tm_test_t, 7_tree_insert_erase_eagain)
     constexpr double EAGAIN_PROBABILITY = 0.1;
     constexpr bool TRACK_CURSORS = false;
     auto kvs = KVPool<test_item_t>::create_raw_range(
-        {8, 11, 64, 256, 301, 320},
-        {8, 16, 128, 512, 576, 640},
+        {8, 11,  64, 128,  255,  256},
+        {8, 13,  64, 512, 2035, 2048},
+        {8, 16, 128, 576,  992, 1200},
         {0, 8}, {0, 10}, {0, 4});
     auto moved_nm = NodeExtentManager::create_seastore(
         *tm, L_ADDR_MIN, EAGAIN_PROBABILITY);
     auto p_nm = static_cast<SeastoreNodeExtentManager<true>*>(moved_nm.get());
-    auto tree = std::make_unique<TreeBuilder<TRACK_CURSORS, BoundedValue>>(
+    auto tree = std::make_unique<TreeBuilder<TRACK_CURSORS, ExtendedValue>>(
         kvs, std::move(moved_nm));
     unsigned num_ops = 0;
     unsigned num_ops_eagain = 0;

--- a/src/test/crimson/seastore/onode_tree/test_value.h
+++ b/src/test/crimson/seastore/onode_tree/test_value.h
@@ -38,7 +38,10 @@ inline std::ostream& operator<<(std::ostream& os, const test_item_t& item) {
 
 class TestValue final : public Value {
  public:
-  static constexpr auto HEADER_MAGIC = value_magic_t::TEST;
+  static constexpr tree_conf_t TREE_CONF = {
+    value_magic_t::TEST
+  };
+
   using id_t = test_item_t::id_t;
   using magic_t = test_item_t::magic_t;
   struct magic_packed_t {
@@ -94,7 +97,7 @@ class TestValue final : public Value {
 
    protected:
     value_magic_t get_header_magic() const override {
-      return HEADER_MAGIC;
+      return TREE_CONF.value_magic;
     }
 
     void apply_value_delta(ceph::bufferlist::const_iterator& delta,

--- a/src/test/crimson/seastore/onode_tree/test_value.h
+++ b/src/test/crimson/seastore/onode_tree/test_value.h
@@ -203,8 +203,11 @@ class TestValue final : public Value {
 };
 
 using UnboundedValue = TestValue<
-  value_magic_t::TEST_UNBOUND, 4096, 4096, 4096, 4096, 4096, false>;
+  value_magic_t::TEST_UNBOUND, 4096, 4096, 4096, 4096,  4096, false>;
 using BoundedValue   = TestValue<
-  value_magic_t::TEST_BOUNDED,  320,  320,  640, 4096, 4096, true>;
+  value_magic_t::TEST_BOUNDED,  320,  320,  640, 4096,  4096, true>;
+// should be the same configuration with FLTreeOnode
+using ExtendedValue  = TestValue<
+  value_magic_t::TEST_EXTENDED, 256, 2048, 1200, 8192, 16384, true>;
 
 }

--- a/src/test/crimson/seastore/onode_tree/test_value.h
+++ b/src/test/crimson/seastore/onode_tree/test_value.h
@@ -39,14 +39,18 @@ inline std::ostream& operator<<(std::ostream& os, const test_item_t& item) {
 template <value_magic_t MAGIC,
           string_size_t MAX_NS_SIZE,
           string_size_t MAX_OID_SIZE,
-          value_size_t  MAX_VALUE_PAYLOAD_SIZE>
+          value_size_t  MAX_VALUE_PAYLOAD_SIZE,
+          extent_len_t  INTERNAL_NODE_SIZE,
+          extent_len_t  LEAF_NODE_SIZE>
 class TestValue final : public Value {
  public:
   static constexpr tree_conf_t TREE_CONF = {
     MAGIC,
     MAX_NS_SIZE,
     MAX_OID_SIZE,
-    MAX_VALUE_PAYLOAD_SIZE
+    MAX_VALUE_PAYLOAD_SIZE,
+    INTERNAL_NODE_SIZE,
+    LEAF_NODE_SIZE
   };
 
   using id_t = test_item_t::id_t;
@@ -197,8 +201,8 @@ class TestValue final : public Value {
 };
 
 using UnboundedValue = TestValue<
-  value_magic_t::TEST_UNBOUND, 4096, 4096, 4096>;
+  value_magic_t::TEST_UNBOUND, 4096, 4096, 4096, 4096, 4096>;
 using BoundedValue   = TestValue<
-  value_magic_t::TEST_BOUNDED,  320,  320,  640>;
+  value_magic_t::TEST_BOUNDED,  320,  320,  640, 4096, 4096>;
 
 }

--- a/src/test/crimson/seastore/onode_tree/test_value.h
+++ b/src/test/crimson/seastore/onode_tree/test_value.h
@@ -36,10 +36,15 @@ inline std::ostream& operator<<(std::ostream& os, const test_item_t& item) {
   return os << "TestItem(#" << item.id << ", " << item.size << "B)";
 }
 
+template <value_magic_t MAGIC,
+          string_size_t MAX_NS_SIZE,
+          string_size_t MAX_OID_SIZE>
 class TestValue final : public Value {
  public:
   static constexpr tree_conf_t TREE_CONF = {
-    value_magic_t::TEST
+    MAGIC,
+    MAX_NS_SIZE,
+    MAX_OID_SIZE
   };
 
   using id_t = test_item_t::id_t;
@@ -188,5 +193,10 @@ class TestValue final : public Value {
     ceph_assert(get_tail_magic() == item.magic);
   }
 };
+
+using UnboundedValue = TestValue<
+  value_magic_t::TEST_UNBOUND, 4096, 4096>;
+using BoundedValue   = TestValue<
+  value_magic_t::TEST_BOUNDED,  320,  320>;
 
 }

--- a/src/test/crimson/seastore/onode_tree/test_value.h
+++ b/src/test/crimson/seastore/onode_tree/test_value.h
@@ -38,13 +38,15 @@ inline std::ostream& operator<<(std::ostream& os, const test_item_t& item) {
 
 template <value_magic_t MAGIC,
           string_size_t MAX_NS_SIZE,
-          string_size_t MAX_OID_SIZE>
+          string_size_t MAX_OID_SIZE,
+          value_size_t  MAX_VALUE_PAYLOAD_SIZE>
 class TestValue final : public Value {
  public:
   static constexpr tree_conf_t TREE_CONF = {
     MAGIC,
     MAX_NS_SIZE,
-    MAX_OID_SIZE
+    MAX_OID_SIZE,
+    MAX_VALUE_PAYLOAD_SIZE
   };
 
   using id_t = test_item_t::id_t;
@@ -195,8 +197,8 @@ class TestValue final : public Value {
 };
 
 using UnboundedValue = TestValue<
-  value_magic_t::TEST_UNBOUND, 4096, 4096>;
+  value_magic_t::TEST_UNBOUND, 4096, 4096, 4096>;
 using BoundedValue   = TestValue<
-  value_magic_t::TEST_BOUNDED,  320,  320>;
+  value_magic_t::TEST_BOUNDED,  320,  320,  640>;
 
 }

--- a/src/test/crimson/seastore/onode_tree/test_value.h
+++ b/src/test/crimson/seastore/onode_tree/test_value.h
@@ -41,7 +41,8 @@ template <value_magic_t MAGIC,
           string_size_t MAX_OID_SIZE,
           value_size_t  MAX_VALUE_PAYLOAD_SIZE,
           extent_len_t  INTERNAL_NODE_SIZE,
-          extent_len_t  LEAF_NODE_SIZE>
+          extent_len_t  LEAF_NODE_SIZE,
+          bool          DO_SPLIT_CHECK>
 class TestValue final : public Value {
  public:
   static constexpr tree_conf_t TREE_CONF = {
@@ -50,7 +51,8 @@ class TestValue final : public Value {
     MAX_OID_SIZE,
     MAX_VALUE_PAYLOAD_SIZE,
     INTERNAL_NODE_SIZE,
-    LEAF_NODE_SIZE
+    LEAF_NODE_SIZE,
+    DO_SPLIT_CHECK
   };
 
   using id_t = test_item_t::id_t;
@@ -201,8 +203,8 @@ class TestValue final : public Value {
 };
 
 using UnboundedValue = TestValue<
-  value_magic_t::TEST_UNBOUND, 4096, 4096, 4096, 4096, 4096>;
+  value_magic_t::TEST_UNBOUND, 4096, 4096, 4096, 4096, 4096, false>;
 using BoundedValue   = TestValue<
-  value_magic_t::TEST_BOUNDED,  320,  320,  640, 4096, 4096>;
+  value_magic_t::TEST_BOUNDED,  320,  320,  640, 4096, 4096, true>;
 
 }

--- a/src/tools/crimson/perf_staged_fltree.cc
+++ b/src/tools/crimson/perf_staged_fltree.cc
@@ -30,7 +30,7 @@ class PerfTree : public TMTestState {
   seastar::future<> run(KVPool<test_item_t>& kvs, double erase_ratio) {
     return tm_setup().then([this, &kvs, erase_ratio] {
       return seastar::async([this, &kvs, erase_ratio] {
-        auto tree = std::make_unique<TreeBuilder<TRACK, TestValue>>(kvs,
+        auto tree = std::make_unique<TreeBuilder<TRACK, BoundedValue>>(kvs,
             (is_dummy ? NodeExtentManager::create_dummy(true)
                       : NodeExtentManager::create_seastore(*tm)));
         {

--- a/src/tools/crimson/perf_staged_fltree.cc
+++ b/src/tools/crimson/perf_staged_fltree.cc
@@ -30,7 +30,7 @@ class PerfTree : public TMTestState {
   seastar::future<> run(KVPool<test_item_t>& kvs, double erase_ratio) {
     return tm_setup().then([this, &kvs, erase_ratio] {
       return seastar::async([this, &kvs, erase_ratio] {
-        auto tree = std::make_unique<TreeBuilder<TRACK, test_item_t>>(kvs,
+        auto tree = std::make_unique<TreeBuilder<TRACK, TestValue>>(kvs,
             (is_dummy ? NodeExtentManager::create_dummy(true)
                       : NodeExtentManager::create_seastore(*tm)));
         {

--- a/src/tools/crimson/perf_staged_fltree.cc
+++ b/src/tools/crimson/perf_staged_fltree.cc
@@ -30,7 +30,7 @@ class PerfTree : public TMTestState {
   seastar::future<> run(KVPool<test_item_t>& kvs, double erase_ratio) {
     return tm_setup().then([this, &kvs, erase_ratio] {
       return seastar::async([this, &kvs, erase_ratio] {
-        auto tree = std::make_unique<TreeBuilder<TRACK, BoundedValue>>(kvs,
+        auto tree = std::make_unique<TreeBuilder<TRACK, ExtendedValue>>(kvs,
             (is_dummy ? NodeExtentManager::create_dummy(true)
                       : NodeExtentManager::create_seastore(*tm)));
         {
@@ -88,7 +88,8 @@ seastar::future<> run(const bpo::variables_map& config) {
     } else {
       ceph_abort(false && "invalid backend");
     }
-    auto str_sizes = config["str-sizes"].as<std::vector<size_t>>();
+    auto ns_sizes = config["ns-sizes"].as<std::vector<size_t>>();
+    auto oid_sizes = config["oid-sizes"].as<std::vector<size_t>>();
     auto onode_sizes = config["onode-sizes"].as<std::vector<size_t>>();
     auto range2 = config["range2"].as<std::vector<int>>();
     ceph_assert(range2.size() == 2);
@@ -113,7 +114,7 @@ seastar::future<> run(const bpo::variables_map& config) {
     });
 
     auto kvs = KVPool<test_item_t>::create_raw_range(
-        str_sizes, onode_sizes,
+        ns_sizes, oid_sizes, onode_sizes,
         {range2[0], range2[1]},
         {range1[0], range1[1]},
         {range0[0], range0[1]});
@@ -131,11 +132,14 @@ int main(int argc, char** argv)
      "tree backend: dummy, seastore")
     ("tracked", bpo::value<bool>()->default_value(false),
      "track inserted cursors")
-    ("str-sizes", bpo::value<std::vector<size_t>>()->default_value(
-        {8, 11, 64, 256, 301, 320}),
-     "sizes of ns/oid strings")
+    ("ns-sizes", bpo::value<std::vector<size_t>>()->default_value(
+        {8, 11, 64, 128, 255, 256}),
+     "sizes of ns strings")
+    ("oid-sizes", bpo::value<std::vector<size_t>>()->default_value(
+        {8, 13, 64, 512, 2035, 2048}),
+     "sizes of oid strings")
     ("onode-sizes", bpo::value<std::vector<size_t>>()->default_value(
-        {8, 16, 128, 512, 576, 640}),
+        {8, 16, 128, 576, 992, 1200}),
      "sizes of onode")
     ("range2", bpo::value<std::vector<int>>()->default_value(
         {0, 128}),


### PR DESCRIPTION
- fix corner cases of merge logic;
- improve node size equation and implement validation;
- implement compile-time insert upper-bounds;
- switch to runtime node size at node layout level;
- adjust layout data structures to support larger nodes;
- extend tree node sizes to fit insert upper-bounds;
- tests, cleanups and misc other fixes;

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
