### PR TITLE
rgw: RGWSwiftWebsiteHandler::is_web_dir checks empty subdir_name

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2551,6 +2551,9 @@ bool RGWSwiftWebsiteHandler::is_web_dir() const
     return false;
   } else if (subdir_name.back() == '/') {
     subdir_name.pop_back();
+    if (subdir_name.empty()) {
+      return false;
+    }
   }
 
   std::unique_ptr<rgw::sal::Object> obj = s->bucket->get_object(rgw_obj_key(std::move(subdir_name)));


### PR DESCRIPTION
Hello everyone,

it seems like the fix for CVE-2021-3531 has not been merged to master yet.

Here is the reference to the other commits that have already been included:
* Nautilus: https://github.com/ceph/ceph/commit/f44a8ae8aa27ecef69528db9aec220f12492810e
* Octopus: https://github.com/ceph/ceph/commit/b87e64e3206210580f4a6df2d77f9ae3f1033039
* Pacific: https://github.com/ceph/ceph/commit/bf06990ab41d7ac299e4441ad9cd434e926a18e7

Thank you
