### PR TITLE
mon,osd,mds: allow fs authorize to update caps

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -173,6 +173,11 @@
   than the number mentioned against the config tunable `mds_max_snaps_per_dir`
   so that a new snapshot can be created and retained during the next schedule
   run.
+* cephfs: Running the command "ceph fs authorize" for an existing entity now
+  upgrades the entity's capabilities instead of printing an error. It can now
+  also change read/write permissions in a capability that the entity already
+  holds. If the capability passed by user is same as one of the capabilities
+  that the entity already holds, idempotency is maintained.
 
 >=17.2.1
 

--- a/doc/cephfs/client-auth.rst
+++ b/doc/cephfs/client-auth.rst
@@ -259,3 +259,121 @@ Following is an example of enabling root_squash in a filesystem except within
 	caps mds = "allow rw fsname=a root_squash, allow rw fsname=a path=/volumes"
 	caps mon = "allow r fsname=a"
 	caps osd = "allow rw tag cephfs data=a"
+
+Updating Capabilities using ``fs authorize``
+============================================
+After Ceph's Reef version, ``fs authorize`` can not only be used to create a
+new client with caps for a CephFS but it can also be used to add new caps
+(for a another CephFS or another path in same FS) to an already existing
+client.
+
+Let's say we run following and create a new client::
+
+    $ ceph fs authorize a client.x / rw
+    [client.x]
+        key = AQAOtSVk9WWtIhAAJ3gSpsjwfIQ0gQ6vfSx/0w==
+    $ ceph auth get client.x
+    [client.x]
+            key = AQAOtSVk9WWtIhAAJ3gSpsjwfIQ0gQ6vfSx/0w==
+            caps mds = "allow rw fsname=a"
+            caps mon = "allow r fsname=a"
+            caps osd = "allow rw tag cephfs data=a"
+
+Previously, running ``fs authorize a client.x / rw`` a second time used to
+print an error message. But after Reef, it instead prints message that
+there's not update::
+
+    $ ./bin/ceph fs authorize a client.x / rw
+    no update for caps of client.x
+
+Adding New Caps Using ``fs authorize``
+--------------------------------------
+Users can now add caps for another path in same CephFS::
+
+    $ ceph fs authorize a client.x /dir1 rw
+    updated caps for client.x
+    $ ceph auth get client.x
+    [client.x]
+            key = AQAOtSVk9WWtIhAAJ3gSpsjwfIQ0gQ6vfSx/0w==
+            caps mds = "allow r fsname=a, allow rw fsname=a path=some/dir"
+            caps mon = "allow r fsname=a"
+            caps osd = "allow rw tag cephfs data=a"
+
+And even add caps for another CephFS on Ceph cluster::
+
+    $ ceph fs authorize b client.x / rw
+    updated caps for client.x
+    $ ceph auth get client.x
+    [client.x]
+            key = AQD6tiVk0uJdARAABMaQuLRotxTi3Qdj47FkBA==
+            caps mds = "allow rw fsname=a, allow rw fsname=b"
+            caps mon = "allow r fsname=a, allow r fsname=b"
+            caps osd = "allow rw tag cephfs data=a, allow rw tag cephfs data=b"
+
+Changing rw permissions in caps
+-------------------------------
+
+It's not possible to modify caps by running ``fs authorize`` except for the
+case when read/write permissions have to be changed. This so because the
+``fs authorize`` becomes ambiguous. For example, user runs ``fs authorize
+cephfs1 /dir1 client.x rw`` to create a client and then runs ``fs authorize
+cephfs1 /dir2 client.x rw`` (notice ``/dir1`` is changed to ``/dir2``).
+Running second command can be interpreted as changing ``/dir1`` to ``/dir2``
+in current cap or can also be interpreted as authorizing the client with a
+new cap for path ``/dir2``. As seen in previous sections, second
+interpretation is chosen and therefore it's impossible to update a part of
+capability granted except rw permissions. Following is how read/write
+permissions for ``client.x`` (that was created above) can be changed::
+
+    $ ceph fs authorize a client.x / r
+    [client.x]
+        key = AQBBKjBkIFhBDBAA6q5PmDDWaZtYjd+jafeVUQ==
+    $ ceph auth get client.x
+    [client.x]
+            key = AQBBKjBkIFhBDBAA6q5PmDDWaZtYjd+jafeVUQ==
+            caps mds = "allow r fsname=a"
+            caps mon = "allow r fsname=a"
+            caps osd = "allow r tag cephfs data=a"
+
+``fs authorize`` never deducts any part of caps
+-----------------------------------------------
+It's not possible to remove caps issued to a client by running ``fs
+authorize`` again. For example, if a client cap has ``root_squash`` applied
+on a certain CephFS, running ``fs authorize`` again for the same CephFS but
+without ``root_squash`` will not lead to any update, the client caps will
+remain unchanged::
+
+    $ ceph fs authorize a client.x / rw root_squash
+    [client.x]
+            key = AQD61CVkcA1QCRAAd0XYqPbHvcc+lpUAuc6Vcw==
+    $ ceph auth get client.x
+    [client.x]
+            key = AQD61CVkcA1QCRAAd0XYqPbHvcc+lpUAuc6Vcw==
+            caps mds = "allow rw fsname=a root_squash"
+            caps mon = "allow r fsname=a"
+            caps osd = "allow rw tag cephfs data=a"
+    $ ceph fs authorize a client.x / rw
+    [client.x]
+            key = AQD61CVkcA1QCRAAd0XYqPbHvcc+lpUAuc6Vcw==
+    no update was performed for caps of client.x. caps of client.x remains unchanged.
+
+And if a client already has a caps for FS name ``a`` and path ``dir1``,
+running ``fs authorize`` again for FS name ``a`` but path ``dir2``, instead
+of modifying the caps client already holds, a new cap for ``dir2`` will be
+granted::
+
+    $ ceph fs authorize a client.x /dir1 rw
+    $ ceph auth get client.x
+    [client.x]
+            key = AQC1tyVknMt+JxAAp0pVnbZGbSr/nJrmkMNKqA==
+            caps mds = "allow rw fsname=a path=/dir1"
+            caps mon = "allow r fsname=a"
+            caps osd = "allow rw tag cephfs data=a"
+    $ ceph fs authorize a client.x /dir2 rw
+    updated caps for client.x
+    $ ceph auth get client.x
+    [client.x]
+            key = AQC1tyVknMt+JxAAp0pVnbZGbSr/nJrmkMNKqA==
+            caps mds = "allow rw fsname=a path=dir1, allow rw fsname=a path=dir2"
+            caps mon = "allow r fsname=a"
+            caps osd = "allow rw tag cephfs data=a"

--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -368,9 +368,16 @@ Usage::
 
     ceph fs add_data_pool <fs-name> <pool name/id>
 
-Subcommand ``authorize`` creates a new client that will be authorized for the
-given path in ``<fs_name>``. Pass ``/`` to authorize for the entire FS.
-``<perms>`` below can be ``r``, ``rw`` or ``rwp``.
+Subcommand ``authorize`` creates a new client (if the client doesn't exists
+on the cluster) that will be authorized for the given path in ``<fs_name>``.
+Pass ``/`` to authorize for the entire FS. ``<perms>`` below can be ``r``,
+``rw`` or ``rwp``.
+
+Running it for an existing client can grant the client a new capability
+(capability for a different CephFS on the same cluster or for a different
+path on the same CephFS). Or it can also change read/write permission in the
+capability that client already holds.
+
 
 Usage::
 

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -458,4 +458,4 @@ class CephFSTestCase(CephTestCase, RunCephCmd):
             cmd += ['mds', mdscap]
 
         self.run_ceph_cmd(*cmd)
-        return self.run_ceph_cmd(f'auth get {self.client_name}')
+        return self.get_ceph_cmd_stdout(f'auth get {self.client_name}')

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -11,7 +11,8 @@ from teuthology.exceptions import CommandFailedError
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from tasks.cephfs.filesystem import FileLayout, FSMissing
 from tasks.cephfs.fuse_mount import FuseMount
-from tasks.cephfs.caps_helper import CapTester
+from tasks.cephfs.caps_helper import (CapTester, gen_mon_cap_str,
+                                      gen_osd_cap_str, gen_mds_cap_str)
 
 log = logging.getLogger(__name__)
 
@@ -1298,6 +1299,294 @@ class TestFsAuthorize(CephFSTestCase):
         self.mount_a.remount(client_id=self.client_id,
                              client_keyring_path=keyring_path,
                              cephfs_mntpt=path)
+
+
+class TestFsAuthorizeUpdate(CephFSTestCase):
+    client_id = 'testuser'
+    client_name = f'client.{client_id}'
+    CLIENTS_REQUIRED = 2
+    MDSS_REQUIRED = 3
+
+    ######################################
+    # cases where "fs authorize" adds caps
+    ######################################
+
+    def test_add_caps_for_another_FS(self):
+        """
+        Test that "ceph fs authorize" adds caps for a second FS to a keyring
+        that already had caps for first FS.
+        """
+        self.fs1 = self.fs
+        self.fs2 = self.mds_cluster.newfs('testcephfs2')
+        self.mount_b.remount(cephfs_name=self.fs2.name)
+        self.captesters = (CapTester(self.mount_a), CapTester(self.mount_b))
+        self.fs1.authorize(self.client_id, ('/', 'rw'))
+
+        ########### testing begins here.
+        TEST_PERM = 'rw'
+        self.fs2.authorize(self.client_id, ('/', TEST_PERM,))
+        keyring = self.fs.mon_manager.get_keyring(self.client_id)
+        moncap = gen_mon_cap_str((('r', self.fs1.name),
+                                  ('r', self.fs2.name)))
+        osdcap = gen_osd_cap_str(((TEST_PERM, self.fs1.name),
+                                  (TEST_PERM, self.fs2.name)))
+        mdscap = gen_mds_cap_str(((TEST_PERM, self.fs1.name),
+                                  (TEST_PERM, self.fs2.name)))
+        for cap in (moncap, osdcap, mdscap):
+            self.assertIn(cap, keyring)
+        self._remount(self.mount_a, self.fs1.name, keyring)
+        self._remount(self.mount_b, self.fs2.name, keyring)
+        self.captesters[0].run_cap_tests(self.fs1, self.client_id, TEST_PERM)
+        self.captesters[0].run_cap_tests(self.fs1, self.client_id, TEST_PERM)
+
+    def test_add_caps_for_same_FS_diff_path(self):
+        '''
+        Test that "ceph fs authorze" grants a new cap when it is run for a
+        second time for same client and same FS but with a differnt paths.
+
+        In other words, running following two commands -
+        $ ceph fs authorize a client.x1 /dir1 rw
+        $ ceph fs authorize a client.x1 /dir2 rw
+
+        Should produce following MDS caps -
+        caps mon = "allow r fsname=a"
+        caps osd = "allow rw tag cephfs data=a"
+        caps mds = "allow rw fsname=a path=dir1, allow rw fsname=a path=dir2"
+        '''
+        PERM, PATH1, PATH2 = 'rw', 'dir1', 'dir2'
+        self.mount_a.run_shell('mkdir dir1 dir2')
+        self.captester_a = CapTester(self.mount_a, PATH1)
+        self.captester_b = CapTester(self.mount_b, PATH2)
+        self.fs.authorize(self.client_id, ('/', PERM))
+
+        ########## testing begins here.
+        self.fs.authorize(self.client_id, (PATH1, PERM))
+        keyring = self.fs.mon_manager.get_keyring(self.client_id)
+        moncap = gen_mon_cap_str((('r', self.fs.name),))
+        osdcap = gen_osd_cap_str(((PERM, self.fs.name),))
+        mdscap = gen_mds_cap_str(((PERM, self.fs.name, PATH1),))
+        for cap in (moncap, osdcap, mdscap):
+            self.assertIn(cap, keyring)
+        self._remount(self.mount_a, self.fs.name, keyring, PATH1)
+        self.captester_a.run_cap_tests(self.fs, self.client_id, PERM, PATH1)
+
+        ########### testing once more
+        self.fs.authorize(self.client_id, (PATH2, PERM))
+        keyring = self.fs.mon_manager.get_keyring(self.client_id)
+        moncap = gen_mon_cap_str((('r', self.fs.name),))
+        osdcap = gen_osd_cap_str(((PERM, self.fs.name),))
+        mdscap = gen_mds_cap_str(((PERM, self.fs.name, PATH1),
+                                  (PERM, self.fs.name, PATH2)))
+        for cap in (moncap, osdcap, mdscap):
+            self.assertIn(cap, keyring)
+        self._remount(self.mount_b, self.fs.name, keyring, PATH2)
+        self.captester_b.run_cap_tests(self.fs, self.client_id, PERM, PATH2)
+
+    def test_add_caps_for_client_with_no_caps(self):
+        """
+        Test that "ceph fs authorize" adds caps to the keyring when the
+        entity already has a keyring but it contains no caps.
+        """
+        TEST_PERM = 'rw'
+        self.captester = CapTester(self.mount_a)
+        self.run_ceph_cmd(f'auth add {self.client_name}')
+
+        ######## testing begins here.
+        self.fs.authorize(self.client_id, ('/', TEST_PERM))
+        keyring = self.fs.mon_manager.get_keyring(self.client_id)
+        moncap = gen_mon_cap_str((('r', self.fs.name,),))
+        osdcap = gen_osd_cap_str(((TEST_PERM, self.fs.name),))
+        mdscap = gen_mds_cap_str(((TEST_PERM, self.fs.name),))
+        for cap in (moncap, osdcap, mdscap):
+            self.assertIn(cap, keyring)
+        self._remount(self.mount_a, self.fs.name, keyring)
+        self.captester.run_cap_tests(self.fs, self.client_id, TEST_PERM)
+
+
+    #########################################
+    # cases where "fs authorize" changes caps
+    #########################################
+
+    def test_change_perms(self):
+        """
+        Test that "ceph fs authorize" updates the caps for a FS when the caps
+        for that FS were already present in that keyring.
+        """
+        OLD_PERM = 'rw'
+        NEW_PERM = 'r'
+        self.captester = CapTester(self.mount_a)
+
+        self.fs.authorize(self.client_id, ('/', OLD_PERM))
+        ########### testing begins here
+        self.fs.authorize(self.client_id, ('/', NEW_PERM))
+        keyring = self.fs.mon_manager.get_keyring(self.client_id)
+        moncap = gen_mon_cap_str((('r', self.fs.name,),))
+        osdcap = gen_osd_cap_str(((NEW_PERM, self.fs.name),))
+        mdscap = gen_mds_cap_str(((NEW_PERM, self.fs.name),))
+        for cap in (moncap, osdcap, mdscap):
+            self.assertIn(cap, keyring)
+        self._remount(self.mount_a, self.fs.name, keyring)
+        self.captester.run_cap_tests(self.fs, self.client_id, NEW_PERM)
+
+    ################################################
+    # Cases where fs authorize maintains idempotency
+    ################################################
+
+    def test_idem_caps_passed_same_as_current_caps(self):
+        """
+        Test that "ceph fs authorize" exits with the keyring on stdout and the
+        expected error message on stderr when caps supplied to the subcommand
+        are already present in the entity's keyring.
+        """
+        PERM = 'rw'
+        self.captester = CapTester(self.mount_a)
+        self.fs.authorize(self.client_id, ('/', PERM))
+        keyring1 = self.fs.mon_manager.get_keyring(self.client_id)
+
+        ############# testing begins here.
+        proc = self.fs.mon_manager.run_cluster_cmd(
+            args=f'fs authorize {self.fs.name} {self.client_name} / {PERM}',
+            stdout=StringIO(), stderr=StringIO())
+        errmsg = proc.stderr.getvalue()
+        self.assertIn(f'no update for caps of {self.client_name}', errmsg)
+
+        keyring2 = self.fs.mon_manager.get_keyring(self.client_id)
+        self.assertIn(keyring1, keyring2)
+
+        self._remount(self.mount_a, self.fs.name, keyring2)
+        self.captester.run_cap_tests(self.fs, self.client_id, PERM)
+
+    def test_idem_unaffected_root_squash(self):
+        """
+        Test that "root_squash" is not deleted from MDS caps when user runs
+        "fs authorize" a second time passing same FS name and path but not
+        with "root_squash"
+        In other words,
+        $ ceph fs authorize a client.x / rw root_squash
+        [client.x]
+        key = AQCvsyVkiDJZBBAAn1ClsPKvTfrCkUs01Eh8og==
+        $ ceph auth get client.x
+        [client.x]
+                key = AQD61CVkcA1QCRAAd0XYqPbHvcc+lpUAuc6Vcw==
+                caps mds = "allow rw fsname=a root_squash"
+                caps mon = "allow r fsname=a"
+                caps osd = "allow rw tag cephfs data=a"
+        $ ceph fs authorize a client.x / rw
+        $ ceph auth get client.x
+        [client.x]
+                key = AQD61CVkcA1QCRAAd0XYqPbHvcc+lpUAuc6Vcw==
+                caps mds = "allow rw fsname=a root_squash"
+                caps mon = "allow r fsname=a"
+                caps osd = "allow rw tag cephfs data=a"
+        """
+        PERM, PATH = 'rw', 'dir1'
+        self.mount_a.run_shell(f'mkdir {PATH}')
+        self.captester = CapTester(self.mount_a, PATH)
+        self.fs.authorize(self.client_id, (PATH, PERM, 'root_squash'))
+
+        ############# testing begins here.
+        self.fs.authorize(self.client_id, (PATH, PERM))
+        keyring = self.fs.mon_manager.get_keyring(self.client_id)
+        moncap = gen_mon_cap_str((('r', self.fs.name,),))
+        osdcap = gen_osd_cap_str(((PERM, self.fs.name),))
+        mdscap = gen_mds_cap_str(((PERM, self.fs.name, PATH),))
+        for cap in (moncap, osdcap, mdscap):
+            self.assertIn(cap, keyring)
+        self._remount(self.mount_a, self.fs.name, keyring, PATH)
+        self.captester.run_cap_tests(self.fs, self.client_id, PERM, PATH)
+
+    def _get_uid(self):
+        return self.mount_a.client_remote.run(
+            args='id -u', stdout=StringIO()).stdout.getvalue().strip()
+
+    def _get_gid(self):
+        return self.mount_a.client_remote.run(
+            args='id -g', stdout=StringIO()).stdout.getvalue().strip()
+
+    def test_idem_unaffected_uid(self):
+        '''
+        1. Create a client with caps that has FS name and UID in it.
+        2. Run "ceph fs authorize" command for that client with same FS name.
+        3. Test that UID (as well as any other part of cap) is unaffected,
+           i.e. same as before.
+        '''
+        PERM, UID = 'rw', self._get_uid()
+        self.captester = CapTester(self.mount_a)
+        moncap = gen_mon_cap_str((('r', self.fs.name,),))
+        osdcap = gen_osd_cap_str(((PERM, self.fs.name),))
+        mdscap = f'allow rw uid={UID}'
+        self.fs.mon_manager.run_cluster_cmd(
+            args=(f'auth add {self.client_name} mon "{moncap}" '
+                  f'osd "{osdcap}" mds "{mdscap}"'))
+
+        ############# testing begins here.
+        self.fs.authorize(self.client_id, ('/', PERM))
+        keyring = self.fs.mon_manager.get_keyring(self.client_id)
+        for cap in (moncap, osdcap, mdscap):
+            self.assertIn(cap, keyring)
+        self._remount(self.mount_a, self.fs.name, keyring)
+        self.captester.run_cap_tests(self.fs, self.client_id, PERM)
+
+    def test_idem_unaffected_gids(self):
+        '''
+        1. Create a client with caps that has FS name, UID and GID in it.
+        2. Run "ceph fs authorize" command for that client with same FS name.
+        3. Test that GID (as well as any other part of cap) is unaffected,
+           i.e. same as before.
+        '''
+        PERM, UID, GID = 'rw', self._get_uid(), self._get_gid()
+        self.captester = CapTester(self.mount_a)
+        moncap = gen_mon_cap_str((('r', self.fs.name),))
+        osdcap = gen_osd_cap_str(((PERM, self.fs.name),))
+        mdscap = f'allow rw uid={UID} gids={GID}'
+        self.fs.mon_manager.run_cluster_cmd(
+            args=(f'auth add {self.client_name} mon "{moncap}" '
+                  f'osd "{osdcap}" mds "{mdscap}"'))
+
+        ############# testing begins here.
+        self.fs.authorize(self.client_id, ('/', PERM))
+        keyring = self.fs.mon_manager.get_keyring(self.client_id)
+        for cap in (moncap, osdcap, mdscap):
+            self.assertIn(cap, keyring)
+        self._remount(self.mount_a, self.fs.name, keyring)
+        self.captester.run_cap_tests(self.fs, self.client_id, PERM)
+
+    def test_idem_unaffected_gids_multiple(self):
+        '''
+        1. Create client with caps with FS name, UID & multiple GIDs in it.
+        2. Run "ceph fs authorize" command for that client with same FS name.
+        3. Test that multiple GIDs (as well as any other part of cap) is
+           unaffected, i.e. same as before.
+        '''
+        PERM, UID = 'rw', self._get_uid()
+        gids = [int(self._get_gid()), 1001, 1002]
+        # Apparently code for MDS caps always arranges GID in ascending
+        # order. Let's sort so that latter cap string matches with keyring.
+        gids.sort()
+        gids = f'{gids[0]},{gids[1]},{gids[2]}'
+        self.captester = CapTester(self.mount_a)
+        moncap = gen_mon_cap_str((('r', self.fs.name),))
+        osdcap = gen_osd_cap_str(((PERM, self.fs.name),))
+        mdscap = f'allow rw uid={UID} gids={gids}'
+        self.fs.mon_manager.run_cluster_cmd(
+            args=(f'auth add {self.client_name} mon "{moncap}" '
+                  f'osd "{osdcap}" mds "{mdscap}"'))
+
+        ############# testing begins here.
+        self.fs.authorize(self.client_id, ('/', PERM))
+        keyring = self.fs.mon_manager.get_keyring(self.client_id)
+        for cap in (moncap, osdcap, mdscap):
+            self.assertIn(cap, keyring)
+        self._remount(self.mount_a, self.fs.name, keyring)
+        self.captester.run_cap_tests(self.fs, self.client_id, PERM)
+
+    def _remount(self, mount_x, fsname, keyring, cephfs_mntpt='/'):
+        if len(cephfs_mntpt) > 1 and cephfs_mntpt[0] != '/':
+            cephfs_mntpt = '/' + cephfs_mntpt
+        keyring_path = mount_x.client_remote.mktemp(data=keyring)
+        mount_x.remount(client_id=self.client_id,
+                        client_keyring_path=keyring_path,
+                        cephfs_mntpt=cephfs_mntpt, cephfs_name=fsname)
 
 
 class TestAdminCommandIdempotency(CephFSTestCase):

--- a/qa/tasks/cephfs/test_multifs_auth.py
+++ b/qa/tasks/cephfs/test_multifs_auth.py
@@ -96,9 +96,9 @@ class TestMDSCaps(TestMultiFS):
         self.captesters[1].run_mds_cap_tests(PERM)
 
     def test_rw_with_fsname_and_path_in_cap(self):
-        PERM, CEPHFS_MNTPT = 'rw', 'dir1'
-        self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
+        PERM, CEPHFS_MNTPT = 'rw', '/dir1'
+        self.mount_a.run_shell(f'mkdir .{CEPHFS_MNTPT}')
+        self.mount_b.run_shell(f'mkdir .{CEPHFS_MNTPT}')
         self.captesters = (MdsCapTester(self.mount_a, CEPHFS_MNTPT),
                            MdsCapTester(self.mount_b, CEPHFS_MNTPT))
 
@@ -110,9 +110,9 @@ class TestMDSCaps(TestMultiFS):
         self.captesters[1].run_mds_cap_tests(PERM, CEPHFS_MNTPT)
 
     def test_r_with_fsname_and_path_in_cap(self):
-        PERM, CEPHFS_MNTPT = 'r', 'dir1'
-        self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
+        PERM, CEPHFS_MNTPT = 'r', '/dir1'
+        self.mount_a.run_shell(f'mkdir .{CEPHFS_MNTPT}')
+        self.mount_b.run_shell(f'mkdir .{CEPHFS_MNTPT}')
         self.captesters = (MdsCapTester(self.mount_a, CEPHFS_MNTPT),
                            MdsCapTester(self.mount_b, CEPHFS_MNTPT))
 
@@ -126,9 +126,9 @@ class TestMDSCaps(TestMultiFS):
     # XXX: this tests the backward compatibility; "allow rw path=<dir1>" is
     # treated as "allow rw fsname=* path=<dir1>"
     def test_rw_with_no_fsname_and_path_in_cap(self):
-        PERM, CEPHFS_MNTPT = 'rw', 'dir1'
-        self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
+        PERM, CEPHFS_MNTPT = 'rw', '/dir1'
+        self.mount_a.run_shell(f'mkdir .{CEPHFS_MNTPT}')
+        self.mount_b.run_shell(f'mkdir .{CEPHFS_MNTPT}')
         self.captesters = (MdsCapTester(self.mount_a, CEPHFS_MNTPT),
                            MdsCapTester(self.mount_b, CEPHFS_MNTPT))
 
@@ -142,9 +142,9 @@ class TestMDSCaps(TestMultiFS):
     # XXX: this tests the backward compatibility; "allow r path=<dir1>" is
     # treated as "allow r fsname=* path=<dir1>"
     def test_r_with_no_fsname_and_path_in_cap(self):
-        PERM, CEPHFS_MNTPT = 'r', 'dir1'
-        self.mount_a.run_shell(f'mkdir {CEPHFS_MNTPT}')
-        self.mount_b.run_shell(f'mkdir {CEPHFS_MNTPT}')
+        PERM, CEPHFS_MNTPT = 'r', '/dir1'
+        self.mount_a.run_shell(f'mkdir .{CEPHFS_MNTPT}')
+        self.mount_b.run_shell(f'mkdir .{CEPHFS_MNTPT}')
         self.captesters = (MdsCapTester(self.mount_a, CEPHFS_MNTPT),
                            MdsCapTester(self.mount_b, CEPHFS_MNTPT))
 
@@ -202,7 +202,8 @@ class TestMDSCaps(TestMultiFS):
     def remount_with_new_client(self, keyring, cephfs_mntpt='/'):
         log.info(f'keyring generated for testing is -\n{keyring}')
 
-        if isinstance(cephfs_mntpt, str) and cephfs_mntpt != '/' :
+        if (isinstance(cephfs_mntpt, str) and cephfs_mntpt != '/'  and
+            cephfs_mntpt[0] != '/'):
             cephfs_mntpt = '/' + cephfs_mntpt
 
         keyring_path = self.mount_a.client_remote.mktemp(data=keyring)

--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -93,6 +93,17 @@ struct MDSCapSpec {
   bool allow_full() const {
     return (caps & FULL);
   }
+
+  unsigned get_caps() {
+    return caps;
+  }
+
+  void set_caps(unsigned int _caps) {
+    caps = _caps;
+  }
+
+  std::string to_string();
+
 private:
   unsigned caps = 0;
 };
@@ -135,6 +146,7 @@ struct MDSCapMatch {
    * @param target_path filesystem path without leading '/'
    */
   bool match_path(std::string_view target_path) const;
+  std::string to_string();
 
   // Require UID to be equal to this, if !=MDS_AUTH_UID_ANY
   int64_t uid = MDS_AUTH_UID_ANY;
@@ -156,6 +168,7 @@ struct MDSCapGrant {
   MDSCapGrant() {}
 
   void parse_network();
+  std::string to_string();
 
   MDSCapSpec spec;
   MDSCapMatch match;
@@ -181,6 +194,7 @@ public:
 
   void set_allow_all();
   bool parse(std::string_view str, std::ostream *err);
+  bool merge(MDSAuthCaps newcap);
 
   bool allow_all() const;
   bool is_capable(std::string_view inode_path,
@@ -211,7 +225,9 @@ public:
     return false;
   }
 
+
   friend std::ostream &operator<<(std::ostream &out, const MDSAuthCaps &cap);
+  std::string to_string();
 private:
   std::vector<MDSCapGrant> grants;
 };

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1789,19 +1789,6 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
 
     EntityAuth entity_auth;
     if (mon.key_server.get_auth(entity, entity_auth)) {
-      for (const auto& [cap_entity, cap] : encoded_caps) {
-	if (entity_auth.caps.count(cap_entity) == 0 ||
-	    !entity_auth.caps[cap_entity].contents_equal(cap)) {
-	  ss << entity << " already has fs capabilities that differ from "
-	     << "those supplied. To generate a new auth key for " << entity
-	     << ", first remove " << entity << " from configuration files, "
-	     << "execute 'ceph auth rm " << entity << "', then execute this "
-	     << "command again.";
-	  err = -EINVAL;
-	  goto done;
-	}
-      }
-
       int rv = _gen_wanted_caps(entity_auth, newcaps, ss);
       ceph_assert(rv == CAPS_UPDATE_REQD or rv == CAPS_UPDATE_NOT_REQD or
 	          rv == CAPS_PARSING_ERR);

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1778,12 +1778,12 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       + " data=" + filesystem;
 
     map<string, bufferlist> encoded_caps;
-    map<string, string> wanted_caps = {
+    map<string, string> newcaps = {
       {"mon", mon_cap_string},
       {"osd", osd_cap_string},
       {"mds", mds_cap_string}
     };
-    if (err = _check_and_encode_caps(wanted_caps, encoded_caps, ss); err < 0) {
+    if (err = _check_and_encode_caps(newcaps, encoded_caps, ss); err < 0) {
       goto done;
     }
 
@@ -1807,7 +1807,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       goto done;
     }
 
-    err = _create_entity(entity, wanted_caps, op, ds, &rdata, f.get());
+    err = _create_entity(entity, newcaps, op, ds, &rdata, f.get());
     if (err == 0) {
       return true;
     } else {

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1789,9 +1789,9 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
 
     EntityAuth entity_auth;
     if (mon.key_server.get_auth(entity, entity_auth)) {
-      for (const auto &sys_cap : encoded_caps) {
-	if (entity_auth.caps.count(sys_cap.first) == 0 ||
-	    !entity_auth.caps[sys_cap.first].contents_equal(sys_cap.second)) {
+      for (const auto& [cap_entity, cap] : encoded_caps) {
+	if (entity_auth.caps.count(cap_entity) == 0 ||
+	    !entity_auth.caps[cap_entity].contents_equal(cap)) {
 	  ss << entity << " already has fs capabilities that differ from "
 	     << "those supplied. To generate a new auth key for " << entity
 	     << ", first remove " << entity << " from configuration files, "
@@ -1802,9 +1802,28 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
 	}
       }
 
-      _encode_key(entity, entity_auth, rdata, f.get(), false, &encoded_caps);
-      err = 0;
-      goto done;
+      int rv = _gen_wanted_caps(entity_auth, newcaps, ss);
+      ceph_assert(rv == CAPS_UPDATE_REQD or rv == CAPS_UPDATE_NOT_REQD or
+	          rv == CAPS_PARSING_ERR);
+      if (rv == CAPS_PARSING_ERR) {
+	goto done;
+      } else if (rv == CAPS_UPDATE_NOT_REQD) {
+	ss << "no update for caps of " << entity;
+	err = 0;
+	goto done;
+      }
+
+      dout(20) << "caps that will be enforced -" << dendl;
+      for (const auto& it : newcaps) {
+	dout(20) << it.first << " cap = \"" << it.second << "\"" << dendl;
+      }
+
+      err = _update_caps(entity, newcaps, op, ds, &rdata, f.get());
+      if (err == 0) {
+	return true;
+      } else {
+	goto done;
+      }
     }
 
     err = _create_entity(entity, newcaps, op, ds, &rdata, f.get());
@@ -1840,6 +1859,75 @@ done:
   getline(ss, rs, '\0');
   mon.reply_command(op, err, rs, rdata, get_last_committed());
   return false;
+}
+
+template<typename CAP_ENTITY_CLASS>
+AuthMonitor::caps_update AuthMonitor::_merge_caps(const string& cap_entity,
+  const string& new_cap_str, const string& cur_cap_str,
+  map<string, string>& newcaps, ostream& out)
+{
+  CAP_ENTITY_CLASS cur_cap, new_cap;
+
+  if (not cur_cap.parse(cur_cap_str, &out)) {
+    out << "error parsing " << cap_entity << "caps client already holds";
+    return CAPS_PARSING_ERR;
+  }
+  if (not new_cap.parse(new_cap_str, &out)) {
+    out << "error parsing new " << cap_entity << "caps";
+    return CAPS_PARSING_ERR;
+  }
+
+  if (cur_cap.merge(new_cap)) {
+    newcaps[cap_entity] = cur_cap.to_string();
+    return CAPS_UPDATE_REQD;
+  } else {
+    newcaps[cap_entity] = cur_cap_str;
+    return CAPS_UPDATE_NOT_REQD;
+  }
+}
+
+/* Generate the caps that should be present in the entity's auth keyring
+ * after running the "fs authorize" command. This is done by merging the
+ * caps already present in the client's auth keyring with the new caps
+ * provided by the user at "fs authorize" command.
+ */
+AuthMonitor::caps_update AuthMonitor::_gen_wanted_caps(EntityAuth& e_auth,
+  map<string, string>& newcaps, ostream& out)
+{
+  caps_update is_caps_update_reqd = CAPS_UPDATE_NOT_REQD;
+
+  if (e_auth.caps.empty()) {
+    return CAPS_UPDATE_REQD;
+  }
+
+  // new_cap_str is the new cap to be added to the current cap
+  for (const auto& [cap_entity, new_cap_str] : newcaps) {
+    string cur_cap_str; // current cap held by entity's auth keyring
+
+    if (e_auth.caps.count(cap_entity) == 0) {
+      is_caps_update_reqd = CAPS_UPDATE_REQD;
+      continue;
+    }
+
+    auto iter = e_auth.caps[cap_entity].cbegin();
+    decode(cur_cap_str, iter);
+    if (cur_cap_str == new_cap_str) {
+      continue;
+    }
+
+    if (cap_entity == "mon") {
+      is_caps_update_reqd = _merge_caps<MonCap>(cap_entity, new_cap_str,
+	cur_cap_str, newcaps, out);
+    } else if (cap_entity == "osd") {
+      is_caps_update_reqd = _merge_caps<OSDCap>(cap_entity, new_cap_str,
+	cur_cap_str, newcaps, out);
+    } else if (cap_entity == "mds") {
+      is_caps_update_reqd = _merge_caps<MDSAuthCaps>(cap_entity, new_cap_str,
+	cur_cap_str, newcaps, out);
+    }
+  }
+
+  return is_caps_update_reqd;
 }
 
 void AuthMonitor::_encode_keyring(KeyRing& kr, const EntityName& entity,

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -31,7 +31,12 @@ class Monitor;
 #define MIN_GLOBAL_ID 0x1000
 
 class AuthMonitor : public PaxosService {
+
 public:
+  typedef enum {
+    CAPS_UPDATE_NOT_REQD, CAPS_UPDATE_REQD, CAPS_PARSING_ERR
+  } caps_update;
+
   enum IncType {
     GLOBAL_ID,
     AUTH_DATA,
@@ -194,6 +199,13 @@ private:
   int _update_caps(const EntityName& entity,
     const std::map<std::string, std::string>& caps, MonOpRequestRef op,
     std::stringstream& ds, bufferlist* rdata, Formatter* fmtr);
+
+  caps_update _gen_wanted_caps(EntityAuth& e_auth,
+    std::map<std::string, std::string>& newcaps, std::ostream& out);
+  template<typename CAP_ENTITY_CLASS>
+  caps_update _merge_caps(const std::string& cap_entity,
+    const std::string& new_cap_str, const std::string& cur_cap_str,
+    std::map<std::string, std::string>& newcaps, std::ostream& out);
 
   bool check_rotate();
   void process_used_pending_keys(const std::map<EntityName,CryptoKey>& keys);

--- a/src/mon/MonCap.h
+++ b/src/mon/MonCap.h
@@ -137,6 +137,8 @@ struct MonCapGrant {
       command.length() == 0 &&
       fs_name.empty();
   }
+
+  std::string to_string();
 };
 
 std::ostream& operator<<(std::ostream& out, const MonCapGrant& g);
@@ -151,10 +153,12 @@ struct MonCap {
   std::string get_str() const {
     return text;
   }
+  std::string to_string();
 
   bool is_allow_all() const;
   void set_allow_all();
   bool parse(const std::string& str, std::ostream *err=NULL);
+  bool merge(MonCap newcap);
 
   /**
    * check if we are capable of something

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -539,3 +539,71 @@ bool OSDCap::parse(const string& str, ostream *err)
 
   return false; 
 }
+
+bool OSDCap::merge(OSDCap newcap)
+{
+  ceph_assert(newcap.grants.size() == 1);
+  auto ng = newcap.grants[0];
+
+  for (auto& g : grants) {
+    /* TODO: check case where cap is "allow rw tag cephfs *". */
+
+    if (g.match.pool_tag.application == ng.match.pool_tag.application and
+	g.match.pool_tag.key == ng.match.pool_tag.key and
+	g.match.pool_tag.value == ng.match.pool_tag.value) {
+      if (g.spec.allow == ng.spec.allow) {
+	// no update required, maintaining idempotency.
+	return false;
+      } else if (g.spec.allow != ng.spec.allow) {
+	// cap for given application is present, let's update it.
+	g.spec.allow = ng.spec.allow;
+	return true;
+      }
+    }
+  }
+
+  // cap for given application is absent, let's add a new cap for it.
+  grants.push_back(OSDCapGrant(
+    OSDCapMatch(OSDCapPoolTag(ng.match.pool_tag.application,
+      ng.match.pool_tag.key, ng.match.pool_tag.value)),
+    OSDCapSpec(ng.spec.allow)));
+  return true;
+}
+
+string OSDCapGrant::to_string() {
+  string str = "allow ";
+
+  if (spec.allow & OSD_CAP_R)
+    str += "r";
+  if (spec.allow & OSD_CAP_W)
+    str += "w";
+
+  if ((spec.allow & OSD_CAP_X) == OSD_CAP_X)
+    str += "x";
+  else {
+    if (spec.allow & OSD_CAP_CLS_R)
+      str += " class-read";
+    else if (spec.allow & OSD_CAP_CLS_W)
+      str += " class-write";
+  }
+
+  if (not (match.pool_tag.application.empty() and match.pool_tag.key.empty()
+	   and match.pool_tag.value.empty()))
+    str += " tag " + match.pool_tag.application + " " + \
+	   match.pool_tag.key + "=" + match.pool_tag.value;
+
+  return str;
+}
+
+string OSDCap::to_string()
+{
+  string str;
+
+  for (size_t i = 0; i < grants.size(); ++i) {
+    str += grants[i].to_string();
+    if (i < grants.size() - 1)
+      str += ", ";
+  }
+
+  return str;
+}

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -216,6 +216,7 @@ struct OSDCapGrant {
                   std::vector<bool>* class_allowed) const;
 
   void expand_profile();
+  std::string to_string();
 };
 
 ostream& operator<<(ostream& out, const OSDCapGrant& g);
@@ -230,6 +231,8 @@ struct OSDCap {
   bool allow_all() const;
   void set_allow_all();
   bool parse(const std::string& str, ostream *err=NULL);
+  bool merge(OSDCap newcap);
+  std::string to_string();
 
   /**
    * check if we are capable of something


### PR DESCRIPTION
Related PRs:  #42335, #46991, #46993, #46994, #47013, #50312, #50497, #50664, #50665, #50874, #50876, #50882, #51004, #51127 and #52008.

Modifies the code for `fs authorize` to update auth caps instead of exiting with an error when entity already has caps (whether or not for the FS). Very related case where this modification has an impact is that, unlike before, auth caps are updated even when the entity has no caps

Fixes: https://tracker.ceph.com/issues/47264



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug
- [x] Add pending release note?

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>