### PR TITLE
mon/MonCommands: remove obsolete commands 

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -281,16 +281,9 @@ COMMAND("versions",
  */
 
 COMMAND_WITH_FLAG("mds stat", "show MDS status", "mds", "r", FLAG(HIDDEN))
-COMMAND_WITH_FLAG("mds dump "
-	"name=epoch,type=CephInt,req=false,range=0",
-	"dump legacy MDS cluster info, optionally from epoch",
-        "mds", "r", FLAG(OBSOLETE))
 COMMAND("fs dump "
 	"name=epoch,type=CephInt,req=false,range=0",
 	"dump all CephFS status, optionally from epoch", "mds", "r")
-COMMAND_WITH_FLAG("mds getmap "
-	"name=epoch,type=CephInt,req=false,range=0",
-	"get MDS map, optionally from epoch", "mds", "r", FLAG(OBSOLETE))
 COMMAND("mds metadata name=who,type=CephString,req=false",
 	"fetch metadata for mds <role>",
 	"mds", "r")
@@ -300,29 +293,11 @@ COMMAND("mds count-metadata name=property,type=CephString",
 COMMAND("mds versions",
 	"check running versions of MDSs",
 	"mds", "r")
-COMMAND_WITH_FLAG("mds tell "
-	"name=who,type=CephString "
-	"name=args,type=CephString,n=N",
-	"send command to particular mds", "mds", "rw", FLAG(OBSOLETE))
 COMMAND("mds compat show", "show mds compatibility settings",
 	"mds", "r")
-COMMAND_WITH_FLAG("mds stop name=role,type=CephString", "stop mds",
-	"mds", "rw", FLAG(OBSOLETE))
-COMMAND_WITH_FLAG("mds deactivate name=role,type=CephString",
-        "clean up specified MDS rank (use with `set max_mds` to shrink cluster)",
-	"mds", "rw", FLAG(OBSOLETE))
 COMMAND("mds ok-to-stop name=ids,type=CephString,n=N",
 	"check whether stopping the specified MDS would reduce immediate availability",
 	"mds", "r")
-COMMAND_WITH_FLAG("mds set_max_mds "
-	"name=maxmds,type=CephInt,range=0",
-	"set max MDS index", "mds", "rw", FLAG(OBSOLETE))
-COMMAND_WITH_FLAG("mds set "
-	"name=var,type=CephChoices,strings=max_mds|max_file_size|inline_data|"
-	"allow_new_snaps|allow_multimds|allow_multimds_snaps|allow_dirfrags "
-	"name=val,type=CephString "
-	"name=yes_i_really_mean_it,type=CephBool,req=false",
-	"set mds parameter <var> to <val>", "mds", "rw", FLAG(OBSOLETE))
 COMMAND_WITH_FLAG("mds freeze name=role_or_gid,type=CephString"
 	" name=val,type=CephString",
 	"freeze MDS yes/no", "mds", "rw", FLAG(HIDDEN))
@@ -344,29 +319,12 @@ COMMAND("mds rm "
 COMMAND_WITH_FLAG("mds rmfailed name=role,type=CephString "
         "name=yes_i_really_mean_it,type=CephBool,req=false",
 	"remove failed rank", "mds", "rw", FLAG(HIDDEN))
-COMMAND_WITH_FLAG("mds cluster_down", "take MDS cluster down", "mds", "rw", FLAG(OBSOLETE))
-COMMAND_WITH_FLAG("mds cluster_up", "bring MDS cluster up", "mds", "rw", FLAG(OBSOLETE))
 COMMAND("mds compat rm_compat "
 	"name=feature,type=CephInt,range=0",
 	"remove compatible feature", "mds", "rw")
 COMMAND("mds compat rm_incompat "
 	"name=feature,type=CephInt,range=0",
 	"remove incompatible feature", "mds", "rw")
-COMMAND_WITH_FLAG("mds add_data_pool "
-	"name=pool,type=CephString",
-	"add data pool <pool>", "mds", "rw", FLAG(OBSOLETE))
-COMMAND_WITH_FLAG("mds rm_data_pool "
-	"name=pool,type=CephString",
-	"remove data pool <pool>", "mds", "rw", FLAG(OBSOLETE))
-COMMAND_WITH_FLAG("mds remove_data_pool "
-	"name=pool,type=CephString",
-	"remove data pool <pool>", "mds", "rw", FLAG(OBSOLETE))
-COMMAND_WITH_FLAG("mds newfs "
-	"name=metadata,type=CephInt,range=0 "
-	"name=data,type=CephInt,range=0 "
-	"name=yes_i_really_mean_it,type=CephBool,req=false",
-	"make new filesystem using pools <metadata> and <data>",
-	"mds", "rw", FLAG(OBSOLETE))
 COMMAND("fs new "
 	"name=fs_name,type=CephString,goodchars=[A-Za-z0-9-_.] "
 	"name=metadata,type=CephString "

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -200,9 +200,6 @@ COMMAND("auth rm "
 COMMAND_WITH_FLAG("compact", "cause compaction of monitor's leveldb/rocksdb storage",
 	     "mon", "rw",
              FLAG(TELL))
-COMMAND_WITH_FLAG("scrub", "scrub the monitor stores",
-             "mon", "rw",
-             FLAG(OBSOLETE))
 COMMAND("fsid", "show cluster FSID/UUID", "mon", "r")
 COMMAND("log name=logtext,type=CephString,n=N",
 	"log supplied text to the monitor log", "mon", "rw")


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
