### PR TITLE
nautilus: librbd: race when disabling object map with overlapping in-flight writes

### DIFF
--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -165,8 +165,14 @@ void ObjectMap<I>::close(Context *on_finish) {
     return;
   }
 
-  auto req = object_map::UnlockRequest<I>::create(m_image_ctx, on_finish);
-  req->send();
+  auto ctx = new FunctionContext([this, on_finish](int r) {
+      auto req = object_map::UnlockRequest<I>::create(m_image_ctx, on_finish);
+      req->send();
+    });
+
+  // ensure the block guard for aio updates is empty before unlocking
+  // the object map
+  m_async_op_tracker.wait_for_ops(ctx);
 }
 
 template <typename I>
@@ -268,6 +274,7 @@ void ObjectMap<I>::detained_aio_update(UpdateOperation &&op) {
     lderr(cct) << "failed to detain object map update: " << cpp_strerror(r)
                << dendl;
     m_image_ctx.op_work_queue->queue(op.on_finish, r);
+    m_async_op_tracker.finish_op();
     return;
   } else if (r > 0) {
     ldout(cct, 20) << "detaining object map update due to in-flight update: "
@@ -307,6 +314,7 @@ void ObjectMap<I>::handle_detained_aio_update(BlockGuardCell *cell, int r,
   }
 
   on_finish->complete(r);
+  m_async_op_tracker.finish_op();
 }
 
 template <typename I>

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -8,6 +8,7 @@
 #include "include/fs_types.h"
 #include "include/rados/librados_fwd.hpp"
 #include "include/rbd/object_map_types.h"
+#include "common/AsyncOpTracker.h"
 #include "common/bit_vector.hpp"
 #include "librbd/Utils.h"
 #include <boost/optional.hpp>
@@ -89,6 +90,7 @@ public:
         return false;
       }
 
+      m_async_op_tracker.start_op();
       UpdateOperation update_operation(start_object_no, end_object_no,
                                        new_state, current_state, parent_trace,
                                        ignore_enoent,
@@ -135,6 +137,7 @@ private:
   ceph::BitVector<2> m_object_map;
   uint64_t m_snap_id;
 
+  AsyncOpTracker m_async_op_tracker;
   UpdateGuard *m_update_guard = nullptr;
 
   void detained_aio_update(UpdateOperation &&update_operation);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46149

---

backport of https://github.com/ceph/ceph/pull/35658
parent tracker: https://tracker.ceph.com/issues/46083

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh