### PR TITLE
nautilus: librbd: fix sporadic failures in TestMigration.StressLive

### DIFF
--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -122,13 +122,18 @@ void ImageCopyRequest<I>::send_next_object_copy() {
 
   ++m_current_ops;
 
+  uint32_t flags = 0;
+  if (m_flatten) {
+    flags |= OBJECT_COPY_REQUEST_FLAG_FLATTEN;
+  }
+
   Context *ctx = new FunctionContext(
     [this, ono](int r) {
       handle_object_copy(ono, r);
     });
   ObjectCopyRequest<I> *req = ObjectCopyRequest<I>::create(
     m_src_image_ctx, m_dst_image_ctx, m_src_snap_id_start, m_dst_snap_id_start,
-    m_snap_map, ono, m_flatten, ctx);
+    m_snap_map, ono, flags, ctx);
   req->send();
 }
 

--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -47,12 +47,12 @@ ObjectCopyRequest<I>::ObjectCopyRequest(I *src_image_ctx,
                                         librados::snap_t dst_snap_id_start,
                                         const SnapMap &snap_map,
                                         uint64_t dst_object_number,
-                                        bool flatten, Context *on_finish)
+                                        uint32_t flags, Context *on_finish)
   : m_src_image_ctx(src_image_ctx),
     m_dst_image_ctx(dst_image_ctx), m_cct(dst_image_ctx->cct),
     m_src_snap_id_start(src_snap_id_start),
     m_dst_snap_id_start(dst_snap_id_start), m_snap_map(snap_map),
-    m_dst_object_number(dst_object_number), m_flatten(flatten),
+    m_dst_object_number(dst_object_number), m_flags(flags),
     m_on_finish(on_finish) {
   ceph_assert(src_image_ctx->data_ctx.is_valid());
   ceph_assert(dst_image_ctx->data_ctx.is_valid());
@@ -750,7 +750,8 @@ void ObjectCopyRequest<I>::compute_read_from_parent_ops(
     return;
   }
 
-  if (noent_count == m_src_object_extents.size() && !m_flatten) {
+  bool flatten = ((m_flags & OBJECT_COPY_REQUEST_FLAG_FLATTEN) != 0);
+  if (noent_count == m_src_object_extents.size() && !flatten) {
     ldout(m_cct, 20) << "reading all extents skipped when no flatten"
                      << dendl;
     return;

--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -342,7 +342,9 @@ void ObjectCopyRequest<I>::send_write_object() {
   librados::ObjectWriteOperation op;
   uint64_t buffer_offset;
 
-  if (!m_dst_image_ctx->migration_info.empty()) {
+  bool migration = ((m_flags & OBJECT_COPY_REQUEST_FLAG_MIGRATION) != 0);
+  if (migration) {
+    ldout(m_cct, 20) << "assert_snapc_seq=" << dst_snap_seq << dendl;
     cls_client::assert_snapc_seq(&op, dst_snap_seq,
                                  cls::rbd::ASSERT_SNAPC_SEQ_GT_SNAPSET_SEQ);
   }
@@ -384,7 +386,7 @@ void ObjectCopyRequest<I>::send_write_object() {
     }
   }
 
-  if (op.size() == (m_dst_image_ctx->migration_info.empty() ? 0 : 1)) {
+  if (op.size() == (migration ? 1 : 0)) {
     handle_write_object(0);
     return;
   }

--- a/src/librbd/deep_copy/ObjectCopyRequest.h
+++ b/src/librbd/deep_copy/ObjectCopyRequest.h
@@ -32,17 +32,17 @@ public:
                                    librados::snap_t src_snap_id_start,
                                    librados::snap_t dst_snap_id_start,
                                    const SnapMap &snap_map,
-                                   uint64_t object_number, bool flatten,
+                                   uint64_t object_number, uint32_t flags,
                                    Context *on_finish) {
     return new ObjectCopyRequest(src_image_ctx, dst_image_ctx,
                                  src_snap_id_start, dst_snap_id_start, snap_map,
-                                 object_number, flatten, on_finish);
+                                 object_number, flags, on_finish);
   }
 
   ObjectCopyRequest(ImageCtxT *src_image_ctx, ImageCtxT *dst_image_ctx,
                     librados::snap_t src_snap_id_start,
                     librados::snap_t dst_snap_id_start, const SnapMap &snap_map,
-                    uint64_t object_number, bool flatten, Context *on_finish);
+                    uint64_t object_number, uint32_t flags, Context *on_finish);
 
   void send();
 
@@ -144,7 +144,7 @@ private:
   librados::snap_t m_dst_snap_id_start;
   SnapMap m_snap_map;
   uint64_t m_dst_object_number;
-  bool m_flatten;
+  uint32_t m_flags;
   Context *m_on_finish;
 
   decltype(m_src_image_ctx->data_ctx) m_src_io_ctx;

--- a/src/librbd/deep_copy/Types.h
+++ b/src/librbd/deep_copy/Types.h
@@ -11,6 +11,10 @@
 namespace librbd {
 namespace deep_copy {
 
+enum {
+  OBJECT_COPY_REQUEST_FLAG_FLATTEN = 1U << 0,
+};
+
 typedef std::vector<librados::snap_t> SnapIds;
 typedef std::map<librados::snap_t, SnapIds> SnapMap;
 

--- a/src/librbd/deep_copy/Types.h
+++ b/src/librbd/deep_copy/Types.h
@@ -12,7 +12,8 @@ namespace librbd {
 namespace deep_copy {
 
 enum {
-  OBJECT_COPY_REQUEST_FLAG_FLATTEN = 1U << 0,
+  OBJECT_COPY_REQUEST_FLAG_FLATTEN   = 1U << 0,
+  OBJECT_COPY_REQUEST_FLAG_MIGRATION = 1U << 1,
 };
 
 typedef std::vector<librados::snap_t> SnapIds;

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -232,11 +232,16 @@ void CopyupRequest<I>::deep_copy() {
 
   ldout(cct, 20) << "oid=" << m_oid << ", flatten=" << m_flatten << dendl;
 
+  uint32_t flags = 0;
+  if (m_flatten) {
+    flags |= deep_copy::OBJECT_COPY_REQUEST_FLAG_FLATTEN;
+  }
+
   auto ctx = util::create_context_callback<
     CopyupRequest<I>, &CopyupRequest<I>::handle_deep_copy>(this);
   auto req = deep_copy::ObjectCopyRequest<I>::create(
     m_image_ctx->parent, m_image_ctx, 0, 0,
-    m_image_ctx->migration_info.snap_map, m_object_no, m_flatten, ctx);
+    m_image_ctx->migration_info.snap_map, m_object_no, flags, ctx);
 
   req->send();
 }

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -232,7 +232,7 @@ void CopyupRequest<I>::deep_copy() {
 
   ldout(cct, 20) << "oid=" << m_oid << ", flatten=" << m_flatten << dendl;
 
-  uint32_t flags = 0;
+  uint32_t flags = deep_copy::OBJECT_COPY_REQUEST_FLAG_MIGRATION;
   if (m_flatten) {
     flags |= deep_copy::OBJECT_COPY_REQUEST_FLAG_FLATTEN;
   }

--- a/src/librbd/operation/MigrateRequest.cc
+++ b/src/librbd/operation/MigrateRequest.cc
@@ -130,7 +130,7 @@ private:
     } else {
       ceph_assert(image_ctx.parent != nullptr);
 
-      uint32_t flags = 0;
+      uint32_t flags = deep_copy::OBJECT_COPY_REQUEST_FLAG_MIGRATION;
       if (image_ctx.migration_info.flatten) {
         flags |= deep_copy::OBJECT_COPY_REQUEST_FLAG_FLATTEN;
       }

--- a/src/librbd/operation/MigrateRequest.cc
+++ b/src/librbd/operation/MigrateRequest.cc
@@ -130,9 +130,14 @@ private:
     } else {
       ceph_assert(image_ctx.parent != nullptr);
 
+      uint32_t flags = 0;
+      if (image_ctx.migration_info.flatten) {
+        flags |= deep_copy::OBJECT_COPY_REQUEST_FLAG_FLATTEN;
+      }
+
       auto req = deep_copy::ObjectCopyRequest<I>::create(
         image_ctx.parent, &image_ctx, 0, 0, image_ctx.migration_info.snap_map,
-        m_object_no, image_ctx.migration_info.flatten, ctx);
+        m_object_no, flags, ctx);
 
       ldout(cct, 20) << "deep copy object req " << req << ", object_no "
                      << m_object_no << dendl;

--- a/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
@@ -53,7 +53,7 @@ struct ObjectCopyRequest<librbd::MockTestImageCtx> {
       librados::snap_t src_snap_id_start,
       librados::snap_t dst_snap_id_start,
       const SnapMap &snap_map,
-      uint64_t object_number, bool flatten, Context *on_finish) {
+      uint64_t object_number, uint32_t flags, Context *on_finish) {
     ceph_assert(s_instance != nullptr);
     Mutex::Locker locker(s_instance->lock);
     s_instance->snap_map = &snap_map;

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -212,7 +212,7 @@ public:
     expect_get_object_name(mock_dst_image_ctx);
     return new MockObjectCopyRequest(&mock_src_image_ctx, &mock_dst_image_ctx,
                                      src_snap_id_start, dst_snap_id_start,
-                                     m_snap_map, 0, false, on_finish);
+                                     m_snap_map, 0, 0, on_finish);
   }
 
   void expect_set_snap_read(librados::MockTestMemIoCtxImpl &mock_io_ctx,

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -50,11 +50,12 @@ struct ObjectCopyRequest<librbd::MockTestImageCtx> {
                                    librados::snap_t src_snap_id_start,
                                    librados::snap_t dst_snap_id_start,
                                    const SnapMap &snap_map,
-                                   uint64_t object_number, bool flatten,
+                                   uint64_t object_number, uint32_t flags,
                                    Context *on_finish) {
     ceph_assert(s_instance != nullptr);
     s_instance->object_number = object_number;
-    s_instance->flatten = flatten;
+    s_instance->flatten = (
+      (flags & deep_copy::OBJECT_COPY_REQUEST_FLAG_FLATTEN) != 0);
     s_instance->on_finish = on_finish;
     return s_instance;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48565

---

backport of https://github.com/ceph/ceph/pull/38494
parent tracker: https://tracker.ceph.com/issues/45694

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh