### PR TITLE
nautilus: rbd-mirror: image replayer stop might race with instance replayer shut down

### DIFF
--- a/src/common/AsyncOpTracker.h
+++ b/src/common/AsyncOpTracker.h
@@ -5,8 +5,7 @@
 #define CEPH_ASYNC_OP_TRACKER_H
 
 #include "common/ceph_mutex.h"
-
-struct Context;
+#include "include/Context.h"
 
 class AsyncOpTracker {
 public:
@@ -25,6 +24,25 @@ private:
   uint32_t m_pending_ops = 0;
   Context *m_on_finish = nullptr;
 
+};
+
+class C_TrackedOp : public Context {
+public:
+  C_TrackedOp(AsyncOpTracker& async_op_tracker, Context* on_finish)
+    : m_async_op_tracker(async_op_tracker), m_on_finish(on_finish) {
+    m_async_op_tracker.start_op();
+  }
+
+  void finish(int r) override {
+    if (m_on_finish != nullptr) {
+      m_on_finish->complete(r);
+    }
+    m_async_op_tracker.finish_op();
+  }
+
+private:
+  AsyncOpTracker& m_async_op_tracker;
+  Context* m_on_finish;
 };
 
 #endif // CEPH_ASYNC_OP_TRACKER_H

--- a/src/test/rbd_mirror/test_mock_InstanceReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_InstanceReplayer.cc
@@ -87,7 +87,7 @@ struct ImageReplayer<librbd::MockTestImageCtx> {
   MOCK_METHOD0(destroy, void());
   MOCK_METHOD2(start, void(Context *, bool));
   MOCK_METHOD2(stop, void(Context *, bool));
-  MOCK_METHOD0(restart, void());
+  MOCK_METHOD1(restart, void(Context*));
   MOCK_METHOD0(flush, void());
   MOCK_METHOD2(print_status, void(Formatter *, stringstream *));
   MOCK_METHOD2(add_peer, void(const std::string &, librados::IoCtx &));
@@ -192,7 +192,8 @@ TEST_F(TestMockInstanceReplayer, AcquireReleaseImage) {
   EXPECT_CALL(mock_image_replayer, is_stopped()).WillOnce(Return(true));
   EXPECT_CALL(mock_image_replayer, is_blacklisted()).WillOnce(Return(false));
   EXPECT_CALL(mock_image_replayer, is_finished()).WillOnce(Return(false));
-  EXPECT_CALL(mock_image_replayer, start(nullptr, false));
+  EXPECT_CALL(mock_image_replayer, start(_, false))
+    .WillOnce(CompleteContext(0));
   expect_work_queue(mock_threads);
 
   instance_replayer.acquire_image(&mock_instance_watcher, global_image_id,
@@ -261,7 +262,8 @@ TEST_F(TestMockInstanceReplayer, RemoveFinishedImage) {
   EXPECT_CALL(mock_image_replayer, is_stopped()).WillOnce(Return(true));
   EXPECT_CALL(mock_image_replayer, is_blacklisted()).WillOnce(Return(false));
   EXPECT_CALL(mock_image_replayer, is_finished()).WillOnce(Return(false));
-  EXPECT_CALL(mock_image_replayer, start(nullptr, false));
+  EXPECT_CALL(mock_image_replayer, start(_, false))
+    .WillOnce(CompleteContext(0));
   expect_work_queue(mock_threads);
 
   instance_replayer.acquire_image(&mock_instance_watcher, global_image_id,
@@ -332,7 +334,8 @@ TEST_F(TestMockInstanceReplayer, Reacquire) {
   EXPECT_CALL(mock_image_replayer, is_stopped()).WillOnce(Return(true));
   EXPECT_CALL(mock_image_replayer, is_blacklisted()).WillOnce(Return(false));
   EXPECT_CALL(mock_image_replayer, is_finished()).WillOnce(Return(false));
-  EXPECT_CALL(mock_image_replayer, start(nullptr, false));
+  EXPECT_CALL(mock_image_replayer, start(_, false))
+    .WillOnce(CompleteContext(0));
   expect_work_queue(mock_threads);
 
   C_SaferCond on_acquire1;
@@ -342,7 +345,8 @@ TEST_F(TestMockInstanceReplayer, Reacquire) {
 
   // Re-acquire
   EXPECT_CALL(mock_image_replayer, set_finished(false));
-  EXPECT_CALL(mock_image_replayer, restart());
+  EXPECT_CALL(mock_image_replayer, restart(_))
+    .WillOnce(CompleteContext(0));
   expect_work_queue(mock_threads);
 
   C_SaferCond on_acquire2;

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -342,7 +342,7 @@ void ImageReplayer<I>::set_state_description(int r, const std::string &desc) {
 }
 
 template <typename I>
-void ImageReplayer<I>::start(Context *on_finish, bool manual)
+void ImageReplayer<I>::start(Context *on_finish, bool manual, bool restart)
 {
   dout(10) << "on_finish=" << on_finish << dendl;
 
@@ -356,12 +356,16 @@ void ImageReplayer<I>::start(Context *on_finish, bool manual)
       dout(5) << "stopped manually, ignoring start without manual flag"
 	      << dendl;
       r = -EPERM;
+    } else if (restart && !m_restart_requested) {
+      dout(10) << "canceled restart" << dendl;
+      r = -ECANCELED;
     } else {
       m_state = STATE_STARTING;
       m_last_r = 0;
       m_state_desc.clear();
       m_manual_stop = false;
       m_delete_requested = false;
+      m_restart_requested = false;
 
       if (on_finish != nullptr) {
         ceph_assert(m_on_start_finish == nullptr);
@@ -729,11 +733,10 @@ bool ImageReplayer<I>::on_start_interrupted(Mutex& lock) {
 }
 
 template <typename I>
-void ImageReplayer<I>::stop(Context *on_finish, bool manual, int r,
-			    const std::string& desc)
+void ImageReplayer<I>::stop(Context *on_finish, bool manual, bool restart)
 {
   dout(10) << "on_finish=" << on_finish << ", manual=" << manual
-	   << ", desc=" << desc << dendl;
+           << ", restart=" << restart << dendl;
 
   image_replayer::BootstrapRequest<I> *bootstrap_request = nullptr;
   bool shut_down_replay = false;
@@ -741,8 +744,16 @@ void ImageReplayer<I>::stop(Context *on_finish, bool manual, int r,
   {
     Mutex::Locker locker(m_lock);
 
+    if (restart) {
+      m_restart_requested = true;
+    }
+
     if (!is_running_()) {
       running = false;
+      if (!restart && m_restart_requested) {
+        dout(10) << "canceling restart" << dendl;
+        m_restart_requested = false;
+      }
     } else {
       if (!is_stopped_()) {
 	if (m_state == STATE_STARTING) {
@@ -780,7 +791,7 @@ void ImageReplayer<I>::stop(Context *on_finish, bool manual, int r,
   }
 
   if (shut_down_replay) {
-    on_stop_journal_replay(r, desc);
+    on_stop_journal_replay();
   } else if (on_finish != nullptr) {
     on_finish->complete(0);
   }
@@ -842,14 +853,19 @@ void ImageReplayer<I>::handle_replay_ready()
 template <typename I>
 void ImageReplayer<I>::restart(Context *on_finish)
 {
+  {
+    Mutex::Locker locker(m_lock);
+    m_restart_requested = true;
+  }
+
   FunctionContext *ctx = new FunctionContext(
     [this, on_finish](int r) {
       if (r < 0) {
 	// Try start anyway.
       }
-      start(on_finish, true);
+      start(on_finish, true, true);
     });
-  stop(ctx);
+  stop(ctx, false, true);
 }
 
 template <typename I>
@@ -1782,7 +1798,7 @@ void ImageReplayer<I>::handle_remote_journal_metadata_updated() {
 
   if (client.state != cls::journal::CLIENT_STATE_CONNECTED) {
     dout(0) << "client flagged disconnected, stopping image replay" << dendl;
-    stop(nullptr, false, -ENOTCONN, "disconnected");
+    stop(nullptr, false, false);
   }
 }
 

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -639,7 +639,9 @@ template <typename I>
 void ImageReplayer<I>::handle_start_replay(int r) {
   dout(10) << "r=" << r << dendl;
 
-  if (r < 0) {
+  if (on_start_interrupted()) {
+    return;
+  } else if (r < 0) {
     ceph_assert(m_local_replay == nullptr);
     derr << "error starting external replay on local image "
 	 <<  m_local_image_id << ": " << cpp_strerror(r) << dendl;
@@ -664,10 +666,6 @@ void ImageReplayer<I>::handle_start_replay(int r) {
 
   update_mirror_image_status(true, boost::none);
   reschedule_update_status_task(30);
-
-  if (on_replay_interrupted()) {
-    return;
-  }
 
   {
     CephContext *cct = static_cast<CephContext *>(m_local->cct());

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -113,9 +113,10 @@ public:
     return m_global_image_id;
   }
 
-  void start(Context *on_finish = nullptr, bool manual = false);
+  void start(Context *on_finish = nullptr, bool manual = false,
+             bool restart = false);
   void stop(Context *on_finish = nullptr, bool manual = false,
-	    int r = 0, const std::string& desc = "");
+            bool restart = false);
   void restart(Context *on_finish = nullptr);
   void flush();
 
@@ -197,11 +198,11 @@ protected:
    * @endverbatim
    */
 
-  virtual void on_start_fail(int r, const std::string &desc);
-  virtual bool on_start_interrupted();
-  virtual bool on_start_interrupted(Mutex& lock);
+  void on_start_fail(int r, const std::string &desc);
+  bool on_start_interrupted();
+  bool on_start_interrupted(Mutex& lock);
 
-  virtual void on_stop_journal_replay(int r = 0, const std::string &desc = "");
+  void on_stop_journal_replay(int r = 0, const std::string &desc = "");
 
   bool on_replay_interrupted();
 
@@ -292,6 +293,7 @@ private:
   bool m_finished = false;
   bool m_delete_requested = false;
   bool m_resync_requested = false;
+  bool m_restart_requested = false;
 
   image_replayer::EventPreprocessor<ImageCtxT> *m_event_preprocessor = nullptr;
   image_replayer::ReplayStatusFormatter<ImageCtxT> *m_replay_status_formatter =

--- a/src/tools/rbd_mirror/InstanceReplayer.cc
+++ b/src/tools/rbd_mirror/InstanceReplayer.cc
@@ -168,7 +168,7 @@ void InstanceReplayer<I>::acquire_image(InstanceWatcher<I> *instance_watcher,
     // detect if the image has been deleted while the leader was offline
     auto& image_replayer = it->second;
     image_replayer->set_finished(false);
-    image_replayer->restart();
+    image_replayer->restart(new C_TrackedOp(m_async_op_tracker, nullptr));
   }
 
   m_threads->work_queue->queue(on_finish, 0);
@@ -217,7 +217,7 @@ void InstanceReplayer<I>::remove_peer_image(const std::string &global_image_id,
     // it will eventually detect that the peer image is missing and
     // determine if a delete propagation is required.
     auto image_replayer = it->second;
-    image_replayer->restart();
+    image_replayer->restart(new C_TrackedOp(m_async_op_tracker, nullptr));
   }
   m_threads->work_queue->queue(on_finish, 0);
 }
@@ -249,10 +249,15 @@ void InstanceReplayer<I>::start()
 
   m_manual_stop = false;
 
+  auto cct = static_cast<CephContext *>(m_local_rados->cct());
+  auto gather_ctx = new C_Gather(
+    cct, new C_TrackedOp(m_async_op_tracker, nullptr));
   for (auto &kv : m_image_replayers) {
     auto &image_replayer = kv.second;
-    image_replayer->start(nullptr, true);
+    image_replayer->start(gather_ctx->new_sub(), true);
   }
+
+  gather_ctx->activate();
 }
 
 template <typename I>
@@ -260,14 +265,21 @@ void InstanceReplayer<I>::stop()
 {
   dout(10) << dendl;
 
-  Mutex::Locker locker(m_lock);
+  auto cct = static_cast<CephContext *>(m_local_rados->cct());
+  auto gather_ctx = new C_Gather(
+    cct, new C_TrackedOp(m_async_op_tracker, nullptr));
+  {
+    Mutex::Locker locker(m_lock);
 
-  m_manual_stop = true;
+    m_manual_stop = true;
 
-  for (auto &kv : m_image_replayers) {
-    auto &image_replayer = kv.second;
-    image_replayer->stop(nullptr, true);
+    for (auto &kv : m_image_replayers) {
+      auto &image_replayer = kv.second;
+      image_replayer->stop(gather_ctx->new_sub(), true);
+    }
   }
+
+  gather_ctx->activate();
 }
 
 template <typename I>
@@ -281,7 +293,7 @@ void InstanceReplayer<I>::restart()
 
   for (auto &kv : m_image_replayers) {
     auto &image_replayer = kv.second;
-    image_replayer->restart();
+    image_replayer->restart(new C_TrackedOp(m_async_op_tracker, nullptr));
   }
 }
 
@@ -323,7 +335,7 @@ void InstanceReplayer<I>::start_image_replayer(
   }
 
   dout(10) << "global_image_id=" << global_image_id << dendl;
-  image_replayer->start(nullptr, false);
+  image_replayer->start(new C_TrackedOp(m_async_op_tracker, nullptr), false);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/InstanceReplayer.cc
+++ b/src/tools/rbd_mirror/InstanceReplayer.cc
@@ -265,9 +265,9 @@ void InstanceReplayer<I>::stop()
 {
   dout(10) << dendl;
 
+  auto on_finish = new C_TrackedOp(m_async_op_tracker, nullptr);
   auto cct = static_cast<CephContext *>(m_local_rados->cct());
-  auto gather_ctx = new C_Gather(
-    cct, new C_TrackedOp(m_async_op_tracker, nullptr));
+  auto gather_ctx = new C_Gather(cct, on_finish);
   {
     Mutex::Locker locker(m_lock);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45275
backport tracker: https://tracker.ceph.com/issues/45764

---

backport of https://github.com/ceph/ceph/pull/34615
parent tracker: https://tracker.ceph.com/issues/45072

backport of https://github.com/ceph/ceph/pull/3493
parent tracker: https://tracker.ceph.com/issues/45716

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh