### PR TITLE
rgw multisite: remove destination shard id from rgw_bucket_sync_pair_info

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1011,7 +1011,7 @@ public:
       lease_cr(std::move(lease_cr)), sync_pair(_sync_pair), progress(progress),
       status_oid(RGWBucketPipeSyncStatusManager::status_oid(sc->source_zone, sync_pair)),
       tn(sync_env->sync_tracer->add_node(_tn_parent, "bucket",
-                                         SSTR(bucket_shard_str{_sync_pair.dest_bs} << "<-" << bucket_shard_str{_sync_pair.source_bs} ))) {
+                                         SSTR(bucket_str{_sync_pair.dest_bucket} << "<-" << bucket_shard_str{_sync_pair.source_bs} ))) {
   }
 
   int operate(const DoutPrefixProvider *dpp) override;
@@ -2400,7 +2400,7 @@ public:
           }
 
           if (!dest_bucket_perms.verify_bucket_permission(RGW_PERM_WRITE)) {
-            ldout(cct, 0) << "ERROR: " << __func__ << ": permission check failed: user not allowed to write into bucket (bucket=" << sync_pipe.info.dest_bs.bucket.get_key() << ")" << dendl;
+            ldout(cct, 0) << "ERROR: " << __func__ << ": permission check failed: user not allowed to write into bucket (bucket=" << sync_pipe.info.dest_bucket.get_key() << ")" << dendl;
             return -EPERM;
           }
 
@@ -2843,15 +2843,9 @@ RGWRemoteBucketManager::RGWRemoteBucketManager(const DoutPrefixProvider *_dpp,
     auto& sync_pair = sync_pairs[i];
 
     sync_pair.source_bs.bucket = source_bucket_info.bucket;
-    sync_pair.dest_bs.bucket = dest_bucket;
+    sync_pair.dest_bucket = dest_bucket;
 
     sync_pair.source_bs.shard_id = (source_bucket_info.layout.current_index.layout.normal.num_shards > 0 ? cur_shard : -1);
-
-    if (dest_bucket == source_bucket_info.bucket) {
-      sync_pair.dest_bs.shard_id = sync_pair.source_bs.shard_id;
-    } else {
-      sync_pair.dest_bs.shard_id = -1;
-    }
   }
 
   sc.init(sync_env, conn, source_zone);
@@ -3576,7 +3570,7 @@ public:
     data_sync_module = sync_env->sync_module->get_data_handler();
     
     zones_trace = _zones_trace;
-    zones_trace.insert(sync_env->svc->zone->get_zone().id, _sync_pipe.info.dest_bs.get_key());
+    zones_trace.insert(sync_env->svc->zone->get_zone().id, _sync_pipe.info.dest_bucket.get_key());
   }
 
   int operate(const DoutPrefixProvider *dpp) override {
@@ -3747,7 +3741,7 @@ public:
                                          SSTR(bucket_shard_str{bs}))),
       marker_tracker(sc, status_oid, sync_info.full_marker, tn, objv_tracker)
   {
-    zones_trace.insert(sc->source_zone.id, sync_pipe.info.dest_bs.bucket.get_key());
+    zones_trace.insert(sc->source_zone.id, sync_pipe.info.dest_bucket.get_key());
     prefix_handler.set_rules(sync_pipe.get_rules());
   }
 
@@ -3912,7 +3906,7 @@ public:
         << bucket_shard_str{bs};
     set_status("init");
     rules = sync_pipe.get_rules();
-    target_location_key = sync_pipe.info.dest_bs.bucket.get_key();
+    target_location_key = sync_pipe.info.dest_bucket.get_key();
   }
 
   bool check_key_handled(const rgw_obj_key& key) {
@@ -4338,7 +4332,7 @@ int RGWRunBucketSourcesSyncCR::operate(const DoutPrefixProvider *dpp)
         } else {
           sync_pair.source_bs.bucket = siter->source.get_bucket();
         }
-        sync_pair.dest_bs.bucket = siter->target.get_bucket();
+        sync_pair.dest_bucket = siter->target.get_bucket();
 
         sync_pair.handler = siter->handler;
 
@@ -4359,11 +4353,6 @@ int RGWRunBucketSourcesSyncCR::operate(const DoutPrefixProvider *dpp)
          * this affects the crafted status oid
          */
         sync_pair.source_bs.shard_id = (source_num_shards > 0 ? cur_shard : -1);
-        if (source_num_shards == target_num_shards) {
-          sync_pair.dest_bs.shard_id = sync_pair.source_bs.shard_id;
-        } else {
-          sync_pair.dest_bs.shard_id = -1;
-        }
 
         ldpp_dout(dpp, 20) << __func__ << "(): sync_pair=" << sync_pair << dendl;
 
@@ -4702,7 +4691,7 @@ int RGWRunBucketSyncCoroutine::operate(const DoutPrefixProvider *dpp)
       return set_cr_error(retcode);
     }
 
-    yield call(new RGWSyncGetBucketInfoCR(sync_env, sync_pair.dest_bs.bucket, &sync_pipe.dest_bucket_info, 
+    yield call(new RGWSyncGetBucketInfoCR(sync_env, sync_pair.dest_bucket, &sync_pipe.dest_bucket_info,
                                           &sync_pipe.dest_bucket_attrs, tn));
     if (retcode < 0) {
       tn->log(0, SSTR("ERROR: failed to retrieve bucket info for bucket=" << bucket_str{sync_pair.source_bs.bucket}));
@@ -4907,10 +4896,10 @@ std::ostream& RGWBucketPipeSyncStatusManager::gen_prefix(std::ostream& out) cons
 string RGWBucketPipeSyncStatusManager::status_oid(const rgw_zone_id& source_zone,
                                               const rgw_bucket_sync_pair_info& sync_pair)
 {
-  if (sync_pair.source_bs == sync_pair.dest_bs) {
-    return bucket_status_oid_prefix + "." + source_zone.id + ":" + sync_pair.dest_bs.get_key();
+  if (sync_pair.source_bs.bucket == sync_pair.dest_bucket) {
+    return bucket_status_oid_prefix + "." + source_zone.id + ":" + sync_pair.source_bs.get_key();
   } else {
-    return bucket_status_oid_prefix + "." + source_zone.id + ":" + sync_pair.dest_bs.get_key() + ":" + sync_pair.source_bs.get_key();
+    return bucket_status_oid_prefix + "." + source_zone.id + ":" + sync_pair.dest_bucket.get_key() + ":" + sync_pair.source_bs.get_key();
   }
 }
 
@@ -4958,15 +4947,7 @@ class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
   rgw::sal::RadosStore* const store;
   RGWDataSyncCtx *const sc;
   RGWDataSyncEnv *const env;
-  RGWBucketInfo source_bucket_info;
-  RGWBucketInfo dest_bucket_info;
-  rgw_bucket_shard source_bs;
-  rgw_bucket_shard dest_bs;
-
   rgw_bucket_sync_pair_info sync_pair;
-
-  bool shard_to_shard_sync;
-
   using Vector = std::vector<rgw_bucket_shard_sync_info>;
   Vector::iterator i, end;
 
@@ -4977,34 +4958,19 @@ class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
                                Vector *status)
     : RGWShardCollectCR(sc->cct, max_concurrent_shards),
       store(store), sc(sc), env(sc->env),
-      source_bucket_info(source_bucket_info),
-      dest_bucket_info(dest_bucket_info),
       i(status->begin()), end(status->end())
   {
-    shard_to_shard_sync = (source_bucket_info.layout.current_index.layout.normal.num_shards == dest_bucket_info.layout.current_index.layout.normal.num_shards);
-
-    source_bs = rgw_bucket_shard(source_bucket_info.bucket, source_bucket_info.layout.current_index.layout.normal.num_shards > 0 ? 0 : -1);
-    dest_bs = rgw_bucket_shard(dest_bucket_info.bucket, dest_bucket_info.layout.current_index.layout.normal.num_shards > 0 ? 0 : -1);
-
-    status->clear();
-    status->resize(std::max<size_t>(1, source_bucket_info.layout.current_index.layout.normal.num_shards));
-
-    i = status->begin();
-    end = status->end();
+    sync_pair.source_bs = rgw_bucket_shard(source_bucket_info.bucket, source_bucket_info.layout.current_index.layout.normal.num_shards > 0 ? 0 : -1);
+    sync_pair.dest_bucket = dest_bucket_info.bucket;
   }
 
   bool spawn_next() override {
     if (i == end) {
       return false;
     }
-    sync_pair.source_bs = source_bs;
-    sync_pair.dest_bs = dest_bs;
     spawn(new RGWReadBucketPipeSyncStatusCoroutine(sc, sync_pair, &*i, nullptr), false);
     ++i;
-    ++source_bs.shard_id;
-    if (shard_to_shard_sync) {
-      dest_bs.shard_id = source_bs.shard_id;
-    }
+    ++sync_pair.source_bs.shard_id;
     return true;
   }
 };

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -47,19 +47,14 @@ struct rgw_sync_bucket_pipe;
 struct rgw_bucket_sync_pair_info {
   RGWBucketSyncFlowManager::pipe_handler handler; /* responsible for sync filters */
   rgw_bucket_shard source_bs;
-  rgw_bucket_shard dest_bs;
+  rgw_bucket dest_bucket;
 };
 
 inline ostream& operator<<(ostream& out, const rgw_bucket_sync_pair_info& p) {
-  if (p.source_bs.bucket == p.dest_bs.bucket) {
+  if (p.source_bs.bucket == p.dest_bucket) {
     return out << p.source_bs;
   }
-
-  out << p.source_bs;
-
-  out << "->" << p.dest_bs.bucket;
-
-  return out;
+  return out << p.source_bs << "->" << p.dest_bucket;
 }
 
 struct rgw_bucket_sync_pipe {


### PR DESCRIPTION
the sync_pair is used as input to RGWBucketPipeSyncStatusManager::status_oid() to generate the per-shard sync status object names

this sync status tracks incremental bucket sync, which reads changes from a source bucket's bilog shard, and copies objects from the remote source bucket to the local destination bucket

this doesn't require sync to know anything about the destination bucket shards, so rgw_bucket_sync_pair_info and status_oid() now only track the the destination's rgw_bucket instead of rgw_bucket_shard

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
