### PR TITLE
cephadm: validate `--fsid` during bootstrap

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4026,12 +4026,15 @@ def command_bootstrap(ctx):
 
     # initial vars
     fsid = ctx.fsid or make_fsid()
+    if not is_fsid(fsid):
+        raise Error('not an fsid: %s' % fsid)
+    logger.info('Cluster fsid: %s' % fsid)
+
     hostname = get_hostname()
     if '.' in hostname and not ctx.allow_fqdn_hostname:
         raise Error('hostname is a fully qualified domain name (%s); either fix (e.g., "sudo hostname %s" or similar) or pass --allow-fqdn-hostname' % (hostname, hostname.split('.')[0]))
     mon_id = ctx.mon_id or hostname
     mgr_id = ctx.mgr_id or generate_service_id()
-    logger.info('Cluster fsid: %s' % fsid)
 
     lock = FileLock(ctx, fsid)
     lock.acquire()

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1157,3 +1157,24 @@ class TestBootstrap(TestCephAdm):
         with with_cephadm_ctx(cmd, hostname=hostname) as ctx:
             retval = cd.command_bootstrap(ctx)
             assert retval == 0
+
+    @pytest.mark.parametrize('fsid, err',
+        [
+            ('', None),
+            ('00000000-0000-0000-0000-0000deadbeef', None),
+            ('00000000-0000-0000-0000-0000deadbeez', 'not an fsid'),
+        ])
+    def test_fsid(self, fsid, err, cephadm_fs):
+        cmd = self._get_cmd(
+            '--mon-ip', '192.168.1.1',
+            '--skip-mon-network',
+            '--fsid', fsid,
+        )
+
+        with with_cephadm_ctx(cmd) as ctx:
+            if err:
+                with pytest.raises(cd.Error, match=err):
+                    cd.command_bootstrap(ctx)
+            else:
+                retval = cd.command_bootstrap(ctx)
+                assert retval == 0


### PR DESCRIPTION
... instead of waiting for bootstrap to fail during mon create:

```
host1:~ # ~/cephadm bootstrap --mon-ip 192.168.1.1 --fsid x 
This is a development version of cephadm.
For information regarding the latest stable release:
    https://docs.ceph.com/docs/pacific/cephadm/install
Verifying podman|docker is present...
Verifying lvm2 is present...
Verifying time synchronization is in place...
Unit chronyd.service is enabled and running
Repeating the final host check...
podman|docker (/usr/bin/podman) is present
systemctl is present
lvcreate is present
Unit chronyd.service is enabled and running
Host looks OK
Cluster fsid: x
Verifying IP 192.168.1.1 port 3300 ...
Verifying IP 192.168.1.1 port 6789 ...
- internal network (--cluster-network) has not been provided, OSD replication will default to the public_network
Pulling container image quay.ceph.io/ceph-ci/ceph:master...
Ceph version: ceph version 17.0.0-5046-g64281bb3 (64281bb394b31b67b94ee70d0da4eb3c588dae48) quincy (dev)
Extracting ceph user uid/gid from container image...
Creating initial keys...
Creating initial monmap...
Creating mon...
Non-zero exit code 1 from /usr/bin/podman run --rm --ipc=host --stop-signal=SIGTERM --net=host --entrypoint /usr/bin/ceph-mon --init -e CONTAINER_IMAGE=quay.ceph.io/ceph-ci/ceph:master -e NODE_NAME=host1 -e CEPH_USE_RANDOM_NONCE=1 -v /var/log/ceph/x:/var/log/ceph:z -v /var/lib/ceph/x/mon.host1:/var/lib/ceph/mon/ceph-host1:z -v /tmp/ceph-tmpay9r6396:/tmp/keyring:z -v /tmp/ceph-tmpchimx571:/tmp/monmap:z quay.ceph.io/ceph-ci/ceph:master --mkfs -i host1 --fsid x -c /dev/null --monmap /tmp/monmap --keyring /tmp/keyring --setuser ceph --setgroup ceph --default-log-to-file=false --default-log-to-journald=true --default-log-to-stderr=false --default-mon-cluster-log-to-file=false --default-mon-cluster-log-to-journald=true --default-mon-cluster-log-to-stderr=false
/usr/bin/ceph-mon: stderr parse error setting 'fsid' to 'x'
/usr/bin/ceph-mon: stderr 
/usr/bin/ceph-mon: stderr too many arguments: [--monmap,/tmp/monmap,--keyring,/tmp/keyring,--setuser,ceph,--setgroup,ceph,--default-log-to-file=false,--default-log-to-journald=true,--default-log-to-stderr=false,--default-mon-cluster-log-to-file=false,--default-mon-cluster-log-to-journald=true,--default-mon-cluster-log-to-stderr=false]
Traceback (most recent call last):
  File "/root/cephadm", line 8232, in <module>
    main()
  File "/root/cephadm", line 8220, in main
    r = ctx.func(ctx)
  File "/root/cephadm", line 1760, in _default_image
    return func(ctx)
  File "/root/cephadm", line 4070, in command_bootstrap
    prepare_create_mon(ctx, uid, gid, fsid, mon_id,
  File "/root/cephadm", line 3636, in prepare_create_mon
    out = CephContainer(
  File "/root/cephadm", line 3287, in run
    out, _, _ = call_throws(self.ctx, self.run_cmd(),
  File "/root/cephadm", line 1454, in call_throws
    raise RuntimeError('Failed command: %s' % ' '.join(command))
RuntimeError: Failed command: /usr/bin/podman run --rm --ipc=host --stop-signal=SIGTERM --net=host --entrypoint /usr/bin/ceph-mon --init -e CONTAINER_IMAGE=quay.ceph.io/ceph-ci/ceph:master -e NODE_NAME=host1 -e CEPH_USE_RANDOM_NONCE=1 -v /var/log/ceph/x:/var/log/ceph:z -v /var/lib/ceph/x/mon.host1:/var/lib/ceph/mon/ceph-host1:z -v /tmp/ceph-tmpay9r6396:/tmp/keyring:z -v /tmp/ceph-tmpchimx571:/tmp/monmap:z quay.ceph.io/ceph-ci/ceph:master --mkfs -i host1 --fsid x -c /dev/null --monmap /tmp/monmap --keyring /tmp/keyring --setuser ceph --setgroup ceph --default-log-to-file=false --default-log-to-journald=true --default-log-to-stderr=false --default-mon-cluster-log-to-file=false --default-mon-cluster-log-to-journald=true --default-mon-cluster-log-to-stderr=false
```


Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
