### PR TITLE
[RFC] rgw/rgw_cache: implement sharded ObjectCache

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -277,6 +277,21 @@ options:
   see_also:
   - rgw_cache_enabled
   with_legacy: true
+- name: rgw_cache_shard_count
+  type: uint 
+  level: advanced
+  desc: The number of RGW cache shards.
+  long_desc: The number of independent cache shards to use for the rados object gateway.
+    Each cache shard will store up to rgw_cache_lru_size items.
+  fmt_desc: The number of Coph Object Gateway cache shards.
+  default: 4
+  min: 1
+  max: 1024
+  services:
+  - rgw
+  see_also:
+  - rgw_cache_lru_size
+  with_legacy: true
 - name: rgw_dns_name
   type: str
   level: advanced

--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -90,7 +90,7 @@ int ObjectCache::get(const DoutPrefixProvider *dpp, const string& name, ObjectCa
 
 bool ObjectCache::chain_cache_entry(const DoutPrefixProvider *dpp,
                                     std::initializer_list<rgw_cache_entry_info*> cache_info_entries,
-				    RGWChainedCache::Entry *chained_entry)
+				    RGWChainedCache::Entry *chained_entry, const string& key)
 {
   std::lock_guard l(lock);
   if (!enabled) {

--- a/src/rgw/rgw_cache.h
+++ b/src/rgw/rgw_cache.h
@@ -160,7 +160,7 @@ class ObjectCache {
   unsigned long lru_size;
   unsigned long lru_counter;
   unsigned long lru_window;
-  ceph::shared_mutex lock = ceph::make_shared_mutex("ObjectCache");
+  ceph::mutex lock = ceph::make_mutex("ObjectCache");
   CephContext *cct;
 
   vector<RGWChainedCache *> chained_cache;
@@ -187,7 +187,7 @@ public:
 
   template<typename F>
   void for_each(const F& f) {
-    std::shared_lock l{lock};
+    std::lock_guard l(lock);
     if (enabled) {
       auto now  = ceph::coarse_mono_clock::now();
       for (const auto& [name, entry] : cache_map) {

--- a/src/rgw/services/svc_sys_obj_cache.cc
+++ b/src/rgw/services/svc_sys_obj_cache.cc
@@ -481,9 +481,9 @@ void RGWSI_SysObj_Cache::set_enabled(bool status)
 
 bool RGWSI_SysObj_Cache::chain_cache_entry(const DoutPrefixProvider *dpp,
                                            std::initializer_list<rgw_cache_entry_info *> cache_info_entries,
-                                           RGWChainedCache::Entry *chained_entry)
+                                           RGWChainedCache::Entry *chained_entry, const string& key)
 {
-  return cache.chain_cache_entry(dpp, cache_info_entries, chained_entry);
+  return cache.chain_cache_entry(dpp, cache_info_entries, chained_entry, key);
 }
 
 void RGWSI_SysObj_Cache::register_chained_cache(RGWChainedCache *cc)

--- a/src/rgw/services/svc_sys_obj_cache.h
+++ b/src/rgw/services/svc_sys_obj_cache.h
@@ -21,7 +21,7 @@ class RGWSI_SysObj_Cache : public RGWSI_SysObj_Core
   friend class ASocketHandler;
 
   RGWSI_Notify *notify_svc{nullptr};
-  ObjectCache cache;
+  ShardedObjectCache cache;
 
   std::shared_ptr<RGWSI_SysObj_Cache_CB> cb;
 
@@ -106,7 +106,7 @@ public:
 
   bool chain_cache_entry(const DoutPrefixProvider *dpp,
                          std::initializer_list<rgw_cache_entry_info *> cache_info_entries,
-                         RGWChainedCache::Entry *chained_entry);
+                         RGWChainedCache::Entry *chained_entry, const string& key);
   void register_chained_cache(RGWChainedCache *cc);
   void unregister_chained_cache(RGWChainedCache *cc);
 
@@ -198,7 +198,7 @@ public:
     Entry chain_entry(this, key, entry);
 
     /* we need the svc cache to call us under its lock to maintain lock ordering */
-    return svc->chain_cache_entry(dpp, cache_info_entries, &chain_entry);
+    return svc->chain_cache_entry(dpp, cache_info_entries, &chain_entry, key);
   }
 
   void chain_cb(const string& key, void *data) override {


### PR DESCRIPTION
This is a barebones wrapper to shard the RGW ObjectCache after observing significant lock contention in the cache during 4K object put/get/del workloads.  I didn't bother to implement an abstract base class but one could be written easily to cover both the existing cache and the sharded version since they use all of the same public methods.  Anecdotally I didn't notice as much benefit from this as I hoped but I haven't really dug too deeply into test results yet.

FWIW @mattbenjamin may have a much more comprehensive rewrite of the ObjectCache that likely would be superior to this version, but I thought I would create a PR here in case anyone feels it's worth considering.

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
