### PR TITLE
Get rid of TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES environment

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -139,7 +139,10 @@ int main(int argc, const char **argv)
     args, CEPH_ENTITY_TYPE_OSD,
     CODE_ENVIRONMENT_DAEMON, 0);
   ceph_heap_profiler_init();
-
+  uint64_t max_threadcache_bytes = g_conf().get_val<Option::size_t>("osd_memory_thread_cache_bytes");
+  if (max_threadcache_bytes != 0) {
+    ceph_heap_set_numeric_property("tcmalloc.max_total_thread_cache_bytes", max_threadcache_bytes);
+  }
   Preforker forker;
 
   // osd specific args

--- a/src/common/PriorityCache.cc
+++ b/src/common/PriorityCache.cc
@@ -92,6 +92,14 @@ namespace PriorityCache
               "aggregate bytes in use by the heap", "h",
               PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
 
+    b.add_u64(MallocStats::M_MAX_THREADCACHE_BYTES, "max_threadcache_bytes",
+              "current tcmalloc.max_total_thread_cache_bytes", "m_tc",
+              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+
+    b.add_u64(MallocStats::M_CURR_THREADCACHE_BYTES, "current_threadcache_bytes",
+              "current tcmalloc.current_total_thread_cache_bytes", "c_tc",
+              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+
     b.add_u64(MallocStats::M_CACHE_BYTES, "cache_bytes",
               "current memory available for caches.", "c",
               PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
@@ -114,10 +122,13 @@ namespace PriorityCache
     size_t heap_size = 0;
     size_t unmapped = 0;
     uint64_t mapped = 0;
-
+    size_t max_threadcache_size = 0;
+    size_t curr_threadcache_size = 0;
     ceph_heap_release_free_memory();
     ceph_heap_get_numeric_property("generic.heap_size", &heap_size);
     ceph_heap_get_numeric_property("tcmalloc.pageheap_unmapped_bytes", &unmapped);
+    ceph_heap_get_numeric_property("tcmalloc.max_total_thread_cache_bytes", &max_threadcache_size);
+    ceph_heap_get_numeric_property("tcmalloc.current_total_thread_cache_bytes", &curr_threadcache_size);
     mapped = heap_size - unmapped;
 
     uint64_t new_size = tuned_mem;
@@ -147,6 +158,8 @@ namespace PriorityCache
     logger->set(MallocStats::M_MAPPED_BYTES, mapped);
     logger->set(MallocStats::M_UNMAPPED_BYTES, unmapped);
     logger->set(MallocStats::M_HEAP_BYTES, heap_size);
+    logger->set(MallocStats::M_MAX_THREADCACHE_BYTES, max_threadcache_size);
+    logger->set(MallocStats::M_CURR_THREADCACHE_BYTES, curr_threadcache_size);
     logger->set(MallocStats::M_CACHE_BYTES, new_size);
   }
 

--- a/src/common/PriorityCache.h
+++ b/src/common/PriorityCache.h
@@ -34,6 +34,8 @@ namespace PriorityCache {
     M_MAPPED_BYTES,
     M_UNMAPPED_BYTES,
     M_HEAP_BYTES,
+    M_MAX_THREADCACHE_BYTES,
+    M_CURR_THREADCACHE_BYTES,
     M_CACHE_BYTES,
     M_LAST,
   };

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3682,6 +3682,29 @@ options:
   min: 896_M
   flags:
   - runtime
+- name: osd_memory_thread_cache_bytes
+  type: size
+  level: basic
+  desc: When tcmalloc is enabled it specifies thread cache size
+  long_desc: Sets tcmalloc.max_total_thread_cache_bytes value.
+    If set this will override settings privided via environment variable
+    TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES.
+  fmt_desc: TCMalloc assigns each thread a thread-local cache.
+    Small allocations are satisfied from the thread-local cache.
+    Objects are moved from central data structures into a thread-local cache as needed,
+    and periodic garbage collections are used to migrate memory back from
+    a thread-local cache into the central data structures.
+    Programs with intensive use of dynamic memory for thread-local, short-lived objects
+    do benefit greately from having large cache.
+    TCMalloc default - 32_M. TCMalloc minimum - 512_K. Recommended for OSD - 128_M.
+  default: 0
+  see_also:
+  - bluestore_cache_autotune
+  - osd_memory_cache_min
+  - osd_memory_base
+  - osd_memory_target_autotune
+  flags:
+  - startup
 - name: osd_memory_target_autotune
   type: bool
   default: false


### PR DESCRIPTION
Now instead of giving TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES
one can set "osd memory thread cache bytes" and get it done.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
