### PR TITLE
mgr/dashboard: bucket details: show lock retention period only in days

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html
@@ -121,11 +121,6 @@
               class="bold">Days</td>
           <td>{{ selection.lock_retention_period_days }}</td>
         </tr>
-        <tr>
-          <td i18n
-              class="bold">Years</td>
-          <td>{{ selection.lock_retention_period_years }}</td>
-        </tr>
       </ng-container>
     </tbody>
   </table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.ts
@@ -16,6 +16,7 @@ export class RgwBucketDetailsComponent implements OnChanges {
   ngOnChanges() {
     if (this.selection) {
       this.rgwBucketService.get(this.selection.bid).subscribe((bucket: object) => {
+        bucket['lock_retention_period_days'] = this.rgwBucketService.getLockDays(bucket);
         this.selection = bucket;
       });
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
@@ -372,10 +372,5 @@ describe('RgwBucketFormComponent', () => {
     it('should have valid values [2]', () => {
       expectValidLockInputs(false, 'Compliance', '2');
     });
-
-    it('should convert retention years to days', () => {
-      expect(component['getLockDays']({ lock_retention_period_years: 1000 })).toBe(365242);
-      expect(component['getLockDays']({ lock_retention_period_days: 5 })).toBe(5);
-    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -132,7 +132,7 @@ export class RgwBucketFormComponent extends CdForm implements OnInit {
           // the Angular react framework will throw an error if there is no
           // field for a given key.
           let value: object = _.pick(bidResp, _.keys(defaults));
-          value['lock_retention_period_days'] = this.getLockDays(bidResp);
+          value['lock_retention_period_days'] = this.rgwBucketService.getLockDays(bidResp);
           value['placement-target'] = bidResp['placement_rule'];
           value['versioning'] = bidResp['versioning'] === RgwBucketVersioning.ENABLED;
           value['mfa-delete'] = bidResp['mfa_delete'] === RgwBucketMfaDelete.ENABLED;
@@ -357,13 +357,5 @@ export class RgwBucketFormComponent extends CdForm implements OnInit {
 
   getMfaDeleteStatus() {
     return this.isMfaDeleteEnabled ? RgwBucketMfaDelete.ENABLED : RgwBucketMfaDelete.DISABLED;
-  }
-
-  private getLockDays(bucketData: object): number {
-    if (bucketData['lock_retention_period_years'] > 0) {
-      return Math.floor(bucketData['lock_retention_period_years'] * 365.242);
-    }
-
-    return bucketData['lock_retention_period_days'];
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
@@ -85,4 +85,10 @@ describe('RgwBucketService', () => {
     req.flush(['foo', 'bar']);
     expect(result).toBe(true);
   });
+
+  it('should convert lock retention period to days', () => {
+    expect(service.getLockDays({ lock_retention_period_years: 1000 })).toBe(365242);
+    expect(service.getLockDays({ lock_retention_period_days: 5 })).toBe(5);
+    expect(service.getLockDays({})).toBe(0);
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
@@ -108,4 +108,12 @@ export class RgwBucketService {
       })
     );
   }
+
+  getLockDays(bucketData: object): number {
+    if (bucketData['lock_retention_period_years'] > 0) {
+      return Math.floor(bucketData['lock_retention_period_years'] * 365.242);
+    }
+
+    return bucketData['lock_retention_period_days'] || 0;
+  }
 }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/51164
Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
