### PR TITLE
cephadm: expose gather-facts api method

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1491,6 +1491,19 @@ Then run the following:
         return list(self.inventory.all_specs())
 
     @handle_orch_error
+    def get_facts(self, hostname: Optional[str] = None) -> List[Dict[str, Any]]:
+        """
+        Return a list of hosts metadata(gather_facts) managed by the orchestrator.
+
+        Notes:
+          - skip async: manager reads from cache.
+        """
+        if hostname:
+            return [self.cache.get_facts(hostname)]
+
+        return [self.cache.get_facts(hostname) for hostname in self.cache.get_hosts()]
+
+    @handle_orch_error
     def add_host_label(self, host: str, label: str) -> str:
         self.inventory.add_label(host, label)
         self.log.info('Added label %s to host %s' % (label, host))

--- a/src/pybind/mgr/cephadm/tests/test_facts.py
+++ b/src/pybind/mgr/cephadm/tests/test_facts.py
@@ -1,0 +1,12 @@
+import pytest
+
+from ..inventory import HostCache
+from ..import CephadmOrchestrator
+
+
+@pytest.fixture()
+def test_facts():
+    facts = {'node-1.ceph.com', {'bios_version': 'F2', 'cpu_cores': 16}}
+    HostCache.facts = facts
+    ret_facts = CephadmOrchestrator.get_facts('node-1.ceph.com')
+    assert ret_facts == [{'bios_version': 'F2', 'cpu_cores': 16}]

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -63,6 +63,10 @@ class HostManger(ResourceManager):
         return hosts[0] if hosts else None
 
     @wait_api_result
+    def get_facts(self, hostname: Optional[str] = None) -> List[Dict[str, Any]]:
+        return self.api.get_facts(hostname)
+
+    @wait_api_result
     def add(self, hostname: str, addr: str, labels: List[str], status: str):
         return self.api.add_host(HostSpec(hostname, addr=addr, labels=labels, status=status))
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -368,6 +368,12 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def get_facts(self, hostname: Optional[str] = None) -> OrchResult[List[Dict[str, Any]]]:
+        """
+        Return hosts metadata(gather_facts).
+        """
+        raise NotImplementedError()
+
     def add_host_label(self, host: str, label: str) -> OrchResult[str]:
         """
         Add a host label


### PR DESCRIPTION
This PR intends to expose host metadata(gather-facts) api method

Fixes: https://tracker.ceph.com/issues/51209

Signed-off-by: Avan Thakkar <athakkar@redhat.com>
Signed-off-by: Aashish Sharma <aasharma@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
