### PR TITLE
pacific: .github/labeler: add api-change label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,6 @@
+api-change:
+  - src/pybind/mgr/dashboard/openapi.yaml
+
 build/ops:
   - "**/CMakeLists.txt"
   - admin/**


### PR DESCRIPTION
Backport of #41407. Only needed in Pacific to ensure API stability commitment starting by Pacific release.

To flag PRs changing the Ceph REST API. It might also work for another
APIs.

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>
(cherry picked from commit 756d4b18aa9cb8590d2edb92de803b8f589247df)