### PR TITLE
install-deph.sh: install missing libarchive centos-8

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -361,6 +361,7 @@ else
     centos|fedora|rhel|ol|virtuozzo)
         builddepcmd="dnf -y builddep --allowerasing"
         echo "Using dnf to install dependencies"
+	$SUDO dnf install -y libarchive
         case "$ID" in
             fedora)
                 $SUDO dnf install -y dnf-utils


### PR DESCRIPTION
When trying to build ceph from ceph-dev (centos 8) and also on my fedora 33 machine I ran into this error:
```bash
+ cmake -GNinja -DWITH_PYTHON3=3.6 -DWITH_CCACHE=ON -DBOOST_J=10 -D ENABLE_GIT_VERSION=OFF ..
cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd

```

it was solved installing the libarchive dependency.
Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
