### PR TITLE
cephadm: raise Error() when unable to bind to an ip

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3501,19 +3501,21 @@ def prepare_mon_addresses(
     if not ctx.skip_mon_network:
         # make sure IP is configured locally, and then figure out the
         # CIDR network
+        errmsg = f'Cannot infer CIDR network for mon IP `{base_ip}`'
         for net, ifaces in list_networks(ctx).items():
             ips: List[str] = []
             for iface, ls in ifaces.items():
                 ips.extend(ls)
-            if ipaddress.ip_address(unwrap_ipv6(base_ip)) in \
-                    [ipaddress.ip_address(ip) for ip in ips]:
-                mon_network = net
-                logger.info('Mon IP %s is in CIDR network %s' % (base_ip,
-                                                                 mon_network))
-                break
+            try:
+                if ipaddress.ip_address(unwrap_ipv6(base_ip)) in \
+                        [ipaddress.ip_address(ip) for ip in ips]:
+                    mon_network = net
+                    logger.info(f'Mon IP `{base_ip}` is in CIDR network `{mon_network}`')
+                    break
+            except ValueError as e:
+                logger.warning(f'{errmsg}: {e}')
         if not mon_network:
-            raise Error('Failed to infer CIDR network for mon ip %s; pass '
-                        '--skip-mon-network to configure it later' % base_ip)
+            raise Error(f'{errmsg}: pass --skip-mon-network to configure it later')
 
     return (addr_arg, ipv6, mon_network)
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1008,13 +1008,15 @@ def attempt_bind(ctx, s, address, port):
     try:
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         s.bind((address, port))
-    except (socket.error, OSError) as e:  # py2 and py3
+    except OSError as e:
         if e.errno == errno.EADDRINUSE:
             msg = 'Cannot bind to IP %s port %d: %s' % (address, port, e)
             logger.warning(msg)
             raise PortOccupiedError(msg)
         else:
-            raise e
+            raise Error(e)
+    except Exception as e:
+        raise Error(e)
     finally:
         s.close()
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1024,7 +1024,7 @@ class TestMonitoring(object):
         assert mock.call().__enter__().write('bar') in _open.mock_calls
 
 
-class TestBootstrap(TestCephAdm):
+class TestBootstrap(object):
 
     @staticmethod
     def _get_cmd(*args):

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -54,8 +54,8 @@ class TestCephAdm(object):
 
         for side_effect, expected_exception in (
             (os_error(errno.EADDRINUSE), cd.PortOccupiedError),
-            (os_error(errno.EAFNOSUPPORT), OSError),
-            (os_error(errno.EADDRNOTAVAIL), OSError),
+            (os_error(errno.EAFNOSUPPORT), cd.Error),
+            (os_error(errno.EADDRNOTAVAIL), cd.Error),
             (None, None),
         ):
             _socket = mock.Mock()
@@ -122,8 +122,8 @@ class TestCephAdm(object):
         ):
             for side_effect, expected_exception in (
                 (os_error(errno.EADDRINUSE), cd.PortOccupiedError),
-                (os_error(errno.EADDRNOTAVAIL), OSError),
-                (os_error(errno.EAFNOSUPPORT), OSError),
+                (os_error(errno.EADDRNOTAVAIL), cd.Error),
+                (os_error(errno.EAFNOSUPPORT), cd.Error),
                 (None, None),
             ):
                 mock_socket_obj = mock.Mock()

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1065,7 +1065,7 @@ class TestBootstrap(object):
         cmd = self._get_cmd('--mon-ip', '192.168.1.1')
 
         with with_cephadm_ctx(cmd, list_networks={}) as ctx:
-            msg = r'Failed to infer CIDR network'
+            msg = r'--skip-mon-network'
             with pytest.raises(cd.Error, match=msg):
                 cd.command_bootstrap(ctx)
 
@@ -1132,8 +1132,8 @@ class TestBootstrap(object):
     def test_mon_ip(self, mon_ip, list_networks, result, cephadm_fs):
         cmd = self._get_cmd('--mon-ip', mon_ip)
         if not result:
-            with with_cephadm_ctx(cmd, list_networks={}) as ctx:
-                msg = r'Failed to infer CIDR network'
+            with with_cephadm_ctx(cmd, list_networks=list_networks) as ctx:
+                msg = r'--skip-mon-network'
                 with pytest.raises(cd.Error, match=msg):
                     cd.command_bootstrap(ctx)
         else:


### PR DESCRIPTION
... instead of `socket.gaierror` when passed an invalid mon IP:

```
host1:~ # ~/cephadm bootstrap --mon-ip eth0                                    
This is a development version of cephadm.
For information regarding the latest stable release:
    https://docs.ceph.com/docs/pacific/cephadm/install
Verifying podman|docker is present...
Verifying lvm2 is present...
Verifying time synchronization is in place...
Unit chronyd.service is enabled and running
Repeating the final host check...
podman|docker (/usr/bin/podman) is present
systemctl is present
lvcreate is present
Unit chronyd.service is enabled and running
Host looks OK
Cluster fsid: 3bdbc1be-ca65-11eb-91f4-3214b45e364b
Address: eth0 is not a valid IP address
Verifying IP eth0 port 3300 ...
Address: eth0 is not a valid IP address
Traceback (most recent call last):
  File "/root/cephadm", line 8230, in <module>
    main()
  File "/root/cephadm", line 8218, in main
    r = ctx.func(ctx)
  File "/root/cephadm", line 1758, in _default_image
    return func(ctx)
  File "/root/cephadm", line 4039, in command_bootstrap
    (addr_arg, ipv6, mon_network) = prepare_mon_addresses(ctx)
  File "/root/cephadm", line 3476, in prepare_mon_addresses
    check_ip_port(ctx, ctx.mon_ip, 3300)
  File "/root/cephadm", line 1057, in check_ip_port
    attempt_bind(ctx, s, ip, port)
  File "/root/cephadm", line 1017, in attempt_bind
    raise e
  File "/root/cephadm", line 1010, in attempt_bind
    s.bind((address, port))
socket.gaierror: [Errno -2] Name or service not known
```

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
