### PR TITLE
os/bluestore/AvlAllocator: specialize _block_picker() and cleanups

### DIFF
--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -266,10 +266,7 @@ int AvlAllocator::_allocate(
        * not guarantee that other allocations sizes may exist in the same
        * region.
        */
-      uint64_t align = size & -size;
-      ceph_assert(align != 0);
-      uint64_t* cursor = &lbas[cbits(align) - 1];
-
+      uint64_t* cursor = &lbas[cbits(size) - 1];
       start = _pick_block_after(cursor, size, unit);
       dout(20) << __func__ << " first fit=" << start << " size=" << size << dendl;
       if (start != uint64_t(-1ULL)) {

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -339,12 +339,7 @@ AvlAllocator::AvlAllocator(CephContext* cct,
 			   int64_t device_size,
 			   int64_t block_size,
 			   std::string_view name) :
-  Allocator(name, device_size, block_size),
-  range_size_alloc_threshold(
-    cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_threshold")),
-  range_size_alloc_free_pct(
-    cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_free_pct")),
-  cct(cct)
+  AvlAllocator(cct, device_size, block_size, 0 /* max_mem */, name)
 {}
 
 AvlAllocator::~AvlAllocator()

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -92,8 +92,14 @@ public:
   void shutdown() override;
 
 private:
-  template<class Tree>
-  uint64_t _block_picker(const Tree& t, uint64_t *cursor, uint64_t size,
+  // pick a range by search from cursor forward
+  uint64_t _pick_block_after(
+    uint64_t *cursor,
+    uint64_t size,
+    uint64_t align);
+  // pick a range with exactly the same size or larger
+  uint64_t _pick_block_fits(
+    uint64_t size,
     uint64_t align);
   int _allocate(
     uint64_t size,


### PR DESCRIPTION
this change is a spin-off of #41615.

i think it is still an improvement without the `bluestore_avl_alloc_ff_max*` options which could be controversial. these changes are extracted out into a separate change, so they can be merged sooner. 

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
