### PR TITLE
rgw/amqp: remove the explicit "disconnect()" interface

### DIFF
--- a/src/rgw/rgw_amqp.h
+++ b/src/rgw/rgw_amqp.h
@@ -72,8 +72,5 @@ size_t get_max_inflight();
 // maximum number of messages in the queue
 size_t get_max_queue();
 
-// disconnect from an amqp broker
-bool disconnect(connection_ptr_t& conn);
-
 }
 

--- a/src/test/rgw/amqp_url.c
+++ b/src/test/rgw/amqp_url.c
@@ -118,6 +118,8 @@ int amqp_parse_url(char *url, struct amqp_connection_info *parsed) {
 
   amqp_default_connection_info(parsed);
 
+  parsed->port = 5672;
+  parsed->ssl = 0;
   /* check the prefix */
   if (!strncmp(url, "amqp://", 7)) {
     /* do nothing */


### PR DESCRIPTION
note that the removed interface is not used in RGW code.
and that connection cleanup should be done based on idleness and
not on explicit disconnect. see: https://tracker.ceph.com/issues/49033
    
Fixes: https://tracker.ceph.com/issues/51114

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
