### PR TITLE
octopus: rbd: retrieve global config overrides from the MONs

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -137,6 +137,14 @@ int MonClient::get_monmap_and_config()
     }
   });
 
+  want_bootstrap_config = true;
+  auto shutdown_config = make_scope_guard([this] {
+    std::unique_lock l(monc_lock);
+    want_bootstrap_config = false;
+    bootstrap_config.reset();
+  });
+
+  ceph::ref_t<MConfig> config;
   while (tries-- > 0) {
     r = init();
     if (r < 0) {
@@ -160,7 +168,7 @@ int MonClient::get_monmap_and_config()
 	r = 0;
 	break;
       }
-      while ((!got_config || monmap.get_epoch() == 0) && r == 0) {
+      while ((!bootstrap_config || monmap.get_epoch() == 0) && r == 0) {
 	ldout(cct,20) << __func__ << " waiting for monmap|config" << dendl;
 	auto status = map_cond.wait_for(l, ceph::make_timespan(
 	    cct->_conf->mon_client_hunt_interval));
@@ -168,8 +176,10 @@ int MonClient::get_monmap_and_config()
 	  r = -ETIMEDOUT;
 	}
       }
-      if (got_config) {
+
+      if (bootstrap_config) {
 	ldout(cct,10) << __func__ << " success" << dendl;
+	config = std::move(bootstrap_config);
 	r = 0;
 	break;
       }
@@ -177,6 +187,12 @@ int MonClient::get_monmap_and_config()
     lderr(cct) << __func__ << " failed to get config" << dendl;
     shutdown();
     continue;
+  }
+
+  if (config) {
+    // apply the bootstrap config to ensure its applied prior to completing
+    // the bootstrap
+    cct->_conf.set_mon_vals(cct, config->config, config_cb);
   }
 
   shutdown();
@@ -437,6 +453,15 @@ void MonClient::handle_monmap(MMonMap *m)
 void MonClient::handle_config(MConfig *m)
 {
   ldout(cct,10) << __func__ << " " << *m << dendl;
+
+  if (want_bootstrap_config) {
+    // get_monmap_and_config is waiting for config which it will apply
+    // synchronously
+    bootstrap_config = ceph::ref_t<MConfig>(m, false);
+    map_cond.notify_all();
+    return;
+  }
+
   finisher.queue(new LambdaContext([this, m](int r) {
 	cct->_conf.set_mon_vals(cct, m->config, config_cb);
 	if (config_notify_cb) {
@@ -444,8 +469,6 @@ void MonClient::handle_config(MConfig *m)
 	}
 	m->put();
       }));
-  got_config = true;
-  map_cond.notify_all();
 }
 
 // ----------------------

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -290,7 +290,9 @@ private:
   bool want_monmap;
   ceph::condition_variable map_cond;
   bool passthrough_monmap = false;
-  bool got_config = false;
+
+  bool want_bootstrap_config = false;
+  ceph::ref_t<MConfig> bootstrap_config;
 
   // authenticate
   std::unique_ptr<AuthClientHandler> auth;

--- a/src/tools/rbd/Schedule.cc
+++ b/src/tools/rbd/Schedule.cc
@@ -95,8 +95,6 @@ int get_level_spec_args(const po::variables_map &vm,
 
     if (vm.count(at::POOL_NAME)) {
       pool_name = vm[at::POOL_NAME].as<std::string>();
-    } else if (pool_name.empty()) {
-      pool_name = utils::get_default_pool_name();
     }
 
     if (vm.count(at::NAMESPACE_NAME)) {
@@ -118,8 +116,6 @@ int get_level_spec_args(const po::variables_map &vm,
 
     if (vm.count(at::POOL_NAME)) {
       pool_name = vm[at::POOL_NAME].as<std::string>();
-    } else {
-      pool_name = utils::get_default_pool_name();
     }
 
     namespace_name = vm[at::NAMESPACE_NAME].as<std::string>();
@@ -140,6 +136,20 @@ int get_level_spec_args(const po::variables_map &vm,
   (*args)["level_spec"] = "";
 
   return 0;
+}
+
+void normalize_level_spec_args(std::map<std::string, std::string> *args) {
+  std::map<std::string, std::string> raw_args;
+  std::swap(raw_args, *args);
+
+  auto default_pool_name = utils::get_default_pool_name();
+  for (auto [key, value] : raw_args) {
+    if (key == "level_spec" && !value.empty() && value[0] == '/') {
+      value = default_pool_name + value;
+    }
+
+    (*args)[key] = value;
+  }
 }
 
 void add_schedule_options(po::options_description *positional) {

--- a/src/tools/rbd/Schedule.h
+++ b/src/tools/rbd/Schedule.h
@@ -20,6 +20,8 @@ void add_level_spec_options(
   boost::program_options::options_description *options, bool allow_image=true);
 int get_level_spec_args(const boost::program_options::variables_map &vm,
                         std::map<std::string, std::string> *args);
+void normalize_level_spec_args(std::map<std::string, std::string> *args);
+
 void add_schedule_options(
   boost::program_options::options_description *positional);
 int get_schedule_args(const boost::program_options::variables_map &vm,

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -661,7 +661,6 @@ int get_formatter(const po::variables_map &vm,
 void init_context() {
   g_conf().set_val_or_die("rbd_cache_writethrough_until_flush", "false");
   g_conf().apply_changes(nullptr);
-  common_init_finish(g_ceph_context);
 }
 
 int init_rados(librados::Rados *rados) {

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -183,6 +183,12 @@ std::string get_positional_argument(const po::variables_map &vm, size_t index) {
   return "";
 }
 
+void normalize_pool_name(std::string* pool_name) {
+  if (pool_name->empty()) {
+    *pool_name = get_default_pool_name();
+  }
+}
+
 std::string get_default_pool_name() {
   return g_ceph_context->_conf.get_val<std::string>("rbd_default_pool");
 }
@@ -209,10 +215,6 @@ int get_pool_and_namespace_names(
       }
       ++(*arg_index);
     }
-  }
-
-  if (default_empty_pool_name && pool_name->empty()) {
-    *pool_name = get_default_pool_name();
   }
 
   if (!g_ceph_context->_conf.get_val<bool>("rbd_validate_names")) {
@@ -259,10 +261,6 @@ int get_pool_image_id(const po::variables_map &vm,
         return r;
       }
     }
-  }
-
-  if (pool_name != nullptr && pool_name->empty()) {
-    *pool_name = get_default_pool_name();
   }
 
   if (image_id != nullptr && image_id->empty()) {
@@ -350,10 +348,6 @@ int get_pool_generic_snapshot_names(const po::variables_map &vm,
     }
   }
 
-  if (pool_name != nullptr && pool_name->empty()) {
-    *pool_name = get_default_pool_name();
-  }
-
   if (generic_name != nullptr && generic_name_required &&
       generic_name->empty()) {
     std::string prefix = at::get_description_prefix(mod);
@@ -363,7 +357,7 @@ int get_pool_generic_snapshot_names(const po::variables_map &vm,
     return -EINVAL;
   }
 
-  std::regex pattern("^[^@/]+?$");
+  std::regex pattern("^[^@/]*?$");
   if (spec_validation == SPEC_VALIDATION_FULL) {
     // validate pool name while creating/renaming/copying/cloning/importing/etc
     if ((pool_name != nullptr) && !std::regex_match (*pool_name, pattern)) {
@@ -697,8 +691,10 @@ int init(const std::string &pool_name, const std::string& namespace_name,
   return 0;
 }
 
-int init_io_ctx(librados::Rados &rados, const std::string &pool_name,
+int init_io_ctx(librados::Rados &rados, std::string pool_name,
                 const std::string& namespace_name, librados::IoCtx *io_ctx) {
+  normalize_pool_name(&pool_name);
+
   int r = rados.ioctx_create(pool_name.c_str(), *io_ctx);
   if (r < 0) {
     if (r == -ENOENT && pool_name == get_default_pool_name()) {

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -445,8 +445,6 @@ int get_image_options(const boost::program_options::variables_map &vm,
   if (vm.count(at::IMAGE_FEATURES)) {
     features = vm[at::IMAGE_FEATURES].as<uint64_t>();
     features_specified = true;
-  } else {
-    features = get_rbd_default_features(g_ceph_context);
   }
 
   if (vm.count(at::IMAGE_STRIPE_UNIT)) {

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -99,7 +99,9 @@ int extract_spec(const std::string &spec, std::string *pool_name,
 std::string get_positional_argument(
     const boost::program_options::variables_map &vm, size_t index);
 
+void normalize_pool_name(std::string* pool_name);
 std::string get_default_pool_name();
+
 int get_pool_and_namespace_names(
     const boost::program_options::variables_map &vm,
     bool default_empty_pool_name, bool validate_pool_name,
@@ -154,9 +156,9 @@ void init_context();
 
 int init_rados(librados::Rados *rados);
 
-int init(const std::string &pool_name, const std::string& namespace_name,
+int init(const std::string& pool_name, const std::string& namespace_name,
          librados::Rados *rados, librados::IoCtx *io_ctx);
-int init_io_ctx(librados::Rados &rados, const std::string &pool_name,
+int init_io_ctx(librados::Rados &rados, std::string pool_name,
                 const std::string& namespace_name, librados::IoCtx *io_ctx);
 int set_namespace(const std::string& namespace_name, librados::IoCtx *io_ctx);
 

--- a/src/tools/rbd/action/Kernel.cc
+++ b/src/tools/rbd/action/Kernel.cc
@@ -27,11 +27,7 @@ namespace kernel {
 namespace at = argument_types;
 namespace po = boost::program_options;
 
-namespace {
-
-std::map<std::string, std::string> map_options; // used for both map and unmap
-
-} // anonymous namespace
+typedef std::map<std::string, std::string> MapOptions;
 
 static std::string map_option_uuid_cb(const char *value_char)
 {
@@ -97,13 +93,15 @@ static std::string map_option_ms_mode_cb(const char *value_char)
   return "";
 }
 
-static void put_map_option(const std::string &key, const std::string &val)
+static void put_map_option(const std::string &key, const std::string &val,
+                           MapOptions* map_options)
 {
-  map_options[key] = val;
+  (*map_options)[key] = val;
 }
 
 static int put_map_option_value(const std::string &opt, const char *value_char,
-                                std::string (*parse_cb)(const char *))
+                                std::string (*parse_cb)(const char *),
+                                MapOptions* map_options)
 {
   if (!value_char || *value_char == '\0') {
     std::cerr << "rbd: " << opt << " option requires a value" << std::endl;
@@ -117,11 +115,12 @@ static int put_map_option_value(const std::string &opt, const char *value_char,
     return -EINVAL;
   }
 
-  put_map_option(opt, opt + "=" + value);
+  put_map_option(opt, opt + "=" + value, map_options);
   return 0;
 }
 
-static int parse_map_options(const std::string &options_string)
+static int parse_map_options(const std::string &options_string,
+                             MapOptions* map_options)
 {
   char *options = strdup(options_string.c_str());
   BOOST_SCOPE_EXIT(options) {
@@ -137,72 +136,82 @@ static int parse_map_options(const std::string &options_string)
       *value_char++ = '\0';
 
     if (!strcmp(this_char, "fsid")) {
-      if (put_map_option_value("fsid", value_char, map_option_uuid_cb))
+      if (put_map_option_value("fsid", value_char, map_option_uuid_cb,
+                               map_options))
         return -EINVAL;
     } else if (!strcmp(this_char, "ip")) {
-      if (put_map_option_value("ip", value_char, map_option_ip_cb))
+      if (put_map_option_value("ip", value_char, map_option_ip_cb,
+                               map_options))
         return -EINVAL;
     } else if (!strcmp(this_char, "share") || !strcmp(this_char, "noshare")) {
-      put_map_option("share", this_char);
+      put_map_option("share", this_char, map_options);
     } else if (!strcmp(this_char, "crc") || !strcmp(this_char, "nocrc")) {
-      put_map_option("crc", this_char);
+      put_map_option("crc", this_char, map_options);
     } else if (!strcmp(this_char, "cephx_require_signatures") ||
                !strcmp(this_char, "nocephx_require_signatures")) {
-      put_map_option("cephx_require_signatures", this_char);
+      put_map_option("cephx_require_signatures", this_char, map_options);
     } else if (!strcmp(this_char, "tcp_nodelay") ||
                !strcmp(this_char, "notcp_nodelay")) {
-      put_map_option("tcp_nodelay", this_char);
+      put_map_option("tcp_nodelay", this_char, map_options);
     } else if (!strcmp(this_char, "cephx_sign_messages") ||
                !strcmp(this_char, "nocephx_sign_messages")) {
-      put_map_option("cephx_sign_messages", this_char);
+      put_map_option("cephx_sign_messages", this_char, map_options);
     } else if (!strcmp(this_char, "mount_timeout")) {
-      if (put_map_option_value("mount_timeout", value_char, map_option_int_cb))
+      if (put_map_option_value("mount_timeout", value_char, map_option_int_cb,
+                               map_options))
         return -EINVAL;
     } else if (!strcmp(this_char, "osd_request_timeout")) {
-      if (put_map_option_value("osd_request_timeout", value_char, map_option_int_cb))
+      if (put_map_option_value("osd_request_timeout", value_char,
+                               map_option_int_cb, map_options))
         return -EINVAL;
     } else if (!strcmp(this_char, "lock_timeout")) {
-      if (put_map_option_value("lock_timeout", value_char, map_option_int_cb))
+      if (put_map_option_value("lock_timeout", value_char, map_option_int_cb,
+                               map_options))
         return -EINVAL;
     } else if (!strcmp(this_char, "osdkeepalive")) {
-      if (put_map_option_value("osdkeepalive", value_char, map_option_int_cb))
+      if (put_map_option_value("osdkeepalive", value_char, map_option_int_cb,
+                               map_options))
         return -EINVAL;
     } else if (!strcmp(this_char, "osd_idle_ttl")) {
-      if (put_map_option_value("osd_idle_ttl", value_char, map_option_int_cb))
+      if (put_map_option_value("osd_idle_ttl", value_char, map_option_int_cb,
+                               map_options))
         return -EINVAL;
     } else if (!strcmp(this_char, "rw") || !strcmp(this_char, "ro")) {
-      put_map_option("rw", this_char);
+      put_map_option("rw", this_char, map_options);
     } else if (!strcmp(this_char, "queue_depth")) {
-      if (put_map_option_value("queue_depth", value_char, map_option_int_cb))
+      if (put_map_option_value("queue_depth", value_char, map_option_int_cb,
+                               map_options))
         return -EINVAL;
     } else if (!strcmp(this_char, "lock_on_read")) {
-      put_map_option("lock_on_read", this_char);
+      put_map_option("lock_on_read", this_char, map_options);
     } else if (!strcmp(this_char, "exclusive")) {
-      put_map_option("exclusive", this_char);
+      put_map_option("exclusive", this_char, map_options);
     } else if (!strcmp(this_char, "notrim")) {
-      put_map_option("notrim", this_char);
+      put_map_option("notrim", this_char, map_options);
     } else if (!strcmp(this_char, "abort_on_full")) {
-      put_map_option("abort_on_full", this_char);
+      put_map_option("abort_on_full", this_char, map_options);
     } else if (!strcmp(this_char, "alloc_size")) {
-      if (put_map_option_value("alloc_size", value_char, map_option_int_cb))
+      if (put_map_option_value("alloc_size", value_char, map_option_int_cb,
+                               map_options))
         return -EINVAL;
     } else if (!strcmp(this_char, "crush_location")) {
       if (put_map_option_value("crush_location", value_char,
-                               map_option_string_cb))
+                               map_option_string_cb, map_options))
         return -EINVAL;
     } else if (!strcmp(this_char, "read_from_replica")) {
       if (put_map_option_value("read_from_replica", value_char,
-                               map_option_read_from_replica_cb))
+                               map_option_read_from_replica_cb, map_options))
         return -EINVAL;
     } else if (!strcmp(this_char, "compression_hint")) {
       if (put_map_option_value("compression_hint", value_char,
-                               map_option_compression_hint_cb))
+                               map_option_compression_hint_cb, map_options))
         return -EINVAL;
     } else if (!strcmp(this_char, "ms_mode")) {
-      if (put_map_option_value("ms_mode", value_char, map_option_ms_mode_cb))
+      if (put_map_option_value("ms_mode", value_char, map_option_ms_mode_cb,
+                               map_options))
         return -EINVAL;
     } else if (!strcmp(this_char, "udev") || !strcmp(this_char, "noudev")) {
-      put_map_option("udev", this_char);
+      put_map_option("udev", this_char, map_options);
     } else {
       std::cerr << "rbd: unknown map option '" << this_char << "'" << std::endl;
       return -EINVAL;
@@ -212,7 +221,8 @@ static int parse_map_options(const std::string &options_string)
   return 0;
 }
 
-static int parse_unmap_options(const std::string &options_string)
+static int parse_unmap_options(const std::string &options_string,
+                               MapOptions* map_options)
 {
   char *options = strdup(options_string.c_str());
   BOOST_SCOPE_EXIT(options) {
@@ -228,11 +238,12 @@ static int parse_unmap_options(const std::string &options_string)
       *value_char++ = '\0';
 
     if (!strcmp(this_char, "force")) {
-      put_map_option("force", this_char);
+      put_map_option("force", this_char, map_options);
     } else if (!strcmp(this_char, "udev") || !strcmp(this_char, "noudev")) {
-      put_map_option("udev", this_char);
+      put_map_option("udev", this_char, map_options);
     } else {
-      std::cerr << "rbd: unknown unmap option '" << this_char << "'" << std::endl;
+      std::cerr << "rbd: unknown unmap option '" << this_char << "'"
+                << std::endl;
       return -EINVAL;
     }
   }
@@ -364,7 +375,8 @@ static void print_error_description(const char *poolname,
 }
 
 static int do_kernel_map(const char *poolname, const char *nspace_name,
-                         const char *imgname, const char *snapname)
+                         const char *imgname, const char *snapname,
+                         MapOptions&& map_options)
 {
 #if defined(WITH_KRBD)
   struct krbd_ctx *krbd;
@@ -427,7 +439,7 @@ out:
 
 static int do_kernel_unmap(const char *dev, const char *poolname,
                            const char *nspace_name, const char *imgname,
-                           const char *snapname)
+                           const char *snapname, MapOptions&& map_options)
 {
 #if defined(WITH_KRBD)
   struct krbd_ctx *krbd;
@@ -500,17 +512,10 @@ int execute_map(const po::variables_map &vm,
     return r;
   }
 
-  // parse default options first so they can be overwritten by cli options
-  r = parse_map_options(
-      g_conf().get_val<std::string>("rbd_default_map_options"));
-  if (r < 0) {
-    std::cerr << "rbd: couldn't parse default map options" << std::endl;
-    return r;
-  }
-
+  MapOptions map_options;
   if (vm.count("options")) {
     for (auto &options : vm["options"].as<std::vector<std::string>>()) {
-      r = parse_map_options(options);
+      r = parse_map_options(options, &map_options);
       if (r < 0) {
         std::cerr << "rbd: couldn't parse map options" << std::endl;
         return r;
@@ -522,16 +527,38 @@ int execute_map(const po::variables_map &vm,
   // options so that common options win (in particular "-o rw --read-only"
   // should result in read-only mapping)
   if (vm["read-only"].as<bool>()) {
-    put_map_option("rw", "ro");
+    put_map_option("rw", "ro", &map_options);
   }
   if (vm["exclusive"].as<bool>()) {
-    put_map_option("exclusive", "exclusive");
+    put_map_option("exclusive", "exclusive", &map_options);
   }
 
-  utils::init_context();
+  librados::Rados rados;
+  librados::IoCtx ioctx;
+  r = utils::init(pool_name, nspace_name, &rados, &ioctx);
+  if (r < 0) {
+    return r;
+  }
+
+  // delay processing default options until after global option overrides have
+  // been received
+  MapOptions default_map_options;
+  r = parse_map_options(
+      g_conf().get_val<std::string>("rbd_default_map_options"),
+      &default_map_options);
+  if (r < 0) {
+    std::cerr << "rbd: couldn't parse default map options" << std::endl;
+    return r;
+  }
+
+  for (auto& [key, value] : default_map_options) {
+    if (map_options.count(key) == 0) {
+      map_options[key] = value;
+    }
+  }
 
   r = do_kernel_map(pool_name.c_str(), nspace_name.c_str(), image_name.c_str(),
-                    snap_name.c_str());
+                    snap_name.c_str(), std::move(map_options));
   if (r < 0) {
     std::cerr << "rbd: map failed: " << cpp_strerror(r) << std::endl;
     return r;
@@ -569,9 +596,10 @@ int execute_unmap(const po::variables_map &vm,
     return -EINVAL;
   }
 
+  MapOptions map_options;
   if (vm.count("options")) {
     for (auto &options : vm["options"].as<std::vector<std::string>>()) {
-      r = parse_unmap_options(options);
+      r = parse_unmap_options(options, &map_options);
       if (r < 0) {
         std::cerr << "rbd: couldn't parse unmap options" << std::endl;
         return r;
@@ -583,7 +611,8 @@ int execute_unmap(const po::variables_map &vm,
 
   r = do_kernel_unmap(device_name.empty() ? nullptr : device_name.c_str(),
                       pool_name.c_str(), nspace_name.c_str(),
-                      image_name.c_str(), snap_name.c_str());
+                      image_name.c_str(), snap_name.c_str(),
+                      std::move(map_options));
   if (r < 0) {
     std::cerr << "rbd: unmap failed: " << cpp_strerror(r) << std::endl;
     return r;

--- a/src/tools/rbd/action/Kernel.cc
+++ b/src/tools/rbd/action/Kernel.cc
@@ -533,15 +533,16 @@ int execute_map(const po::variables_map &vm,
     put_map_option("exclusive", "exclusive", &map_options);
   }
 
+  // connect to the cluster to get the default pool and the default map
+  // options
   librados::Rados rados;
-  librados::IoCtx ioctx;
-  r = utils::init(pool_name, nspace_name, &rados, &ioctx);
+  r = utils::init_rados(&rados);
   if (r < 0) {
     return r;
   }
 
-  // delay processing default options until after global option overrides have
-  // been received
+  utils::normalize_pool_name(&pool_name);
+
   MapOptions default_map_options;
   r = parse_map_options(
       g_conf().get_val<std::string>("rbd_default_map_options"),
@@ -550,7 +551,6 @@ int execute_map(const po::variables_map &vm,
     std::cerr << "rbd: couldn't parse default map options" << std::endl;
     return r;
   }
-
   for (auto& [key, value] : default_map_options) {
     if (map_options.count(key) == 0) {
       map_options[key] = value;
@@ -607,7 +607,16 @@ int execute_unmap(const po::variables_map &vm,
     }
   }
 
-  utils::init_context();
+  if (device_name.empty() && pool_name.empty()) {
+    // connect to the cluster to get the default pool
+    librados::Rados rados;
+    r = utils::init_rados(&rados);
+    if (r < 0) {
+      return r;
+    }
+
+    utils::normalize_pool_name(&pool_name);
+  }
 
   r = do_kernel_unmap(device_name.empty() ? nullptr : device_name.c_str(),
                       pool_name.c_str(), nspace_name.c_str(),

--- a/src/tools/rbd/action/List.cc
+++ b/src/tools/rbd/action/List.cc
@@ -168,23 +168,24 @@ int list_process_image(librados::Rados* rados, WorkerEntry* w, bool lflag, Forma
 }
 
 int do_list(const std::string &pool_name, const std::string& namespace_name,
-            bool lflag, int threads, Formatter *f) {
+            bool lflag, Formatter *f) {
   std::vector<WorkerEntry*> workers;
   std::vector<librbd::image_spec_t> images;
   librados::Rados rados;
   librbd::RBD rbd;
   librados::IoCtx ioctx;
 
+  int r = utils::init(pool_name, namespace_name, &rados, &ioctx);
+  if (r < 0) {
+    return r;
+  }
+
+  int threads = g_conf().get_val<uint64_t>("rbd_concurrent_management_ops");
   if (threads < 1) {
     threads = 1;
   }
   if (threads > 32) {
     threads = 32;
-  }
-
-  int r = utils::init(pool_name, namespace_name, &rados, &ioctx);
-  if (r < 0) {
-    return r;
   }
 
   utils::disable_cache();
@@ -325,7 +326,6 @@ int execute(const po::variables_map &vm,
   }
 
   r = do_list(pool_name, namespace_name, vm["long"].as<bool>(),
-              g_conf().get_val<uint64_t>("rbd_concurrent_management_ops"),
               formatter.get());
   if (r < 0) {
     std::cerr << "rbd: listing images failed: " << cpp_strerror(r)

--- a/src/tools/rbd/action/Migration.cc
+++ b/src/tools/rbd/action/Migration.cc
@@ -189,12 +189,11 @@ int execute_prepare(const po::variables_map &vm,
   }
 
   librados::IoCtx dest_io_ctx;
-  if (!dest_pool_name.empty()) {
-    r = utils::init_io_ctx(rados, dest_pool_name, dest_namespace_name,
-                           &dest_io_ctx);
-    if (r < 0) {
-      return r;
-    }
+  utils::normalize_pool_name(&dest_pool_name);
+  r = utils::init_io_ctx(rados, dest_pool_name, dest_namespace_name,
+                         &dest_io_ctx);
+  if (r < 0) {
+    return r;
   }
 
   r = do_prepare(io_ctx, image_name, dest_pool_name.empty() ? io_ctx :

--- a/src/tools/rbd/action/MirrorSnapshotSchedule.cc
+++ b/src/tools/rbd/action/MirrorSnapshotSchedule.cc
@@ -143,6 +143,7 @@ int execute_add(const po::variables_map &vm,
     return r;
   }
 
+  normalize_level_spec_args(&args);
   r = utils::mgr_command(rados, "rbd mirror snapshot schedule add", args,
                          &std::cout, &std::cerr);
   if (r < 0) {
@@ -177,6 +178,7 @@ int execute_remove(const po::variables_map &vm,
     return r;
   }
 
+  normalize_level_spec_args(&args);
   r = utils::mgr_command(rados, "rbd mirror snapshot schedule remove", args,
                          &std::cout, &std::cerr);
   if (r < 0) {
@@ -215,6 +217,7 @@ int execute_list(const po::variables_map &vm,
     return r;
   }
 
+  normalize_level_spec_args(&args);
   std::stringstream out;
   r = utils::mgr_command(rados, "rbd mirror snapshot schedule list", args, &out,
                          &std::cerr);
@@ -279,6 +282,7 @@ int execute_status(const po::variables_map &vm,
     return r;
   }
 
+  normalize_level_spec_args(&args);
   std::stringstream out;
   r = utils::mgr_command(rados, "rbd mirror snapshot schedule status", args,
                          &out, &std::cerr);

--- a/src/tools/rbd/action/Perf.cc
+++ b/src/tools/rbd/action/Perf.cc
@@ -617,6 +617,7 @@ int execute_iostat(const po::variables_map &vm,
     return r;
   }
 
+  utils::normalize_pool_name(&pool);
   std::string pool_spec = format_pool_spec(pool, pool_namespace);
 
   // no point to refreshing faster than the stats period
@@ -679,6 +680,7 @@ int execute_iotop(const po::variables_map &vm,
     return r;
   }
 
+  utils::normalize_pool_name(&pool);
   iotop::MainWindow mainWindow(rados, format_pool_spec(pool, pool_namespace));
   r = mainWindow.run();
   if (r < 0) {

--- a/src/tools/rbd/action/TrashPurgeSchedule.cc
+++ b/src/tools/rbd/action/TrashPurgeSchedule.cc
@@ -173,6 +173,7 @@ int execute_add(const po::variables_map &vm,
     return r;
   }
 
+  normalize_level_spec_args(&args);
   r = utils::mgr_command(rados, "rbd trash purge schedule add", args,
                          &std::cout, &std::cerr);
   if (r < 0) {
@@ -207,6 +208,7 @@ int execute_remove(const po::variables_map &vm,
     return r;
   }
 
+  normalize_level_spec_args(&args);
   r = utils::mgr_command(rados, "rbd trash purge schedule remove", args,
                          &std::cout, &std::cerr);
   if (r < 0) {
@@ -245,6 +247,7 @@ int execute_list(const po::variables_map &vm,
     return r;
   }
 
+  normalize_level_spec_args(&args);
   std::stringstream out;
   r = utils::mgr_command(rados, "rbd trash purge schedule list", args, &out,
                          &std::cerr);
@@ -309,6 +312,7 @@ int execute_status(const po::variables_map &vm,
     return r;
   }
 
+  normalize_level_spec_args(&args);
   std::stringstream out;
   r = utils::mgr_command(rados, "rbd trash purge schedule status", args, &out,
                          &std::cerr);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47093

---

backport of https://github.com/ceph/ceph/pull/36380
backport of https://github.com/ceph/ceph/pull/36854
parent tracker: https://tracker.ceph.com/issues/46754

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh