### PR TITLE
qa: update cli syntax to conventional

### DIFF
--- a/doc/cephfs/snap-schedule.rst
+++ b/doc/cephfs/snap-schedule.rst
@@ -91,9 +91,9 @@ path.
 Examples::
 
   ceph fs snap-schedule status /
-  ceph fs snap-schedule status /foo/bar format=json
+  ceph fs snap-schedule status /foo/bar --format=json
   ceph fs snap-schedule list /
-  ceph fs snap-schedule list / recursive=true # list all schedules in the tree
+  ceph fs snap-schedule list / --recursive=true # list all schedules in the tree
 
 
 Add and remove schedules
@@ -117,7 +117,7 @@ Examples::
   ceph fs snap-schedule add / 1h 11:55
   ceph fs snap-schedule add / 2h 11:55
   ceph fs snap-schedule remove / 1h 11:55 # removes one single schedule
-  ceph fs snap-schedule remove / 1h # removes all schedules with repeat=1h
+  ceph fs snap-schedule remove / 1h # removes all schedules with --repeat=1h
   ceph fs snap-schedule remove / # removes all schedules on path /
 
 Add and remove retention policies


### PR DESCRIPTION
This was using an obscure syntax that worked at one time and wasn't
documented (AFAIK).

Fixes: https://tracker.ceph.com/issues/51182
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
