### PR TITLE
doc: update testing.rst and build-integration test to say ./run-make-check.sh

### DIFF
--- a/doc/dev/testing.rst
+++ b/doc/dev/testing.rst
@@ -32,7 +32,7 @@ Using
 
 #. Smoke test::
 
-     ninja && ctest -j12
+     ./run-make-check.sh
 
 #. Push to ceph-ci::
 

--- a/doc/dev/testing.rst
+++ b/doc/dev/testing.rst
@@ -32,7 +32,7 @@ Using
 
 #. Smoke test::
 
-     make && ctest -j12
+     ninja && ctest -j12
 
 #. Push to ceph-ci::
 

--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -109,4 +109,4 @@ for pr in prs:
 
 print('--- done. these PRs were included:')
 print('\n'.join(prtext).encode('ascii', errors='ignore').decode())
-print('--- perhaps you want to: make && ctest -j12 && git push ci %s' % branch)
+print('--- perhaps you want to: ./run-make-check.sh && git push ci %s' % branch)


### PR DESCRIPTION
The current version of Ceph uses "ninja" rather than "make," so the testing documentation needs to be updated.

Signed-off-by: Laura Flores <lflores@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
