### PR TITLE
os/bluestore: Revise the naming scheme for per-zone cleaning informat…

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1590,8 +1590,8 @@ public:
     // negative of the previous ondisk offset.  We need to maintain a vector of
     // offsets because *within the same transaction* an object may be truncated
     // and then written again, or an object may be overwritten multiple times to
-    // different zones.  See update_cleaning_metadata function for how this map
-    // is used.
+    // different zones.  See _zoned_update_cleaning_metadata function for how
+    // this map is used.
     std::map<OnodeRef, std::vector<int64_t>> zoned_onode_to_offset_map;
 #endif
     
@@ -2400,7 +2400,7 @@ private:
   uint64_t _zoned_piggyback_device_parameters_onto(uint64_t min_alloc_size);
   int _zoned_check_config_settings();
   void _zoned_update_cleaning_metadata(TransContext *txc);
-  std::string _zoned_get_prefix(uint64_t offset);
+  std::string _zoned_key(uint64_t offset, const ghobject_t *oid);
 #endif
 
 public:


### PR DESCRIPTION
…ion.

Use a single letter (G) for the namespace, and use zone_num+oid as the key.

Signed-off-by: Abutalib Aghayev <agayev@psu.edu>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
