### PR TITLE
mgr/orch: pass dict to yaml.SafeDumper.represent_dict()

### DIFF
--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -16,9 +16,9 @@ import re
 from collections import namedtuple, OrderedDict
 from contextlib import contextmanager
 from functools import wraps, reduce
-
 from typing import TypeVar, Generic, List, Optional, Union, Tuple, Iterator, Callable, Any, \
     Sequence, Dict, cast
+from yaml.nodes import Node
 
 try:
     from typing import Protocol  # Protocol was added in Python 3.8
@@ -1035,7 +1035,7 @@ class DaemonDescription(object):
         return DaemonDescription.from_json(self.to_json())
 
     @staticmethod
-    def yaml_representer(dumper: 'yaml.SafeDumper', data: 'DaemonDescription') -> Any:
+    def yaml_representer(dumper: 'yaml.SafeDumper', data: 'DaemonDescription') -> Node:
         return dumper.represent_dict(data.to_json())
 
 
@@ -1174,7 +1174,7 @@ class ServiceDescription(object):
         return cls(spec=spec, events=events, **c_status)
 
     @staticmethod
-    def yaml_representer(dumper: 'yaml.SafeDumper', data: 'DaemonDescription') -> Any:
+    def yaml_representer(dumper: 'yaml.SafeDumper', data: 'DaemonDescription') -> Node:
         return dumper.represent_dict(data.to_json())
 
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1174,7 +1174,7 @@ class ServiceDescription(object):
         return cls(spec=spec, events=events, **c_status)
 
     @staticmethod
-    def yaml_representer(dumper: 'yaml.SafeDumper', data: 'DaemonDescription') -> Node:
+    def yaml_representer(dumper: 'yaml.SafeDumper', data: 'ServiceDescription') -> Node:
         return dumper.represent_dict(data.to_json())
 
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1036,7 +1036,7 @@ class DaemonDescription(object):
 
     @staticmethod
     def yaml_representer(dumper: 'yaml.SafeDumper', data: 'DaemonDescription') -> Any:
-        return dumper.represent_dict(data.to_json().items())
+        return dumper.represent_dict(data.to_json())
 
 
 yaml.add_representer(DaemonDescription, DaemonDescription.yaml_representer)
@@ -1175,7 +1175,7 @@ class ServiceDescription(object):
 
     @staticmethod
     def yaml_representer(dumper: 'yaml.SafeDumper', data: 'DaemonDescription') -> Any:
-        return dumper.represent_dict(data.to_json().items())
+        return dumper.represent_dict(data.to_json())
 
 
 yaml.add_representer(ServiceDescription, ServiceDescription.yaml_representer)

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1112,7 +1112,7 @@ class ServiceDescription(object):
             return ''
         return f"{(self.virtual_ip or '?').split('/')[0]}:{','.join(map(str, self.ports or []))}"
 
-    def to_json(self) -> OrderedDict:
+    def to_json(self) -> dict:
         out = self.spec.to_json()
         status = {
             'container_image_id': self.container_image_id,
@@ -1135,7 +1135,7 @@ class ServiceDescription(object):
             out['events'] = [e.to_json() for e in self.events]
         return out
 
-    def to_dict(self) -> OrderedDict:
+    def to_dict(self) -> dict:
         out = self.spec.to_json()
         status = {
             'container_image_id': self.container_image_id,

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -81,20 +81,22 @@ def test_apply():
 
 
 def test_yaml():
-    y = """daemon_type: crash
-daemon_id: ubuntu
-hostname: ubuntu
-status: 1
-status_desc: starting
-is_active: false
+    y = """daemon_id: ubuntu
+daemon_type: crash
 events:
 - 2020-06-10T10:08:22.933241Z daemon:crash.ubuntu [INFO] "Deployed crash.ubuntu on
   host 'ubuntu'"
+hostname: ubuntu
+is_active: false
+status: 1
+status_desc: starting
 ---
-service_type: crash
-service_name: crash
+events:
+- 2020-06-10T10:37:31.139159Z service:crash [INFO] "service was created"
 placement:
   host_pattern: '*'
+service_name: crash
+service_type: crash
 status:
   container_image_id: 74803e884bea289d2d2d3ebdf6d37cd560499e955595695b1390a89800f4e37a
   container_image_name: docker.io/ceph/daemon-base:latest-master-devel
@@ -102,8 +104,6 @@ status:
   last_refresh: '2020-06-10T10:57:40.715637Z'
   running: 1
   size: 1
-events:
-- 2020-06-10T10:37:31.139159Z service:crash [INFO] "service was created"
 """
     types = (DaemonDescription, ServiceDescription)
 

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -656,7 +656,7 @@ class ServiceSpec(object):
 
     @staticmethod
     def yaml_representer(dumper: 'yaml.SafeDumper', data: 'ServiceSpec') -> Any:
-        return dumper.represent_dict(data.to_json().items())
+        return dumper.represent_dict(data.to_json())
 
 
 yaml.add_representer(ServiceSpec, ServiceSpec.yaml_representer)

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1,6 +1,5 @@
 import fnmatch
 import re
-from collections import OrderedDict
 from functools import wraps
 from ipaddress import ip_network, ip_address
 from typing import Optional, Dict, Any, List, Union, Callable, Iterable, Type, TypeVar, cast, \
@@ -588,9 +587,8 @@ class ServiceSpec(object):
     def get_virtual_ip(self) -> Optional[str]:
         return None
 
-    def to_json(self):
-        # type: () -> OrderedDict[str, Any]
-        ret: OrderedDict[str, Any] = OrderedDict()
+    def to_json(self) -> Dict[str, Any]:
+        ret: Dict[str, Any] = dict()
         ret['service_type'] = self.service_type
         if self.service_id:
             ret['service_id'] = self.service_id

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -194,36 +194,36 @@ def test_osd_unmanaged():
     assert dg_spec.unmanaged == True
 
 def test_yaml():
-    y = """service_type: crash
-service_name: crash
-placement:
+    y = """placement:
   host_pattern: '*'
----
+service_name: crash
 service_type: crash
-service_name: crash
+---
 placement:
   host_pattern: '*'
+service_name: crash
+service_type: crash
 unmanaged: true
 ---
-service_type: rgw
-service_id: default-rgw-realm.eu-central-1.1
-service_name: rgw.default-rgw-realm.eu-central-1.1
-placement:
-  hosts:
-  - ceph-001
 networks:
 - 10.0.0.0/8
 - 192.168.0.0/16
+placement:
+  hosts:
+  - ceph-001
+service_id: default-rgw-realm.eu-central-1.1
+service_name: rgw.default-rgw-realm.eu-central-1.1
+service_type: rgw
 spec:
   rgw_frontend_type: civetweb
   rgw_realm: default-rgw-realm
   rgw_zone: eu-central-1
 ---
-service_type: osd
-service_id: osd_spec_default
-service_name: osd.osd_spec_default
 placement:
   host_pattern: '*'
+service_id: osd_spec_default
+service_name: osd.osd_spec_default
+service_type: osd
 spec:
   data_devices:
     model: MC-55-44-XZ
@@ -239,8 +239,8 @@ spec:
         data = yaml.safe_load(y)
         object = ServiceSpec.from_json(data)
 
-        assert yaml.dump(object) == y
-        assert yaml.dump(ServiceSpec.from_json(object.to_json())) == y
+        assert yaml.dump(object, sort_keys=True) == y
+        assert yaml.dump(ServiceSpec.from_json(object.to_json()), sort_keys=True) == y
 
 @pytest.mark.parametrize("spec1, spec2, eq",
                          [


### PR DESCRIPTION
yaml.SafeDumper.represent_dict() in turn calls SafeRepresenter.represent_dict().
and SafeRepresenter.represent_dict() calls BaseRepresenter.represent_mapping()
which sets `mapping` to `list(mapping.items())` before dumping it. see
https://github.com/yaml/pyyaml/blob/ee37f4653c08fc07aecff69cfd92848e6b1a540e/lib3/yaml/representer.py#L103-L129

this change alsow silences mypy errors like:

orchestrator/_interface.py: note: In member "yaml_representer" of class "DaemonDescription":
orchestrator/_interface.py:1039: error: Argument 1 to "represent_dict" of "SafeRepresenter" has incompatible type "ItemsView[Any, Any]"; expected "Mapping[Any, Any]"

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
