### PR TITLE
crimson: errorator parallel_for_each

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -1,5 +1,5 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-// vim: ts=8 sw=2 smarttab
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab expandtab
 
 #pragma once
 
@@ -713,6 +713,7 @@ private:
     friend inline auto ::seastar::internal::do_with_impl(T1&& rv1, T2&& rv2, T3_or_F&& rv3, More&&... more);
     template<typename, typename>
     friend class ::crimson::interruptible::interruptible_future_detail;
+    friend class errorator<AllowedErrors...>::parallel_for_each_state;
   };
 
   class Enabler {};
@@ -857,6 +858,44 @@ public:
 
   static auto now() {
     return make_ready_future<>();
+  }
+
+  template <typename Iterator, typename Func>
+  static inline errorator<AllowedErrors...>::future<>
+  parallel_for_each(Iterator first, Iterator last, Func&& func) noexcept {
+    parallel_for_each_state* s = nullptr;
+    // Process all elements, giving each future the following treatment:
+    //   - available, not failed: do nothing
+    //   - available, failed: collect exception in ex
+    //   - not available: collect in s (allocating it if needed)
+    for (;first != last; ++first) {
+      auto f = seastar::futurize_invoke(std::forward<Func>(func), *first);
+      if (!f.available() || f.failed()) {
+        if (!s) {
+          using itraits = std::iterator_traits<Iterator>;
+          auto n = (seastar::internal::iterator_range_estimate_vector_capacity(
+                first, last, typename itraits::iterator_category()) + 1);
+          s = new parallel_for_each_state(n);
+        }
+        s->add_future(std::move(f));
+      }
+    }
+    // If any futures were not available, hand off to parallel_for_each_state::start().
+    // Otherwise we can return a result immediately.
+    if (s) {
+      // s->get_future() takes ownership of s (and chains it to one of the futures it contains)
+      // so this isn't a leak
+      return s->get_future();
+    }
+    return seastar::make_ready_future<>();
+  }
+
+  template <typename Container, typename Func>
+  static inline auto parallel_for_each(Container&& container, Func&& func) noexcept {
+    return parallel_for_each(
+        std::begin(container),
+        std::end(container),
+        std::forward<Func>(func));
   }
 
 private:
@@ -1006,6 +1045,53 @@ private:
     // calling via interface class due to encapsulation and friend relations.
     return e.error_t<std::decay_t<ErrorT>>::to_exception_ptr();
   }
+
+  class parallel_for_each_state final : private seastar::continuation_base<> {
+    using future_t = errorator<AllowedErrors...>::future<>;
+    std::vector<future_t> _incomplete;
+    seastar::promise<> _result;
+    std::exception_ptr _ex;
+  private:
+    void wait_for_one() noexcept {
+      while (!_incomplete.empty() && _incomplete.back().available()) {
+        if (_incomplete.back().failed()) {
+          _ex = _incomplete.back().get_exception();
+        }
+        _incomplete.pop_back();
+      }
+      if (!_incomplete.empty()) {
+        seastar::internal::set_callback(_incomplete.back(), static_cast<continuation_base<>*>(this));
+        _incomplete.pop_back();
+        return;
+      }
+      if (__builtin_expect(bool(_ex), false)) {
+        _result.set_exception(std::move(_ex));
+      } else {
+        _result.set_value();
+      }
+      delete this;
+    }
+    virtual void run_and_dispose() noexcept override {
+      if (_state.failed()) {
+        _ex = std::move(_state).get_exception();
+      }
+      _state = {};
+      wait_for_one();
+    }
+    task* waiting_task() noexcept override { return _result.waiting_task(); }
+  public:
+    parallel_for_each_state(size_t n) {
+      _incomplete.reserve(n);
+    }
+    void add_future(future_t&& f) {
+      _incomplete.push_back(std::move(f));
+    }
+    future_t get_future() {
+      auto ret = _result.get_future();
+      wait_for_one();
+      return ret;
+    }
+  };
 
   // needed because of:
   //  * return_errorator_t::template futurize<...> in `safe_then()`,

--- a/src/test/crimson/test_errorator.cc
+++ b/src/test/crimson/test_errorator.cc
@@ -1,10 +1,14 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <boost/iterator/counting_iterator.hpp>
+#include <numeric>
+
 #include "test/crimson/gtest_seastar.h"
 
 #include "crimson/common/errorator.h"
 #include "crimson/common/log.h"
+#include "seastar/core/sleep.hh"
 
 struct errorator_test_t : public seastar_test_suite_t {
   using ertr = crimson::errorator<crimson::ct_error::invarg>;
@@ -16,6 +20,21 @@ struct errorator_test_t : public seastar_test_suite_t {
       } else {
         return ertr::make_ready_future<bool>(true);
       }
+    });
+  }
+  static constexpr int SIZE = 42;
+  ertr::future<> test_parallel_for_each() {
+    auto sum = std::make_unique<int>(0);
+    return ertr::parallel_for_each(
+      boost::make_counting_iterator(0),
+      boost::make_counting_iterator(SIZE),
+      [sum=sum.get()](int i) {
+	*sum += i;
+    }).safe_then([sum=std::move(sum)] {
+      int expected = std::accumulate(boost::make_counting_iterator(0),
+				     boost::make_counting_iterator(SIZE),
+				     0);
+      ASSERT_EQ(*sum, expected);
     });
   }
   struct noncopyable_t {
@@ -52,6 +71,13 @@ TEST_F(errorator_test_t, basic)
 {
   run_async([this] {
     test_do_until().unsafe_get0();
+  });
+}
+
+TEST_F(errorator_test_t, parallel_for_each)
+{
+  run_async([this] {
+    test_parallel_for_each().unsafe_get0();
   });
 }
 


### PR DESCRIPTION
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
