### PR TITLE
rgw: remove one dupicated action memset by just using zeroize_for_security instead in rgw_kms.cc

### DIFF
--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -201,8 +201,7 @@ protected:
     while (res && isspace(buf[res-1])) {
       --res;
     }
-    vault_token->assign(std::string{buf, static_cast<size_t>(res)});
-    memset(buf, 0, sizeof(buf));
+    vault_token->assign(std::string{buf, static_cast<size_t>(res)});    
     ::ceph::crypto::zeroize_for_security(buf, sizeof(buf));
     return res;
   }


### PR DESCRIPTION
rgw: remove one dupicated action memset by using zeroize_for_security instead

Commit :f93efbd2db596d740e151bfb4d88924b77c3c9d8
Author: bangmingcheng <bangmingcheng@gmail.com>
Date: Thur,May 22 2020
rgw_kms.cc :memset(buf, 0, sizeof(buf)) and  ::ceph::crypto::zeroize_for_security(buf, sizeof(buf)) are methods with the same function. 

Signed-off-by: bangmingcheng <bangmingcheng@gmail.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
