### PR TITLE
global,tox.ini: add mypy-constrains.txt

### DIFF
--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -11,7 +11,7 @@ commands=flake8 --select=F,E9 --exclude=venv,.tox
 [testenv:mypy]
 basepython = python3
 deps =
-  mypy==0.901
+  mypy
   types-boto
   types-requests
   types-jwt
@@ -19,6 +19,7 @@ deps =
   types-PyYAML
   types-cryptography
   types-python-dateutil
+  -c{toxinidir}/../src/mypy-constrains.txt
 commands = mypy {posargs:.}
 
 [testenv:import-tasks]

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -41,7 +41,9 @@ commands=pytest {posargs}
 
 [testenv:mypy]
 basepython = python3
-deps = mypy==0.901
+deps = 
+    mypy
+    -c{toxinidir}/../mypy-constrains.txt
 commands = mypy --config-file ../mypy.ini {posargs:cephadm}
 
 [testenv:fix]

--- a/src/mypy-constrains.txt
+++ b/src/mypy-constrains.txt
@@ -1,0 +1,19 @@
+# let's avoid getting new versions of those packages by accident. 
+# Unfortunately this means we have to manually update those 
+# packages regularly. 
+
+mypy==0.901
+
+# global
+types-python-dateutil==0.1.3
+types-requests==0.1.11
+types-jwt==0.1.3
+types-PyYAML==5.4.0
+
+# src/pybind
+types-backports==0.1.2
+
+# qa/
+types-boto==0.1.0
+types-cryptography==0.1.1
+types-paramiko==0.1.3

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -58,7 +58,8 @@ basepython = python3
 deps =
     cython
     -rrequirements.txt
-    mypy==0.901
+    -c{toxinidir}/../../mypy-constrains.txt
+    mypy
     types-backports
     types-python-dateutil
     types-requests

--- a/src/pybind/tox.ini
+++ b/src/pybind/tox.ini
@@ -7,7 +7,9 @@ skipsdist = true
 [testenv]
 
 [testenv:mypy]
-deps = mypy
+deps = 
+    mypy
+    -c{toxinidir}/../mypy-constrains.txt
 commands =
   python -m mypy --config-file ../mypy.ini \
     -m ceph_daemon \

--- a/src/python-common/requirements.txt
+++ b/src/python-common/requirements.txt
@@ -1,6 +1,6 @@
 pytest >=2.1.3,<5; python_version < '3.5'
 mock; python_version < '3.3'
-mypy==0.901; python_version >= '3'
+mypy; python_version >= '3'
 pytest-mypy; python_version >= '3'
 pytest >= 2.1.3; python_version >= '3'
 pyyaml

--- a/src/python-common/tox.ini
+++ b/src/python-common/tox.ini
@@ -5,6 +5,7 @@ skip_missing_interpreters = true
 [testenv:py3]
 deps=
     -rrequirements.txt
+    -c{toxinidir}/../mypy-constrains.txt
 commands=
     pytest --doctest-modules ceph/deployment/service_spec.py
     pytest {posargs}


### PR DESCRIPTION
See #41854 for a quick fix

let's avoid getting new versions of those packages by accident.
Unfortunately this means we have to manually update those
packages regurarly.

Signed-off-by: Sebastian Wagner <sewagner@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
