### PR TITLE
crimson/net: Complete the refactor to std::unique_ptr inside Messenger

### DIFF
--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -70,7 +70,7 @@ void Client::ms_handle_connect(crimson::net::ConnectionRef c)
   gate.dispatch_in_background(__func__, *this, [this, c] {
     if (conn == c) {
       // ask for the mgrconfigure message
-      auto m = ceph::make_message<MMgrOpen>();
+      auto m = crimson::make_message<MMgrOpen>();
       m->daemon_name = local_conf()->name.get_id();
       return conn->send(std::move(m));
     } else {

--- a/src/crimson/mgr/client.h
+++ b/src/crimson/mgr/client.h
@@ -24,7 +24,7 @@ namespace crimson::mgr
 // implement WithStats if you want to report stats to mgr periodically
 class WithStats {
 public:
-  virtual MessageRef get_stats() const = 0;
+  virtual MessageURef get_stats() const = 0;
   virtual ~WithStats() {}
 };
 

--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -127,8 +127,6 @@ class Connection : public seastar::enable_shared_from_this<Connection> {
 
   /// send a message over a connection that has completed its handshake
   virtual seastar::future<> send(MessageURef msg) = 0;
-  // The version with MessageRef will be dropped in the future
-  virtual seastar::future<> send(MessageRef msg) = 0;
 
   /// send a keepalive message over a connection that has completed its
   /// handshake

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -110,7 +110,7 @@ ceph::bufferlist Protocol::sweep_messages_and_move_to_sent(
   return bl;
 }
 
-seastar::future<> Protocol::send(MessageRef msg)
+seastar::future<> Protocol::send(MessageURef msg)
 {
   if (write_state != write_state_t::drop) {
     conn.out_q.push_back(std::move(msg));
@@ -153,7 +153,7 @@ void Protocol::requeue_sent()
   conn.out_seq -= conn.sent.size();
   logger().debug("{} requeue {} items, revert out_seq to {}",
                  conn, conn.sent.size(), conn.out_seq);
-  for (MessageRef& msg : conn.sent) {
+  for (MessageURef& msg : conn.sent) {
     msg->clear_payload();
     msg->set_seq(0);
   }
@@ -204,7 +204,7 @@ void Protocol::ack_writes(seq_num_t seq)
   }
   while (!conn.sent.empty() && conn.sent.front()->get_seq() <= seq) {
     logger().trace("{} got ack seq {} >= {}, pop {}",
-                   conn, seq, conn.sent.front()->get_seq(), conn.sent.front());
+                   conn, seq, conn.sent.front()->get_seq(), *conn.sent.front());
     conn.sent.pop_front();
   }
 }

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -56,7 +56,7 @@ class Protocol {
   virtual void trigger_close() = 0;
 
   virtual ceph::bufferlist do_sweep_messages(
-      const std::deque<MessageRef>& msgs,
+      const std::deque<MessageURef>& msgs,
       size_t num_msgs,
       bool require_keepalive,
       std::optional<utime_t> keepalive_ack,
@@ -90,7 +90,7 @@ class Protocol {
 
 // the write state-machine
  public:
-  seastar::future<> send(MessageRef msg);
+  seastar::future<> send(MessageURef msg);
   seastar::future<> keepalive();
 
 // TODO: encapsulate a SessionedSender class

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1792,7 +1792,7 @@ void ProtocolV2::trigger_replacing(bool reconnect,
 // READY state
 
 ceph::bufferlist ProtocolV2::do_sweep_messages(
-    const std::deque<MessageRef>& msgs,
+    const std::deque<MessageURef>& msgs,
     size_t num_msgs,
     bool require_keepalive,
     std::optional<utime_t> _keepalive_ack,
@@ -1818,7 +1818,7 @@ ceph::bufferlist ProtocolV2::do_sweep_messages(
     INTERCEPT_FRAME(ceph::msgr::v2::Tag::ACK, bp_type_t::WRITE);
   }
 
-  std::for_each(msgs.begin(), msgs.begin()+num_msgs, [this, &bl](const MessageRef& msg) {
+  std::for_each(msgs.begin(), msgs.begin()+num_msgs, [this, &bl](const MessageURef& msg) {
     // TODO: move to common code
     // set priority
     msg->get_header().src = messenger.get_myname();

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -31,7 +31,7 @@ class ProtocolV2 final : public Protocol {
   void trigger_close() override;
 
   ceph::bufferlist do_sweep_messages(
-      const std::deque<MessageRef>& msgs,
+      const std::deque<MessageURef>& msgs,
       size_t num_msgs,
       bool require_keepalive,
       std::optional<utime_t> keepalive_ack,

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -72,12 +72,6 @@ bool SocketConnection::peer_wins() const
 seastar::future<> SocketConnection::send(MessageURef msg)
 {
   assert(seastar::this_shard_id() == shard_id());
-  return protocol->send(MessageRef{msg.release(), false});
-}
-
-seastar::future<> SocketConnection::send(MessageRef msg)
-{
-  assert(seastar::this_shard_id() == shard_id());
   return protocol->send(std::move(msg));
 }
 

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -44,9 +44,9 @@ class SocketConnection : public Connection {
   bool update_rx_seq(seq_num_t seq);
 
   // messages to be resent after connection gets reset
-  std::deque<MessageRef> out_q;
+  std::deque<MessageURef> out_q;
   // messages sent, but not yet acked by peer
-  std::deque<MessageRef> sent;
+  std::deque<MessageURef> sent;
 
   seastar::shard_id shard_id() const;
 
@@ -70,7 +70,6 @@ class SocketConnection : public Connection {
 #endif
 
   seastar::future<> send(MessageURef msg) override;
-  seastar::future<> send(MessageRef msg) override;
 
   seastar::future<> keepalive() override;
 

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -760,11 +760,11 @@ void OSD::update_stats()
   });
 }
 
-MessageRef OSD::get_stats() const
+MessageURef OSD::get_stats() const
 {
   // todo: m-to-n: collect stats using map-reduce
   // MPGStats::had_map_for is not used since PGMonitor was removed
-  auto m = ceph::make_message<MPGStats>(monc->get_fsid(), osdmap->get_epoch());
+  auto m = crimson::make_message<MPGStats>(monc->get_fsid(), osdmap->get_epoch());
   m->osd_stat = osd_stat;
   for (auto [pgid, pg] : pg_map.get_pgs()) {
     if (pg->is_primary()) {

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -105,7 +105,7 @@ class OSD final : public crimson::net::Dispatcher,
   osd_stat_t osd_stat;
   uint32_t osd_stat_seq = 0;
   void update_stats();
-  MessageRef get_stats() const final;
+  MessageURef get_stats() const final;
 
   // AuthHandler methods
   void handle_authentication(const EntityName& name,

--- a/src/crimson/osd/osd_operations/peering_event.cc
+++ b/src/crimson/osd/osd_operations/peering_event.cc
@@ -124,7 +124,7 @@ void RemotePeeringEvent::on_pg_absent()
     const pg_info_t empty{spg_t{pgid.pgid, q.query.to}};
     if (q.query.type == q.query.LOG ||
 	q.query.type == q.query.FULLLOG)  {
-      auto m = ceph::make_message<MOSDPGLog>(q.query.from, q.query.to,
+      auto m = crimson::make_message<MOSDPGLog>(q.query.from, q.query.to,
 					     map_epoch, empty,
 					     q.query.epoch_sent);
       ctx.send_osd_message(q.from.osd, std::move(m));

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1103,11 +1103,11 @@ PG::interruptible_future<> PG::handle_rep_op(Ref<MOSDRepOp> req)
       [req, lcod=peering_state.get_info().last_complete, this] {
       peering_state.update_last_complete_ondisk(lcod);
       const auto map_epoch = get_osdmap_epoch();
-      auto reply = ceph::make_message<MOSDRepOpReply>(
+      auto reply = crimson::make_message<MOSDRepOpReply>(
         req.get(), pg_whoami, 0,
 	map_epoch, req->get_min_epoch(), CEPH_OSD_FLAG_ONDISK);
       reply->set_last_complete_ondisk(lcod);
-      return shard_services.send_to_osd(req->from.osd, reply, map_epoch);
+      return shard_services.send_to_osd(req->from.osd, std::move(reply), map_epoch);
     });
 }
 

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -736,7 +736,7 @@ PG::do_osd_ops_execute(
   }));
 }
 
-PG::do_osd_ops_iertr::future<PG::pg_rep_op_fut_t<Ref<MOSDOpReply>>>
+PG::do_osd_ops_iertr::future<PG::pg_rep_op_fut_t<MURef<MOSDOpReply>>>
 PG::do_osd_ops(
   Ref<MOSDOp> m,
   ObjectContextRef obc,
@@ -745,7 +745,7 @@ PG::do_osd_ops(
   if (__builtin_expect(stopping, false)) {
     throw crimson::common::system_shutdown_exception();
   }
-  return do_osd_ops_execute<Ref<MOSDOpReply>>(
+  return do_osd_ops_execute<MURef<MOSDOpReply>>(
     seastar::make_lw_shared<OpsExecuter>(
       std::move(obc), op_info, get_pool().info, get_backend(), *m),
     m->ops,
@@ -757,7 +757,7 @@ PG::do_osd_ops(
       if (result > 0 && !rvec) {
         result = 0;
       }
-      auto reply = ceph::make_message<MOSDOpReply>(m.get(),
+      auto reply = crimson::make_message<MOSDOpReply>(m.get(),
                                              result,
                                              get_osdmap_epoch(),
                                              0,
@@ -767,16 +767,16 @@ PG::do_osd_ops(
         "do_osd_ops: {} - object {} sending reply",
         *m,
         m->get_hobj());
-      return do_osd_ops_iertr::make_ready_future<Ref<MOSDOpReply>>(
+      return do_osd_ops_iertr::make_ready_future<MURef<MOSDOpReply>>(
         std::move(reply));
     },
     [m, this] (const std::error_code& e) {
-      auto reply = ceph::make_message<MOSDOpReply>(
+      auto reply = crimson::make_message<MOSDOpReply>(
         m.get(), -e.value(), get_osdmap_epoch(), 0, false);
       reply->set_enoent_reply_versions(
         peering_state.get_info().last_update,
         peering_state.get_info().last_user_version);
-      return do_osd_ops_iertr::make_ready_future<Ref<MOSDOpReply>>(std::move(reply));
+      return do_osd_ops_iertr::make_ready_future<MURef<MOSDOpReply>>(std::move(reply));
     });
 }
 
@@ -798,7 +798,7 @@ PG::do_osd_ops(
     std::move(failure_func));
 }
 
-PG::interruptible_future<Ref<MOSDOpReply>> PG::do_pg_ops(Ref<MOSDOp> m)
+PG::interruptible_future<MURef<MOSDOpReply>> PG::do_pg_ops(Ref<MOSDOp> m)
 {
   if (__builtin_expect(stopping, false)) {
     throw crimson::common::system_shutdown_exception();
@@ -810,16 +810,16 @@ PG::interruptible_future<Ref<MOSDOpReply>> PG::do_pg_ops(Ref<MOSDOp> m)
     logger().debug("will be handling pg op {}", ceph_osd_op_name(osd_op.op.op));
     return ox->execute_op(osd_op);
   }).then_interruptible([m, this, ox = std::move(ox)] {
-    auto reply = ceph::make_message<MOSDOpReply>(m.get(), 0, get_osdmap_epoch(),
+    auto reply = crimson::make_message<MOSDOpReply>(m.get(), 0, get_osdmap_epoch(),
                                            CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK,
                                            false);
-    return seastar::make_ready_future<Ref<MOSDOpReply>>(std::move(reply));
+    return seastar::make_ready_future<MURef<MOSDOpReply>>(std::move(reply));
   }).handle_exception_type_interruptible([=](const crimson::osd::error& e) {
-    auto reply = ceph::make_message<MOSDOpReply>(
+    auto reply = crimson::make_message<MOSDOpReply>(
       m.get(), -e.code().value(), get_osdmap_epoch(), 0, false);
     reply->set_enoent_reply_versions(peering_state.get_info().last_update,
 				     peering_state.get_info().last_user_version);
-    return seastar::make_ready_future<Ref<MOSDOpReply>>(std::move(reply));
+    return seastar::make_ready_future<MURef<MOSDOpReply>>(std::move(reply));
   });
 }
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -571,7 +571,7 @@ private:
   using pg_rep_op_fut_t =
     std::tuple<interruptible_future<>,
                do_osd_ops_iertr::future<Ret>>;
-  do_osd_ops_iertr::future<pg_rep_op_fut_t<Ref<MOSDOpReply>>> do_osd_ops(
+  do_osd_ops_iertr::future<pg_rep_op_fut_t<MURef<MOSDOpReply>>> do_osd_ops(
     Ref<MOSDOp> m,
     ObjectContextRef obc,
     const OpInfo &op_info);
@@ -594,7 +594,7 @@ private:
     const OpInfo &op_info,
     SuccessFunc&& success_func,
     FailureFunc&& failure_func);
-  interruptible_future<Ref<MOSDOpReply>> do_pg_ops(Ref<MOSDOp> m);
+  interruptible_future<MURef<MOSDOpReply>> do_pg_ops(Ref<MOSDOp> m);
   std::tuple<interruptible_future<>, interruptible_future<>>
   submit_transaction(
     const OpInfo& op_info,

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -459,7 +459,7 @@ void PGRecovery::enqueue_drop(
   // allocate a pair if target is seen for the first time
   auto& req = backfill_drop_requests[target];
   if (!req) {
-    req = ceph::make_message<MOSDPGBackfillRemove>(
+    req = crimson::make_message<MOSDPGBackfillRemove>(
       spg_t(pg->get_pgid().pgid, target.shard), pg->get_osdmap_epoch());
   }
   req->ls.emplace_back(obj, v);

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -89,7 +89,7 @@ private:
   // backfill begin
   std::unique_ptr<crimson::osd::BackfillState> backfill_state;
   std::map<pg_shard_t,
-           ceph::ref_t<MOSDPGBackfillRemove>> backfill_drop_requests;
+           MURef<MOSDPGBackfillRemove>> backfill_drop_requests;
 
   template <class EventT>
   void start_backfill_recovery(

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -85,9 +85,8 @@ void ShardServices::handle_conf_change(const ConfigProxy& conf,
   }
 }
 
-template<class MsgT>
-seastar::future<> ShardServices::do_send_to_osd(
-  int peer, MsgT m, epoch_t from_epoch)
+seastar::future<> ShardServices::send_to_osd(
+  int peer, MessageURef m, epoch_t from_epoch)
 {
   if (osdmap->is_down(peer)) {
     logger().info("{}: osd.{} is_down", __func__, peer);
@@ -101,18 +100,6 @@ seastar::future<> ShardServices::do_send_to_osd(
         osdmap->get_cluster_addrs(peer).front(), CEPH_ENTITY_TYPE_OSD);
     return conn->send(std::move(m));
   }
-}
-
-seastar::future<> ShardServices::send_to_osd(
-  int peer, MessageRef m, epoch_t from_epoch) 
-{
-  return do_send_to_osd(peer, std::move(m), from_epoch);
-}
-
-seastar::future<> ShardServices::send_to_osd(
-  int peer, MessageURef m, epoch_t from_epoch) 
-{
-  return do_send_to_osd(peer, std::move(m), from_epoch);
 }
 
 seastar::future<> ShardServices::dispatch_context_transaction(

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -133,7 +133,7 @@ seastar::future<> ShardServices::dispatch_context_messages(
       logger().debug("dispatch_context_messages sending messages to {}", peer);
       return seastar::parallel_for_each(
         std::move(messages), [=, peer=peer](auto& m) {
-        return send_to_osd(peer, m, osdmap->get_epoch());
+        return send_to_osd(peer, std::move(m), osdmap->get_epoch());
       });
     });
   ctx.message_map.clear();

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -59,8 +59,6 @@ class ShardServices : public md_config_obs_t {
   const char** get_tracked_conf_keys() const final;
   void handle_conf_change(const ConfigProxy& conf,
                           const std::set <std::string> &changed) final;
-  template<class MsgT>
-  seastar::future<> do_send_to_osd(int peer, MsgT m, epoch_t from_epoch);
 
 public:
   ShardServices(
@@ -71,11 +69,6 @@ public:
     crimson::mon::Client &monc,
     crimson::mgr::Client &mgrc,
     crimson::os::FuturizedStore &store);
-
-  seastar::future<> send_to_osd(
-    int peer,
-    MessageRef m,
-    epoch_t from_epoch);
 
   seastar::future<> send_to_osd(
     int peer,

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -42,7 +42,7 @@ BufferedRecoveryMessages::BufferedRecoveryMessages(PeeringCtx &ctx)
 void BufferedRecoveryMessages::send_notify(int to, const pg_notify_t &n)
 {
   spg_t pgid(n.info.pgid.pgid, n.to);
-  send_osd_message(to, make_message<MOSDPGNotify2>(pgid, n));
+  send_osd_message(to, TOPNSPC::make_message<MOSDPGNotify2>(pgid, n));
 }
 
 void BufferedRecoveryMessages::send_query(
@@ -50,7 +50,7 @@ void BufferedRecoveryMessages::send_query(
   spg_t to_spgid,
   const pg_query_t &q)
 {
-  send_osd_message(to, make_message<MOSDPGQuery2>(to_spgid, q));
+  send_osd_message(to, TOPNSPC::make_message<MOSDPGQuery2>(to_spgid, q));
 }
 
 void BufferedRecoveryMessages::send_info(
@@ -64,7 +64,7 @@ void BufferedRecoveryMessages::send_info(
 {
   send_osd_message(
     to,
-    make_message<MOSDPGInfo2>(
+    TOPNSPC::make_message<MOSDPGInfo2>(
       to_spgid,
       info,
       cur_epoch,

--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -49,7 +49,7 @@ struct Server {
     {
       std::cout << "server got ping " << *m << std::endl;
       // reply with a pong
-      return c->send(make_message<MPing>()).then([this] {
+      return c->send(crimson::make_message<MPing>()).then([this] {
         ++count;
         on_reply.signal();
         return seastar::now();
@@ -214,7 +214,7 @@ seastar_echo(const entity_addr_t addr, echo_role role, unsigned count)
         return seastar::do_until(
           [&disp,count] { return disp.count >= count; },
           [&disp,conn] {
-            return conn->send(make_message<MPing>()).then([&] {
+            return conn->send(crimson::make_message<MPing>()).then([&] {
               return disp.on_reply.wait();
             });
           }

--- a/src/tools/crimson/perf_crimson_msgr.cc
+++ b/src/tools/crimson/perf_crimson_msgr.cc
@@ -162,7 +162,7 @@ static seastar::future<> run(
         const static hobject_t hobj(object_t(), oloc.key, CEPH_NOSNAP, pgid.ps(),
                                     pgid.pool(), oloc.nspace);
         static spg_t spgid(pgid);
-        auto rep = make_message<MOSDOp>(0, 0, hobj, spgid, 0, 0, 0);
+        auto rep = crimson::make_message<MOSDOp>(0, 0, hobj, spgid, 0, 0, 0);
         bufferlist data(msg_data);
         rep->write(0, msg_len, data);
         rep->set_tid(m->get_tid());
@@ -583,7 +583,7 @@ static seastar::future<> run(
           const static hobject_t hobj(object_t(), oloc.key, CEPH_NOSNAP, pgid.ps(),
                                       pgid.pool(), oloc.nspace);
           static spg_t spgid(pgid);
-          auto m = make_message<MOSDOp>(0, 0, hobj, spgid, 0, 0, 0);
+          auto m = crimson::make_message<MOSDOp>(0, 0, hobj, spgid, 0, 0, 0);
           bufferlist data(msg_data);
           m->write(0, msg_len, data);
           // use tid as the identity of each round


### PR DESCRIPTION
This PR should be the last of the 3 PRs that refactor Messenger to use `std::unique_ptr`. It includes a few more changes to the shared code in `PeeringState` as well as refactoring any last users of the previous version of `make_message` and wrapper functions to `Connection::send()`

Signed-off-by: Amnon Hanuhov <ahanukov@redhat.com>
