### PR TITLE
common, osd: add fmtlib formatting of some OSD types

### DIFF
--- a/src/common/hobject_fmt.h
+++ b/src/common/hobject_fmt.h
@@ -1,0 +1,52 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+
+/**
+ * \file fmtlib formatters for some hobject.h classes
+ */
+#include <fmt/format.h>
+
+#include "common/hobject.h"
+#include "include/types_fmt.h"
+#include "msg/msg_fmt.h"
+
+// \todo reimplement
+static inline void append_out_escaped(const std::string& in, std::string* out)
+{
+  for (auto i = in.cbegin(); i != in.cend(); ++i) {
+    if (*i == '%' || *i == ':' || *i == '/' || *i < 32 || *i >= 127) {
+      char buf[4];
+      snprintf(buf, sizeof(buf), "%%%02x", (int)(unsigned char)*i);
+      out->append(buf);
+    } else {
+      out->push_back(*i);
+    }
+  }
+}
+
+template <> struct fmt::formatter<hobject_t> {
+
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext> auto format(const hobject_t& ho, FormatContext& ctx)
+  {
+    if (ho == hobject_t{}) {
+      return fmt::format_to(ctx.out(), "MIN");
+    }
+
+    if (ho.is_max()) {
+      return fmt::format_to(ctx.out(), "MAX");
+    }
+
+    std::string v;
+    append_out_escaped(ho.nspace, &v);
+    v.push_back(':');
+    append_out_escaped(ho.get_key(), &v);
+    v.push_back(':');
+    append_out_escaped(ho.oid.name, &v);
+
+    return fmt::format_to(ctx.out(), "{}:{:08x}:{}:{}", static_cast<uint64_t>(ho.pool),
+			  ho.get_bitwise_key_u32(), v, ho.snap);
+  }
+};

--- a/src/include/types_fmt.h
+++ b/src/include/types_fmt.h
@@ -1,0 +1,28 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+/**
+ * \file fmtlib formatters for some types.h classes
+ */
+
+#include <fmt/format.h>
+
+#include <string_view>
+
+#include "include/types.h"
+
+template <class A, class B, class Comp, class Alloc>
+struct fmt::formatter<std::map<A, B, Comp, Alloc>> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const std::map<A, B, Comp, Alloc>& m, FormatContext& ctx)
+  {
+    std::string_view sep = "{";
+    for (const auto& [k, v] : m) {
+      fmt::format_to(ctx.out(), "{}{}={}", sep, k, v);
+      sep = ",";
+    }
+    return fmt::format_to(ctx.out(), "}}");
+  }
+};

--- a/src/msg/msg_fmt.h
+++ b/src/msg/msg_fmt.h
@@ -1,0 +1,26 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+
+/**
+ * \file fmtlib formatters for some msg_types.h classes
+ */
+
+#include <fmt/format.h>
+
+#include "include/types_fmt.h"
+#include "msg/msg_types.h"
+
+template <>
+struct fmt::formatter<entity_name_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const entity_name_t& addr, FormatContext& ctx)
+  {
+    if (addr.is_new() || addr.num() < 0) {
+      return fmt::format_to(ctx.out(), "{}.?", addr.type_str());
+    }
+    return fmt::format_to(ctx.out(), "{}.{}", addr.type_str(), addr.num());
+  }
+};

--- a/src/osd/PrimaryLogScrub.cc
+++ b/src/osd/PrimaryLogScrub.cc
@@ -4,6 +4,7 @@
 #include "PrimaryLogScrub.h"
 
 #include "common/scrub_types.h"
+#include "osd/osd_types_fmt.h"
 
 #include "PeeringState.h"
 #include "PrimaryLogPG.h"
@@ -576,12 +577,13 @@ void PrimaryLogScrub::stats_of_handled_objects(const object_stat_sum_t& delta_st
   // included when the scrubber gets to that object.
   if (is_primary() && is_scrub_active()) {
     if (soid < m_start) {
-      dout(20) << __func__ << " " << soid << " < [" << m_start << "," << m_end << ")"
-	       << dendl;
+
+      dout(20) << fmt::format("{} {} < [{},{})", __func__, soid, m_start, m_end) << dendl;
       m_scrub_cstat.add(delta_stats);
+
     } else {
-      dout(25) << __func__ << " " << soid << " >= [" << m_start << "," << m_end << ")"
-	       << dendl;
+
+      dout(25) << fmt::format("{} {} >= [{},{})", __func__, soid, m_start, m_end) << dendl;
     }
   }
 }

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -1,0 +1,106 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+/**
+ * \file fmtlib formatters for some types.h classes
+ */
+
+#include "common/hobject_fmt.h"
+#include "osd/osd_types.h"
+
+template <>
+struct fmt::formatter<osd_reqid_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const osd_reqid_t& req_id, FormatContext& ctx)
+  {
+    return fmt::format_to(ctx.out(), "{}.{}:{}", req_id.name, req_id.inc,
+			  req_id.tid);
+  }
+};
+
+template <>
+struct fmt::formatter<pg_shard_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const pg_shard_t& shrd, FormatContext& ctx)
+  {
+    if (shrd.is_undefined()) {
+      return fmt::format_to(ctx.out(), "?");
+    }
+    if (shrd.shard == shard_id_t::NO_SHARD) {
+      return fmt::format_to(ctx.out(), "{}", shrd.get_osd());
+    }
+    return fmt::format_to(ctx.out(), "{}({})", shrd.get_osd(), shrd.shard);
+  }
+};
+
+template <>
+struct fmt::formatter<eversion_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const eversion_t& ev, FormatContext& ctx)
+  {
+    return fmt::format_to(ctx.out(), "{}'{}", ev.epoch, ev.version);
+  }
+};
+
+template <>
+struct fmt::formatter<chunk_info_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const chunk_info_t& ci, FormatContext& ctx)
+  {
+    return fmt::format_to(ctx.out(), "(len: {} oid: {} offset: {} flags: {})",
+			  ci.length, ci.oid, ci.offset,
+			  ci.get_flag_string(ci.flags));
+  }
+};
+
+template <>
+struct fmt::formatter<object_manifest_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const object_manifest_t& om, FormatContext& ctx)
+  {
+    fmt::format_to(ctx.out(), "manifest({}", om.get_type_name());
+    if (om.is_redirect()) {
+      fmt::format_to(ctx.out(), " {}", om.redirect_target);
+    } else if (om.is_chunked()) {
+      fmt::format_to(ctx.out(), " {}", om.chunk_map);
+    }
+    return fmt::format_to(ctx.out(), ")");
+  }
+};
+
+template <>
+struct fmt::formatter<object_info_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const object_info_t& oi, FormatContext& ctx)
+  {
+    fmt::format_to(ctx.out(), "{}({} {} {} s {} uv {}", oi.soid, oi.version,
+		   oi.last_reqid, (oi.flags ? oi.get_flag_string() : ""), oi.size,
+		   oi.user_version);
+    if (oi.is_data_digest()) {
+      fmt::format_to(ctx.out(), " dd {:x}", oi.data_digest);
+    }
+    if (oi.is_omap_digest()) {
+      fmt::format_to(ctx.out(), " od {:x}", oi.omap_digest);
+    }
+
+    fmt::format_to(ctx.out(), " alloc_hint [{} {} {}]", oi.expected_object_size,
+		   oi.expected_write_size, oi.alloc_hint_flags);
+
+    if (oi.has_manifest()) {
+      fmt::format_to(ctx.out(), " {}", oi.manifest);
+    }
+    return fmt::format_to(ctx.out(), ")");
+  }
+};


### PR DESCRIPTION
Adding fmtlib support for some "user-defined" OSD types.

A use-case added, as a proof of viability (per @tchaikov request).

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>