### PR TITLE
mgr/rook: pass zone attribute to CephObjectStore CR when creating rgw

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -439,16 +439,16 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
     @handle_orch_error
     def remove_daemons(self, names: List[str]) -> List[str]:
         return self.rook_cluster.remove_pods(names)
-
+    """
     @handle_orch_error
     def create_osds(self, drive_group):
         # type: (DriveGroupSpec) -> str
-        """ Creates OSDs from a drive group specification.
+        # Creates OSDs from a drive group specification.
 
-        $: ceph orch osd create -i <dg.file>
+        # $: ceph orch osd create -i <dg.file>
 
-        The drivegroup file must only contain one spec at a time.
-        """
+        # The drivegroup file must only contain one spec at a time.
+        # 
 
         targets = []  # type: List[str]
         if drive_group.data_devices and drive_group.data_devices.paths:
@@ -475,7 +475,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         return self.rook_cluster.add_osds(drive_group, matching_hosts)
 
         # TODO: this was the code to update the progress reference:
-        """
+        
         @handle_orch_error
         def has_osds(matching_hosts: List[str]) -> bool:
 
@@ -506,8 +506,8 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                         osd_id, metadata['devices'] if metadata else 'DNE'
                     ))
 
-            return found is not None
-        """
+            return found is not None        
+    """
 
     @handle_orch_error
     def blink_device_light(self, ident_fault: str, on: bool, locs: List[orchestrator.DeviceLightLoc]) -> List[str]:


### PR DESCRIPTION
Added the option to pass zone when running `ceph orch apply rgw <rgw-name>` with the rook orchestrator backend using `--realm=<realm-name>` and `--zone=<zone-name>` options. 

Pointed the rook-client-python submodule at [Sebastian Wagner's repo](https://github.com/sebastian-philipp/rook-client-python/tree/update-june-21) which is updated with the correct API classes that the mgr/rook code is using.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
