### PR TITLE
client: check if a mds rank is `up` before fetching connection addr

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -14970,7 +14970,7 @@ void Client::ms_handle_remote_reset(Connection *con)
       mds_rank_t mds = MDS_RANK_NONE;
       MetaSession *s = NULL;
       for (auto &p : mds_sessions) {
-	if (mdsmap->get_addrs(p.first) == con->get_peer_addrs()) {
+	if (mdsmap->have_inst(p.first) && mdsmap->get_addrs(p.first) == con->get_peer_addrs()) {
 	  mds = p.first;
 	  s = &p.second;
 	}


### PR DESCRIPTION
Client segfaults when trying to infer which mds rank a connection
reset call is coming from. It does this by iterating `mds_sessions`
and checking the mds addr (in mdsmap) to the `Connection *`.

However, cases where the mds is blocklisted, the client receives
an updated mdsmap in which the corresponding mds is not in `up`
set thereby resulting in a segfault when calling `mdsmap->get_addrs`
since it expects that the mds should be in `up` state.

Note that this leaves the `Connection *` as it is and does not clean
it up. That needs to fixed separately probably by maintaining a map
of `Connection *` to mds rank for lookup.

Fixes: http://tracker.ceph.com/issues/50530
Signed-off-by: Venky Shankar <vshankar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
