### PR TITLE
mgr/cephadm: If the daemon of osd have been down before execute 'ceph…

### DIFF
--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -800,7 +800,7 @@ class OSDRemovalQueue(object):
 
     def idling_osds(self) -> List["OSD"]:
         with self.lock:
-            return [osd for osd in self.osds if not osd.is_draining and not osd.is_empty]
+            return [osd for osd in self.osds if not osd.is_draining]
 
     def empty_osds(self) -> List["OSD"]:
         with self.lock:


### PR DESCRIPTION
… orch osd rm xxx', the pg of osd is 0.

So the value of 'ok_to_stop_osds' is null, it will do not execute 'start_draining'. The command of 'osd safe-to-destroy' will always return False

Signed-off-by: jianglong01 <jianglong01@qianxin.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
