### PR TITLE
crimson/seastore: fix crimson-store-nbd to run with --type=seastore

### DIFF
--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -153,11 +153,17 @@ SegmentCleaner::SegmentCleaner(config_t config, bool detailed)
 
 void SegmentCleaner::register_metrics()
 {
-  namespace sm = seastar::metrics;
-  metrics.add_group("segment_cleaner", {
-    sm::make_counter("segments_released", stats.segments_released,
-		     sm::description("total number of extents released by SegmentCleaner")),
-  });
+  try {
+    namespace sm = seastar::metrics;
+    metrics.add_group("segment_cleaner", {
+      sm::make_counter("segments_released", stats.segments_released,
+                       sm::description("total number of extents released by SegmentCleaner")),
+    });
+  } catch (...) {
+    logger().error("SegmentCleaner::register_metrics got unexpected exception {}",
+                   std::current_exception());
+    ceph_abort();
+  }
 }
 
 SegmentCleaner::get_segment_ret SegmentCleaner::get_segment()

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -377,21 +377,27 @@ TransactionManager::~TransactionManager() {}
 
 void TransactionManager::register_metrics()
 {
-  namespace sm = seastar::metrics;
-  metrics.add_group("tm", {
-    sm::make_counter("extents_retired_total", stats.extents_retired_total,
-		     sm::description("total number of retired extents in TransactionManager")),
-    sm::make_counter("extents_retired_bytes", stats.extents_retired_bytes,
-		     sm::description("total size of retired extents in TransactionManager")),
-    sm::make_counter("extents_mutated_total", stats.extents_mutated_total,
-		     sm::description("total number of mutated extents in TransactionManager")),
-    sm::make_counter("extents_mutated_bytes", stats.extents_mutated_bytes,
-		     sm::description("total size of mutated extents in TransactionManager")),
-    sm::make_counter("extents_allocated_total", stats.extents_allocated_total,
-		     sm::description("total number of allocated extents in TransactionManager")),
-    sm::make_counter("extents_allocated_bytes", stats.extents_allocated_bytes,
-		     sm::description("total size of allocated extents in TransactionManager")),
-  });
+  LOG_PREFIX(TransactionManager::register_metrics);
+  try {
+    namespace sm = seastar::metrics;
+    metrics.add_group("tm", {
+      sm::make_counter("extents_retired_total", stats.extents_retired_total,
+                       sm::description("total number of retired extents in TransactionManager")),
+      sm::make_counter("extents_retired_bytes", stats.extents_retired_bytes,
+                       sm::description("total size of retired extents in TransactionManager")),
+      sm::make_counter("extents_mutated_total", stats.extents_mutated_total,
+                       sm::description("total number of mutated extents in TransactionManager")),
+      sm::make_counter("extents_mutated_bytes", stats.extents_mutated_bytes,
+                       sm::description("total size of mutated extents in TransactionManager")),
+      sm::make_counter("extents_allocated_total", stats.extents_allocated_total,
+                       sm::description("total number of allocated extents in TransactionManager")),
+      sm::make_counter("extents_allocated_bytes", stats.extents_allocated_bytes,
+                       sm::description("total size of allocated extents in TransactionManager")),
+    });
+  } catch (...) {
+    ERROR("got unexpected exception {}", std::current_exception());
+    ceph_abort();
+  }
 }
 
 }


### PR DESCRIPTION
There are still issues but might be minor as a test tool:
- Futurized-store backends expect `--device-path` to be a directory containing a file or a symbolic link named `block`;
- ~~`crimson-store-nbd` cannot handle `ctrl-c` properly for a graceful shutdown;~~
- Need to erase `/tmp/store_nbd_socket.sock` manually before re-running `crimson-store-nbd`;

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
