### PR TITLE
os/bluestore: fix bluefs log run out of space

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2524,8 +2524,21 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
 
   // allocate some more space (before we run out)?
   // BTW: this triggers `flush()` in the `page_aligned_appender` of `log_writer`.
+  int64_t estimate_log_t_size = 0;
+  {
+    bufferlist bl;
+    ::encode(log_t, bl);
+
+    bluefs_transaction_t tmp_log_t;
+    tmp_log_t.op_file_update(log_writer->file->fnode);
+    bufferlist tmp_bl;
+    ::encode(tmp_log_t, tmp_bl);
+
+    estimate_log_t_size = round_up_to(bl.length(), super.block_size) + round_up_to(tmp_bl.length(), super.block_size);
+  }
+
   int64_t runway = log_writer->file->fnode.get_allocated() -
-    log_writer->get_effective_write_pos();
+    log_writer->get_effective_write_pos() - estimate_log_t_size;
   bool just_expanded_log = false;
   if (runway < (int64_t)cct->_conf->bluefs_min_log_runway) {
     dout(10) << __func__ << " allocating more log runway (0x"
@@ -2535,11 +2548,14 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
       log_cond.wait(l);
     }
     vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
-    int r = _allocate(
-      vselector->select_prefer_bdev(log_writer->file->vselector_hint),
-      cct->_conf->bluefs_max_log_runway,
-      &log_writer->file->fnode);
-    ceph_assert(r == 0);
+    do {
+      int r = _allocate(
+        vselector->select_prefer_bdev(log_writer->file->vselector_hint),
+        cct->_conf->bluefs_max_log_runway,
+        &log_writer->file->fnode);
+      ceph_assert(r == 0);
+      runway += cct->_conf->bluefs_max_log_runway;
+    } while (runway < (int64_t)cct->_conf->bluefs_min_log_runway)
     vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
     log_t.op_file_update(log_writer->file->fnode);
     just_expanded_log = true;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/51217
Signed-off-by: Shu Yu <yushu20171007@163.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
