### PR TITLE
osd/OSD: mkfs need wait for transcation completely finish

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2142,6 +2142,7 @@ int OSD::mkfs(CephContext *cct,
 	   << "queue_transaction returned " << cpp_strerror(ret) << dendl;
       return ret;
     }
+    ch->flush();
   }
 
   ret = write_meta(cct, store.get(), sb.cluster_fsid, sb.osd_fsid, whoami, osdspec_affinity);


### PR DESCRIPTION
osd/OSD: mkfs need wait for transcation completely finish

 when do ceph-osd mkfs, when ceph-osd process exit, sometimes
 the block data could be written incompletely. we need add
 wait for it complete.

Signed-off-by: fan.chen  <fan.chen@easystack.cn>
