### PR TITLE
pacific: rgw: crash on multipart upload to bucket with policy

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -581,7 +581,10 @@ int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosS
       s->bucket_exists = false;
       return -ERR_NO_SUCH_BUCKET;
     }
-
+    if (!rgw::sal::RGWObject::empty(s->object.get())) {
+      s->object->set_bucket(s->bucket.get());
+    }
+    
     s->bucket_mtime = s->bucket->get_modification_time();
     s->bucket_attrs = s->bucket->get_attrs();
     ret = read_bucket_policy(dpp, store, s, s->bucket->get_info(),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51001

---

backport of https://github.com/ceph/ceph/pull/41288
parent tracker: https://tracker.ceph.com/issues/50556

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh