### PR TITLE
rbd: don't disable rbd_discard_on_zeroed_write_same

### DIFF
--- a/src/tools/rbd/action/Create.cc
+++ b/src/tools/rbd/action/Create.cc
@@ -175,14 +175,9 @@ err_writesame:
 
 int thick_write(const std::string &image_name,librados::IoCtx &io_ctx,
                 librbd::ImageOptions &opts, bool no_progress) {
-  int r = 0;
+  int r;
   librbd::Image image;
 
-  // To prevent writesame from discarding data, thick_write sets
-  // the rbd_discard_on_zeroed_write_same option to false.
-  ceph_assert(g_ceph_context != nullptr);
-  r = g_conf().set_val("rbd_discard_on_zeroed_write_same", "false");
-  ceph_assert(r == 0);
   r = utils::open_image(io_ctx, image_name, false, &image);
   if (r < 0) {
     return r;


### PR DESCRIPTION
After commit 0e8aa956a3b6 ("rbd: switch thick-provision image creation
to use new write_zeroes API") it is no longer necessary.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>