### PR TITLE
rgw/notification: add time to notification when deleting a delete marker

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4914,9 +4914,10 @@ void RGWDeleteObj::execute(optional_yield y)
     }
 
     const auto obj_state = obj_ctx->get_state(s->object->get_obj());
+    const auto mtime = real_clock::is_zero(obj_state->mtime) ? ceph::real_clock::now() : obj_state->mtime;
 
     // send request to notification manager
-    int ret = res->publish_commit(this, obj_state->size, obj_state->mtime, attrs[RGW_ATTR_ETAG].to_str());
+    int ret = res->publish_commit(this, obj_state->size, mtime, attrs[RGW_ATTR_ETAG].to_str());
     if (ret < 0) {
       ldpp_dout(this, 1) << "ERROR: publishing notification failed, with error: " << ret << dendl;
       // too late to rollback operation, hence op_ret is not set here
@@ -6837,7 +6838,8 @@ void RGWDeleteMultiObj::execute(optional_yield y)
     const auto etag = obj_state->get_attr(RGW_ATTR_ETAG, etag_bl) ? etag_bl.to_str() : "";
 
     // send request to notification manager
-    int ret = res->publish_commit(this, obj_state->size, obj_state->mtime, etag);
+    const auto mtime = real_clock::is_zero(obj_state->mtime) ? ceph::real_clock::now() : obj_state->mtime;
+    int ret = res->publish_commit(this, obj_state->size, mtime, etag);
     if (ret < 0) {
       ldpp_dout(this, 1) << "ERROR: publishing notification failed, with error: " << ret << dendl;
       // too late to rollback operation, hence op_ret is not set here

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -6,6 +6,7 @@ import threading
 import subprocess
 import socket
 import time
+import dateutil.parser
 import os
 import string
 import boto
@@ -1985,12 +1986,14 @@ def test_ps_s3_versioned_deletion_on_master():
     print('wait for 5sec for the messages...')
     time.sleep(5)
 
+
     # check amqp receiver
     events = receiver.get_and_reset_events()
     delete_events = 0
     delete_marker_create_events = 0
     for event_list in events:
         for event in event_list['Records']:
+            assert dateutil.parser.isoparse(event['eventTime']).timestamp() > 0
             if event['eventName'] == 'ObjectRemoved:Delete':
                 delete_events += 1
                 assert event['s3']['configurationId'] in [notification_name+'_1', notification_name+'_3']


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/51247

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
