### PR TITLE
tools/crushdiff: new tool to test crushmap change

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -416,6 +416,7 @@ My Do <mhdo@umich.edu>
 My Do <mhdo@umich.edu> <mhdo2@users.noreply.github.com>
 Mykola Golub <mgolub@mirantis.com> <mgolub@zhuzha.mirantis.lviv.net>
 Mykola Golub <mgolub@suse.com>
+Mykola Golub <mykola.golub@clyso.com>
 Mykola Golub <to.my.trociny@gmail.com>
 Myna Vajha <mynaramana@gmail.com>
 Myoungwon Oh <myoungwon.oh@samsung.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -134,6 +134,7 @@ Cloudwatt <libre.licensing@cloudwatt.com> Christophe Courtaut <christophe.courta
 Cloudwatt <libre.licensing@cloudwatt.com> Florent Flament <florent.flament@cloudwatt.com>
 Cloudwatt <libre.licensing@cloudwatt.com> Loic Dachary <loic@dachary.org>
 Cloudwatt <libre.licensing@cloudwatt.com> Sahid Orentino Ferdjaoui <sahid.ferdjaoui@cloudwatt.com>
+Clyso GmbH <contact@clyso.com> Mykola Golub <mykola.golub@clyso.com>
 CohortFS, LLC <contact@cohortfs.com> Casey Bodley <casey@cohortfs.com>
 CohortFS, LLC <contact@cohortfs.com> Matt Benjamin <matt@cohortfs.com>
 Commerce Guys <contact@commerceguys.com> Nikola Kotur <kotnick@gmail.com>

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1577,6 +1577,7 @@ exit 0
 %{_bindir}/cephfs-data-scan
 %{_bindir}/cephfs-journal-tool
 %{_bindir}/cephfs-table-tool
+%{_bindir}/crushdiff
 %{_bindir}/rados
 %{_bindir}/radosgw-admin
 %{_bindir}/rbd

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1603,6 +1603,7 @@ exit 0
 %{_mandir}/man8/ceph-syn.8*
 %{_mandir}/man8/ceph-post-file.8*
 %{_mandir}/man8/ceph.8*
+%{_mandir}/man8/crushdiff.8*
 %{_mandir}/man8/mount.ceph.8*
 %{_mandir}/man8/rados.8*
 %{_mandir}/man8/radosgw-admin.8*

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -15,6 +15,7 @@ usr/bin/ceph-syn
 usr/bin/cephfs-data-scan
 usr/bin/cephfs-journal-tool
 usr/bin/cephfs-table-tool
+usr/bin/crushdiff
 usr/bin/rados
 usr/bin/radosgw-admin
 usr/bin/rbd

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -33,6 +33,7 @@ usr/share/man/man8/ceph-rbdnamer.8
 usr/share/man/man8/ceph-syn.8
 usr/share/man/man8/ceph-post-file.8
 usr/share/man/man8/ceph.8
+usr/share/man/man8/crushdiff.8
 usr/share/man/man8/mount.ceph.8
 usr/share/man/man8/rados.8
 usr/share/man/man8/radosgw-admin.8

--- a/doc/man/8/CMakeLists.txt
+++ b/doc/man/8/CMakeLists.txt
@@ -24,6 +24,7 @@ set(osd_srcs
   ceph-volume.rst
   ceph-volume-systemd.rst
   ceph-osd.rst
+  crushdiff.rst
   osdmaptool.rst
   ceph-bluestore-tool.rst)
 

--- a/doc/man/8/crushdiff.rst
+++ b/doc/man/8/crushdiff.rst
@@ -1,0 +1,118 @@
+:orphan:
+
+.. _crushdiff:
+
+=======================================
+ crushdiff -- ceph crush map test tool
+=======================================
+
+.. program:: crushdiff
+
+Synopsis
+========
+
+| **crushdiff** [ --osdmap *osdmap* ] [ --pg-dump *pg-dump* ]
+  [ --compiled ] [ --verbose ] *command* *crushmap*
+
+
+Description
+===========
+
+**crushdiff** is a utility that lets you test the effect of a crushmap
+change: number of pgs, objects, bytes moved. This is a wrapper around
+:doc:`osdmaptool <osdmaptool>`\(8), relying on its **--test-map-pgs-dump**
+option to get the list of changed pgs. Additionally it uses pg stats
+to calculate the numbers of objects and bytes moved.
+
+By default, **crushdiff** will use the cluster current osdmap and pg
+stats, which requires access to the cluster. Though one can use the
+**--osdmap** and **--pg-dump** options to test against previously
+obtained data.
+
+Options
+=======
+
+.. option:: --compiled
+
+   The input/output crushmap is compiled. If the options is not
+   specified the expected/returned crushmap is in txt (decompiled)
+   format.
+
+.. option:: --pg-dump <pg-dump>
+
+   JSON output of **ceph pg dump**. If not specified **crushdiff**
+   will try to get data running the command itself.
+
+.. option:: --osdmap <osdmap>
+
+   The cluster osdmap, obtained with **ceph osd getmap** command. If
+   not specified **crushdiff** will try to get data running the
+   command itself.
+
+.. option:: --verbose
+
+   Produce diagnostic output.
+
+Commands
+========
+
+:command:`compare` *crushmap*
+  Compare the crushmap from *crushmap* file with the crushmap from
+  the cluster osdmap. The output will show the expected number of pgs,
+  objects, bytes moved when the new crushmap is installed.
+
+:command:`export` *crushmap*
+  Export crushmap to *crushmap* file from the cluster osdmap.
+
+:command:`import` *crushmap*
+  Import crushmap from *crushmap* file to the cluster osdmap.
+
+Example
+=======
+
+Get the current crushmap::
+
+        crushdiff export cm.txt
+
+Edit the map::
+
+        $EDITOR cm.txt
+
+Check the result::
+
+        crushdiff compare cm.txt
+
+        79/416 (18.99%) pgs affected
+        281/1392 (20.19%) objects affected
+        80/1248 (6.41%) pg shards to move
+        281/4176 (6.73%) pg object shards to move
+        730.52Mi/10.55Gi (6.76%) bytes to move
+
+When running with **--verbose** option the output will also contain
+detailed information about the affected pgs, like below::
+
+        4.3	[0, 2, 1] -> [1, 4, 2]
+        4.b	[0, 1, 3] -> [2, 1, 3]
+        4.c	[4, 0, 1] -> [4, 1, 2]
+
+i.e. a pg number, and its old and the new osd active sets.
+
+If the result is satisfactory install the updated map::
+
+        crushdiff import cm.txt
+
+
+Availability
+============
+
+**crushdiff** is part of Ceph, a massively scalable, open-source, distributed storage system.  Please
+refer to the Ceph documentation at https://docs.ceph.com for more
+information.
+
+
+See also
+========
+
+:doc:`ceph <ceph>`\(8),
+:doc:`crushtool <crushtool>`\(8),
+:doc:`osdmaptool <osdmaptool>`\(8),

--- a/doc/man_index.rst
+++ b/doc/man_index.rst
@@ -26,6 +26,7 @@
    man/8/cephfs-top
    man/8/cephfs-mirror
    man/8/cephfs-shell
+   man/8/crushdiff
    man/8/crushtool
    man/8/librados-config
    man/8/monmaptool

--- a/doc/rados/man/index.rst
+++ b/doc/rados/man/index.rst
@@ -18,6 +18,7 @@
    ../../man/8/ceph-kvstore-tool.rst
    ../../man/8/ceph-run.rst
    ../../man/8/ceph-syn.rst
+   ../../man/8/crushdiff.rst
    ../../man/8/crushtool.rst
    ../../man/8/librados-config.rst
    ../../man/8/monmaptool.rst

--- a/qa/suites/rados/singleton-nomsgr/all/crushdiff.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/crushdiff.yaml
@@ -1,0 +1,24 @@
+openstack:
+  - volumes: # attached to each instance
+      count: 4
+      size: 10 # GB
+roles:
+- [mon.a, mgr.x, osd.0, osd.1, osd.2, osd.3, client.0]
+
+overrides:
+  ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr_pool false --force
+    log-ignorelist:
+    - but it is still running
+    - overall HEALTH_
+    - \(POOL_APP_NOT_ENABLED\)
+    - \(PG_DEGRADED\)
+
+tasks:
+- install:
+- ceph:
+- workunit:
+    clients:
+      all:
+        - rados/test_crushdiff.sh

--- a/qa/workunits/rados/test_crushdiff.sh
+++ b/qa/workunits/rados/test_crushdiff.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -ex
+
+REP_POOL=
+EC_POOL=
+TEMPDIR=
+
+OSD_NUM=$(ceph osd ls | wc -l)
+test ${OSD_NUM} -gt 0
+
+setup() {
+    local pool
+
+    TEMPDIR=`mktemp -d`
+
+    pool=test-crushdiff-rep-$$
+    ceph osd pool create ${pool} 32
+    REP_POOL=${pool}
+    rados -p ${REP_POOL} bench 5 write --no-cleanup
+
+    if [ ${OSD_NUM} -gt 3 ]; then
+        pool=test-crushdiff-ec-$$
+        ceph osd pool create ${pool} 32 32 erasure
+        EC_POOL=${pool}
+        rados -p ${EC_POOL} bench 5 write --no-cleanup
+    fi
+}
+
+cleanup() {
+    set +e
+
+    test -n "${EC_POOL}" &&
+        ceph osd pool delete "${EC_POOL}" "${EC_POOL}" \
+             --yes-i-really-really-mean-it
+    EC_POOL=
+
+    test -n "${REP_POOL}" &&
+        ceph osd pool delete "${REP_POOL}" "${REP_POOL}" \
+             --yes-i-really-really-mean-it
+    REP_POOL=
+
+    test -n "${TEMPDIR}" && rm -Rf ${TEMPDIR}
+    TEMPDIR=
+}
+
+trap "cleanup" INT TERM EXIT
+
+setup
+
+# test without crushmap modification
+
+crushdiff export ${TEMPDIR}/cm.txt --verbose
+crushdiff compare ${TEMPDIR}/cm.txt --verbose
+crushdiff import ${TEMPDIR}/cm.txt --verbose
+
+# test using a compiled crushmap
+
+crushdiff export ${TEMPDIR}/cm --compiled --verbose
+crushdiff compare ${TEMPDIR}/cm --compiled --verbose
+crushdiff import ${TEMPDIR}/cm --compiled --verbose
+
+# test using "offline" osdmap and pg-dump
+
+ceph osd getmap -o ${TEMPDIR}/osdmap
+ceph pg dump --format json > ${TEMPDIR}/pg-dump
+
+crushdiff export ${TEMPDIR}/cm.txt --osdmap ${TEMPDIR}/osdmap --verbose
+crushdiff compare ${TEMPDIR}/cm.txt --osdmap ${TEMPDIR}/osdmap \
+          --pg-dump ${TEMPDIR}/pg-dump --verbose | tee ${TEMPDIR}/compare.txt
+
+# test the diff is zero when the crushmap is not modified
+
+grep '^0/[0-9]* (0\.00%) pgs affected' ${TEMPDIR}/compare.txt
+grep '^0/[0-9]* (0\.00%) objects affected' ${TEMPDIR}/compare.txt
+grep '^0/[0-9]* (0\.00%) pg shards to move' ${TEMPDIR}/compare.txt
+grep '^0/[0-9]* (0\.00%) pg object shards to move' ${TEMPDIR}/compare.txt
+grep '^0\.00/.* (0\.00%) bytes to move' ${TEMPDIR}/compare.txt
+crushdiff import ${TEMPDIR}/cm.txt --osdmap ${TEMPDIR}/osdmap --verbose
+
+if [ ${OSD_NUM} -gt 3 ]; then
+
+    # test the diff is non-zero when the crushmap is modified
+
+    cat ${TEMPDIR}/cm.txt >&2
+
+    weight=$(awk '/item osd\.0 weight ([0-9.]+)/ {print $4 * 3}' \
+                 ${TEMPDIR}/cm.txt)
+    test -n "${weight}"
+    sed -i -Ee 's/^(.*item osd\.0 weight )[0-9.]+/\1'${weight}'/' \
+        ${TEMPDIR}/cm.txt
+    crushdiff compare ${TEMPDIR}/cm.txt --osdmap ${TEMPDIR}/osdmap \
+        --pg-dump ${TEMPDIR}/pg-dump --verbose | tee ${TEMPDIR}/compare.txt
+    grep '^[1-9][0-9]*/[0-9]* (.*%) pgs affected' ${TEMPDIR}/compare.txt
+    grep '^[1-9][0-9]*/[0-9]* (.*%) objects affected' ${TEMPDIR}/compare.txt
+    grep '^[1-9][0-9]*/[0-9]* (.*%) pg shards to move' ${TEMPDIR}/compare.txt
+    grep '^[1-9][0-9]*/[0-9]* (.*%) pg object shards to move' \
+         ${TEMPDIR}/compare.txt
+    grep '^.*/.* (.*%) bytes to move' ${TEMPDIR}/compare.txt
+    crushdiff import ${TEMPDIR}/cm.txt --osdmap ${TEMPDIR}/osdmap --verbose
+fi
+
+echo OK

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -96,6 +96,8 @@ add_executable(osdmaptool ${osdomaptool_srcs})
 target_link_libraries(osdmaptool global)
 install(TARGETS osdmaptool DESTINATION bin)
 
+install(PROGRAMS crushdiff DESTINATION bin)
+
 set(ceph-diff-sorted_srcs ceph-diff-sorted.cc)
 add_executable(ceph-diff-sorted ${ceph-diff-sorted_srcs})
 set_target_properties(ceph-diff-sorted PROPERTIES

--- a/src/tools/crushdiff
+++ b/src/tools/crushdiff
@@ -1,0 +1,335 @@
+#!/usr/bin/python3
+#
+# A tool to test the effect (number of pgs, objects, bytes moved) of a
+# crushmap change. This is a wrapper around osdmaptool, hardly relying
+# on its --test-map-pgs-dump option to get the list of changed pgs.
+# Additionally it uses pg stats to calculate the numbers of objects
+# and bytes moved.
+#
+# Typical usage:
+#
+# # Get current crushmap
+# $ crushdiff export cm.txt
+# # Edit the map
+# $ $EDITOR cm.txt
+# # Check the result
+# $ crushdiff compare cm.txt
+# # Install the updated map
+# $ crushdiff import cm.txt
+#
+# By default, crushdiff will use the cluster current osdmap and pg
+# stats, which requires access to the cluster. But one can use the
+# --osdmap and --pg-dump options to test against previously obtained
+# data.
+#
+
+import argparse
+import re
+import json
+import os
+import sys
+import tempfile
+
+#
+# Global
+#
+
+parser = argparse.ArgumentParser(prog='crushdiff',
+                                 description='Tool for updating crush map')
+parser.add_argument(
+    'command',
+    metavar='compare|export|import',
+    help='command',
+    default=None,
+)
+parser.add_argument(
+    '-c', '--compiled',
+    action='store_true',
+    help='use compiled crush map',
+    default=False,
+)
+parser.add_argument(
+    'crushmap',
+    metavar='crushmap',
+    help='crushmap json file',
+    default=None,
+)
+parser.add_argument(
+    '-m', '--osdmap',
+    metavar='osdmap',
+    help='',
+    default=None,
+)
+parser.add_argument(
+    '-p', '--pg-dump',
+    metavar='pg-dump',
+    help='`ceph pg dump` json output',
+    default=None,
+)
+parser.add_argument(
+    '-v', '--verbose',
+    action='store_true',
+    help='be verbose',
+    default=False,
+)
+
+#
+# Functions
+#
+
+def get_human_readable(bytes, precision=2):
+    suffixes = ['', 'Ki', 'Mi', 'Gi', 'Ti']
+    suffix_index = 0
+    while bytes > 1024 and suffix_index < 4:
+        # increment the index of the suffix
+        suffix_index += 1
+        # apply the division
+        bytes = bytes / 1024.0
+    return '%.*f%s' % (precision, bytes, suffixes[suffix_index])
+
+def run_cmd(cmd, verbose=False):
+    if verbose:
+        print(cmd, file=sys.stderr, flush=True)
+    os.system(cmd)
+
+def get_osdmap(file):
+    with open(file, "r") as f:
+        return json.load(f)
+
+def get_pools(osdmap):
+    return {p['pool']: p for p in osdmap['pools']}
+
+def get_erasure_code_profiles(osdmap):
+    return osdmap['erasure_code_profiles']
+
+def get_pgmap(pg_dump_file):
+    with open(pg_dump_file, "r") as f:
+        return json.load(f)['pg_map']
+
+def get_pg_stats(pgmap):
+    return {pg['pgid']: pg for pg in pgmap['pg_stats']}
+
+def parse_test_map_pgs_dump(file):
+    # Format:
+    # pool 1 pg_num 16
+    # 1.0	[1,0,2]	1
+    # 1.1	[2,0,1]	2
+    # ...
+    # pool 2 pg_num 32
+    # 2.0	[2,1,0]	2
+    # 2.1	[2,1,0]	2
+    # ...
+    # #osd	count	first	primary	c wt	wt
+    # osd.1	208	123	123	0.098587	1
+
+    pgs = {}
+
+    with open(file, "r") as f:
+        pool = None
+        for l in f.readlines():
+            m = re.match('^pool (\d+) pg_num (\d+)', l)
+            if m:
+                pool = m.group(1)
+                continue
+            if not pool:
+                continue
+            m = re.match('^#osd', l)
+            if m:
+                break
+            m = re.match('^(\d+\.[0-9a-f]+)\s+\[([\d,]+)\]', l)
+            if not m:
+                continue
+            pgid = m.group(1)
+            osds = [int(x) for x in m.group(2).split(',')]
+            pgs[pgid] = osds
+
+    return pgs
+
+def do_compare(new_crushmap_in, osdmap=None, pg_dump=None, compiled=False,
+               verbose=False):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        if compiled:
+            new_crushmap_file = new_crushmap_in
+        else:
+            new_crushmap_file = os.path.join(tmpdirname, 'crushmap')
+            run_cmd('crushtool -c {} -o {}'.format(new_crushmap_in,
+                                                   new_crushmap_file), verbose)
+
+        osdmap_file = os.path.join(tmpdirname, 'osdmap')
+        if osdmap:
+            run_cmd('cp {} {}'.format(osdmap, osdmap_file), verbose)
+        else:
+            run_cmd('ceph osd getmap -o {}'.format(osdmap_file), verbose)
+
+        if not pg_dump:
+            pg_dump = os.path.join(tmpdirname, 'pg_dump.json')
+            run_cmd('ceph pg dump --format json > {}'.format(pg_dump), verbose)
+
+        old_test_map_pgs_dump = os.path.join(tmpdirname, 'pgs.old.txt')
+        run_cmd('osdmaptool {} --test-map-pgs-dump > {}'.format(
+            osdmap_file, old_test_map_pgs_dump), verbose)
+        if verbose:
+            run_cmd('cat {} >&2'.format(old_test_map_pgs_dump), True)
+
+        new_test_map_pgs_dump = os.path.join(tmpdirname, 'pgs.new.txt')
+        run_cmd(
+            'osdmaptool {} --import-crush {} --test-map-pgs-dump > {}'.format(
+                osdmap_file, new_crushmap_file, new_test_map_pgs_dump), verbose)
+        if verbose:
+            run_cmd('cat {} >&2'.format(new_test_map_pgs_dump), True)
+
+        osdmap_file_json = os.path.join(tmpdirname, 'osdmap.json')
+        run_cmd('osdmaptool {} --dump json > {}'.format(
+            osdmap_file, osdmap_file_json), verbose)
+        osdmap = get_osdmap(osdmap_file_json)
+        pools = get_pools(osdmap)
+        ec_profiles = get_erasure_code_profiles(osdmap)
+
+        pgmap = get_pgmap(pg_dump)
+        pg_stats = get_pg_stats(pgmap)
+
+        old_pgs = parse_test_map_pgs_dump(old_test_map_pgs_dump)
+        new_pgs = parse_test_map_pgs_dump(new_test_map_pgs_dump)
+
+    diff_pg_count = 0
+    total_object_count = 0
+    diff_object_count = 0
+    for pgid in old_pgs:
+        objects = pg_stats[pgid]['stat_sum']['num_objects']
+        total_object_count += objects
+
+        if old_pgs[pgid] == new_pgs[pgid]:
+            continue
+
+        pool_id = int(pgid.split('.')[0])
+
+        if len(new_pgs[pgid]) < pools[pool_id]['size']:
+            print("WARNING: {} will be undersized ({})".format(
+                pgid, new_pgs[pgid]), file=sys.stderr, flush=True)
+
+        if not pools[pool_id]['erasure_code_profile'] and \
+           sorted(old_pgs[pgid]) == sorted(new_pgs[pgid]):
+            continue
+
+        if verbose:
+            print("{}\t{} -> {}".format(pgid, old_pgs[pgid], new_pgs[pgid]),
+                  file=sys.stderr, flush=True)
+        diff_pg_count += 1
+        diff_object_count += objects
+
+    print("{}/{} ({:.2f}%) pgs affected".format(
+        diff_pg_count, len(old_pgs),
+        100 * diff_pg_count / len(old_pgs) if len(old_pgs) else 0),
+        flush=True)
+    print("{}/{} ({:.2f}%) objects affected".format(
+        diff_object_count, total_object_count,
+        100 * diff_object_count / total_object_count \
+        if total_object_count else 0), flush=True)
+
+    total_pg_shard_count = 0
+    diff_pg_shard_count = 0
+    total_object_shard_count = 0
+    diff_object_shard_count = 0
+    total_bytes = 0
+    diff_bytes = 0
+    for pgid in old_pgs:
+        pool_id = int(pgid.split('.')[0])
+        ec_profile = pools[pool_id]['erasure_code_profile']
+        if ec_profile:
+            k = int(ec_profiles[ec_profile]['k'])
+            m = int(ec_profiles[ec_profile]['m'])
+        else:
+            k = 1
+            m = pools[pool_id]['size'] - 1
+
+        bytes = pg_stats[pgid]['stat_sum']['num_bytes'] + \
+            pg_stats[pgid]['stat_sum']['num_omap_bytes']
+        objects = pg_stats[pgid]['stat_sum']['num_objects']
+
+        total_pg_shard_count += len(old_pgs[pgid])
+        total_object_shard_count += objects * (k + m)
+        total_bytes += bytes * (k + m) / k
+
+        if old_pgs[pgid] == new_pgs[pgid]:
+            continue
+
+        old_count = diff_pg_shard_count
+
+        if ec_profile:
+            for i in range(len(old_pgs[pgid])):
+                if old_pgs[pgid][i] != new_pgs[pgid][i]:
+                    diff_pg_shard_count += 1
+                    diff_object_shard_count += objects
+                    diff_bytes += bytes / k
+        else:
+            for osd in old_pgs[pgid]:
+                if osd not in new_pgs[pgid]:
+                    diff_pg_shard_count += 1
+                    diff_object_shard_count += objects
+                    diff_bytes += bytes / k
+
+        if old_count == diff_pg_shard_count:
+            continue
+
+        if verbose:
+            print("{}\t{} -> {}".format(pgid, old_pgs[pgid], new_pgs[pgid]),
+                  file=sys.stderr, flush=True)
+
+    print("{}/{} ({:.2f}%) pg shards to move".format(
+        diff_pg_shard_count, total_pg_shard_count,
+        100 * diff_pg_shard_count / total_pg_shard_count \
+        if total_pg_shard_count else 0), flush=True)
+    print("{}/{} ({:.2f}%) pg object shards to move".format(
+        diff_object_shard_count, total_object_shard_count,
+        100 * diff_object_shard_count / total_object_shard_count \
+        if total_object_shard_count else 0), flush=True)
+    print("{}/{} ({:.2f}%) bytes to move".format(
+        get_human_readable(int(diff_bytes)),
+        get_human_readable(int(total_bytes)),
+        100 * diff_bytes / total_bytes if total_bytes else 0),
+        flush=True)
+
+def do_export(crushmap_out, osdmap_file=None, compiled=False, verbose=False):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        if not osdmap_file:
+            osdmap_file = os.path.join(tmpdirname, 'osdmap')
+            run_cmd('ceph osd getmap -o {}'.format(osdmap_file), verbose)
+
+        crushmap_file = crushmap_out if compiled else \
+            os.path.join(tmpdirname, 'crushmap')
+        run_cmd('osdmaptool {} --export-crush {}'.format(
+            osdmap_file, crushmap_file), verbose)
+        if not compiled:
+            run_cmd('crushtool -d {} -o {}'.format(crushmap_file, crushmap_out),
+                    verbose)
+
+def do_import(crushmap_in, osdmap=None, compiled=False, verbose=False):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        if compiled:
+            crushmap_file = crushmap_in
+        else:
+            crushmap_file = os.path.join(tmpdirname, 'crushmap')
+            run_cmd('crushtool -c {} -o {}'.format(crushmap_in,
+                                                   crushmap_file), verbose)
+        if osdmap:
+            run_cmd('osdmaptool {} --import-crush {}'.format(
+                osdmap, crushmap_file), verbose)
+        else:
+            run_cmd('ceph osd setcrushmap -i {}'.format(crushmap_file), verbose)
+
+def main():
+    args = parser.parse_args()
+
+    if args.command == 'compare':
+        do_compare(args.crushmap, args.osdmap, args.pg_dump, args.compiled,
+                   args.verbose)
+    elif args.command == 'export':
+        do_export(args.crushmap, args.osdmap, args.compiled, args.verbose)
+    elif args.command == 'import':
+        do_import(args.crushmap, args.osdmap, args.compiled, args.verbose)
+
+#
+# main
+#
+
+main()


### PR DESCRIPTION
A tool to test the effect (number of pgs, objects, bytes moved)
of a crushmap change. This is a wrapper around osdmaptool, hardly
relying on its --test-map-pgs-dump option to get the list of
changed pgs.  Additionally it uses pg stats to calculate the
numbers of objects and bytes moved.

Signed-off-by: Mykola Golub <mykola.golub@clyso.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
