### PR TITLE
os/bluestore: More support for cleaning zones.

### DIFF
--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -199,6 +199,9 @@ public:
     ceph_assert(is_smr());
     return conventional_region_size;
   }
+  virtual void reset_zones(const std::set<uint64_t> *zones) {
+    ceph_assert(is_smr());
+  }
 
   virtual void aio_submit(IOContext *ioc) = 0;
 

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -199,7 +199,7 @@ public:
     ceph_assert(is_smr());
     return conventional_region_size;
   }
-  virtual void reset_zones(const std::set<uint64_t> *zones) {
+  virtual void reset_zones(const std::set<uint64_t>& zones) {
     ceph_assert(is_smr());
   }
 

--- a/src/blk/zoned/HMSMRDevice.cc
+++ b/src/blk/zoned/HMSMRDevice.cc
@@ -414,7 +414,7 @@ void HMSMRDevice::_detect_vdo()
 
 void HMSMRDevice::reset_zones(const std::set<uint64_t>& zones) {
   for (auto zone_num : zones) {
-    if (zbd_reset_zones(zbd_dev, zone_num * zone_size, zone_size) != 0) {
+    if (zbd_reset_zones(zbd_fd, zone_num * zone_size, zone_size) != 0) {
       derr << __func__ << " resetting zone failed for zone " << zone_num << dendl;
     }
   }

--- a/src/blk/zoned/HMSMRDevice.cc
+++ b/src/blk/zoned/HMSMRDevice.cc
@@ -412,6 +412,14 @@ void HMSMRDevice::_detect_vdo()
   return;
 }
 
+void HMSMRDevice::reset_zones(const std::set<uint64_t> *zones) {
+  for (auto zone_num : *zones) {
+    if (zbd_reset_zones(zbd_dev, zone_num * zone_size, zone_size) != 0) {
+      derr << __func__ << " resetting zone failed for zone " << zone_num << dendl;
+    }
+  }
+}
+
 bool HMSMRDevice::get_thin_utilization(uint64_t *total, uint64_t *avail) const
 {
   if (vdo_fd < 0) {

--- a/src/blk/zoned/HMSMRDevice.cc
+++ b/src/blk/zoned/HMSMRDevice.cc
@@ -412,8 +412,8 @@ void HMSMRDevice::_detect_vdo()
   return;
 }
 
-void HMSMRDevice::reset_zones(const std::set<uint64_t> *zones) {
-  for (auto zone_num : *zones) {
+void HMSMRDevice::reset_zones(const std::set<uint64_t>& zones) {
+  for (auto zone_num : zones) {
     if (zbd_reset_zones(zbd_dev, zone_num * zone_size, zone_size) != 0) {
       derr << __func__ << " resetting zone failed for zone " << zone_num << dendl;
     }

--- a/src/blk/zoned/HMSMRDevice.h
+++ b/src/blk/zoned/HMSMRDevice.h
@@ -136,7 +136,7 @@ public:
 
   bool is_smr() const final { return true; }
 
-  void reset_zones(const std::set<uint64_t> *zones) override;
+  void reset_zones(const std::set<uint64_t>& zones) override;
 
   bool get_thin_utilization(uint64_t *total, uint64_t *avail) const final;
 

--- a/src/blk/zoned/HMSMRDevice.h
+++ b/src/blk/zoned/HMSMRDevice.h
@@ -41,7 +41,7 @@ class HMSMRDevice final : public BlockDevice {
   string vdo_name;
 
   std::string devname;  ///< kernel dev name (/sys/block/$devname), if any
-  int zbd_dev;
+  int zbd_fd = -1;	///< fd for the zoned block device
 
   ceph::mutex debug_lock = ceph::make_mutex("HMSMRDevice::debug_lock");
   interval_set<uint64_t> debug_inflight;

--- a/src/blk/zoned/HMSMRDevice.h
+++ b/src/blk/zoned/HMSMRDevice.h
@@ -41,6 +41,7 @@ class HMSMRDevice final : public BlockDevice {
   string vdo_name;
 
   std::string devname;  ///< kernel dev name (/sys/block/$devname), if any
+  int zbd_dev;
 
   ceph::mutex debug_lock = ceph::make_mutex("HMSMRDevice::debug_lock");
   interval_set<uint64_t> debug_inflight;
@@ -134,6 +135,8 @@ public:
   int get_devices(std::set<std::string> *ls) const final;
 
   bool is_smr() const final { return true; }
+
+  void reset_zones(const std::set<uint64_t> *zones) override;
 
   bool get_thin_utilization(uint64_t *total, uint64_t *avail) const final;
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12418,9 +12418,11 @@ void BlueStore::_zoned_cleaner_thread() {
       dout(20) << __func__ << " wake" << dendl;
     } else {
       l.unlock();
+      f->mark_zones_to_clean_in_progress(zones_to_clean, db);
       for (auto zone_num : *zones_to_clean) {
 	_zoned_clean_zone(zone_num);
       }
+      bdev->reset_zones(zones_to_clean);
       f->mark_zones_to_clean_free(zones_to_clean, db);
       a->mark_zones_to_clean_free();
       l.lock();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12418,12 +12418,12 @@ void BlueStore::_zoned_cleaner_thread() {
       dout(20) << __func__ << " wake" << dendl;
     } else {
       l.unlock();
-      f->mark_zones_to_clean_in_progress(zones_to_clean, db);
+      f->mark_zones_to_clean_in_progress(*zones_to_clean, db);
       for (auto zone_num : *zones_to_clean) {
 	_zoned_clean_zone(zone_num);
       }
-      bdev->reset_zones(zones_to_clean);
-      f->mark_zones_to_clean_free(zones_to_clean, db);
+      bdev->reset_zones(*zones_to_clean);
+      f->mark_zones_to_clean_free(*zones_to_clean, db);
       a->mark_zones_to_clean_free();
       l.lock();
     }

--- a/src/os/bluestore/ZonedFreelistManager.cc
+++ b/src/os/bluestore/ZonedFreelistManager.cc
@@ -315,19 +315,17 @@ int ZonedFreelistManager::_read_cfg(cfg_reader_t cfg_reader) {
 }
 
 void ZonedFreelistManager::mark_zones_to_clean_free(
-    const std::set<uint64_t> *zones_to_clean, KeyValueDB *kvdb) {
+    const std::set<uint64_t>& zones_to_clean, KeyValueDB *kvdb) {
   dout(10) << __func__ << dendl;
 
   KeyValueDB::Transaction txn = kvdb->get_transaction();
-  for (auto zone_num : *zones_to_clean) {
+  for (auto zone_num : zones_to_clean) {
     ldout(cct, 10) << __func__ << " zone " << zone_num << " is now clean in DB" << dendl;
 
     zone_state_t zone_state;
     write_zone_state_to_db(zone_num, zone_state, txn);
   }
-
   txn->rmkey(meta_prefix, "cleaning_in_progress_zones");
-
   kvdb->submit_transaction_sync(txn);
 }
 
@@ -336,7 +334,7 @@ void ZonedFreelistManager::mark_zones_to_clean_free(
 // if there is a key "cleaning_in_progress_zones" in the meta_prefix namespace,
 // and if so, will read the zones and resume cleaning.
 void ZonedFreelistManager::mark_zones_to_clean_in_progress(
-    const std::set<uint64_t> *zones_to_clean, KeyValueDB *kvdb) {
+    const std::set<uint64_t>& zones_to_clean, KeyValueDB *kvdb) {
   dout(10) << __func__ << dendl;
 
   bufferlist bl;

--- a/src/os/bluestore/ZonedFreelistManager.cc
+++ b/src/os/bluestore/ZonedFreelistManager.cc
@@ -338,10 +338,7 @@ void ZonedFreelistManager::mark_zones_to_clean_in_progress(
   dout(10) << __func__ << dendl;
 
   bufferlist bl;
-  uint64_t num_zones = zones_to_clean->size();
-  encode(num_zones, bl);
-  for (auto zone_num : *zones_to_clean)
-    encode(zone_num, bl);
+  encode(zones_to_clean, bl);
   
   KeyValueDB::Transaction txn = kvdb->get_transaction();
   txn->set(meta_prefix, "cleaning_in_progress_zones", bl);

--- a/src/os/bluestore/ZonedFreelistManager.cc
+++ b/src/os/bluestore/ZonedFreelistManager.cc
@@ -314,6 +314,16 @@ int ZonedFreelistManager::_read_cfg(cfg_reader_t cfg_reader) {
   return 0;
 }
 
+std::set<uint64_t> ZonedFreelistManager::get_cleaning_in_progress_zones(
+    KeyValueDB *kvdb) const {
+  bufferlist bl;
+  std::set<uint64_t> zones_to_clean;
+  if (kvdb->get(meta_prefix, CLEANING_IN_PROGRESS_KEY, &bl) == 0) {
+    decode(zones_to_clean, bl);
+  }
+  return zones_to_clean;
+}
+
 void ZonedFreelistManager::mark_zones_to_clean_free(
     const std::set<uint64_t>& zones_to_clean, KeyValueDB *kvdb) {
   dout(10) << __func__ << dendl;
@@ -325,14 +335,14 @@ void ZonedFreelistManager::mark_zones_to_clean_free(
     zone_state_t zone_state;
     write_zone_state_to_db(zone_num, zone_state, txn);
   }
-  txn->rmkey(meta_prefix, "cleaning_in_progress_zones");
+  txn->rmkey(meta_prefix, CLEANING_IN_PROGRESS_KEY);
   kvdb->submit_transaction_sync(txn);
 }
 
 // Marks the zones currently being cleaned in the db. Should be called before
 // starting the cleaning. If we crash mid-cleaning, the recovery code will check
-// if there is a key "cleaning_in_progress_zones" in the meta_prefix namespace,
-// and if so, will read the zones and resume cleaning.
+// if there is a key CLEANING_IN_PROGRESS_KEY in the meta_prefix namespace, and
+// if so, will read the zones and resume cleaning.
 void ZonedFreelistManager::mark_zones_to_clean_in_progress(
     const std::set<uint64_t>& zones_to_clean, KeyValueDB *kvdb) {
   dout(10) << __func__ << dendl;
@@ -341,6 +351,6 @@ void ZonedFreelistManager::mark_zones_to_clean_in_progress(
   encode(zones_to_clean, bl);
   
   KeyValueDB::Transaction txn = kvdb->get_transaction();
-  txn->set(meta_prefix, "cleaning_in_progress_zones", bl);
+  txn->set(meta_prefix, CLEANING_IN_PROGRESS_KEY, bl);
   kvdb->submit_transaction_sync(txn);
 }

--- a/src/os/bluestore/ZonedFreelistManager.h
+++ b/src/os/bluestore/ZonedFreelistManager.h
@@ -2,9 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 //
-// A freelist manager for zoned devices.  This iteration just keeps the write
-// pointer per zone.  Following iterations will add enough information to enable
-// cleaning of zones.
+// A freelist manager for zoned devices.
 //
 // Copyright (C) 2020 Abutalib Aghayev
 //
@@ -23,6 +21,8 @@
 #include "zoned_types.h"
 
 using cfg_reader_t = std::function<int(const std::string&, std::string*)>;
+
+const string CLEANING_IN_PROGRESS_KEY = "cleaning_in_progress";
 
 class ZonedFreelistManager : public FreelistManager {
   std::string meta_prefix;    ///< device size, zone size, etc.
@@ -102,6 +102,7 @@ public:
 		std::vector<std::pair<string, string>>*) const override;
 
   std::vector<zone_state_t> get_zone_states(KeyValueDB *kvdb) const;
+  std::set<uint64_t> get_cleaning_in_progress_zones(KeyValueDB *kvdb) const;
   void mark_zones_to_clean_free(const std::set<uint64_t>& zones_to_clean, 
 				KeyValueDB *kvdb);
   void mark_zones_to_clean_in_progress(const std::set<uint64_t>& zones_to_clean,

--- a/src/os/bluestore/ZonedFreelistManager.h
+++ b/src/os/bluestore/ZonedFreelistManager.h
@@ -104,6 +104,8 @@ public:
   std::vector<zone_state_t> get_zone_states(KeyValueDB *kvdb) const;
   void mark_zones_to_clean_free(const std::set<uint64_t> *zones_to_clean, 
 				KeyValueDB *kvdb);
+  void mark_zones_to_clean_in_progress(const std::set<uint64_t> *zones_to_clean,
+				       KeyValueDB *kvdb);
 };
 
 #endif

--- a/src/os/bluestore/ZonedFreelistManager.h
+++ b/src/os/bluestore/ZonedFreelistManager.h
@@ -102,9 +102,9 @@ public:
 		std::vector<std::pair<string, string>>*) const override;
 
   std::vector<zone_state_t> get_zone_states(KeyValueDB *kvdb) const;
-  void mark_zones_to_clean_free(const std::set<uint64_t> *zones_to_clean, 
+  void mark_zones_to_clean_free(const std::set<uint64_t>& zones_to_clean, 
 				KeyValueDB *kvdb);
-  void mark_zones_to_clean_in_progress(const std::set<uint64_t> *zones_to_clean,
+  void mark_zones_to_clean_in_progress(const std::set<uint64_t>& zones_to_clean,
 				       KeyValueDB *kvdb);
 };
 


### PR DESCRIPTION

    The protocol for cleaning zones is as follows:                                     
                                                                                       
    1. The ZonedAllocator wakes up the cleaner thread.                                 
    2. The cleaner thread acquires the list of zones to clean                          
    3. Cleaning multiple zones is not atomic; therefore, to support resuming the       
       cleaning if crashed, the cleaner thread first persists the list of zones to     
       clean as a value of a key "cleaning_in_progress_zones", by calling              
       ZonedFreelistManager's mark_zones_to_clean_in_progress.                         
    4. The cleaner thread then iterates over the zones and cleans zones by calling     
       _zoned_clean_zone on each zone. The latter calls an operation                   
       _do_move on each live object on the zone that atomically moves an object from   
       the cleaned zone to a new zone. (_do_move is to be implemented.)                
    5. Once all of the zones are cleaned, the cleaner thread calls reset_zones,        
       which resets the write pointer within the physical zoned block device           
    6. Finally, it calls ZonedFreelistManager's mark_zones_to_clean_free method which  
       in one atomic operation resets the write pointer of the cleaned zones in the    
       db and deletes the key "cleaning_in_progress_zones", that is, the list of       
       zones to be cleaned recorded in step 3.                                         
                                                                                       
    A crash between or within any of these steps will leave the system in consistent   
    state. Specifically, each zone will either be completely cleaned, or partially     
    cleaned, or not cleaned. A recovery code will need to check for the existence of   
    the "cleaning_in_progress_zones" key and if found, it will resume cleaning zones   
    where it left off. It is possible that if we crash between steps 5 and 6, or       
    within step 5, we end resetting the write pointer within the physical zoned        
    block device multiple times, but that's okay because the latter is an idempotent   
    operation.                                                                         
                                                                                       
    Signed-off-by: Abutalib Aghayev <agayev@psu.edu>                                   


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
