### PR TITLE
octopus: qa/suites/rados/perf: pin to 18.04

### DIFF
--- a/qa/suites/perf-basic/ubuntu_18.04.yaml
+++ b/qa/suites/perf-basic/ubuntu_18.04.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/ubuntu_18.04.yaml

--- a/qa/suites/rados/cephadm/smoke/distro/ubuntu_latest.yaml
+++ b/qa/suites/rados/cephadm/smoke/distro/ubuntu_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/ubuntu_latest.yaml

--- a/qa/suites/rados/perf/ubuntu_18.04.yaml
+++ b/qa/suites/rados/perf/ubuntu_18.04.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/ubuntu_18.04.yaml

--- a/qa/suites/rados/perf/ubuntu_latest.yaml
+++ b/qa/suites/rados/perf/ubuntu_latest.yaml
@@ -1,1 +1,0 @@
-.qa/distros/supported/ubuntu_latest.yaml


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51269

---

backport of https://github.com/ceph/ceph/pull/39275
parent tracker: https://tracker.ceph.com/issues/49139

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh