### PR TITLE
rgw: add package version support to lua scripting

### DIFF
--- a/doc/radosgw/lua-scripting.rst
+++ b/doc/radosgw/lua-scripting.rst
@@ -57,11 +57,36 @@ To add a package to the allowlist:
   # radosgw-admin script-package add --package={package name} [--allow-compilation]
 
 
+To add a specific version of a package to the allowlist:
+
+::
+
+  # radosgw-admin script-package add --package='{package name} {package version}' [--allow-compilation]
+
+
+* When adding a diffrent version of a package which already exists in the list, the newly
+  added version will override the existing one.
+
+* When adding a package without a version specified, the latest version of the package
+  will be added.
+
+
 To remove a package from the allowlist:
 
 ::
 
   # radosgw-admin script-package rm --package={package name}
+
+
+To remove a specific version of a package from the allowlist:
+
+::
+
+  # radosgw-admin script-package rm --package='{package name} {package version}'
+
+
+* When removing a package without a version specified, any existing versions of the
+  package will be removed.
 
 
 To print the list of packages in the allowlist:


### PR DESCRIPTION
This patch allows users to set the package version when adding packages
to rgw's luarocks package manager.
Previously, when stating a specific version the package was not found.

Fixes: https://tracker.ceph.com/issues/51193
Signed-off-by: Matan Breizman <Matan.Brz@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
