### PR TITLE
mgr/dashboard: Add a few type annotations

### DIFF
--- a/src/pybind/mgr/dashboard/exceptions.py
+++ b/src/pybind/mgr/dashboard/exceptions.py
@@ -53,57 +53,57 @@ class InvalidCredentialsError(DashboardException):
 
 # access control module exceptions
 class RoleAlreadyExists(Exception):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super(RoleAlreadyExists, self).__init__(
             "Role '{}' already exists".format(name))
 
 
 class RoleDoesNotExist(Exception):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super(RoleDoesNotExist, self).__init__(
             "Role '{}' does not exist".format(name))
 
 
 class ScopeNotValid(Exception):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super(ScopeNotValid, self).__init__(
             "Scope '{}' is not valid".format(name))
 
 
 class PermissionNotValid(Exception):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super(PermissionNotValid, self).__init__(
             "Permission '{}' is not valid".format(name))
 
 
 class RoleIsAssociatedWithUser(Exception):
-    def __init__(self, rolename, username):
+    def __init__(self, rolename: str, username: str) -> None:
         super(RoleIsAssociatedWithUser, self).__init__(
             "Role '{}' is still associated with user '{}'"
             .format(rolename, username))
 
 
 class UserAlreadyExists(Exception):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super(UserAlreadyExists, self).__init__(
             "User '{}' already exists".format(name))
 
 
 class UserDoesNotExist(Exception):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super(UserDoesNotExist, self).__init__(
             "User '{}' does not exist".format(name))
 
 
 class ScopeNotInRole(Exception):
-    def __init__(self, scopename, rolename):
+    def __init__(self, scopename: str, rolename: str) -> None:
         super(ScopeNotInRole, self).__init__(
             "There are no permissions for scope '{}' in role '{}'"
             .format(scopename, rolename))
 
 
 class RoleNotInUser(Exception):
-    def __init__(self, rolename, username):
+    def __init__(self, rolename: str, username: str) -> None:
         super(RoleNotInUser, self).__init__(
             "Role '{}' is not associated with user '{}'"
             .format(rolename, username))

--- a/src/pybind/mgr/dashboard/security.py
+++ b/src/pybind/mgr/dashboard/security.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import inspect
+from typing import List
 
 
 class Scope(object):
@@ -28,14 +29,14 @@ class Scope(object):
     NFS_GANESHA = "nfs-ganesha"
 
     @classmethod
-    def all_scopes(cls):
+    def all_scopes(cls) -> List[str]:
         return [val for scope, val in
                 inspect.getmembers(cls,
                                    lambda memb: not inspect.isroutine(memb))
                 if not scope.startswith('_')]
 
     @classmethod
-    def valid_scope(cls, scope_name):
+    def valid_scope(cls, scope_name: str) -> bool:
         return scope_name in cls.all_scopes()
 
 
@@ -49,12 +50,12 @@ class Permission(object):
     DELETE = "delete"
 
     @classmethod
-    def all_permissions(cls):
+    def all_permissions(cls) -> List[str]:
         return [val for perm, val in
                 inspect.getmembers(cls,
                                    lambda memb: not inspect.isroutine(memb))
                 if not perm.startswith('_')]
 
     @classmethod
-    def valid_permission(cls, perm_name):
+    def valid_permission(cls, perm_name: str) -> bool:
         return perm_name in cls.all_permissions()


### PR DESCRIPTION
Using pytest-annotate

Signed-off-by: Sebastian Wagner <sewagner@redhat.com>

Howto:

* https://github.com/kensho-technologies/pytest-annotate
* https://github.com/dropbox/pyannotate

```diff
diff --git a/src/pybind/mgr/dashboard/tox.ini b/src/pybind/mgr/dashboard/tox.ini
index 1cda4c45ac..d1d0958662 100644
--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -21,6 +21,8 @@ addopts =
 deps =
     -rrequirements.txt
     -cconstraints.txt
+    pytest-annotate
+    pyannotate
 
 [base-test]
 deps =
@@ -45,7 +47,7 @@ setenv =
     UNITTEST = true
     WEBTEST_INTERACTIVE = false
 commands =
-    pytest {posargs}
+    pytest     --annotate-output=./annotations.json  {posargs}
 
 [testenv:run]
 basepython=python3
```
* `tox -e py3`
* `pyannotate --py3 -w --type-info ./annotations.json $(find * -name '*.py')`



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
