### PR TITLE
crimson/onode-staged-tree: improve logs to understand inconsistent load from seastore

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_delta_recorder.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_delta_recorder.h
@@ -42,7 +42,7 @@ class DeltaRecorder {
   virtual field_type_t field_type() const = 0;
   virtual void apply_delta(ceph::bufferlist::const_iterator&,
                            NodeExtentMutable&,
-                           laddr_t) = 0;
+                           const NodeExtent&) = 0;
 
  protected:
   DeltaRecorder() = default;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.cc
@@ -5,20 +5,8 @@
 
 #include "node_extent_manager/dummy.h"
 #include "node_extent_manager/seastore.h"
-#include "stages/node_stage_layout.h"
 
 namespace crimson::os::seastore::onode {
-
-std::pair<node_type_t, field_type_t> NodeExtent::get_types() const
-{
-  const auto header = reinterpret_cast<const node_header_t*>(get_read());
-  auto node_type = header->get_node_type();
-  auto field_type = header->get_field_type();
-  if (!field_type.has_value()) {
-    throw std::runtime_error("load failed: bad field type");
-  }
-  return {node_type, *field_type};
-}
 
 NodeExtentManagerURef NodeExtentManager::create_dummy(bool is_sync)
 {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
@@ -47,6 +47,10 @@ class NodeExtent : public LogicalCachedExtent {
     return NodeExtentMutable(get_bptr().c_str(), get_length());
   }
 
+  std::ostream& print_detail_l(std::ostream& out) const final {
+    return out << ", fltree_header=" << get_header();
+  }
+
   /**
    * Abstracted interfaces to implement:
    * - CacheExtent::duplicate_for_write() -> CachedExtentRef

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
@@ -8,9 +8,10 @@
 #include "crimson/os/seastore/transaction_manager.h"
 
 #include "fwd.h"
-#include "super.h"
 #include "node_extent_mutable.h"
 #include "node_types.h"
+#include "stages/node_stage_layout.h"
+#include "super.h"
 
 /**
  * node_extent_manager.h
@@ -24,7 +25,9 @@ using crimson::os::seastore::LogicalCachedExtent;
 class NodeExtent : public LogicalCachedExtent {
  public:
   virtual ~NodeExtent() = default;
-  std::pair<node_type_t, field_type_t> get_types() const;
+  const node_header_t& get_header() const {
+    return *reinterpret_cast<const node_header_t*>(get_read());
+  }
   const char* get_read() const {
     return get_bptr().c_str();
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
@@ -103,8 +103,8 @@ class DummyNodeExtentManager final: public NodeExtentManager {
 
   retire_ertr::future<> retire_extent(
       Transaction& t, NodeExtentRef extent) override {
-    TRACET("retiring {}B at {:#x} ...",
-           t, extent->get_length(), extent->get_laddr());
+    TRACET("retiring {}B at {:#x} -- {} ...",
+           t, extent->get_length(), extent->get_laddr(), *extent);
     if constexpr (SYNC) {
       return retire_extent_sync(t, extent);
     } else {
@@ -138,7 +138,8 @@ class DummyNodeExtentManager final: public NodeExtentManager {
     auto iter = allocate_map.find(addr);
     assert(iter != allocate_map.end());
     auto extent = iter->second;
-    TRACET("read {}B at {:#x}", t, extent->get_length(), extent->get_laddr());
+    TRACET("read {}B at {:#x} -- {}",
+           t, extent->get_length(), extent->get_laddr(), *extent);
     assert(extent->get_laddr() == addr);
     return read_ertr::make_ready_future<NodeExtentRef>(extent);
   }
@@ -153,7 +154,8 @@ class DummyNodeExtentManager final: public NodeExtentManager {
     extent->set_laddr(addr);
     assert(allocate_map.find(extent->get_laddr()) == allocate_map.end());
     allocate_map.insert({extent->get_laddr(), extent});
-    DEBUGT("allocated {}B at {:#x}", t, extent->get_length(), extent->get_laddr());
+    DEBUGT("allocated {}B at {:#x} -- {}",
+           t, extent->get_length(), extent->get_laddr(), *extent);
     assert(extent->get_length() == len);
     return alloc_ertr::make_ready_future<NodeExtentRef>(extent);
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
@@ -40,6 +40,7 @@ class DummyNodeExtent final: public NodeExtent {
   DummyNodeExtent(ceph::bufferptr &&ptr) : NodeExtent(std::move(ptr)) {
     state = extent_state_t::INITIAL_WRITE_PENDING;
   }
+  DummyNodeExtent(const DummyNodeExtent& other) = delete;
   ~DummyNodeExtent() override = default;
 
   void retire() {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
@@ -47,7 +47,7 @@ static DeltaRecorderURef create_replay_recorder(
 NodeExtentRef SeastoreNodeExtent::mutate(
     context_t c, DeltaRecorderURef&& _recorder)
 {
-  DEBUGT("mutate {:#x} ...", c.t, get_laddr());
+  DEBUGT("mutate {} ...", c.t, *this);
   auto p_handle = static_cast<TransactionManagerHandle*>(&c.nm);
   auto extent = p_handle->tm.get_mutable_extent(c.t, this);
   auto ret = extent->cast<SeastoreNodeExtent>();
@@ -60,7 +60,7 @@ NodeExtentRef SeastoreNodeExtent::mutate(
 
 void SeastoreNodeExtent::apply_delta(const ceph::bufferlist& bl)
 {
-  DEBUG("replay {:#x} ...", get_laddr());
+  DEBUG("replay {} ...", *this);
   if (!recorder) {
     auto header = get_header();
     auto field_type = header.get_field_type();
@@ -77,11 +77,12 @@ void SeastoreNodeExtent::apply_delta(const ceph::bufferlist& bl)
     assert(recorder->field_type() == *header.get_field_type());
 #endif
   }
-  auto node = do_get_mutable();
+  auto mut = do_get_mutable();
   auto p = bl.cbegin();
   while (p != bl.end()) {
-    recorder->apply_delta(p, node, get_laddr());
+    recorder->apply_delta(p, mut, *this);
   }
+  DEBUG("relay done!");
 }
 
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/test_replay.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/test_replay.h
@@ -30,7 +30,7 @@ class TestReplayExtent final: public NodeExtent {
     auto bl = recorder->get_delta();
     assert(bl.length());
     auto p = bl.cbegin();
-    recorder->apply_delta(p, mut, 0u);
+    recorder->apply_delta(p, mut, *this);
     assert(p == bl.end());
     auto cmp = std::memcmp(get_read(), replayed_extent->get_read(), get_length());
     ceph_assert(cmp == 0 && "replay mismatch!");

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.cc
@@ -46,32 +46,32 @@ LeafNodeImpl::allocate(
 }
 
 InternalNodeImplURef InternalNodeImpl::load(
-    NodeExtentRef extent, field_type_t type, bool expect_is_level_tail)
+    NodeExtentRef extent, field_type_t type)
 {
   if (type == field_type_t::N0) {
-    return InternalNode0::load(extent, expect_is_level_tail);
+    return InternalNode0::load(extent);
   } else if (type == field_type_t::N1) {
-    return InternalNode1::load(extent, expect_is_level_tail);
+    return InternalNode1::load(extent);
   } else if (type == field_type_t::N2) {
-    return InternalNode2::load(extent, expect_is_level_tail);
+    return InternalNode2::load(extent);
   } else if (type == field_type_t::N3) {
-    return InternalNode3::load(extent, expect_is_level_tail);
+    return InternalNode3::load(extent);
   } else {
     ceph_abort("impossible path");
   }
 }
 
 LeafNodeImplURef LeafNodeImpl::load(
-    NodeExtentRef extent, field_type_t type, bool expect_is_level_tail)
+    NodeExtentRef extent, field_type_t type)
 {
   if (type == field_type_t::N0) {
-    return LeafNode0::load(extent, expect_is_level_tail);
+    return LeafNode0::load(extent);
   } else if (type == field_type_t::N1) {
-    return LeafNode1::load(extent, expect_is_level_tail);
+    return LeafNode1::load(extent);
   } else if (type == field_type_t::N2) {
-    return LeafNode2::load(extent, expect_is_level_tail);
+    return LeafNode2::load(extent);
   } else if (type == field_type_t::N3) {
-    return LeafNode3::load(extent, expect_is_level_tail);
+    return LeafNode3::load(extent);
   } else {
     ceph_abort("impossible path");
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -181,7 +181,7 @@ class InternalNodeImpl : public NodeImpl {
   };
   static eagain_future<fresh_impl_t> allocate(context_t, field_type_t, bool, level_t);
 
-  static InternalNodeImplURef load(NodeExtentRef, field_type_t, bool);
+  static InternalNodeImplURef load(NodeExtentRef, field_type_t);
 
  protected:
   InternalNodeImpl() = default;
@@ -261,7 +261,7 @@ class LeafNodeImpl : public NodeImpl {
   };
   static eagain_future<fresh_impl_t> allocate(context_t, field_type_t, bool);
 
-  static LeafNodeImplURef load(NodeExtentRef, field_type_t, bool);
+  static LeafNodeImplURef load(NodeExtentRef, field_type_t);
 
  protected:
   LeafNodeImpl() = default;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -60,9 +60,8 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   NodeLayoutT& operator=(NodeLayoutT&&) = delete;
   ~NodeLayoutT() override = default;
 
-  static URef load(NodeExtentRef extent, bool expect_is_level_tail) {
+  static URef load(NodeExtentRef extent) {
     std::unique_ptr<NodeLayoutT> ret(new NodeLayoutT(extent));
-    assert(ret->is_level_tail() == expect_is_level_tail);
     return ret;
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
@@ -56,6 +56,17 @@ struct node_header_t {
     is_level_tail = static_cast<uint8_t>(value);
   }
 } __attribute__((packed));
+inline std::ostream& operator<<(std::ostream& os, const node_header_t& header) {
+  auto field_type = header.get_field_type();
+  if (field_type.has_value()) {
+    os << "header" << header.get_node_type() << *field_type
+       << "(is_level_tail=" << header.get_is_level_tail()
+       << ", level=" << (unsigned)header.level << ")";
+  } else {
+    os << "header(INVALID)";
+  }
+  return os;
+}
 
 template <typename FixedKeyType, field_type_t _FIELD_TYPE>
 struct _slot_t {


### PR DESCRIPTION
The recorded failure from https://gist.github.com/xxhdx1985126/0c45786915aa1ae77963a48a6d32a8d4 is `Assertion 'ret->is_level_tail() == expect_is_level_tail' failed.`, which shows that `Node::load()` expects the node to be the very last (the tail) node in the same level, but got a non-tail node, or maybe the reversed case. 

I think this is most likely caused by concurrent transactions, as the log shows:
```
4 transactions are included here:
- T1 is 0x61300019c240;
- T2 is 0x613000208880;
- T3 is 0x613000208f80;
- T4 is 0x6130002078c0;

Log analysis:
17:15:02,628  T1 splits the tail node (marked $) at laddr 0xb009000, which updates it to a non-tail node.
17:15:03,071  T1 calls submit_transaction();
17:15:04,802  T2 InternalNode::get_or_track_child() sees the node 0xb009000 is still a tail node;
17:15:04,803  T3 starts to read the tail node 0xb009000, should be expecting it to be a tail node;
17:15:04,810  T4 InternalNode::apply_child_split() sees the node 0xb009000 is still a tail node;
17:15:04,838  T1 calls complete_commit(), making the non-tail version of node 0xb009000 visable;
17:15:04,855  T3 successfully reads the node 0xb009000, should see it a non-tail node, causing the above assert failure;
```

IIUC this should be able to be fixed by @athanatos 's current work, because T1 needs to update the parent node of 0xb009000 in order to complete the split operation, and T3 needs to include the same parent node into its read-set before reading out 0xb009000. That parent node should be able to become the bridge for the committed T1 to invalidate T3 before T3 sees the inconsistent view of 0xb009000.

This PR doesn't fix anything, but is supposed to bring better information to debug similar issues in the onode tree.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
