### PR TITLE
mgr/cephadm: introduce http endpoint

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -13,6 +13,7 @@ import os
 import platform
 import pwd
 import random
+import requests
 import shlex
 import shutil
 import socket
@@ -7522,6 +7523,30 @@ def command_maintenance(ctx: CephadmContext):
                 else:
                     return f'success - systemd target {target} enabled and started'
 
+
+##################################
+
+
+def command_send_metadata_http(ctx: CephadmContext):
+    """send host metadata to mgr over http"""
+    ls = list_daemons(ctx)
+    ls_str = json.dumps(ls)
+
+    facts = HostFacts(ctx)
+    facts_str = facts.dump()
+
+    networks = list_networks(ctx)
+    networks_str = json.dumps(networks)
+
+    data = {'host': socket.gethostname(),
+            'ls': ls_str,
+            'networks': networks_str,
+            'facts': facts_str}
+
+    url = f'http://{ctx.mgr_ip}:{ctx.mgr_port}'
+    http_out = requests.post(url, data=data)
+    print(http_out.text)
+
 ##################################
 
 
@@ -8158,6 +8183,18 @@ def _get_parser():
         choices=['enter', 'exit'],
         help='Maintenance action - enter maintenance, or exit maintenance')
     parser_maintenance.set_defaults(func=command_maintenance)
+
+    parser_send_metadata_http = subparsers.add_parser(
+        'send-metadata-http', help='send host metadata to mgr at given ip')
+    parser_send_metadata_http.set_defaults(func=command_send_metadata_http)
+    parser_send_metadata_http.add_argument(
+        '--mgr-ip',
+        required=True,
+        help='ip of host were mgr lives')
+    parser_send_metadata_http.add_argument(
+        '--mgr-port',
+        required=True,
+        help='port where cephadm mgr module is listening')
 
     return parser
 

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -37,6 +37,7 @@ deps =
   pyfakefs
   mock
   pytest
+  requests
 commands=pytest {posargs}
 
 [testenv:mypy]
@@ -44,6 +45,7 @@ basepython = python3
 deps = 
     mypy
     -c{toxinidir}/../mypy-constrains.txt
+    types-requests
 commands = mypy --config-file ../mypy.ini {posargs:cephadm}
 
 [testenv:fix]

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -530,11 +530,10 @@ class HostCache():
             return True
         return False
 
-    def update_host_devices_networks(
+    def update_host_devices(
             self,
             host: str,
             dls: List[inventory.Device],
-            nets: Dict[str, Dict[str, List[str]]]
     ) -> None:
         if (
                 host not in self.devices
@@ -544,6 +543,12 @@ class HostCache():
             self.last_device_change[host] = datetime_now()
         self.last_device_update[host] = datetime_now()
         self.devices[host] = dls
+
+    def update_host_networks(
+            self,
+            host: str,
+            nets: Dict[str, Dict[str, List[str]]]
+    ) -> None:
         self.networks[host] = nets
 
     def update_daemon_config_deps(self, host: str, name: str, deps: List[str], stamp: datetime.datetime) -> None:

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -332,9 +332,8 @@ class TestCephadm(object):
                 'value': '127.0.0.0/8'
             })
 
-            cephadm_module.cache.update_host_devices_networks(
+            cephadm_module.cache.update_host_networks(
                 'test',
-                [],
                 {
                     "127.0.0.0/8": [
                         "127.0.0.1"
@@ -605,7 +604,7 @@ spec:
                 ),
             ])
 
-            cephadm_module.cache.update_host_devices_networks('test', inventory.devices, {})
+            cephadm_module.cache.update_host_devices('test', inventory.devices)
 
             _run_cephadm.return_value = (['{}'], '', 0)
 
@@ -643,7 +642,7 @@ spec:
                 Device('/dev/sdd', available=True)
             ])
 
-            cephadm_module.cache.update_host_devices_networks('test', inventory.devices, {})
+            cephadm_module.cache.update_host_devices('test', inventory.devices)
 
             _run_cephadm.return_value = (['{}'], '', 0)
 

--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -8,4 +8,5 @@ pyOpenSSL
 execnet
 remoto
 Jinja2
+cherrypy
 pyfakefs


### PR DESCRIPTION
Not very useful in its current form here
but will serve as a place to send metadata
for the cephadm agent once that is implemented

Part of: https://tracker.ceph.com/issues/51004

Fixes: https://tracker.ceph.com/issues/51005
Fices: https://tracker.ceph.com/issues/51006

Signed-off-by: Adam King <adking@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
