### PR TITLE
mgr: generate crash dumps for Python exceptions in mgr modules

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1231,6 +1231,40 @@ These warnings can be disabled entirely with::
 
   ceph config set mgr/crash/warn_recent_interval 0
 
+RECENT_MGR_MODULE_CRASH
+_______________________
+
+One or more ceph-mgr modules has crashed recently, and the crash as
+not yet been archived (acknowledged) by the administrator.  This
+generally indicates a software bug in one of the software modules run
+inside the ceph-mgr daemon.  Although the module that experienced the
+problem maybe be disabled as a result, the function of other modules
+is normally unaffected.
+
+As with the *RECENT_CRASH* health alert, the crash can be inspected with::
+
+    ceph crash info <crash-id>
+
+This warning can be silenced by "archiving" the crash (perhaps after
+being examined by an administrator) so that it does not generate this
+warning::
+
+  ceph crash archive <crash-id>
+
+Similarly, all new crashes can be archived with::
+
+  ceph crash archive-all
+
+Archived crashes will still be visible via ``ceph crash ls`` but not
+``ceph crash ls-new``.
+
+The time period for what "recent" means is controlled by the option
+``mgr/crash/warn_recent_interval`` (default: two weeks).
+
+These warnings can be disabled entirely with::
+
+  ceph config set mgr/crash/warn_recent_interval 0
+
 TELEMETRY_CHANGED
 _________________
 

--- a/qa/suites/rados/mgr/tasks/module_selftest.yaml
+++ b/qa/suites/rados/mgr/tasks/module_selftest.yaml
@@ -20,6 +20,7 @@ tasks:
         - foo bar
         - Failed to open Telegraf
         - evicting unresponsive client
+        - 1 mgr modules have recently crashed \(RECENT_MGR_MODULE_CRASH\)
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_module_selftest

--- a/src/common/BackTrace.cc
+++ b/src/common/BackTrace.cc
@@ -11,7 +11,7 @@
 
 namespace ceph {
 
-void BackTrace::print(std::ostream& out) const
+void ClibBackTrace::print(std::ostream& out) const
 {
   out << " " << pretty_version_to_str() << std::endl;
   for (size_t i = skip; i < size; i++) {
@@ -19,7 +19,7 @@ void BackTrace::print(std::ostream& out) const
   }
 }
 
-void BackTrace::dump(Formatter *f) const
+void ClibBackTrace::dump(Formatter *f) const
 {
   f->open_array_section("backtrace");
   for (size_t i = skip; i < size; i++) {
@@ -29,7 +29,7 @@ void BackTrace::dump(Formatter *f) const
   f->close_section();
 }
 
-std::string BackTrace::demangle(const char* name)
+std::string ClibBackTrace::demangle(const char* name)
 {
   // find the parentheses and address offset surrounding the mangled name
 #ifdef __FreeBSD__
@@ -68,6 +68,22 @@ std::string BackTrace::demangle(const char* name)
   } else {
     // didn't find the mangled name, just print the whole line
     return name;
+  }
+}
+
+void PyBackTrace::dump(Formatter *f) const
+{
+  f->open_array_section("backtrace");
+  for (auto& i : strings) {
+    f->dump_string("frame", i);
+  }
+  f->close_section();
+}
+
+void PyBackTrace::print(std::ostream& out) const
+{
+  for (auto& i : strings) {
+    out << i << std::endl;
   }
 }
 

--- a/src/common/BackTrace.h
+++ b/src/common/BackTrace.h
@@ -11,6 +11,9 @@
 #endif
 #include <stdlib.h>
 
+#include <list>
+#include <string>
+
 namespace ceph {
 
 class Formatter;
@@ -23,6 +26,18 @@ struct BackTrace {
   size_t size;
   char **strings;
 
+  std::list<std::string> src_strings;
+
+  explicit BackTrace(std::list<std::string>& s)
+    : skip(0),
+      size(s.size()) {
+    src_strings = s;
+    strings = (char **)malloc(sizeof(*strings) * src_strings.size());
+    unsigned i = 0;
+    for (auto& s : src_strings) {
+      strings[i++] = (char *)s.c_str();
+    }
+  }
   explicit BackTrace(int s) : skip(s) {
 #ifdef HAVE_EXECINFO_H
     size = backtrace(array, max);

--- a/src/common/BackTrace.h
+++ b/src/common/BackTrace.h
@@ -19,6 +19,18 @@ namespace ceph {
 class Formatter;
 
 struct BackTrace {
+  virtual ~BackTrace() {}
+  virtual void print(std::ostream& out) const = 0;
+  virtual void dump(Formatter *f) const = 0;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const BackTrace& bt) {
+  bt.print(out);
+  return out;
+}
+
+
+struct ClibBackTrace : public BackTrace {
   const static int max = 32;
 
   int skip;
@@ -26,20 +38,9 @@ struct BackTrace {
   size_t size;
   char **strings;
 
-  std::list<std::string> src_strings;
-
-  explicit BackTrace(std::list<std::string>& s)
-    : skip(0),
-      size(s.size()) {
-    src_strings = s;
-    strings = (char **)malloc(sizeof(*strings) * src_strings.size());
-    unsigned i = 0;
-    for (auto& s : src_strings) {
-      strings[i++] = (char *)s.c_str();
-    }
-  }
-  explicit BackTrace(int s) : skip(s) {
+  explicit ClibBackTrace(int s) {
 #ifdef HAVE_EXECINFO_H
+    skip = s;
     size = backtrace(array, max);
     strings = backtrace_symbols(array, size);
 #else
@@ -48,22 +49,29 @@ struct BackTrace {
     strings = nullptr;
 #endif
   }
-  ~BackTrace() {
+  ~ClibBackTrace() {
     free(strings);
   }
 
-  BackTrace(const BackTrace& other);
-  const BackTrace& operator=(const BackTrace& other);
+  ClibBackTrace(const ClibBackTrace& other);
+  const ClibBackTrace& operator=(const ClibBackTrace& other);
 
-  void print(std::ostream& out) const;
-  void dump(Formatter *f) const;
+  void print(std::ostream& out) const override;
+  void dump(Formatter *f) const override;
+
   static std::string demangle(const char* name);
 };
 
-inline std::ostream& operator<<(std::ostream& out, const BackTrace& bt) {
-  bt.print(out);
-  return out;
-}
+
+struct PyBackTrace : public BackTrace {
+  std::list<std::string> strings;
+
+  explicit PyBackTrace(std::list<std::string>& s) : strings(s) {}
+
+  void dump(Formatter *f) const override;
+  void print(std::ostream& out) const override;
+};
+
 
 }
 

--- a/src/common/assert.cc
+++ b/src/common/assert.cc
@@ -59,7 +59,7 @@ namespace ceph {
 
     // TODO: get rid of this memory allocation.
     ostringstream oss;
-    oss << BackTrace(1);
+    oss << ClibBackTrace(1);
     dout_emergency(oss.str());
 
     if (g_assert_context) {
@@ -126,7 +126,7 @@ namespace ceph {
 		       sizeof(g_assert_thread_name));
 
     BufAppender ba(g_assert_msg, sizeof(g_assert_msg));
-    BackTrace *bt = new BackTrace(1);
+    BackTrace *bt = new ClibBackTrace(1);
     ba.printf("%s: In function '%s' thread %llx time %s\n"
 	     "%s: %d: FAILED ceph_assert(%s)\n",
 	     file, func, (unsigned long long)pthread_self(), tss.str().c_str(),
@@ -171,7 +171,7 @@ namespace ceph {
     ceph_pthread_getname(pthread_self(), g_assert_thread_name,
 		       sizeof(g_assert_thread_name));
 
-    BackTrace *bt = new BackTrace(1);
+    BackTrace *bt = new ClibBackTrace(1);
     snprintf(g_assert_msg, sizeof(g_assert_msg),
              "%s: In function '%s' thread %llx time %s\n"
 	     "%s: %d: ceph_abort_msg(\"%s\")\n", file, func,
@@ -214,7 +214,7 @@ namespace ceph {
 		       sizeof(g_assert_thread_name));
 
     BufAppender ba(g_assert_msg, sizeof(g_assert_msg));
-    BackTrace *bt = new BackTrace(1);
+    BackTrace *bt = new ClibBackTrace(1);
     ba.printf("%s: In function '%s' thread %llx time %s\n"
 	      "%s: %d: abort()\n",
 	      file, func, (unsigned long long)pthread_self(), tss.str().c_str(),

--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -438,7 +438,7 @@ handle_bad_get(CephContext *cct, const string& k, const char *tname)
   lderr(cct) << errstr.str() << dendl;
 
   ostringstream oss;
-  oss << BackTrace(1);
+  oss << ClibBackTrace(1);
   lderr(cct) << oss.str() << dendl;
 
   if (status == 0)

--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -297,7 +297,7 @@ int lockdep_will_lock(const char *name, int id, bool force_backtrace,
       if (!recursive) {
 	lockdep_dout(0) << "\n";
 	*_dout << "recursive lock of " << name << " (" << id << ")\n";
-	auto bt = new ceph::BackTrace(BACKTRACE_SKIP);
+	auto bt = new ceph::ClibBackTrace(BACKTRACE_SKIP);
 	bt->print(*_dout);
 	if (p->second) {
 	  *_dout << "\npreviously locked at\n";
@@ -312,7 +312,7 @@ int lockdep_will_lock(const char *name, int id, bool force_backtrace,
 
       // did we just create a cycle?
       if (does_follow(id, p->first)) {
-        auto bt = new ceph::BackTrace(BACKTRACE_SKIP);
+        auto bt = new ceph::ClibBackTrace(BACKTRACE_SKIP);
 	lockdep_dout(0) << "new dependency " << lock_names[p->first]
 		<< " (" << p->first << ") -> " << name << " (" << id << ")"
 		<< " creates a cycle at\n";
@@ -338,7 +338,7 @@ int lockdep_will_lock(const char *name, int id, bool force_backtrace,
       } else {
 	ceph::BackTrace* bt = NULL;
         if (force_backtrace || lockdep_force_backtrace()) {
-          bt = new ceph::BackTrace(BACKTRACE_SKIP);
+          bt = new ceph::ClibBackTrace(BACKTRACE_SKIP);
         }
         follows[p->first].set(id);
         follows_bt[p->first][id] = bt;
@@ -363,7 +363,7 @@ int lockdep_locked(const char *name, int id, bool force_backtrace)
 
   lockdep_dout(20) << "_locked " << name << dendl;
   if (force_backtrace || lockdep_force_backtrace())
-    held[p][id] = new ceph::BackTrace(BACKTRACE_SKIP);
+    held[p][id] = new ceph::ClibBackTrace(BACKTRACE_SKIP);
   else
     held[p][id] = 0;
 out:

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -322,7 +322,7 @@ static void handle_oneshot_fatal_signal(int signum)
   // TODO: don't use an ostringstream here. It could call malloc(), which we
   // don't want inside a signal handler.
   // Also fix the backtrace code not to allocate memory.
-  BackTrace bt(1);
+  ClibBackTrace bt(1);
   ostringstream oss;
   bt.print(oss);
   dout_emergency(oss.str());

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -145,55 +145,14 @@ static int parse_from_os_release(
   return 0;
 }
 
-static void handle_oneshot_fatal_signal(int signum)
+
+void generate_crash_dump(char *base,
+			 const BackTrace& bt,
+			 std::map<std::string,std::string> *extra)
 {
-  constexpr static pid_t NULL_TID{0};
-  static std::atomic<pid_t> handler_tid{NULL_TID};
-  if (auto expected{NULL_TID};
-      !handler_tid.compare_exchange_strong(expected, ceph_gettid())) {
-    if (expected == ceph_gettid()) {
-      // The handler code may itself trigger a SIGSEGV if the heap is corrupt.
-      // In that case, SIG_DFL followed by return specifies that the default
-      // signal handler -- presumably dump core -- will handle it.
-      signal(signum, SIG_DFL);
-    } else {
-      // Huh, another thread got into troubles while we are handling the fault.
-      // If this is i.e. SIGSEGV handler, returning means retrying the faulty
-      // instruction one more time, and thus all those extra threads will run
-      // into a busy-wait basically.
-    }
-    return;
-  }
-
-  char buf[1024];
-  char pthread_name[16] = {0}; //limited by 16B include terminating null byte.
-  int r = ceph_pthread_getname(pthread_self(), pthread_name, sizeof(pthread_name));
-  (void)r;
-#if defined(__sun)
-  char message[SIG2STR_MAX];
-  sig2str(signum,message);
-  snprintf(buf, sizeof(buf), "*** Caught signal (%s) **\n "
-	    "in thread %llx thread_name:%s\n", message, (unsigned long long)pthread_self(),
-	    pthread_name);
-#else
-  snprintf(buf, sizeof(buf), "*** Caught signal (%s) **\n "
-	    "in thread %llx thread_name:%s\n", sig_str(signum), (unsigned long long)pthread_self(),
-	    pthread_name);
-#endif
-  dout_emergency(buf);
-  pidfile_remove();
-
-  // TODO: don't use an ostringstream here. It could call malloc(), which we
-  // don't want inside a signal handler.
-  // Also fix the backtrace code not to allocate memory.
-  BackTrace bt(1);
-  ostringstream oss;
-  bt.print(oss);
-  dout_emergency(oss.str());
-
-  char base[PATH_MAX] = { 0 };
   if (g_ceph_context &&
       g_ceph_context->_conf->crash_dir.size()) {
+
     // -- crash dump --
     // id
     ostringstream idss;
@@ -205,7 +164,7 @@ static void handle_oneshot_fatal_signal(int signum)
     string id = idss.str();
     std::replace(id.begin(), id.end(), ' ', '_');
 
-    snprintf(base, sizeof(base), "%s/%s",
+    snprintf(base, PATH_MAX, "%s/%s",
 	     g_ceph_context->_conf->crash_dir.c_str(),
 	     id.c_str());
     int r = ::mkdir(base, 0700);
@@ -300,8 +259,13 @@ static void handle_oneshot_fatal_signal(int signum)
 	  }
 	}
 
-	// backtrace
 	bt.dump(&jf);
+
+	if (extra) {
+	  for (auto& i : *extra) {
+	    jf.dump_string(i.first, i.second);
+	  }
+	}
 
 	jf.close_section();
 	ostringstream oss;
@@ -315,6 +279,57 @@ static void handle_oneshot_fatal_signal(int signum)
       ::creat(fn, 0444);
     }
   }
+}
+
+static void handle_oneshot_fatal_signal(int signum)
+{
+  constexpr static pid_t NULL_TID{0};
+  static std::atomic<pid_t> handler_tid{NULL_TID};
+  if (auto expected{NULL_TID};
+      !handler_tid.compare_exchange_strong(expected, ceph_gettid())) {
+    if (expected == ceph_gettid()) {
+      // The handler code may itself trigger a SIGSEGV if the heap is corrupt.
+      // In that case, SIG_DFL followed by return specifies that the default
+      // signal handler -- presumably dump core -- will handle it.
+      signal(signum, SIG_DFL);
+    } else {
+      // Huh, another thread got into troubles while we are handling the fault.
+      // If this is i.e. SIGSEGV handler, returning means retrying the faulty
+      // instruction one more time, and thus all those extra threads will run
+      // into a busy-wait basically.
+    }
+    return;
+  }
+
+  char buf[1024];
+  char pthread_name[16] = {0}; //limited by 16B include terminating null byte.
+  int r = ceph_pthread_getname(pthread_self(), pthread_name, sizeof(pthread_name));
+  (void)r;
+#if defined(__sun)
+  char message[SIG2STR_MAX];
+  sig2str(signum,message);
+  snprintf(buf, sizeof(buf), "*** Caught signal (%s) **\n "
+	    "in thread %llx thread_name:%s\n", message, (unsigned long long)pthread_self(),
+	    pthread_name);
+#else
+  snprintf(buf, sizeof(buf), "*** Caught signal (%s) **\n "
+	    "in thread %llx thread_name:%s\n", sig_str(signum), (unsigned long long)pthread_self(),
+	    pthread_name);
+#endif
+  dout_emergency(buf);
+  pidfile_remove();
+
+  // TODO: don't use an ostringstream here. It could call malloc(), which we
+  // don't want inside a signal handler.
+  // Also fix the backtrace code not to allocate memory.
+  BackTrace bt(1);
+  ostringstream oss;
+  bt.print(oss);
+  dout_emergency(oss.str());
+
+  char crash_base[PATH_MAX] = { 0 };
+  
+  generate_crash_dump(crash_base, bt);
 
   // avoid recursion back into logging code if that is where
   // we got the SEGV.
@@ -331,9 +346,9 @@ static void handle_oneshot_fatal_signal(int signum)
 
     g_ceph_context->_log->dump_recent();
 
-    if (base[0]) {
+    if (crash_base[0]) {
       char fn[PATH_MAX*2];
-      snprintf(fn, sizeof(fn)-1, "%s/log", base);
+      snprintf(fn, sizeof(fn)-1, "%s/log", crash_base);
       g_ceph_context->_log->set_log_file(fn);
       g_ceph_context->_log->reopen_log_file();
       g_ceph_context->_log->dump_recent();

--- a/src/global/signal_handler.h
+++ b/src/global/signal_handler.h
@@ -17,8 +17,13 @@
 
 #include <signal.h>
 #include "acconfig.h"
+#include <map>
+#include <string>
 
 typedef void (*signal_handler_t)(int);
+namespace ceph {
+  struct BackTrace;
+}
 
 #if defined(HAVE_SIGDESCR_NP)
 # define sig_str(signum) sigdescr_np(signum)
@@ -52,5 +57,9 @@ void register_async_signal_handler_oneshot(int signum, signal_handler_t handler)
 
 /// uninstall a safe async signal callback
 void unregister_async_signal_handler(int signum, signal_handler_t handler);
+
+void generate_crash_dump(char *base,
+			 const ceph::BackTrace& bt,
+			 std::map<std::string,std::string> *extra = 0);
 
 #endif

--- a/src/mgr/ActivePyModule.cc
+++ b/src/mgr/ActivePyModule.cc
@@ -42,7 +42,7 @@ int ActivePyModule::load(ActivePyModules *py_modules)
   Py_DECREF(pArgs);
   if (pClassInstance == nullptr) {
     derr << "Failed to construct class in '" << get_name() << "'" << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, get_name(), "ActivePyModule::load") << dendl;
     return -EINVAL;
   } else {
     dout(1) << "Constructed class from module: " << get_name() << dendl;
@@ -71,7 +71,7 @@ void ActivePyModule::notify(const std::string &notify_type, const std::string &n
     Py_DECREF(pValue);
   } else {
     derr << get_name() << ".notify:" << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, get_name(), "ActivePyModule::notify") << dendl;
     // FIXME: callers can't be expected to handle a python module
     // that has spontaneously broken, but Mgr() should provide
     // a hook to unload misbehaving modules when they have an
@@ -104,7 +104,7 @@ void ActivePyModule::notify_clog(const LogEntry &log_entry)
     Py_DECREF(pValue);
   } else {
     derr << get_name() << ".notify_clog:" << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, get_name(), "ActivePyModule::notify_clog") << dendl;
     // FIXME: callers can't be expected to handle a python module
     // that has spontaneously broken, but Mgr() should provide
     // a hook to unload misbehaving modules when they have an
@@ -159,7 +159,8 @@ PyObject *ActivePyModule::dispatch_remote(
     // Because the caller is in a different context, we can't let this
     // exception bubble up, need to re-raise it from the caller's
     // context later.
-    *err = handle_pyerror();
+    std::string caller = "ActivePyModule::dispatch_remote "s + method;
+    *err = handle_pyerror(true, get_name(), caller);
   } else {
     dout(20) << "Success calling '" << method << "'" << dendl;
   }

--- a/src/mgr/ActivePyModule.h
+++ b/src/mgr/ActivePyModule.h
@@ -1,4 +1,3 @@
-
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
@@ -25,6 +24,7 @@
 #include "mgr/Gil.h"
 
 #include "PyModuleRunner.h"
+#include "PyModule.h"
 
 #include <vector>
 #include <string>
@@ -98,5 +98,4 @@ public:
 
 };
 
-std::string handle_pyerror();
 

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -987,7 +987,8 @@ PyObject *construct_with_capsule(
   PyObject *module = PyImport_ImportModule(module_name.c_str());
   if (!module) {
     derr << "Failed to import python module:" << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, module_name,
+			   "construct_with_capsule "s + module_name + " " + clsname) << dendl;
   }
   ceph_assert(module);
 
@@ -995,7 +996,8 @@ PyObject *construct_with_capsule(
       module, (const char*)clsname.c_str());
   if (!wrapper_type) {
     derr << "Failed to get python type:" << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, module_name,
+			   "construct_with_capsule "s + module_name + " " + clsname) << dendl;
   }
   ceph_assert(wrapper_type);
 
@@ -1008,7 +1010,8 @@ PyObject *construct_with_capsule(
   auto wrapper_instance = PyObject_CallObject(wrapper_type, pArgs);
   if (wrapper_instance == nullptr) {
     derr << "Failed to construct python OSDMap:" << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, module_name,
+			   "construct_with_capsule "s + module_name + " " + clsname) << dendl;
   }
   ceph_assert(wrapper_instance != nullptr);
   Py_DECREF(pArgs);

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -106,8 +106,7 @@ std::string handle_pyerror(
     PyObject *l = get_managed_object(formatted_list, boost::python::tag);
     if (PyList_Check(l)) {
       // skip first line, which is: "Traceback (most recent call last):\n"
-      // omit last line, which contains a runtime value that may be identifying!
-      for (unsigned i = 1; i < PyList_Size(l) - 1; ++i) {
+      for (unsigned i = 1; i < PyList_Size(l); ++i) {
 	PyObject *val = PyList_GET_ITEM(l, i);
 	std::string s = PyUnicode_AsUTF8(val);
 	s.resize(s.size() - 1);  // strip off newline character

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -19,6 +19,10 @@
 
 #include "PyModule.h"
 
+#include "include/stringify.h"
+#include "common/BackTrace.h"
+#include "global/signal_handler.h"
+
 #include "common/debug.h"
 #include "common/errno.h"
 #define dout_context g_ceph_context
@@ -40,49 +44,83 @@ std::string PyModule::mgr_store_prefix = "mgr/";
 #undef BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/algorithm/string/predicate.hpp>
 #include "include/ceph_assert.h"  // boost clobbers this
-// decode a Python exception into a string
-std::string handle_pyerror()
-{
-    using namespace boost::python;
-    using namespace boost;
 
-    PyObject *exc, *val, *tb;
-    object formatted_list, formatted;
-    PyErr_Fetch(&exc, &val, &tb);
-    PyErr_NormalizeException(&exc, &val, &tb);
-    handle<> hexc(exc), hval(allow_null(val)), htb(allow_null(tb));
-    object traceback(import("traceback"));
-    if (!tb) {
-        object format_exception_only(traceback.attr("format_exception_only"));
-        try {
-          formatted_list = format_exception_only(hexc, hval);
-        } catch (error_already_set const &) {
-          // error while processing exception object
-          // returning only the exception string value
-          PyObject *name_attr = PyObject_GetAttrString(exc, "__name__");
-          std::stringstream ss;
-          ss << PyUnicode_AsUTF8(name_attr) << ": " << PyUnicode_AsUTF8(val);
-          Py_XDECREF(name_attr);
-          ss << "\nError processing exception object: " << peek_pyerror();
-          return ss.str();
-        }
-    } else {
-        object format_exception(traceback.attr("format_exception"));
-        try {
-          formatted_list = format_exception(hexc, hval, htb);
-        } catch (error_already_set const &) {
-          // error while processing exception object
-          // returning only the exception string value
-          PyObject *name_attr = PyObject_GetAttrString(exc, "__name__");
-          std::stringstream ss;
-          ss << PyUnicode_AsUTF8(name_attr) << ": " << PyUnicode_AsUTF8(val);
-          Py_XDECREF(name_attr);
-          ss << "\nError processing exception object: " << peek_pyerror();
-          return ss.str();
-        }
+
+// decode a Python exception into a string
+std::string handle_pyerror(
+  bool crash_dump,
+  std::string module,
+  std::string caller)
+{
+  using namespace boost::python;
+  using namespace boost;
+
+  PyObject *exc, *val, *tb;
+  object formatted_list, formatted;
+  PyErr_Fetch(&exc, &val, &tb);
+  PyErr_NormalizeException(&exc, &val, &tb);
+  handle<> hexc(exc), hval(allow_null(val)), htb(allow_null(tb));
+
+  object traceback(import("traceback"));
+  if (!tb) {
+    object format_exception_only(traceback.attr("format_exception_only"));
+    try {
+      formatted_list = format_exception_only(hexc, hval);
+    } catch (error_already_set const &) {
+      // error while processing exception object
+      // returning only the exception string value
+      PyObject *name_attr = PyObject_GetAttrString(exc, "__name__");
+      std::stringstream ss;
+      ss << PyUnicode_AsUTF8(name_attr) << ": " << PyUnicode_AsUTF8(val);
+      Py_XDECREF(name_attr);
+      ss << "\nError processing exception object: " << peek_pyerror();
+      return ss.str();
     }
-    formatted = str("").join(formatted_list);
-    return extract<std::string>(formatted);
+  } else {
+    object format_exception(traceback.attr("format_exception"));
+    try {
+      formatted_list = format_exception(hexc, hval, htb);
+    } catch (error_already_set const &) {
+      // error while processing exception object
+      // returning only the exception string value
+      PyObject *name_attr = PyObject_GetAttrString(exc, "__name__");
+      std::stringstream ss;
+      ss << PyUnicode_AsUTF8(name_attr) << ": " << PyUnicode_AsUTF8(val);
+      Py_XDECREF(name_attr);
+      ss << "\nError processing exception object: " << peek_pyerror();
+      return ss.str();
+    }
+  }
+  formatted = str("").join(formatted_list);
+
+  if (!module.empty()) {
+    std::list<std::string> bt_strings;
+    std::map<std::string, std::string> extra;
+    
+    extra["mgr_module"] = module;
+    extra["mgr_module_caller"] = caller;
+    PyObject *name_attr = PyObject_GetAttrString(exc, "__name__");
+    extra["mgr_python_exception"] = stringify(PyUnicode_AsUTF8(name_attr));
+    Py_XDECREF(name_attr);
+
+    PyObject *l = get_managed_object(formatted_list, boost::python::tag);
+    if (PyList_Check(l)) {
+      // skip first line, which is: "Traceback (most recent call last):\n"
+      // omit last line, which contains a runtime value that may be identifying!
+      for (unsigned i = 1; i < PyList_Size(l) - 1; ++i) {
+	PyObject *val = PyList_GET_ITEM(l, i);
+	std::string s = PyUnicode_AsUTF8(val);
+	s.resize(s.size() - 1);  // strip off newline character
+	bt_strings.push_back(s);
+      }
+    }
+    PyBackTrace bt(bt_strings);
+    
+    char crash_path[PATH_MAX];
+    generate_crash_dump(crash_path, bt, &extra);
+  }
+  
+  return extract<std::string>(formatted);
 }
 
 /**
@@ -405,7 +443,7 @@ int PyModule::load(PyThreadState *pMainThreadState)
       Py_DECREF(pCanRunTuple);
     } else {
       derr << "Exception calling can_run on " << get_name() << dendl;
-      derr << handle_pyerror() << dendl;
+      derr << handle_pyerror(true, get_name(), "PyModule::load") << dendl;
       can_run = false;
     }
   }
@@ -464,7 +502,7 @@ int PyModule::register_options(PyObject *cls)
   } else {
     derr << "Exception calling _register_options on " << get_name()
          << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, module_name, "PyModule::register_options") << dendl;
   }
   return 0;
 }
@@ -479,7 +517,7 @@ int PyModule::load_commands()
   } else {
     derr << "Exception calling _register_commands on " << get_name()
          << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, module_name, "PyModule::load_commands") << dendl;
   }
 
   int r = walk_dict_list("COMMANDS", [this](PyObject *pCommand) -> int {
@@ -633,7 +671,7 @@ int PyModule::load_subclass_of(const char* base_class, PyObject** py_class)
   if (!mgr_module) {
     error_string = peek_pyerror();
     derr << "Module not found: 'mgr_module'" << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, module_name, "PyModule::load_subclass_of") << dendl;
     return -EINVAL;
   }
   auto mgr_module_type = PyObject_GetAttrString(mgr_module, base_class);
@@ -641,7 +679,7 @@ int PyModule::load_subclass_of(const char* base_class, PyObject** py_class)
   if (!mgr_module_type) {
     error_string = peek_pyerror();
     derr << "Unable to import MgrModule from mgr_module" << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, module_name, "PyModule::load_subclass_of") << dendl;
     return -EINVAL;
   }
 
@@ -650,7 +688,7 @@ int PyModule::load_subclass_of(const char* base_class, PyObject** py_class)
   if (!plugin_module) {
     error_string = peek_pyerror();
     derr << "Module not found: '" << module_name << "'" << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, module_name, "PyModule::load_subclass_of") << dendl;
     return -ENOENT;
   }
   auto locals = PyModule_GetDict(plugin_module);

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -26,7 +26,9 @@
 
 class MonClient;
 
-std::string handle_pyerror();
+std::string handle_pyerror(bool generate_crash_dump = false,
+			   std::string module = {},
+			   std::string caller = {});
 
 std::string peek_pyerror();
 

--- a/src/mgr/PyModuleRunner.cc
+++ b/src/mgr/PyModuleRunner.cc
@@ -63,7 +63,7 @@ int PyModuleRunner::serve()
                   << "' while running on mgr." << g_conf()->name.get_id()
                   << ": " << exc_msg;
     derr << get_name() << ".serve:" << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, get_name(), "PyModuleRunner::serve") << dendl;
 
     py_module->fail(exc_msg);
 
@@ -86,7 +86,7 @@ void PyModuleRunner::shutdown()
     Py_DECREF(pValue);
   } else {
     derr << "Failed to invoke shutdown() on " << get_name() << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, get_name(), "PyModuleRunner::shutdown") << dendl;
   }
 
   dead = true;

--- a/src/mgr/StandbyPyModules.cc
+++ b/src/mgr/StandbyPyModules.cc
@@ -114,7 +114,7 @@ int StandbyPyModule::load()
   Py_DECREF(pArgs);
   if (pClassInstance == nullptr) {
     derr << "Failed to construct class in '" << get_name() << "'" << dendl;
-    derr << handle_pyerror() << dendl;
+    derr << handle_pyerror(true, get_name(), "StandbyPyModule::load") << dendl;
     return -EINVAL;
   } else {
     dout(1) << "Constructed class from module: " << get_name() << dendl;

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -4134,7 +4134,7 @@ public:
   }
 
   void finish(int r) override {
-    BackTrace *bt = new BackTrace(1);
+    BackTrace *bt = new ClibBackTrace(1);
     generic_dout(-1) << "FileStore: sync_entry timed out after "
 	   << m_commit_timeo << " seconds.\n";
     bt->print(*_dout);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -136,7 +136,7 @@ uint64_t PG::get_with_id()
   ref++;
   std::lock_guard l(_ref_id_lock);
   uint64_t id = ++_ref_id;
-  BackTrace bt(0);
+  ClibBackTrace bt(0);
   stringstream ss;
   bt.print(ss);
   lgeneric_subdout(cct, refs, 5) << "PG::get " << this << " " << info.pgid

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -306,7 +306,10 @@ class Module(MgrModule):
             if errno:
                 continue
             c = json.loads(crashinfo)
+
+            # redact hostname
             del c['utsname_hostname']
+
             # entity_name might have more than one '.', beware
             (etype, eid) = c.get('entity_name', '').split('.', 1)
             m = hashlib.sha1()
@@ -315,6 +318,12 @@ class Module(MgrModule):
             m.update(eid.encode('utf-8'))
             m.update(self.salt.encode('utf-8'))
             c['entity_name'] = etype + '.' + m.hexdigest()
+
+            # redact final line of python tracebacks, as the exception
+            # payload may contain identifying information
+            if 'mgr_module' in c:
+                c['backtrace'][-1] = '<redacted>'
+
             crashlist.append(c)
         return crashlist
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -302,8 +302,7 @@ class Module(MgrModule):
         if errno:
             return crashlist
         for crashid in crashids.split():
-            cmd = {'id': crashid}
-            errno, crashinfo, err = self.remote('crash', 'do_info', cmd, '')
+            errno, crashinfo, err = self.remote('crash', 'do_info', crashid)
             if errno:
                 continue
             c = json.loads(crashinfo)

--- a/src/test/common/test_back_trace.cc
+++ b/src/test/common/test_back_trace.cc
@@ -16,7 +16,7 @@
 std::string foo()
 {
   std::ostringstream oss;
-  oss << ceph::BackTrace(1);
+  oss << ceph::ClibBackTrace(1);
   return oss.str();
 }
 


### PR DESCRIPTION
They look like so:

```
{
    "crash_id": "2021-06-18T20:52:36.836075Z_7a14ad79-c96a-484a-9ff5-828dc438148d",
    "timestamp": "2021-06-18T20:52:36.836075Z",
    "process_name": "ceph-mgr",
    "entity_name": "mgr.x",
    "ceph_version": "17.0.0-5306-gdfd9f85d5fd",
    "utsname_hostname": "dael",
    "utsname_sysname": "Linux",
    "utsname_release": "4.18.0-269.el8.x86_64",
    "utsname_version": "#1 SMP Tue Jan 12 17:55:05 UTC 2021",
    "utsname_machine": "x86_64",
    "os_name": "CentOS Stream",
    "os_id": "centos",
    "os_version_id": "8",
    "os_version": "8",
    "backtrace": [
        "  File \"/home/sage/src/ceph/src/pybind/mgr/balancer/module.py\", line 652, in serve\n    self.ifail()",
        "  File \"/home/sage/src/ceph/src/pybind/mgr/balancer/module.py\", line 648, in ifail\n    raise RuntimeError('test')",
    ],
    "mgr_module": "balancer",
    "mgr_module_caller": "PyModuleRunner::serve",
    "mgr_python_exception": "RuntimeError",
}
```

Notably, we exclude the 'value' portion of the exception when reporting telemetry, as that may contain identifying information.