### PR TITLE
mgr/cephadm: include addr in HOST_CHECK_FAILED alert detail

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -368,20 +368,21 @@ class CephadmServe:
             return None
         self.log.debug(' checking %s' % host)
         try:
+            addr = self.mgr.inventory.get_addr(host) if host in self.mgr.inventory else host
             out, err, code = self._run_cephadm(
                 host, cephadmNoImage, 'check-host', [],
                 error_ok=True, no_fsid=True)
             self.mgr.cache.update_last_host_check(host)
             self.mgr.cache.save_host(host)
             if code:
-                self.log.debug(' host %s failed check' % host)
+                self.log.debug(' host %s (%s) failed check' % (host, addr))
                 if self.mgr.warn_on_failed_host_check:
-                    return 'host %s failed check: %s' % (host, err)
+                    return 'host %s (%s) failed check: %s' % (host, addr, err)
             else:
-                self.log.debug(' host %s ok' % host)
+                self.log.debug(' host %s (%s) ok' % (host, addr))
         except Exception as e:
-            self.log.debug(' host %s failed check' % host)
-            return 'host %s failed check: %s' % (host, e)
+            self.log.debug(' host %s (%s) failed check' % (host, addr))
+            return 'host %s (%s) failed check: %s' % (host, addr, e)
         return None
 
     def _refresh_host_daemons(self, host: str) -> Optional[str]:


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>