### PR TITLE
pacific: mgr/dashboard: bucket details: show lock retention period only in days 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html
@@ -121,11 +121,6 @@
               class="bold">Days</td>
           <td>{{ selection.lock_retention_period_days }}</td>
         </tr>
-        <tr>
-          <td i18n
-              class="bold">Years</td>
-          <td>{{ selection.lock_retention_period_years }}</td>
-        </tr>
       </ng-container>
     </tbody>
   </table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.ts
@@ -16,6 +16,7 @@ export class RgwBucketDetailsComponent implements OnChanges {
   ngOnChanges() {
     if (this.selection) {
       this.rgwBucketService.get(this.selection.bid).subscribe((bucket: object) => {
+        bucket['lock_retention_period_days'] = this.rgwBucketService.getLockDays(bucket);
         this.selection = bucket;
       });
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
@@ -372,10 +372,5 @@ describe('RgwBucketFormComponent', () => {
     it('should have valid values [2]', () => {
       expectValidLockInputs(false, 'Compliance', '2');
     });
-
-    it('should convert retention years to days', () => {
-      expect(component['getLockDays']({ lock_retention_period_years: 1000 })).toBe(365242);
-      expect(component['getLockDays']({ lock_retention_period_days: 5 })).toBe(5);
-    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -132,7 +132,7 @@ export class RgwBucketFormComponent extends CdForm implements OnInit {
           // the Angular react framework will throw an error if there is no
           // field for a given key.
           let value: object = _.pick(bidResp, _.keys(defaults));
-          value['lock_retention_period_days'] = this.getLockDays(bidResp);
+          value['lock_retention_period_days'] = this.rgwBucketService.getLockDays(bidResp);
           value['placement-target'] = bidResp['placement_rule'];
           value['versioning'] = bidResp['versioning'] === RgwBucketVersioning.ENABLED;
           value['mfa-delete'] = bidResp['mfa_delete'] === RgwBucketMfaDelete.ENABLED;
@@ -357,13 +357,5 @@ export class RgwBucketFormComponent extends CdForm implements OnInit {
 
   getMfaDeleteStatus() {
     return this.isMfaDeleteEnabled ? RgwBucketMfaDelete.ENABLED : RgwBucketMfaDelete.DISABLED;
-  }
-
-  private getLockDays(bucketData: object): number {
-    if (bucketData['lock_retention_period_years'] > 0) {
-      return Math.floor(bucketData['lock_retention_period_years'] * 365.242);
-    }
-
-    return bucketData['lock_retention_period_days'];
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
@@ -85,4 +85,10 @@ describe('RgwBucketService', () => {
     req.flush(['foo', 'bar']);
     expect(result).toBe(true);
   });
+
+  it('should convert lock retention period to days', () => {
+    expect(service.getLockDays({ lock_retention_period_years: 1000 })).toBe(365242);
+    expect(service.getLockDays({ lock_retention_period_days: 5 })).toBe(5);
+    expect(service.getLockDays({})).toBe(0);
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
@@ -108,4 +108,12 @@ export class RgwBucketService {
       })
     );
   }
+
+  getLockDays(bucketData: object): number {
+    if (bucketData['lock_retention_period_years'] > 0) {
+      return Math.floor(bucketData['lock_retention_period_years'] * 365.242);
+    }
+
+    return bucketData['lock_retention_period_days'] || 0;
+  }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51273

---

backport of https://github.com/ceph/ceph/pull/41808
parent tracker: https://tracker.ceph.com/issues/51164

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh