### PR TITLE
crimson/osd: expose metrics using http server

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -10,7 +10,10 @@
 #include <seastar/apps/lib/stop_signal.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/print.hh>
+#include <seastar/core/prometheus.hh>
 #include <seastar/core/thread.hh>
+#include <seastar/http/httpd.hh>
+#include <seastar/net/inet_address.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/std-compat.hh>
 
@@ -25,6 +28,7 @@
 
 #include "osd.h"
 
+namespace bpo = boost::program_options;
 using config_t = crimson::common::ConfigProxy;
 
 void usage(const char* prog) {
@@ -35,7 +39,6 @@ void usage(const char* prog) {
 
 auto partition_args(seastar::app_template& app, char** argv_begin, char** argv_end)
 {
-  namespace bpo = boost::program_options;
   // collect all options consumed by seastar::app_template
   auto parsed = bpo::command_line_parser(std::distance(argv_begin, argv_end),
                                          argv_begin)
@@ -186,7 +189,13 @@ int main(int argc, char* argv[])
               "This is normally used in combination with --mkfs")
     ("mkfs", "create a [new] data directory")
     ("debug", "enable debug output on all loggers")
-    ("no-mon-config", "do not retrieve configuration from monitors on boot");
+    ("no-mon-config", "do not retrieve configuration from monitors on boot")
+    ("prometheus_port", bpo::value<uint16_t>()->default_value(9180),
+     "Prometheus port. Set to zero to disable")
+    ("prometheus_address", bpo::value<string>()->default_value("0.0.0.0"),
+     "Prometheus listening address")
+    ("prometheus_prefix", bpo::value<string>()->default_value("osd"),
+     "Prometheus metrics prefix");
 
   auto [ceph_args, app_args] = partition_args(app, argv, argv + argc);
   if (ceph_argparse_need_usage(ceph_args) &&
@@ -239,6 +248,29 @@ int main(int argc, char* argv[])
           // just ignore SIGHUP, we don't reread settings. keep in mind signals
           // handled by S* must be blocked for alien threads (see AlienStore).
           seastar::engine().handle_signal(SIGHUP, [] {});
+
+          // start prometheus API server
+          seastar::httpd::http_server_control prom_server;
+          std::any stop_prometheus;
+          if (uint16_t prom_port = config["prometheus_port"].as<uint16_t>();
+              prom_port != 0) {
+            prom_server.start("prometheus").get();
+            stop_prometheus = seastar::make_shared(seastar::defer([&] {
+              prom_server.stop().get();
+            }));
+
+            seastar::prometheus::config prom_config;
+            prom_config.prefix = config["prometheus_prefix"].as<string>();
+            seastar::prometheus::start(prom_server, prom_config).get();
+            seastar::net::inet_address prom_addr(config["prometheus_address"].as<string>());
+            prom_server.listen(seastar::socket_address{prom_addr, prom_port})
+              .handle_exception([=] (auto ep) {
+              std::cerr << seastar::format("Could not start Prometheus API server on {}:{}: {}\n",
+                                           prom_addr, prom_port, ep);
+              return seastar::make_exception_future(ep);
+            }).get();
+          }
+
           const int whoami = std::stoi(local_conf()->name.get_id());
           const auto nonce = get_nonce();
           crimson::net::MessengerRef cluster_msgr, client_msgr;


### PR DESCRIPTION
so, we can query the metrics using HTTP API, like

http://localhost:9180/metrics?name=io*

or

http://192.168.2.8:9180/metrics?name=io_queue_delay

or

http://localhost:9180/metrics

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
