### PR TITLE
mgr/dashboard: fix OSD out count

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/osd-summary.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/osd-summary.pipe.spec.ts
@@ -46,7 +46,7 @@ describe('OsdSummaryPipe', () => {
     ]);
   });
 
-  it('transforms having 3 osd with 2 up, 1 in, 1 down, 1 out', () => {
+  it('transforms having 3 osd with 2 up, 1 in, 1 down, 2 out', () => {
     const value = {
       osds: [
         { up: 1, in: 1 },
@@ -72,18 +72,18 @@ describe('OsdSummaryPipe', () => {
         class: 'card-text-line-break'
       },
       {
-        content: '1 down, 1 out',
+        content: '1 down, 2 out',
         class: 'card-text-error'
       }
     ]);
   });
 
-  it('transforms having 3 osd with 2 up, 2 in, 1 down, 0 out', () => {
+  it('transforms having 3 osd with 2 up, 3 in, 1 down, 0 out', () => {
     const value = {
       osds: [
         { up: 1, in: 1 },
         { up: 1, in: 1 },
-        { up: 0, in: 0 }
+        { up: 0, in: 1 }
       ]
     };
     expect(pipe.transform(value)).toEqual([
@@ -96,7 +96,7 @@ describe('OsdSummaryPipe', () => {
         class: 'card-text-line-break'
       },
       {
-        content: '2 up, 2 in',
+        content: '2 up, 3 in',
         class: ''
       },
       {
@@ -137,6 +137,39 @@ describe('OsdSummaryPipe', () => {
       },
       {
         content: '1 out',
+        class: 'card-text-error'
+      }
+    ]);
+  });
+
+  it('transforms having 4 osd with 3 up, 2 in, 1 down, another 2 out', () => {
+    const value = {
+      osds: [
+        { up: 1, in: 1 },
+        { up: 1, in: 0 },
+        { up: 1, in: 0 },
+        { up: 0, in: 1 }
+      ]
+    };
+    expect(pipe.transform(value)).toEqual([
+      {
+        content: '4 total',
+        class: ''
+      },
+      {
+        content: '',
+        class: 'card-text-line-break'
+      },
+      {
+        content: '3 up, 2 in',
+        class: ''
+      },
+      {
+        content: '',
+        class: 'card-text-line-break'
+      },
+      {
+        content: '1 down, 2 out',
         class: 'card-text-error'
       }
     ]);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/osd-summary.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/osd-summary.pipe.ts
@@ -38,7 +38,7 @@ export class OsdSummaryPipe implements PipeTransform {
     });
 
     const downCount = value.osds.length - upCount;
-    const outCount = upCount - inCount;
+    const outCount = value.osds.length - inCount;
     if (downCount > 0 || outCount > 0) {
       osdSummary.push({
         content: '',


### PR DESCRIPTION
Think we have 3 OSDs out but up (prepare for re-formating to change min_alloc_size), and another OSD down but in (during reboot). The dashboard will display "1 down, 2 out", which is obviously incorrect. It should be "1 down, 3 out"

Fixes: https://tracker.ceph.com/issues/51376
Signed-off-by: 胡玮文 <huww98@outlook.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
