### PR TITLE
rbd-nbd: support notrim option with map command

### DIFF
--- a/doc/man/8/rbd-nbd.rst
+++ b/doc/man/8/rbd-nbd.rst
@@ -9,7 +9,7 @@
 Synopsis
 ========
 
-| **rbd-nbd** [-c conf] [--read-only] [--device *nbd device*] [--nbds_max *limit*] [--max_part *limit*] [--exclusive] [--encryption-format *format*] [--encryption-passphrase-file *passphrase-file*] [--io-timeout *seconds*] [--reattach-timeout *seconds*] map *image-spec* | *snap-spec*
+| **rbd-nbd** [-c conf] [--read-only] [--device *nbd device*] [--nbds_max *limit*] [--max_part *limit*] [--exclusive] [--notrim] [--encryption-format *format*] [--encryption-passphrase-file *passphrase-file*] [--io-timeout *seconds*] [--reattach-timeout *seconds*] map *image-spec* | *snap-spec*
 | **rbd-nbd** unmap *nbd device* | *image-spec* | *snap-spec*
 | **rbd-nbd** list-mapped
 | **rbd-nbd** attach --device *nbd device* *image-spec* | *snap-spec*
@@ -46,6 +46,10 @@ Options
 .. option:: --exclusive
 
    Forbid writes by other clients.
+
+.. option:: --notrim
+
+   Turn off trim/discard.
 
 .. option:: --encryption-format
 


### PR DESCRIPTION
currently --notrim option works for rbd kernel mounter, but fails with rbd-nbd

```
$ rbd device --options notrim map rbd-pool/image0
/dev/rbd0
$ rbd device list
id  pool      namespace  image   snap  device
0   rbd-pool             image0  -     /dev/rbd0

$ rbd device --device-type nbd --options try-netlink,notrim map rbd-pool/image0
rbd-nbd: unknown args: --notrim
rbd: rbd-nbd failed with error: /data/ceph/build/bin/rbd-nbd: exit status: 1
```
With these changes:
```
$ rbd device --device-type nbd --options try-netlink,notrim map rbd-pool/image0
/dev/nbd0
$ rbd-nbd list-mapped
id    pool      namespace  image   snap  device
6945  rbd-pool             image0  -     /dev/nbd0
$ ps -eo "cmd" |grep [r]bd-nbd
/data/ceph/build/bin/rbd-nbd map rbd-pool/image0 --try-netlink --notrim
```

Fixes: https://github.com/ceph/ceph-csi/issues/2171

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>