### PR TITLE
mgr/dashboard: isolate the logic from controller to host service

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -1,21 +1,13 @@
 # -*- coding: utf-8 -*-
-
-import copy
-import os
-import time
 from typing import Dict, List, Optional
-
-import cherrypy
-from mgr_util import merge_dicts
-from orchestrator import HostSpec
 
 from .. import mgr
 from ..exceptions import DashboardException
 from ..security import Scope
 from ..services.ceph_service import CephService
 from ..services.exception import handle_orchestrator_error
-from ..services.orchestrator import OrchClient, OrchFeature
-from ..tools import TaskManager, str_to_bool
+from ..services.host import HostService
+from ..services.orchestrator import OrchFeature
 from . import ApiController, BaseController, ControllerDoc, Endpoint, \
     EndpointDoc, ReadPermission, RESTController, Task, UiApiController, \
     UpdatePermission, allow_empty_body
@@ -111,161 +103,6 @@ def host_task(name, metadata, wait_for=10.0):
     return Task("host/{}".format(name), metadata, wait_for)
 
 
-def merge_hosts_by_hostname(ceph_hosts, orch_hosts):
-    # type: (List[dict], List[HostSpec]) -> List[dict]
-    """
-    Merge Ceph hosts with orchestrator hosts by hostnames.
-
-    :param ceph_hosts: hosts returned from mgr
-    :type ceph_hosts: list of dict
-    :param orch_hosts: hosts returned from ochestrator
-    :type orch_hosts: list of HostSpec
-    :return list of dict
-    """
-    hosts = copy.deepcopy(ceph_hosts)
-    orch_hosts_map = {host.hostname: host.to_json() for host in orch_hosts}
-
-    # Sort labels.
-    for hostname in orch_hosts_map:
-        orch_hosts_map[hostname]['labels'].sort()
-
-    # Hosts in both Ceph and Orchestrator.
-    for host in hosts:
-        hostname = host['hostname']
-        if hostname in orch_hosts_map:
-            host.update(orch_hosts_map[hostname])
-            host['sources']['orchestrator'] = True
-            orch_hosts_map.pop(hostname)
-
-    # Hosts only in Orchestrator.
-    orch_hosts_only = [
-        merge_dicts(
-            {
-                'ceph_version': '',
-                'services': [],
-                'sources': {
-                    'ceph': False,
-                    'orchestrator': True
-                }
-            }, orch_hosts_map[hostname]) for hostname in orch_hosts_map
-    ]
-    hosts.extend(orch_hosts_only)
-    return hosts
-
-
-def get_hosts(from_ceph=True, from_orchestrator=True):
-    """
-    Get hosts from various sources.
-    """
-    ceph_hosts = []
-    if from_ceph:
-        ceph_hosts = [
-            merge_dicts(
-                server, {
-                    'addr': '',
-                    'labels': [],
-                    'service_type': '',
-                    'sources': {
-                        'ceph': True,
-                        'orchestrator': False
-                    },
-                    'status': ''
-                }) for server in mgr.list_servers()
-        ]
-    if from_orchestrator:
-        orch = OrchClient.instance()
-        if orch.available():
-            return merge_hosts_by_hostname(ceph_hosts, orch.hosts.list())
-    return ceph_hosts
-
-
-def get_host(hostname: str) -> Dict:
-    """
-    Get a specific host from Ceph or Orchestrator (if available).
-    :param hostname: The name of the host to fetch.
-    :raises: cherrypy.HTTPError: If host not found.
-    """
-    for host in get_hosts():
-        if host['hostname'] == hostname:
-            return host
-    raise cherrypy.HTTPError(404)
-
-
-def get_device_osd_map():
-    """Get mappings from inventory devices to OSD IDs.
-
-    :return: Returns a dictionary containing mappings. Note one device might
-        shared between multiple OSDs.
-        e.g. {
-                 'node1': {
-                     'nvme0n1': [0, 1],
-                     'vdc': [0],
-                     'vdb': [1]
-                 },
-                 'node2': {
-                     'vdc': [2]
-                 }
-             }
-    :rtype: dict
-    """
-    result: dict = {}
-    for osd_id, osd_metadata in mgr.get('osd_metadata').items():
-        hostname = osd_metadata.get('hostname')
-        devices = osd_metadata.get('devices')
-        if not hostname or not devices:
-            continue
-        if hostname not in result:
-            result[hostname] = {}
-        # for OSD contains multiple devices, devices is in `sda,sdb`
-        for device in devices.split(','):
-            if device not in result[hostname]:
-                result[hostname][device] = [int(osd_id)]
-            else:
-                result[hostname][device].append(int(osd_id))
-    return result
-
-
-def get_inventories(hosts: Optional[List[str]] = None,
-                    refresh: Optional[bool] = None) -> List[dict]:
-    """Get inventories from the Orchestrator and link devices with OSD IDs.
-
-    :param hosts: Hostnames to query.
-    :param refresh: Ask the Orchestrator to refresh the inventories. Note the this is an
-                    asynchronous operation, the updated version of inventories need to
-                    be re-qeuried later.
-    :return: Returns list of inventory.
-    :rtype: list
-    """
-    do_refresh = False
-    if refresh is not None:
-        do_refresh = str_to_bool(refresh)
-    orch = OrchClient.instance()
-    inventory_hosts = [host.to_json()
-                       for host in orch.inventory.list(hosts=hosts, refresh=do_refresh)]
-    device_osd_map = get_device_osd_map()
-    for inventory_host in inventory_hosts:
-        host_osds = device_osd_map.get(inventory_host['name'])
-        for device in inventory_host['devices']:
-            if host_osds:  # pragma: no cover
-                dev_name = os.path.basename(device['path'])
-                device['osd_ids'] = sorted(host_osds.get(dev_name, []))
-            else:
-                device['osd_ids'] = []
-    return inventory_hosts
-
-
-@allow_empty_body
-def add_host(hostname: str, addr: Optional[str] = None,
-             labels: Optional[List[str]] = None,
-             status: Optional[str] = None):
-    orch_client = OrchClient.instance()
-    host = Host()
-    host.check_orchestrator_host_op(orch_client, hostname)
-    orch_client.hosts.add(hostname, addr, labels)
-    if status == 'maintenance':
-        orch_client.hosts.enter_maintenance(hostname)
-
-
 @ApiController('/host', Scope.HOSTS)
 @ControllerDoc("Get Host Details", "Host")
 class Host(RESTController):
@@ -275,12 +112,7 @@ class Host(RESTController):
                  },
                  responses={200: LIST_HOST_SCHEMA})
     def list(self, sources=None):
-        if sources is None:
-            return get_hosts()
-        _sources = sources.split(',')
-        from_ceph = 'ceph' in _sources
-        from_orchestrator = 'orchestrator' in _sources
-        return get_hosts(from_ceph, from_orchestrator)
+        return HostService.get_hosts(sources)
 
     @raise_if_no_orchestrator([OrchFeature.HOST_LIST, OrchFeature.HOST_CREATE])
     @handle_orchestrator_error('host')
@@ -294,39 +126,19 @@ class Host(RESTController):
                  },
                  responses={200: None, 204: None})
     @RESTController.MethodMap(version='0.1')
+    @allow_empty_body
     def create(self, hostname: str,
                addr: Optional[str] = None,
                labels: Optional[List[str]] = None,
                status: Optional[str] = None):  # pragma: no cover - requires realtime env
-        add_host(hostname, addr, labels, status)
+        HostService.add_host(hostname, addr, labels, status)
 
     @raise_if_no_orchestrator([OrchFeature.HOST_LIST, OrchFeature.HOST_DELETE])
     @handle_orchestrator_error('host')
     @host_task('delete', {'hostname': '{hostname}'})
     @allow_empty_body
     def delete(self, hostname):  # pragma: no cover - requires realtime env
-        orch_client = OrchClient.instance()
-        self.check_orchestrator_host_op(orch_client, hostname, False)
-        orch_client.hosts.remove(hostname)
-
-    def check_orchestrator_host_op(self, orch_client, hostname, add=True):  # pragma:no cover
-        """Check if we can adding or removing a host with orchestrator
-
-        :param orch_client: Orchestrator client
-        :param add: True for adding host operation, False for removing host
-        :raise DashboardException
-        """
-        host = orch_client.hosts.get(hostname)
-        if add and host:
-            raise DashboardException(
-                code='orchestrator_add_existed_host',
-                msg='{} is already in orchestrator'.format(hostname),
-                component='orchestrator')
-        if not add and not host:
-            raise DashboardException(
-                code='orchestrator_remove_nonexistent_host',
-                msg='Remove a non-existent host {} from orchestrator'.format(hostname),
-                component='orchestrator')
+        HostService.delete_host(hostname)
 
     @RESTController.Resource('GET')
     def devices(self, hostname):
@@ -348,7 +160,7 @@ class Host(RESTController):
                  },
                  responses={200: INVENTORY_SCHEMA})
     def inventory(self, hostname, refresh=None):
-        inventory = get_inventories([hostname], refresh)
+        inventory = HostService.get_inventories([hostname], refresh)
         if inventory:
             return inventory[0]
         return {}
@@ -367,22 +179,12 @@ class Host(RESTController):
         ``ABC1234DEF567-1R1234_ABC8DE0Q``.
         :param duration: The duration in seconds how long the LED should flash.
         """
-        orch = OrchClient.instance()
-        TaskManager.current_task().set_progress(0)
-        orch.blink_device_light(hostname, device, 'ident', True)
-        for i in range(int(duration)):
-            percentage = int(round(i / float(duration) * 100))
-            TaskManager.current_task().set_progress(percentage)
-            time.sleep(1)
-        orch.blink_device_light(hostname, device, 'ident', False)
-        TaskManager.current_task().set_progress(100)
+        HostService.identify_device(hostname, device, duration)
 
     @RESTController.Resource('GET')
     @raise_if_no_orchestrator([OrchFeature.DAEMON_LIST])
     def daemons(self, hostname: str) -> List[dict]:
-        orch = OrchClient.instance()
-        daemons = orch.services.list_daemons(hostname=hostname)
-        return [d.to_dict() for d in daemons]
+        return HostService.list_daemons(hostname)
 
     @handle_orchestrator_error('host')
     def get(self, hostname: str) -> Dict:
@@ -390,7 +192,7 @@ class Host(RESTController):
         Get the specified host.
         :raises: cherrypy.HTTPError: If host not found.
         """
-        return get_host(hostname)
+        return HostService.get_host(hostname)
 
     @raise_if_no_orchestrator([OrchFeature.HOST_LABEL_ADD,
                                OrchFeature.HOST_LABEL_REMOVE,
@@ -419,33 +221,7 @@ class Host(RESTController):
         :param maintenance: Enter/Exit maintenance mode.
         :param force: Force enter maintenance mode.
         """
-        orch = OrchClient.instance()
-        host = get_host(hostname)
-
-        if maintenance:
-            status = host['status']
-            if status != 'maintenance':
-                orch.hosts.enter_maintenance(hostname, force)
-
-            if status == 'maintenance':
-                orch.hosts.exit_maintenance(hostname)
-
-        if update_labels:
-            # only allow List[str] type for labels
-            if not isinstance(labels, list):
-                raise DashboardException(
-                    msg='Expected list of labels. Please check API documentation.',
-                    http_status_code=400,
-                    component='orchestrator')
-            current_labels = set(host['labels'])
-            # Remove labels.
-            remove_labels = list(current_labels.difference(set(labels)))
-            for label in remove_labels:
-                orch.hosts.remove_label(hostname, label)
-            # Add labels.
-            add_labels = list(set(labels).difference(current_labels))
-            for label in add_labels:
-                orch.hosts.add_label(hostname, label)
+        HostService.update_host(hostname, update_labels, labels, maintenance, force)
 
 
 @UiApiController('/host', Scope.HOSTS)
@@ -460,17 +236,11 @@ class HostUi(BaseController):
         If Ceph Orchestrator is not enabled, an empty list is returned.
         :return: A list of all host labels.
         """
-        labels = []
-        orch = OrchClient.instance()
-        if orch.available():
-            for host in orch.hosts.list():
-                labels.extend(host.labels)
-        labels.sort()
-        return list(set(labels))  # Filter duplicate labels.
+        return HostService.get_labels()
 
     @Endpoint('GET')
     @ReadPermission
     @raise_if_no_orchestrator([OrchFeature.DEVICE_LIST])
     @handle_orchestrator_error('host')
     def inventory(self, refresh=None):
-        return get_inventories(None, refresh)
+        return HostService.get_inventories(None, refresh)

--- a/src/pybind/mgr/dashboard/services/host.py
+++ b/src/pybind/mgr/dashboard/services/host.py
@@ -1,0 +1,282 @@
+import os
+import time
+import copy
+from typing import Dict, List, Optional
+
+
+import cherrypy
+from mgr_util import merge_dicts
+from orchestrator import HostSpec
+
+from .. import mgr
+from ..exceptions import DashboardException
+from ..services.orchestrator import OrchClient
+from ..tools import TaskManager, str_to_bool
+
+
+"""class HostFacts(NamedTuple):
+  memory_total_bytes: int
+  hdd_capacity_bytes:int
+  flash_capacity_bytes: int
+  raw_capacity: int
+
+  
+class Host(NamedTuple):
+  name: str
+  labels: List[str]
+  facts: HostFacts"""
+
+
+class HostService(object):
+
+    @staticmethod
+    def _merge_hosts_by_hostname(ceph_hosts, orch_hosts):
+        # type: (List[dict], List[HostSpec]) -> List[dict]
+        """
+        Merge Ceph hosts with orchestrator hosts by hostnames.
+
+        :param ceph_hosts: hosts returned from mgr
+        :type ceph_hosts: list of dict
+        :param orch_hosts: hosts returned from ochestrator
+        :type orch_hosts: list of HostSpec
+        :return list of dict
+        """
+        hosts = copy.deepcopy(ceph_hosts)
+        orch_hosts_map = {host.hostname: host.to_json() for host in orch_hosts}
+
+        # Sort labels.
+        for hostname in orch_hosts_map:
+            orch_hosts_map[hostname]['labels'].sort()
+
+        # Hosts in both Ceph and Orchestrator.
+        for host in hosts:
+            hostname = host['hostname']
+            if hostname in orch_hosts_map:
+                host.update(orch_hosts_map[hostname])
+                host['sources']['orchestrator'] = True
+                orch_hosts_map.pop(hostname)
+
+        # Hosts only in Orchestrator.
+        orch_hosts_only = [
+            merge_dicts(
+                {
+                    'ceph_version': '',
+                    'services': [],
+                    'sources': {
+                        'ceph': False,
+                        'orchestrator': True
+                    }
+                }, orch_hosts_map[hostname]) for hostname in orch_hosts_map
+        ]
+        hosts.extend(orch_hosts_only)
+        return hosts
+
+    @staticmethod
+    def _check_orchestrator_host_op(orch_client, hostname, add=True):  # pragma:no cover
+        """Check if we can adding or removing a host with orchestrator
+
+        :param orch_client: Orchestrator client
+        :param add: True for adding host operation, False for removing host
+        :raise DashboardException
+        """
+        host = orch_client.hosts.get(hostname)
+        if add and host:
+            raise DashboardException(
+                code='orchestrator_add_existed_host',
+                msg='{} is already in orchestrator'.format(hostname),
+                component='orchestrator')
+        if not add and not host:
+            raise DashboardException(
+                code='orchestrator_remove_nonexistent_host',
+                msg='Remove a non-existent host {} from orchestrator'.format(hostname),
+                component='orchestrator')
+
+    
+    @staticmethod
+    def get_hosts(sources=None):
+        """
+        Get hosts from various sources.
+        """
+        from_ceph = True
+        from_orchestrator = True
+        if sources is not None:
+            _sources = sources.split(',')
+            from_ceph = 'ceph' in _sources
+            from_orchestrator = 'orchestrator' in _sources
+
+        ceph_hosts = []
+        if from_ceph:
+            ceph_hosts = [
+                merge_dicts(
+                    server, {
+                        'addr': '',
+                        'labels': [],
+                        'service_type': '',
+                        'sources': {
+                        'ceph': True,
+                        'orchestrator': False
+                    },
+                    'status': ''
+                }) for server in mgr.list_servers()
+            ]
+        if from_orchestrator:
+            orch = OrchClient.instance()
+            if orch.available():
+                return HostService._merge_hosts_by_hostname(ceph_hosts, orch.hosts.list())
+        return ceph_hosts
+
+    @staticmethod
+    def get_host(hostname: str) -> Dict:
+        """
+        Get a specific host from Ceph or Orchestrator (if available).
+        :param hostname: The name of the host to fetch.
+        :raises: cherrypy.HTTPError: If host not found.
+        """
+        for host in HostService.get_hosts():
+            if host['hostname'] == hostname:
+                return host
+        raise cherrypy.HTTPError(404)
+
+
+    @staticmethod
+    def add_host(hostname: str, addr: Optional[str] = None,
+                labels: Optional[List[str]] = None,
+                status: Optional[str] = None):
+        orch_client = OrchClient.instance()
+        HostService._check_orchestrator_host_op(orch_client, hostname)
+        orch_client.hosts.add(hostname, addr, labels)
+        if status == 'maintenance':
+            orch_client.hosts.enter_maintenance(hostname)
+
+
+    @staticmethod
+    def delete_host(hostname: str):
+        orch_client = OrchClient.instance()
+        HostService._check_orchestrator_host_op(orch_client, hostname, False)
+        orch_client.hosts.remove(hostname)
+
+    @staticmethod
+    def update_host(hostname: str, update_labels: bool = False,
+                labels: List[str] = None, maintenance: bool = False,
+                force: bool = False):
+        orch = OrchClient.instance()
+        host = HostService.get_host(hostname)
+
+        if maintenance:
+            status = host['status']
+            if status != 'maintenance':
+                orch.hosts.enter_maintenance(hostname, force)
+
+            if status == 'maintenance':
+                orch.hosts.exit_maintenance(hostname)
+
+        if update_labels:
+            # only allow List[str] type for labels
+            if not isinstance(labels, list):
+                raise DashboardException(
+                    msg='Expected list of labels. Please check API documentation.',
+                    http_status_code=400,
+                    component='orchestrator')
+            current_labels = set(host['labels'])
+            # Remove labels.
+            remove_labels = list(current_labels.difference(set(labels)))
+            for label in remove_labels:
+                orch.hosts.remove_label(hostname, label)
+            # Add labels.
+            add_labels = list(set(labels).difference(current_labels))
+            for label in add_labels:
+                orch.hosts.add_label(hostname, label)
+
+    @staticmethod
+    def get_labels() -> List[str]:
+        labels = []
+        orch = OrchClient.instance()
+        if orch.available():
+            for host in orch.hosts.list():
+                labels.extend(host.labels)
+        labels.sort()
+        return list(set(labels))  # Filter duplicate labels.
+
+    @staticmethod
+    def get_device_osd_map():
+        """Get mappings from inventory devices to OSD IDs.
+
+        :return: Returns a dictionary containing mappings. Note one device might
+            shared between multiple OSDs.
+            e.g. {
+                    'node1': {
+                        'nvme0n1': [0, 1],
+                        'vdc': [0],
+                        'vdb': [1]
+                    },
+                    'node2': {
+                        'vdc': [2]
+                    }
+                }
+        :rtype: dict
+        """
+        result: dict = {}
+        for osd_id, osd_metadata in mgr.get('osd_metadata').items():
+            hostname = osd_metadata.get('hostname')
+            devices = osd_metadata.get('devices')
+            if not hostname or not devices:
+                continue
+            if hostname not in result:
+                result[hostname] = {}
+            # for OSD contains multiple devices, devices is in `sda,sdb`
+            for device in devices.split(','):
+                if device not in result[hostname]:
+                    result[hostname][device] = [int(osd_id)]
+                else:
+                    result[hostname][device].append(int(osd_id))
+        return result
+
+    @staticmethod
+    def get_inventories(hosts: Optional[List[str]] = None,
+                        refresh: Optional[bool] = None) -> List[dict]:
+        """Get inventories from the Orchestrator and link devices with OSD IDs.
+
+        :param hosts: Hostnames to query.
+        :param refresh: Ask the Orchestrator to refresh the inventories. Note the this is an
+                        asynchronous operation, the updated version of inventories need to
+                        be re-qeuried later.
+        :return: Returns list of inventory.
+        :rtype: list
+        """
+        do_refresh = False
+        if refresh is not None:
+            do_refresh = str_to_bool(refresh)
+        orch = OrchClient.instance()
+        inventory_hosts = [host.to_json()
+                        for host in orch.inventory.list(hosts=hosts, refresh=do_refresh)]
+        device_osd_map = HostService.get_device_osd_map()
+        for inventory_host in inventory_hosts:
+            host_osds = device_osd_map.get(inventory_host['name'])
+            for device in inventory_host['devices']:
+                if host_osds:  # pragma: no cover
+                    dev_name = os.path.basename(device['path'])
+                    device['osd_ids'] = sorted(host_osds.get(dev_name, []))
+                else:
+                    device['osd_ids'] = []
+        
+        return inventory_hosts
+
+    @staticmethod
+    def identify_device(hostname, device, duration):
+        orch = OrchClient.instance()
+        TaskManager.current_task().set_progress(0)
+        orch.blink_device_light(hostname, device, 'ident', True)
+        for i in range(int(duration)):
+            percentage = int(round(i / float(duration) * 100))
+            TaskManager.current_task().set_progress(percentage)
+            time.sleep(1)
+        orch.blink_device_light(hostname, device, 'ident', False)
+        TaskManager.current_task().set_progress(100)
+
+    @staticmethod
+    def list_daemons(hostname: str) -> List[dict]:
+        orch = OrchClient.instance()
+        daemons = orch.services.list_daemons(hostname=hostname)
+        return [d.to_dict() for d in daemons]
+
+

--- a/src/pybind/mgr/dashboard/tests/test_host.py
+++ b/src/pybind/mgr/dashboard/tests/test_host.py
@@ -6,7 +6,8 @@ from unittest import mock
 from orchestrator import HostSpec, InventoryHost
 
 from .. import mgr
-from ..controllers.host import Host, HostUi, get_device_osd_map, get_hosts, get_inventories
+from ..controllers.host import Host, HostUi
+from ..services.host import HostService
 from ..tools import NotificationQueue, TaskManager
 from . import ControllerTestCase  # pylint: disable=no-name-in-module
 
@@ -126,8 +127,198 @@ class HostControllerTest(ControllerTestCase):
             self.assertIn('status', self.json_body())
             self.assertIn('addr', self.json_body())
 
-    @mock.patch('dashboard.controllers.host.add_host')
-    def test_add_host(self, mock_add_host):
+    @mock.patch('dashboard.services.host.time')
+    def test_identify_device(self, mock_time):
+        url = '{}/host-0/identify_device'.format(self.URL_HOST)
+        with patch_orch(True) as fake_client:
+            payload = {
+                'device': '/dev/sdz',
+                'duration': '1'
+            }
+            self._task_post(url, payload)
+            self.assertStatus(200)
+            mock_time.sleep.assert_called()
+            calls = [
+                mock.call('host-0', '/dev/sdz', 'ident', True),
+                mock.call('host-0', '/dev/sdz', 'ident', False),
+            ]
+            fake_client.blink_device_light.assert_has_calls(calls)
+
+    @mock.patch('dashboard.services.host.HostService.get_inventories')
+    def test_inventory(self, mock_get_inventories):
+        inventory_url = '{}/host-0/inventory'.format(self.URL_HOST)
+        with patch_orch(True):
+            tests = [
+                {
+                    'url': inventory_url,
+                    'inventories': [{'a': 'b'}],
+                    'refresh': None,
+                    'resp': {'a': 'b'}
+                },
+                {
+                    'url': '{}?refresh=true'.format(inventory_url),
+                    'inventories': [{'a': 'b'}],
+                    'refresh': "true",
+                    'resp': {'a': 'b'}
+                },
+                {
+                    'url': inventory_url,
+                    'inventories': [],
+                    'refresh': None,
+                    'resp': {}
+                },
+            ]
+            for test in tests:
+                mock_get_inventories.reset_mock()
+                mock_get_inventories.return_value = test['inventories']
+                self._get(test['url'])
+                mock_get_inventories.assert_called_once_with(['host-0'], test['refresh'])
+                self.assertEqual(self.json_body(), test['resp'])
+                self.assertStatus(200)
+
+        # list without orchestrator service
+        with patch_orch(False):
+            self._get(inventory_url)
+            self.assertStatus(503)
+
+
+class HostServiceTest(unittest.TestCase):
+    def test_get_hosts(self):
+        mgr.list_servers.return_value = [{
+            'hostname': 'node1'
+        }, {
+            'hostname': 'localhost'
+        }]
+        orch_hosts = [
+            HostSpec('node1', labels=['foo', 'bar']),
+            HostSpec('node2', labels=['bar'])
+        ]
+
+        with patch_orch(True, hosts=orch_hosts):
+            hosts = HostService.get_hosts()
+            self.assertEqual(len(hosts), 3)
+            checks = {
+                'localhost': {
+                    'sources': {
+                        'ceph': True,
+                        'orchestrator': False
+                    },
+                    'labels': []
+                },
+                'node1': {
+                    'sources': {
+                        'ceph': True,
+                        'orchestrator': True
+                    },
+                    'labels': ['bar', 'foo']
+                },
+                'node2': {
+                    'sources': {
+                        'ceph': False,
+                        'orchestrator': True
+                    },
+                    'labels': ['bar']
+                }
+            }
+            for host in hosts:
+                hostname = host['hostname']
+                self.assertDictEqual(host['sources'], checks[hostname]['sources'])
+                self.assertListEqual(host['labels'], checks[hostname]['labels'])
+
+    @mock.patch('dashboard.services.host.mgr.get')
+    def test_get_device_osd_map(self, mgr_get):
+        mgr_get.side_effect = lambda key: {
+            'osd_metadata': {
+                '0': {
+                    'hostname': 'node0',
+                    'devices': 'nvme0n1,sdb',
+                },
+                '1': {
+                    'hostname': 'node0',
+                    'devices': 'nvme0n1,sdc',
+                },
+                '2': {
+                    'hostname': 'node1',
+                    'devices': 'sda',
+                },
+                '3': {
+                    'hostname': 'node2',
+                    'devices': '',
+                }
+            }
+        }[key]
+
+        device_osd_map = HostService.get_device_osd_map()
+        mgr.get.assert_called_with('osd_metadata')
+        # sort OSD IDs to make assertDictEqual work
+        for devices in device_osd_map.values():
+            for host in devices.keys():
+                devices[host] = sorted(devices[host])
+        self.assertDictEqual(device_osd_map, {
+            'node0': {
+                'nvme0n1': [0, 1],
+                'sdb': [0],
+                'sdc': [1],
+            },
+            'node1': {
+                'sda': [2]
+            }
+        })
+
+    @mock.patch('dashboard.services.host.str_to_bool')
+    @mock.patch('dashboard.services.host.HostService.get_device_osd_map')
+    def test_get_inventories(self, mock_get_device_osd_map, mock_str_to_bool):
+        mock_get_device_osd_map.return_value = {
+            'host-0': {
+                'nvme0n1': [1, 2],
+                'sdb': [1],
+                'sdc': [2]
+            },
+            'host-1': {
+                'sdb': [3]
+            }
+        }
+        inventory = [
+            {
+                'name': 'host-0',
+                'addr': '1.2.3.4',
+                'devices': [
+                    {'path': 'nvme0n1'},
+                    {'path': '/dev/sdb'},
+                    {'path': '/dev/sdc'},
+                ]
+            },
+            {
+                'name': 'host-1',
+                'addr': '1.2.3.5',
+                'devices': [
+                    {'path': '/dev/sda'},
+                    {'path': 'sdb'},
+                ]
+            }
+        ]
+
+        with patch_orch(True, inventory=inventory) as orch_client:
+            mock_str_to_bool.return_value = True
+
+            hosts = ['host-0', 'host-1']
+            inventories = HostService.get_inventories(hosts, 'true')
+            mock_str_to_bool.assert_called_with('true')
+            orch_client.inventory.list.assert_called_once_with(hosts=hosts, refresh=True)
+            self.assertEqual(len(inventories), 2)
+            host0 = inventories[0]
+            self.assertEqual(host0['name'], 'host-0')
+            self.assertEqual(host0['addr'], '1.2.3.4')
+            self.assertEqual(host0['devices'][0]['osd_ids'], [1, 2])
+            self.assertEqual(host0['devices'][1]['osd_ids'], [1])
+            self.assertEqual(host0['devices'][2]['osd_ids'], [2])
+            host1 = inventories[1]
+            self.assertEqual(host1['name'], 'host-1')
+            self.assertEqual(host1['addr'], '1.2.3.5')
+            self.assertEqual(host1['devices'][0]['osd_ids'], [])
+            self.assertEqual(host1['devices'][1]['osd_ids'], [3])
+
+    def test_add_host(self):
         with patch_orch(True):
             payload = {
                 'hostname': 'node0',
@@ -137,6 +328,7 @@ class HostControllerTest(ControllerTestCase):
             }
             self._post(self.URL_HOST, payload, version='0.1')
             self.assertStatus(201)
+            HostService.add_host('node0', '192.0.2.0', 'mon', 'maintenance')
             mock_add_host.assert_called()
 
     def test_set_labels(self):
@@ -178,6 +370,8 @@ class HostControllerTest(ControllerTestCase):
             self._put('{}/node1'.format(self.URL_HOST), {'maintenance': True, 'force': True},
                       version='0.1')
             self.assertStatus(200)
+            self.assertHeader('Content-Type',
+                              'application/vnd.ceph.api.v0.1+json')
 
             # exit maintenance mode
             self._put('{}/node0'.format(self.URL_HOST), {'maintenance': True}, version='0.1')
@@ -190,70 +384,6 @@ class HostControllerTest(ControllerTestCase):
             self._put('{}/node0'.format(self.URL_HOST), {'maintenance': True}, version='0.1')
             self.assertStatus(503)
 
-    @mock.patch('dashboard.controllers.host.time')
-    def test_identify_device(self, mock_time):
-        url = '{}/host-0/identify_device'.format(self.URL_HOST)
-        with patch_orch(True) as fake_client:
-            payload = {
-                'device': '/dev/sdz',
-                'duration': '1'
-            }
-            self._task_post(url, payload)
-            self.assertStatus(200)
-            mock_time.sleep.assert_called()
-            calls = [
-                mock.call('host-0', '/dev/sdz', 'ident', True),
-                mock.call('host-0', '/dev/sdz', 'ident', False),
-            ]
-            fake_client.blink_device_light.assert_has_calls(calls)
-
-    @mock.patch('dashboard.controllers.host.get_inventories')
-    def test_inventory(self, mock_get_inventories):
-        inventory_url = '{}/host-0/inventory'.format(self.URL_HOST)
-        with patch_orch(True):
-            tests = [
-                {
-                    'url': inventory_url,
-                    'inventories': [{'a': 'b'}],
-                    'refresh': None,
-                    'resp': {'a': 'b'}
-                },
-                {
-                    'url': '{}?refresh=true'.format(inventory_url),
-                    'inventories': [{'a': 'b'}],
-                    'refresh': "true",
-                    'resp': {'a': 'b'}
-                },
-                {
-                    'url': inventory_url,
-                    'inventories': [],
-                    'refresh': None,
-                    'resp': {}
-                },
-            ]
-            for test in tests:
-                mock_get_inventories.reset_mock()
-                mock_get_inventories.return_value = test['inventories']
-                self._get(test['url'])
-                mock_get_inventories.assert_called_once_with(['host-0'], test['refresh'])
-                self.assertEqual(self.json_body(), test['resp'])
-                self.assertStatus(200)
-
-        # list without orchestrator service
-        with patch_orch(False):
-            self._get(inventory_url)
-            self.assertStatus(503)
-
-
-class HostUiControllerTest(ControllerTestCase):
-    URL_HOST = '/ui-api/host'
-
-    @classmethod
-    def setup_server(cls):
-        # pylint: disable=protected-access
-        HostUi._cp_config['tools.authenticate.on'] = False
-        cls.setup_controllers([HostUi])
-
     def test_labels(self):
         orch_hosts = [
             HostSpec('node1', labels=['foo']),
@@ -261,172 +391,6 @@ class HostUiControllerTest(ControllerTestCase):
         ]
 
         with patch_orch(True, hosts=orch_hosts):
-            self._get('{}/labels'.format(self.URL_HOST))
-            self.assertStatus(200)
-            labels = self.json_body()
+            labels = HostService.get_labels()
             labels.sort()
             self.assertListEqual(labels, ['bar', 'foo'])
-
-    @mock.patch('dashboard.controllers.host.get_inventories')
-    def test_inventory(self, mock_get_inventories):
-        inventory_url = '{}/inventory'.format(self.URL_HOST)
-        with patch_orch(True):
-            tests = [
-                {
-                    'url': inventory_url,
-                    'refresh': None
-                },
-                {
-                    'url': '{}?refresh=true'.format(inventory_url),
-                    'refresh': "true"
-                },
-            ]
-            for test in tests:
-                mock_get_inventories.reset_mock()
-                mock_get_inventories.return_value = [{'a': 'b'}]
-                self._get(test['url'])
-                mock_get_inventories.assert_called_once_with(None, test['refresh'])
-                self.assertEqual(self.json_body(), [{'a': 'b'}])
-                self.assertStatus(200)
-
-        # list without orchestrator service
-        with patch_orch(False):
-            self._get(inventory_url)
-            self.assertStatus(503)
-
-
-class TestHosts(unittest.TestCase):
-    def test_get_hosts(self):
-        mgr.list_servers.return_value = [{
-            'hostname': 'node1'
-        }, {
-            'hostname': 'localhost'
-        }]
-        orch_hosts = [
-            HostSpec('node1', labels=['foo', 'bar']),
-            HostSpec('node2', labels=['bar'])
-        ]
-
-        with patch_orch(True, hosts=orch_hosts):
-            hosts = get_hosts()
-            self.assertEqual(len(hosts), 3)
-            checks = {
-                'localhost': {
-                    'sources': {
-                        'ceph': True,
-                        'orchestrator': False
-                    },
-                    'labels': []
-                },
-                'node1': {
-                    'sources': {
-                        'ceph': True,
-                        'orchestrator': True
-                    },
-                    'labels': ['bar', 'foo']
-                },
-                'node2': {
-                    'sources': {
-                        'ceph': False,
-                        'orchestrator': True
-                    },
-                    'labels': ['bar']
-                }
-            }
-            for host in hosts:
-                hostname = host['hostname']
-                self.assertDictEqual(host['sources'], checks[hostname]['sources'])
-                self.assertListEqual(host['labels'], checks[hostname]['labels'])
-
-    @mock.patch('dashboard.controllers.host.mgr.get')
-    def test_get_device_osd_map(self, mgr_get):
-        mgr_get.side_effect = lambda key: {
-            'osd_metadata': {
-                '0': {
-                    'hostname': 'node0',
-                    'devices': 'nvme0n1,sdb',
-                },
-                '1': {
-                    'hostname': 'node0',
-                    'devices': 'nvme0n1,sdc',
-                },
-                '2': {
-                    'hostname': 'node1',
-                    'devices': 'sda',
-                },
-                '3': {
-                    'hostname': 'node2',
-                    'devices': '',
-                }
-            }
-        }[key]
-
-        device_osd_map = get_device_osd_map()
-        mgr.get.assert_called_with('osd_metadata')
-        # sort OSD IDs to make assertDictEqual work
-        for devices in device_osd_map.values():
-            for host in devices.keys():
-                devices[host] = sorted(devices[host])
-        self.assertDictEqual(device_osd_map, {
-            'node0': {
-                'nvme0n1': [0, 1],
-                'sdb': [0],
-                'sdc': [1],
-            },
-            'node1': {
-                'sda': [2]
-            }
-        })
-
-    @mock.patch('dashboard.controllers.host.str_to_bool')
-    @mock.patch('dashboard.controllers.host.get_device_osd_map')
-    def test_get_inventories(self, mock_get_device_osd_map, mock_str_to_bool):
-        mock_get_device_osd_map.return_value = {
-            'host-0': {
-                'nvme0n1': [1, 2],
-                'sdb': [1],
-                'sdc': [2]
-            },
-            'host-1': {
-                'sdb': [3]
-            }
-        }
-        inventory = [
-            {
-                'name': 'host-0',
-                'addr': '1.2.3.4',
-                'devices': [
-                    {'path': 'nvme0n1'},
-                    {'path': '/dev/sdb'},
-                    {'path': '/dev/sdc'},
-                ]
-            },
-            {
-                'name': 'host-1',
-                'addr': '1.2.3.5',
-                'devices': [
-                    {'path': '/dev/sda'},
-                    {'path': 'sdb'},
-                ]
-            }
-        ]
-
-        with patch_orch(True, inventory=inventory) as orch_client:
-            mock_str_to_bool.return_value = True
-
-            hosts = ['host-0', 'host-1']
-            inventories = get_inventories(hosts, 'true')
-            mock_str_to_bool.assert_called_with('true')
-            orch_client.inventory.list.assert_called_once_with(hosts=hosts, refresh=True)
-            self.assertEqual(len(inventories), 2)
-            host0 = inventories[0]
-            self.assertEqual(host0['name'], 'host-0')
-            self.assertEqual(host0['addr'], '1.2.3.4')
-            self.assertEqual(host0['devices'][0]['osd_ids'], [1, 2])
-            self.assertEqual(host0['devices'][1]['osd_ids'], [1])
-            self.assertEqual(host0['devices'][2]['osd_ids'], [2])
-            host1 = inventories[1]
-            self.assertEqual(host1['name'], 'host-1')
-            self.assertEqual(host1['addr'], '1.2.3.5')
-            self.assertEqual(host1['devices'][0]['osd_ids'], [])
-            self.assertEqual(host1['devices'][1]['osd_ids'], [3])


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/51252
Signed-off-by: Avan Thakkar <athakkar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
