### PR TITLE
mgr/volumes: use dedicated libcephfs handles for subvolume calls

### DIFF
--- a/src/pybind/mgr/volumes/fs/async_job.py
+++ b/src/pybind/mgr/volumes/fs/async_job.py
@@ -4,7 +4,7 @@ import logging
 import threading
 import traceback
 from collections import deque
-from mgr_util import lock_timeout_log
+from mgr_util import lock_timeout_log, CephfsClient
 
 from .exception import NotImplementedException
 
@@ -119,6 +119,8 @@ class AsyncJobs(threading.Thread):
         self.cancel_cv = threading.Condition(self.lock)
         self.nr_concurrent_jobs = nr_concurrent_jobs
         self.name_pfx = name_pfx
+        # each async job group uses its own libcephfs connection (pool)
+        self.fs_client = CephfsClient(self.vc.mgr)
 
         self.threads = []
         for i in range(self.nr_concurrent_jobs):

--- a/src/pybind/mgr/volumes/fs/purge_queue.py
+++ b/src/pybind/mgr/volumes/fs/purge_queue.py
@@ -17,13 +17,13 @@ from .operations.trash import open_trashcan
 log = logging.getLogger(__name__)
 
 # helper for fetching a trash entry for a given volume
-def get_trash_entry_for_volume(volume_client, volname, running_jobs):
+def get_trash_entry_for_volume(fs_client, volspec, volname, running_jobs):
     log.debug("fetching trash entry for volume '{0}'".format(volname))
 
     try:
-        with open_volume_lockless(volume_client, volname) as fs_handle:
+        with open_volume_lockless(fs_client, volname) as fs_handle:
             try:
-                with open_trashcan(fs_handle, volume_client.volspec) as trashcan:
+                with open_trashcan(fs_handle, volspec) as trashcan:
                     path = trashcan.get_trash_entry(running_jobs)
                     return 0, path
             except VolumeException as ve:
@@ -34,14 +34,14 @@ def get_trash_entry_for_volume(volume_client, volname, running_jobs):
         log.error("error fetching trash entry for volume '{0}' ({1})".format(volname, ve))
         return ve.errno, None
 
-def subvolume_purge(volume_client, volname, trashcan, subvolume_trash_entry, should_cancel):
-    groupname, subvolname = resolve_trash(volume_client.volspec, subvolume_trash_entry.decode('utf-8'))
+def subvolume_purge(fs_client, volspec, volname, trashcan, subvolume_trash_entry, should_cancel):
+    groupname, subvolname = resolve_trash(volspec, subvolume_trash_entry.decode('utf-8'))
     log.debug("subvolume resolved to {0}/{1}".format(groupname, subvolname))
 
     try:
-        with open_volume(volume_client, volname) as fs_handle:
-            with open_group(fs_handle, volume_client.volspec, groupname) as group:
-                with open_subvol(volume_client.mgr, fs_handle, volume_client.volspec, group, subvolname, SubvolumeOpType.REMOVE) as subvolume:
+        with open_volume(fs_client, volname) as fs_handle:
+            with open_group(fs_handle, volspec, groupname) as group:
+                with open_subvol(fs_client.mgr, fs_handle, volspec, group, subvolname, SubvolumeOpType.REMOVE) as subvolume:
                     log.debug("subvolume.path={0}, purgeable={1}".format(subvolume.path, subvolume.purgeable))
                     if not subvolume.purgeable:
                         return
@@ -54,13 +54,13 @@ def subvolume_purge(volume_client, volname, trashcan, subvolume_trash_entry, sho
             raise
 
 # helper for starting a purge operation on a trash entry
-def purge_trash_entry_for_volume(volume_client, volname, purge_entry, should_cancel):
+def purge_trash_entry_for_volume(fs_client, volspec, volname, purge_entry, should_cancel):
     log.debug("purging trash entry '{0}' for volume '{1}'".format(purge_entry, volname))
 
     ret = 0
     try:
-        with open_volume_lockless(volume_client, volname) as fs_handle:
-            with open_trashcan(fs_handle, volume_client.volspec) as trashcan:
+        with open_volume_lockless(fs_client, volname) as fs_handle:
+            with open_trashcan(fs_handle, volspec) as trashcan:
                 try:
                     pth = os.path.join(trashcan.path, purge_entry)
                     stx = fs_handle.statx(pth, cephfs.CEPH_STATX_MODE | cephfs.CEPH_STATX_SIZE,
@@ -78,7 +78,7 @@ def purge_trash_entry_for_volume(volume_client, volname, purge_entry, should_can
                                 return ve.errno
                         finally:
                             if delink:
-                                subvolume_purge(volume_client, volname, trashcan, tgt, should_cancel)
+                                subvolume_purge(fs_client, volspec, volname, trashcan, tgt, should_cancel)
                                 log.debug("purging trash link: {0}".format(purge_entry))
                                 trashcan.delink(purge_entry)
                     else:
@@ -103,7 +103,7 @@ class ThreadPoolPurgeQueueMixin(AsyncJobs):
         super(ThreadPoolPurgeQueueMixin, self).__init__(volume_client, "puregejob", tp_size)
 
     def get_next_job(self, volname, running_jobs):
-        return get_trash_entry_for_volume(self.vc, volname, running_jobs)
+        return get_trash_entry_for_volume(self.fs_client, self.vc.volspec, volname, running_jobs)
 
     def execute_job(self, volname, job, should_cancel):
-        purge_trash_entry_for_volume(self.vc, volname, job, should_cancel)
+        purge_trash_entry_for_volume(self.fs_client, self.vc.volspec, volname, job, should_cancel)


### PR DESCRIPTION
…async jobs

Fixes: http://tracker.ceph.com/issues/51271
Signed-off-by: Venky Shankar <vshankar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
