### PR TITLE
doc/install/get-packages: point to current stable release

### DIFF
--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -25,10 +25,13 @@ There are three ways to get packages:
 Install packages with cephadm
 =============================
 
-#. Download the cephadm script::
+#. Download the cephadm script
 
-    curl --silent --remote-name --location https://github.com/ceph/ceph/raw/octopus/src/cephadm/cephadm
-    chmod +x cephadm
+.. prompt:: bash $
+   :substitutions:
+
+   curl --silent --remote-name --location https://github.com/ceph/ceph/raw/|stable-release|/src/cephadm/cephadm
+   chmod +x cephadm
 
 #. Configure the Ceph repository based on the release name::
 


### PR DESCRIPTION
Point to current stable release for downloading the cephadm script

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>

## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
