### PR TITLE
[RFC]Librbd cache/pwl/rwl Cluster Management

### DIFF
--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -271,7 +271,7 @@ struct cls_rbd_rwlcache_map {
       rdma_port(info.rdma_port),
       total_size(info.total_size),
       free_size(info.total_size),
-      expiration(ceph_clock_now()),
+      expiration(ceph_clock_now() + utime_t(RBD_RWLCACHE_DAEMON_PING_TIMEOUT, 0)),
       daemon_addr(inst.addr) {
     }
 

--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -355,7 +355,16 @@ struct cls_rbd_rwlcache_map {
     }
   };
 
+  // cache allocated but not receive ack in uncommitted_caches
+  std::map<epoch_t, std::pair<utime_t, struct Cache>> uncommitted_caches;
+
+  // uncommitted_cache recive ack in time and result is ok. Move cahe from uncommitted_cache
+  // to caches.
   std::map<epoch_t, struct Cache> caches;
+
+  // Primary can't free related daemon's cache-file, etc rdma-disconnect.
+  // So cache move uncommitted_caches or caches to free_daemon_space_caches;
+  std::map<epoch_t, struct Cache> free_daemon_space_caches;
 
   cls_rbd_rwlcache_map() {
     current_cache_id = 0;
@@ -365,7 +374,9 @@ struct cls_rbd_rwlcache_map {
     ENCODE_START(1, 1, bl);
     encode(current_cache_id, bl);
     encode(daemons, bl, features);
+    encode(uncommitted_caches, bl, features);
     encode(caches, bl, features);
+    encode(free_daemon_space_caches, bl, features);
     ENCODE_FINISH(bl);
   }
 
@@ -373,7 +384,9 @@ struct cls_rbd_rwlcache_map {
     DECODE_START(1, it);
     decode(current_cache_id, it);
     decode(daemons, it);
+    decode(uncommitted_caches, it);
     decode(caches, it);
+    decode(free_daemon_space_caches, it);
     DECODE_FINISH(it);
   }
 

--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -9,6 +9,7 @@
 #include "include/rbd_types.h"
 #include "common/Formatter.h"
 #include "cls/rbd/cls_rbd_types.h"
+#include "common/Clock.h"
 
 /// information about our parent image, if any
 struct cls_rbd_parent {
@@ -259,6 +260,20 @@ struct cls_rbd_rwlcache_map {
     utime_t expiration;
 
     struct entity_addr_t daemon_addr;
+
+    Daemon() {
+    }
+
+    Daemon(const cls::rbd::RwlCacheDaemonInfo &info,
+	   const entity_inst_t &inst) :
+      id(info.id),
+      rdma_address(info.rdma_address),
+      rdma_port(info.rdma_port),
+      total_size(info.total_size),
+      free_size(info.total_size),
+      expiration(ceph_clock_now()),
+      daemon_addr(inst.addr) {
+    }
 
     void encode(ceph::buffer::list &bl, uint64_t features) const {
       ENCODE_START(1, 1, bl);

--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -317,6 +317,21 @@ struct cls_rbd_rwlcache_map {
     // unfree space daemons. Before free, daemons.size() == copies
     std::set<uint64_t> daemons;
 
+    Cache() {
+    }
+
+    Cache(epoch_t cache_id,
+	  const cls::rbd::RwlCacheRequest &req,
+	  const struct entity_addr_t &addr,
+	  const std::set<uint64_t> &daemons) :
+      cache_id(cache_id),
+      primary_id(req.id),
+      primary_addr(addr),
+      cache_size(req.size),
+      copies(req.copies),
+      daemons(daemons) {
+    }
+
     void encode(ceph::buffer::list &bl, uint64_t features) const {
       ENCODE_START(1, 1, bl);
       encode(cache_id, bl);

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -3066,5 +3066,16 @@ int rwlcache_request_ack(librados::IoCtx *ioctx, struct cls::rbd::RwlCacheReques
   return  ioctx->operate(std::string(RBD_RWLCACHE_MAP_OBJECT_NAME), &op);
 }
 
+int rwlcache_free(librados::IoCtx *ioctx, struct cls::rbd::RwlCacheFree &req)
+{
+  librados::ObjectWriteOperation op;
+  bufferlist bl;
+
+  encode(req, bl);
+  op.exec("rbd", "rwlcache_free", bl);
+
+  return  ioctx->operate(std::string(RBD_RWLCACHE_MAP_OBJECT_NAME), &op);
+}
+
 } // namespace cls_client
 } // namespace librbd

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -3032,5 +3032,28 @@ int rwlcache_request(librados::IoCtx *ioctx, struct cls::rbd::RwlCacheRequest &r
   return 0;
 }
 
+int rwlcache_get_cacheinfo(librados::IoCtx *ioctx, epoch_t cache_id, struct cls::rbd::RwlCacheInfo &cache)
+{
+  bufferlist in, out;
+  librados::ObjectReadOperation op;
+
+  encode(cache_id, in);
+  op.exec("rbd", "rwlcache_get_cacheinfo", in);
+
+  int r = ioctx->operate(RBD_RWLCACHE_MAP_OBJECT_NAME, &op, &out);
+  if (r < 0) {
+    return r;
+  }
+
+  auto it = out.cbegin();
+  try {
+    decode(cache, it);
+  } catch (const ceph::buffer::error &err) {
+    return -EBADMSG;
+  }
+
+  return 0;
+}
+
 } // namespace cls_client
 } // namespace librbd

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -2992,5 +2992,20 @@ int sparsify(librados::IoCtx *ioctx, const std::string &oid, uint64_t sparse_siz
   return ioctx->operate(oid, &op);
 }
 
+void rwlcache_daemoninfo(librados::ObjectWriteOperation *op,
+			 struct cls::rbd::RwlCacheDaemonInfo &req)
+{
+  bufferlist bl;
+  encode(req, bl);
+  op->exec("rbd", "rwlcache_daemoninfo", bl);
+}
+
+int rwlcache_daemoninfo(librados::IoCtx *ioctx, struct cls::rbd::RwlCacheDaemonInfo &req)
+{
+  librados::ObjectWriteOperation op;
+  rwlcache_daemoninfo(&op, req);
+  return ioctx->operate(std::string(RBD_RWLCACHE_MAP_OBJECT_NAME), &op);
+}
+
 } // namespace cls_client
 } // namespace librbd

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -3007,5 +3007,30 @@ int rwlcache_daemoninfo(librados::IoCtx *ioctx, struct cls::rbd::RwlCacheDaemonI
   return ioctx->operate(std::string(RBD_RWLCACHE_MAP_OBJECT_NAME), &op);
 }
 
+int rwlcache_request(librados::IoCtx *ioctx, struct cls::rbd::RwlCacheRequest &req,
+		      epoch_t &cache_id)
+{
+  bufferlist in, out;
+  librados::ObjectWriteOperation op;
+  int prval;
+
+  encode(req, in);
+  op.exec("rbd", "rwlcache_request", in, &out, &prval);
+
+  int r = ioctx->operate(RBD_RWLCACHE_MAP_OBJECT_NAME, &op, librados::OPERATION_RETURNVEC);
+  if (r < 0) {
+    return r;
+  }
+
+  auto it = out.cbegin();
+  try {
+    decode(cache_id, it);
+  } catch (const ceph::buffer::error &err) {
+    return -EBADMSG;
+  }
+
+  return 0;
+}
+
 } // namespace cls_client
 } // namespace librbd

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -3032,6 +3032,30 @@ int rwlcache_daemonping(librados::IoCtx *ioctx, struct cls::rbd::RwlCacheDaemonP
   return 0;
 }
 
+int rwlcache_get_needfree_caches(librados::IoCtx *ioctx, uint64_t daemon_id,
+				  struct cls::rbd::RwlCacheDaemonNeedFreeCaches &need_free_caches)
+{
+  bufferlist in, out;
+  librados::ObjectReadOperation op;
+
+  encode(daemon_id, in);
+  op.exec("rbd", "rwlcache_get_needfree_caches", in);
+
+  int r = ioctx->operate(RBD_RWLCACHE_MAP_OBJECT_NAME, &op, &out);
+  if (r < 0) {
+    return r;
+  }
+
+  auto it = out.cbegin();
+  try {
+    decode(need_free_caches, it);
+  } catch (const ceph::buffer::error &err) {
+    return -EBADMSG;
+  }
+
+  return 0;
+}
+
 int rwlcache_request(librados::IoCtx *ioctx, struct cls::rbd::RwlCacheRequest &req,
 		      epoch_t &cache_id)
 {

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -3055,5 +3055,16 @@ int rwlcache_get_cacheinfo(librados::IoCtx *ioctx, epoch_t cache_id, struct cls:
   return 0;
 }
 
+int rwlcache_request_ack(librados::IoCtx *ioctx, struct cls::rbd::RwlCacheRequestAck &req)
+{
+  librados::ObjectWriteOperation op;
+  bufferlist bl;
+
+  encode(req, bl);
+  op.exec("rbd", "rwlcache_request_ack", bl);
+
+  return  ioctx->operate(std::string(RBD_RWLCACHE_MAP_OBJECT_NAME), &op);
+}
+
 } // namespace cls_client
 } // namespace librbd

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -662,6 +662,7 @@ void rwlcache_daemoninfo(librados::ObjectWriteOperation *op, struct cls::rbd::Rw
 int rwlcache_daemoninfo(librados::IoCtx *ioct, struct cls::rbd::RwlCacheDaemonInfo &req);
 
 int rwlcache_request(librados::IoCtx *ioct, struct cls::rbd::RwlCacheRequest &req, epoch_t &cache_id);
+int rwlcache_get_cacheinfo(librados::IoCtx *ioct, epoch_t cache_id, struct cls::rbd::RwlCacheInfo &cache);
 
 } // namespace cls_client
 } // namespace librbd

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -673,6 +673,9 @@ int rwlcache_get_cacheinfo(librados::IoCtx *ioct, epoch_t cache_id, struct cls::
 int rwlcache_request_ack(librados::IoCtx *ioct, struct cls::rbd::RwlCacheRequestAck &req);
 
 int rwlcache_free(librados::IoCtx *ioctx, struct cls::rbd::RwlCacheFree &req);
+
+int rwlcache_primaryping(librados::IoCtx *ioctx, epoch_t cache_id, bool &has_removed_daemon);
+
 } // namespace cls_client
 } // namespace librbd
 

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -660,6 +660,9 @@ int sparsify(librados::IoCtx *ioctx, const std::string &oid, uint64_t sparse_siz
 // operations on rwlcache object
 void rwlcache_daemoninfo(librados::ObjectWriteOperation *op, struct cls::rbd::RwlCacheDaemonInfo &req);
 int rwlcache_daemoninfo(librados::IoCtx *ioct, struct cls::rbd::RwlCacheDaemonInfo &req);
+
+int rwlcache_request(librados::IoCtx *ioct, struct cls::rbd::RwlCacheRequest &req, epoch_t &cache_id);
+
 } // namespace cls_client
 } // namespace librbd
 

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -664,6 +664,8 @@ int rwlcache_daemoninfo(librados::IoCtx *ioct, struct cls::rbd::RwlCacheDaemonIn
 int rwlcache_request(librados::IoCtx *ioct, struct cls::rbd::RwlCacheRequest &req, epoch_t &cache_id);
 int rwlcache_get_cacheinfo(librados::IoCtx *ioct, epoch_t cache_id, struct cls::rbd::RwlCacheInfo &cache);
 
+int rwlcache_request_ack(librados::IoCtx *ioct, struct cls::rbd::RwlCacheRequestAck &req);
+
 } // namespace cls_client
 } // namespace librbd
 

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -664,6 +664,9 @@ int rwlcache_daemoninfo(librados::IoCtx *ioct, struct cls::rbd::RwlCacheDaemonIn
 int rwlcache_daemonping(librados::IoCtx *ioct, struct cls::rbd::RwlCacheDaemonPing &ping,
 			bool &has_need_free_cache);
 
+int rwlcache_get_needfree_caches(librados::IoCtx *ioctx, uint64_t daemon_id,
+				  struct cls::rbd::RwlCacheDaemonNeedFreeCaches &need_free_caches);
+
 int rwlcache_request(librados::IoCtx *ioct, struct cls::rbd::RwlCacheRequest &req, epoch_t &cache_id);
 int rwlcache_get_cacheinfo(librados::IoCtx *ioct, epoch_t cache_id, struct cls::rbd::RwlCacheInfo &cache);
 

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -657,6 +657,9 @@ void sparsify(librados::ObjectWriteOperation *op, uint64_t sparse_size,
 int sparsify(librados::IoCtx *ioctx, const std::string &oid, uint64_t sparse_size,
              bool remove_empty);
 
+// operations on rwlcache object
+void rwlcache_daemoninfo(librados::ObjectWriteOperation *op, struct cls::rbd::RwlCacheDaemonInfo &req);
+int rwlcache_daemoninfo(librados::IoCtx *ioct, struct cls::rbd::RwlCacheDaemonInfo &req);
 } // namespace cls_client
 } // namespace librbd
 

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -661,6 +661,9 @@ int sparsify(librados::IoCtx *ioctx, const std::string &oid, uint64_t sparse_siz
 void rwlcache_daemoninfo(librados::ObjectWriteOperation *op, struct cls::rbd::RwlCacheDaemonInfo &req);
 int rwlcache_daemoninfo(librados::IoCtx *ioct, struct cls::rbd::RwlCacheDaemonInfo &req);
 
+int rwlcache_daemonping(librados::IoCtx *ioct, struct cls::rbd::RwlCacheDaemonPing &ping,
+			bool &has_need_free_cache);
+
 int rwlcache_request(librados::IoCtx *ioct, struct cls::rbd::RwlCacheRequest &req, epoch_t &cache_id);
 int rwlcache_get_cacheinfo(librados::IoCtx *ioct, epoch_t cache_id, struct cls::rbd::RwlCacheInfo &cache);
 

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -666,6 +666,7 @@ int rwlcache_get_cacheinfo(librados::IoCtx *ioct, epoch_t cache_id, struct cls::
 
 int rwlcache_request_ack(librados::IoCtx *ioct, struct cls::rbd::RwlCacheRequestAck &req);
 
+int rwlcache_free(librados::IoCtx *ioctx, struct cls::rbd::RwlCacheFree &req);
 } // namespace cls_client
 } // namespace librbd
 

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -1389,6 +1389,22 @@ void RwlCacheDaemonPing::decode(bufferlist::const_iterator &it)
   DECODE_FINISH(it);
 }
 
+void RwlCacheDaemonNeedFreeCaches::encode(bufferlist &bl) const
+{
+  using ceph::encode;
+  ENCODE_START(1, 1, bl);
+  encode(need_free_caches, bl);
+  ENCODE_FINISH(bl);
+}
+
+void RwlCacheDaemonNeedFreeCaches::decode(bufferlist::const_iterator &it)
+{
+  using ceph::decode;
+  DECODE_START(1, it);
+  decode(need_free_caches, it);
+  DECODE_FINISH(it);
+}
+
 void RwlCacheRequest::encode(bufferlist &bl) const {
   using ceph::encode;
   ENCODE_START(1, 1, bl);

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -1371,5 +1371,23 @@ void RwlCacheDaemonInfo::decode(bufferlist::const_iterator &it) {
   DECODE_FINISH(it);
 }
 
+void RwlCacheRequest::encode(bufferlist &bl) const {
+  using ceph::encode;
+  ENCODE_START(1, 1, bl);
+  encode(id, bl);
+  encode(size, bl);
+  encode(copies, bl);
+  ENCODE_FINISH(bl);
+}
+
+void RwlCacheRequest::decode(bufferlist::const_iterator &it) {
+  using ceph::decode;
+  DECODE_START(1, it);
+  decode(id, it);
+  decode(size, it);
+  decode(copies, it);
+  DECODE_FINISH(it);
+}
+
 } // namespace rbd
 } // namespace cls

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -1423,5 +1423,23 @@ void RwlCacheInfo::decode(bufferlist::const_iterator &it) {
   DECODE_FINISH(it);
 }
 
+void RwlCacheRequestAck::encode(bufferlist &bl) const {
+  using ceph::encode;
+  ENCODE_START(1, 1, bl);
+  encode(cache_id, bl);
+  encode(result, bl);
+  encode(need_free_daemons, bl);
+  ENCODE_FINISH(bl);
+}
+
+void RwlCacheRequestAck::decode(bufferlist::const_iterator &it) {
+  using ceph::decode;
+  DECODE_START(1, it);
+  decode(cache_id, it);
+  decode(result, it);
+  decode(need_free_daemons, it);
+  DECODE_FINISH(it);
+}
+
 } // namespace rbd
 } // namespace cls

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -1441,5 +1441,21 @@ void RwlCacheRequestAck::decode(bufferlist::const_iterator &it) {
   DECODE_FINISH(it);
 }
 
+void RwlCacheFree::encode(bufferlist &bl) const {
+  using ceph::encode;
+  ENCODE_START(1, 1, bl);
+  encode(cache_id, bl);
+  encode(need_free_daemons, bl);
+  ENCODE_FINISH(bl);
+}
+
+void RwlCacheFree::decode(bufferlist::const_iterator &it) {
+  using ceph::decode;
+  DECODE_START(1, it);
+  decode(cache_id, it);
+  decode(need_free_daemons, it);
+  DECODE_FINISH(it);
+}
+
 } // namespace rbd
 } // namespace cls

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -1371,6 +1371,24 @@ void RwlCacheDaemonInfo::decode(bufferlist::const_iterator &it) {
   DECODE_FINISH(it);
 }
 
+void RwlCacheDaemonPing::encode(bufferlist &bl) const
+{
+  using ceph::decode;
+  ENCODE_START(1, 1, bl);
+  encode(id, bl);
+  encode(freed_caches, bl);
+  ENCODE_FINISH(bl);
+}
+
+void RwlCacheDaemonPing::decode(bufferlist::const_iterator &it)
+{
+  using ceph::decode;
+  DECODE_START(1, it);
+  decode(id, it);
+  decode(freed_caches, it);
+  DECODE_FINISH(it);
+}
+
 void RwlCacheRequest::encode(bufferlist &bl) const {
   using ceph::encode;
   ENCODE_START(1, 1, bl);

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -1389,5 +1389,39 @@ void RwlCacheRequest::decode(bufferlist::const_iterator &it) {
   DECODE_FINISH(it);
 }
 
+void RwlCacheInfo::DaemonInfo::encode(bufferlist &bl) const {
+  using ceph::encode;
+  ENCODE_START(1, 1, bl);
+  encode(id, bl);
+  encode(rdma_address, bl);
+  encode(rdma_port, bl);
+  ENCODE_FINISH(bl);
+}
+
+void RwlCacheInfo::DaemonInfo::decode(bufferlist::const_iterator &it) {
+  using ceph::decode;
+  DECODE_START(1, it);
+  decode(id, it);
+  decode(rdma_address, it);
+  decode(rdma_port, it);
+  DECODE_FINISH(it);
+}
+
+void RwlCacheInfo::encode(bufferlist &bl) const {
+  using ceph::encode;
+  ENCODE_START(1, 1, bl);
+  encode(cache_id, bl);
+  encode(daemons, bl);
+  ENCODE_FINISH(bl);
+}
+
+void RwlCacheInfo::decode(bufferlist::const_iterator &it) {
+  using ceph::decode;
+  DECODE_START(1, it);
+  decode(cache_id, it);
+  decode(daemons, it);
+  DECODE_FINISH(it);
+}
+
 } // namespace rbd
 } // namespace cls

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -1351,5 +1351,25 @@ void sanitize_entity_inst(entity_inst_t* entity_inst) {
   entity_inst->addr.set_type(entity_addr_t::TYPE_ANY);
 }
 
+void RwlCacheDaemonInfo::encode(bufferlist &bl) const {
+  using ceph::encode;
+  ENCODE_START(1, 1, bl);
+  encode(id, bl);
+  encode(rdma_address, bl);
+  encode(rdma_port, bl);
+  encode(total_size, bl);
+  ENCODE_FINISH(bl);
+}
+
+void RwlCacheDaemonInfo::decode(bufferlist::const_iterator &it) {
+  using ceph::decode;
+  DECODE_START(1, it);
+  decode(id, it);
+  decode(rdma_address, it);
+  decode(rdma_port, it);
+  decode(total_size, it);
+  DECODE_FINISH(it);
+}
+
 } // namespace rbd
 } // namespace cls

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -1031,6 +1031,16 @@ struct RwlCacheDaemonInfo {
 };
 WRITE_CLASS_ENCODER(RwlCacheDaemonInfo)
 
+struct RwlCacheRequest{
+  uint64_t id;
+  uint64_t size;
+  uint32_t copies;
+
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+};
+WRITE_CLASS_ENCODER(RwlCacheRequest)
+
 } // namespace rbd
 } // namespace cls
 

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -1041,6 +1041,26 @@ struct RwlCacheRequest{
 };
 WRITE_CLASS_ENCODER(RwlCacheRequest)
 
+struct RwlCacheInfo {
+  epoch_t cache_id;
+
+  struct DaemonInfo {
+    uint64_t id;
+    std::string rdma_address;
+    int32_t rdma_port;
+
+    void encode(ceph::buffer::list &bl) const;
+    void decode(ceph::buffer::list::const_iterator &it);
+  };
+
+  std::vector<struct DaemonInfo> daemons;
+
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+};
+WRITE_CLASS_ENCODER(RwlCacheInfo::DaemonInfo)
+WRITE_CLASS_ENCODER(RwlCacheInfo)
+
 } // namespace rbd
 } // namespace cls
 

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -1079,6 +1079,17 @@ struct RwlCacheRequestAck {
 };
 WRITE_CLASS_ENCODER(RwlCacheRequestAck)
 
+struct RwlCacheFree {
+  epoch_t cache_id;
+  // Primary can't free daemon space, need objclass help
+  std::set<uint64_t> need_free_daemons;
+
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+
+};
+WRITE_CLASS_ENCODER(RwlCacheFree)
+
 } // namespace rbd
 } // namespace cls
 

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -1020,6 +1020,7 @@ void sanitize_entity_inst(entity_inst_t* entity_inst);
 
 #define RBD_RWLCACHE_MAP_OBJECT_NAME "rbd_rwlcache_map"
 #define RBD_RWLCACHE_REQUEST_ACK_TIMEOUT 120 //Unit is second
+#define RBD_RWLCACHE_DAEMON_PING_TIMEOUT 120 //Unit is second
 
 struct RwlCacheDaemonInfo {
     uint64_t id;
@@ -1031,6 +1032,15 @@ struct RwlCacheDaemonInfo {
     void decode(ceph::buffer::list::const_iterator &it);
 };
 WRITE_CLASS_ENCODER(RwlCacheDaemonInfo)
+
+struct RwlCacheDaemonPing {
+  uint64_t id;
+  std::set<epoch_t> freed_caches;
+
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+};
+WRITE_CLASS_ENCODER(RwlCacheDaemonPing)
 
 struct RwlCacheRequest{
   uint64_t id;

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -1019,6 +1019,7 @@ std::ostream& operator<<(std::ostream& os, const AssertSnapcSeqState& state);
 void sanitize_entity_inst(entity_inst_t* entity_inst);
 
 #define RBD_RWLCACHE_MAP_OBJECT_NAME "rbd_rwlcache_map"
+#define RBD_RWLCACHE_REQUEST_ACK_TIMEOUT 120 //Unit is second
 
 struct RwlCacheDaemonInfo {
     uint64_t id;
@@ -1060,6 +1061,23 @@ struct RwlCacheInfo {
 };
 WRITE_CLASS_ENCODER(RwlCacheInfo::DaemonInfo)
 WRITE_CLASS_ENCODER(RwlCacheInfo)
+
+struct RwlCacheRequestAck {
+  epoch_t cache_id;
+
+  // result == 0, mean initialize success. others mean error
+  int result;
+
+  // If initialize failed:
+  // daemon maybe already allocated space and
+  // primary can't free(etc, rdma disconnect).
+  // So objclass need send free message to daemons.
+  std::set<uint64_t> need_free_daemons;
+
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+};
+WRITE_CLASS_ENCODER(RwlCacheRequestAck)
 
 } // namespace rbd
 } // namespace cls

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -1018,6 +1018,19 @@ std::ostream& operator<<(std::ostream& os, const AssertSnapcSeqState& state);
 
 void sanitize_entity_inst(entity_inst_t* entity_inst);
 
+#define RBD_RWLCACHE_MAP_OBJECT_NAME "rbd_rwlcache_map"
+
+struct RwlCacheDaemonInfo {
+    uint64_t id;
+    std::string rdma_address;
+    int32_t rdma_port;
+    uint64_t total_size;
+
+    void encode(ceph::buffer::list &bl) const;
+    void decode(ceph::buffer::list::const_iterator &it);
+};
+WRITE_CLASS_ENCODER(RwlCacheDaemonInfo)
+
 } // namespace rbd
 } // namespace cls
 

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -1042,6 +1042,14 @@ struct RwlCacheDaemonPing {
 };
 WRITE_CLASS_ENCODER(RwlCacheDaemonPing)
 
+struct RwlCacheDaemonNeedFreeCaches {
+  std::set<epoch_t> need_free_caches;
+
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &it);
+};
+WRITE_CLASS_ENCODER(RwlCacheDaemonNeedFreeCaches)
+
 struct RwlCacheRequest{
   uint64_t id;
   uint64_t size;

--- a/src/common/options/rbd.yaml.in
+++ b/src/common/options/rbd.yaml.in
@@ -836,6 +836,13 @@ options:
   default: /tmp
   services:
   - rbd
+- name: rbd_persistent_replicated_cache_cls_pool
+  type: str
+  level: advanced
+  desc: The cls pool is the pool which store object of managing rbd persistent
+    replicated cache cluster info.
+  services:
+  - rbd
 - name: rbd_persistent_replicated_cache_alloc_from_same_host
   type: bool
   level: advanced

--- a/src/common/options/rbd.yaml.in
+++ b/src/common/options/rbd.yaml.in
@@ -836,6 +836,13 @@ options:
   default: /tmp
   services:
   - rbd
+- name: rbd_persistent_replicated_cache_alloc_from_same_host
+  type: bool
+  level: advanced
+  desc: Whether primary and replciated in the same host. Only for test.
+  default: false
+  services:
+  - rbd
 - name: rbd_quiesce_notification_attempts
   type: uint
   level: dev

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -3413,3 +3413,78 @@ TEST_F(TestClsRbd, sparsify)
   ASSERT_EQ(0, ioctx.remove(oid));
   ioctx.close();
 }
+
+TEST_F(TestClsRbd, rwlcache)
+{
+  // make option: rbd_persistent_replicated_cache_cls_pool is equal _pool_name
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  cls::rbd::RwlCacheDaemonInfo d_info = {1000, "192.168.0.1", 8000, 100UL * 1024 * 1024 * 1024};
+
+  ASSERT_EQ(0, rwlcache_daemoninfo(&ioctx, d_info));
+
+  {
+    cls::rbd::RwlCacheDaemonInfo d_info1 = {1000, "192.168.0.1", 8000, 100UL * 1024 * 1024 * 1024};
+    ASSERT_EQ(-EEXIST, rwlcache_daemoninfo(&ioctx, d_info1));
+
+    d_info1.id = 1001;
+    ASSERT_EQ(-EEXIST, rwlcache_daemoninfo(&ioctx, d_info1));
+  }
+
+  {
+    cls::rbd::RwlCacheRequest req = {1002, 50UL * 1024  * 1024 * 1024, 1};
+    epoch_t cache_id;
+
+    ASSERT_EQ(0, rwlcache_request(&ioctx, req, cache_id));
+    ASSERT_TRUE(cache_id == 1);
+
+    cls::rbd::RwlCacheInfo info;
+    ASSERT_EQ(0, rwlcache_get_cacheinfo(&ioctx, cache_id, info));
+    ASSERT_TRUE(info.cache_id == cache_id);
+    auto &daemon = info.daemons[0];
+    ASSERT_TRUE(daemon.rdma_address == "192.168.0.1" && daemon.rdma_port == 8000);
+
+    cls::rbd::RwlCacheRequestAck ack = {cache_id, 0};
+    ASSERT_EQ(0, rwlcache_request_ack(&ioctx, ack));
+
+    cls::rbd::RwlCacheRequest req1 = {1004, 60UL * 1024  * 1024 * 1024, 1};
+    ASSERT_EQ(-ENOSPC, rwlcache_request(&ioctx, req1, cache_id));
+
+    cls::rbd::RwlCacheFree free = {info.cache_id};
+    ASSERT_EQ(0, rwlcache_free(&ioctx, free));
+
+    // After freeing req
+    ASSERT_EQ(0, rwlcache_request(&ioctx, req1, cache_id));
+    ASSERT_EQ(0, rwlcache_get_cacheinfo(&ioctx, cache_id, info));
+    ASSERT_TRUE(info.daemons[0].id == 1000);
+    ASSERT_TRUE(cache_id == info.cache_id);
+
+    cls::rbd::RwlCacheRequestAck ack1 = {cache_id, 0};
+    ASSERT_EQ(0, rwlcache_request_ack(&ioctx, ack1));
+
+    cls::rbd::RwlCacheDaemonPing ping = {d_info.id};
+    bool has_need_free_cache = true;
+    ASSERT_EQ(0, rwlcache_daemonping(&ioctx, ping, has_need_free_cache));
+    ASSERT_TRUE(!has_need_free_cache);
+
+    bool has_removed_daemon = true;
+    ASSERT_EQ(0, rwlcache_primaryping(&ioctx, cache_id, has_removed_daemon));
+    ASSERT_TRUE(!has_removed_daemon);
+
+    cls::rbd::RwlCacheFree free1;
+    free1.cache_id = cache_id;
+    free1.need_free_daemons.insert(info.daemons[0].id);
+    ASSERT_EQ(0, rwlcache_free(&ioctx, free1));
+
+    ASSERT_EQ(0, rwlcache_daemonping(&ioctx, ping, has_need_free_cache));
+    ASSERT_TRUE(has_need_free_cache);
+
+    struct cls::rbd::RwlCacheDaemonNeedFreeCaches need_free_caches;
+    ASSERT_EQ(0, rwlcache_get_needfree_caches(&ioctx, d_info.id, need_free_caches));
+    ASSERT_TRUE(need_free_caches.need_free_caches.count(cache_id) == 1);
+  }
+
+  ioctx.close();
+
+}


### PR DESCRIPTION
This PR is for librbd/cache/pwl/rwl cluster management which use objclass to manage cluster map.
At firstly, we wanted use Monitor/ PaxosService to manage cluster map. But in the CDM meeting, Samuel worried that with the increase of librbd client, the burden on Monitor will also increase. So he suggested we can use objclass to manger this part.

1. firstly, we should set a pool( rbd_persistent_replicated_cache_cls_pool) and use object(name :RBD_RWLCACHE_MAP_OBJECT_NAME) to store cluster map(as key/value mode)
2. cluster map include: 
   a)daemon infos:  daemon contain multi replciated-cache. The info include rdma_addrss/rdma_port/id/size. When daemon start it will report those info to objclass. If Daemon restart, it will clean up all replicated-cache(flush data to osd /delete file) And report those info to objclass.  Directly at the daemon, they don’t communicate。
  b)cache infos:  When librbd(primary) request relicated-cache, it will send infos which copies/size to objclass.  Objclass based on those info to allocate space from daemons to librbd. Currently, we use the simplest method to allocate: daemon and librbd can't be on the same host. But for test case, we add an option " rbd_persistent_replicated_cache_alloc_from_same_host" to allow allocate space when daemon & librbd in the same host. 
  c) We divide the cache into three categories
     aa: uncommitted_cache:  After allocated success, the cache is uncommitted cache.  Only wait for librbd to establish a link with the daemon, after the daemon allocates space. And reply an ack to objclass, we can move the cache from uncommitted to cache.
    If ack timeout, we move this cache to need_free_daemon_sapce_caches.  This because objclass allocate space from daemon, but if librbd curshed before setup rdma-connection. The daemon don't know the allocated info and can't free the space.
   If ack is failed and some daemon can't make sure to free space, we move cache from uncommitted cache to need_free_daemon_space_caches.
    bb)normal caches:  can do IO cache normally. Only move from uncommitted cache.
    cc)need_free_daemon_sapce_caches:  can't do io and some daemon space still existed.  It can from uncommitted cache or normal cache.  In this state, we should tell daemon to free cache file. If all daemons' space removed, cache can removed.
3: we add the following cls ops:
   a)basic ops:
    aa)rwlcache_daemoninfo: when daemon start/restart, it report daemon info to objeclass.
    bb)rwlcache_request: librbd(primary) request space.
    cc)rwlcache_free:  librbd free space.
  b)health check op:
   aa) rwlcache_daemonping:  Periodically send ping commands to indicate the status of the daemon. This command include freed cache_id.
  c)limited by option:  **osd_max_write_op_reply_len**. we add
   aa)rwlcache_get_cacheinfo:  rwlcache_request will return cache_id.  rwlcache_get_cacheinfo based cache_id to get related daemon infos.
   bb)rwlcache_get_needfree_caches:  rwlcache_daemonping return bool value mean daemon need free some caches. rwlcache_get_needfree_caches to get the need-free-cache-id.
   d) others:
     aa) rwlcache_request_ack: after rwlcache_get_cacheinfo, librbd setup rdma-connection and daemon create cache-file. rwlcache_request_ack include init-process status(success or fail, if failed, it  need contain damons which need to free space).
    bb)rwlcache_primaryping to fix the problem: if daemonping timeout and removed this daemon. But the librbd and daemon's rdma connection still work. We should tell librbd to close and free space.
