### PR TITLE
[WIP]mgr/dashboard: monitoring: replace Grafana JSON with code-based generators

### DIFF
--- a/monitoring/grafana/dashboards/pool-detail.py
+++ b/monitoring/grafana/dashboards/pool-detail.py
@@ -1,0 +1,290 @@
+from grafanalib.core import (
+    Annotations, Dashboard, Gauge, Graph, GridPos,
+    NULL_AS_NULL, SeriesOverride, SingleStat, SparkLine, Templating, Tooltip, XAxis, Target, YAxes, YAxis
+)
+
+
+dashboard = Dashboard(
+    title="Ceph Pool Details",
+    refresh="15s",
+    schemaVersion=16,
+    timezone="browser",
+    uid="-xyV8KCiz",
+    version=1,
+    templating=Templating(list=[{
+        "current": {
+        "text": "Prometheus admin.virt1.home.fajerski.name:9090",
+        "value": "Prometheus admin.virt1.home.fajerski.name:9090"
+        },
+        "hide": 0,
+        "label": "Data Source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": False,
+        "type": "datasource"
+      },
+      {
+        "allValue": NULL_AS_NULL,
+        "current": {},
+        "datasource": "$datasource",
+        "hide": 0,
+        "includeAll": False,
+        "label": "Pool Name",
+        "multi": False,
+        "name": "pool_name",
+        "options": [],
+        "query": "label_values(ceph_pool_metadata,name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": False,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": False
+      }
+    ]),
+    annotations=Annotations(list=[{
+
+        "builtIn": 1,
+
+        "datasource": "-- Grafana --",
+
+        "enable": True,
+
+        "hide": True,
+
+        "iconColor": "rgba(0, 211, 255, 1)",
+
+        "name": "Annotations & Alerts",
+
+        "type": "dashboard"
+
+    }]),
+    panels=[
+        SingleStat(
+            title="Capacity used",
+            dataSource="$datasource",
+            id=12,
+            gridPos=GridPos(h=7, w=7, x=0, y=0),
+            format="percentunit",
+            gauge=Gauge(
+                maxValue=1,
+                minValue=0,
+                show=True,
+                thresholdLabels=False,
+                thresholdMarkers=True
+            ),
+            sparkline=SparkLine(
+                show=True
+            ),
+            thresholds= ".7,.8",
+            valueName="current",
+            valueFontSize="50%",
+            targets=[
+                Target(
+                    expr='(ceph_pool_stored / (ceph_pool_stored + ceph_pool_max_avail)) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}',
+                    legendFormat="",
+                    intervalFactor=1,
+                    refId='A',
+                    format="time_series"
+                )
+            ],
+        ),
+        SingleStat(
+            title="Time till full",
+            dataSource="$datasource",
+            id=14,
+            gridPos=GridPos(h=7, w=5, x=7, y=0),
+            format="s",
+            valueName="current",
+            valueFontSize="80%",
+            description="Time till pool is full assuming the average fill rate of the last 6 hours",
+            targets=[
+                Target(
+                    expr='(ceph_pool_max_avail / deriv(ceph_pool_stored[6h])) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"} > 0',
+                    legendFormat="",
+                    intervalFactor=1,
+                    refId='A',
+                    format="time_series"
+                )
+            ],
+        ),
+        Graph(
+            aliasColors={
+                "read_op_per_sec": "#3F6833",
+                "write_op_per_sec": "#E5AC0E"
+            },
+            title="$pool_name Object Ingress/Egress",
+            tooltip=Tooltip(
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=10,
+            gridPos=GridPos(h=7, w=12, x=12, y=0),
+            description='This chart shows the sum of read and write IOPS from all clients by pool',
+            targets=[
+                Target(
+                    expr='deriv(ceph_pool_objects[1m]) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}',
+                    legendFormat="Objects per second",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='B',
+                )
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='ops',
+                    label='Objects out(-) / in(+) ',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+        Graph(
+            aliasColors={
+                "read_op_per_sec": "#3F6833",
+                "write_op_per_sec": "#E5AC0E"
+            },
+            title="$pool_name Client IOPS",
+            tooltip=Tooltip(
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=6,
+            seriesOverrides=SeriesOverride(
+                 alias= "reads",
+            ),
+            gridPos=GridPos(h=7, w=12, x=0, y=7),
+            targets=[
+                Target(
+                    expr='irate(ceph_pool_rd[1m]) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}',
+                    legendFormat="reads",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='B',
+                ),
+                Target(
+                    expr='irate(ceph_pool_wr[1m]) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}',
+                    legendFormat="writes",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='C',
+                )
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='iops',
+                    label='Read (-) / Write (+)',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+       Graph(
+            aliasColors={
+                "read_op_per_sec": "#3F6833",
+                "write_op_per_sec": "#E5AC0E"
+            },
+            title="$pool_name Client Throughput",
+            tooltip=Tooltip(
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=7,
+            seriesOverrides=SeriesOverride(
+                 alias= "reads",
+            ),
+            gridPos=GridPos(h=7, w=12, x=12, y=7),
+            targets=[
+                Target(
+                    expr='irate(ceph_pool_rd_bytes[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}',
+                    legendFormat="reads",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='A',
+                ),
+                Target(
+                    expr='irate(ceph_pool_wr_bytes[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}',
+                    legendFormat="writes",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='C',
+                )
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='Bps',
+                    label='Read (-) / Write (+)',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+        Graph(
+            aliasColors={
+                "read_op_per_sec": "#3F6833",
+                "write_op_per_sec": "#E5AC0E"
+            },
+            title="$pool_name Objects",
+            tooltip=Tooltip(
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=8,
+            seriesOverrides=SeriesOverride(
+                 alias= "reads",
+            ),
+            gridPos=GridPos(h=7, w=12, x=0, y=14),
+            targets=[
+                Target(
+                    expr='ceph_pool_objects * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}',
+                    legendFormat="Number of Objects",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='B',
+                )
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='short',
+                    label='Objects',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+    ]
+)

--- a/monitoring/grafana/dashboards/pool-overview.py
+++ b/monitoring/grafana/dashboards/pool-overview.py
@@ -1,0 +1,572 @@
+from grafanalib.core import (
+    Annotations, Dashboard, Graph, GridPos,
+    NULL_AS_NULL, SingleStat, Table, Templating, Tooltip, XAxis, Target, YAxes, YAxis
+)
+
+
+dashboard = Dashboard(
+    title="Ceph Pools Overview",
+    refresh="15s",
+    schemaVersion=22,
+    timezone="browser",
+    uid="z99hzWtmk",
+    version=10,
+    templating=Templating(list=[{
+          "current": {
+            "selected": False,
+            "text": "Dashboard1",
+            "value": "Dashboard1"
+          },
+          "hide": 0,
+          "includeAll": False,
+          "label": "Data Source",
+          "multi": False,
+          "name": "datasource",
+          "options": [],
+          "query": "prometheus",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": False,
+          "type": "datasource"
+        },
+        {
+          "current": {
+            "text": "15",
+            "value": "15"
+          },
+          "hide": 0,
+          "label": "Top K",
+          "name": "topk",
+          "options": [
+            {
+              "text": "15",
+              "value": "15"
+            }
+          ],
+          "query": "15",
+          "skipUrlSync": False,
+          "type": "textbox"
+    }]),
+    annotations=Annotations(list=[{
+
+        "builtIn": 1,
+
+        "datasource": "-- Grafana --",
+
+        "enable": True,
+
+        "hide": True,
+
+        "iconColor": "rgba(0, 211, 255, 1)",
+
+        "name": "Annotations & Alerts",
+
+        "type": "dashboard"
+
+    }]),
+    panels=[
+        SingleStat(
+            title="Pool",
+            dataSource="$datasource",
+            id=21,
+            gridPos=GridPos(h=3, w=3, x=0, y=0),
+            targets=[
+                Target(
+                    expr='count(ceph_pool_metadata)',
+                    legendFormat="",
+                    refId='A',
+                    format="table"
+                )
+            ],
+        ),
+        SingleStat(
+            title="Pools with Compression",
+            dataSource="$datasource",
+            id=7,
+            gridPos=GridPos(h=3, w=3, x=3, y=0),
+            description='Count of the pools that have compression enabled',
+            targets=[
+                Target(
+                    expr='count(ceph_pool_metadata{compression_mode!=\"none\"})',
+                    legendFormat="",
+                    refId='A',
+                )
+            ],
+        ),
+        SingleStat(
+            title="Total Raw Capacity",
+            dataSource="$datasource",
+            decimals=1,
+            format="bytes",
+            id=27,
+            gridPos=GridPos(h=3, w=3, x=6, y=0),
+            description='Total raw capacity available to the cluster',
+            targets=[
+                Target(
+                    expr='sum(ceph_osd_stat_bytes)',
+                    legendFormat="",
+                    refId='A',
+                )
+            ],
+        ),
+        SingleStat(
+            title="Raw Capacity Consumed",
+            dataSource="$datasource",
+            decimals=2,
+            format="bytes",
+            id=25,
+            gridPos=GridPos(h=3, w=3, x=9, y=0),
+            description='Total raw capacity consumed by user data and associated overheads (metadata + redundancy)',
+            targets=[
+                Target(
+                    expr='sum(ceph_pool_bytes_used)',
+                    legendFormat="",
+                    refId='A',
+                )
+            ],
+        ),
+        SingleStat(
+            title="Logical Stored ",
+            dataSource="$datasource",
+            decimals=1,
+            format="bytes",
+            id=23,
+            gridPos=GridPos(h=3, w=3, x=12, y=0),
+            description='Total of client data stored in the cluster',
+            targets=[
+                Target(
+                    expr='sum(ceph_pool_stored)',
+                    legendFormat="",
+                    refId='A',
+                )
+            ],
+        ),
+        SingleStat(
+            title="Compression Savings",
+            dataSource="$datasource",
+            decimals=1,
+            format="bytes",
+            id=9,
+            gridPos=GridPos(h=3, w=3, x=15, y=0),
+            description='A compression saving is determined as the data eligible to be compressed minus the capacity used to store the data after compression',
+            targets=[
+                Target(
+                    expr='sum(ceph_pool_compress_under_bytes - ceph_pool_compress_bytes_used)',
+                    legendFormat="",
+                    refId='A',
+                )
+            ],
+        ),
+        SingleStat(
+            title="Compression Eligibility",
+            dataSource="$datasource",
+            format="percent",
+            id=17,
+            gridPos=GridPos(h=3, w=3, x=18, y=0),
+            description='Indicates how suitable the data is within the pools that are/have been enabled for compression - averaged across all pools holding compressed data\n',
+            targets=[
+                Target(
+                    expr='(sum(ceph_pool_compress_under_bytes > 0) / sum(ceph_pool_stored_raw and ceph_pool_compress_under_bytes > 0)) * 100',
+                    legendFormat="",
+                    refId='A',
+                )
+            ],
+        ),
+        SingleStat(
+            title="Compression Factor",
+            dataSource="$datasource",
+            format="none",
+            id=15,
+            gridPos=GridPos(h=3, w=3, x=21, y=0),
+            description='This factor describes the average ratio of data eligible to be compressed divided by the data actually stored. It does not account for data written that was ineligible for compression (too small, or compression yield too low)',
+            targets=[
+                Target(
+                    expr='sum(ceph_pool_compress_under_bytes > 0) / sum(ceph_pool_compress_bytes_used > 0)',
+                    legendFormat="",
+                    refId='A',
+                )
+            ],
+        ),
+        Table(
+            title="Pool Overview",
+            dataSource="$datasource",
+            id=5,
+            gridPos=GridPos(h=6, w=24, x=0, y=3),
+            transform="table",
+            styles=[{
+                "alias": "",
+                "decimals": 2,
+                "pattern": "Time",
+                "type": "hidden",
+                "unit": "short"
+            },
+            {
+                "alias": "",
+                "decimals": 2,
+                "pattern": "instance",
+                "type": "hidden",
+                "unit": "short"
+            },
+            {
+                "alias": "",
+                "decimals": 2,
+                "pattern": "job",
+                "type": "hidden",
+                "unit": "short"
+            },
+            {
+                "alias": "Pool Name",
+                "align": "auto",
+                "colorMode": NULL_AS_NULL,
+                "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+                ],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "pattern": "name",
+                "thresholds": [],
+                "type": "string",
+                "unit": "short"
+            },
+            {
+                "alias": "Pool ID",
+                "decimals": 0,
+                "pattern": "pool_id",
+                "type": "hidden",
+                "unit": "none"
+            },
+            {
+                "alias": "Compression Factor",
+                "decimals": 1,
+                "mappingType": 1,
+                "pattern": "Value #A",
+                "type": "number",
+                "unit": "none"
+            },
+            {
+                "alias": "% Used",
+                "decimals": 2,
+                "mappingType": 1,
+                "pattern": "Value #D",
+                "thresholds": [
+                "70",
+                "85"
+                ],
+                "type": "number",
+                "unit": "percentunit"
+            },
+            {
+                "alias": "Usable Free",
+                "decimals": 2,
+                "mappingType": 1,
+                "pattern": "Value #B",
+                "thresholds": [],
+                "type": "number",
+                "unit": "bytes"
+            },
+            {
+                "alias": "Compression Eligibility",
+                "decimals": 0,
+                "mappingType": 1,
+                "pattern": "Value #C",
+                "thresholds": [],
+                "type": "number",
+                "unit": "percent"
+            },
+            {
+                "alias": "Compression Savings",
+                "decimals": 1,
+                "mappingType": 1,
+                "pattern": "Value #E",
+                "thresholds": [],
+                "type": "number",
+                "unit": "bytes"
+            },
+            {
+                "alias": "Growth (5d)",
+                "decimals": 2,
+                "mappingType": 1,
+                "pattern": "Value #F",
+                "thresholds": [
+                "0",
+                "0"
+                ],
+                "type": "number",
+                "unit": "bytes"
+            },
+            {
+                "alias": "IOPS",
+                "decimals": 0,
+                "mappingType": 1,
+                "pattern": "Value #G",
+                "thresholds": [],
+                "type": "number",
+                "unit": "none"
+            },
+            {
+                "alias": "Bandwidth",
+                "decimals": 0,
+                "mappingType": 1,
+                "pattern": "Value #H",
+                "thresholds": [],
+                "type": "number",
+                "unit": "Bps"
+            },
+            {
+                "alias": "",
+                "decimals": 2,
+                "mappingType": 1,
+                "pattern": "__name__",
+                "thresholds": [],
+                "type": "hidden",
+                "unit": "short"
+            },
+            {
+                "alias": "",
+                "decimals": 2,
+                "mappingType": 1,
+                "pattern": "type",
+                "thresholds": [],
+                "type": "hidden",
+                "unit": "short"
+            },
+            {
+                "alias": "",
+                "decimals": 2,
+                "mappingType": 1,
+                "pattern": "compression_mode",
+                "thresholds": [],
+                "type": "hidden",
+                "unit": "short"
+            },
+            {
+                "alias": "Type",
+                "decimals": 2,
+                "mappingType": 1,
+                "pattern": "description",
+                "thresholds": [],
+                "type": "string",
+                "unit": "short"
+            },
+            {
+                "alias": "Stored",
+                "decimals": 1,
+                "mappingType": 1,
+                "pattern": "Value #J",
+                "thresholds": [],
+                "type": "number",
+                "unit": "bytes"
+            },
+            {
+                "alias": "",
+                "decimals": 2,
+                "mappingType": 1,
+                "pattern": "Value #I",
+                "thresholds": [],
+                "type": "hidden",
+                "unit": "short"
+            },
+            {
+                "alias": "Compression",
+                "decimals": 2,
+                "mappingType": 1,
+                "pattern": "Value #K",
+                "thresholds": [],
+                "type": "string",
+                "unit": "short",
+                "valueMaps": [
+                {
+                    "text": "ON",
+                    "value": "1"
+                }
+                ]
+            }
+            ],
+            targets=[
+                Target(
+                    expr='(ceph_pool_percent_used * on(pool_id) group_left(name) ceph_pool_metadata)',
+                    format="table",
+                    legendFormat="",
+                    refId='D',
+                ),
+                Target(
+                    expr='ceph_pool_stored * on(pool_id) group_left ceph_pool_metadata',
+                    format="table",
+                    legendFormat="",
+                    refId='J',
+                ),
+                Target(
+                    expr='ceph_pool_max_avail * on(pool_id) group_left(name) ceph_pool_metadata',
+                    format="table",
+                    legendFormat="",
+                    refId='B',
+                ),
+                Target(
+                    expr='delta(ceph_pool_stored[5d])',
+                    format="table",
+                    legendFormat="",
+                    refId='F',
+                ),
+                Target(
+                    expr='ceph_pool_metadata',
+                    format="table",
+                    legendFormat="",
+                    refId='I',
+                ),
+                Target(
+                    expr='ceph_pool_metadata{compression_mode!=\"none\"}',
+                    format="table",
+                    legendFormat="",
+                    refId='K',
+                ),
+                Target(
+                    expr='(ceph_pool_compress_under_bytes / ceph_pool_compress_bytes_used > 0) and on(pool_id) (((ceph_pool_compress_under_bytes > 0) / ceph_pool_stored_raw) * 100 > 0.5)',
+                    format="table",
+                    legendFormat="",
+                    refId='A',
+                ),
+                Target(
+                    expr='((ceph_pool_compress_under_bytes > 0) / ceph_pool_stored_raw) * 100',
+                    format="table",
+                    legendFormat="",
+                    refId='C',
+                ),
+                Target(
+                    expr='(ceph_pool_compress_under_bytes - ceph_pool_compress_bytes_used > 0)',
+                    format="table",
+                    legendFormat="",
+                    refId='E',
+                ),
+                Target(
+                    expr='rate(ceph_pool_rd[30s]) + rate(ceph_pool_wr[30s])',
+                    format="table",
+                    legendFormat="",
+                    refId='G',
+                ),
+                Target(
+                    expr='rate(ceph_pool_rd_bytes[30s]) + rate(ceph_pool_wr_bytes[30s])',
+                    format="table",
+                    legendFormat="",
+                    refId='H',
+                ),
+                Target(
+                    expr='(ceph_pool_compress_under_bytes - ceph_pool_compress_bytes_used > 0)',
+                    format="table",
+                    legendFormat="",
+                    refId='L',
+                ),
+            ],
+        ),
+        Graph(
+            title="Top $topk Client IOPS by Pool",
+            tooltip=Tooltip(
+                sort=2,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=1,
+            gridPos=GridPos(h=8, w=12, x=0, y=9),
+            description='This chart shows the sum of read and write IOPS from all clients by pool',
+            targets=[
+                Target(
+                    expr='topk($topk,round((rate(ceph_pool_rd[30s]) + rate(ceph_pool_wr[30s])),1) * on(pool_id) group_left(instance,name) ceph_pool_metadata) ',
+                    legendFormat="{{name}} ",
+                    hide = False,
+                    format="time_Series",
+                    refId='F',
+                ),
+                Target(
+                    expr='topk($topk,rate(ceph_pool_wr[30s]) + on(pool_id) group_left(instance,name) ceph_pool_metadata) ',
+                    legendFormat="{{name}} - write",
+                    hide = True,
+                    format="time_Series",
+                    refId='A',
+                )
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='short',
+                    label='IOPS',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+        Graph(
+            title="Top $topk Client Bandwidth by Pool",
+            tooltip=Tooltip(
+                sort=2,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=2,
+            gridPos=GridPos(h=8, w=12, x=12, y=9),
+            description='The chart shows the sum of read and write bytes from all clients, by pool',
+            targets=[
+                Target(
+                    expr='topk($topk,(rate(ceph_pool_rd_bytes[30s]) + rate(ceph_pool_wr_bytes[30s])) * on(pool_id) group_left(instance,name) ceph_pool_metadata)',
+                    legendFormat="{{name}} ",
+                    hide = False,
+                    format="time_Series",
+                    refId='A',
+                )
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='Bps',
+                    label='Throughput',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+        Graph(
+            title="Pool Capacity Usage (RAW)",
+            tooltip=Tooltip(
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=19,
+            gridPos=GridPos(h=7, w=24, x=0, y=17),
+            timeFrom="14d",
+            description='Historical view of capacity usage, to help identify growth and trends in pool consumption',
+            targets=[
+                Target(
+                    expr='ceph_pool_bytes_used * on(pool_id) group_right ceph_pool_metadata',
+                    legendFormat="{{name}} ",
+                    hide = False,
+                    refId='A',
+                )
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='bytes',
+                    label='Capacity Used',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        )
+    ]
+)

--- a/monitoring/grafana/dashboards/radosgw-detail.py
+++ b/monitoring/grafana/dashboards/radosgw-detail.py
@@ -1,0 +1,259 @@
+from grafanalib.core import (
+    Annotations, Dashboard, Graph, GridPos,
+    PieChart, RowPanel, SeriesOverride, Templating, Tooltip, XAxis, Target, YAxes, YAxis,
+)
+
+dashboard = Dashboard(
+    title="RGW Instance Detail",
+    refresh="15s",
+    schemaVersion=16,
+    uid="x5ARzZtmk",
+    version=2,
+    templating=Templating(list=[{
+        "current": {
+          "tags": [],
+          "text": "default",
+          "value": "default"
+          },
+          "hide": 0,
+          "label": "Data Source",
+          "name": "datasource",
+          "options": [],
+          "query": "prometheus",
+          "refresh": 1,
+          "regex": "",
+          "type": "datasource"
+        },
+        {
+          "current": {},
+          "datasource": "$datasource",
+          "hide": 0,
+          "includeAll": True,
+          "multi": False,
+          "name": "rgw_servers",
+          "options": [],
+          "query": "label_values(ceph_rgw_req, ceph_daemon)",
+          "refresh": 1,
+          "regex": "",
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": False
+        }
+    ]),
+    annotations=Annotations(list=[{
+
+        "builtIn": 1,
+
+        "datasource": "-- Grafana --",
+
+        "enable": True,
+
+        "hide": True,
+
+        "iconColor": "rgba(0, 211, 255, 1)",
+
+        "name": "Annotations & Alerts",
+
+        "type": "dashboard"
+
+    }]),
+    panels=[
+        RowPanel(
+            title="RGW Host Detail : $rgw_servers",
+            gridPos=GridPos(h=1, w=24, x=0, y=0),
+            id=12
+        ),
+        Graph(
+            title="$rgw_servers GET/PUT Latencies",
+            tooltip=Tooltip(
+                shared=True,
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=34,
+            renderer="flot",
+            lineWidth=1,
+            gridPos=GridPos(h=8, w=6, x=0, y=1),
+            description='This chart shows the sum of read and write IOPS from all clients by pool',
+            targets=[
+                Target(
+                    expr='sum by (ceph_daemon) (rate(ceph_rgw_get_initial_lat_sum{ceph_daemon=~\"($rgw_servers)\"}[30s]) / rate(ceph_rgw_get_initial_lat_count{ceph_daemon=~\"($rgw_servers)\"}[30s]))',
+                    legendFormat="GET {{ceph_daemon}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='A',
+                ),
+                Target(
+                    expr='sum by (ceph_daemon)(rate(ceph_rgw_put_initial_lat_sum{ceph_daemon=~\"($rgw_servers)\"}[30s]) / rate(ceph_rgw_put_initial_lat_count{ceph_daemon=~\"($rgw_servers)\"}[30s]))',
+                    legendFormat="PUT {{ceph_daemon}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='B',
+                )
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='s',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+        Graph(
+            title="Bandwidth by HTTP Operation",
+            tooltip=Tooltip(
+                shared=True,
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=18,
+            renderer="flot",
+            lineWidth=1,
+            gridPos=GridPos(h=8, w=7, x=6, y=1),
+            description='This chart shows the sum of read and write IOPS from all clients by pool',
+            targets=[
+                Target(
+                    expr='rate(ceph_rgw_get_b{ceph_daemon=~\"$rgw_servers\"}[30s])',
+                    legendFormat="GETs {{ceph_daemon}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='B',
+                ),
+                Target(
+                    expr='rate(ceph_rgw_put_b{ceph_daemon=~\"$rgw_servers\"}[30s])',
+                    legendFormat="PUTs {{ceph_daemon}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='A',
+                ),
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='bytes',
+                    decimals=0,
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+        Graph(
+            aliasColors={
+                "GETs": "#7eb26d",
+                "Other": "#447ebc",
+                "PUTs": "#eab839",
+                "Requests": "#3f2b5b",
+                "Requests Failed": "#bf1b00"
+            },
+            title="HTTP Request Breakdown",
+            tooltip=Tooltip(
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=14,
+            seriesOverrides=SeriesOverride(
+                 alias= "reads",
+            ),
+            gridPos=GridPos(h=8, w=7, x=13, y=1),
+            targets=[
+                Target(
+                    expr='rate(ceph_rgw_failed_req{ceph_daemon=~\"$rgw_servers\"}[30s])',
+                    legendFormat="Requests Failed {{ceph_daemon}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='B',
+                ),
+                Target(
+                    expr='rate(ceph_rgw_get{ceph_daemon=~\"$rgw_servers\"}[30s])',
+                    legendFormat="GETs {{ceph_daemon}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='C',
+                ),
+                Target(
+                    expr='rate(ceph_rgw_put{ceph_daemon=~\"$rgw_servers\"}[30s])',
+                    legendFormat="PUTs {{ceph_daemon}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='D',
+                ),
+                Target(
+                    expr='rate(ceph_rgw_req{ceph_daemon=~\"$rgw_servers\"}[30s]) -\n  (rate(ceph_rgw_get{ceph_daemon=~\"$rgw_servers\"}[30s]) +\n   rate(ceph_rgw_put{ceph_daemon=~\"$rgw_servers\"}[30s]))',
+                    legendFormat="Other {{ceph_daemon}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='A',
+                )
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='short',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+        PieChart(
+            title="Workload Breakdown",
+            dataSource="$datasource",
+            id=23,
+            legendType="Under graph",
+            maxDataPoints=3,
+            pieType="pie",
+            gridPos=GridPos(h=8, w=4, x=20, y=1),
+            targets=[
+                Target(
+                    expr='rate(ceph_rgw_failed_req{ceph_daemon=~\"$rgw_servers\"}[30s])',
+                    legendFormat="Failures {{ceph_daemon}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='A',
+                ),
+                Target(
+                    expr='rate(ceph_rgw_get{ceph_daemon=~\"$rgw_servers\"}[30s])',
+                    legendFormat="GETs {{ceph_daemon}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='B',
+                ),
+                Target(
+                    expr='rate(ceph_rgw_put{ceph_daemon=~\"$rgw_servers\"}[30s])',
+                    legendFormat="PUTs {{ceph_daemon}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='C',
+                ),
+                Target(
+                    expr='rate(ceph_rgw_req{ceph_daemon=~\"$rgw_servers\"}[30s]) -\n  (rate(ceph_rgw_get{ceph_daemon=~\"$rgw_servers\"}[30s]) +\n   rate(ceph_rgw_put{ceph_daemon=~\"$rgw_servers\"}[30s]))',
+                    legendFormat="Other (DELETE,LIST) {{ceph_daemon}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='D',
+                )
+            ],
+        ),
+    ]
+)

--- a/monitoring/grafana/dashboards/radosgw-overview.py
+++ b/monitoring/grafana/dashboards/radosgw-overview.py
@@ -1,0 +1,291 @@
+from grafanalib.core import (
+    Annotations, Dashboard, Graph, GridPos, NULL_AS_NULL,
+    RowPanel, Templating, Tooltip, XAxis, Target, YAxes, YAxis,
+)
+
+dashboard = Dashboard(
+    title="RGW Overview",
+    refresh="15s",
+    schemaVersion=16,
+    uid="WAkugZpiz",
+    version=2,
+    templating=Templating(list=[{
+        "allValue": NULL_AS_NULL,
+          "current": {},
+          "datasource": "$datasource",
+          "hide": 2,
+          "includeAll": True,
+          "label": NULL_AS_NULL,
+          "multi": False,
+          "name": "rgw_servers",
+          "options": [],
+          "query": "label_values(ceph_rgw_req, ceph_daemon)",
+          "refresh": 1,
+          "regex": "",
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": False
+        },
+        {
+          "current": {
+          "tags": [],
+          "text": "default",
+          "value": "default"
+          },
+          "hide": 0,
+          "label": "Data Source",
+          "name": "datasource",
+          "options": [],
+          "query": "prometheus",
+          "refresh": 1,
+          "regex": "",
+          "type": "datasource"
+        }
+    ]),
+    annotations=Annotations(list=[{
+
+        "builtIn": 1,
+
+        "datasource": "-- Grafana --",
+
+        "enable": True,
+
+        "hide": True,
+
+        "iconColor": "rgba(0, 211, 255, 1)",
+
+        "name": "Annotations & Alerts",
+
+        "type": "dashboard"
+
+    }]),
+    panels=[
+        RowPanel(
+            title="RGW Overview - All Gateways",
+            gridPos=GridPos(h=1, w=24, x=0, y=0),
+            id=2
+        ),
+        Graph(
+            title="Average GET/PUT Latencies",
+            tooltip=Tooltip(
+                shared=True,
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=29,
+            renderer="flot",
+            lineWidth=1,
+            gridPos=GridPos(h=7, w=8, x=0, y=1),
+            description='This chart shows the sum of read and write IOPS from all clients by pool',
+            targets=[
+                Target(
+                    expr='rate(ceph_rgw_get_initial_lat_sum[30s]) / rate(ceph_rgw_get_initial_lat_count[30s])',
+                    legendFormat="GET AVG",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='A',
+                ),
+                Target(
+                    expr='rate(ceph_rgw_put_initial_lat_sum[30s]) / rate(ceph_rgw_put_initial_lat_count[30s])',
+                    legendFormat="PUT AVG",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='B',
+                )
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='s',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+        Graph(
+            title="Total Requests/sec by RGW Instance",
+            tooltip=Tooltip(
+                shared=True,
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=4,
+            renderer="flot",
+            lineWidth=1,
+            gridPos=GridPos(h=7, w=7, x=8, y=1),
+            description='This chart shows the sum of read and write IOPS from all clients by pool',
+            targets=[
+                Target(
+                    expr='sum by(rgw_host) (label_replace(rate(ceph_rgw_req[30s]), \"rgw_host\", \"$1\", \"ceph_daemon\", \"rgw.(.*)\"))',
+                    legendFormat="{{rgw_host}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='A',
+                ),
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='none',
+                    decimals=0,
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+        Graph(
+            title="GET Latencies by RGW Instance",
+            description="Latencies are shown stacked, without a yaxis to provide a visual indication of GET latency imbalance across RGW hosts",
+            tooltip=Tooltip(
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=31,
+            gridPos=GridPos(h=7, w=6, x=15, y=1),
+            targets=[
+                Target(
+                    expr='label_replace(rate(ceph_rgw_get_initial_lat_sum[30s]),\"rgw_host\",\"$1\",\"ceph_daemon\",\"rgw.(.*)\") / \nlabel_replace(rate(ceph_rgw_get_initial_lat_count[30s]),\"rgw_host\",\"$1\",\"ceph_daemon\",\"rgw.(.*)\")',
+                    legendFormat="{{rgw_host}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='A',
+                )
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='s',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+        Graph(
+            title="Bandwidth Consumed by Type",
+            description="Total bytes transferred in/out of all radosgw instances within the cluster",
+            tooltip=Tooltip(
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=6,
+            gridPos=GridPos(h=6, w=8, x=0, y=8),
+            targets=[
+                Target(
+                    expr='sum(rate(ceph_rgw_get_b[30s]))',
+                    legendFormat="GETs",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='A',
+                ),
+                Target(
+                    expr='sum(rate(ceph_rgw_put_b[30s]))',
+                    legendFormat="PUTs",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='B',
+                )
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='bytes',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+        Graph(
+            title="Bandwidth by RGW Instance",
+            description="Total bytes transferred in/out through get/put operations, by radosgw instance",
+            tooltip=Tooltip(
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=9,
+            gridPos=GridPos(h=6, w=7, x=8, y=8),
+            targets=[
+                Target(
+                    expr='sum by(rgw_host) (\n  (label_replace(rate(ceph_rgw_get_b[30s]), \"rgw_host\",\"$1\",\"ceph_daemon\",\"rgw.(.*)\")) + \n  (label_replace(rate(ceph_rgw_put_b[30s]), \"rgw_host\",\"$1\",\"ceph_daemon\",\"rgw.(.*)\"))\n)',
+                    legendFormat="{{rgw_host}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='A',
+                ),
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='bytes',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+        Graph(
+            title="PUT Latencies by RGW Instance",
+            description="Latencies are shown stacked, without a yaxis to provide a visual indication of PUT latency imbalance across RGW hosts",
+            tooltip=Tooltip(
+                sort=0,
+                valueType='individual'
+            ),
+            dataSource="$datasource",
+            id=32,
+            gridPos=GridPos(h=6, w=6, x=15, y=8),
+            targets=[
+                Target(
+                    expr='label_replace(rate(ceph_rgw_put_initial_lat_sum[30s]),\"rgw_host\",\"$1\",\"ceph_daemon\",\"rgw.(.*)\") / \nlabel_replace(rate(ceph_rgw_put_initial_lat_count[30s]),\"rgw_host\",\"$1\",\"ceph_daemon\",\"rgw.(.*)\")',
+                    legendFormat="{{rgw_host}}",
+                    format="time_Series",
+                    intervalFactor=1,
+                    refId='A',
+                ),
+            ],
+            yAxes=YAxes(
+                YAxis(
+                    format='s',
+                    logBase=1,
+                ),
+                YAxis(
+                    format='short',
+                    logBase=1
+                    )
+            ),
+            xAxis=XAxis(
+                mode="time",
+            )
+        ),
+    ]
+)


### PR DESCRIPTION
This PR intends to add grafanalib library to generate grafana JSON files through python files

Fixes: https://tracker.ceph.com/issues/45184
Signed-off-by: Aashish Sharma <aasharma@redhat.com>



<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
