### PR TITLE
rgw: fix list op raced with put op maybe cause index delete (copy + fix)

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2110,6 +2110,13 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         return -EINVAL;
       }
 
+      if (cur_disk.pending_map.size() == 0) {
+        /* if none stale pending_map left, should do nothing.
+         * this can avoid list op get inconsistent state when raced with another op
+         */
+        continue;
+      }
+
       real_time cur_time = real_clock::now();
       auto iter = cur_disk.pending_map.begin();
       while(iter != cur_disk.pending_map.end()) {


### PR DESCRIPTION
Like the issue http://tracker.ceph.com/issues/22555 , a special sequence can cause this new situation.

IO sequence:
1.put index prepare
2.list, get stale index
3.check_disk_state, find the head obj not exist
4.write head obj
5.index complete
6.aio_operate dir_suggest_changes CEPH_RGW_REMOVE

step 6 will delete the index

**NOTE: This is a copy of https://github.com/ceph/ceph/pull/28654 (which I closed) with one additional commit, so the tests compile and pass.**

**Primary credit goes to Tianshan Qu <tianshan@xsky.com>.**

Fixes: http://tracker.ceph.com/issues/24744