### PR TITLE
deps: use Python 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,9 +467,9 @@ endif (WITH_RADOSGW)
 option(WITH_CEPHFS "CephFS is enabled" ON)
 
 if(NOT WIN32)
-# Please specify 3.[0-7] if you want to build with a certain version of python3.
-set(WITH_PYTHON3 "3" CACHE STRING "build with specified python3 version")
-if(NOT WITH_PYTHON3 STREQUAL "3")
+# Please specify 3.[0-8] if you want to build with a certain version of python3.
+set(WITH_PYTHON3 "3.8" CACHE STRING "build with specified python3 version")
+if(NOT WITH_PYTHON3 STREQUAL "3.8")
   set(find_python3_exact "EXACT")
 endif()
 find_package(Python3 ${WITH_PYTHON3} ${find_python3_exact} REQUIRED

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -113,9 +113,10 @@
 
 %{!?_udevrulesdir: %global _udevrulesdir /lib/udev/rules.d}
 %{!?tmpfiles_create: %global tmpfiles_create systemd-tmpfiles --create}
+
 %{!?python3_pkgversion: %global python3_pkgversion 3}
-%{!?python3_version_nodots: %global python3_version_nodots 3}
-%{!?python3_version: %global python3_version 3}
+%{!?python3_version_nodots: %global python3_version_nodots 38}
+%{!?python3_version: %global python3_version 3.8}
 
 # disable dwz which compresses the debuginfo
 %global _find_debuginfo_dwz_opts %{nil}
@@ -212,6 +213,7 @@ BuildRequires:	cryptsetup-devel
 BuildRequires:	libcurl-devel
 BuildRequires:	libcap-ng-devel
 BuildRequires:	fmt-devel >= 6.2.1
+BuildRequires:  git
 BuildRequires:	pkgconfig(libudev)
 BuildRequires:	libnl3-devel
 BuildRequires:	liboath-devel
@@ -225,10 +227,10 @@ BuildRequires:	patch
 BuildRequires:	perl
 BuildRequires:	pkgconfig
 BuildRequires:  procps
-BuildRequires:	python%{python3_pkgversion}
-BuildRequires:	python%{python3_pkgversion}-devel
-BuildRequires:	python%{python3_pkgversion}-setuptools
-BuildRequires:	python%{python3_pkgversion}-Cython
+BuildRequires:	python%{python3_version_nodots}
+BuildRequires:	python%{python3_version_nodots}-devel
+BuildRequires:	python%{python3_version_nodots}-setuptools
+BuildRequires:	python%{python3_version_nodots}-Cython
 BuildRequires:	snappy-devel
 BuildRequires:	sqlite-devel
 BuildRequires:	sudo
@@ -344,7 +346,6 @@ BuildRequires:  openldap-devel
 BuildRequires:  openssl-devel
 BuildRequires:  CUnit-devel
 BuildRequires:  redhat-lsb-core
-BuildRequires:	python%{python3_pkgversion}-devel
 BuildRequires:	python%{python3_pkgversion}-prettytable
 BuildRequires:	python%{python3_pkgversion}-pyyaml
 BuildRequires:	python%{python3_pkgversion}-sphinx
@@ -450,7 +451,7 @@ Requires:      grep
 Requires:      logrotate
 Requires:      parted
 Requires:      psmisc
-Requires:      python%{python3_pkgversion}-setuptools
+Requires:      python%{python3_version_nodots}-setuptools
 Requires:      util-linux
 Requires:      xfsprogs
 Requires:      which
@@ -555,7 +556,7 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-base = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-mgr-modules-core = %{_epoch_prefix}%{version}-%{release}
-Requires:	    libcephsqlite = %{_epoch_prefix}%{version}-%{release}
+Requires:       libcephsqlite = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?weak_deps}
 Recommends:	ceph-mgr-dashboard = %{_epoch_prefix}%{version}-%{release}
 Recommends:	ceph-mgr-diskprediction-local = %{_epoch_prefix}%{version}-%{release}
@@ -575,6 +576,7 @@ BuildArch:      noarch
 %if 0%{?suse_version}
 Group:          System/Filesystems
 %endif
+Requires:       python%{python3_version_nodots}
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-grafana-dashboards = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-prometheus-alerts = %{_epoch_prefix}%{version}-%{release}

--- a/debian/control
+++ b/debian/control
@@ -84,7 +84,8 @@ Build-Depends: automake,
                pkg-config,
                prometheus <pkg.ceph.check>,
                protobuf-compiler <pkg.ceph.crimson>,
-               python3-all-dev,
+               python3.8,
+               python3.8-dev,
                python3-cherrypy3,
                python3-jwt <pkg.ceph.check>,
                python3-nose <pkg.ceph.check>,
@@ -1032,7 +1033,7 @@ Description: Meta-package for python libraries for the Ceph libraries
  storage system that runs on commodity hardware and delivers object,
  block and file system storage.
  .
- This package is a metapackage for all Python 2 bindings.
+ This package is a metapackage for all Python 3 bindings.
 
 Package: python3-rados
 Architecture: linux-any

--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -34,11 +34,11 @@ if [ -r /etc/os-release ]; then
           if [ "$MAJOR_VER" -ge "9" ] ; then
               PYBUILD="3.9"
           elif [ "$MAJOR_VER" -ge "8" ] ; then
-              PYBUILD="3.6"
+              PYBUILD="3.8"
           fi
           ;;
       opensuse*|suse|sles)
-          PYBUILD="3"
+          PYBUILD="3.8"
           ARGS+=" -DWITH_RADOSGW_AMQP_ENDPOINT=OFF"
           ARGS+=" -DWITH_RADOSGW_KAFKA_ENDPOINT=OFF"
           ;;

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -387,7 +387,6 @@ else
         esac
         munge_ceph_spec_in $with_seastar $with_zbd $for_make_check $DIR/ceph.spec
         # for python3_pkgversion macro defined by python-srpm-macros, which is required by python3-devel
-        $SUDO dnf install -y python3-devel
         $SUDO $builddepcmd $DIR/ceph.spec 2>&1 | tee $DIR/yum-builddep.out
         [ ${PIPESTATUS[0]} -ne 0 ] && exit 1
         IGNORE_YUM_BUILDEP_ERRORS="ValueError: SELinux policy is not managed or store cannot be accessed."
@@ -477,5 +476,4 @@ if $for_make_check; then
     done
     rm -rf $top_srcdir/install-deps-python3
     rm -rf $XDG_CACHE_HOME
-    type git > /dev/null || (echo "Dashboard uses git to pull dependencies." ; false)
 fi


### PR DESCRIPTION
Reasons:
* Making dependencies on Python minor version numbers explicit ([PEP-20](https://www.python.org/dev/peps/pep-0020/): explicit is better than implicit): Ceph packages don't explicitly require a minor Python version, but they actually rely on 3.6 features (f-strings just to name one).
* Python 3.6 reaches End of Life this Dec '21 (3.8 EoL is [Oct '24](https://www.python.org/dev/peps/pep-0569/)).
* Python 3.8 provides new features that might help write more efficient and solid code:
  * Improved `typing` support
  * `dataclasses`
  * `async`
  * An `statistics` package
  * And other features [[1]](https://docs.python.org/3/whatsnew/3.8.html) [[2]](https://docs.python.org/3/whatsnew/3.7.html)
* Performance-wise: Python 3.7/3.8 brought [dramatic performance improvements](https://speed.python.org/comparison/?exe=12%2BL%2B3.6%2C12%2BL%2B3.8%2C12%2BL%2B3.9%2C12%2BL%2Bmaster&ben=616%2C617%2C618%2C619%2C620%2C621%2C622%2C623%2C624%2C625%2C626%2C627%2C628%2C629%2C630%2C631%2C632%2C680%2C633%2C634%2C635%2C636%2C637%2C638%2C639%2C640%2C641%2C642%2C643%2C644%2C645%2C646%2C647%2C648%2C681%2C649%2C650%2C651%2C652%2C653%2C654%2C655%2C656%2C657%2C658%2C659%2C660%2C661%2C682%2C662%2C663%2C664%2C665%2C666%2C667%2C669%2C668%2C670%2C671%2C672%2C673%2C674%2C675%2C678%2C677%2C676%2C679&env=1%2C2&hor=true&bas=none&chart=stacked+bars):
![image](https://user-images.githubusercontent.com/37327689/123262130-d629b400-d4f7-11eb-8220-5a86ed0deb91.png)


Other changes:
* ceph.spec.in: use `python3_version` and `python3_version_nodots` [Fedora/EPEL RPM macros](https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_macros). Added custom `python3_version_major`.

Check distro support:
- [x] CentOS 8
- [x] Ubuntu >20.04
- [x] OpenSUSE Leap 15.3


Fixes: https://tracker.ceph.com/issues/51319
Fixes: https://tracker.ceph.com/issues/56945
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
