### PR TITLE
pacific: crush/crush: ensure alignof(crush_work_bucket) is 1

### DIFF
--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -540,7 +540,7 @@ struct crush_work_bucket {
 	__u32 perm_x; /* @x for which *perm is defined */
 	__u32 perm_n; /* num elements of *perm that are permuted/defined */
 	__u32 *perm;  /* Permutation of the bucket's items */
-};
+} __attribute__ ((packed));
 
 struct crush_work {
 	struct crush_work_bucket **work; /* Per-bucket working store */


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50986

---

backport of https://github.com/ceph/ceph/pull/41546
parent tracker: https://tracker.ceph.com/issues/50978

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh