### PR TITLE
crimson/os/alienstore: cleanups of ThreadPool

### DIFF
--- a/src/crimson/os/alienstore/thread_pool.h
+++ b/src/crimson/os/alienstore/thread_pool.h
@@ -90,8 +90,10 @@ public:
     return work_item;
   }
   void stop() {
-    std::unique_lock lock{mutex};
-    stopping = true;
+    {
+      std::unique_lock lock{mutex};
+      stopping = true;
+    }
     cond.notify_all();
   }
   void push_back(WorkItem* work_item) {

--- a/src/crimson/os/alienstore/thread_pool.h
+++ b/src/crimson/os/alienstore/thread_pool.h
@@ -26,8 +26,8 @@ struct Task final : WorkItem {
   using T = std::invoke_result_t<Func>;
   using future_stored_type_t =
     std::conditional_t<std::is_void_v<T>,
-		       seastar::internal::future_stored_type_t<>,
-		       seastar::internal::future_stored_type_t<T>>;
+                       seastar::internal::future_stored_type_t<>,
+                       seastar::internal::future_stored_type_t<T>>;
   using futurator_t = seastar::futurize<T>;
 public:
   explicit Task(Func&& f)
@@ -49,9 +49,9 @@ public:
   typename futurator_t::type get_future() {
     return on_done.wait().then([this](size_t) {
       if (state.failed()) {
-	return futurator_t::make_exception_future(state.get_exception());
+        return futurator_t::make_exception_future(state.get_exception());
       } else {
-	return futurator_t::from_tuple(state.get_value());
+        return futurator_t::from_tuple(state.get_value());
       }
     });
   }
@@ -77,8 +77,7 @@ public:
   WorkItem* pop_front(std::chrono::milliseconds& queue_max_wait) {
     WorkItem* work_item = nullptr;
     std::unique_lock lock{mutex};
-    cond.wait_for(lock, queue_max_wait,
-		  [this, &work_item] {
+    cond.wait_for(lock, queue_max_wait, [this, &work_item] {
       bool empty = true;
       if (!pending.empty()) {
         empty = false;
@@ -162,7 +161,7 @@ public:
           .then([packaged=std::move(packaged), shard, this] {
             auto task = new Task{std::move(packaged)};
             auto fut = task->get_future();
-	    pending_queues[shard].push_back(task);
+            pending_queues[shard].push_back(task);
             return fut.finally([task, this] {
               local_free_slots().signal();
               delete task;
@@ -173,8 +172,7 @@ public:
 
   template<typename Func>
   auto submit(Func&& func) {
-    return submit(::rand() % n_threads,
-		  std::forward<Func>(func));
+    return submit(::rand() % n_threads, std::forward<Func>(func));
   }
 };
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
