### PR TITLE
pacific: mgr/dashboard: Alertmanager fails to POST alerts

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/prometheus.py
+++ b/src/pybind/mgr/dashboard/controllers/prometheus.py
@@ -19,7 +19,7 @@ class PrometheusReceiver(BaseController):
     """
     notifications = []
 
-    @Endpoint('POST', path='/')
+    @Endpoint('POST', path='/', version=None)
     def fetch_alert(self, **notification):
         notification['notified'] = datetime.now().isoformat()
         notification['id'] = str(len(self.notifications))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51326

---

backport of https://github.com/ceph/ceph/pull/41974
parent tracker: https://tracker.ceph.com/issues/51312

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh