### PR TITLE
doc/cephadm: enrich "deployment of daemons"

### DIFF
--- a/doc/cephadm/service-management.rst
+++ b/doc/cephadm/service-management.rst
@@ -316,22 +316,25 @@ Cephadm uses a declarative state to define the layout of the cluster. This
 state consists of a list of service specifications containing placement
 specifications (See :ref:`orchestrator-cli-service-spec` ). 
 
-Cephadm constantly compares list of actually running daemons in the cluster
-with the desired service specifications and will either add or remove new 
-daemons.
+Cephadm continually compares a list of daemons actually running in the cluster
+against the list in the service specifications. Cephadm adds new daemons and
+removes old daemons as necessary in order to conform to the service
+specifications.
 
-First, cephadm will select a list of candidate hosts. It first looks for 
-explicit host names and will select those. In case there are no explicit hosts 
-defined, cephadm looks for a label specification. If there is no label defined 
-in the specification, cephadm will select hosts based on a host pattern. If 
-there is no pattern defined, cepham will finally select all known hosts as
-candidates.
+Cephadm does the following to maintain compliance with the service
+specifications.
 
-Then, cephadm will consider existing daemons of this services and will try to
-avoid moving any daemons.
+Cephadm first selects a list of candidate hosts. Cephadm seeks explicit host
+names and selects them. If cephadm finds no explicit host names, it looks for
+label specifications. If no label is defined in the specification, cephadm
+selects hosts based on a host pattern. If no host pattern is defined, as a last
+resort, cephadm selects all known hosts as candidates.
 
-Cephadm supports the deployment of a specific amount of services. Let's 
-consider a service specification like so:
+Cephadm is aware of existing daemons running services and tries to avoid moving
+them.
+
+Cephadm supports the deployment of a specific amount of services.
+Consider the following service specification:
 
 .. code-block:: yaml
 
@@ -341,22 +344,24 @@ consider a service specification like so:
       count: 3
       label: myfs
 
-This instructs cephadm to deploy three daemons on hosts labeled with
-``myfs`` across the cluster.
+This service specifcation instructs cephadm to deploy three daemons on hosts
+labeled ``myfs`` across the cluster.
 
-Then, in case there are less than three daemons deployed on the candidate 
-hosts, cephadm will then randomly choose hosts for deploying new daemons.
+If there are fewer than three daemons deployed on the candidate hosts, cephadm
+randomly chooses hosts on which to deploy new daemons.
 
-In case there are more than three daemons deployed, cephadm will remove 
-existing daemons.
+If there are more than three daemons deployed on the candidate hosts, cephadm
+removes existing daemons.
 
-Finally, cephadm will remove daemons on hosts that are outside of the list of 
+Finally, cephadm removes daemons on hosts that are outside of the list of
 candidate hosts.
 
-However, there is a special cases that cephadm needs to consider.
+.. note::
+    
+   There is a special case that cephadm must consider.
 
-In case the are fewer hosts selected by the placement specification than 
-demanded by ``count``, cephadm will only deploy on selected hosts.
+   If there are fewer hosts selected by the placement specification than 
+   demanded by ``count``, cephadm will deploy only on the selected hosts.
 
 
 .. _cephadm-spec-unmanaged:


### PR DESCRIPTION
service-management.rst contained a section called
"Deployment of Daemons" that needed a rewrite by
a native English speaker.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
