### PR TITLE
osd/scrub: replace a ceph_assert() with a test

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1330,8 +1330,11 @@ bool PG::sched_scrub()
 	  << (is_active() ? ") <active>" : ") <not-active>")
 	  << (is_clean() ? " <clean>" : " <not-clean>") << dendl;
   ceph_assert(ceph_mutex_is_locked(_lock));
-  ceph_assert(!is_scrubbing());
 
+  if (m_scrubber && m_scrubber->is_scrub_active()) {
+    return false;
+  }
+  
   if (!is_primary() || !is_active() || !is_clean()) {
     return false;
   }


### PR DESCRIPTION
We are using two distinct conditions to decide whether a candidate PG is already being scrubbed. The OSD
checks pgs_scrub_active(), while the PG asserts on the value of PG_STATE_FLAG.
There is a time window when PG_STATE_FLAG is set but is_scrub_active() wasn't yet set. is_reserving()
covers most of that period, but the ceph_assert is just before the is_reserving check.

fixes: https://tracker.ceph.com/issues/50346

