### PR TITLE
ceph.spec.in, debian/rules: enable rbd-rwl-cache by default only on x86_64

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -31,13 +31,13 @@
 %endif
 %bcond_with system_pmdk
 %bcond_without rbd_ssd_cache
-%if 0%{?fedora} || 0%{?rhel}
-%bcond_without selinux
-%ifarch x86_64 ppc64le
+%ifarch x86_64
 %bcond_without rbd_rwl_cache
 %else
 %bcond_with rbd_rwl_cache
 %endif
+%if 0%{?fedora} || 0%{?rhel}
+%bcond_without selinux
 %if 0%{?rhel} >= 8
 %bcond_with cephfs_java
 %else
@@ -59,10 +59,8 @@
 %bcond_with libradosstriper
 %ifarch x86_64 aarch64 ppc64le
 %bcond_without lttng
-%bcond_without rbd_rwl_cache
 %else
 %bcond_with lttng
-%bcond_with rbd_rwl_cache
 %endif
 %bcond_with ocf
 %bcond_with selinux

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -30,14 +30,13 @@
 %bcond_without tcmalloc
 %endif
 %bcond_with system_pmdk
+%bcond_without rbd_ssd_cache
 %if 0%{?fedora} || 0%{?rhel}
 %bcond_without selinux
 %ifarch x86_64 ppc64le
 %bcond_without rbd_rwl_cache
-%bcond_without rbd_ssd_cache
 %else
 %bcond_with rbd_rwl_cache
-%bcond_with rbd_ssd_cache
 %endif
 %if 0%{?rhel} >= 8
 %bcond_with cephfs_java
@@ -61,11 +60,9 @@
 %ifarch x86_64 aarch64 ppc64le
 %bcond_without lttng
 %bcond_without rbd_rwl_cache
-%bcond_without rbd_ssd_cache
 %else
 %bcond_with lttng
 %bcond_with rbd_rwl_cache
-%bcond_with rbd_ssd_cache
 %endif
 %bcond_with ocf
 %bcond_with selinux

--- a/debian/rules
+++ b/debian/rules
@@ -24,7 +24,11 @@ extraopts += -DWITH_CEPHFS_JAVA=ON
 extraopts += -DWITH_CEPHFS_SHELL=ON
 extraopts += -DWITH_SYSTEMD=ON -DCEPH_SYSTEMD_ENV_DIR=/etc/default
 extraopts += -DWITH_GRAFANA=ON
-extraopts += -DWITH_RBD_RWL=ON
+ifeq ($(DEB_HOST_ARCH), amd64)
+  extraopts += -DWITH_RBD_RWL=ON
+else
+  extraopts += -DWITH_RBD_RWL=OFF
+endif
 extraopts += -DWITH_RBD_SSD_CACHE=ON
 # assumes that ceph is exmpt from multiarch support, so we override the libdir.
 extraopts += -DCMAKE_INSTALL_LIBDIR=/usr/lib


### PR DESCRIPTION
set rwl cache option on arm64 as PMDK is not well supported


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
Currently, PMDK is not well supported on Arm64. The PMDK make check can not pass, and librpmem(remote persist memory lib) is not enabled on Arm64.
So in Ceph we can make it optional and wait for PMDK changes on Arm64

Tracker Link: https://tracker.ceph.com/issues/51339

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
