### PR TITLE
common/armor: mark dst_end a const pointer

### DIFF
--- a/src/common/armor.c
+++ b/src/common/armor.c
@@ -45,7 +45,7 @@ static int set_str_val(char **pdst, const char *end, char c)
 	return 0;
 }
 
-int ceph_armor_line_break(char *dst, const char *dst_end, const char *src, const char *end, int line_width)
+int ceph_armor_line_break(char *dst, char * const dst_end, const char *src, const char *end, int line_width)
 {
 	int olen = 0;
 	int line = 0;
@@ -91,12 +91,12 @@ int ceph_armor_line_break(char *dst, const char *dst_end, const char *src, const
 	return olen;
 }
 
-int ceph_armor(char *dst, const char *dst_end, const char *src, const char *end)
+int ceph_armor(char *dst, char * const dst_end, const char *src, const char *end)
 {
 	return ceph_armor_line_break(dst, dst_end, src, end, 0);
 }
 
-int ceph_unarmor(char *dst, const char *dst_end, const char *src, const char *end)
+int ceph_unarmor(char *dst, char * const dst_end, const char *src, const char *end)
 {
 	int olen = 0;
 

--- a/src/common/armor.h
+++ b/src/common/armor.h
@@ -5,14 +5,14 @@
 extern "C" {
 #endif
 
-int ceph_armor(char *dst, const char *dst_end,
-	       const char *src, const char *end);
+int ceph_armor(char *dst, char * const dst_end,
+	       const char * src, const char *end);
 
-int ceph_armor_linebreak(char *dst, const char *dst_end,
+int ceph_armor_linebreak(char *dst, char * const dst_end,
 	       const char *src, const char *end,
 	       int line_width);
-int ceph_unarmor(char *dst, const char *dst_end,
-		 const char *src, const char *end);
+int ceph_unarmor(char *dst, char * const dst_end,
+		 const char *src, const char * const end);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
to silence GCC-11 warnings like:

../src/common/secret.c: In function ‘set_kernel_secret’:
../src/common/secret.c:65:9: warning: ‘<unknown>’ may be used uninitialized [-Wmaybe-uninitialized]
   65 |   ret = ceph_unarmor(payload, payload+sizeof(payload), secret, secret+secret_len);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../src/common/secret.c:23:
../src/common/armor.h:14:5: note: by argument 2 of type ‘const char *’ to ‘ceph_unarmor’ declared here
   14 | int ceph_unarmor(char *dst, const char *dst_end,
      |     ^~~~~~~~~~~~

see also https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100417

this warning is false positive. but it's still annoying.

since semantically, we are changing the dst buffer, and the dst_end
specify the non-inclusive upper bound of the output buffer, this
change is not quite wrong by changing the type of this pointer
from a pointer to a const char to a constant pointer to a (mutable) char.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
