### PR TITLE
crimson/onode-staged-tree: fix ref-counter assert failures

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -1801,7 +1801,7 @@ LeafNode::erase(context_t c, const search_position_t& pos, bool get_next)
       return eagain_ertr::make_ready_future<Ref<tree_cursor_t>>();
     }
   }).safe_then([c, &pos, this_ref = std::move(this_ref),
-                this, FNAME] (Ref<tree_cursor_t> next_cursor) {
+                this, FNAME] (Ref<tree_cursor_t> next_cursor) mutable {
     if (next_cursor && next_cursor->is_end()) {
       // reset the node reference from the end cursor
       next_cursor.reset();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -336,7 +336,7 @@ class Node
    * - If false, the returned cursor points to the conflicting element in tree;
    */
   eagain_future<std::pair<Ref<tree_cursor_t>, bool>> insert(
-      context_t, const key_hobj_t&, value_config_t);
+      context_t, const key_hobj_t&, value_config_t, Ref<Node>&&);
 
   /**
    * erase
@@ -345,7 +345,7 @@ class Node
    *
    * Returns the number of erased key-value pairs (0 or 1).
    */
-  eagain_future<std::size_t> erase(context_t, const key_hobj_t&);
+  eagain_future<std::size_t> erase(context_t, const key_hobj_t&, Ref<Node>&&);
 
   /// Recursively collects the statistics of the sub-tree formed by this node
   eagain_future<tree_stats_t> get_tree_stats(context_t);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
@@ -268,7 +268,7 @@ class Btree {
       [this, &t, vconf](auto& key) -> eagain_future<std::pair<Cursor, bool>> {
         ceph_assert(key.is_valid());
         return get_root(t).safe_then([this, &t, &key, vconf](auto root) {
-          return root->insert(get_context(t), key, vconf);
+          return root->insert(get_context(t), key, vconf, std::move(root));
         }).safe_then([this](auto ret) {
           auto& [cursor, success] = ret;
           return std::make_pair(Cursor(this, cursor), success);
@@ -282,7 +282,7 @@ class Btree {
       full_key_t<KeyT::HOBJ>(obj),
       [this, &t](auto& key) -> eagain_future<std::size_t> {
         return get_root(t).safe_then([this, &t, &key](auto root) {
-          return root->erase(get_context(t), key);
+          return root->erase(get_context(t), key, std::move(root));
         });
       }
     );


### PR DESCRIPTION
Root-caused and fixed issues related to lambda functions and their resource managements.
These should fail our make check, but somehow hidden by the "Debug" build.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
