### PR TITLE
test/librbd: use really invalid domain

### DIFF
--- a/src/test/librbd/migration/test_mock_HttpClient.cc
+++ b/src/test/librbd/migration/test_mock_HttpClient.cc
@@ -341,7 +341,7 @@ TEST_F(TestMockMigrationHttpClient, OpenInvalidUrl) {
 
 TEST_F(TestMockMigrationHttpClient, OpenResolveFail) {
   MockTestImageCtx mock_test_image_ctx(*m_image_ctx);
-  MockHttpClient http_client(&mock_test_image_ctx, "http://invalid.ceph.com");
+  MockHttpClient http_client(&mock_test_image_ctx, "http://foo.example");
 
   C_SaferCond ctx;
   http_client.open(&ctx);


### PR DESCRIPTION
in TestMockMigrationHttpClient.OpenResolveFail

"dne.invalid" seems to be a good choice as according to rfc2606:

  ".invalid" is intended for use in online construction of domain
  names that are sure to be invalid and which it is obvious at a
  glance are invalid.

[1] https://datatracker.ietf.org/doc/html/rfc2606#section-2

Fixes: https://tracker.ceph.com/issues/51342

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
