### PR TITLE
pacific: test/librbd: use really invalid domain

### DIFF
--- a/src/test/librbd/migration/test_mock_HttpClient.cc
+++ b/src/test/librbd/migration/test_mock_HttpClient.cc
@@ -341,7 +341,7 @@ TEST_F(TestMockMigrationHttpClient, OpenInvalidUrl) {
 
 TEST_F(TestMockMigrationHttpClient, OpenResolveFail) {
   MockTestImageCtx mock_test_image_ctx(*m_image_ctx);
-  MockHttpClient http_client(&mock_test_image_ctx, "http://invalid.ceph.com");
+  MockHttpClient http_client(&mock_test_image_ctx, "http://foo.example");
 
   C_SaferCond ctx;
   http_client.open(&ctx);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51345

---

backport of https://github.com/ceph/ceph/pull/42005
parent tracker: https://tracker.ceph.com/issues/51342

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh