### PR TITLE
rgw/notifications: support v4 auth for topics and notifications

### DIFF
--- a/examples/boto3/README.md
+++ b/examples/boto3/README.md
@@ -14,11 +14,6 @@ The standard [AWS CLI](https://docs.aws.amazon.com/cli/latest/) may also be used
 aws --endpoint-url http://localhost:8000 s3api list-objects --bucket=mybucket --allow-unordered
 ```
 
-- Use the following command to set SNS signature to s3v2:
-```
-aws configure set default.sns.signature_version s3
-```
-
 - Topic creation with endpoint:
 ```
 aws --endpoint-url http://localhost:8000 sns create-topic --name=mytopic --attributes='{"push-endpoint": "amqp://localhost:5672", "amqp-exchange": "ex1", "amqp-ack-level": "broker"}'

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5372,7 +5372,11 @@ AWSGeneralAbstractor::get_auth_data_v4(const req_state* const s,
       s->op_type == RGW_OP_CREATE_OIDC_PROVIDER ||
       s->op_type == RGW_OP_DELETE_OIDC_PROVIDER ||
       s->op_type == RGW_OP_GET_OIDC_PROVIDER ||
-      s->op_type == RGW_OP_LIST_OIDC_PROVIDERS) {
+      s->op_type == RGW_OP_LIST_OIDC_PROVIDERS ||
+      s->op_type == RGW_OP_PUBSUB_TOPIC_CREATE ||
+      s->op_type == RGW_OP_PUBSUB_TOPICS_LIST ||
+      s->op_type == RGW_OP_PUBSUB_TOPIC_GET ||
+      s->op_type == RGW_OP_PUBSUB_TOPIC_DELETE) {
     is_non_s3_op = true;
   }
 
@@ -5473,6 +5477,8 @@ AWSGeneralAbstractor::get_auth_data_v4(const req_state* const s,
         case RGW_OP_PUT_LC:
         case RGW_OP_SET_REQUEST_PAYMENT:
         case RGW_OP_PUBSUB_NOTIF_CREATE:
+        case RGW_OP_PUBSUB_NOTIF_DELETE:
+        case RGW_OP_PUBSUB_NOTIF_LIST:
         case RGW_OP_PUT_BUCKET_OBJ_LOCK:
         case RGW_OP_PUT_OBJ_RETENTION:
         case RGW_OP_PUT_OBJ_LEGAL_HOLD:

--- a/src/test/rgw/bucket_notification/api.py
+++ b/src/test/rgw/bucket_notification/api.py
@@ -19,8 +19,7 @@ def put_object_tagging(conn, bucket_name, key, tags):
     client = boto3.client('s3',
             endpoint_url='http://'+conn.host+':'+str(conn.port),
             aws_access_key_id=conn.aws_access_key_id,
-            aws_secret_access_key=conn.aws_secret_access_key,
-            config=Config(signature_version='s3'))
+            aws_secret_access_key=conn.aws_secret_access_key)
     return client.put_object(Body='aaaaaaaaaaa', Bucket=bucket_name, Key=key, Tagging=tags)
 
 def make_request(conn, method, resource, parameters=None, sign_parameters=False, extra_parameters=None):
@@ -64,8 +63,7 @@ def delete_all_s3_topics(zone, region):
                 aws_access_key_id=conn.aws_access_key_id,
                 aws_secret_access_key=conn.aws_secret_access_key,
                 region_name=region,
-                verify='./cert.pem',
-                config=Config(signature_version='s3'))
+                verify='./cert.pem')
 
         topics = client.list_topics()['Topics']
         for topic in topics:
@@ -111,8 +109,7 @@ class PSTopicS3:
                            aws_access_key_id=conn.aws_access_key_id,
                            aws_secret_access_key=conn.aws_secret_access_key,
                            region_name=region,
-                           verify='./cert.pem',
-                           config=Config(signature_version='s3'))
+                           verify='./cert.pem')
 
     def get_config(self):
         """get topic info"""
@@ -201,8 +198,7 @@ class PSNotificationS3:
         self.client = boto3.client('s3',
                                    endpoint_url='http://'+conn.host+':'+str(conn.port),
                                    aws_access_key_id=conn.aws_access_key_id,
-                                   aws_secret_access_key=conn.aws_secret_access_key,
-                                   config=Config(signature_version='s3'))
+                                   aws_secret_access_key=conn.aws_secret_access_key)
 
     def send_request(self, method, parameters=None):
         """send request to radosgw"""


### PR DESCRIPTION

Fixes: https://tracker.ceph.com/issues/50039

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
