### PR TITLE
mon/LogMonitor: store log entries more efficiently

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -618,7 +618,6 @@ int main(int argc, const char **argv)
 
   // set up signal handlers, now that we've daemonized/forked.
   init_async_signal_handler();
-  register_async_signal_handler(SIGHUP, sighup_handler);
 
   MonitorDBStore *store = new MonitorDBStore(g_conf()->mon_data);
 
@@ -913,6 +912,7 @@ int main(int argc, const char **argv)
 
   register_async_signal_handler_oneshot(SIGINT, handle_mon_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_mon_signal);
+  register_async_signal_handler(SIGHUP, handle_mon_signal);
 
   if (g_conf()->inject_early_sigterm)
     kill(getpid(), SIGTERM);
@@ -922,7 +922,7 @@ int main(int argc, const char **argv)
 
   store->close();
 
-  unregister_async_signal_handler(SIGHUP, sighup_handler);
+  unregister_async_signal_handler(SIGHUP, handle_mon_signal);
   unregister_async_signal_handler(SIGINT, handle_mon_signal);
   unregister_async_signal_handler(SIGTERM, handle_mon_signal);
   shutdown_async_signal_handler();

--- a/src/common/LRUSet.h
+++ b/src/common/LRUSet.h
@@ -1,0 +1,145 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <functional>
+#include <boost/intrusive/list.hpp>
+#include <boost/intrusive/unordered_set.hpp>
+#include "include/encoding.h"
+
+/// Combination of an LRU with fast hash-based membership lookup
+template<class T, int NUM_BUCKETS=128>
+class LRUSet {
+  /// internal node
+  struct Node
+    : boost::intrusive::unordered_set_base_hook<> {
+    // actual payload
+    T value;
+
+    // for the lru
+    boost::intrusive::list_member_hook<> lru_item;
+
+    Node(const T& v) : value(v) {}
+
+    friend std::size_t hash_value(const Node &node) {
+      return std::hash<T>{}(node.value);
+    }
+    friend bool operator<(const Node &a, const Node &b) {
+      return a.value < b.value;
+    }
+    friend bool operator>(const Node &a, const Node &b) {
+      return a.value > b.value;
+    }
+    friend bool operator==(const Node &a, const Node &b) {
+      return a.value == b.value;
+    }
+  };
+
+  struct NodeDeleteDisposer {
+    void operator()(Node *n) { delete n; }
+  };
+
+  // lru
+  boost::intrusive::list<
+    Node,
+    boost::intrusive::member_hook<Node,
+				  boost::intrusive::list_member_hook<>,
+				  &Node::lru_item>
+    > lru;
+
+  // hash-based set
+  typename boost::intrusive::unordered_set<Node>::bucket_type base_buckets[NUM_BUCKETS];
+  boost::intrusive::unordered_set<Node> set;
+
+ public:
+  LRUSet()
+    : set(typename boost::intrusive::unordered_set<Node>::bucket_traits(base_buckets,
+									NUM_BUCKETS))
+    {}
+  ~LRUSet() {
+    clear();
+  }
+
+  LRUSet(const LRUSet& other)
+    : set(typename boost::intrusive::unordered_set<Node>::bucket_traits(base_buckets,
+									NUM_BUCKETS)) {
+    for (auto & i : other.lru) {
+      insert(i.value);
+    }
+  }
+  const LRUSet& operator=(const LRUSet& other) {
+    clear();
+    for (auto& i : other.lru) {
+      insert(i.value);
+    }
+    return *this;
+  }
+
+  size_t size() const {
+    return set.size();
+  }
+
+  bool empty() const {
+    return set.empty();
+  }
+
+  bool contains(const T& item) const {
+    return set.count(item) > 0;
+  }
+
+  void clear() {
+    prune(0);
+  }
+
+  void insert(const T& item) {
+    erase(item);
+    Node *n = new Node(item);
+    lru.push_back(*n);
+    set.insert(*n);
+  }
+
+  bool erase(const T& item) {
+    auto p = set.find(item);
+    if (p == set.end()) {
+      return false;
+    }
+    lru.erase(lru.iterator_to(*p));
+    set.erase_and_dispose(p, NodeDeleteDisposer());
+    return true;
+  }
+
+  void prune(size_t max) {
+    while (set.size() > max) {
+      auto p = lru.begin();
+      set.erase(*p);
+      lru.erase_and_dispose(p, NodeDeleteDisposer());
+    }
+  }
+
+  void encode(bufferlist& bl) const {
+    using ceph::encode;
+    ENCODE_START(1, 1, bl);
+    uint32_t n = set.size();
+    encode(n, bl);
+    auto p = set.begin();
+    while (n--) {
+      encode(p->value, bl);
+      ++p;
+    }
+    ENCODE_FINISH(bl);
+  }
+  
+  void decode(bufferlist::const_iterator& p) {
+    using ceph::decode;
+    DECODE_START(1, p);
+    uint32_t n;
+    decode(n, p);
+    while (n--) {
+      T v;
+      decode(v, p);
+      insert(v);
+    }
+    DECODE_FINISH(p);
+  }
+};

--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -278,7 +278,7 @@ void LogEntry::generate_test_instances(list<LogEntry*>& o)
 
 // -----
 
-void LogSummary::build_ordered_tail(list<LogEntry> *tail) const
+void LogSummary::build_ordered_tail_legacy(list<LogEntry> *tail) const
 {
   tail->clear();
   // channel -> (begin, end)
@@ -313,31 +313,37 @@ void LogSummary::encode(bufferlist& bl, uint64_t features) const
     ENCODE_START(2, 2, bl);
     encode(version, bl);
     list<LogEntry> tail;
-    build_ordered_tail(&tail);
+    build_ordered_tail_legacy(&tail);
     encode(tail, bl, features);
     ENCODE_FINISH(bl);
     return;
   }
-  ENCODE_START(3, 3, bl);
+  ENCODE_START(4, 3, bl);
   encode(version, bl);
   encode(seq, bl);
   encode(tail_by_channel, bl, features);
+  encode(channel_info, bl);
+  recent_keys.encode(bl);
   ENCODE_FINISH(bl);
 }
 
 void LogSummary::decode(bufferlist::const_iterator& bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(3, 2, 2, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(4, 2, 2, bl);
   decode(version, bl);
   if (struct_v < 3) {
     list<LogEntry> tail;
     decode(tail, bl);
     for (auto& i : tail) {
-      add(i);
+      add_legacy(i);
     }
   } else {
     decode(seq, bl);
     decode(tail_by_channel, bl);
+    if (struct_v >= 4) {
+      decode(channel_info, bl);
+      recent_keys.decode(bl);
+    }
   }
   DECODE_FINISH(bl);
   keys.clear();

--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -187,7 +187,7 @@ string clog_type_to_string(clog_type t)
   }
 }
 
-void LogEntry::log_to_syslog(string level, string facility)
+void LogEntry::log_to_syslog(string level, string facility) const
 {
   int min = string_to_syslog_level(level);
   int l = clog_type_to_syslog_level(prio);

--- a/src/common/LogEntry.h
+++ b/src/common/LogEntry.h
@@ -19,6 +19,7 @@
 #include "msg/msg_types.h"
 #include "common/entity_name.h"
 #include "ostream_temp.h"
+#include "LRUSet.h"
 
 namespace ceph {
   class Formatter;
@@ -75,7 +76,22 @@ public:
   friend bool operator==(const LogEntryKey& l, const LogEntryKey& r) {
     return l.rank == r.rank && l.stamp == r.stamp && l.seq == r.seq;
   }
+
+  void encode(bufferlist& bl) const {
+    using ceph::encode;
+    encode(rank, bl);
+    encode(stamp, bl);
+    encode(seq, bl);
+  }
+  void decode(bufferlist::const_iterator &p) {
+    using ceph::decode;
+    decode(rank, p);
+    decode(stamp, p);
+    decode(seq, p);
+  }
 };
+WRITE_CLASS_ENCODER(LogEntryKey)
+
 
 namespace std {
 template<> struct hash<LogEntryKey> {
@@ -111,16 +127,22 @@ WRITE_CLASS_ENCODER_FEATURES(LogEntry)
 
 struct LogSummary {
   version_t version;
+
+  // ---- pre-quincy ----
   // channel -> [(seq#, entry), ...]
   std::map<std::string,std::list<std::pair<uint64_t,LogEntry>>> tail_by_channel;
   uint64_t seq = 0;
   ceph::unordered_set<LogEntryKey> keys;
 
+  // ---- quincy+ ----
+  LRUSet<LogEntryKey> recent_keys;
+  std::map<std::string, pair<uint64_t,uint64_t>> channel_info; // channel -> [begin, end)
+
   LogSummary() : version(0) {}
 
-  void build_ordered_tail(std::list<LogEntry> *tail) const;
+  void build_ordered_tail_legacy(std::list<LogEntry> *tail) const;
 
-  void add(const LogEntry& e) {
+  void add_legacy(const LogEntry& e) {
     keys.insert(e.key());
     tail_by_channel[e.channel].push_back(std::make_pair(++seq, e));
   }
@@ -131,9 +153,10 @@ struct LogSummary {
 	i.second.pop_front();
       }
     }
+    recent_keys.prune(max);
   }
   bool contains(const LogEntryKey& k) const {
-    return keys.count(k);
+    return keys.count(k) || recent_keys.contains(k);
   }
 
   void encode(ceph::buffer::list& bl, uint64_t features) const;

--- a/src/common/LogEntry.h
+++ b/src/common/LogEntry.h
@@ -99,7 +99,7 @@ struct LogEntry {
 
   LogEntryKey key() const { return LogEntryKey(rank, stamp, seq); }
 
-  void log_to_syslog(std::string level, std::string facility);
+  void log_to_syslog(std::string level, std::string facility) const;
 
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& bl);

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -201,13 +201,28 @@ options:
   - mon
   flags:
   - runtime
-- name: mon_log_max_summary
+- name: mon_log_max
   type: uint
   level: advanced
   desc: number of recent cluster log messages to retain
+  default: 10000
+  services:
+  - mon
+  with_legacy: true
+- name: mon_log_max_summary
+  type: uint
+  level: advanced
+  desc: number of recent cluster log messages to dedup against
   default: 50
   services:
   - mon
+  with_legacy: true
+- name: mon_log_full_interval
+  type: uint
+  level: advanced
+  desc: how many epochs before we encode a full copy of recent log keys
+  default: 50
+  services: [mon]
   with_legacy: true
 - name: mon_max_log_entries_per_event
   type: int

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -228,6 +228,7 @@ void LogMonitor::create_initial()
   e.addrs = mon.messenger->get_myaddrs();
   e.stamp = ceph_clock_now();
   e.prio = CLOG_INFO;
+  e.channel = CLOG_CHANNEL_CLUSTER;
   std::stringstream ss;
   ss << "mkfs " << mon.monmap->get_fsid();
   e.msg = ss.str();

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -618,7 +618,6 @@ bool LogMonitor::preprocess_command(MonOpRequestRef op)
     if (channel == "*") {
       list<LogEntry> full_tail;
       summary.build_ordered_tail(&full_tail);
-      derr << "full " << full_tail << dendl;
       auto rp = full_tail.rbegin();
       for (; num > 0 && rp != full_tail.rend(); ++rp) {
 	if (match(*rp)) {

--- a/src/mon/LogMonitor.h
+++ b/src/mon/LogMonitor.h
@@ -44,7 +44,9 @@ class LogMonitor : public PaxosService,
 private:
   std::multimap<utime_t,LogEntry> pending_log;
   unordered_set<LogEntryKey> pending_keys;
+
   LogSummary summary;
+
   version_t external_log_to = 0;
   std::map<std::string, int> channel_fds;
 
@@ -128,6 +130,7 @@ private:
   void update_from_paxos(bool *need_bootstrap) override;
   void create_pending() override;  // prepare a new pending
   // propose pending update to peers
+  void generate_logentry_key(const std::string& channel, version_t v, std::string *out);
   void encode_pending(MonitorDBStore::TransactionRef t) override;
   void encode_full(MonitorDBStore::TransactionRef t) override;
   version_t get_trim_to() const override;
@@ -140,10 +143,7 @@ private:
 
   bool should_propose(double& delay) override;
 
-  bool should_stash_full() override {
-    // commit a LogSummary on every commit
-    return true;
-  }
+  bool should_stash_full() override;
 
   struct C_Log;
 

--- a/src/mon/LogMonitor.h
+++ b/src/mon/LogMonitor.h
@@ -43,8 +43,8 @@ class LogMonitor : public PaxosService,
                    public md_config_obs_t {
 private:
   std::multimap<utime_t,LogEntry> pending_log;
-  LogSummary pending_summary, summary;
-
+  unordered_set<LogEntryKey> pending_keys;
+  LogSummary summary;
   version_t external_log_to = 0;
   std::map<std::string, int> channel_fds;
 

--- a/src/mon/LogMonitor.h
+++ b/src/mon/LogMonitor.h
@@ -45,6 +45,7 @@ private:
   std::multimap<utime_t,LogEntry> pending_log;
   LogSummary pending_summary, summary;
 
+  version_t external_log_to = 0;
   std::map<std::string, int> channel_fds;
 
   fmt::memory_buffer file_log_buffer;
@@ -168,6 +169,7 @@ private:
 
   void log_external_close_fds();
   void log_external(const LogEntry& le);
+  void log_external_backlog();
 
   /**
    * translate log sub name ('log-info') to integer id

--- a/src/mon/LogMonitor.h
+++ b/src/mon/LogMonitor.h
@@ -18,6 +18,9 @@
 #include <map>
 #include <set>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 #include "include/types.h"
 #include "PaxosService.h"
 
@@ -41,6 +44,10 @@ class LogMonitor : public PaxosService,
 private:
   std::multimap<utime_t,LogEntry> pending_log;
   LogSummary pending_summary, summary;
+
+  std::map<std::string, int> channel_fds;
+
+  fmt::memory_buffer file_log_buffer;
 
   struct log_channel_info {
 
@@ -158,6 +165,9 @@ private:
 
   void check_subs();
   void check_sub(Subscription *s);
+
+  void log_external_close_fds();
+  void log_external(const LogEntry& le);
 
   /**
    * translate log sub name ('log-info') to integer id

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -493,9 +493,13 @@ abort:
 
 void Monitor::handle_signal(int signum)
 {
-  ceph_assert(signum == SIGINT || signum == SIGTERM);
   derr << "*** Got Signal " << sig_str(signum) << " ***" << dendl;
-  shutdown();
+  if (signum == SIGHUP) {
+    sighup_handler(signum);
+  } else {
+    ceph_assert(signum == SIGINT || signum == SIGTERM);
+    shutdown();
+  }
 }
 
 CompatSet Monitor::get_initial_supported_features()

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -611,6 +611,7 @@ const char** Monitor::get_tracked_conf_keys() const
     "clog_to_graylog",
     "clog_to_graylog_host",
     "clog_to_graylog_port",
+    "mon_cluster_log_to_file",
     "host",
     "fsid",
     // periodic health to clog

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -55,6 +55,13 @@ add_executable(unittest_bloom_filter
 add_ceph_unittest(unittest_bloom_filter)
 target_link_libraries(unittest_bloom_filter ceph-common)
 
+# unittest_lruset
+add_executable(unittest_lruset
+  test_lruset.cc
+  )
+add_ceph_unittest(unittest_lruset)
+target_link_libraries(unittest_lruset)
+
 # unittest_histogram
 add_executable(unittest_histogram
   histogram.cc

--- a/src/test/common/test_lruset.cc
+++ b/src/test/common/test_lruset.cc
@@ -1,0 +1,109 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2013 Inktank <info@inktank.com>
+ *
+ * LGPL-2.1 (see COPYING-LGPL2.1) or later
+ */
+
+#include <iostream>
+#include <gtest/gtest.h>
+
+#include "common/LRUSet.h"
+
+struct thing {
+  int a;
+  thing(int i) : a(i) {}
+  friend bool operator==(const thing &a, const thing &b) {
+    return a.a == b.a;
+  }
+  friend std::size_t hash_value(const thing &value) {
+    return value.a;
+  }
+};
+
+namespace std {
+  template<> struct hash<thing> {
+    size_t operator()(const thing& r) const {
+      return r.a;
+    }
+  };
+}
+
+
+TEST(LRUSet, insert_complex) {
+  LRUSet<thing> s;
+  s.insert(thing(1));
+  s.insert(thing(2));
+
+  ASSERT_TRUE(s.contains(thing(1)));
+  ASSERT_TRUE(s.contains(thing(2)));
+  ASSERT_FALSE(s.contains(thing(3)));
+}
+
+TEST(LRUSet, insert) {
+  LRUSet<int> s;
+  s.insert(1);
+  s.insert(2);
+
+  ASSERT_TRUE(s.contains(1));
+  ASSERT_TRUE(s.contains(2));
+  ASSERT_FALSE(s.contains(3));
+}
+
+TEST(LRUSet, erase) {
+  LRUSet<int> s;
+  s.insert(1);
+  s.insert(2);
+  s.insert(3);
+
+  s.erase(2);
+  ASSERT_TRUE(s.contains(1));
+  ASSERT_FALSE(s.contains(2));
+  ASSERT_TRUE(s.contains(3));
+  s.prune(1);
+  ASSERT_TRUE(s.contains(3));
+  ASSERT_FALSE(s.contains(1));
+}
+
+TEST(LRUSet, prune) {
+  LRUSet<int> s;
+  int max = 1000;
+  for (int i=0; i<max; ++i) {
+    s.insert(i);
+    s.prune(max / 10);
+  }
+  s.prune(0);
+  ASSERT_TRUE(s.empty());
+}
+
+TEST(LRUSet, lru) {
+  LRUSet<int> s;
+  s.insert(1);
+  s.insert(2);
+  s.insert(3);
+  s.prune(2);
+  ASSERT_FALSE(s.contains(1));
+  ASSERT_TRUE(s.contains(2));
+  ASSERT_TRUE(s.contains(3));
+
+  s.insert(2);
+  s.insert(4);
+  s.prune(2);
+  ASSERT_FALSE(s.contains(3));
+  ASSERT_TRUE(s.contains(2));
+  ASSERT_TRUE(s.contains(4));
+}
+
+TEST(LRUSet, copy) {
+  LRUSet<int> a, b;
+  a.insert(1);
+  b.insert(2);
+  b.insert(3);
+  a = b;
+  ASSERT_FALSE(a.contains(1));
+  ASSERT_TRUE(a.contains(2));
+  ASSERT_TRUE(a.contains(3));
+}

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1072,7 +1072,7 @@ EOF
         debug echo Enabling cephadm orchestrator
 	if [ "$new" -eq 1 ]; then
 		digest=$(curl -s \
-		https://registry.hub.docker.com/v2/repositories/ceph/daemon-base/tags/latest-master-devel \
+		https://hub.docker.com/v2/repositories/ceph/daemon-base/tags/latest-master-devel \
 		| jq -r '.images[0].digest')
 		ceph_adm config set global container_image "docker.io/ceph/daemon-base@$digest"
 	fi


### PR DESCRIPTION
Previously, we kept all log messages in the LogSummary structure, and (re)encoded it on every commit.  This is horribly inefficient, and we get away with it only because the mon only keeps 50 entries per channel.

Instead, keep log entries in separate keys, and keep just the bounds and the last few LogEntryKeys in LogSummary.  That way we can use the summary to check for dup entries, but otherwise are not rewriting redundant information on each commit.  Also, only record the LogSummary every N commits, and bring it back up to date from incrementals on mon restart.

See https://trello.com/c/aM3mOa4D/623-mon-make-logmonitor-more-efficient



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>