### PR TITLE
pacific: mgr/dashboard: fix typo: Filesystems to File Systems

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/filesystems/filesystems.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/filesystems/filesystems.e2e-spec.ts
@@ -11,7 +11,7 @@ describe('File Systems page', () => {
 
   describe('breadcrumb test', () => {
     it('should open and show breadcrumb', () => {
-      filesystems.expectBreadcrumbText('Filesystems');
+      filesystems.expectBreadcrumbText('File Systems');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/filesystems/filesystems.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/filesystems/filesystems.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { FilesystemsPageHelper } from './filesystems.po';
 
-describe('Filesystems page', () => {
+describe('File Systems page', () => {
   const filesystems = new FilesystemsPageHelper();
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/navigation.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/navigation.po.ts
@@ -40,7 +40,7 @@ export class NavigationPageHelper extends PageHelper {
         { menu: 'iSCSI', component: 'cd-iscsi' }
       ]
     },
-    { menu: 'Filesystem', component: 'cd-cephfs-list' }
+    { menu: 'File System', component: 'cd-cephfs-list' }
   ];
 
   getVerticalMenu() {

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/navigation.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/navigation.po.ts
@@ -40,7 +40,7 @@ export class NavigationPageHelper extends PageHelper {
         { menu: 'iSCSI', component: 'cd-iscsi' }
       ]
     },
-    { menu: 'File System', component: 'cd-cephfs-list' }
+    { menu: 'File Systems', component: 'cd-cephfs-list' }
   ];
 
   getVerticalMenu() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -264,7 +264,7 @@ const routes: Routes = [
         data: { breadcrumbs: true, text: 'Block', path: null },
         loadChildren: () => import('./ceph/block/block.module').then((m) => m.RoutedBlockModule)
       },
-      // Filesystems
+      // File Systems
       {
         path: 'cephfs',
         component: CephfsListComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -269,7 +269,7 @@ const routes: Routes = [
         path: 'cephfs',
         component: CephfsListComponent,
         canActivate: [FeatureTogglesGuardService],
-        data: { breadcrumbs: 'Filesystems' }
+        data: { breadcrumbs: 'File Systems' }
       },
       // Object Gateway
       {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -230,7 +230,7 @@
         *ngIf="permissions.cephfs.read && enabledFeature.cephfs">
       <a i18n
          class="nav-link"
-         routerLink="/cephfs">Filesystems</a>
+         routerLink="/cephfs">File Systems</a>
     </li>
 
     <!-- Object Gateway -->


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50773

---

backport of https://github.com/ceph/ceph/pull/41103
parent tracker: https://tracker.ceph.com/issues/50341

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh