### PR TITLE
mgr/cephadm: add ceph orch host drain and limit host removal to empty hosts

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -64,48 +64,35 @@ To add each new host to the cluster, perform two steps:
 Removing Hosts
 ==============
 
-If the node that want you to remove is running OSDs, make sure you remove the OSDs from the node.
+A host can safely be removed from a the cluster once all daemons are removed from it.
 
-To remove a host from a cluster, do the following:
-
-For all Ceph service types, except for ``node-exporter`` and ``crash``, remove
-the host from the placement specification file (for example, cluster.yml).
-For example, if you are removing the host named host2, remove all occurrences of
-``- host2`` from all ``placement:`` sections.
-
-Update:
-
-.. code-block:: yaml
-
-  service_type: rgw
-  placement:
-    hosts:
-    - host1
-    - host2
-
-To:
-
-.. code-block:: yaml
-
-
-  service_type: rgw
-  placement:
-    hosts:
-    - host1
-
-Remove the host from cephadm's environment:
+To drain all daemons from a host do the following:
 
 .. prompt:: bash #
 
-  ceph orch host rm host2
+  ceph orch host drain *<host>*
 
+The '_no_schedule' label will be applied to the host. See :ref:`cephadm-special-host-labels`
 
-If the host is running ``node-exporter`` and crash services, remove them by running
-the following command on the host:
+All osds on the host will be scheduled to be removed. You can check osd removal progress with the following:
 
 .. prompt:: bash #
 
-  cephadm rm-daemon --fsid CLUSTER_ID --name SERVICE_NAME
+  ceph orch osd rm status
+
+see :ref:`cephadm-osd-removal` for more details about osd removal
+
+You can check if there are no deamons left on the host with the following:
+
+.. prompt:: bash #
+
+  ceph orch ps <host> 
+
+Once all daemons are removed you can remove the host with the following:
+
+.. prompt:: bash #
+
+  ceph orch host rm <host>
 
 .. _orchestrator-host-labels:
 

--- a/doc/cephadm/osd.rst
+++ b/doc/cephadm/osd.rst
@@ -211,6 +211,7 @@ If you want to avoid this behavior (disable automatic creation of OSD on availab
 
 * For cephadm, see also :ref:`cephadm-spec-unmanaged`.
 
+.. _cephadm-osd-removal:
 
 Remove an OSD
 =============

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -351,6 +351,14 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def drain_host(self, hostname: str) -> OrchResult[str]:
+        """
+        drain all daemons from a host
+
+        :param hostname: hostname
+        """
+        raise NotImplementedError()
+
     def update_host_addr(self, host: str, addr: str) -> OrchResult[str]:
         """
         Update a host's address

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -352,6 +352,13 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
+    @_cli_write_command('orch host drain')
+    def _drain_host(self, hostname: str) -> HandleCommandResult:
+        """drain all daemons from a host"""
+        completion = self.drain_host(hostname)
+        raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
     @_cli_write_command('orch host set-addr')
     def _update_set_addr(self, hostname: str, addr: str) -> HandleCommandResult:
         """Update a host address"""


### PR DESCRIPTION
ceph orch host drain removes all daemons from a host so it can be safely removed
ceph orch host rm will only remove host that a safe to remove

_no_schedule and the existing osd removal feature are used to drain the host

![image](https://user-images.githubusercontent.com/22037319/123333936-5f4ce500-d510-11eb-9a40-44a5e546962c.png)

Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>
fixes: https://tracker.ceph.com/issues/48624 https://tracker.ceph.com/issues/49622