### PR TITLE
crimson/os/seastore/cache: remove incorrect is_valid assert in get_ex…

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -181,7 +181,7 @@ public:
       auto ret = TCachedExtentRef<T>(static_cast<T*>(&*iter));
       return ret->wait_io(
       ).then([ret=std::move(ret)]() mutable -> get_extent_ret<T> {
-	assert(ret->is_valid());
+	// ret may be invalid, caller must check
 	return get_extent_ret<T>(
 	  get_extent_ertr::ready_future_marker{},
 	  std::move(ret));


### PR DESCRIPTION
…tent

After wait_io, the extent may have been mutated again, so it may be invalid.
Callers should check (interruptible_future callers will check implicitely).

Signed-off-by: Samuel Just <sjust@redhat.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
