### PR TITLE
crimson/os/seastore: transaction conflict handling improvements

### DIFF
--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
@@ -729,7 +729,15 @@ get_lba_node_ret get_lba_btree_extent(
 	  ceph_assert(meta.begin <= ret->begin()->get_key());
 	  ceph_assert(meta.end > (ret->end() - 1)->get_key());
 	}
-	assert(!(parent->has_been_invalidated() || ret->has_been_invalidated()));
+	if (parent->has_been_invalidated() || ret->has_been_invalidated()) {
+	  logger().debug(
+	    "get_lba_btree_extent: parent {} or ret {} is invalid, transaction {} is conflicted: {}",
+	    *parent,
+	    *ret,
+	    (void*)&c.trans,
+	    c.trans.is_conflicted());
+	  assert(!(parent->has_been_invalidated() || ret->has_been_invalidated()));
+	}
 	if (!ret->is_pending() && !ret->pin.is_linked()) {
 	  ret->pin.set_range(meta);
 	  c.pins.add_pin(ret->pin);
@@ -758,7 +766,15 @@ get_lba_node_ret get_lba_btree_extent(
 	  ceph_assert(meta.begin <= ret->begin()->get_key());
 	  ceph_assert(meta.end > (ret->end() - 1)->get_key());
 	}
-	assert(!(parent->has_been_invalidated() || ret->has_been_invalidated()));
+	if (parent->has_been_invalidated() || ret->has_been_invalidated()) {
+	  logger().debug(
+	    "get_lba_btree_extent: parent {} or ret {} is invalid, transaction {} is conflicted: {}",
+	    *parent,
+	    *ret,
+	    (void*)&c.trans,
+	    c.trans.is_conflicted());
+	  assert(!(parent->has_been_invalidated() || ret->has_been_invalidated()));
+	}
 	if (!ret->is_pending() && !ret->pin.is_linked()) {
 	  ret->pin.set_range(meta);
 	  c.pins.add_pin(ret->pin);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -684,7 +684,12 @@ eagain_future<Ref<Node>> Node::load(
              c.t, addr, expect_is_level_tail);
       ceph_abort("fatal error");
     })
-  ).safe_then([FNAME, c, addr, expect_is_level_tail](auto extent) {
+  ).safe_then([FNAME, c, addr, expect_is_level_tail](auto extent)
+	      -> eagain_future<Ref<Node>> {
+    if (c.t.is_conflicted()) {
+      return crimson::ct_error::eagain::make();
+    }
+    assert(extent->is_valid());
     auto header = extent->get_header();
     auto field_type = header.get_field_type();
     if (!field_type) {
@@ -709,7 +714,8 @@ eagain_future<Ref<Node>> Node::load(
         ceph_abort("fatal error");
       }
       auto impl = LeafNodeImpl::load(extent, *field_type);
-      return Ref<Node>(new LeafNode(impl.get(), std::move(impl)));
+      return eagain_ertr::make_ready_future<Ref<Node>>(
+	new LeafNode(impl.get(), std::move(impl)));
     } else if (node_type == node_type_t::INTERNAL) {
       if (extent->get_length() != c.vb.get_internal_node_size()) {
         ERRORT("load addr={:x}, is_level_tail={} error, "
@@ -718,7 +724,8 @@ eagain_future<Ref<Node>> Node::load(
         ceph_abort("fatal error");
       }
       auto impl = InternalNodeImpl::load(extent, *field_type);
-      return Ref<Node>(new InternalNode(impl.get(), std::move(impl)));
+      return eagain_ertr::make_ready_future<Ref<Node>>(
+	new InternalNode(impl.get(), std::move(impl)));
     } else {
       ceph_abort("impossible path");
     }

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -117,6 +117,10 @@ public:
     return weak;
   }
 
+  bool is_conflicted() const {
+    return conflicted;
+  }
+
 private:
   friend class Cache;
   friend Ref make_test_transaction();


### PR DESCRIPTION
Quick fixes for some upper level transaction conflict handling.  The better fix will be to convert TransactionManager users
to interruptible_future.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
