### PR TITLE
ceph.spec.in: increase memory per core to 3000MB on SUSE distros

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -138,6 +138,8 @@
 %global _smp_ncpus_max 1
 %else
 # 3.0 GiB mem per job
+# SUSE distros use %limit_build in the place of smp_limit_mem_per_job, please
+# be sure to update it as well when changing this number.
 %global _smp_ncpus_max %{smp_limit_mem_per_job 3000000}
 %endif
 %endif
@@ -1253,7 +1255,7 @@ done
 %endif
 
 %if 0%{?suse_version}
-%limit_build -m 2600
+%limit_build -m 3000
 %endif
 
 export CPPFLAGS="$java_inc"


### PR DESCRIPTION
in the KVM instance offered by OBS, we have
```
[  346s] + cat /proc/meminfo
[  347s] MemTotal:       10167736 kB
[  347s] MemFree:         4983964 kB
[  347s] MemAvailable:    9826800 kB
[  347s] Buffers:           85856 kB
[  347s] Cached:          4615192 kB
[  347s] SwapCached:            0 kB
...
[  347s] SwapTotal:       2097148 kB
```
and its number of hardware threads is
```
[  346s] ++ /usr/bin/getconf _NPROCESSORS_ONLN
[  346s] + _threads=8

so ($MemTotal+$SwapTotal)/1024/2600 = 4.6, which is less
than the # of threads, so "4" was used for the number of jobs.
```
but per our recent observation in
38be14bc0fa32be6877dea08ebd35495d39e464f, some compiling jobs could
take up to 3GB. in the OOM failure in OBS, we had
```
[24915s] [24848.843594] Out of memory: Killed process 16894 (cc1plus) total-vm:4293756kB, anon-rss:2970012kB, file-rss:0kB, shmem-rss:0kB, UID:399 pgtables:8324kB oom_score_adj:0
```
where 4GiB memory was allocated, in which 3GiB was mapped into
memory. this matches with our findings.

in this change, the memory per core is bumped up to 3000MB
in hope to address the OOB. the downside of this change is
that it would take even longer to finish the build if the
building host is limited in memory.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
