### PR TITLE
mgr/dashboard: fix POST alerts request

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/prometheus.py
+++ b/src/pybind/mgr/dashboard/controllers/prometheus.py
@@ -8,7 +8,8 @@ import requests
 from ..exceptions import DashboardException
 from ..security import Scope
 from ..settings import Settings
-from . import ApiController, BaseController, Controller, ControllerDoc, Endpoint, RESTController
+from . import ApiController, BaseController, Controller, ControllerDoc, \
+    Endpoint, RESTController, allow_empty_body
 
 
 @Controller('/api/prometheus_receiver', secure=False)
@@ -19,7 +20,13 @@ class PrometheusReceiver(BaseController):
     notifications = []
 
     @Endpoint('POST', path='/', version=None)
+    @allow_empty_body
     def fetch_alert(self, **notification):
+        if not notification:
+            raise DashboardException(
+                "Sending empty notification is not allowed.",
+                http_status_code=400,
+                component='prometheus')
         notification['notified'] = datetime.now().isoformat()
         notification['id'] = str(len(self.notifications))
         self.notifications.append(notification)

--- a/src/pybind/mgr/dashboard/tests/test_prometheus.py
+++ b/src/pybind/mgr/dashboard/tests/test_prometheus.py
@@ -79,6 +79,13 @@ class PrometheusControllerTest(ControllerTestCase):
         self.assertEqual(notification['name'], 'foo')
         self.assertTrue(len(notification['notified']) > 20)
 
+        # test with empty body
+        self._post('/api/prometheus_receiver')
+        self.assertStatus(400)
+        self.assertJsonBody({'detail': 'Sending empty notification is not allowed.',
+                             'component': 'prometheus'})
+        self.assertEqual(len(PrometheusReceiver.notifications), 1)
+
     def test_get_empty_list_with_no_notifications(self):
         PrometheusReceiver.notifications = []
         self._get('/api/prometheus/notifications')


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/51360
Signed-off-by: Avan Thakkar <athakkar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
