### PR TITLE
rgw: Modification in the usage of force-branch

### DIFF
--- a/qa/suites/rgw/notifications/tasks/test_amqp.yaml
+++ b/qa/suites/rgw/notifications/tasks/test_amqp.yaml
@@ -3,6 +3,5 @@ tasks:
     client.0:
 - notification-tests:
     client.0:
-      force-branch: master
       extra_attr: ["amqp_test"]
       rgw_server: client.0

--- a/qa/suites/rgw/notifications/tasks/test_kafka.yaml
+++ b/qa/suites/rgw/notifications/tasks/test_kafka.yaml
@@ -4,6 +4,5 @@ tasks:
       kafka_version: 2.6.0
 - notification-tests:
     client.0:
-      force-branch: master
       extra_attr: ["kafka_test"]
       rgw_server: client.0

--- a/qa/suites/rgw/notifications/tasks/test_others.yaml
+++ b/qa/suites/rgw/notifications/tasks/test_others.yaml
@@ -1,5 +1,4 @@
 tasks:
 - notification-tests:
     client.0:
-      force-branch: master
       rgw_server: client.0

--- a/qa/tasks/kafka.py
+++ b/qa/tasks/kafka.py
@@ -173,6 +173,7 @@ def task(ctx,config):
     tasks:
     - kafka:
         client.0:
+          kafka_version: 2.6.0
     """
     assert config is None or isinstance(config, list) \
         or isinstance(config, dict), \


### PR DESCRIPTION
Signed-off-by: Kalpesh Pandya <kapandya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
