### PR TITLE
pybind/mgr/autoscaler: don't scale pools with overlapping roots

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/tests/test_cal_final_pg_target.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_cal_final_pg_target.py
@@ -1,9 +1,10 @@
-#python unit test
+# python unit test
 import unittest
 from tests import mock
 import pytest
 import json
 from pg_autoscaler import module
+
 
 class RootMapItem:
 
@@ -14,23 +15,31 @@ class RootMapItem:
         self.pg_left = pg_left
         self.pool_used = 0
 
+
 class TestPgAutoscaler(object):
 
     def setup(self):
         # a bunch of attributes for testing.
         self.autoscaler = module.PgAutoscaler('module_name', 0, 0)
 
-    def helper_test(self, pools, root_map, bias, profile):
+    def helper_test(self, pools, root_map, bias, profile, overlapped_roots):
         # Here we simulate how _calc_pool_target() works.
         even_pools = {}
         for pool_name, p in pools.items():
+            root_id = p['root_id']
+            if root_id in overlapped_roots and profile == "scale-down":
+                # for scale-down profile skip pools
+                # with overlapping roots
+                assert p['no_scale']
+                continue
+
             final_ratio, pool_pg_target, final_pg_target = self.autoscaler._calc_final_pg_target(p, pool_name, root_map,
-                p['root_id'], p['capacity_ratio'], even_pools, bias, True, profile)
+                                                                                                 p['root_id'], p['capacity_ratio'], even_pools, bias, True, profile)
 
             if final_ratio == None:
                 # no final_ratio means current pool is an even pool
                 # and we do not have to do any assertion on it.
-                # You will never hit this case with a scale up profile. 
+                # You will never hit this case with a scale up profile.
                 continue
 
             assert p['expected_final_pg_target'] == final_pg_target
@@ -38,12 +47,12 @@ class TestPgAutoscaler(object):
 
             if profile == "scale-down":
                 # We only care about even_pools when profile is a scale-down
-                assert not p['even_pools'] and pool_name not in even_pools 
+                assert not p['even_pools'] and pool_name not in even_pools
 
         if profile == "scale-down":
             for pool_name, p in even_pools.items():
                 final_ratio, pool_pg_target, final_pg_target = self.autoscaler._calc_final_pg_target(p, pool_name, root_map,
-                    p['root_id'], p['capacity_ratio'], even_pools, bias, False, profile)
+                                                                                                     p['root_id'], p['capacity_ratio'], even_pools, bias, False, profile)
 
                 assert p['expected_final_pg_target'] == final_pg_target
                 assert p['expected_final_ratio'] == final_ratio
@@ -52,433 +61,552 @@ class TestPgAutoscaler(object):
     def test_all_even_pools_scale_up(self):
         pools = {
 
-                "test0":{
+            "test0": {
 
-                    "pool": 0,
-                    "pool_name": "test0",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.2,
-                    "root_id":"0",
-                    "expected_final_pg_target": 64,
-                    "expected_final_ratio": 0.2,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+                "pool": 0,
+                "pool_name": "test0",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.2,
+                "root_id": 0,
+                "expected_final_pg_target": 64,
+                "expected_final_ratio": 0.2,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                "test1":{
+            "test1": {
 
-                    "pool": 1,
-                    "pool_name": "test1",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.2,
-                    "root_id":"0",
-                    "expected_final_pg_target": 64,
-                    "expected_final_ratio": 0.2,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+                "pool": 1,
+                "pool_name": "test1",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.2,
+                "root_id": 0,
+                "expected_final_pg_target": 64,
+                "expected_final_ratio": 0.2,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                "test2":{
+            "test2": {
 
-                    "pool": 2,
-                    "pool_name": "test2",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.2,
-                    "root_id":"0",
-                    "expected_final_pg_target": 64,
-                    "expected_final_ratio": 0.2,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+                "pool": 2,
+                "pool_name": "test2",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.2,
+                "root_id": 0,
+                "expected_final_pg_target": 64,
+                "expected_final_ratio": 0.2,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                "test3":{
+            "test3": {
 
-                    "pool": 3,
-                    "pool_name": "test3",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.1,
-                    "root_id": "0",
-                    "expected_final_pg_target": 32,
-                    "expected_final_ratio": 0.1,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+                "pool": 3,
+                "pool_name": "test3",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.1,
+                "root_id": 0,
+                "expected_final_pg_target": 32,
+                "expected_final_ratio": 0.1,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                }
+        }
 
         root_map = {
 
-                "0": RootMapItem(4, 400, 400),
-                "1": RootMapItem(4, 400, 400),
+            0: RootMapItem(4, 400, 400),
+            1: RootMapItem(4, 400, 400),
 
-                }
+        }
 
         profile = "scale-up"
         bias = 1
-        self.helper_test(pools, root_map, bias, profile)
+        overlapped_roots = set()
+        self.helper_test(pools, root_map, bias, profile, overlapped_roots)
 
     def test_all_even_pools_scale_down(self):
         pools = {
 
-                "test0":{
-                    
-                    "pool": 0,
-                    "pool_name": "test0",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.2,
-                    "root_id":"0",
-                    "expected_final_pg_target": 128,
-                    "expected_final_ratio": 0.25,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+            "test0": {
 
-                "test1":{
+                "pool": 0,
+                "pool_name": "test0",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.2,
+                "root_id": 0,
+                "expected_final_pg_target": 128,
+                "expected_final_ratio": 0.25,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                    "pool": 1,
-                    "pool_name": "test1",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.2,
-                    "root_id":"0",
-                    "expected_final_pg_target": 128,
-                    "expected_final_ratio": 0.25,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+            "test1": {
 
-                "test2":{
+                "pool": 1,
+                "pool_name": "test1",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.2,
+                "root_id": 0,
+                "expected_final_pg_target": 128,
+                "expected_final_ratio": 0.25,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                    "pool": 2,
-                    "pool_name": "test2",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.2,
-                    "root_id":"0",
-                    "expected_final_pg_target": 128,
-                    "expected_final_ratio": 0.25,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+            "test2": {
 
-                "test3":{
+                "pool": 2,
+                "pool_name": "test2",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.2,
+                "root_id": 0,
+                "expected_final_pg_target": 128,
+                "expected_final_ratio": 0.25,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                    "pool": 3,
-                    "pool_name": "test3",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.1,
-                    "root_id": "0",
-                    "expected_final_pg_target": 128,
-                    "expected_final_ratio": 0.25,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+            "test3": {
 
-                }
+                "pool": 3,
+                "pool_name": "test3",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.1,
+                "root_id": 0,
+                "expected_final_pg_target": 128,
+                "expected_final_ratio": 0.25,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
+
+        }
 
         root_map = {
 
-                "0": RootMapItem(4, 400, 400),
-                "1": RootMapItem(4, 400, 400),
+            0: RootMapItem(4, 400, 400),
+            1: RootMapItem(4, 400, 400),
 
-                }
+        }
 
-        profile = "scale-down" 
+        profile = "scale-down"
         bias = 1
-        self.helper_test(pools, root_map, bias, profile)
+        overlapped_roots = set()
+        self.helper_test(pools, root_map, bias, profile, overlapped_roots)
 
     def test_uneven_pools_scale_up(self):
         pools = {
 
-                "test0":{
+            "test0": {
 
-                    "pool": 0,
-                    "pool_name": "test0",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.1,
-                    "root_id":"0",
-                    "expected_final_pg_target": 32,
-                    "expected_final_ratio": 0.1,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+                "pool": 0,
+                "pool_name": "test0",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.1,
+                "root_id": 0,
+                "expected_final_pg_target": 32,
+                "expected_final_ratio": 0.1,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                "test1":{
+            "test1": {
 
-                    "pool": 1,
-                    "pool_name": "test1",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.5,
-                    "root_id":"0",
-                    "expected_final_pg_target": 256,
-                    "expected_final_ratio": 0.5,
-                    "even_pools": False,
-                    "size": 1,
-                    },
+                "pool": 1,
+                "pool_name": "test1",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.5,
+                "root_id": 0,
+                "expected_final_pg_target": 256,
+                "expected_final_ratio": 0.5,
+                "even_pools": False,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                "test2":{
+            "test2": {
 
-                    "pool": 2,
-                    "pool_name": "test2",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.1,
-                    "root_id":"0",
-                    "expected_final_pg_target": 32,
-                    "expected_final_ratio": 0.1,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+                "pool": 2,
+                "pool_name": "test2",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.1,
+                "root_id": 0,
+                "expected_final_pg_target": 32,
+                "expected_final_ratio": 0.1,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                "test3":{
+            "test3": {
 
-                    "pool": 3,
-                    "pool_name": "test3",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.1,
-                    "root_id": "0",
-                    "expected_final_pg_target": 32,
-                    "expected_final_ratio": 0.1,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+                "pool": 3,
+                "pool_name": "test3",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.1,
+                "root_id": 0,
+                "expected_final_pg_target": 32,
+                "expected_final_ratio": 0.1,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                }
+        }
 
         root_map = {
 
-                "0": RootMapItem(4, 400, 400),
-                "1": RootMapItem(4, 400, 400),
+            0: RootMapItem(4, 400, 400),
+            1: RootMapItem(4, 400, 400),
 
-                }
+        }
 
         profile = "scale-up"
         bias = 1
-        self.helper_test(pools, root_map, bias, profile)
+        overlapped_roots = set()
+        self.helper_test(pools, root_map, bias, profile, overlapped_roots)
 
     def test_uneven_pools_scale_down(self):
         pools = {
 
-                "test0":{
-                    
-                    "pool": 0,
-                    "pool_name": "test0",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.1,
-                    "root_id":"0",
-                    "expected_final_pg_target": 64,
-                    "expected_final_ratio": 1/3,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+            "test0": {
 
-                "test1":{
+                "pool": 0,
+                "pool_name": "test0",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.1,
+                "root_id": 0,
+                "expected_final_pg_target": 64,
+                "expected_final_ratio": 1/3,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                    "pool": 1,
-                    "pool_name": "test1",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.5,
-                    "root_id":"0",
-                    "expected_final_pg_target": 256,
-                    "expected_final_ratio": 0.5,
-                    "even_pools": False,
-                    "size": 1,
-                    },
+            "test1": {
 
-                "test2":{
+                "pool": 1,
+                "pool_name": "test1",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.5,
+                "root_id": 0,
+                "expected_final_pg_target": 256,
+                "expected_final_ratio": 0.5,
+                "even_pools": False,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                    "pool": 2,
-                    "pool_name": "test2",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.1,
-                    "root_id":"0",
-                    "expected_final_pg_target": 64,
-                    "expected_final_ratio": 1/3,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+            "test2": {
 
-                "test3":{
+                "pool": 2,
+                "pool_name": "test2",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.1,
+                "root_id": 0,
+                "expected_final_pg_target": 64,
+                "expected_final_ratio": 1/3,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                    "pool": 3,
-                    "pool_name": "test3",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.1,
-                    "root_id": "0",
-                    "expected_final_pg_target": 64,
-                    "expected_final_ratio": 1/3,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+            "test3": {
 
-                }
+                "pool": 3,
+                "pool_name": "test3",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.1,
+                "root_id": 0,
+                "expected_final_pg_target": 64,
+                "expected_final_ratio": 1/3,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
+
+        }
 
         root_map = {
 
-                "0": RootMapItem(4, 400, 400),
-                "1": RootMapItem(4, 400, 400),
+            0: RootMapItem(4, 400, 400),
+            1: RootMapItem(4, 400, 400),
 
-                }
+        }
 
-        profile = "scale-down" 
+        profile = "scale-down"
         bias = 1
-        self.helper_test(pools, root_map, bias, profile)
+        overlapped_roots = set()
+        self.helper_test(pools, root_map, bias, profile, overlapped_roots)
 
     def test_uneven_pools_with_diff_roots_scale_up(self):
         pools = {
 
-                "test0":{
+            "test0": {
 
-                    "pool": 0,
-                    "pool_name": "test0",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.4,
-                    "root_id":"0",
-                    "expected_final_pg_target": 2048,
-                    "expected_final_ratio": 0.4,
-                    "even_pools": False,
-                    "size": 1,
-                    },
+                "pool": 0,
+                "pool_name": "test0",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.4,
+                "root_id": 0,
+                "expected_final_pg_target": 2048,
+                "expected_final_ratio": 0.4,
+                "even_pools": False,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                "test1":{
+            "test1": {
 
-                    "pool": 1,
-                    "pool_name": "test1",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.6,
-                    "root_id":"1",
-                    "expected_final_pg_target": 2048,
-                    "expected_final_ratio": 0.6,
-                    "even_pools": False,
-                    "size": 1,
-                    },
+                "pool": 1,
+                "pool_name": "test1",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.6,
+                "root_id": 1,
+                "expected_final_pg_target": 2048,
+                "expected_final_ratio": 0.6,
+                "even_pools": False,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                "test2":{
+            "test2": {
 
-                    "pool": 2,
-                    "pool_name": "test2",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.5,
-                    "root_id":"0",
-                    "expected_final_pg_target": 2048,
-                    "expected_final_ratio": 0.5,
-                    "even_pools": False,
-                    "size": 1,
-                    },
+                "pool": 2,
+                "pool_name": "test2",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.5,
+                "root_id": 0,
+                "expected_final_pg_target": 2048,
+                "expected_final_ratio": 0.5,
+                "even_pools": False,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                "test3":{
+            "test3": {
 
-                    "pool": 3,
-                    "pool_name": "test3",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.1,
-                    "root_id": "0",
-                    "expected_final_pg_target": 512,
-                    "expected_final_ratio": 0.1,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+                "pool": 3,
+                "pool_name": "test3",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.1,
+                "root_id": 0,
+                "expected_final_pg_target": 512,
+                "expected_final_ratio": 0.1,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                "test4":{
+            "test4": {
 
-                    "pool": 4,
-                    "pool_name": "test4",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.4,
-                    "root_id": "1",
-                    "expected_final_pg_target": 2048,
-                    "expected_final_ratio": 0.4,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+                "pool": 4,
+                "pool_name": "test4",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.4,
+                "root_id": 1,
+                "expected_final_pg_target": 2048,
+                "expected_final_ratio": 0.4,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                }
+        }
 
         root_map = {
 
-                "0": RootMapItem(3, 5000, 5000),
-                "1": RootMapItem(2, 5000, 5000),
+            0: RootMapItem(3, 5000, 5000),
+            1: RootMapItem(2, 5000, 5000),
 
-                }
+        }
 
         profile = "scale-up"
         bias = 1
-        self.helper_test(pools, root_map, bias, profile)
+        overlapped_roots = set()
+        self.helper_test(pools, root_map, bias, profile, overlapped_roots)
 
     def test_uneven_pools_with_diff_roots_scale_down(self):
         pools = {
 
-                "test0":{
-                    
-                    "pool": 0,
-                    "pool_name": "test0",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.4,
-                    "root_id":"0",
-                    "expected_final_pg_target": 2048,
-                    "expected_final_ratio": 0.4,
-                    "even_pools": False,
-                    "size": 1,
-                    },
+            "test0": {
 
-                "test1":{
+                "pool": 0,
+                "pool_name": "test0",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.4,
+                "root_id": 0,
+                "expected_final_pg_target": 2048,
+                "expected_final_ratio": 0.4,
+                "even_pools": False,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                    "pool": 1,
-                    "pool_name": "test1",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.6,
-                    "root_id":"1",
-                    "expected_final_pg_target": 2048,
-                    "expected_final_ratio": 0.6,
-                    "even_pools": False,
-                    "size": 1,
-                    },
+            "test1": {
 
-                "test2":{
+                "pool": 1,
+                "pool_name": "test1",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.6,
+                "root_id": 1,
+                "expected_final_pg_target": 2048,
+                "expected_final_ratio": 0.6,
+                "even_pools": False,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                    "pool": 2,
-                    "pool_name": "test2",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.5,
-                    "root_id":"0",
-                    "expected_final_pg_target": 2048,
-                    "expected_final_ratio": 0.5,
-                    "even_pools": False,
-                    "size": 1,
-                    },
+            "test2": {
 
-                "test3":{
+                "pool": 2,
+                "pool_name": "test2",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.5,
+                "root_id": 0,
+                "expected_final_pg_target": 2048,
+                "expected_final_ratio": 0.5,
+                "even_pools": False,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                    "pool": 3,
-                    "pool_name": "test3",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.1,
-                    "root_id": "0",
-                    "expected_final_pg_target": 512,
-                    "expected_final_ratio": 1,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+            "test3": {
 
-                "test4":{
+                "pool": 3,
+                "pool_name": "test3",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.1,
+                "root_id": 0,
+                "expected_final_pg_target": 512,
+                "expected_final_ratio": 1,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
 
-                    "pool": 4,
-                    "pool_name": "test4",
-                    "pg_num_target": 32,
-                    "capacity_ratio": 0.4,
-                    "root_id": "1",
-                    "expected_final_pg_target": 2048,
-                    "expected_final_ratio": 1,
-                    "even_pools": True,
-                    "size": 1,
-                    },
+            "test4": {
 
-                }
+                "pool": 4,
+                "pool_name": "test4",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.4,
+                "root_id": 1,
+                "expected_final_pg_target": 2048,
+                "expected_final_ratio": 1,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": False,
+            },
+
+        }
 
         root_map = {
 
-                "0": RootMapItem(3, 5000, 5000),
-                "1": RootMapItem(2, 5000, 5000),
+            0: RootMapItem(3, 5000, 5000),
+            1: RootMapItem(2, 5000, 5000),
 
-                }
+        }
 
         profile = "scale-down"
         bias = 1
-        self.helper_test(pools, root_map, bias, profile)
+        overlapped_roots = set()
+        self.helper_test(pools, root_map, bias, profile, overlapped_roots)
+
+    def test_uneven_pools_with_overllaped_roots_scale_down(self):
+        pools = {
+
+            "test0": {
+
+                "pool": 0,
+                "pool_name": "test0",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.4,
+                "root_id": 0,
+                "expected_final_pg_target": 2048,
+                "expected_final_ratio": 0.4,
+                "even_pools": False,
+                "size": 1,
+                "no_scale": True,
+            },
+
+            "test1": {
+
+                "pool": 1,
+                "pool_name": "test1",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.6,
+                "root_id": 1,
+                "expected_final_pg_target": 2048,
+                "expected_final_ratio": 0.6,
+                "even_pools": False,
+                "size": 1,
+                "no_scale": True,
+            },
+
+            "test2": {
+
+                "pool": 2,
+                "pool_name": "test2",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.5,
+                "root_id": 0,
+                "expected_final_pg_target": 2048,
+                "expected_final_ratio": 0.5,
+                "even_pools": False,
+                "size": 1,
+                "no_scale": True,
+            },
+
+            "test3": {
+
+                "pool": 3,
+                "pool_name": "test3",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.1,
+                "root_id": 0,
+                "expected_final_pg_target": 512,
+                "expected_final_ratio": 1,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": True,
+            },
+
+            "test4": {
+
+                "pool": 4,
+                "pool_name": "test4",
+                "pg_num_target": 32,
+                "capacity_ratio": 0.4,
+                "root_id": 1,
+                "expected_final_pg_target": 2048,
+                "expected_final_ratio": 1,
+                "even_pools": True,
+                "size": 1,
+                "no_scale": True,
+            },
+
+        }
+
+        root_map = {
+
+            0: RootMapItem(3, 5000, 5000),
+            1: RootMapItem(2, 5000, 5000),
+
+        }
+
+        profile = "scale-down"
+        bias = 1
+        overlapped_roots = {0, 1}
+        self.helper_test(pools, root_map, bias, profile, overlapped_roots)

--- a/src/pybind/mgr/pg_autoscaler/tests/test_cal_ratio.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_cal_ratio.py
@@ -1,10 +1,12 @@
 from pg_autoscaler import effective_target_ratio
 from pytest import approx
 
+
 def check_simple_ratio(target_ratio, tot_ratio):
     etr = effective_target_ratio(target_ratio, tot_ratio, 0, 0)
     assert (target_ratio / tot_ratio) == approx(etr)
     return etr
+
 
 def test_simple():
     etr1 = check_simple_ratio(0.2, 0.9)
@@ -18,6 +20,7 @@ def test_simple():
     etr1 = check_simple_ratio(1, 2)
     etr2 = check_simple_ratio(0.5, 1.0)
     assert etr1 == approx(etr2)
+
 
 def test_total_bytes():
     etr = effective_target_ratio(1, 10, 5, 10)

--- a/src/pybind/mgr/pg_autoscaler/tests/test_overlapping_roots.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_overlapping_roots.py
@@ -1,0 +1,479 @@
+# python unit test
+import unittest
+from tests import mock
+import pytest
+import json
+from pg_autoscaler import module
+
+
+class OSDMAP:
+    def __init__(self, pools):
+        self.pools = pools
+
+    def get_pools(self):
+        return self.pools
+
+    def pool_raw_used_rate(pool_id):
+        return 1
+
+
+class CRUSH:
+    def __init__(self, rules, osd_dic):
+        self.rules = rules
+        self.osd_dic = osd_dic
+
+    def get_rule_by_id(self, rule_id):
+        for rule in self.rules:
+            if rule['rule_id'] == rule_id:
+                return rule
+
+        return None
+
+    def get_rule_root(self, rule_name):
+        for rule in self.rules:
+            if rule['rule_name'] == rule_name:
+                return rule['root_id']
+
+        return None
+
+    def get_osds_under(self, root_id):
+        return self.osd_dic[root_id]
+
+
+class TestPgAutoscaler(object):
+
+    def setup(self):
+        # a bunch of attributes for testing.
+        self.autoscaler = module.PgAutoscaler('module_name', 0, 0)
+
+    def helper_test(self, osd_dic, rules, pools, expected_overlapped_roots):
+        result = {}
+        roots = []
+        overlapped_roots = set()
+        osdmap = OSDMAP(pools)
+        crush = CRUSH(rules, osd_dic)
+        roots, overlapped_roots = self.autoscaler.identify_subtrees_and_overlaps(osdmap,
+                                                                                 crush, result, overlapped_roots, roots)
+        assert overlapped_roots == expected_overlapped_roots
+
+    def test_subtrees_and_overlaps(self):
+        osd_dic = {
+            -1: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            -40: [11, 12, 13, 14, 15],
+            -5: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        }
+
+        rules = [
+            {
+                "rule_id": 0,
+                "rule_name": "data",
+                "ruleset": 0,
+                "type": 1,
+                "min_size": 1,
+                "max_size": 10,
+                "root_id": -1,
+            },
+            {
+                "rule_id": 1,
+                "rule_name": "teuthology-data-ec",
+                "ruleset": 1,
+                "type": 3,
+                "min_size": 3,
+                "max_size": 6,
+                "root_id": -5,
+            },
+            {
+                "rule_id": 4,
+                "rule_name": "rep-ssd",
+                "ruleset": 4,
+                "type": 1,
+                "min_size": 1,
+                "max_size": 10,
+                "root_id": -40,
+            },
+        ]
+        pools = {
+            0: {
+                "pool_name": "data",
+                "pg_num_target": 1024,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0.1624,
+                "options": {
+                    "pg_num_min": 1024,
+                },
+                "expected_final_pg_target": 1024,
+            },
+            1: {
+                "pool_name": "metadata",
+                "pg_num_target": 64,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0.0144,
+                "options": {
+                    "pg_num_min": 64,
+                },
+                "expected_final_pg_target": 64,
+            },
+            4: {
+                "pool_name": "libvirt-pool",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0.0001,
+                "options": {},
+                "expected_final_pg_target": 128,
+            },
+            93: {
+                "pool_name": ".rgw.root",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0,
+                "options": {},
+                "expected_final_pg_target": 32,
+            },
+            94: {
+                "pool_name": "default.rgw.control",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0,
+                "options": {},
+                "expected_final_pg_target": 32,
+            },
+            95: {
+                "pool_name": "default.rgw.meta",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0,
+                "options": {},
+                "expected_final_pg_target": 32,
+            },
+            96: {
+                "pool_name": "default.rgw.log",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0,
+                "options": {},
+                "expected_final_pg_target": 32,
+            },
+            97: {
+                "pool_name": "default.rgw.buckets.index",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0.0002,
+                "options": {},
+                "expected_final_pg_target": 32,
+            },
+            98: {
+                "pool_name": "default.rgw.buckets.data",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0.0457,
+                "options": {},
+                "expected_final_pg_target": 128,
+            },
+            99: {
+                "pool_name": "default.rgw.buckets.non-ec",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0,
+                "options": {},
+                "expected_final_pg_target": 32,
+            },
+            100: {
+                "pool_name": "device_health_metrics",
+                "pg_num_target": 1,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0,
+                "options": {
+                    "pg_num_min": 1
+                },
+                "expected_final_pg_target": 1,
+            },
+            113: {
+                "pool_name": "cephfs.teuthology.meta",
+                "pg_num_target": 64,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0.1389,
+                "options": {
+                    "pg_autoscale_bias": 4,
+                    "pg_num_min": 64,
+                },
+                "expected_final_pg_target": 512,
+            },
+            114: {
+                "pool_name": "cephfs.teuthology.data",
+                "pg_num_target": 256,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0.0006,
+                "options": {
+                    "pg_num_min": 128,
+                },
+                "expected_final_pg_target": 1024,
+                "expected_final_pg_target": 256,
+            },
+            117: {
+                "pool_name": "cephfs.scratch.meta",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0.0027,
+                "options": {
+                    "pg_autoscale_bias": 4,
+                    "pg_num_min": 16,
+                },
+                "expected_final_pg_target": 64,
+            },
+            118: {
+                "pool_name": "cephfs.scratch.data",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0.0027,
+                "options": {},
+                "expected_final_pg_target": 128,
+            },
+            119: {
+                "pool_name": "cephfs.teuthology.data-ec",
+                "pg_num_target": 1024,
+                "size": 6,
+                "crush_rule": 1,
+                "capacity_ratio": 0.8490,
+                "options": {
+                    "pg_num_min": 1024
+                },
+                "expected_final_pg_target": 1024,
+            },
+            121: {
+                "pool_name": "cephsqlite",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0,
+                "options": {},
+                "expected_final_pg_target": 128,
+            },
+        }
+        expected_overlapped_roots = {-40, -1, -5}
+        self.helper_test(osd_dic, rules, pools, expected_overlapped_roots)
+
+    def test_no_overlaps(self):
+        osd_dic = {
+            -1: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            -40: [11, 12, 13, 14, 15],
+            -5: [16, 17, 18],
+        }
+
+        rules = [
+            {
+                "rule_id": 0,
+                "rule_name": "data",
+                "ruleset": 0,
+                "type": 1,
+                "min_size": 1,
+                "max_size": 10,
+                "root_id": -1,
+            },
+            {
+                "rule_id": 1,
+                "rule_name": "teuthology-data-ec",
+                "ruleset": 1,
+                "type": 3,
+                "min_size": 3,
+                "max_size": 6,
+                "root_id": -5,
+            },
+            {
+                "rule_id": 4,
+                "rule_name": "rep-ssd",
+                "ruleset": 4,
+                "type": 1,
+                "min_size": 1,
+                "max_size": 10,
+                "root_id": -40,
+            },
+        ]
+        pools = {
+            0: {
+                "pool_name": "data",
+                "pg_num_target": 1024,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0.1624,
+                "options": {
+                    "pg_num_min": 1024,
+                },
+                "expected_final_pg_target": 1024,
+            },
+            1: {
+                "pool_name": "metadata",
+                "pg_num_target": 64,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0.0144,
+                "options": {
+                    "pg_num_min": 64,
+                },
+                "expected_final_pg_target": 64,
+            },
+            4: {
+                "pool_name": "libvirt-pool",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0.0001,
+                "options": {},
+                "expected_final_pg_target": 128,
+            },
+            93: {
+                "pool_name": ".rgw.root",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0,
+                "options": {},
+                "expected_final_pg_target": 32,
+            },
+            94: {
+                "pool_name": "default.rgw.control",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0,
+                "options": {},
+                "expected_final_pg_target": 32,
+            },
+            95: {
+                "pool_name": "default.rgw.meta",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0,
+                "options": {},
+                "expected_final_pg_target": 32,
+            },
+            96: {
+                "pool_name": "default.rgw.log",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0,
+                "options": {},
+                "expected_final_pg_target": 32,
+            },
+            97: {
+                "pool_name": "default.rgw.buckets.index",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0.0002,
+                "options": {},
+                "expected_final_pg_target": 32,
+            },
+            98: {
+                "pool_name": "default.rgw.buckets.data",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0.0457,
+                "options": {},
+                "expected_final_pg_target": 128,
+            },
+            99: {
+                "pool_name": "default.rgw.buckets.non-ec",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0,
+                "options": {},
+                "expected_final_pg_target": 32,
+            },
+            100: {
+                "pool_name": "device_health_metrics",
+                "pg_num_target": 1,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0,
+                "options": {
+                    "pg_num_min": 1
+                },
+                "expected_final_pg_target": 1,
+            },
+            113: {
+                "pool_name": "cephfs.teuthology.meta",
+                "pg_num_target": 64,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0.1389,
+                "options": {
+                    "pg_autoscale_bias": 4,
+                    "pg_num_min": 64,
+                },
+                "expected_final_pg_target": 512,
+            },
+            114: {
+                "pool_name": "cephfs.teuthology.data",
+                "pg_num_target": 256,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0.0006,
+                "options": {
+                    "pg_num_min": 128,
+                },
+                "expected_final_pg_target": 1024,
+                "expected_final_pg_target": 256,
+            },
+            117: {
+                "pool_name": "cephfs.scratch.meta",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0.0027,
+                "options": {
+                    "pg_autoscale_bias": 4,
+                    "pg_num_min": 16,
+                },
+                "expected_final_pg_target": 64,
+            },
+            118: {
+                "pool_name": "cephfs.scratch.data",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 0,
+                "capacity_ratio": 0.0027,
+                "options": {},
+                "expected_final_pg_target": 128,
+            },
+            119: {
+                "pool_name": "cephfs.teuthology.data-ec",
+                "pg_num_target": 1024,
+                "size": 6,
+                "crush_rule": 1,
+                "capacity_ratio": 0.8490,
+                "options": {
+                    "pg_num_min": 1024
+                },
+                "expected_final_pg_target": 1024,
+            },
+            121: {
+                "pool_name": "cephsqlite",
+                "pg_num_target": 32,
+                "size": 3,
+                "crush_rule": 4,
+                "capacity_ratio": 0,
+                "options": {},
+                "expected_final_pg_target": 128,
+            },
+        }
+        expected_overlapped_roots = set()
+        self.helper_test(osd_dic, rules, pools, expected_overlapped_roots)


### PR DESCRIPTION
In the previous version of get_subtree_resource_status() in
src/pybind/mgr/pg_autoscaler/module.py we ignore overlapping
pools which in some cases if combined with the new `scale-down`
algorithm in https://github.com/ceph/ceph/pull/38805 can cause
some pools to scale up/down to inapproriate amount of pgs.

Therefore, the PR identifies the overlapping roots and prevent the pools
with such roots from scaling. This only happens with `scale-down` profile
as we see no problem with the default `scale-up` profile.

Removed the variable `pool_root` since it is not used anywhere in
the code, it only gets assigned and reassigned.

Also included a unit test test_overlapping_roots.py that tests the function
identify_subtrees_and_overlaps() as well as edited test_cal_final_pg_target.py
to account for pools that contain overlapping roots, therefore, those pools
are expected not to scale.

Signed-off-by: Kamoltat <ksirivad@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
