### PR TITLE
mds: fix compile warning

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5700,7 +5700,6 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
           return;
         mdr->locking_state |= MutationImpl::ALL_LOCKED;
       }
-      SnapRealm *realm = cur->find_snaprealm();
       const auto srnode = cur->get_projected_srnode();
       if (val == (srnode && srnode->is_subvolume())) {
         dout(20) << "already marked subvolume" << dendl;


### PR DESCRIPTION
    ../src/mds/Server.cc: In member function ‘void Server::handle_set_vxattr(MDRequestRef&, CInode*)’:
    ../src/mds/Server.cc:5703:18: warning: unused variable ‘realm’ [-Wunused-variable]
           SnapRealm *realm = cur->find_snaprealm();
                      ^~~~~

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
