### PR TITLE
common/options: convert a millisecs opt to a chrono::milliseconds and cleanups

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10774,7 +10774,7 @@ int Client::statfs(const char *path, struct statvfs *stbuf,
   if (data_pools.size() == 1) {
     objecter->get_fs_stats(stats, data_pools[0], &cond);
   } else {
-    objecter->get_fs_stats(stats, boost::optional<int64_t>(), &cond);
+    objecter->get_fs_stats(stats, std::optional<int64_t>(), &cond);
   }
 
   lock.unlock();

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -16,8 +16,8 @@
 #define CEPH_CONFIG_H
 
 #include <map>
+#include <variant>
 #include <boost/container/small_vector.hpp>
-#include <boost/variant.hpp>
 #include "common/ConfUtils.h"
 #include "common/code_environment.h"
 #include "log/SubsystemMap.h"
@@ -70,14 +70,14 @@ extern const char *ceph_conf_level_name(int level);
  */
 struct md_config_t {
 public:
-  typedef boost::variant<int64_t ConfigValues::*,
-                         uint64_t ConfigValues::*,
-                         std::string ConfigValues::*,
-                         double ConfigValues::*,
-                         bool ConfigValues::*,
-                         entity_addr_t ConfigValues::*,
-			 entity_addrvec_t ConfigValues::*,
-                         uuid_d ConfigValues::*> member_ptr_t;
+  typedef std::variant<int64_t ConfigValues::*,
+                       uint64_t ConfigValues::*,
+                       std::string ConfigValues::*,
+                       double ConfigValues::*,
+                       bool ConfigValues::*,
+                       entity_addr_t ConfigValues::*,
+                       entity_addrvec_t ConfigValues::*,
+                       uuid_d ConfigValues::*> member_ptr_t;
 
   // For use when intercepting configuration updates
   typedef std::function<bool(
@@ -361,7 +361,7 @@ const T md_config_t::get_val(const ConfigValues& values,
   return std::get<T>(this->get_val_generic(values, key));
 }
 
-inline std::ostream& operator<<(std::ostream& o, const boost::blank& ) {
+inline std::ostream& operator<<(std::ostream& o, const std::monostate&) {
       return o << "INVALID_CONFIG_VALUE";
 }
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <boost/container/small_vector.hpp>
+#include <boost/variant.hpp>
 #include "common/ConfUtils.h"
 #include "common/code_environment.h"
 #include "log/SubsystemMap.h"
@@ -201,7 +202,7 @@ public:
 		Callback&& cb, Args&&... args) const ->
     std::result_of_t<Callback(const T&, Args...)> {
     return std::forward<Callback>(cb)(
-      boost::get<T>(this->get_val_generic(values, key)),
+      std::get<T>(this->get_val_generic(values, key)),
       std::forward<Args>(args)...);
   }
 
@@ -357,7 +358,7 @@ public:
 template<typename T>
 const T md_config_t::get_val(const ConfigValues& values,
 			     const std::string_view key) const {
-  return boost::get<T>(this->get_val_generic(values, key));
+  return std::get<T>(this->get_val_generic(values, key));
 }
 
 inline std::ostream& operator<<(std::ostream& o, const boost::blank& ) {

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -210,8 +210,8 @@ int Option::parse_value(
     }
   } else if (type == Option::TYPE_MILLISECS) {
     try {
-      *out = std::chrono::milliseconds(boost::lexical_cast<uint64_t>(val));
-    } catch (const boost::bad_lexical_cast& e) {
+      *out = std::chrono::milliseconds(std::stoull(val));
+    } catch (const std::logic_error& e) {
       *error_message = e.what();
       return -EINVAL;
     }

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -210,7 +210,7 @@ int Option::parse_value(
     }
   } else if (type == Option::TYPE_MILLISECS) {
     try {
-      *out = boost::lexical_cast<uint64_t>(val);
+      *out = std::chrono::milliseconds(boost::lexical_cast<uint64_t>(val));
     } catch (const boost::bad_lexical_cast& e) {
       *error_message = e.what();
       return -EINVAL;

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -27,7 +27,7 @@ using ceph::Formatter;
 using ceph::parse_timespan;
 
 namespace {
-class printer : public boost::static_visitor<> {
+class printer {
   ostream& out;
 public:
   explicit printer(ostream& os)
@@ -36,7 +36,7 @@ public:
   void operator()(const T& v) const {
     out << v;
   }
-  void operator()(boost::blank blank) const {
+  void operator()(std::monostate) const {
     return;
   }
   void operator()(bool v) const {
@@ -59,29 +59,29 @@ public:
 
 ostream& operator<<(ostream& os, const Option::value_t& v) {
   printer p{os};
-  v.apply_visitor(p);
+  std::visit(p, v);
   return os;
 }
 
 void Option::dump_value(const char *field_name,
     const Option::value_t &v, Formatter *f) const
 {
-  if (boost::get<boost::blank>(&v)) {
+  if (v == value_t{}) {
     // This should be nil but Formatter doesn't allow it.
     f->dump_string(field_name, "");
     return;
   }
   switch (type) {
   case TYPE_INT:
-    f->dump_int(field_name, boost::get<int64_t>(v)); break;
+    f->dump_int(field_name, std::get<int64_t>(v)); break;
   case TYPE_UINT:
-    f->dump_unsigned(field_name, boost::get<uint64_t>(v)); break;
+    f->dump_unsigned(field_name, std::get<uint64_t>(v)); break;
   case TYPE_STR:
-    f->dump_string(field_name, boost::get<std::string>(v)); break;
+    f->dump_string(field_name, std::get<std::string>(v)); break;
   case TYPE_FLOAT:
-    f->dump_float(field_name, boost::get<double>(v)); break;
+    f->dump_float(field_name, std::get<double>(v)); break;
   case TYPE_BOOL:
-    f->dump_bool(field_name, boost::get<bool>(v)); break;
+    f->dump_bool(field_name, std::get<bool>(v)); break;
   default:
     f->dump_stream(field_name) << v; break;
   }
@@ -99,7 +99,7 @@ int Option::pre_validate(std::string *new_value, std::string *err) const
 int Option::validate(const Option::value_t &new_value, std::string *err) const
 {
   // Generic validation: min
-  if (!boost::get<boost::blank>(&(min))) {
+  if (min != value_t{}) {
     if (new_value < min) {
       std::ostringstream oss;
       oss << "Value '" << new_value << "' is below minimum " << min;
@@ -109,7 +109,7 @@ int Option::validate(const Option::value_t &new_value, std::string *err) const
   }
 
   // Generic validation: max
-  if (!boost::get<boost::blank>(&(max))) {
+  if (max != value_t{}) {
     if (new_value > max) {
       std::ostringstream oss;
       oss << "Value '" << new_value << "' exceeds maximum " << max;
@@ -121,7 +121,7 @@ int Option::validate(const Option::value_t &new_value, std::string *err) const
   // Generic validation: enum
   if (!enum_allowed.empty() && type == Option::TYPE_STR) {
     auto found = std::find(enum_allowed.begin(), enum_allowed.end(),
-                           boost::get<std::string>(new_value));
+                           std::get<std::string>(new_value));
     if (found == enum_allowed.end()) {
       std::ostringstream oss;
       oss << "'" << new_value << "' is not one of the permitted "
@@ -303,7 +303,7 @@ void Option::print(ostream *out) const
 {
   *out << name << " - " << desc << "\n";
   *out << "  (" << type_to_str(type) << ", " << level_to_str(level) << ")\n";
-  if (!boost::get<boost::blank>(&daemon_value)) {
+  if (daemon_value != value_t{}) {
     *out << "  Default (non-daemon): " << stringify(value) << "\n";
     *out << "  Default (daemon): " << stringify(daemon_value) << "\n";
   } else {
@@ -316,7 +316,7 @@ void Option::print(ostream *out) const
     }
     *out << "\n";
   }
-  if (!boost::get<boost::blank>(&min)) {
+  if (min != value_t{}) {
     *out << "  Minimum: " << stringify(min) << "\n"
 	 << "  Maximum: " << stringify(max) << "\n";
   }

--- a/src/common/options.h
+++ b/src/common/options.h
@@ -5,8 +5,8 @@
 
 #include <chrono>
 #include <string>
+#include <variant>
 #include <vector>
-#include <boost/variant.hpp>
 #include "include/str_list.h"
 #include "msg/msg_types.h"
 #include "include/uuid.h"
@@ -136,8 +136,8 @@ struct Option {
     }
   };
 
-  using value_t = boost::variant<
-    boost::blank,
+  using value_t = std::variant<
+    std::monostate,
     std::string,
     uint64_t,
     int64_t,
@@ -198,7 +198,7 @@ struct Option {
   Option(std::string const &name, type_t t, level_t l)
     : name(name), type(t), level(l)
   {
-    // While value_t is nullable (via boost::blank), we don't ever
+    // While value_t is nullable (via std::monostate), we don't ever
     // want it set that way in an Option instance: within an instance,
     // the type of ::value should always match the declared type.
     switch (type) {

--- a/src/include/uuid.h
+++ b/src/include/uuid.h
@@ -92,6 +92,9 @@ inline bool operator!=(const uuid_d& l, const uuid_d& r) {
 inline bool operator<(const uuid_d& l, const uuid_d& r) {
   return l.to_string() < r.to_string();
 }
+inline bool operator>(const uuid_d& l, const uuid_d& r) {
+  return l.to_string() > r.to_string();
+}
 
 
 #endif

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -646,7 +646,7 @@ int librados::RadosClient::get_fs_stats(ceph_statfs& stats)
   int ret = 0;
   {
     std::lock_guard l{mylock};
-    objecter->get_fs_stats(stats, boost::optional<int64_t> (),
+    objecter->get_fs_stats(stats, std::optional<int64_t> (),
 			   new C_SafeCond(mylock, cond, &done, &ret));
   }
   {

--- a/src/messages/MKVData.h
+++ b/src/messages/MKVData.h
@@ -15,7 +15,7 @@ public:
   bool incremental = false;
 
   // use transparent comparator so we can lookup in it by std::string_view keys
-  std::map<std::string,boost::optional<bufferlist>,std::less<>> data;
+  std::map<std::string,std::optional<bufferlist>,std::less<>> data;
 
   MKVData() : Message{MSG_KV_DATA, HEAD_VERSION, COMPAT_VERSION} { }
 

--- a/src/messages/MStatfs.h
+++ b/src/messages/MStatfs.h
@@ -16,6 +16,7 @@
 #ifndef CEPH_MSTATFS_H
 #define CEPH_MSTATFS_H
 
+#include <optional>
 #include <sys/statvfs.h>    /* or <sys/statfs.h> */
 #include "messages/PaxosServiceMessage.h"
 
@@ -26,10 +27,10 @@ private:
 
 public:
   uuid_d fsid;
-  boost::optional<int64_t> data_pool;
+  std::optional<int64_t> data_pool;
 
   MStatfs() : PaxosServiceMessage{CEPH_MSG_STATFS, 0, HEAD_VERSION, COMPAT_VERSION} {}
-  MStatfs(const uuid_d& f, ceph_tid_t t, boost::optional<int64_t> _data_pool,
+  MStatfs(const uuid_d& f, ceph_tid_t t, std::optional<int64_t> _data_pool,
 	  version_t v)
     : PaxosServiceMessage{CEPH_MSG_STATFS, v, HEAD_VERSION, COMPAT_VERSION},
       fsid(f), data_pool(_data_pool) {
@@ -60,7 +61,7 @@ public:
     if (header.version >= 2) {
       decode(data_pool, p);
     } else {
-      data_pool = boost::optional<int64_t> ();
+      data_pool = std::optional<int64_t> ();
     }
   }
 private:

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -661,7 +661,7 @@ PyObject *ActivePyModules::get_store_prefix(const std::string &module_name,
 }
 
 void ActivePyModules::set_store(const std::string &module_name,
-    const std::string &key, const boost::optional<std::string>& val)
+    const std::string &key, const std::optional<std::string>& val)
 {
   const std::string global_key = PyModule::mgr_store_prefix
                                    + module_name + "/" + key;
@@ -708,7 +708,7 @@ void ActivePyModules::set_store(const std::string &module_name,
 std::pair<int, std::string> ActivePyModules::set_config(
   const std::string &module_name,
   const std::string &key,
-  const boost::optional<std::string>& val)
+  const std::optional<std::string>& val)
 {
   return module_config.set_config(&monc, module_name, key, val);
 }
@@ -730,7 +730,7 @@ std::map<std::string, std::string> ActivePyModules::get_services() const
 void ActivePyModules::update_kv_data(
   const std::string prefix,
   bool incremental,
-  const map<std::string, boost::optional<bufferlist>, std::less<>>& data)
+  const map<std::string, std::optional<bufferlist>, std::less<>>& data)
 {
   std::lock_guard l(lock);
   bool do_config = false;

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -1117,7 +1117,7 @@ PyObject *ActivePyModules::get_foreign_config(
     value = p->second;
   } else {
     if (!entity.is_client() &&
-	!boost::get<boost::blank>(&opt->daemon_value)) {
+	opt->daemon_value != Option::value_t{}) {
       value = Option::to_str(opt->daemon_value);
     } else {
       value = Option::to_str(opt->value);

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -127,12 +127,12 @@ public:
   PyObject *get_store_prefix(const std::string &module_name,
 			      const std::string &prefix) const;
   void set_store(const std::string &module_name,
-      const std::string &key, const boost::optional<std::string> &val);
+      const std::string &key, const std::optional<std::string> &val);
 
   bool get_config(const std::string &module_name,
       const std::string &key, std::string *val) const;
   std::pair<int, std::string> set_config(const std::string &module_name,
-      const std::string &key, const boost::optional<std::string> &val);
+      const std::string &key, const std::optional<std::string> &val);
 
   PyObject *get_typed_config(const std::string &module_name,
 			     const std::string &key,
@@ -174,7 +174,7 @@ public:
   void update_kv_data(
     const std::string prefix,
     bool incremental,
-    const map<std::string, boost::optional<bufferlist>, std::less<>>& data);
+    const map<std::string, std::optional<bufferlist>, std::less<>>& data);
   void _refresh_config_map();
 
   // Public so that MonCommandCompletion can use it

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -486,7 +486,7 @@ ceph_set_module_option(BaseMgrModule *self, PyObject *args)
     derr << "Invalid args!" << dendl;
     return nullptr;
   }
-  boost::optional<string> val;
+  std::optional<string> val;
   if (value) {
     val = value;
   }
@@ -529,7 +529,7 @@ ceph_store_set(BaseMgrModule *self, PyObject *args)
   if (!PyArg_ParseTuple(args, "sz:ceph_store_set", &key, &value)) {
     return nullptr;
   }
-  boost::optional<string> val;
+  std::optional<string> val;
   if (value) {
     val = value;
   }

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -185,7 +185,7 @@ PyModuleConfig::~PyModuleConfig() = default;
 std::pair<int, std::string> PyModuleConfig::set_config(
     MonClient *monc,
     const std::string &module_name,
-    const std::string &key, const boost::optional<std::string>& val)
+    const std::string &key, const std::optional<std::string>& val)
 {
   const std::string global_key = "mgr/" + module_name + "/" + key;
   Command set_cmd;

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -181,6 +181,6 @@ public:
   std::pair<int, std::string> set_config(
     MonClient *monc,
     const std::string &module_name,
-    const std::string &key, const boost::optional<std::string>& val);
+    const std::string &key, const std::optional<std::string>& val);
 
 };

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -69,7 +69,7 @@ public:
   void update_kv_data(
     const std::string prefix,
     bool incremental,
-    const map<std::string, boost::optional<bufferlist>, std::less<>>& data) {
+    const map<std::string, std::optional<bufferlist>, std::less<>>& data) {
     ceph_assert(active_modules);
     active_modules->update_kv_data(prefix, incremental, data);
   }

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <ostream>
 #include <string>
 
@@ -146,7 +147,7 @@ struct ConfigChangeSet {
   std::string name;
 
   // key -> (old value, new value)
-  std::map<std::string,std::pair<boost::optional<std::string>,boost::optional<std::string>>> diff;
+  std::map<std::string,std::pair<std::optional<std::string>,std::optional<std::string>>> diff;
 
   void dump(ceph::Formatter *f) const;
   void print(std::ostream& out) const;

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -587,7 +587,7 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
       bl.append(value);
       pending[key] = bl;
     } else {
-      pending[key] = boost::none;
+      pending[key].reset();
     }
     goto update;
   } else if (prefix == "config reset") {
@@ -614,7 +614,7 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
 	  bl.append(*i.second.first);
 	  pending[i.first] = bl;
 	} else if (i.second.second) {
-	  pending[i.first] = boost::none;
+	  pending[i.first].reset();
 	}
       }
     }
@@ -798,7 +798,7 @@ void ConfigMonitor::load_config()
       if (p != renamed_pacific.end()) {
 	if (mon.monmap->min_mon_release >= ceph_release_t::pacific) {
 	  // schedule a cleanup
-	  pending_cleanup[key] = boost::none;
+	  pending_cleanup[key].reset();
 	  pending_cleanup[who + "/" + p->second] = it->value();
 	}
 	// continue loading under the new name
@@ -831,18 +831,18 @@ void ConfigMonitor::load_config()
     if (who.size() &&
 	!ConfigMap::parse_mask(who, &section_name, &mopt.mask)) {
       derr << __func__ << " invalid mask for key " << key << dendl;
-      pending_cleanup[key] = boost::none;
+      pending_cleanup[key].reset();
     } else if (opt->has_flag(Option::FLAG_NO_MON_UPDATE)) {
       dout(10) << __func__ << " NO_MON_UPDATE option '"
 	       << name << "' = '" << value << "' for " << name
 	       << dendl;
-      pending_cleanup[key] = boost::none;
+      pending_cleanup[key].reset();
     } else {
       if (section_name.empty()) {
 	// we prefer global/$option instead of just $option
 	derr << __func__ << " adding global/ prefix to key '" << key << "'"
 	     << dendl;
-	pending_cleanup[key] = boost::none;
+	pending_cleanup[key].reset();
 	pending_cleanup["global/"s + key] = it->value();
       }
       Section *section = &config_map.global;;

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -348,7 +348,7 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
 	goto reply;
       }
       if (!entity.is_client() &&
-	  !boost::get<boost::blank>(&opt->daemon_value)) {
+	  opt->daemon_value != Option::value_t{}) {
 	odata.append(Option::to_str(opt->daemon_value));
       } else {
 	odata.append(Option::to_str(opt->value));

--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "ConfigMap.h"
 #include "mon/PaxosService.h"
@@ -14,9 +14,9 @@ class ConfigMonitor : public PaxosService
 {
   version_t version = 0;
   ConfigMap config_map;
-  std::map<std::string,boost::optional<ceph::buffer::list>> pending;
+  std::map<std::string,std::optional<ceph::buffer::list>> pending;
   std::string pending_description;
-  std::map<std::string,boost::optional<ceph::buffer::list>> pending_cleanup;
+  std::map<std::string,std::optional<ceph::buffer::list>> pending_cleanup;
 
   std::map<std::string,ceph::buffer::list> current;
 

--- a/src/mon/KVMonitor.cc
+++ b/src/mon/KVMonitor.cc
@@ -298,7 +298,7 @@ bool KVMonitor::prepare_command(MonOpRequestRef op)
   else if (prefix == "config-key del" ||
 	   prefix == "config-key rm") {
     ss << "key deleted";
-    pending[key] = boost::none;
+    pending[key].reset();
     goto update;
   }
   else {
@@ -375,7 +375,7 @@ void KVMonitor::do_osd_destroy(int32_t id, uuid_d& uuid)
     if (iter->key().find(prefix) != 0) {
       break;
     }
-    pending[iter->key()] = boost::none;
+    pending[iter->key()].reset();
   }
 
   propose_pending();
@@ -491,7 +491,7 @@ bool KVMonitor::maybe_send_update(Subscription *sub)
       int err = get_version(cur, bl);
       ceph_assert(err == 0);
 
-      std::map<std::string,boost::optional<ceph::buffer::list>> pending;
+      std::map<std::string,std::optional<ceph::buffer::list>> pending;
       auto p = bl.cbegin();
       ceph::decode(pending, p);
 

--- a/src/mon/KVMonitor.h
+++ b/src/mon/KVMonitor.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "mon/PaxosService.h"
 
@@ -14,7 +14,7 @@ extern const std::string KV_PREFIX;
 class KVMonitor : public PaxosService
 {
   version_t version = 0;
-  std::map<std::string,boost::optional<ceph::buffer::list>> pending;
+  std::map<std::string,std::optional<ceph::buffer::list>> pending;
 
   bool _have_prefix(const string &prefix);
 
@@ -64,6 +64,6 @@ public:
     pending[key] = v;
   }
   void enqueue_rm(const std::string& key) {
-    pending[key] = boost::none;
+    pending[key].reset();
   }
 };

--- a/src/mon/MgrStatMonitor.h
+++ b/src/mon/MgrStatMonitor.h
@@ -84,7 +84,7 @@ public:
   }
 
   ceph_statfs get_statfs(OSDMap& osdmap,
-			 boost::optional<int64_t> data_pool) const {
+			 std::optional<int64_t> data_pool) const {
     return digest.get_statfs(osdmap, data_pool);
   }
 

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -692,7 +692,7 @@ void PGMapDigest::pool_cache_io_rate_summary(ceph::Formatter *f, ostream *out,
 }
 
 ceph_statfs PGMapDigest::get_statfs(OSDMap &osdmap,
-				    boost::optional<int64_t> data_pool) const
+				    std::optional<int64_t> data_pool) const
 {
   ceph_statfs statfs;
   bool filter = false;

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -197,7 +197,7 @@ public:
   }
 
   ceph_statfs get_statfs(OSDMap &osdmap,
-                         boost::optional<int64_t> data_pool) const;
+                         std::optional<int64_t> data_pool) const;
 
   int64_t get_rule_avail(int ruleno) const {
     auto i = avail_space_by_rule.find(ruleno);

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -694,6 +694,9 @@ struct entity_addrvec_t {
   friend bool operator<(const entity_addrvec_t& l, const entity_addrvec_t& r) {
     return l.v < r.v;  // see lexicographical_compare()
   }
+  friend bool operator>(const entity_addrvec_t& l, const entity_addrvec_t& r) {
+    return l.v > r.v;  // see lexicographical_compare()
+  }
 };
 WRITE_CLASS_ENCODER_FEATURES(entity_addrvec_t);
 

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1077,7 +1077,7 @@ void RADOS::stat_pools(const std::vector<std::string>& pools,
 
 void RADOS::stat_fs(std::optional<std::int64_t> _pool,
 		    std::unique_ptr<StatFSComp> c) {
-  boost::optional<int64_t> pool;
+  std::optional<int64_t> pool;
   if (_pool)
     pool = *pool;
   impl->objecter->get_fs_stats(

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -4211,7 +4211,7 @@ void Objecter::_finish_pool_stat_op(PoolStatOp *op, int r)
   delete op;
 }
 
-void Objecter::get_fs_stats(boost::optional<int64_t> poolid,
+void Objecter::get_fs_stats(std::optional<int64_t> poolid,
 			    decltype(StatfsOp::onfinish)&& onfinish)
 {
   ldout(cct, 10) << "get_fs_stats" << dendl;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2164,7 +2164,7 @@ public:
 
   struct StatfsOp {
     ceph_tid_t tid;
-    boost::optional<int64_t> data_pool;
+    std::optional<int64_t> data_pool;
     using OpSig = void(boost::system::error_code,
 		       const struct ceph_statfs);
     using OpComp = ceph::async::Completion<OpSig>;
@@ -3783,10 +3783,10 @@ private:
   void _fs_stats_submit(StatfsOp *op);
 public:
   void handle_fs_stats_reply(MStatfsReply *m);
-  void get_fs_stats(boost::optional<int64_t> poolid,
+  void get_fs_stats(std::optional<int64_t> poolid,
 		    decltype(StatfsOp::onfinish)&& onfinish);
   template<typename CompletionToken>
-  auto get_fs_stats(boost::optional<int64_t> poolid,
+  auto get_fs_stats(std::optional<int64_t> poolid,
 		    CompletionToken&& token) {
     boost::asio::async_completion<CompletionToken, StatfsOp::OpSig> init(token);
     get_fs_stats(poolid,
@@ -3794,7 +3794,7 @@ public:
 					  std::move(init.completion_handler)));
     return init.result.get();
   }
-  void get_fs_stats(struct ceph_statfs& result, boost::optional<int64_t> poolid,
+  void get_fs_stats(struct ceph_statfs& result, std::optional<int64_t> poolid,
 		    Context *onfinish) {
     get_fs_stats(poolid, OpContextVert(onfinish, result));
   }

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -353,6 +353,9 @@ add_ceph_unittest(unittest_cdc)
 add_executable(unittest_ceph_timer test_ceph_timer.cc)
 add_ceph_unittest(unittest_ceph_timer)
 
+add_executable(unittest_option test_option.cc)
+target_link_libraries(unittest_option ceph-common GTest::Main)
+add_ceph_unittest(unittest_option)
 
 add_executable(unittest_blocked_completion test_blocked_completion.cc)
 add_ceph_unittest(unittest_blocked_completion)

--- a/src/test/common/test_option.cc
+++ b/src/test/common/test_option.cc
@@ -1,0 +1,71 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab expandtab
+
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include <gtest/gtest.h>
+
+#include "common/options.h"
+
+TEST(Option, validate_min_max)
+{
+  auto opt = Option{"foo", Option::TYPE_MILLISECS, Option::LEVEL_ADVANCED}
+    .set_default(42)
+    .set_min_max(10, 128);
+  struct test_t {
+    unsigned new_val;
+    int expected_retval;
+  };
+  test_t tests[] =
+    {{9, -EINVAL},
+     {10, 0},
+     {11, 0},
+     {128, 0},
+     {1024, -EINVAL}
+  };
+  for (auto& test : tests) {
+    Option::value_t new_value = std::chrono::milliseconds{test.new_val};
+    std::string err;
+    GTEST_ASSERT_EQ(test.expected_retval, opt.validate(new_value, &err));
+  }
+}
+
+TEST(Option, parse)
+{
+  auto opt = Option{"foo", Option::TYPE_MILLISECS, Option::LEVEL_ADVANCED}
+    .set_default(42)
+    .set_min_max(10, 128);
+  struct test_t {
+    string new_val;
+    int expected_retval;
+    unsigned expected_parsed_val;
+  };
+  test_t tests[] =
+    {{"9", -EINVAL, 0},
+     {"10", 0, 10},
+     {"11", 0, 11},
+     {"128", 0, 128},
+     {"1024", -EINVAL, 0}
+  };
+  for (auto& test : tests) {
+    Option::value_t parsed_val;
+    std::string err;
+    GTEST_ASSERT_EQ(test.expected_retval,
+                    opt.parse_value(test.new_val, &parsed_val, &err));
+    if (test.expected_retval == 0) {
+      Option::value_t expected_parsed_val =
+        std::chrono::milliseconds{test.expected_parsed_val};
+      GTEST_ASSERT_EQ(parsed_val, expected_parsed_val);
+    }
+  }
+}
+
+/*
+ * Local Variables:
+ * compile-command: "cd ../../../build ;
+ *   ninja unittest_option && bin/unittest_option
+ *   "
+ * End:
+ */


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/51375

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
