### PR TITLE
doc/cephadm: enrich "Disabling Automatic Deploy..."

### DIFF
--- a/doc/cephadm/service-management.rst
+++ b/doc/cephadm/service-management.rst
@@ -361,14 +361,17 @@ demanded by ``count``, cephadm will only deploy on selected hosts.
 
 .. _cephadm-spec-unmanaged:
 
-Disable automatic deployment of daemons
-=======================================
+Disabling automatic deployment of daemons
+=========================================
 
-Cephadm supports disabling the automated deployment and removal of daemons per service. In
-this case, the CLI supports two commands that are dedicated to this mode. 
+Cephadm supports disabling the automated deployment and removal of daemons on a
+per service basis. The CLI supports two commands for this.
 
-To disable the automatic management of dameons, apply
-the :ref:`orchestrator-cli-service-spec` with ``unmanaged=True``. 
+Disabling automatic management of daemons
+-----------------------------------------
+
+To disable the automatic management of dameons, set ``unmanaged=True`` in the
+:ref:`orchestrator-cli-service-spec` (``mgr.yaml``).
 
 ``mgr.yaml``:
 
@@ -379,16 +382,22 @@ the :ref:`orchestrator-cli-service-spec` with ``unmanaged=True``.
   placement:
     label: mgr
 
-.. code-block:: bash
 
-  ceph orch apply -i mgr.yaml
+.. prompt:: bash #
+
+   ceph orch apply -i mgr.yaml
+
 
 .. note::
 
-  cephadm will no longer deploy any new daemons, if the placement
-  specification matches additional hosts.
+  After you apply this change in the Service Specification, cephadm will no
+  longer deploy any new daemons (even if the placement specification matches
+  additional hosts).
 
-To manually deploy a daemon on a host, please execute:
+Deploying a daemon on a host manually
+-------------------------------------
+
+To manually deploy a daemon on a host, run a command of the following form:
 
    .. prompt:: bash #
 
@@ -400,7 +409,10 @@ For example :
 
      ceph orch daemon add mgr --placement=my_host
 
-To manually remove a daemon, please run:
+Removing a daemon from a host manually
+--------------------------------------
+
+To manually remove a daemon, run a command of the following form:
 
    .. prompt:: bash #
 
@@ -416,6 +428,9 @@ For example:
 
   For managed services (``unmanaged=False``), cephadm will automatically
   deploy a new daemon a few seconds later.
+
+See also
+--------
     
 * See :ref:`cephadm-osd-declarative` for special handling of unmanaged OSDs. 
 * See also :ref:`cephadm-pause`


### PR DESCRIPTION
This PR rewrites and reformats the section "Disabling Automatic
Deployment of Daemons" in the "Service Management" chapter of the
cephadm guide.

I've rewritten some sentences, removed some "please"s, and added
some section titles so that the content in this is better
signposted.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
