### PR TITLE
pacific: mds: Error ENOSYS: mds.a started profiler

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -180,6 +180,7 @@ void MDSDaemon::asok_command(
 	heapcmd_vec.push_back(value);
       }
       ceph_heap_profiler_handle_command(heapcmd_vec, ss);
+      r = 0;
     }
   } else if (command == "cpu_profiler") {
     string arg;


### PR DESCRIPTION
https://tracker.ceph.com/issues/50630