### PR TITLE
pacific: mds: journal recovery thread is possibly asserting with mds_lock not locked

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -959,7 +959,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
 
       // Oh dear, something unreadable in the store for this rank: require
       // operator intervention.
-      mds->damaged();
+      mds->damaged_unlocked();
       ceph_abort();  // damaged should not return
   }
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/50846