### PR TITLE
pacific: qa: fs:bugs does not specify distro

### DIFF
--- a/qa/suites/fs/bugs/client_trim_caps/centos_latest.yaml
+++ b/qa/suites/fs/bugs/client_trim_caps/centos_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/centos_latest.yaml


### PR DESCRIPTION
https://tracker.ceph.com/issues/51230