### PR TITLE
pacific: qa: test_data_scan.TestDataScan.test_pg_files AssertionError: Items in the second set but not the first:

### DIFF
--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -545,7 +545,7 @@ class TestDataScan(CephFSTestCase):
 
         pg_count = self.fs.pgs_per_fs_pool
         for pg_n in range(0, pg_count):
-            pg_str = "{0}.{1}".format(self.fs.get_data_pool_id(), pg_n)
+            pg_str = "{0}.{1:x}".format(self.fs.get_data_pool_id(), pg_n)
             out = self.fs.data_scan(["pg_files", "mydir", pg_str])
             lines = [l for l in out.split("\n") if l]
             log.info("{0}: {1}".format(pg_str, lines))


### PR DESCRIPTION
https://tracker.ceph.com/issues/51322