### PR TITLE
common: Use double instead of long double to improve performance

### DIFF
--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -224,7 +224,7 @@ public:
 
   // cast to double
   operator double() const {
-    return (double)sec() + ((double)nsec() / 1000000000.0L);
+    return (double)sec() + ((double)nsec() / 1000000000.0f);
   }
   operator ceph_timespec() const {
     ceph_timespec ts;


### PR DESCRIPTION
To convert namoseconds to seconds, the precision needs to be 10,
and the precision of double is 15, which is enough to use.
On aarch64, double division uses the div instruction, while long
double uses the gcc buildin _divtf3, which has poor performance.
Therefore, use double instead of long double for better performance.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
