### PR TITLE
osd, crimson/osd: do_cmp_xattr() related cleanups

### DIFF
--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -830,29 +830,31 @@ PGBackend::get_attr_ierrorator::future<> PGBackend::get_xattrs(
     return get_attr_errorator::now();
   });
 }
-static int do_xattr_cmp_str(int op, const string& lhs, bufferlist& rhs_xattr)
+
+namespace {
+
+template<typename U, typename V>
+int do_cmp_xattr(int op, const U& lhs, const V& rhs)
 {
-  string rhs(rhs_xattr.c_str(), rhs_xattr.length());
-
-  logger().debug("do_xattr_cmp_str '{}' vs '{}' op {}", lhs, rhs, op);
-
   switch (op) {
   case CEPH_OSD_CMPXATTR_OP_EQ:
-    return (lhs.compare(rhs) == 0);
+    return lhs == rhs;
   case CEPH_OSD_CMPXATTR_OP_NE:
-    return (lhs.compare(rhs) != 0);
+    return lhs != rhs;
   case CEPH_OSD_CMPXATTR_OP_GT:
-    return (lhs.compare(rhs) > 0);
+    return lhs > rhs;
   case CEPH_OSD_CMPXATTR_OP_GTE:
-    return (lhs.compare(rhs) >= 0);
+    return lhs >= rhs;
   case CEPH_OSD_CMPXATTR_OP_LT:
-    return (lhs.compare(rhs) < 0);
+    return lhs < rhs;
   case CEPH_OSD_CMPXATTR_OP_LTE:
-    return (lhs.compare(rhs) <= 0);
+    return lhs <= rhs;
   default:
     return -EINVAL;
   }
 }
+
+} // anonymous namespace
 
 static int do_xattr_cmp_u64(int op, uint64_t lhs, bufferlist& rhs_xattr)
 {
@@ -864,24 +866,9 @@ static int do_xattr_cmp_u64(int op, uint64_t lhs, bufferlist& rhs_xattr)
     rhs = 0;
   }
   logger().debug("do_xattr_cmp_u64 '{}' vs '{}' op {}", lhs, rhs, op);
-
-  switch (op) {
-  case CEPH_OSD_CMPXATTR_OP_EQ:
-    return (lhs == rhs);
-  case CEPH_OSD_CMPXATTR_OP_NE:
-    return (lhs != rhs);
-  case CEPH_OSD_CMPXATTR_OP_GT:
-    return (lhs > rhs);
-  case CEPH_OSD_CMPXATTR_OP_GTE:
-    return (lhs >= rhs);
-  case CEPH_OSD_CMPXATTR_OP_LT:
-    return (lhs < rhs);
-  case CEPH_OSD_CMPXATTR_OP_LTE:
-    return (lhs <= rhs);
-  default:
-    return -EINVAL;
-  }
+  return do_cmp_xattr(op, lhs, rhs);
 }
+
 PGBackend::cmp_xattr_ierrorator::future<> PGBackend::cmp_xattr(
   const ObjectState& os,
   OSDOp& osd_op) const
@@ -900,10 +887,11 @@ PGBackend::cmp_xattr_ierrorator::future<> PGBackend::cmp_xattr(
     switch (osd_op.op.xattr.cmp_mode) {
     case CEPH_OSD_CMPXATTR_MODE_STRING:
       {
-        string val;
-        bp.copy(osd_op.op.xattr.value_len, val);
-        result = do_xattr_cmp_str(osd_op.op.xattr.cmp_op, val, xattr);
-        logger().debug("cmpxattr val={}, xattr= {}", val, xattr);
+        string lhs;
+        bp.copy(osd_op.op.xattr.value_len, lhs);
+        string_view rhs(xattr.c_str(), xattr.length());
+        result = do_cmp_xattr(osd_op.op.xattr.cmp_op, lhs, rhs);
+        logger().debug("cmpxattr lhs={}, rhs={}", lhs, rhs);
       }
     break;
     case CEPH_OSD_CMPXATTR_MODE_U64:

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -862,7 +862,11 @@ static int do_xattr_cmp_u64(int op, uint64_t lhs, bufferlist& rhs_xattr)
   uint64_t rhs;
 
   if (rhs_xattr.length() > 0) {
-    std::from_chars(rhs_xattr.c_str(), rhs_xattr.c_str() + rhs_xattr.length(), rhs);
+    const char* first = rhs_xattr.c_str();
+    if (auto [p, ec] = std::from_chars(first, first + rhs_xattr.length(), rhs);
+	ec != std::errc()) {
+      return -EINVAL;
+    }
   } else {
     rhs = 0;
   }

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -901,15 +901,15 @@ PGBackend::cmp_xattr_ierrorator::future<> PGBackend::cmp_xattr(
     break;
     case CEPH_OSD_CMPXATTR_MODE_U64:
       {
-        uint64_t val;
+        uint64_t lhs;
         try {
-          decode(val, bp);
+          decode(lhs, bp);
 	} catch (ceph::buffer::error& e) {
           logger().info("cmp_xattr: buffer error expection");
           result = -EINVAL;
           break;
 	}
-        result = do_xattr_cmp_u64(osd_op.op.xattr.cmp_op, val, xattr);
+        result = do_xattr_cmp_u64(osd_op.op.xattr.cmp_op, lhs, xattr);
       }
     break;
     default:

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -3,6 +3,7 @@
 
 #include "pg_backend.h"
 
+#include <charconv>
 #include <optional>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -15,10 +15,15 @@
  *
  */
 
-#include <charconv>
+#include <errno.h>
 
-#include "boost/tuple/tuple.hpp"
-#include "boost/intrusive_ptr.hpp"
+#include <charconv>
+#include <sstream>
+#include <utility>
+
+#include <boost/intrusive_ptr.hpp>
+#include <boost/tuple/tuple.hpp>
+
 #include "PG.h"
 #include "pg_scrubber.h"
 #include "PrimaryLogPG.h"
@@ -32,9 +37,12 @@
 
 #include "cls/cas/cls_cas_ops.h"
 #include "common/ceph_crypto.h"
+#include "common/config.h"
 #include "common/errno.h"
 #include "common/scrub_types.h"
 #include "common/perf_counters.h"
+#include "common/CDC.h"
+#include "common/EventTrace.h"
 
 #include "messages/MOSDOp.h"
 #include "messages/MOSDBackoff.h"
@@ -48,9 +56,7 @@
 #include "messages/MOSDPGUpdateLogMissingReply.h"
 #include "messages/MCommandReply.h"
 #include "messages/MOSDScrubReserve.h"
-#include "common/EventTrace.h"
 
-#include "common/config.h"
 #include "include/compat.h"
 #include "mon/MonClient.h"
 #include "osdc/Objecter.h"
@@ -71,15 +77,9 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)
 
-#include <sstream>
-#include <utility>
-
-#include <errno.h>
 #ifdef HAVE_JAEGER
 #include "common/tracer.h"
 #endif
-
-#include <common/CDC.h>
 
 MEMPOOL_DEFINE_OBJECT_FACTORY(PrimaryLogPG, replicatedpg, osd);
 

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1379,7 +1379,7 @@ protected:
                    unsigned split_bits) override;
   void apply_and_flush_repops(bool requeue);
 
-  int do_xattr_cmp_u64(int op, __u64 v1, ceph::buffer::list& xattr);
+  int do_xattr_cmp_u64(int op, uint64_t v1, ceph::buffer::list& xattr);
   int do_xattr_cmp_str(int op, std::string& v1s, ceph::buffer::list& xattr);
 
   // -- checksum --


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
