### PR TITLE
mgr/volumes: subvoulme snapshot mirroring interface

### DIFF
--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
@@ -332,3 +332,12 @@ class SubvolumeBase(object):
             'bytes_quota': "infinite" if nsize == 0 else nsize, 'bytes_used': int(usedbytes),
             'bytes_pcent': "undefined" if nsize == 0 else '{0:.2f}'.format((float(usedbytes) / nsize) * 100.0),
             'pool_namespace': pool_namespace, 'features': self.features, 'state': self.state.value}
+
+    def set_mirrored(self):
+        self.metadata_mgr.update_global_section("mirrored", 1)
+        self.metadata_mgr.flush()
+
+    def unset_mirrored(self):
+        self.metadata_mgr.remove_option(MetadataManager.GLOBAL_SECTION, "mirrored")
+        self.metadata_mgr.flush()
+

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -320,6 +320,24 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'desc': "Cancel an pending or ongoing clone operation.",
             'perm': 'r'
         },
+        {
+            'cmd': 'fs subvolume snapshot mirror enable '
+                   'name=vol_name,type=CephString '
+                   'name=sub_name,type=CephString '
+                   'name=group_name,type=CephString,req=false ',
+                   'desc': "Enable snapshot mirroring of a CephFS subvolume in a volume, "
+                           "and optionally, in a specific subvolume group",
+                   'perm': 'rw'
+        },
+        {
+            'cmd': 'fs subvolume snapshot mirror disable '
+                   'name=vol_name,type=CephString '
+                   'name=sub_name,type=CephString '
+                   'name=group_name,type=CephString,req=false ',
+                   'desc': "Disable snapshot mirroring of a CephFS subvolume in a volume, "
+                           "and optionally, in a specific subvolume group",
+                   'perm': 'rw'
+        },
         # volume ls [recursive]
         # subvolume ls <volume>
         # volume authorize/deauthorize
@@ -615,3 +633,16 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _cmd_fs_clone_cancel(self, inbuf, cmd):
         return self.vc.clone_cancel(
             vol_name=cmd['vol_name'], clone_name=cmd['clone_name'],  group_name=cmd.get('group_name', None))
+
+    @mgr_cmd_wrap
+    def _cmd_fs_subvolume_snapshot_mirror_enable(self, inbuf, cmd):
+        return self.vc.subvolume_snapshot_mirror_enable(vol_name=cmd['vol_name'],
+                                                        sub_name=cmd['sub_name'],
+                                                        group_name=cmd.get('group_name', None))
+
+    @mgr_cmd_wrap
+    def _cmd_fs_subvolume_snapshot_mirror_disable(self, inbuf, cmd):
+        return self.vc.subvolume_snapshot_mirror_disable(vol_name=cmd['vol_name'],
+                                                         sub_name=cmd['sub_name'],
+                                                         group_name=cmd.get('group_name', None))
+


### PR DESCRIPTION
Keeping this draft atm.

The idea is to introduce mirroring interfaces in mgr/volumes to synchronize subvolume snapshots. The approach is pretty straightforward, however, we probably need to discuss more about accessibility of the synchronized snapshots via `ceph fs subvolume ...` based mgr interfaces.

Since snapshots are synchronized by copying snap data to the remote file system followed by taking a snapshot of the remote directory, there is a possibility of an interrupted sync (mirror daemon terminating, etc..) which could lead to the remote directory content half-baked. This can cause subvolume based commands on the remote file system not function as expected (think if the .meta is left in a half-baked state when the mirror daemon is interrupted). I.e., the "remote" subvolume is in an inconsistent state till the mirror daemon snaps the remote directory.

Signed-off-by: Venky Shankar <vshankar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
