### PR TITLE
doc/radosgw/vault: update the vault documentation

### DIFF
--- a/doc/radosgw/vault.rst
+++ b/doc/radosgw/vault.rst
@@ -174,58 +174,6 @@ Adjust these settinsg to match your configuration.
 For security reasons, the token file must be readable by the Object Gateway
 only.
 
-You might set up vault agent as follows::
-
-  vault write auth/approle/role/rgw-ap \
-    token_policies=rgw-transit-policy,default \
-    token_max_ttl=60m
-
-Change the policy here to match your configuration.
-
-Get the role-id::
-
-  vault read auth/approle/role/rgw-ap/role-id -format=json | \
-    jq -r .data.role_id
-
-Store the output in some file, such as /usr/local/etc/vault/.rgw-ap-role-id
-
-Get the secret-id::
-
-  vault read auth/approle/role/rgw-ap/role-id -format=json | \
-    jq -r .data.role_id
-
-Store the output in some file, such as /usr/local/etc/vault/.rgw-ap-secret-id
-
-Create configuration for the Vault agent, such as::
-
-  pid_file = "/run/rgw-vault-agent-pid"
-  auto_auth {
-    method "AppRole" {
-      mount_path = "auth/approle"
-      config = {
-        role_id_file_path ="/usr/local/etc/vault/.rgw-ap-role-id"
-        secret_id_file_path ="/usr/local/etc/vault/.rgw-ap-secret-id"
-        remove_secret_id_file_after_reading ="false"
-      }
-    }
-    sink "file" {
-      config = {
-        path = "/run/.rgw-vault-token"
-      }
-    }
-  }
-  vault {
-    address = "https://vault-server-fqdn:8200"
-  }
-
-Then use systemctl or another method of your choice to run
-a persistent daemon with the following arguments::
-
-    /usr/local/bin/vault agent -config=/usr/local/etc/vault/rgw-agent.hcl
-
-Once the vault agent is running, the token file should be populated
-with a valid token.
-
 Vault agent
 -----------
 
@@ -345,7 +293,7 @@ The command above creates a keyring, which contains a key of type
 ``aes256-gcm96`` by default. To verify that the key was correctly created, use
 the following command::
 
-  vault read transit/mybucketkey
+  vault read transit/keys/mybucketkey
 
 Sample output::
 


### PR DESCRIPTION
The details about vault agent specified twice the doc, removing the
additional reference from `vault token` section.

Signed-off-by: Jiffin Tony Thottan <jthottan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
