### PR TITLE
os/bluestore: BlueFS fine grain locking

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -464,7 +464,7 @@ void BlueFS::dump_block_extents(ostream& out)
 
 int BlueFS::get_block_extents(unsigned id, interval_set<uint64_t> *extents)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " bdev " << id << dendl;
   ceph_assert(id < alloc.size());
   for (auto& p : nodes.file_map) {
@@ -517,13 +517,13 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
   ceph_assert(log.seq_live == 1);
   log.t.seq = 1;
   log.t.op_init();
-  flush_and_sync_log();
+  _flush_and_sync_log_LD();
 
   // write supers
   super.log_fnode = log_file->fnode;
   super.memorized_layout = layout;
   _write_super(BDEV_DB);
-  flush_bdev();
+  _flush_bdev();
 
   // clean up
   super = bluefs_super_t();
@@ -866,7 +866,7 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
       new_log_dev_cur = BDEV_NEWDB;
       new_log_dev_next = BDEV_DB;
     }
-    rewrite_log_and_layout_sync(false,
+    _rewrite_log_and_layout_sync_LN_LD(false,
       BDEV_NEWDB,
       new_log_dev_cur,
       new_log_dev_next,
@@ -874,7 +874,7 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
       layout);
     //}
   } else if(id == BDEV_NEWWAL) {
-    rewrite_log_and_layout_sync(false,
+    _rewrite_log_and_layout_sync_LN_LD(false,
       BDEV_DB,
       BDEV_NEWWAL,
       BDEV_WAL,
@@ -1089,7 +1089,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
       int r = _read(log_reader, read_pos, super.block_size,
 		    &bl, NULL);
       if (r != (int)super.block_size && cct->_conf->bluefs_replay_recovery) {
-	r += do_replay_recovery_read(log_reader, pos, read_pos + r, super.block_size - r, &bl);
+	r += _do_replay_recovery_read(log_reader, pos, read_pos + r, super.block_size - r, &bl);
       }
       assert(r == (int)super.block_size);
       read_pos += r;
@@ -1149,7 +1149,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
                  << ", which is past eof" << dendl;
 	if (cct->_conf->bluefs_replay_recovery) {
 	  //try to search for more data
-	  r += do_replay_recovery_read(log_reader, pos, read_pos + r, more - r, &t);
+	  r += _do_replay_recovery_read(log_reader, pos, read_pos + r, more - r, &t);
 	  if (r < (int)more) {
 	    //in normal mode we must read r==more, for recovery it is too strict
 	    break;
@@ -1650,7 +1650,7 @@ int BlueFS::device_migrate_to_existing(
         new_log_dev_next;
   }
 
-  rewrite_log_and_layout_sync(
+  _rewrite_log_and_layout_sync_LN_LD(
     false,
     (flags & REMOVE_DB) ? BDEV_SLOW : BDEV_DB,
     new_log_dev_cur,
@@ -1785,7 +1785,7 @@ int BlueFS::device_migrate_to_new(
         BDEV_DB :
 	BDEV_SLOW;
 
-  rewrite_log_and_layout_sync(
+  _rewrite_log_and_layout_sync_LN_LD(
     false,
     super_dev,
     new_log_dev_cur,
@@ -1810,7 +1810,7 @@ BlueFS::FileRef BlueFS::_get_file(uint64_t ino)
   }
 }
 
-void BlueFS::_drop_link(FileRef file)
+void BlueFS::_drop_link_D(FileRef file)
 {
   dout(20) << __func__ << " had refs " << file->refs
 	   << " on " << file->fnode << dendl;
@@ -2078,9 +2078,9 @@ void BlueFS::invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
   }
 }
 
-uint64_t BlueFS::estimate_log_size()
+uint64_t BlueFS::_estimate_log_size_N()
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   int avg_dir_size = 40;  // fixme
   int avg_file_size = 12;
   uint64_t size = 4096 * 2;
@@ -2094,14 +2094,14 @@ void BlueFS::compact_log()
 {
   if (!cct->_conf->bluefs_replay_recovery_disable_compact) {
     if (cct->_conf->bluefs_compact_log_sync) {
-      compact_log_sync();
+      _compact_log_sync_LN_LD();
     } else {
-      compact_log_async();
+      _compact_log_async_LD_NF_D();
     }
   }
 }
 
-bool BlueFS::should_start_compact_log()
+bool BlueFS::_should_start_compact_log_L_N()
 {
   if (log_is_compacting.load() == true) {
     // compaction is already running
@@ -2109,10 +2109,10 @@ bool BlueFS::should_start_compact_log()
   }
   uint64_t current;
   {
-    std::lock_guard dirl(log.lock);
+    std::lock_guard ll(log.lock);
     current = log.writer->file->fnode.size;
   }
-  uint64_t expected = estimate_log_size();
+  uint64_t expected = _estimate_log_size_N();
   float ratio = (float)current / (float)expected;
   dout(10) << __func__ << " current 0x" << std::hex << current
 	   << " expected " << expected << std::dec
@@ -2125,10 +2125,10 @@ bool BlueFS::should_start_compact_log()
   return true;
 }
 
-void BlueFS::compact_log_dump_metadata(bluefs_transaction_t *t,
+void BlueFS::_compact_log_dump_metadata_N(bluefs_transaction_t *t,
 					int flags)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
 
   t->seq = 1;
   t->uuid = super.uuid;
@@ -2176,12 +2176,12 @@ void BlueFS::compact_log_dump_metadata(bluefs_transaction_t *t,
   }
 }
 
-void BlueFS::compact_log_sync()
+void BlueFS::_compact_log_sync_LN_LD()
 {
   dout(10) << __func__ << dendl;
   auto prefer_bdev =
     vselector->select_prefer_bdev(log.writer->file->vselector_hint);
-  rewrite_log_and_layout_sync(true,
+  _rewrite_log_and_layout_sync_LN_LD(true,
     BDEV_DB,
     prefer_bdev,
     prefer_bdev,
@@ -2190,7 +2190,7 @@ void BlueFS::compact_log_sync()
   logger->inc(l_bluefs_log_compactions);
 }
 
-void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
+void BlueFS::_rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
 					 int super_dev,
 					 int log_dev,
 					 int log_dev_new,
@@ -2216,7 +2216,7 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
 		       << " flags:" << flags
 		       << dendl;
   bluefs_transaction_t t;
-  compact_log_dump_metadata(&t, flags);
+  _compact_log_dump_metadata_N(&t, flags);
 
   dout(20) << __func__ << " op_jump_seq " << log.seq_live << dendl;
   t.op_jump_seq(log.seq_live);
@@ -2260,11 +2260,11 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
     _claim_completed_aios(log.writer, &completed_ios);
-    wait_for_aio(log.writer);
+    _wait_for_aio(log.writer);
     completed_ios.clear();
   }
 #endif
-  flush_bdev();
+  _flush_bdev();
 
   super.memorized_layout = layout;
   super.log_fnode = log_file->fnode;
@@ -2279,7 +2279,7 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
 
   ++super.version;
   _write_super(super_dev);
-  flush_bdev();
+  _flush_bdev();
 
   dout(10) << __func__ << " release old log extents " << old_fnode.extents << dendl;
   std::lock_guard dl(dirty.lock);
@@ -2311,7 +2311,7 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
  * 8. Release the old log space.  Clean up.
  */
 
-void BlueFS::compact_log_async()
+void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
 {
   dout(10) << __func__ << dendl;
   // only one compaction allowed at one time
@@ -2367,8 +2367,8 @@ void BlueFS::compact_log_async()
   // we need to flush all bdev because we will be streaming all dirty files to log
   // TODO - think - if _flush_and_sync_log_jump will not add dirty files nor release pending allocations
   // then flush_bdev() will not be necessary
-  flush_bdev();
-  _flush_and_sync_log_jump(old_log_jump_to, runway);
+  _flush_bdev();
+  _flush_and_sync_log_jump_D(old_log_jump_to, runway);
 
   log.lock.unlock();
   // out of jump section - now log can be used to write to
@@ -2378,7 +2378,7 @@ void BlueFS::compact_log_async()
   //this needs files lock
   //what will happen, if a file is modified *twice* before we stream it to log?
   //the later state that we capture will be seen earlier and replay will see a temporary retraction (!)
-  compact_log_dump_metadata(&t, 0);
+  compact_log_dump_metadata_N(&t, 0);
 
   uint64_t max_alloc_size = std::max(alloc_size[BDEV_WAL],
 				     std::max(alloc_size[BDEV_DB],
@@ -2409,6 +2409,7 @@ void BlueFS::compact_log_async()
   new_log_writer = _create_writer(new_log);
 
   new_log_writer->append(bl);
+  new_log->lock.lock();
   new_log_writer->lock.lock();
   // 3. flush
   r = _flush_special(new_log_writer);
@@ -2417,6 +2418,7 @@ void BlueFS::compact_log_async()
   // 4. wait
   _flush_bdev(new_log_writer);
   new_log_writer->lock.unlock();
+  new_log->lock.unlock();
   // 5. update our log fnode
   // discard first old_log_jump_to extents
 
@@ -2468,7 +2470,7 @@ void BlueFS::compact_log_async()
   ++super.version;
   _write_super(BDEV_DB);
 
-  flush_bdev();
+  _flush_bdev();
 
   old_forbidden = atomic_exchange(&log_forbidden_to_expand, false);
   ceph_assert(old_forbidden == true);
@@ -2641,9 +2643,9 @@ void BlueFS::_flush_and_sync_log_core(int64_t runway)
 }
 
 // Clears dirty.files up to (including) seq_stable.
-void BlueFS::clear_dirty_set_stable(uint64_t seq)
+void BlueFS::_clear_dirty_set_stable_D(uint64_t seq)
 {
-  std::lock_guard lg(dirty.lock);
+  std::lock_guard dl(dirty.lock);
 
   // clean dirty files
   if (seq > dirty.seq_stable) {
@@ -2678,7 +2680,7 @@ void BlueFS::clear_dirty_set_stable(uint64_t seq)
   }
 }
 
-void BlueFS::release_pending_allocations(vector<interval_set<uint64_t>>& to_release)
+void BlueFS::_release_pending_allocations(vector<interval_set<uint64_t>>& to_release)
 {
   for (unsigned i = 0; i < to_release.size(); ++i) {
     if (!to_release[i].empty()) {
@@ -2701,9 +2703,8 @@ void BlueFS::release_pending_allocations(vector<interval_set<uint64_t>>& to_rele
   }
 }
 
-int BlueFS::flush_and_sync_log(uint64_t want_seq)
+int BlueFS::_flush_and_sync_log_LD(uint64_t want_seq)
 {
-  // we synchronize writing to log, by lock to log_lock
   int64_t available_runway;
   do {
     log.lock.lock();
@@ -2742,15 +2743,15 @@ int BlueFS::flush_and_sync_log(uint64_t want_seq)
   //now log.lock is no longer needed
   log.lock.unlock();
 
-  clear_dirty_set_stable(seq);
-  release_pending_allocations(to_release);
+  _clear_dirty_set_stable_D(seq);
+  _release_pending_allocations(to_release);
 
   _update_logger_stats();
   return 0;
 }
 
 // Flushes log and immediately adjusts log_writer pos.
-int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
+int BlueFS::_flush_and_sync_log_jump_D(uint64_t jump_to,
 				     int64_t available_runway)
 {
   ceph_assert(ceph_mutex_is_locked(log.lock));
@@ -2775,8 +2776,8 @@ int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
 
   _flush_bdev(log.writer);
 
-  clear_dirty_set_stable(seq);
-  release_pending_allocations(to_release);
+  _clear_dirty_set_stable_D(seq);
+  _release_pending_allocations(to_release);
 
   _update_logger_stats();
   return 0;
@@ -2825,7 +2826,7 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
   return bl;
 }
 
-int BlueFS::_signal_dirty_to_log(FileWriter *h)
+int BlueFS::_signal_dirty_to_log_D(FileWriter *h)
 {
   ceph_assert(ceph_mutex_is_locked(h->lock));
   std::lock_guard dl(dirty.lock);
@@ -2854,12 +2855,12 @@ int BlueFS::_signal_dirty_to_log(FileWriter *h)
   return 0;
 }
 
-void BlueFS::flush_range(FileWriter *h, uint64_t offset, uint64_t length) {
+void BlueFS::flush_range/*WF*/(FileWriter *h, uint64_t offset, uint64_t length) {
   std::unique_lock hl(h->lock);
-  _flush_range(h, offset, length);
+  _flush_range_F(h, offset, length);
 }
 
-int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
+int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
 {
   ceph_assert(ceph_mutex_is_locked(h->lock));
   dout(10) << __func__ << " " << h << " pos 0x" << std::hex << h->pos
@@ -2918,8 +2919,10 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
 
 int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered)
 {
-  //ceph_assert(ceph_mutex_is_locked(h->lock));
-  //ceph_assert(ceph_mutex_is_locked(h->file->lock));
+  if (h->file->fnode.ino != 1) {
+    ceph_assert(ceph_mutex_is_locked(h->lock));
+    ceph_assert(ceph_mutex_is_locked(h->file->lock));
+  }
   uint64_t x_off = 0;
   auto p = h->file->fnode.seek(offset, &x_off);
   ceph_assert(p != h->file->fnode.extents.end());
@@ -3009,7 +3012,7 @@ void BlueFS::_claim_completed_aios(FileWriter *h, list<aio_t> *ls)
   dout(10) << __func__ << " got " << ls->size() << " aios" << dendl;
 }
 
-void BlueFS::wait_for_aio(FileWriter *h)
+void BlueFS::_wait_for_aio(FileWriter *h)
 {
   // NOTE: this is safe to call without a lock, as long as our reference is
   // stable.
@@ -3027,7 +3030,7 @@ void BlueFS::wait_for_aio(FileWriter *h)
 #endif
 
 
-void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
+void BlueFS::append_try_flush/*_WFL_WFN*/(FileWriter *h, const char* buf, size_t len)
 {
   std::unique_lock hl(h->lock);
   size_t max_size = 1ull << 30; // cap to 1GB
@@ -3043,10 +3046,10 @@ void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
     }
     if (need_flush) {
       bool flushed = false;
-      int r = _flush(h, true, &flushed);
+      int r = _flush_F(h, true, &flushed);
       ceph_assert(r == 0);
       if (r == 0 && flushed) {
-	maybe_compact_log();
+	_maybe_compact_log_LN_N_LD_D();
       }
       // make sure we've made any progress with flush hence the
       // loop doesn't iterate forever
@@ -3059,14 +3062,14 @@ void BlueFS::flush(FileWriter *h, bool force)
 {
   std::unique_lock hl(h->lock);
   bool flushed = false;
-  int r = _flush(h, force, &flushed);
+  int r = _flush_F(h, force, &flushed);
   ceph_assert(r == 0);
   if (r == 0 && flushed) {
-    maybe_compact_log();
+    _maybe_compact_log_LN_NF_LD_D();
   }
 }
 
-int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
+int BlueFS::_flush_F(FileWriter *h, bool force, bool *flushed)
 {
   ceph_assert(ceph_mutex_is_locked(h->lock));
   uint64_t length = h->get_buffer_length();
@@ -3090,7 +3093,7 @@ int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
            << std::hex << offset << "~" << length << std::dec
 	   << " to " << h->file->fnode << dendl;
   ceph_assert(h->pos <= h->file->fnode.size);
-  int r = _flush_range(h, offset, length);
+  int r = _flush_range_F(h, offset, length);
   if (flushed) {
     *flushed = true;
   }
@@ -3105,8 +3108,7 @@ int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
 // smart enough to discover it on its own.
 int BlueFS::_flush_special(FileWriter *h)
 {
-  //ceph_assert(ceph_mutex_is_locked(h->lock));
-  //ceph_assert(ceph_mutex_is_locked(h->file->lock));
+  ceph_assert(h->file->fnode.ino <= 1);
   uint64_t length = h->get_buffer_length();
   uint64_t offset = h->pos;
   ceph_assert(length + offset <= h->file->fnode.get_allocated());
@@ -3137,7 +3139,7 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)
     ceph_abort_msg("actually this shouldn't happen");
   }
   if (h->get_buffer_length()) {
-    int r = _flush(h, true);
+    int r = _flush_F(h, true);
     if (r < 0)
       return r;
   }
@@ -3159,28 +3161,36 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)
 int BlueFS::fsync(FileWriter *h)
 {
   std::unique_lock hl(h->lock);
-  dout(10) << __func__ << " " << h << " " << h->file->fnode << dendl;
-  int r = _flush(h, true);
-  if (r < 0)
-     return r;
-  if (h->file->is_dirty) {
-    _signal_dirty_to_log(h);
-    h->file->is_dirty = false;
+  uint64_t old_dirty_seq = 0;
+  {
+    dout(10) << __func__ << " " << h << " " << h->file->fnode << dendl;
+    int r = _flush_F(h, true);
+    if (r < 0)
+      return r;
+    _flush_bdev(h);
+    if (h->file->is_dirty) {
+      _signal_dirty_to_log_D(h);
+      h->file->is_dirty = false;
+    }
+    {
+      std::lock_guard dl(dirty.lock);
+      if (dirty.seq_stable < h->file->dirty_seq) {
+	old_dirty_seq = h->file->dirty_seq;
+	dout(20) << __func__ << " file metadata was dirty (" << old_dirty_seq
+		 << ") on " << h->file->fnode << ", flushing log" << dendl;
+      }
+    }
   }
-  uint64_t old_dirty_seq = h->file->dirty_seq;
-
-  _flush_bdev(h);
-
   if (old_dirty_seq) {
     uint64_t s = log.seq_live; // AKAK !!! locks!
     dout(20) << __func__ << " file metadata was dirty (" << old_dirty_seq
 	     << ") on " << h->file->fnode << ", flushing log" << dendl;
-    flush_and_sync_log(old_dirty_seq);
+    _flush_and_sync_log_LD(old_dirty_seq);
     // AK - TODO - think - how can dirty_seq change if we are under h lock?
     ceph_assert(h->file->dirty_seq == 0 ||  // cleaned
 		h->file->dirty_seq >= s);    // or redirtied by someone else
   }
-  maybe_compact_log();
+  _maybe_compact_log_LN_NF_LD_D();
   return 0;
 }
 
@@ -3198,14 +3208,14 @@ void BlueFS::_flush_bdev(FileWriter *h)
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
     _claim_completed_aios(h, &completed_ios);
-    wait_for_aio(h);
+    _wait_for_aio(h);
     completed_ios.clear();
   }
 #endif
-  flush_bdev(flush_devs);
+  _flush_bdev(flush_devs);
 }
 
-void BlueFS::flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs)
+void BlueFS::_flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs)
 {
   // NOTE: this is safe to call without a lock.
   dout(20) << __func__ << dendl;
@@ -3215,7 +3225,7 @@ void BlueFS::flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs)
   }
 }
 
-void BlueFS::flush_bdev()
+void BlueFS::_flush_bdev()
 {
   // NOTE: this is safe to call without a lock.
   dout(20) << __func__ << dendl;
@@ -3378,24 +3388,24 @@ void BlueFS::sync_metadata(bool avoid_compact)
     lgeneric_subdout(cct, bluefs, 10) << __func__;
     start = ceph_clock_now();
     *_dout <<  dendl;
-    flush_bdev(); // FIXME?
-    flush_and_sync_log();
+    _flush_bdev(); // FIXME?
+    _flush_and_sync_log_LD();
     dout(10) << __func__ << " done in " << (ceph_clock_now() - start) << dendl;
   }
 
   if (!avoid_compact) {
-    maybe_compact_log();
+    _maybe_compact_log_LN_NF_LD_D();
   }
 }
 
-void BlueFS::maybe_compact_log()
+void BlueFS::_maybe_compact_log_LN_NF_LD_D()
 {
   if (!cct->_conf->bluefs_replay_recovery_disable_compact &&
-      should_start_compact_log()) {
+      _should_start_compact_log_L_N()) {
     if (cct->_conf->bluefs_compact_log_sync) {
-      compact_log_sync();
+      _compact_log_sync_LN_LD();
     } else {
-      compact_log_async();
+      _compact_log_async_LD_NF_D();
     }
   }
 }
@@ -3406,7 +3416,7 @@ int BlueFS::open_for_write(
   FileWriter **h,
   bool overwrite)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   DirRef dir;
@@ -3553,7 +3563,7 @@ int BlueFS::open_for_read(
   FileReader **h,
   bool random)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename
 	   << (random ? " (random)":" (sequential)") << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
@@ -3582,8 +3592,8 @@ int BlueFS::rename(
   std::string_view old_dirname, std::string_view old_filename,
   std::string_view new_dirname, std::string_view new_filename)
 {
-  std::lock_guard dirl(nodes.lock);
   std::lock_guard ll(log.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << old_dirname << "/" << old_filename
 	   << " -> " << new_dirname << "/" << new_filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(old_dirname);
@@ -3614,7 +3624,7 @@ int BlueFS::rename(
 	     << " already exists, unlinking" << dendl;
     ceph_assert(q->second != file);
     log.t.op_dir_unlink(new_dirname, new_filename);
-    _drop_link(q->second);
+    _drop_link_D(q->second);
   }
 
   dout(10) << __func__ << " " << new_dirname << "/" << new_filename << " "
@@ -3630,8 +3640,8 @@ int BlueFS::rename(
 
 int BlueFS::mkdir(std::string_view dirname)
 {
-  std::lock_guard dirl(nodes.lock);
   std::lock_guard ll(log.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   if (p != nodes.dir_map.end()) {
@@ -3645,8 +3655,8 @@ int BlueFS::mkdir(std::string_view dirname)
 
 int BlueFS::rmdir(std::string_view dirname)
 {
-  std::lock_guard dirl(nodes.lock);
   std::lock_guard ll(log.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << dendl;
   auto p = nodes.dir_map.find(dirname);
   if (p == nodes.dir_map.end()) {
@@ -3665,7 +3675,7 @@ int BlueFS::rmdir(std::string_view dirname)
 
 bool BlueFS::dir_exists(std::string_view dirname)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   bool exists = p != nodes.dir_map.end();
   dout(10) << __func__ << " " << dirname << " = " << (int)exists << dendl;
@@ -3675,7 +3685,7 @@ bool BlueFS::dir_exists(std::string_view dirname)
 int BlueFS::stat(std::string_view dirname, std::string_view filename,
 		 uint64_t *size, utime_t *mtime)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   if (p == nodes.dir_map.end()) {
@@ -3703,7 +3713,8 @@ int BlueFS::stat(std::string_view dirname, std::string_view filename,
 int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 		      FileLock **plock)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard ll(log.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   if (p == nodes.dir_map.end()) {
@@ -3723,7 +3734,6 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
     nodes.file_map[ino_last] = file;
     dir->file_map[string{filename}] = file;
     ++file->refs;
-    std::lock_guard ll(log.lock);
     log.t.op_file_update(file->fnode);
     log.t.op_dir_link(dirname, filename, file->fnode.ino);
   } else {
@@ -3742,7 +3752,7 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 
 int BlueFS::unlock_file(FileLock *fl)
 {
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << fl << " on " << fl->file->fnode << dendl;
   ceph_assert(fl->file->locked);
   fl->file->locked = false;
@@ -3756,7 +3766,7 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
   if (!dirname.empty() && dirname.back() == '/') {
     dirname.remove_suffix(1);
   }
-  std::lock_guard dirl(nodes.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << dendl;
   if (dirname.empty()) {
     // list dirs
@@ -3784,8 +3794,8 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
 
 int BlueFS::unlink(std::string_view dirname, std::string_view filename)
 {
-  std::lock_guard dirl(nodes.lock);
   std::lock_guard ll(log.lock);
+  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   if (p == nodes.dir_map.end()) {
@@ -3807,7 +3817,7 @@ int BlueFS::unlink(std::string_view dirname, std::string_view filename)
   }
   dir->file_map.erase(string{filename});
   log.t.op_dir_unlink(dirname, filename);
-  _drop_link(file);
+  _drop_link_D(file);
   return 0;
 }
 
@@ -3830,7 +3840,7 @@ bool BlueFS::wal_is_rotational()
   When we find it, we decode following bytes as extent.
   We read that whole extent and then check if merged with existing log part gives a proper bluefs transaction.
  */
-int BlueFS::do_replay_recovery_read(FileReader *log_reader,
+int BlueFS::_do_replay_recovery_read(FileReader *log_reader,
 				    size_t replay_pos,
 				    size_t read_offset,
 				    size_t read_len,

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -148,9 +148,9 @@ private:
       out.append(ss);
     } else if (command == "bluefs files list") {
       const char* devnames[3] = {"wal","db","slow"};
-      std::lock_guard l(bluefs->dirs_lock);
+      std::lock_guard l(bluefs->nodes.lock);
       f->open_array_section("files");
-      for (auto &d : bluefs->dir_map) {
+      for (auto &d : bluefs->nodes.dir_map) {
         std::string dir = d.first;
         for (auto &r : d.second->file_map) {
           f->open_object_section("file");
@@ -314,8 +314,8 @@ void BlueFS::_shutdown_logger()
 void BlueFS::_update_logger_stats()
 {
   // we must be holding the lock
-  logger->set(l_bluefs_num_files, file_map.size());
-  logger->set(l_bluefs_log_bytes, log_writer->file->fnode.size);
+  logger->set(l_bluefs_num_files, nodes.file_map.size());
+  logger->set(l_bluefs_log_bytes, log.writer->file->fnode.size);
 
   if (alloc[BDEV_WAL]) {
     logger->set(l_bluefs_wal_total_bytes, _get_total(BDEV_WAL));
@@ -464,10 +464,10 @@ void BlueFS::dump_block_extents(ostream& out)
 
 int BlueFS::get_block_extents(unsigned id, interval_set<uint64_t> *extents)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " bdev " << id << dendl;
   ceph_assert(id < alloc.size());
-  for (auto& p : file_map) {
+  for (auto& p : nodes.file_map) {
     for (auto& q : p.second->fnode.extents) {
       if (q.bdev == id) {
         extents->insert(q.offset, q.length);
@@ -511,10 +511,10 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
     &log_file->fnode);
   vselector->add_usage(log_file->vselector_hint, log_file->fnode);
   ceph_assert(r == 0);
-  log_writer = _create_writer(log_file);
+  log.writer = _create_writer(log_file);
 
   // initial txn
-  log_t.op_init();
+  log.t.op_init();
   flush_and_sync_log();
 
   // write supers
@@ -525,8 +525,8 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
 
   // clean up
   super = bluefs_super_t();
-  _close_writer(log_writer);
-  log_writer = NULL;
+  _close_writer(log.writer);
+  log.writer = NULL;
   vselector.reset(nullptr);
   _stop_alloc();
   _shutdown_logger();
@@ -781,7 +781,7 @@ int BlueFS::mount()
   }
 
   // init freelist
-  for (auto& p : file_map) {
+  for (auto& p : nodes.file_map) {
     dout(30) << __func__ << " noting alloc for " << p.second->fnode << dendl;
     for (auto& q : p.second->fnode.extents) {
       bool is_shared = is_shared_alloc(q.bdev);
@@ -804,11 +804,11 @@ int BlueFS::mount()
   }
 
   // set up the log for future writes
-  log_writer = _create_writer(_get_file(1));
-  ceph_assert(log_writer->file->fnode.ino == 1);
-  log_writer->pos = log_writer->file->fnode.size;
+  log.writer = _create_writer(_get_file(1));
+  ceph_assert(log.writer->file->fnode.ino == 1);
+  log.writer->pos = log.writer->file->fnode.size;
   dout(10) << __func__ << " log write pos set to 0x"
-           << std::hex << log_writer->pos << std::dec
+           << std::hex << log.writer->pos << std::dec
            << dendl;
 
   return 0;
@@ -841,15 +841,15 @@ void BlueFS::umount(bool avoid_compact)
 
   sync_metadata(avoid_compact);
 
-  _close_writer(log_writer);
-  log_writer = NULL;
+  _close_writer(log.writer);
+  log.writer = NULL;
 
   vselector.reset(nullptr);
   _stop_alloc();
-  file_map.clear();
-  dir_map.clear();
+  nodes.file_map.clear();
+  nodes.dir_map.clear();
   super = bluefs_super_t();
-  log_t.clear();
+  log.t.clear();
   _shutdown_logger();
 }
 
@@ -1033,7 +1033,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 {
   dout(10) << __func__ << (noop ? " NO-OP" : "") << dendl;
   ino_last = 1;  // by the log
-  log_seq = 0;
+  uint64_t log_seq = 0;
 
   FileRef log_file;
   log_file = _get_file(1);
@@ -1297,8 +1297,8 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 	  if (!noop) {
 	    FileRef file = _get_file(ino);
 	    ceph_assert(file->fnode.ino);
-	    map<string,DirRef>::iterator q = dir_map.find(dirname);
-	    ceph_assert(q != dir_map.end());
+	    map<string,DirRef>::iterator q = nodes.dir_map.find(dirname);
+	    ceph_assert(q != nodes.dir_map.end());
 	    map<string,FileRef>::iterator r = q->second->file_map.find(filename);
 	    ceph_assert(r == q->second->file_map.end());
 
@@ -1328,8 +1328,8 @@ int BlueFS::_replay(bool noop, bool to_stdout)
           }
  
 	  if (!noop) {
-	    map<string,DirRef>::iterator q = dir_map.find(dirname);
-	    ceph_assert(q != dir_map.end());
+	    map<string,DirRef>::iterator q = nodes.dir_map.find(dirname);
+	    ceph_assert(q != nodes.dir_map.end());
 	    map<string,FileRef>::iterator r = q->second->file_map.find(filename);
 	    ceph_assert(r != q->second->file_map.end());
             ceph_assert(r->second->refs > 0); 
@@ -1351,9 +1351,9 @@ int BlueFS::_replay(bool noop, bool to_stdout)
           }
 
 	  if (!noop) {
-	    map<string,DirRef>::iterator q = dir_map.find(dirname);
-	    ceph_assert(q == dir_map.end());
-	    dir_map[dirname] = ceph::make_ref<Dir>();
+	    map<string,DirRef>::iterator q = nodes.dir_map.find(dirname);
+	    ceph_assert(q == nodes.dir_map.end());
+	    nodes.dir_map[dirname] = ceph::make_ref<Dir>();
 	  }
 	}
 	break;
@@ -1370,10 +1370,10 @@ int BlueFS::_replay(bool noop, bool to_stdout)
           }
 
 	  if (!noop) {
-	    map<string,DirRef>::iterator q = dir_map.find(dirname);
-	    ceph_assert(q != dir_map.end());
+	    map<string,DirRef>::iterator q = nodes.dir_map.find(dirname);
+	    ceph_assert(q != nodes.dir_map.end());
 	    ceph_assert(q->second->file_map.empty());
-	    dir_map.erase(q);
+	    nodes.dir_map.erase(q);
 	  }
 	}
 	break;
@@ -1434,8 +1434,8 @@ int BlueFS::_replay(bool noop, bool to_stdout)
           }
 
           if (!noop) {
-            auto p = file_map.find(ino);
-            ceph_assert(p != file_map.end());
+            auto p = nodes.file_map.find(ino);
+            ceph_assert(p != nodes.file_map.end());
             vselector->sub_usage(p->second->vselector_hint, p->second->fnode);
             if (cct->_conf->bluefs_log_replay_check_allocations) {
 	      int r = _check_allocations(p->second->fnode,
@@ -1444,7 +1444,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 		return r;
               }
             }
-            file_map.erase(p);
+            nodes.file_map.erase(p);
           }
         }
 	break;
@@ -1464,6 +1464,9 @@ int BlueFS::_replay(bool noop, bool to_stdout)
   }
   if (!noop) {
     vselector->add_usage(log_file->vselector_hint, log_file->fnode);
+    log.seq_live = log_seq;
+    dirty.seq_next = log_seq + 1;
+    dirty.seq_stable = log_seq;
   }
 
   dout(10) << __func__ << " log file size was 0x"
@@ -1477,7 +1480,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 
   if (!noop) {
     // verify file link counts are all >0
-    for (auto& p : file_map) {
+    for (auto& p : nodes.file_map) {
       if (p.second->refs == 0 &&
 	  p.second->fnode.ino > 1) {
 	derr << __func__ << " file with link count 0: " << p.second->fnode
@@ -1494,7 +1497,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 int BlueFS::log_dump()
 {
   // only dump log file's content
-  ceph_assert(log_writer == nullptr && "cannot log_dump on mounted BlueFS");
+  ceph_assert(log.writer == nullptr && "cannot log_dump on mounted BlueFS");
   int r = _open_super();
   if (r < 0) {
     derr << __func__ << " failed to open super: " << cpp_strerror(r) << dendl;
@@ -1536,7 +1539,7 @@ int BlueFS::device_migrate_to_existing(
     dout(0) << __func__ << " super to be written to " << dev_target << dendl;
   }
 
-  for (auto& [ino, file_ref] : file_map) {
+  for (auto& [ino, file_ref] : nodes.file_map) {
     //do not copy log
     if (file_ref->fnode.ino == 1) {
       continue;
@@ -1674,7 +1677,7 @@ int BlueFS::device_migrate_to_new(
   flags |= devs_source.count(BDEV_WAL) ? REMOVE_WAL : 0;
   int dev_target_new = dev_target; //FIXME: remove, makes no sense
 
-  for (auto& p : file_map) {
+  for (auto& p : nodes.file_map) {
     //do not copy log
     if (p.second->fnode.ino == 1) {
       continue;
@@ -1790,10 +1793,10 @@ int BlueFS::device_migrate_to_new(
 
 BlueFS::FileRef BlueFS::_get_file(uint64_t ino)
 {
-  auto p = file_map.find(ino);
-  if (p == file_map.end()) {
+  auto p = nodes.file_map.find(ino);
+  if (p == nodes.file_map.end()) {
     FileRef f = ceph::make_ref<File>();
-    file_map[ino] = f;
+    nodes.file_map[ino] = f;
     dout(30) << __func__ << " ino " << ino << " = " << f
 	     << " (new)" << dendl;
     return f;
@@ -1808,28 +1811,28 @@ void BlueFS::_drop_link(FileRef file)
   dout(20) << __func__ << " had refs " << file->refs
 	   << " on " << file->fnode << dendl;
   ceph_assert(file->refs > 0);
-  ceph_assert(ceph_mutex_is_locked(log_lock));
+  ceph_assert(ceph_mutex_is_locked(log.lock));
 
   --file->refs;
   if (file->refs == 0) {
     dout(20) << __func__ << " destroying " << file->fnode << dendl;
     ceph_assert(file->num_reading.load() == 0);
     vselector->sub_usage(file->vselector_hint, file->fnode);
-    log_t.op_file_remove(file->fnode.ino);
+    log.t.op_file_remove(file->fnode.ino);
 
-    std::lock_guard dl(dirty_lock);
+    std::lock_guard dl(dirty.lock);
     for (auto& r : file->fnode.extents) {
       pending_release[r.bdev].insert(r.offset, r.length);
     }
-    file_map.erase(file->fnode.ino);
+    nodes.file_map.erase(file->fnode.ino);
     file->deleted = true;
 
     if (file->dirty_seq) {
       // retract request to serialize changes
-      ceph_assert(file->dirty_seq > log_seq_stable);
-      ceph_assert(dirty_files.count(file->dirty_seq));
-      auto it = dirty_files[file->dirty_seq].iterator_to(*file);
-      dirty_files[file->dirty_seq].erase(it);
+      ceph_assert(file->dirty_seq > dirty.seq_stable);
+      ceph_assert(dirty.files.count(file->dirty_seq));
+      auto it = dirty.files[file->dirty_seq].iterator_to(*file);
+      dirty.files[file->dirty_seq].erase(it);
       file->dirty_seq = 0;
     }
   }
@@ -2073,13 +2076,13 @@ void BlueFS::invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
 
 uint64_t BlueFS::estimate_log_size()
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   int avg_dir_size = 40;  // fixme
   int avg_file_size = 12;
   uint64_t size = 4096 * 2;
-  size += file_map.size() * (1 + sizeof(bluefs_fnode_t));
-  size += dir_map.size() + (1 + avg_dir_size);
-  size += file_map.size() * (1 + avg_dir_size + avg_file_size);
+  size += nodes.file_map.size() * (1 + sizeof(bluefs_fnode_t));
+  size += nodes.dir_map.size() + (1 + avg_dir_size);
+  size += nodes.file_map.size() * (1 + avg_dir_size + avg_file_size);
   return round_up_to(size, super.block_size);
 }
 
@@ -2102,8 +2105,8 @@ bool BlueFS::should_start_compact_log()
   }
   uint64_t current;
   {
-    std::lock_guard dirl(log_lock);
-    current = log_writer->file->fnode.size;
+    std::lock_guard dirl(log.lock);
+    current = log.writer->file->fnode.size;
   }
   uint64_t expected = estimate_log_size();
   float ratio = (float)current / (float)expected;
@@ -2121,14 +2124,14 @@ bool BlueFS::should_start_compact_log()
 void BlueFS::compact_log_dump_metadata(bluefs_transaction_t *t,
 					int flags)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
 
   t->seq = 1;
   t->uuid = super.uuid;
   dout(20) << __func__ << " op_init" << dendl;
 
   t->op_init();
-  for (auto& [ino, file_ref] : file_map) {
+  for (auto& [ino, file_ref] : nodes.file_map) {
     if (ino == 1)
       continue;
     ceph_assert(ino > 1);
@@ -2158,7 +2161,7 @@ void BlueFS::compact_log_dump_metadata(bluefs_transaction_t *t,
     dout(20) << __func__ << " op_file_update " << file_ref->fnode << dendl;
     t->op_file_update(file_ref->fnode);
   }
-  for (auto& [path, dir_ref] : dir_map) {
+  for (auto& [path, dir_ref] : nodes.dir_map) {
     dout(20) << __func__ << " op_dir_create " << path << dendl;
     t->op_dir_create(path);
     for (auto& [fname, file_ref] : dir_ref->file_map) {
@@ -2173,7 +2176,7 @@ void BlueFS::compact_log_sync()
 {
   dout(10) << __func__ << dendl;
   auto prefer_bdev =
-    vselector->select_prefer_bdev(log_writer->file->vselector_hint);
+    vselector->select_prefer_bdev(log.writer->file->vselector_hint);
   rewrite_log_and_layout_sync(true,
     BDEV_DB,
     prefer_bdev,
@@ -2190,13 +2193,13 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
 					 int flags,
 					 std::optional<bluefs_layout_t> layout)
 {
-  //ceph_assert(ceph_mutex_is_notlocked(log_lock));
-  std::lock_guard ll(log_lock);
+  //ceph_assert(ceph_mutex_is_notlocked(log.lock));
+  std::lock_guard ll(log.lock);
 
-  File *log_file = log_writer->file.get();
+  File *log_file = log.writer->file.get();
 
   // clear out log (be careful who calls us!!!)
-  log_t.clear();
+  log.t.clear();
 
   dout(20) << __func__ << " super_dev:" << super_dev
                        << " log_dev:" << log_dev
@@ -2206,8 +2209,8 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
   bluefs_transaction_t t;
   compact_log_dump_metadata(&t, flags);
 
-  dout(20) << __func__ << " op_jump_seq " << log_seq << dendl;
-  t.op_jump_seq(log_seq);
+  dout(20) << __func__ << " op_jump_seq " << log.seq_live << dendl;
+  t.op_jump_seq(log.seq_live);
 
   bufferlist bl;
   encode(t, bl);
@@ -2234,21 +2237,21 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
     }
   }
 
-  _close_writer(log_writer);
+  _close_writer(log.writer);
 
   log_file->fnode.size = bl.length();
   vselector->sub_usage(log_file->vselector_hint, old_fnode);
   vselector->add_usage(log_file->vselector_hint, log_file->fnode);
 
-  log_writer = _create_writer(log_file);
-  log_writer->append(bl);
-  r = _flush_special(log_writer);
+  log.writer = _create_writer(log_file);
+  log.writer->append(bl);
+  r = _flush_special(log.writer);
   ceph_assert(r == 0);
 #ifdef HAVE_LIBAIO
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
-    _claim_completed_aios(log_writer, &completed_ios);
-    wait_for_aio(log_writer);
+    _claim_completed_aios(log.writer, &completed_ios);
+    wait_for_aio(log.writer);
     completed_ios.clear();
   }
 #endif
@@ -2270,7 +2273,7 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
   flush_bdev();
 
   dout(10) << __func__ << " release old log extents " << old_fnode.extents << dendl;
-  std::lock_guard dl(dirty_lock);
+  std::lock_guard dl(dirty.lock);
   for (auto& r : old_fnode.extents) {
     pending_release[r.bdev].insert(r.offset, r.length);
   }
@@ -2309,8 +2312,8 @@ void BlueFS::compact_log_async()
     return;
   }
 
-  log_lock.lock();
-  File *log_file = log_writer->file.get();
+  log.lock.lock();
+  File *log_file = log.writer->file.get();
   FileWriter *new_log_writer = nullptr;
   FileRef new_log = nullptr;
   uint64_t new_log_jump_to = 0;
@@ -2335,7 +2338,7 @@ void BlueFS::compact_log_async()
 
   // 1.1 allocate new log space and jump to it.
   old_log_jump_to = log_file->fnode.get_allocated();
-  uint64_t runway = log_file->fnode.get_allocated() - log_writer->get_effective_write_pos();
+  uint64_t runway = log_file->fnode.get_allocated() - log.writer->get_effective_write_pos();
   dout(10) << __func__ << " old_log_jump_to 0x" << std::hex << old_log_jump_to
            << " need 0x" << (old_log_jump_to + cct->_conf->bluefs_max_log_runway) << std::dec << dendl;
   int r = _allocate(vselector->select_prefer_bdev(log_file->vselector_hint),
@@ -2348,8 +2351,8 @@ void BlueFS::compact_log_async()
 
   // update the log file change and log a jump to the offset where we want to
   // write the new entries
-  log_t.op_file_update(log_file->fnode); // 1.2
-  log_t.op_jump(log_seq, old_log_jump_to); // 1.3
+  log.t.op_file_update(log_file->fnode); // 1.2
+  log.t.op_jump(log.seq_live, old_log_jump_to); // 1.3
 
   // we need to flush all bdev because we will be streaming all dirty files to log
   // TODO - think - if _flush_and_sync_log_jump will not add dirty files nor release pending allocations
@@ -2357,7 +2360,7 @@ void BlueFS::compact_log_async()
   flush_bdev();
   _flush_and_sync_log_jump(old_log_jump_to, runway);
 
-  log_lock.unlock();
+  log.lock.unlock();
   // out of jump section - now log can be used to write to
 
   // 2. prepare compacted log
@@ -2374,7 +2377,7 @@ void BlueFS::compact_log_async()
   // conservative estimate for final encoded size
   new_log_jump_to = round_up_to(t.op_bl.length() + super.block_size * 2,
                                 max_alloc_size);
-  t.op_jump(log_seq, new_log_jump_to);
+  t.op_jump(log.seq_live, new_log_jump_to);
 
   // allocate
   //FIXME: check if we want DB here?
@@ -2443,8 +2446,8 @@ void BlueFS::compact_log_async()
   // swap the log files. New log file is the log file now.
   new_log->fnode.swap_extents(log_file->fnode);
 
-  log_writer->pos = log_writer->file->fnode.size =
-    log_writer->pos - old_log_jump_to + new_log_jump_to;
+  log.writer->pos = log.writer->file->fnode.size =
+    log.writer->pos - old_log_jump_to + new_log_jump_to;
 
   vselector->add_usage(log_file->vselector_hint, log_file->fnode);
 
@@ -2464,7 +2467,7 @@ void BlueFS::compact_log_async()
   // 7. release old space
   dout(10) << __func__ << " release old log extents " << old_extents << dendl;
   {
-    std::lock_guard dl(dirty_lock);
+    std::lock_guard dl(dirty.lock);
     for (auto& r : old_extents) {
       pending_release[r.bdev].insert(r.offset, r.length);
     }
@@ -2475,10 +2478,10 @@ void BlueFS::compact_log_async()
   // flush_special does not dirty files
   /*
   if (new_log->dirty_seq) {
-    std::lock_guard dl(dirty_lock);
-    ceph_assert(dirty_files.count(new_log->dirty_seq));
-    auto it = dirty_files[new_log->dirty_seq].iterator_to(*new_log);
-    dirty_files[new_log->dirty_seq].erase(it);
+    std::lock_guard dl(dirty.lock);
+    ceph_assert(dirty.files.count(new_log->dirty_seq));
+    auto it = dirty.files[new_log->dirty_seq].iterator_to(*new_log);
+    dirty.files[new_log->dirty_seq].erase(it);
   }
   */
   new_log_writer = nullptr;
@@ -2503,38 +2506,41 @@ void BlueFS::_pad_bl(bufferlist& bl)
 }
 
 /**
- * Adds file modifications from `dirty_files` to bluefs transactions
- * already stored in `log_t`. Writes them to disk and waits until are stable.
+ * Adds file modifications from `dirty.files` to bluefs transactions
+ * already stored in `log.t`. Writes them to disk and waits until are stable.
  * Guarantees that file modifications with `want_seq` are already stable on disk.
  * In addition may insert jump forward transaction to log write position `jump_to`.
  *
  * it should lock ability to:
- * 1) add to log_t
- * 2) modify dirty_files
+ * 1) add to log.t
+ * 2) modify dirty.files
  * 3) add to pending_release
  *
- * pending_release and log_t go with same lock
+ * pending_release and log.t go with same lock
  */
 
-// Adds to log_t file modifications mentioned in `dirty_files`.
-// Note: some bluefs ops may have already been stored in log_t transaction.
+// Adds to log.t file modifications mentioned in `dirty.files`.
+// Note: some bluefs ops may have already been stored in log.t transaction.
 uint64_t BlueFS::_consume_dirty()
 {
-  ceph_assert(ceph_mutex_is_locked(dirty_lock));
-  ceph_assert(ceph_mutex_is_locked(log_lock));
+  ceph_assert(ceph_mutex_is_locked(dirty.lock));
+  ceph_assert(ceph_mutex_is_locked(log.lock));
   //acquire new seq
-  // this will became log_seq_stable once we write
-  uint64_t seq = log_t.seq = ++log_seq;
-  log_t.uuid = super.uuid;
+  // this will became seq_stable once we write
+  ++dirty.seq_next;
+  ++log.seq_live;
+  ceph_assert(dirty.seq_next == log.seq_live + 1);
+  uint64_t seq = log.t.seq = log.seq_live;
+  log.t.uuid = super.uuid;
 
   // log dirty files
-  // we just incremented log_seq. It is now illegal to add to dirty_files[log_seq]
-  auto lsi = dirty_files.find(seq);
-  if (lsi != dirty_files.end()) {
-    dout(20) << __func__ << " " << lsi->second.size() << " dirty_files" << dendl;
+  // we just incremented log_seq. It is now illegal to add to dirty.files[log_seq]
+  auto lsi = dirty.files.find(seq);
+  if (lsi != dirty.files.end()) {
+    dout(20) << __func__ << " " << lsi->second.size() << " dirty.files" << dendl;
     for (auto &f : lsi->second) {
       dout(20) << __func__ << "   op_file_update " << f.fnode << dendl;
-      log_t.op_file_update(f.fnode);
+      log.t.op_file_update(f.fnode);
     }
   }
   return seq;
@@ -2544,11 +2550,11 @@ uint64_t BlueFS::_consume_dirty()
 // Returns space available *BEFORE* adding new space. Signed for additional <0 detection.
 int64_t BlueFS::_maybe_extend_log()
 {
-  ceph_assert(ceph_mutex_is_locked(log_lock));
+  ceph_assert(ceph_mutex_is_locked(log.lock));
   // allocate some more space (before we run out)?
-  // BTW: this triggers `flush()` in the `page_aligned_appender` of `log_writer`.
-  int64_t runway = log_writer->file->fnode.get_allocated() -
-    log_writer->get_effective_write_pos();
+  // BTW: this triggers `flush()` in the `page_aligned_appender` of `log.writer`.
+  int64_t runway = log.writer->file->fnode.get_allocated() -
+    log.writer->get_effective_write_pos();
   if (runway < (int64_t)cct->_conf->bluefs_min_log_runway) {
     dout(10) << __func__ << " allocating more log runway (0x"
 	     << std::hex << runway << std::dec  << " remaining)" << dendl;
@@ -2570,26 +2576,26 @@ int64_t BlueFS::_maybe_extend_log()
     if (log_forbidden_to_expand.load() == true) {
       return -EWOULDBLOCK;
     }
-    vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
+    vselector->sub_usage(log.writer->file->vselector_hint, log.writer->file->fnode);
     int r = _allocate(
-      vselector->select_prefer_bdev(log_writer->file->vselector_hint),
+      vselector->select_prefer_bdev(log.writer->file->vselector_hint),
       cct->_conf->bluefs_max_log_runway,
-      &log_writer->file->fnode);
+      &log.writer->file->fnode);
     ceph_assert(r == 0);
-    vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
-    log_t.op_file_update(log_writer->file->fnode);
+    vselector->add_usage(log.writer->file->vselector_hint, log.writer->file->fnode);
+    log.t.op_file_update(log.writer->file->fnode);
   }
   return runway;
 }
 
 void BlueFS::_flush_and_sync_log_core(int64_t runway)
 {
-  ceph_assert(ceph_mutex_is_locked(log_lock));
-  dout(10) << __func__ << " " << log_t << dendl;
+  ceph_assert(ceph_mutex_is_locked(log.lock));
+  dout(10) << __func__ << " " << log.t << dendl;
 
   bufferlist bl;
   bl.reserve(super.block_size);
-  encode(log_t, bl);
+  encode(log.t, bl);
   // pad to block boundary
   size_t realign = super.block_size - (bl.length() % super.block_size);
   if (realign && realign != super.block_size)
@@ -2602,29 +2608,29 @@ void BlueFS::_flush_and_sync_log_core(int64_t runway)
                                         // transaction will not fit extents before growth -> data loss on _replay
   }
 
-  log_writer->append(bl);
+  log.writer->append(bl);
 
-  log_t.clear();
-  log_t.seq = 0;  // just so debug output is less confusing
+  log.t.clear();
+  log.t.seq = 0;  // just so debug output is less confusing
 
-  int r = _flush_special(log_writer);
+  int r = _flush_special(log.writer);
   ceph_assert(r == 0);
 }
 
-// Clears dirty_files up to (including) seq_stable.
+// Clears dirty.files up to (including) seq_stable.
 void BlueFS::clear_dirty_set_stable(uint64_t seq)
 {
-  std::lock_guard lg(dirty_lock);
+  std::lock_guard lg(dirty.lock);
 
   // clean dirty files
-  if (seq > log_seq_stable) {
-    log_seq_stable = seq;
-    dout(20) << __func__ << " log_seq_stable " << log_seq_stable << dendl;
+  if (seq > dirty.seq_stable) {
+    dirty.seq_stable = seq;
+    dout(20) << __func__ << " seq_stable " << dirty.seq_stable << dendl;
 
     // undirty all files that were already streamed to log
-    auto p = dirty_files.begin();
-    while (p != dirty_files.end()) {
-      if (p->first > log_seq_stable) {
+    auto p = dirty.files.begin();
+    while (p != dirty.files.end()) {
+      if (p->first > dirty.seq_stable) {
         dout(20) << __func__ << " done cleaning up dirty files" << dendl;
         break;
       }
@@ -2633,17 +2639,17 @@ void BlueFS::clear_dirty_set_stable(uint64_t seq)
       while (l != p->second.end()) {
         File *file = &*l;
         ceph_assert(file->dirty_seq > 0);
-        ceph_assert(file->dirty_seq <= log_seq_stable);
+        ceph_assert(file->dirty_seq <= dirty.seq_stable);
         dout(20) << __func__ << " cleaned file " << file->fnode << dendl;
         file->dirty_seq = 0;
         p->second.erase(l++);
       }
 
       ceph_assert(p->second.empty());
-      dirty_files.erase(p++);
+      dirty.files.erase(p++);
     }
   } else {
-    dout(20) << __func__ << " log_seq_stable " << log_seq_stable
+    dout(20) << __func__ << " seq_stable " << dirty.seq_stable
              << " already >= out seq " << seq
              << ", we lost a race against another log flush, done" << dendl;
   }
@@ -2677,22 +2683,22 @@ int BlueFS::flush_and_sync_log(uint64_t want_seq)
   // we synchronize writing to log, by lock to log_lock
   int64_t available_runway;
   do {
-    log_lock.lock();
-    dirty_lock.lock();
-    if (want_seq && want_seq <= log_seq_stable) {
-      dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
-	       << log_seq_stable << ", done" << dendl;
-      dirty_lock.unlock();
-      log_lock.unlock();
+    log.lock.lock();
+    dirty.lock.lock();
+    if (want_seq && want_seq <= dirty.seq_stable) {
+      dout(10) << __func__ << " want_seq " << want_seq << " <= seq_stable "
+	       << dirty.seq_stable << ", done" << dendl;
+      dirty.lock.unlock();
+      log.lock.unlock();
       return 0;
     }
 
     available_runway = _maybe_extend_log();
     if (available_runway == -EWOULDBLOCK) {
       // we are in need of adding runway, but we are during log-switch from compaction
-      dirty_lock.unlock();
-      //instead log_lock_unlock() do move ownership
-      std::unique_lock<ceph::mutex> ll(log_lock, std::adopt_lock);
+      dirty.lock.unlock();
+      //instead log.lock_unlock() do move ownership
+      std::unique_lock<ceph::mutex> ll(log.lock, std::adopt_lock);
       while (log_forbidden_to_expand.load()) {
 	log_cond.wait(ll);
       }
@@ -2706,12 +2712,12 @@ int BlueFS::flush_and_sync_log(uint64_t want_seq)
   uint64_t seq = _consume_dirty();
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
-  dirty_lock.unlock();
+  dirty.lock.unlock();
 
   _flush_and_sync_log_core(available_runway);
-  _flush_bdev(log_writer);
-  //now log_lock is no longer needed
-  log_lock.unlock();
+  _flush_bdev(log.writer);
+  //now log.lock is no longer needed
+  log.lock.unlock();
 
   clear_dirty_set_stable(seq);
   release_pending_allocations(to_release);
@@ -2724,26 +2730,26 @@ int BlueFS::flush_and_sync_log(uint64_t want_seq)
 int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
 				     int64_t available_runway)
 {
-  ceph_assert(ceph_mutex_is_locked(log_lock));
+  ceph_assert(ceph_mutex_is_locked(log.lock));
 
   ceph_assert(jump_to);
   // we synchronize writing to log, by lock to log_lock
 
-  dirty_lock.lock();
+  dirty.lock.lock();
   uint64_t seq = _consume_dirty();
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
-  dirty_lock.unlock();
+  dirty.lock.unlock();
   _flush_and_sync_log_core(available_runway);
 
   dout(10) << __func__ << " jumping log offset from 0x" << std::hex
-	   << log_writer->pos << " -> 0x" << jump_to << std::dec << dendl;
-  log_writer->pos = jump_to;
-  vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
-  log_writer->file->fnode.size = jump_to;
-  vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
+	   << log.writer->pos << " -> 0x" << jump_to << std::dec << dendl;
+  log.writer->pos = jump_to;
+  vselector->sub_usage(log.writer->file->vselector_hint, log.writer->file->fnode.size);
+  log.writer->file->fnode.size = jump_to;
+  vselector->add_usage(log.writer->file->vselector_hint, log.writer->file->fnode.size);
 
-  _flush_bdev(log_writer);
+  _flush_bdev(log.writer);
 
   clear_dirty_set_stable(seq);
   release_pending_allocations(to_release);
@@ -2798,26 +2804,26 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
 int BlueFS::_signal_dirty_to_log(FileWriter *h)
 {
   ceph_assert(ceph_mutex_is_locked(h->lock));
-  std::lock_guard dl(dirty_lock);
+  std::lock_guard dl(dirty.lock);
   h->file->fnode.mtime = ceph_clock_now();
   ceph_assert(h->file->fnode.ino >= 1);
   if (h->file->dirty_seq == 0) {
-    h->file->dirty_seq = log_seq + 1;
-    dirty_files[h->file->dirty_seq].push_back(*h->file);
-    dout(20) << __func__ << " dirty_seq = " << log_seq + 1
+    h->file->dirty_seq = dirty.seq_next;
+    dirty.files[h->file->dirty_seq].push_back(*h->file);
+    dout(20) << __func__ << " dirty_seq = " << dirty.seq_next
 	     << " (was clean)" << dendl;
   } else {
-    if (h->file->dirty_seq != log_seq + 1) {
+    if (h->file->dirty_seq != dirty.seq_next) {
       // need re-dirty, erase from list first
-      ceph_assert(dirty_files.count(h->file->dirty_seq));
-      auto it = dirty_files[h->file->dirty_seq].iterator_to(*h->file);
-      dirty_files[h->file->dirty_seq].erase(it);
-      h->file->dirty_seq = log_seq + 1;
-      dirty_files[h->file->dirty_seq].push_back(*h->file);
-      dout(20) << __func__ << " dirty_seq = " << log_seq + 1
+      ceph_assert(dirty.files.count(h->file->dirty_seq));
+      auto it = dirty.files[h->file->dirty_seq].iterator_to(*h->file);
+      dirty.files[h->file->dirty_seq].erase(it);
+      h->file->dirty_seq = dirty.seq_next;
+      dirty.files[h->file->dirty_seq].push_back(*h->file);
+      dout(20) << __func__ << " dirty_seq = " << dirty.seq_next
 	       << " (was " << h->file->dirty_seq << ")" << dendl;
     } else {
-      dout(20) << __func__ << " dirty_seq = " << log_seq + 1
+      dout(20) << __func__ << " dirty_seq = " << dirty.seq_next
 	       << " (unchanged, do nothing) " << dendl;
     }
   }
@@ -3121,8 +3127,8 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)
   vselector->sub_usage(h->file->vselector_hint, h->file->fnode.size);
   h->file->fnode.size = offset;
   vselector->add_usage(h->file->vselector_hint, h->file->fnode.size);
-  std::lock_guard ll(log_lock);
-  log_t.op_file_update(h->file->fnode);
+  std::lock_guard ll(log.lock);
+  log.t.op_file_update(h->file->fnode);
   return 0;
 }
 
@@ -3142,7 +3148,7 @@ int BlueFS::fsync(FileWriter *h)
   _flush_bdev(h);
 
   if (old_dirty_seq) {
-    uint64_t s = log_seq;
+    uint64_t s = log.seq_live; // AKAK !!! locks!
     dout(20) << __func__ << " file metadata was dirty (" << old_dirty_seq
 	     << ") on " << h->file->fnode << ", flushing log" << dendl;
     flush_and_sync_log(old_dirty_seq);
@@ -3154,13 +3160,13 @@ int BlueFS::fsync(FileWriter *h)
   return 0;
 }
 
-// be careful - either h->file->lock or log_lock must be taken
+// be careful - either h->file->lock or log.lock must be taken
 void BlueFS::_flush_bdev(FileWriter *h)
 {
   if (h->file->fnode.ino != 1) {
     ceph_assert(ceph_mutex_is_locked(h->lock));
   } else {
-    ceph_assert(ceph_mutex_is_locked(log_lock));
+    ceph_assert(ceph_mutex_is_locked(log.lock));
   }
   std::array<bool, MAX_BDEV> flush_devs = h->dirty_devs;
   h->dirty_devs.fill(false);
@@ -3327,8 +3333,8 @@ int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
     vselector->add_usage(f->vselector_hint, f->fnode);
     if (r < 0)
       return r;
-    std::lock_guard ll(log_lock);
-    log_t.op_file_update(f->fnode);
+    std::lock_guard ll(log.lock);
+    log.t.op_file_update(f->fnode);
   }
   return 0;
 }
@@ -3337,9 +3343,9 @@ void BlueFS::sync_metadata(bool avoid_compact)
 {
   bool can_skip_flush;
   {
-    std::lock_guard ll(log_lock);
-    std::lock_guard dl(dirty_lock);
-    can_skip_flush = log_t.empty() && dirty_files.empty();
+    std::lock_guard ll(log.lock);
+    std::lock_guard dl(dirty.lock);
+    can_skip_flush = log.t.empty() && dirty.files.empty();
   }
   if (can_skip_flush) {
     dout(10) << __func__ << " - no pending log events" << dendl;
@@ -3376,11 +3382,11 @@ int BlueFS::open_for_write(
   FileWriter **h,
   bool overwrite)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   DirRef dir;
-  if (p == dir_map.end()) {
+  if (p == nodes.dir_map.end()) {
     // implicitly create the dir
     dout(20) << __func__ << "  dir " << dirname
 	     << " does not exist" << dendl;
@@ -3402,7 +3408,7 @@ int BlueFS::open_for_write(
     }
     file = ceph::make_ref<File>();
     file->fnode.ino = ++ino_last;
-    file_map[ino_last] = file;
+    nodes.file_map[ino_last] = file;
     dir->file_map[string{filename}] = file;
     ++file->refs;
     create = true;
@@ -3439,10 +3445,10 @@ int BlueFS::open_for_write(
 	   << " vsel_hint " << file->vselector_hint
 	   << dendl;
   {
-    std::lock_guard ll(log_lock);
-    log_t.op_file_update(file->fnode);
+    std::lock_guard ll(log.lock);
+    log.t.op_file_update(file->fnode);
     if (create)
-      log_t.op_dir_link(dirname, filename, file->fnode.ino);
+      log.t.op_dir_link(dirname, filename, file->fnode.ino);
   }
   *h = _create_writer(file);
 
@@ -3523,11 +3529,11 @@ int BlueFS::open_for_read(
   FileReader **h,
   bool random)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename
 	   << (random ? " (random)":" (sequential)") << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
-  if (p == dir_map.end()) {
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << dirname << " not found" << dendl;
     return -ENOENT;
   }
@@ -3552,12 +3558,12 @@ int BlueFS::rename(
   std::string_view old_dirname, std::string_view old_filename,
   std::string_view new_dirname, std::string_view new_filename)
 {
-  std::lock_guard dirl(dirs_lock);
-  std::lock_guard ll(log_lock);
+  std::lock_guard dirl(nodes.lock);
+  std::lock_guard ll(log.lock);
   dout(10) << __func__ << " " << old_dirname << "/" << old_filename
 	   << " -> " << new_dirname << "/" << new_filename << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(old_dirname);
-  if (p == dir_map.end()) {
+  map<string,DirRef>::iterator p = nodes.dir_map.find(old_dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << old_dirname << " not found" << dendl;
     return -ENOENT;
   }
@@ -3571,8 +3577,8 @@ int BlueFS::rename(
   }
   FileRef file = q->second;
 
-  p = dir_map.find(new_dirname);
-  if (p == dir_map.end()) {
+  p = nodes.dir_map.find(new_dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << new_dirname << " not found" << dendl;
     return -ENOENT;
   }
@@ -3583,7 +3589,7 @@ int BlueFS::rename(
 	     << ") file " << new_filename
 	     << " already exists, unlinking" << dendl;
     ceph_assert(q->second != file);
-    log_t.op_dir_unlink(new_dirname, new_filename);
+    log.t.op_dir_unlink(new_dirname, new_filename);
     _drop_link(q->second);
   }
 
@@ -3593,33 +3599,33 @@ int BlueFS::rename(
   new_dir->file_map[string{new_filename}] = file;
   old_dir->file_map.erase(string{old_filename});
 
-  log_t.op_dir_link(new_dirname, new_filename, file->fnode.ino);
-  log_t.op_dir_unlink(old_dirname, old_filename);
+  log.t.op_dir_link(new_dirname, new_filename, file->fnode.ino);
+  log.t.op_dir_unlink(old_dirname, old_filename);
   return 0;
 }
 
 int BlueFS::mkdir(std::string_view dirname)
 {
-  std::lock_guard dirl(dirs_lock);
-  std::lock_guard ll(log_lock);
+  std::lock_guard dirl(nodes.lock);
+  std::lock_guard ll(log.lock);
   dout(10) << __func__ << " " << dirname << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
-  if (p != dir_map.end()) {
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+  if (p != nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << dirname << " exists" << dendl;
     return -EEXIST;
   }
-  dir_map[string{dirname}] = ceph::make_ref<Dir>();
-  log_t.op_dir_create(dirname);
+  nodes.dir_map[string{dirname}] = ceph::make_ref<Dir>();
+  log.t.op_dir_create(dirname);
   return 0;
 }
 
 int BlueFS::rmdir(std::string_view dirname)
 {
-  std::lock_guard dirl(dirs_lock);
-  std::lock_guard ll(log_lock);
+  std::lock_guard dirl(nodes.lock);
+  std::lock_guard ll(log.lock);
   dout(10) << __func__ << " " << dirname << dendl;
-  auto p = dir_map.find(dirname);
-  if (p == dir_map.end()) {
+  auto p = nodes.dir_map.find(dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << dirname << " does not exist" << dendl;
     return -ENOENT;
   }
@@ -3628,16 +3634,16 @@ int BlueFS::rmdir(std::string_view dirname)
     dout(20) << __func__ << " dir " << dirname << " not empty" << dendl;
     return -ENOTEMPTY;
   }
-  dir_map.erase(string{dirname});
-  log_t.op_dir_remove(dirname);
+  nodes.dir_map.erase(string{dirname});
+  log.t.op_dir_remove(dirname);
   return 0;
 }
 
 bool BlueFS::dir_exists(std::string_view dirname)
 {
-  std::lock_guard dirl(dirs_lock);
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
-  bool exists = p != dir_map.end();
+  std::lock_guard dirl(nodes.lock);
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+  bool exists = p != nodes.dir_map.end();
   dout(10) << __func__ << " " << dirname << " = " << (int)exists << dendl;
   return exists;
 }
@@ -3645,10 +3651,10 @@ bool BlueFS::dir_exists(std::string_view dirname)
 int BlueFS::stat(std::string_view dirname, std::string_view filename,
 		 uint64_t *size, utime_t *mtime)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
-  if (p == dir_map.end()) {
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << dirname << " not found" << dendl;
     return -ENOENT;
   }
@@ -3673,10 +3679,10 @@ int BlueFS::stat(std::string_view dirname, std::string_view filename,
 int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 		      FileLock **plock)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
-  if (p == dir_map.end()) {
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << dirname << " not found" << dendl;
     return -ENOENT;
   }
@@ -3690,12 +3696,12 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
     file = ceph::make_ref<File>();
     file->fnode.ino = ++ino_last;
     file->fnode.mtime = ceph_clock_now();
-    file_map[ino_last] = file;
+    nodes.file_map[ino_last] = file;
     dir->file_map[string{filename}] = file;
     ++file->refs;
-    std::lock_guard ll(log_lock);
-    log_t.op_file_update(file->fnode);
-    log_t.op_dir_link(dirname, filename, file->fnode.ino);
+    std::lock_guard ll(log.lock);
+    log.t.op_file_update(file->fnode);
+    log.t.op_dir_link(dirname, filename, file->fnode.ino);
   } else {
     file = q->second;
     if (file->locked) {
@@ -3712,7 +3718,7 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 
 int BlueFS::unlock_file(FileLock *fl)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " " << fl << " on " << fl->file->fnode << dendl;
   ceph_assert(fl->file->locked);
   fl->file->locked = false;
@@ -3726,18 +3732,18 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
   if (!dirname.empty() && dirname.back() == '/') {
     dirname.remove_suffix(1);
   }
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " " << dirname << dendl;
   if (dirname.empty()) {
     // list dirs
-    ls->reserve(dir_map.size() + 2);
-    for (auto& q : dir_map) {
+    ls->reserve(nodes.dir_map.size() + 2);
+    for (auto& q : nodes.dir_map) {
       ls->push_back(q.first);
     }
   } else {
     // list files in dir
-    map<string,DirRef>::iterator p = dir_map.find(dirname);
-    if (p == dir_map.end()) {
+    map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+    if (p == nodes.dir_map.end()) {
       dout(20) << __func__ << " dir " << dirname << " not found" << dendl;
       return -ENOENT;
     }
@@ -3754,11 +3760,11 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
 
 int BlueFS::unlink(std::string_view dirname, std::string_view filename)
 {
-  std::lock_guard dirl(dirs_lock);
-  std::lock_guard ll(log_lock);
+  std::lock_guard dirl(nodes.lock);
+  std::lock_guard ll(log.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
-  if (p == dir_map.end()) {
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << dirname << " not found" << dendl;
     return -ENOENT;
   }
@@ -3776,7 +3782,7 @@ int BlueFS::unlink(std::string_view dirname, std::string_view filename)
     return -EBUSY;
   }
   dir->file_map.erase(string{filename});
-  log_t.op_dir_unlink(dirname, filename);
+  log.t.op_dir_unlink(dirname, filename);
   _drop_link(file);
   return 0;
 }
@@ -3855,7 +3861,7 @@ int BlueFS::do_replay_recovery_read(FileReader *log_reader,
     dout(2) << __func__ << " processing " << get_device_name(dev) << dendl;
     interval_set<uint64_t> disk_regions;
     disk_regions.insert(0, bdev[dev]->get_size());
-    for (auto f : file_map) {
+    for (auto f : nodes.file_map) {
       auto& e = f.second->fnode.extents;
       for (auto& p : e) {
 	if (p.bdev == dev) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3366,6 +3366,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
 
 int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
 {
+  std::lock_guard ll(log.lock);
   std::lock_guard fl(f->lock);
   dout(10) << __func__ << " file " << f->fnode << " 0x"
 	   << std::hex << off << "~" << len << std::dec << dendl;
@@ -3385,7 +3386,6 @@ int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
     vselector->add_usage(f->vselector_hint, f->fnode);
     if (r < 0)
       return r;
-    std::lock_guard ll(log.lock);
     log.t.op_file_update(f->fnode);
   }
   return 0;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1831,13 +1831,12 @@ void BlueFS::_drop_link_D(FileRef file)
     nodes.file_map.erase(file->fnode.ino);
     file->deleted = true;
 
-    if (file->dirty_seq) {
+    if (file->dirty_seq > dirty.seq_stable) {
       // retract request to serialize changes
-      ceph_assert(file->dirty_seq > dirty.seq_stable);
       ceph_assert(dirty.files.count(file->dirty_seq));
       auto it = dirty.files[file->dirty_seq].iterator_to(*file);
       dirty.files[file->dirty_seq].erase(it);
-      file->dirty_seq = 0;
+      file->dirty_seq = dirty.seq_stable;
     }
   }
 }
@@ -2175,6 +2174,40 @@ void BlueFS::_compact_log_dump_metadata_N(bluefs_transaction_t *t,
     }
   }
 }
+/* Streams to t files modified before *capture_before_seq* and all dirs */
+void BlueFS::compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
+					     uint64_t capture_before_seq)
+{
+  std::lock_guard nl(nodes.lock);
+
+  t->seq = 1;
+  t->uuid = super.uuid;
+  dout(20) << __func__ << " op_init" << dendl;
+
+  t->op_init();
+  for (auto& [ino, file_ref] : nodes.file_map) {
+    if (ino == 1)
+      continue;
+    ceph_assert(ino > 1);
+    std::lock_guard fl(file_ref->lock);
+    if (file_ref->dirty_seq < capture_before_seq) {
+      dout(20) << __func__ << " op_file_update " << file_ref->fnode << dendl;
+      t->op_file_update(file_ref->fnode);
+    } else {
+      dout(20) << __func__ << " skipping just modified, dirty_seq="
+	       << file_ref->dirty_seq << " " << file_ref->fnode << dendl;
+    }
+  }
+  for (auto& [path, dir_ref] : nodes.dir_map) {
+    dout(20) << __func__ << " op_dir_create " << path << dendl;
+    t->op_dir_create(path);
+    for (auto& [fname, file_ref] : dir_ref->file_map) {
+      dout(20) << __func__ << " op_dir_link " << path << "/" << fname
+	       << " to " << file_ref->fnode.ino << dendl;
+      t->op_dir_link(path, fname, file_ref->fnode.ino);
+    }
+  }
+}
 
 void BlueFS::_compact_log_sync_LN_LD()
 {
@@ -2378,7 +2411,7 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
   //this needs files lock
   //what will happen, if a file is modified *twice* before we stream it to log?
   //the later state that we capture will be seen earlier and replay will see a temporary retraction (!)
-  compact_log_dump_metadata_N(&t, 0);
+  compact_log_async_dump_metadata_NF(&t, seq_now);
 
   uint64_t max_alloc_size = std::max(alloc_size[BDEV_WAL],
 				     std::max(alloc_size[BDEV_DB],
@@ -2663,10 +2696,9 @@ void BlueFS::_clear_dirty_set_stable_D(uint64_t seq)
       auto l = p->second.begin();
       while (l != p->second.end()) {
         File *file = &*l;
-        ceph_assert(file->dirty_seq > 0);
         ceph_assert(file->dirty_seq <= dirty.seq_stable);
         dout(20) << __func__ << " cleaned file " << file->fnode << dendl;
-        file->dirty_seq = 0;
+        file->dirty_seq = dirty.seq_stable;
         p->second.erase(l++);
       }
 
@@ -2832,7 +2864,7 @@ int BlueFS::_signal_dirty_to_log_D(FileWriter *h)
   std::lock_guard dl(dirty.lock);
   h->file->fnode.mtime = ceph_clock_now();
   ceph_assert(h->file->fnode.ino >= 1);
-  if (h->file->dirty_seq == 0) {
+  if (h->file->dirty_seq <= dirty.seq_stable) {
     h->file->dirty_seq = dirty.seq_live;
     dirty.files[h->file->dirty_seq].push_back(*h->file);
     dout(20) << __func__ << " dirty_seq = " << dirty.seq_live
@@ -3182,13 +3214,7 @@ int BlueFS::fsync(FileWriter *h)
     }
   }
   if (old_dirty_seq) {
-    uint64_t s = log.seq_live; // AKAK !!! locks!
-    dout(20) << __func__ << " file metadata was dirty (" << old_dirty_seq
-	     << ") on " << h->file->fnode << ", flushing log" << dendl;
     _flush_and_sync_log_LD(old_dirty_seq);
-    // AK - TODO - think - how can dirty_seq change if we are under h lock?
-    ceph_assert(h->file->dirty_seq == 0 ||  // cleaned
-		h->file->dirty_seq >= s);    // or redirtied by someone else
   }
   _maybe_compact_log_LN_NF_LD_D();
   return 0;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2230,7 +2230,7 @@ void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
 
   log_writer = _create_writer(log_file);
   log_writer->append(bl);
-  r = _flush(log_writer, true);
+  r = _flush_special(log_writer);
   ceph_assert(r == 0);
 #ifdef HAVE_LIBAIO
   if (!cct->_conf->bluefs_sync_write) {
@@ -2367,7 +2367,7 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
   new_log_writer->append(bl);
 
   // 3. flush
-  r = _flush(new_log_writer, true);
+  r = _flush_special(new_log_writer);
   ceph_assert(r == 0);
 
   // 4. wait
@@ -2546,7 +2546,7 @@ void BlueFS::_flush_and_sync_log_core(int64_t runway)
   log_t.clear();
   log_t.seq = 0;  // just so debug output is less confusing
 
-  int r = _flush(log_writer, true);
+  int r = _flush_special(log_writer);
   ceph_assert(r == 0);
 }
 
@@ -2752,11 +2752,8 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
 
   ceph_assert(h->file->num_readers.load() == 0);
 
-  bool buffered;
-  if (h->file->fnode.ino == 1)
-    buffered = false;
-  else
-    buffered = cct->_conf->bluefs_buffered_io;
+  bool buffered = cct->_conf->bluefs_buffered_io;
+  ceph_assert(h->file->fnode.ino > 1);
 
   if (offset + length <= h->pos)
     return 0;
@@ -2777,7 +2774,6 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
   if (allocated < offset + length) {
     // we should never run out of log space here; see the min runway check
     // in _flush_and_sync_log.
-    ceph_assert(h->file->fnode.ino != 1);
     int r = _allocate(vselector->select_prefer_bdev(h->file->vselector_hint),
 		      offset + length - allocated,
 		      &h->file->fnode);
@@ -2793,15 +2789,14 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
   }
   if (h->file->fnode.size < offset + length) {
     h->file->fnode.size = offset + length;
-    if (h->file->fnode.ino > 1) {
-      // we do not need to dirty the log file (or it's compacting
-      // replacement) when the file size changes because replay is
-      // smart enough to discover it on its own.
-      h->file->is_dirty = true;
-    }
+    h->file->is_dirty = true;
   }
   dout(20) << __func__ << " file now, unflushed " << h->file->fnode << dendl;
+  return _flush_data(h, offset, length, buffered);
+}
 
+int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered)
+{
   uint64_t x_off = 0;
   auto p = h->file->fnode.seek(offset, &x_off);
   ceph_assert(p != h->file->fnode.extents.end());
@@ -2946,6 +2941,23 @@ int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
     *flushed = true;
   }
   return r;
+}
+
+// Flush for bluefs special files.
+// Does not add extents to h.
+// Does not mark h as dirty.
+// we do not need to dirty the log file (or it's compacting
+// replacement) when the file size changes because replay is
+// smart enough to discover it on its own.
+int BlueFS::_flush_special(FileWriter *h)
+{
+  uint64_t length = h->get_buffer_length();
+  uint64_t offset = h->pos;
+  ceph_assert(length + offset <= h->file->fnode.get_allocated());
+  if (h->file->fnode.size < offset + length) {
+    h->file->fnode.size = offset + length;
+  }
+  return _flush_data(h, offset, length, false);
 }
 
 int BlueFS::_truncate(FileWriter *h, uint64_t offset)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3434,7 +3434,7 @@ int BlueFS::open_for_write(
   FileWriter **h,
   bool overwrite)
 {
-  std::lock_guard nl(nodes.lock);
+  std::unique_lock nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   DirRef dir;
@@ -3496,6 +3496,7 @@ int BlueFS::open_for_write(
   dout(20) << __func__ << " mapping " << dirname << "/" << filename
 	   << " vsel_hint " << file->vselector_hint
 	   << dendl;
+  nl.unlock();
   {
     std::lock_guard ll(log.lock);
     log.t.op_file_update(file->fnode);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -514,6 +514,8 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
   log.writer = _create_writer(log_file);
 
   // initial txn
+  ceph_assert(log.seq_live == 1);
+  log.t.seq = 1;
   log.t.op_init();
   flush_and_sync_log();
 
@@ -1221,7 +1223,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
                       << std::endl;
           }
 
-	  ceph_assert(next_seq >= log_seq);
+	  ceph_assert(next_seq > log_seq);
 	  log_seq = next_seq - 1; // we will increment it below
 	  uint64_t skip = offset - read_pos;
 	  if (skip) {
@@ -1249,7 +1251,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
                       << ":  op_jump_seq " << next_seq << std::endl;
           }
 
-	  ceph_assert(next_seq >= log_seq);
+	  ceph_assert(next_seq > log_seq);
 	  log_seq = next_seq - 1; // we will increment it below
 	}
 	break;
@@ -1464,8 +1466,10 @@ int BlueFS::_replay(bool noop, bool to_stdout)
   }
   if (!noop) {
     vselector->add_usage(log_file->vselector_hint, log_file->fnode);
-    log.seq_live = log_seq;
-    dirty.seq_next = log_seq + 1;
+    log.seq_live = log_seq + 1;
+    dirty.seq_live = log_seq + 1;
+    log.t.seq = log.seq_live;
+    //log.seq_stable = log_seq;
     dirty.seq_stable = log_seq;
   }
 
@@ -2198,8 +2202,13 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
 
   File *log_file = log.writer->file.get();
 
-  // clear out log (be careful who calls us!!!)
+  // log.t.seq is always set to current live seq
+  ceph_assert(log.t.seq == log.seq_live);
+  // Capturing entire state. Dump anything that has been stored there.
   log.t.clear();
+  log.t.seq = log.seq_live;
+  // From now on, no changes to log.t are permitted until we finish rewriting log.
+  // Can allow dirty to remain dirty - log.seq_live will not change.
 
   dout(20) << __func__ << " super_dev:" << super_dev
                        << " log_dev:" << log_dev
@@ -2351,9 +2360,10 @@ void BlueFS::compact_log_async()
 
   // update the log file change and log a jump to the offset where we want to
   // write the new entries
-  log.t.op_file_update(log_file->fnode); // 1.2
-  log.t.op_jump(log.seq_live, old_log_jump_to); // 1.3
-
+  log.t.op_file_update(log_file->fnode);
+  // jump to new position should mean next seq
+  log.t.op_jump(log.seq_live + 1, old_log_jump_to);
+  uint64_t seq_now = log.seq_live;
   // we need to flush all bdev because we will be streaming all dirty files to log
   // TODO - think - if _flush_and_sync_log_jump will not add dirty files nor release pending allocations
   // then flush_bdev() will not be necessary
@@ -2377,7 +2387,8 @@ void BlueFS::compact_log_async()
   // conservative estimate for final encoded size
   new_log_jump_to = round_up_to(t.op_bl.length() + super.block_size * 2,
                                 max_alloc_size);
-  t.op_jump(log.seq_live, new_log_jump_to);
+  //newly constructed log head will jump to what we had before
+  t.op_jump(seq_now, new_log_jump_to);
 
   // allocate
   //FIXME: check if we want DB here?
@@ -2519,19 +2530,31 @@ void BlueFS::_pad_bl(bufferlist& bl)
  * pending_release and log.t go with same lock
  */
 
-// Adds to log.t file modifications mentioned in `dirty.files`.
-// Note: some bluefs ops may have already been stored in log.t transaction.
-uint64_t BlueFS::_consume_dirty()
+// Returns log seq that was live before advance.
+uint64_t BlueFS::_log_advance_seq()
 {
   ceph_assert(ceph_mutex_is_locked(dirty.lock));
   ceph_assert(ceph_mutex_is_locked(log.lock));
   //acquire new seq
   // this will became seq_stable once we write
-  ++dirty.seq_next;
-  ++log.seq_live;
-  ceph_assert(dirty.seq_next == log.seq_live + 1);
-  uint64_t seq = log.t.seq = log.seq_live;
+  ceph_assert(dirty.seq_stable < dirty.seq_live);
+  ceph_assert(log.t.seq == log.seq_live);
+  uint64_t seq = log.seq_live;
   log.t.uuid = super.uuid;
+
+  ++dirty.seq_live;
+  ++log.seq_live;
+  ceph_assert(dirty.seq_live == log.seq_live);
+  return seq;
+}
+
+
+// Adds to log.t file modifications mentioned in `dirty.files`.
+// Note: some bluefs ops may have already been stored in log.t transaction.
+void BlueFS::_consume_dirty(uint64_t seq)
+{
+  ceph_assert(ceph_mutex_is_locked(dirty.lock));
+  ceph_assert(ceph_mutex_is_locked(log.lock));
 
   // log dirty files
   // we just incremented log_seq. It is now illegal to add to dirty.files[log_seq]
@@ -2543,7 +2566,6 @@ uint64_t BlueFS::_consume_dirty()
       log.t.op_file_update(f.fnode);
     }
   }
-  return seq;
 }
 
 // Extends log if its free space is smaller then bluefs_min_log_runway.
@@ -2610,8 +2632,9 @@ void BlueFS::_flush_and_sync_log_core(int64_t runway)
 
   log.writer->append(bl);
 
+  // prepare log for new transactions
   log.t.clear();
-  log.t.seq = 0;  // just so debug output is less confusing
+  log.t.seq = log.seq_live;
 
   int r = _flush_special(log.writer);
   ceph_assert(r == 0);
@@ -2706,10 +2729,10 @@ int BlueFS::flush_and_sync_log(uint64_t want_seq)
       ceph_assert(available_runway >= 0);
     }
   } while (available_runway < 0);
-
-  ceph_assert(want_seq == 0 || want_seq <= log_seq + 1); // illegal to request seq that was not created yet
-
-  uint64_t seq = _consume_dirty();
+  
+  ceph_assert(want_seq == 0 || want_seq <= dirty.seq_live); // illegal to request seq that was not created yet
+  uint64_t seq =_log_advance_seq();
+  _consume_dirty(seq);
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
   dirty.lock.unlock();
@@ -2736,7 +2759,8 @@ int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
   // we synchronize writing to log, by lock to log_lock
 
   dirty.lock.lock();
-  uint64_t seq = _consume_dirty();
+  uint64_t seq =_log_advance_seq();
+  _consume_dirty(seq);
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
   dirty.lock.unlock();
@@ -2808,22 +2832,22 @@ int BlueFS::_signal_dirty_to_log(FileWriter *h)
   h->file->fnode.mtime = ceph_clock_now();
   ceph_assert(h->file->fnode.ino >= 1);
   if (h->file->dirty_seq == 0) {
-    h->file->dirty_seq = dirty.seq_next;
+    h->file->dirty_seq = dirty.seq_live;
     dirty.files[h->file->dirty_seq].push_back(*h->file);
-    dout(20) << __func__ << " dirty_seq = " << dirty.seq_next
+    dout(20) << __func__ << " dirty_seq = " << dirty.seq_live
 	     << " (was clean)" << dendl;
   } else {
-    if (h->file->dirty_seq != dirty.seq_next) {
+    if (h->file->dirty_seq != dirty.seq_live) {
       // need re-dirty, erase from list first
       ceph_assert(dirty.files.count(h->file->dirty_seq));
       auto it = dirty.files[h->file->dirty_seq].iterator_to(*h->file);
       dirty.files[h->file->dirty_seq].erase(it);
-      h->file->dirty_seq = dirty.seq_next;
+      h->file->dirty_seq = dirty.seq_live;
       dirty.files[h->file->dirty_seq].push_back(*h->file);
-      dout(20) << __func__ << " dirty_seq = " << dirty.seq_next
+      dout(20) << __func__ << " dirty_seq = " << dirty.seq_live
 	       << " (was " << h->file->dirty_seq << ")" << dendl;
     } else {
-      dout(20) << __func__ << " dirty_seq = " << dirty.seq_next
+      dout(20) << __func__ << " dirty_seq = " << dirty.seq_live
 	       << " (unchanged, do nothing) " << dendl;
     }
   }
@@ -3154,7 +3178,7 @@ int BlueFS::fsync(FileWriter *h)
     flush_and_sync_log(old_dirty_seq);
     // AK - TODO - think - how can dirty_seq change if we are under h lock?
     ceph_assert(h->file->dirty_seq == 0 ||  // cleaned
-		h->file->dirty_seq > s);    // or redirtied by someone else
+		h->file->dirty_seq >= s);    // or redirtied by someone else
   }
   maybe_compact_log();
   return 0;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -148,7 +148,7 @@ private:
       out.append(ss);
     } else if (command == "bluefs files list") {
       const char* devnames[3] = {"wal","db","slow"};
-      std::lock_guard l(bluefs->lock);
+      std::lock_guard l(bluefs->dirs_lock);
       f->open_array_section("files");
       for (auto &d : bluefs->dir_map) {
         std::string dir = d.first;
@@ -310,6 +310,7 @@ void BlueFS::_shutdown_logger()
   delete logger;
 }
 
+//AK - TODO - locking needed but not certain
 void BlueFS::_update_logger_stats()
 {
   // we must be holding the lock
@@ -392,7 +393,6 @@ void BlueFS::handle_discard(unsigned id, interval_set<uint64_t>& to_release)
 
 uint64_t BlueFS::get_used()
 {
-  std::lock_guard l(lock);
   uint64_t used = 0;
   for (unsigned id = 0; id < MAX_BDEV; ++id) {
     used += _get_used(id);
@@ -418,7 +418,6 @@ uint64_t BlueFS::get_used(unsigned id)
 {
   ceph_assert(id < alloc.size());
   ceph_assert(alloc[id]);
-  std::lock_guard l(lock);
   return _get_used(id);
 }
 
@@ -431,13 +430,11 @@ uint64_t BlueFS::_get_total(unsigned id) const
 
 uint64_t BlueFS::get_total(unsigned id)
 {
-  std::lock_guard l(lock);
   return _get_total(id);
 }
 
 uint64_t BlueFS::get_free(unsigned id)
 {
-  std::lock_guard l(lock);
   ceph_assert(id < alloc.size());
   return alloc[id]->get_free();
 }
@@ -467,7 +464,7 @@ void BlueFS::dump_block_extents(ostream& out)
 
 int BlueFS::get_block_extents(unsigned id, interval_set<uint64_t> *extents)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " bdev " << id << dendl;
   ceph_assert(id < alloc.size());
   for (auto& p : file_map) {
@@ -482,7 +479,6 @@ int BlueFS::get_block_extents(unsigned id, interval_set<uint64_t> *extents)
 
 int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
 {
-  std::unique_lock l(lock);
   dout(1) << __func__
 	  << " osd_uuid " << osd_uuid
 	  << dendl;
@@ -519,7 +515,7 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
 
   // initial txn
   log_t.op_init();
-  _flush_and_sync_log(l);
+  flush_and_sync_log();
 
   // write supers
   super.log_fnode = log_file->fnode;
@@ -868,7 +864,7 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
       new_log_dev_cur = BDEV_NEWDB;
       new_log_dev_next = BDEV_DB;
     }
-    _rewrite_log_and_layout_sync(false,
+    rewrite_log_and_layout_sync(false,
       BDEV_NEWDB,
       new_log_dev_cur,
       new_log_dev_next,
@@ -876,7 +872,7 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
       layout);
     //}
   } else if(id == BDEV_NEWWAL) {
-    _rewrite_log_and_layout_sync(false,
+    rewrite_log_and_layout_sync(false,
       BDEV_DB,
       BDEV_NEWWAL,
       BDEV_WAL,
@@ -907,7 +903,6 @@ void BlueFS::get_devices(set<string> *ls)
 
 int BlueFS::fsck()
 {
-  std::lock_guard l(lock);
   dout(1) << __func__ << dendl;
   // hrm, i think we check everything on mount...
   return 0;
@@ -1648,7 +1643,7 @@ int BlueFS::device_migrate_to_existing(
         new_log_dev_next;
   }
 
-  _rewrite_log_and_layout_sync(
+  rewrite_log_and_layout_sync(
     false,
     (flags & REMOVE_DB) ? BDEV_SLOW : BDEV_DB,
     new_log_dev_cur,
@@ -1783,7 +1778,7 @@ int BlueFS::device_migrate_to_new(
         BDEV_DB :
 	BDEV_SLOW;
 
-  _rewrite_log_and_layout_sync(
+  rewrite_log_and_layout_sync(
     false,
     super_dev,
     new_log_dev_cur,
@@ -1813,12 +1808,16 @@ void BlueFS::_drop_link(FileRef file)
   dout(20) << __func__ << " had refs " << file->refs
 	   << " on " << file->fnode << dendl;
   ceph_assert(file->refs > 0);
+  ceph_assert(ceph_mutex_is_locked(log_lock));
+
   --file->refs;
   if (file->refs == 0) {
     dout(20) << __func__ << " destroying " << file->fnode << dendl;
     ceph_assert(file->num_reading.load() == 0);
     vselector->sub_usage(file->vselector_hint, file->fnode);
     log_t.op_file_remove(file->fnode.ino);
+
+    std::lock_guard dl(dirty_lock);
     for (auto& r : file->fnode.extents) {
       pending_release[r.bdev].insert(r.offset, r.length);
     }
@@ -1826,6 +1825,7 @@ void BlueFS::_drop_link(FileRef file)
     file->deleted = true;
 
     if (file->dirty_seq) {
+      // retract request to serialize changes
       ceph_assert(file->dirty_seq > log_seq_stable);
       ceph_assert(dirty_files.count(file->dirty_seq));
       auto it = dirty_files[file->dirty_seq].iterator_to(*file);
@@ -2049,8 +2049,9 @@ int64_t BlueFS::_read(
   return ret;
 }
 
-void BlueFS::_invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
+void BlueFS::invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
 {
+  std::lock_guard l(f->lock);
   dout(10) << __func__ << " file " << f->fnode
 	   << " 0x" << std::hex << offset << "~" << length << std::dec
            << dendl;
@@ -2070,8 +2071,9 @@ void BlueFS::_invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
   }
 }
 
-uint64_t BlueFS::_estimate_log_size()
+uint64_t BlueFS::estimate_log_size()
 {
+  std::lock_guard dirl(dirs_lock);
   int avg_dir_size = 40;  // fixme
   int avg_file_size = 12;
   uint64_t size = 4096 * 2;
@@ -2083,37 +2085,44 @@ uint64_t BlueFS::_estimate_log_size()
 
 void BlueFS::compact_log()
 {
-  std::unique_lock<ceph::mutex> l(lock);
   if (!cct->_conf->bluefs_replay_recovery_disable_compact) {
     if (cct->_conf->bluefs_compact_log_sync) {
-      _compact_log_sync();
+      compact_log_sync();
     } else {
-      _compact_log_async(l);
+      compact_log_async();
     }
   }
 }
 
-bool BlueFS::_should_compact_log()
+bool BlueFS::should_start_compact_log()
 {
-  uint64_t current = log_writer->file->fnode.size;
-  uint64_t expected = _estimate_log_size();
+  if (log_is_compacting.load() == true) {
+    // compaction is already running
+    return false;
+  }
+  uint64_t current;
+  {
+    std::lock_guard dirl(log_lock);
+    current = log_writer->file->fnode.size;
+  }
+  uint64_t expected = estimate_log_size();
   float ratio = (float)current / (float)expected;
   dout(10) << __func__ << " current 0x" << std::hex << current
 	   << " expected " << expected << std::dec
 	   << " ratio " << ratio
-	   << (new_log ? " (async compaction in progress)" : "")
 	   << dendl;
-  if (new_log ||
-      current < cct->_conf->bluefs_log_compact_min_size ||
+  if (current < cct->_conf->bluefs_log_compact_min_size ||
       ratio < cct->_conf->bluefs_log_compact_min_ratio) {
     return false;
   }
   return true;
 }
 
-void BlueFS::_compact_log_dump_metadata(bluefs_transaction_t *t,
+void BlueFS::compact_log_dump_metadata(bluefs_transaction_t *t,
 					int flags)
 {
+  std::lock_guard dirl(dirs_lock);
+
   t->seq = 1;
   t->uuid = super.uuid;
   dout(20) << __func__ << " op_init" << dendl;
@@ -2123,7 +2132,7 @@ void BlueFS::_compact_log_dump_metadata(bluefs_transaction_t *t,
     if (ino == 1)
       continue;
     ceph_assert(ino > 1);
-
+    //AK - TODO - touching fnode - need to lock
     for(auto& e : file_ref->fnode.extents) {
       auto bdev = e.bdev;
       auto bdev_new = bdev;
@@ -2160,12 +2169,12 @@ void BlueFS::_compact_log_dump_metadata(bluefs_transaction_t *t,
   }
 }
 
-void BlueFS::_compact_log_sync()
+void BlueFS::compact_log_sync()
 {
   dout(10) << __func__ << dendl;
   auto prefer_bdev =
     vselector->select_prefer_bdev(log_writer->file->vselector_hint);
-  _rewrite_log_and_layout_sync(true,
+  rewrite_log_and_layout_sync(true,
     BDEV_DB,
     prefer_bdev,
     prefer_bdev,
@@ -2174,13 +2183,16 @@ void BlueFS::_compact_log_sync()
   logger->inc(l_bluefs_log_compactions);
 }
 
-void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
-					  int super_dev,
-					  int log_dev,
-					  int log_dev_new,
-					  int flags,
-					  std::optional<bluefs_layout_t> layout)
+void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
+					 int super_dev,
+					 int log_dev,
+					 int log_dev_new,
+					 int flags,
+					 std::optional<bluefs_layout_t> layout)
 {
+  //ceph_assert(ceph_mutex_is_notlocked(log_lock));
+  std::lock_guard ll(log_lock);
+
   File *log_file = log_writer->file.get();
 
   // clear out log (be careful who calls us!!!)
@@ -2192,7 +2204,7 @@ void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
 		       << " flags:" << flags
 		       << dendl;
   bluefs_transaction_t t;
-  _compact_log_dump_metadata(&t, flags);
+  compact_log_dump_metadata(&t, flags);
 
   dout(20) << __func__ << " op_jump_seq " << log_seq << dendl;
   t.op_jump_seq(log_seq);
@@ -2258,6 +2270,7 @@ void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
   flush_bdev();
 
   dout(10) << __func__ << " release old log extents " << old_fnode.extents << dendl;
+  std::lock_guard dl(dirty_lock);
   for (auto& r : old_fnode.extents) {
     pending_release[r.bdev].insert(r.offset, r.length);
   }
@@ -2285,29 +2298,42 @@ void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
  *
  * 8. Release the old log space.  Clean up.
  */
-void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
+
+void BlueFS::compact_log_async()
 {
   dout(10) << __func__ << dendl;
-  File *log_file = log_writer->file.get();
-  ceph_assert(!new_log);
-  ceph_assert(!new_log_writer);
-
-  // create a new log [writer] so that we know compaction is in progress
-  // (see _should_compact_log)
-  new_log = ceph::make_ref<File>();
-  new_log->fnode.ino = 0;   // so that _flush_range won't try to log the fnode
-
-  // 0. wait for any racing flushes to complete.  (We do not want to block
-  // in _flush_sync_log with jump_to set or else a racing thread might flush
-  // our entries and our jump_to update won't be correct.)
-  while (log_flushing) {
-    dout(10) << __func__ << " log is currently flushing, waiting" << dendl;
-    log_cond.wait(l);
+  // only one compaction allowed at one time
+  bool old_is_comp = std::atomic_exchange(&log_is_compacting, true);
+  if (old_is_comp) {
+    dout(10) << __func__ << " ongoing" <<dendl;
+    return;
   }
+
+  log_lock.lock();
+  File *log_file = log_writer->file.get();
+  FileWriter *new_log_writer = nullptr;
+  FileRef new_log = nullptr;
+  uint64_t new_log_jump_to = 0;
+  uint64_t old_log_jump_to = 0;
+
+  new_log = ceph::make_ref<File>();
+  new_log->fnode.ino = 0;   // we use _flush_special to avoid log of the fnode
+
+  // Part 1.
+  // Prepare current log for jumping into it.
+  // 1. Allocate extent
+  // 2. Update op to log
+  // 3. Jump op to log
+  // During that, no one else can write to log, otherwise we risk jumping backwards.
+  // We need to sync log, because we are injecting discontinuity, and writer is not prepared for that.
+
+  //signal _maybe_extend_log that expansion of log is temporary inacceptable
+  bool old_forbidden = atomic_exchange(&log_forbidden_to_expand, true);
+  ceph_assert(old_forbidden == false);
 
   vselector->sub_usage(log_file->vselector_hint, log_file->fnode);
 
-  // 1. allocate new log space and jump to it.
+  // 1.1 allocate new log space and jump to it.
   old_log_jump_to = log_file->fnode.get_allocated();
   uint64_t runway = log_file->fnode.get_allocated() - log_writer->get_effective_write_pos();
   dout(10) << __func__ << " old_log_jump_to 0x" << std::hex << old_log_jump_to
@@ -2322,21 +2348,24 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
 
   // update the log file change and log a jump to the offset where we want to
   // write the new entries
-  log_t.op_file_update(log_file->fnode);
-  log_t.op_jump(log_seq, old_log_jump_to);
+  log_t.op_file_update(log_file->fnode); // 1.2
+  log_t.op_jump(log_seq, old_log_jump_to); // 1.3
 
   // we need to flush all bdev because we will be streaming all dirty files to log
   // TODO - think - if _flush_and_sync_log_jump will not add dirty files nor release pending allocations
   // then flush_bdev() will not be necessary
   flush_bdev();
-
   _flush_and_sync_log_jump(old_log_jump_to, runway);
+
+  log_lock.unlock();
+  // out of jump section - now log can be used to write to
 
   // 2. prepare compacted log
   bluefs_transaction_t t;
-  //avoid record two times in log_t and _compact_log_dump_metadata.
-  log_t.clear();
-  _compact_log_dump_metadata(&t, 0);
+  //this needs files lock
+  //what will happen, if a file is modified *twice* before we stream it to log?
+  //the later state that we capture will be seen earlier and replay will see a temporary retraction (!)
+  compact_log_dump_metadata(&t, 0);
 
   uint64_t max_alloc_size = std::max(alloc_size[BDEV_WAL],
 				     std::max(alloc_size[BDEV_DB],
@@ -2354,7 +2383,7 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
   ceph_assert(r == 0);
 
   // we might have some more ops in log_t due to _allocate call
-  t.claim_ops(log_t);
+  // t.claim_ops(log_t); no we no longer track allocations in log
 
   bufferlist bl;
   encode(t, bl);
@@ -2364,15 +2393,16 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
 	   << std::dec << dendl;
 
   new_log_writer = _create_writer(new_log);
-  new_log_writer->append(bl);
 
+  new_log_writer->append(bl);
+  new_log_writer->lock.lock();
   // 3. flush
   r = _flush_special(new_log_writer);
   ceph_assert(r == 0);
 
   // 4. wait
-  _flush_bdev_safely(new_log_writer);
-
+  _flush_bdev(new_log_writer);
+  new_log_writer->lock.unlock();
   // 5. update our log fnode
   // discard first old_log_jump_to extents
 
@@ -2424,29 +2454,42 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
   ++super.version;
   _write_super(BDEV_DB);
 
-  lock.unlock();
   flush_bdev();
-  lock.lock();
+
+  old_forbidden = atomic_exchange(&log_forbidden_to_expand, false);
+  ceph_assert(old_forbidden == true);
+  //to wake up if someone was in need of expanding log
+  log_cond.notify_all();
 
   // 7. release old space
   dout(10) << __func__ << " release old log extents " << old_extents << dendl;
-  for (auto& r : old_extents) {
-    pending_release[r.bdev].insert(r.offset, r.length);
+  {
+    std::lock_guard dl(dirty_lock);
+    for (auto& r : old_extents) {
+      pending_release[r.bdev].insert(r.offset, r.length);
+    }
   }
 
   // delete the new log, remove from the dirty files list
   _close_writer(new_log_writer);
+  // flush_special does not dirty files
+  /*
   if (new_log->dirty_seq) {
+    std::lock_guard dl(dirty_lock);
     ceph_assert(dirty_files.count(new_log->dirty_seq));
     auto it = dirty_files[new_log->dirty_seq].iterator_to(*new_log);
     dirty_files[new_log->dirty_seq].erase(it);
   }
+  */
   new_log_writer = nullptr;
   new_log = nullptr;
   log_cond.notify_all();
 
   dout(10) << __func__ << " log extents " << log_file->fnode.extents << dendl;
   logger->inc(l_bluefs_log_compactions);
+
+  old_is_comp = atomic_exchange(&log_is_compacting, false);
+  ceph_assert(old_is_comp);
 }
 
 void BlueFS::_pad_bl(bufferlist& bl)
@@ -2459,10 +2502,26 @@ void BlueFS::_pad_bl(bufferlist& bl)
   }
 }
 
+/**
+ * Adds file modifications from `dirty_files` to bluefs transactions
+ * already stored in `log_t`. Writes them to disk and waits until are stable.
+ * Guarantees that file modifications with `want_seq` are already stable on disk.
+ * In addition may insert jump forward transaction to log write position `jump_to`.
+ *
+ * it should lock ability to:
+ * 1) add to log_t
+ * 2) modify dirty_files
+ * 3) add to pending_release
+ *
+ * pending_release and log_t go with same lock
+ */
+
 // Adds to log_t file modifications mentioned in `dirty_files`.
 // Note: some bluefs ops may have already been stored in log_t transaction.
 uint64_t BlueFS::_consume_dirty()
 {
+  ceph_assert(ceph_mutex_is_locked(dirty_lock));
+  ceph_assert(ceph_mutex_is_locked(log_lock));
   //acquire new seq
   // this will became log_seq_stable once we write
   uint64_t seq = log_t.seq = ++log_seq;
@@ -2485,6 +2544,7 @@ uint64_t BlueFS::_consume_dirty()
 // Returns space available *BEFORE* adding new space. Signed for additional <0 detection.
 int64_t BlueFS::_maybe_extend_log()
 {
+  ceph_assert(ceph_mutex_is_locked(log_lock));
   // allocate some more space (before we run out)?
   // BTW: this triggers `flush()` in the `page_aligned_appender` of `log_writer`.
   int64_t runway = log_writer->file->fnode.get_allocated() -
@@ -2507,7 +2567,7 @@ int64_t BlueFS::_maybe_extend_log()
      * - re-run compaction with more runway for old log
      * - add OP_FILE_ADDEXT that adds extent; will be compatible with both logs
      */
-    if (new_log_writer) {
+    if (log_forbidden_to_expand.load() == true) {
       return -EWOULDBLOCK;
     }
     vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
@@ -2524,6 +2584,7 @@ int64_t BlueFS::_maybe_extend_log()
 
 void BlueFS::_flush_and_sync_log_core(int64_t runway)
 {
+  ceph_assert(ceph_mutex_is_locked(log_lock));
   dout(10) << __func__ << " " << log_t << dendl;
 
   bufferlist bl;
@@ -2551,8 +2612,10 @@ void BlueFS::_flush_and_sync_log_core(int64_t runway)
 }
 
 // Clears dirty_files up to (including) seq_stable.
-void BlueFS::_clear_dirty_set_stable(uint64_t seq)
+void BlueFS::clear_dirty_set_stable(uint64_t seq)
 {
+  std::lock_guard lg(dirty_lock);
+
   // clean dirty files
   if (seq > log_seq_stable) {
     log_seq_stable = seq;
@@ -2586,7 +2649,7 @@ void BlueFS::_clear_dirty_set_stable(uint64_t seq)
   }
 }
 
-void BlueFS::_release_pending_allocations(vector<interval_set<uint64_t>>& to_release)
+void BlueFS::release_pending_allocations(vector<interval_set<uint64_t>>& to_release)
 {
   for (unsigned i = 0; i < to_release.size(); ++i) {
     if (!to_release[i].empty()) {
@@ -2609,36 +2672,49 @@ void BlueFS::_release_pending_allocations(vector<interval_set<uint64_t>>& to_rel
   }
 }
 
-int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
-			       uint64_t want_seq)
+int BlueFS::flush_and_sync_log(uint64_t want_seq)
 {
-  if (want_seq && want_seq <= log_seq_stable) {
-    dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
-	     << log_seq_stable << ", done" << dendl;
-    return 0;
-  }
+  // we synchronize writing to log, by lock to log_lock
   int64_t available_runway;
   do {
+    log_lock.lock();
+    dirty_lock.lock();
+    if (want_seq && want_seq <= log_seq_stable) {
+      dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
+	       << log_seq_stable << ", done" << dendl;
+      dirty_lock.unlock();
+      log_lock.unlock();
+      return 0;
+    }
+
     available_runway = _maybe_extend_log();
     if (available_runway == -EWOULDBLOCK) {
-      while (new_log_writer) {
-	dout(10) << __func__ << " waiting for async compaction" << dendl;
-	log_cond.wait(l);
+      // we are in need of adding runway, but we are during log-switch from compaction
+      dirty_lock.unlock();
+      //instead log_lock_unlock() do move ownership
+      std::unique_lock<ceph::mutex> ll(log_lock, std::adopt_lock);
+      while (log_forbidden_to_expand.load()) {
+	log_cond.wait(ll);
       }
+    } else {
+      ceph_assert(available_runway >= 0);
     }
-  } while (available_runway == -EWOULDBLOCK);
+  } while (available_runway < 0);
 
   ceph_assert(want_seq == 0 || want_seq <= log_seq + 1); // illegal to request seq that was not created yet
 
   uint64_t seq = _consume_dirty();
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
+  dirty_lock.unlock();
 
   _flush_and_sync_log_core(available_runway);
-  _flush_bdev_safely(log_writer);
+  _flush_bdev(log_writer);
+  //now log_lock is no longer needed
+  log_lock.unlock();
 
-  _clear_dirty_set_stable(seq);
-  _release_pending_allocations(to_release);
+  clear_dirty_set_stable(seq);
+  release_pending_allocations(to_release);
 
   _update_logger_stats();
   return 0;
@@ -2648,11 +2724,16 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
 int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
 				     int64_t available_runway)
 {
+  ceph_assert(ceph_mutex_is_locked(log_lock));
+
   ceph_assert(jump_to);
+  // we synchronize writing to log, by lock to log_lock
+
+  dirty_lock.lock();
   uint64_t seq = _consume_dirty();
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
-
+  dirty_lock.unlock();
   _flush_and_sync_log_core(available_runway);
 
   dout(10) << __func__ << " jumping log offset from 0x" << std::hex
@@ -2662,10 +2743,10 @@ int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
   log_writer->file->fnode.size = jump_to;
   vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
 
-  _flush_bdev_safely(log_writer);
+  _flush_bdev(log_writer);
 
-  _clear_dirty_set_stable(seq);
-  _release_pending_allocations(to_release);
+  clear_dirty_set_stable(seq);
+  release_pending_allocations(to_release);
 
   _update_logger_stats();
   return 0;
@@ -2677,6 +2758,7 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
   const unsigned length,
   const bluefs_super_t& super)
 {
+  ceph_assert(ceph_mutex_is_locked(this->lock) || file->fnode.ino == 1);
   ceph::bufferlist bl;
   if (partial) {
     tail_block.splice(0, tail_block.length(), &bl);
@@ -2715,6 +2797,8 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
 
 int BlueFS::_signal_dirty_to_log(FileWriter *h)
 {
+  ceph_assert(ceph_mutex_is_locked(h->lock));
+  std::lock_guard dl(dirty_lock);
   h->file->fnode.mtime = ceph_clock_now();
   ceph_assert(h->file->fnode.ino >= 1);
   if (h->file->dirty_seq == 0) {
@@ -2740,8 +2824,14 @@ int BlueFS::_signal_dirty_to_log(FileWriter *h)
   return 0;
 }
 
+void BlueFS::flush_range(FileWriter *h, uint64_t offset, uint64_t length) {
+  std::unique_lock hl(h->lock);
+  _flush_range(h, offset, length);
+}
+
 int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
 {
+  ceph_assert(ceph_mutex_is_locked(h->lock));
   dout(10) << __func__ << " " << h << " pos 0x" << std::hex << h->pos
 	   << " 0x" << offset << "~" << length << std::dec
 	   << " to " << h->file->fnode << dendl;
@@ -2764,13 +2854,13 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
              << std::hex << offset << "~" << length << std::dec
              << dendl;
   }
+  std::lock_guard file_lock(h->file->lock);
   ceph_assert(offset <= h->file->fnode.size);
 
   uint64_t allocated = h->file->fnode.get_allocated();
   vselector->sub_usage(h->file->vselector_hint, h->file->fnode);
   // do not bother to dirty the file if we are overwriting
   // previously allocated extents.
-
   if (allocated < offset + length) {
     // we should never run out of log space here; see the min runway check
     // in _flush_and_sync_log.
@@ -2791,12 +2881,15 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
     h->file->fnode.size = offset + length;
     h->file->is_dirty = true;
   }
+
   dout(20) << __func__ << " file now, unflushed " << h->file->fnode << dendl;
   return _flush_data(h, offset, length, buffered);
 }
 
 int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered)
 {
+  //ceph_assert(ceph_mutex_is_locked(h->lock));
+  //ceph_assert(ceph_mutex_is_locked(h->file->lock));
   uint64_t x_off = 0;
   auto p = h->file->fnode.seek(offset, &x_off);
   ceph_assert(p != h->file->fnode.extents.end());
@@ -2903,18 +2996,49 @@ void BlueFS::wait_for_aio(FileWriter *h)
 }
 #endif
 
-int BlueFS::_flush(FileWriter *h, bool force, std::unique_lock<ceph::mutex>& l)
+
+void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
 {
+  std::unique_lock hl(h->lock);
+  size_t max_size = 1ull << 30; // cap to 1GB
+  while (len > 0) {
+    bool need_flush = true;
+    auto l0 = h->get_buffer_length();
+    if (l0 < max_size) {
+      size_t l = std::min(len, max_size - l0);
+      h->append(buf, l);
+      buf += l;
+      len -= l;
+      need_flush = h->get_buffer_length() >= cct->_conf->bluefs_min_flush_size;
+    }
+    if (need_flush) {
+      bool flushed = false;
+      int r = _flush(h, true, &flushed);
+      ceph_assert(r == 0);
+      if (r == 0 && flushed) {
+	maybe_compact_log();
+      }
+      // make sure we've made any progress with flush hence the
+      // loop doesn't iterate forever
+      ceph_assert(h->get_buffer_length() < max_size);
+    }
+  }
+}
+
+void BlueFS::flush(FileWriter *h, bool force)
+{
+  std::unique_lock hl(h->lock);
   bool flushed = false;
   int r = _flush(h, force, &flushed);
+  ceph_assert(r == 0);
   if (r == 0 && flushed) {
-    _maybe_compact_log(l);
+    maybe_compact_log();
   }
-  return r;
 }
 
 int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
 {
+  ceph_assert(ceph_mutex_is_locked(h->lock));
   uint64_t length = h->get_buffer_length();
   uint64_t offset = h->pos;
   if (flushed) {
@@ -2951,6 +3075,8 @@ int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
 // smart enough to discover it on its own.
 int BlueFS::_flush_special(FileWriter *h)
 {
+  //ceph_assert(ceph_mutex_is_locked(h->lock));
+  //ceph_assert(ceph_mutex_is_locked(h->file->lock));
   uint64_t length = h->get_buffer_length();
   uint64_t offset = h->pos;
   ceph_assert(length + offset <= h->file->fnode.get_allocated());
@@ -2960,8 +3086,9 @@ int BlueFS::_flush_special(FileWriter *h)
   return _flush_data(h, offset, length, false);
 }
 
-int BlueFS::_truncate(FileWriter *h, uint64_t offset)
+int BlueFS::truncate(FileWriter *h, uint64_t offset)
 {
+  std::lock_guard hl(h->lock);
   dout(10) << __func__ << " 0x" << std::hex << offset << std::dec
            << " file " << h->file->fnode << dendl;
   if (h->file->deleted) {
@@ -2994,12 +3121,14 @@ int BlueFS::_truncate(FileWriter *h, uint64_t offset)
   vselector->sub_usage(h->file->vselector_hint, h->file->fnode.size);
   h->file->fnode.size = offset;
   vselector->add_usage(h->file->vselector_hint, h->file->fnode.size);
+  std::lock_guard ll(log_lock);
   log_t.op_file_update(h->file->fnode);
   return 0;
 }
 
-int BlueFS::_fsync(FileWriter *h, std::unique_lock<ceph::mutex>& l)
+int BlueFS::fsync(FileWriter *h)
 {
+  std::unique_lock hl(h->lock);
   dout(10) << __func__ << " " << h << " " << h->file->fnode << dendl;
   int r = _flush(h, true);
   if (r < 0)
@@ -3010,39 +3139,40 @@ int BlueFS::_fsync(FileWriter *h, std::unique_lock<ceph::mutex>& l)
   }
   uint64_t old_dirty_seq = h->file->dirty_seq;
 
-  _flush_bdev_safely(h);
+  _flush_bdev(h);
 
   if (old_dirty_seq) {
     uint64_t s = log_seq;
     dout(20) << __func__ << " file metadata was dirty (" << old_dirty_seq
 	     << ") on " << h->file->fnode << ", flushing log" << dendl;
-    _flush_and_sync_log(l, old_dirty_seq);
+    flush_and_sync_log(old_dirty_seq);
+    // AK - TODO - think - how can dirty_seq change if we are under h lock?
     ceph_assert(h->file->dirty_seq == 0 ||  // cleaned
-	   h->file->dirty_seq > s);    // or redirtied by someone else
+		h->file->dirty_seq > s);    // or redirtied by someone else
   }
+  maybe_compact_log();
   return 0;
 }
 
-void BlueFS::_flush_bdev_safely(FileWriter *h)
+// be careful - either h->file->lock or log_lock must be taken
+void BlueFS::_flush_bdev(FileWriter *h)
 {
+  if (h->file->fnode.ino != 1) {
+    ceph_assert(ceph_mutex_is_locked(h->lock));
+  } else {
+    ceph_assert(ceph_mutex_is_locked(log_lock));
+  }
   std::array<bool, MAX_BDEV> flush_devs = h->dirty_devs;
   h->dirty_devs.fill(false);
 #ifdef HAVE_LIBAIO
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
     _claim_completed_aios(h, &completed_ios);
-    lock.unlock();
     wait_for_aio(h);
     completed_ios.clear();
-    flush_bdev(flush_devs);
-    lock.lock();
-  } else
-#endif
-  {
-    lock.unlock();
-    flush_bdev(flush_devs);
-    lock.lock();
   }
+#endif
+  flush_bdev(flush_devs);
 }
 
 void BlueFS::flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs)
@@ -3176,8 +3306,9 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
   return 0;
 }
 
-int BlueFS::_preallocate(FileRef f, uint64_t off, uint64_t len)
+int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
 {
+  std::lock_guard fl(f->lock);
   dout(10) << __func__ << " file " << f->fnode << " 0x"
 	   << std::hex << off << "~" << len << std::dec << dendl;
   if (f->deleted) {
@@ -3196,6 +3327,7 @@ int BlueFS::_preallocate(FileRef f, uint64_t off, uint64_t len)
     vselector->add_usage(f->vselector_hint, f->fnode);
     if (r < 0)
       return r;
+    std::lock_guard ll(log_lock);
     log_t.op_file_update(f->fnode);
   }
   return 0;
@@ -3203,8 +3335,13 @@ int BlueFS::_preallocate(FileRef f, uint64_t off, uint64_t len)
 
 void BlueFS::sync_metadata(bool avoid_compact)
 {
-  std::unique_lock l(lock);
-  if (log_t.empty() && dirty_files.empty()) {
+  bool can_skip_flush;
+  {
+    std::lock_guard ll(log_lock);
+    std::lock_guard dl(dirty_lock);
+    can_skip_flush = log_t.empty() && dirty_files.empty();
+  }
+  if (can_skip_flush) {
     dout(10) << __func__ << " - no pending log events" << dendl;
   } else {
     utime_t start;
@@ -3212,23 +3349,23 @@ void BlueFS::sync_metadata(bool avoid_compact)
     start = ceph_clock_now();
     *_dout <<  dendl;
     flush_bdev(); // FIXME?
-    _flush_and_sync_log(l);
+    flush_and_sync_log();
     dout(10) << __func__ << " done in " << (ceph_clock_now() - start) << dendl;
   }
 
   if (!avoid_compact) {
-    _maybe_compact_log(l);
+    maybe_compact_log();
   }
 }
 
-void BlueFS::_maybe_compact_log(std::unique_lock<ceph::mutex>& l)
+void BlueFS::maybe_compact_log()
 {
   if (!cct->_conf->bluefs_replay_recovery_disable_compact &&
-      _should_compact_log()) {
+      should_start_compact_log()) {
     if (cct->_conf->bluefs_compact_log_sync) {
-      _compact_log_sync();
+      compact_log_sync();
     } else {
-      _compact_log_async(l);
+      compact_log_async();
     }
   }
 }
@@ -3239,7 +3376,7 @@ int BlueFS::open_for_write(
   FileWriter **h,
   bool overwrite)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   DirRef dir;
@@ -3301,11 +3438,12 @@ int BlueFS::open_for_write(
   dout(20) << __func__ << " mapping " << dirname << "/" << filename
 	   << " vsel_hint " << file->vselector_hint
 	   << dendl;
-
-  log_t.op_file_update(file->fnode);
-  if (create)
-    log_t.op_dir_link(dirname, filename, file->fnode.ino);
-
+  {
+    std::lock_guard ll(log_lock);
+    log_t.op_file_update(file->fnode);
+    if (create)
+      log_t.op_dir_link(dirname, filename, file->fnode.ino);
+  }
   *h = _create_writer(file);
 
   if (boost::algorithm::ends_with(filename, ".log")) {
@@ -3335,7 +3473,7 @@ BlueFS::FileWriter *BlueFS::_create_writer(FileRef f)
   return w;
 }
 
-void BlueFS::_close_writer(FileWriter *h)
+void BlueFS::_drain_writer(FileWriter *h)
 {
   dout(10) << __func__ << " " << h << " type " << h->writer_type << dendl;
   //h->buffer.reassign_to_mempool(mempool::mempool_bluefs_file_writer);
@@ -3351,18 +3489,31 @@ void BlueFS::_close_writer(FileWriter *h)
   if (h->file->fnode.size >= (1ull << 30)) {
     dout(10) << __func__ << " file is unexpectedly large:" << h->file->fnode << dendl;
   }
+}
+
+void BlueFS::_close_writer(FileWriter *h)
+{
+  _drain_writer(h);
+  delete h;
+}
+void BlueFS::close_writer(FileWriter *h)
+{
+  {
+    std::lock_guard l(h->lock);
+    _drain_writer(h);
+  }
   delete h;
 }
 
 uint64_t BlueFS::debug_get_dirty_seq(FileWriter *h)
 {
-  std::lock_guard l(lock);
+  std::lock_guard l(h->lock);
   return h->file->dirty_seq;
 }
 
 bool BlueFS::debug_get_is_dev_dirty(FileWriter *h, uint8_t dev)
 {
-  std::lock_guard l(lock);
+  std::lock_guard l(h->lock);
   return h->dirty_devs[dev];
 }
 
@@ -3372,7 +3523,7 @@ int BlueFS::open_for_read(
   FileReader **h,
   bool random)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename
 	   << (random ? " (random)":" (sequential)") << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
@@ -3401,7 +3552,8 @@ int BlueFS::rename(
   std::string_view old_dirname, std::string_view old_filename,
   std::string_view new_dirname, std::string_view new_filename)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
+  std::lock_guard ll(log_lock);
   dout(10) << __func__ << " " << old_dirname << "/" << old_filename
 	   << " -> " << new_dirname << "/" << new_filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(old_dirname);
@@ -3448,7 +3600,8 @@ int BlueFS::rename(
 
 int BlueFS::mkdir(std::string_view dirname)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
+  std::lock_guard ll(log_lock);
   dout(10) << __func__ << " " << dirname << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   if (p != dir_map.end()) {
@@ -3462,7 +3615,8 @@ int BlueFS::mkdir(std::string_view dirname)
 
 int BlueFS::rmdir(std::string_view dirname)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
+  std::lock_guard ll(log_lock);
   dout(10) << __func__ << " " << dirname << dendl;
   auto p = dir_map.find(dirname);
   if (p == dir_map.end()) {
@@ -3481,7 +3635,7 @@ int BlueFS::rmdir(std::string_view dirname)
 
 bool BlueFS::dir_exists(std::string_view dirname)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   bool exists = p != dir_map.end();
   dout(10) << __func__ << " " << dirname << " = " << (int)exists << dendl;
@@ -3491,7 +3645,7 @@ bool BlueFS::dir_exists(std::string_view dirname)
 int BlueFS::stat(std::string_view dirname, std::string_view filename,
 		 uint64_t *size, utime_t *mtime)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   if (p == dir_map.end()) {
@@ -3519,7 +3673,7 @@ int BlueFS::stat(std::string_view dirname, std::string_view filename,
 int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 		      FileLock **plock)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   if (p == dir_map.end()) {
@@ -3539,6 +3693,7 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
     file_map[ino_last] = file;
     dir->file_map[string{filename}] = file;
     ++file->refs;
+    std::lock_guard ll(log_lock);
     log_t.op_file_update(file->fnode);
     log_t.op_dir_link(dirname, filename, file->fnode.ino);
   } else {
@@ -3557,7 +3712,7 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 
 int BlueFS::unlock_file(FileLock *fl)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << fl << " on " << fl->file->fnode << dendl;
   ceph_assert(fl->file->locked);
   fl->file->locked = false;
@@ -3571,7 +3726,7 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
   if (!dirname.empty() && dirname.back() == '/') {
     dirname.remove_suffix(1);
   }
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << dendl;
   if (dirname.empty()) {
     // list dirs
@@ -3599,7 +3754,8 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
 
 int BlueFS::unlink(std::string_view dirname, std::string_view filename)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
+  std::lock_guard ll(log_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   if (p == dir_map.end()) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2230,7 +2230,6 @@ void BlueFS::_rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
 					 int flags,
 					 std::optional<bluefs_layout_t> layout)
 {
-  //ceph_assert(ceph_mutex_is_notlocked(log.lock));
   std::lock_guard ll(log.lock);
 
   File *log_file = log.writer->file.get();
@@ -2408,11 +2407,7 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
 
   // 2. prepare compacted log
   bluefs_transaction_t t;
-  //this needs files lock
-  //what will happen, if a file is modified *twice* before we stream it to log?
-  //the later state that we capture will be seen earlier and replay will see a temporary retraction (!)
   compact_log_async_dump_metadata_NF(&t, seq_now);
-
   uint64_t max_alloc_size = std::max(alloc_size[BDEV_WAL],
 				     std::max(alloc_size[BDEV_DB],
 					      alloc_size[BDEV_SLOW]));
@@ -2521,15 +2516,6 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
 
   // delete the new log, remove from the dirty files list
   _close_writer(new_log_writer);
-  // flush_special does not dirty files
-  /*
-  if (new_log->dirty_seq) {
-    std::lock_guard dl(dirty.lock);
-    ceph_assert(dirty.files.count(new_log->dirty_seq));
-    auto it = dirty.files[new_log->dirty_seq].iterator_to(*new_log);
-    dirty.files[new_log->dirty_seq].erase(it);
-  }
-  */
   new_log_writer = nullptr;
   new_log = nullptr;
   log_cond.notify_all();
@@ -2789,7 +2775,7 @@ int BlueFS::_flush_and_sync_log_jump_D(uint64_t jump_to,
   ceph_assert(ceph_mutex_is_locked(log.lock));
 
   ceph_assert(jump_to);
-  // we synchronize writing to log, by lock to log_lock
+  // we synchronize writing to log, by lock to log.lock
 
   dirty.lock.lock();
   uint64_t seq =_log_advance_seq();
@@ -3061,41 +3047,47 @@ void BlueFS::_wait_for_aio(FileWriter *h)
 }
 #endif
 
-
-void BlueFS::append_try_flush/*_WFL_WFN*/(FileWriter *h, const char* buf, size_t len)
+void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
 {
-  std::unique_lock hl(h->lock);
-  size_t max_size = 1ull << 30; // cap to 1GB
-  while (len > 0) {
-    bool need_flush = true;
-    auto l0 = h->get_buffer_length();
-    if (l0 < max_size) {
-      size_t l = std::min(len, max_size - l0);
-      h->append(buf, l);
-      buf += l;
-      len -= l;
-      need_flush = h->get_buffer_length() >= cct->_conf->bluefs_min_flush_size;
-    }
-    if (need_flush) {
-      bool flushed = false;
-      int r = _flush_F(h, true, &flushed);
-      ceph_assert(r == 0);
-      if (r == 0 && flushed) {
-	_maybe_compact_log_LN_N_LD_D();
+  bool flushed_sum = false;
+  {
+    std::unique_lock hl(h->lock);
+    size_t max_size = 1ull << 30; // cap to 1GB
+    while (len > 0) {
+      bool need_flush = true;
+      auto l0 = h->get_buffer_length();
+      if (l0 < max_size) {
+	size_t l = std::min(len, max_size - l0);
+	h->append(buf, l);
+	buf += l;
+	len -= l;
+	need_flush = h->get_buffer_length() >= cct->_conf->bluefs_min_flush_size;
       }
-      // make sure we've made any progress with flush hence the
-      // loop doesn't iterate forever
-      ceph_assert(h->get_buffer_length() < max_size);
+      if (need_flush) {
+	bool flushed = false;
+	int r = _flush_F(h, true, &flushed);
+	ceph_assert(r == 0);
+	flushed_sum |= flushed;
+	// make sure we've made any progress with flush hence the
+	// loop doesn't iterate forever
+	ceph_assert(h->get_buffer_length() < max_size);
+      }
     }
+  }
+  if (flushed_sum) {
+    _maybe_compact_log_LN_NF_LD_D();
   }
 }
 
 void BlueFS::flush(FileWriter *h, bool force)
 {
-  std::unique_lock hl(h->lock);
   bool flushed = false;
-  int r = _flush_F(h, force, &flushed);
-  ceph_assert(r == 0);
+  int r;
+  {
+    std::unique_lock hl(h->lock);
+    r = _flush_F(h, force, &flushed);
+    ceph_assert(r == 0);
+  }
   if (r == 0 && flushed) {
     _maybe_compact_log_LN_NF_LD_D();
   }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2309,6 +2309,7 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
 
   // 1. allocate new log space and jump to it.
   old_log_jump_to = log_file->fnode.get_allocated();
+  uint64_t runway = log_file->fnode.get_allocated() - log_writer->get_effective_write_pos();
   dout(10) << __func__ << " old_log_jump_to 0x" << std::hex << old_log_jump_to
            << " need 0x" << (old_log_jump_to + cct->_conf->bluefs_max_log_runway) << std::dec << dendl;
   int r = _allocate(vselector->select_prefer_bdev(log_file->vselector_hint),
@@ -2324,9 +2325,12 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
   log_t.op_file_update(log_file->fnode);
   log_t.op_jump(log_seq, old_log_jump_to);
 
-  flush_bdev();  // FIXME?
+  // we need to flush all bdev because we will be streaming all dirty files to log
+  // TODO - think - if _flush_and_sync_log_jump will not add dirty files nor release pending allocations
+  // then flush_bdev() will not be necessary
+  flush_bdev();
 
-  _flush_and_sync_log(l, 0, old_log_jump_to);
+  _flush_and_sync_log_jump(old_log_jump_to, runway);
 
   // 2. prepare compacted log
   bluefs_transaction_t t;
@@ -2455,38 +2459,17 @@ void BlueFS::_pad_bl(bufferlist& bl)
   }
 }
 
-
-int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
-				uint64_t want_seq,
-				uint64_t jump_to)
+// Adds to log_t file modifications mentioned in `dirty_files`.
+// Note: some bluefs ops may have already been stored in log_t transaction.
+uint64_t BlueFS::_consume_dirty()
 {
-  while (log_flushing) {
-    dout(10) << __func__ << " want_seq " << want_seq
-	     << " log is currently flushing, waiting" << dendl;
-    ceph_assert(!jump_to);
-    log_cond.wait(l);
-  }
-  if (want_seq && want_seq <= log_seq_stable) {
-    dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
-	     << log_seq_stable << ", done" << dendl;
-    ceph_assert(!jump_to);
-    return 0;
-  }
-  if (log_t.empty() && dirty_files.empty()) {
-    dout(10) << __func__ << " want_seq " << want_seq
-	     << " " << log_t << " not dirty, dirty_files empty, no-op" << dendl;
-    ceph_assert(!jump_to);
-    return 0;
-  }
-
-  vector<interval_set<uint64_t>> to_release(pending_release.size());
-  to_release.swap(pending_release);
-
+  //acquire new seq
+  // this will became log_seq_stable once we write
   uint64_t seq = log_t.seq = ++log_seq;
-  ceph_assert(want_seq == 0 || want_seq <= seq);
   log_t.uuid = super.uuid;
 
   // log dirty files
+  // we just incremented log_seq. It is now illegal to add to dirty_files[log_seq]
   auto lsi = dirty_files.find(seq);
   if (lsi != dirty_files.end()) {
     dout(20) << __func__ << " " << lsi->second.size() << " dirty_files" << dendl;
@@ -2495,21 +2478,37 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
       log_t.op_file_update(f.fnode);
     }
   }
+  return seq;
+}
 
-  dout(10) << __func__ << " " << log_t << dendl;
-  ceph_assert(!log_t.empty());
-
+// Extends log if its free space is smaller then bluefs_min_log_runway.
+// Returns space available *BEFORE* adding new space. Signed for additional <0 detection.
+int64_t BlueFS::_maybe_extend_log()
+{
   // allocate some more space (before we run out)?
   // BTW: this triggers `flush()` in the `page_aligned_appender` of `log_writer`.
   int64_t runway = log_writer->file->fnode.get_allocated() -
     log_writer->get_effective_write_pos();
-  bool just_expanded_log = false;
   if (runway < (int64_t)cct->_conf->bluefs_min_log_runway) {
     dout(10) << __func__ << " allocating more log runway (0x"
 	     << std::hex << runway << std::dec  << " remaining)" << dendl;
-    while (new_log_writer) {
-      dout(10) << __func__ << " waiting for async compaction" << dendl;
-      log_cond.wait(l);
+    /*
+     * Usually, when we are low on space in log, we just allocate new extent,
+     * put update op(log) to log and we are fine.
+     * Problem - it interferes with log compaction:
+     * New log produced in compaction will include - as last op - jump into some offset (anchor) of current log.
+     * It is assumed that log region (anchor - end) will contain all changes made by bluefs since
+     * full state capture into new log.
+     * Putting log update into (anchor - end) region is illegal, because any update there must be compatible with
+     * both logs, but old log is different then new log.
+     *
+     * Possible solutions:
+     * - stall extending log until we finish compacting and switch log (CURRENT)
+     * - re-run compaction with more runway for old log
+     * - add OP_FILE_ADDEXT that adds extent; will be compatible with both logs
+     */
+    if (new_log_writer) {
+      return -EWOULDBLOCK;
     }
     vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
     int r = _allocate(
@@ -2519,8 +2518,13 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
     ceph_assert(r == 0);
     vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
     log_t.op_file_update(log_writer->file->fnode);
-    just_expanded_log = true;
   }
+  return runway;
+}
+
+void BlueFS::_flush_and_sync_log_core(int64_t runway)
+{
+  dout(10) << __func__ << " " << log_t << dendl;
 
   bufferlist bl;
   bl.reserve(super.block_size);
@@ -2532,38 +2536,29 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
 
   logger->inc(l_bluefs_logged_bytes, bl.length());
 
-  if (just_expanded_log) {
+  if (true) {
     ceph_assert(bl.length() <= runway); // if we write this, we will have an unrecoverable data loss
+                                        // transaction will not fit extents before growth -> data loss on _replay
   }
 
   log_writer->append(bl);
 
   log_t.clear();
   log_t.seq = 0;  // just so debug output is less confusing
-  log_flushing = true;
 
   int r = _flush(log_writer, true);
   ceph_assert(r == 0);
+}
 
-  if (jump_to) {
-    dout(10) << __func__ << " jumping log offset from 0x" << std::hex
-	     << log_writer->pos << " -> 0x" << jump_to << std::dec << dendl;
-    log_writer->pos = jump_to;
-    vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
-    log_writer->file->fnode.size = jump_to;
-    vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
-  }
-
-  _flush_bdev_safely(log_writer);
-
-  log_flushing = false;
-  log_cond.notify_all();
-
+// Clears dirty_files up to (including) seq_stable.
+void BlueFS::_clear_dirty_set_stable(uint64_t seq)
+{
   // clean dirty files
   if (seq > log_seq_stable) {
     log_seq_stable = seq;
     dout(20) << __func__ << " log_seq_stable " << log_seq_stable << dendl;
 
+    // undirty all files that were already streamed to log
     auto p = dirty_files.begin();
     while (p != dirty_files.end()) {
       if (p->first > log_seq_stable) {
@@ -2589,7 +2584,10 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
              << " already >= out seq " << seq
              << ", we lost a race against another log flush, done" << dendl;
   }
+}
 
+void BlueFS::_release_pending_allocations(vector<interval_set<uint64_t>>& to_release)
+{
   for (unsigned i = 0; i < to_release.size(); ++i) {
     if (!to_release[i].empty()) {
       /* OK, now we have the guarantee alloc[i] won't be null. */
@@ -2609,9 +2607,67 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
       }
     }
   }
+}
+
+int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
+			       uint64_t want_seq)
+{
+  if (want_seq && want_seq <= log_seq_stable) {
+    dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
+	     << log_seq_stable << ", done" << dendl;
+    return 0;
+  }
+  int64_t available_runway;
+  do {
+    available_runway = _maybe_extend_log();
+    if (available_runway == -EWOULDBLOCK) {
+      while (new_log_writer) {
+	dout(10) << __func__ << " waiting for async compaction" << dendl;
+	log_cond.wait(l);
+      }
+    }
+  } while (available_runway == -EWOULDBLOCK);
+
+  ceph_assert(want_seq == 0 || want_seq <= log_seq + 1); // illegal to request seq that was not created yet
+
+  uint64_t seq = _consume_dirty();
+  vector<interval_set<uint64_t>> to_release(pending_release.size());
+  to_release.swap(pending_release);
+
+  _flush_and_sync_log_core(available_runway);
+  _flush_bdev_safely(log_writer);
+
+  _clear_dirty_set_stable(seq);
+  _release_pending_allocations(to_release);
 
   _update_logger_stats();
+  return 0;
+}
 
+// Flushes log and immediately adjusts log_writer pos.
+int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
+				     int64_t available_runway)
+{
+  ceph_assert(jump_to);
+  uint64_t seq = _consume_dirty();
+  vector<interval_set<uint64_t>> to_release(pending_release.size());
+  to_release.swap(pending_release);
+
+  _flush_and_sync_log_core(available_runway);
+
+  dout(10) << __func__ << " jumping log offset from 0x" << std::hex
+	   << log_writer->pos << " -> 0x" << jump_to << std::dec << dendl;
+  log_writer->pos = jump_to;
+  vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
+  log_writer->file->fnode.size = jump_to;
+  vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
+
+  _flush_bdev_safely(log_writer);
+
+  _clear_dirty_set_stable(seq);
+  _release_pending_allocations(to_release);
+
+  _update_logger_stats();
   return 0;
 }
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -400,7 +400,7 @@ private:
 
 
   FileRef _get_file(uint64_t ino);
-  void _drop_link(FileRef f);
+  void _drop_link_D(FileRef f);
 
   unsigned _get_slow_device_id() {
     return bdev[BDEV_SLOW] ? BDEV_SLOW : BDEV_DB;
@@ -412,32 +412,32 @@ private:
 				 PExtentVector* extents);
 
   /* signal replay log to include h->file in nearest log flush */
-  int _signal_dirty_to_log(FileWriter *h);
-  int _flush_range(FileWriter *h, uint64_t offset, uint64_t length);
+  int _signal_dirty_to_log_D(FileWriter *h);
+  int _flush_range_F(FileWriter *h, uint64_t offset, uint64_t length);
   int _flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered);
-  int _flush(FileWriter *h, bool force, bool *flushed = nullptr);
+  int _flush_F(FileWriter *h, bool force, bool *flushed = nullptr);
   int _flush_special(FileWriter *h);
   int _fsync(FileWriter *h);
 
 #ifdef HAVE_LIBAIO
   void _claim_completed_aios(FileWriter *h, std::list<aio_t> *ls);
-  void wait_for_aio(FileWriter *h);  // safe to call without a lock
+  void _wait_for_aio(FileWriter *h);  // safe to call without a lock
 #endif
 
   int64_t _maybe_extend_log();
   void _extend_log();
   uint64_t _log_advance_seq();
   void _consume_dirty(uint64_t seq);
-  void clear_dirty_set_stable(uint64_t seq_stable);
-  void release_pending_allocations(std::vector<interval_set<uint64_t>>& to_release);
+  void _clear_dirty_set_stable_D(uint64_t seq_stable);
+  void _release_pending_allocations(std::vector<interval_set<uint64_t>>& to_release);
 
   void _flush_and_sync_log_core(int64_t available_runway);
-  int _flush_and_sync_log_jump(uint64_t jump_to,
+  int _flush_and_sync_log_jump_D(uint64_t jump_to,
 			       int64_t available_runway);
-  int flush_and_sync_log(uint64_t want_seq = 0);
+  int _flush_and_sync_log_LD(uint64_t want_seq = 0);
 
-  uint64_t estimate_log_size();
-  bool should_start_compact_log();
+  uint64_t _estimate_log_size_N();
+  bool _should_start_compact_log_L_N();
 
   enum {
     REMOVE_DB = 1,
@@ -445,12 +445,12 @@ private:
     RENAME_SLOW2DB = 4,
     RENAME_DB2SLOW = 8,
   };
-  void compact_log_dump_metadata(bluefs_transaction_t *t,
+  void _compact_log_dump_metadata_N(bluefs_transaction_t *t,
 				 int flags);
-  void compact_log_sync();
-  void compact_log_async();
+  void _compact_log_sync_LN_LD();
+  void _compact_log_async_LD_NF_D();
 
-  void rewrite_log_and_layout_sync(bool allocate_with_fallback,
+  void _rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
 				    int super_dev,
 				    int log_dev,
 				    int new_log_dev,
@@ -460,8 +460,8 @@ private:
   //void _aio_finish(void *priv);
 
   void _flush_bdev(FileWriter *h);
-  void flush_bdev();  // this is safe to call without a lock
-  void flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs);  // this is safe to call without a lock
+  void _flush_bdev();  // this is safe to call without a lock
+  void _flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs);  // this is safe to call without a lock
 
   int _preallocate(FileRef f, uint64_t off, uint64_t len);
   int _truncate(FileWriter *h, uint64_t off);
@@ -581,7 +581,7 @@ public:
   /// sync any uncommitted state to disk
   void sync_metadata(bool avoid_compact);
   /// test and compact log, if necessary
-  void maybe_compact_log();
+  void _maybe_compact_log_LN_NF_LD_D();
 
   void set_volume_selector(BlueFSVolumeSelector* s) {
     vselector.reset(s);
@@ -625,11 +625,11 @@ public:
   void invalidate_cache(FileRef f, uint64_t offset, uint64_t len);
   int preallocate(FileRef f, uint64_t offset, uint64_t len);
   int truncate(FileWriter *h, uint64_t offset);
-  int do_replay_recovery_read(FileReader *log,
-			      size_t log_pos,
-			      size_t read_offset,
-			      size_t read_len,
-			      bufferlist* bl);
+  int _do_replay_recovery_read(FileReader *log,
+			       size_t log_pos,
+			       size_t read_offset,
+			       size_t read_len,
+			       bufferlist* bl);
 
   size_t probe_alloc_avail(int dev, uint64_t alloc_size);
 
@@ -695,5 +695,22 @@ public:
 
   void get_paths(const std::string& base, paths& res) const override;
 };
-
+/**
+ * Directional graph of locks.
+ * Vertices - Locks. Edges (directed) - locking progression.
+ * Edge A->B exist if last taken lock was A and next taken lock is B.
+ * 
+ * Column represents last lock taken.
+ * Row represents next lock taken.
+ *
+ *     <        | L | D | N | F | W
+ * -------------|---|---|---|---|---
+ * log        L |     <   <         
+ * dirty      D |                   
+ * nodes      N |             <     
+ * File       F | <                 
+ * FileWriter W | <  <        <      
+ * 
+ * Claim: Deadlock is possible IFF graph contains cycles.
+ */
 #endif

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -447,6 +447,9 @@ private:
   };
   void _compact_log_dump_metadata_N(bluefs_transaction_t *t,
 				 int flags);
+  void compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
+					  uint64_t capture_before_seq);
+
   void _compact_log_sync_LN_LD();
   void _compact_log_async_LD_NF_D();
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -711,8 +711,8 @@ public:
  * log        L |     <   <         
  * dirty      D |                   
  * nodes      N |             <     
- * File       F | <                 
- * FileWriter W | <  <        <      
+ * File       F |                  
+ * FileWriter W | <   <       <      
  * 
  * Claim: Deadlock is possible IFF graph contains cycles.
  */

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -394,8 +394,10 @@ private:
   /* signal replay log to include h->file in nearest log flush */
   int _signal_dirty_to_log(FileWriter *h);
   int _flush_range(FileWriter *h, uint64_t offset, uint64_t length);
+  int _flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered);
   int _flush(FileWriter *h, bool force, std::unique_lock<ceph::mutex>& l);
   int _flush(FileWriter *h, bool force, bool *flushed = nullptr);
+  int _flush_special(FileWriter *h);
   int _fsync(FileWriter *h, std::unique_lock<ceph::mutex>& l);
 
 #ifdef HAVE_LIBAIO

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -403,9 +403,18 @@ private:
   void wait_for_aio(FileWriter *h);  // safe to call without a lock
 #endif
 
+  int64_t _maybe_extend_log();
+  void _extend_log();
+  uint64_t _consume_dirty();
+  void _clear_dirty_set_stable(uint64_t seq_stable);
+  void _release_pending_allocations(std::vector<interval_set<uint64_t>>& to_release);
+
+  void _flush_and_sync_log_core(int64_t available_runway);
+  int _flush_and_sync_log_jump(uint64_t jump_to,
+			       int64_t available_runway);
   int _flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
-			  uint64_t want_seq = 0,
-			  uint64_t jump_to = 0);
+			  uint64_t want_seq = 0);
+
   uint64_t _estimate_log_size();
   bool _should_compact_log();
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -322,22 +322,31 @@ private:
   };
 
   // cache
-  mempool::bluefs::map<std::string, DirRef, std::less<>> dir_map;          ///< dirname -> Dir
-  mempool::bluefs::unordered_map<uint64_t, FileRef> file_map; ///< ino -> File
-
-  // map of dirty files, files of same dirty_seq are grouped into list.
-  std::map<uint64_t, dirty_file_list_t> dirty_files;
+  struct {
+    ceph::mutex lock = ceph::make_mutex("BlueFS::nodes.lock");
+    mempool::bluefs::map<std::string, DirRef, std::less<>> dir_map; ///< dirname -> Dir
+    mempool::bluefs::unordered_map<uint64_t, FileRef> file_map;     ///< ino -> File
+  } nodes;
 
   bluefs_super_t super;        ///< latest superblock (as last written)
   uint64_t ino_last = 0;       ///< last assigned ino (this one is in use)
-  uint64_t log_seq = 0;        ///< last used log seq (by current pending log_t)
-  uint64_t log_seq_stable = 0; ///< last stable/synced log seq
-  FileWriter *log_writer = 0;  ///< writer for the log
-  bluefs_transaction_t log_t;  ///< pending, unwritten log transaction
-  bool log_flushing = false;   ///< true while flushing the log
+
+  struct {
+    ceph::mutex lock = ceph::make_mutex("BlueFS::log.lock");
+    uint64_t seq_live = 0; //seq that log is currently writing to
+    FileWriter *writer = 0;
+    bluefs_transaction_t t;
+  } log;
+
+  struct {
+    ceph::mutex lock = ceph::make_mutex("BlueFS::dirty.lock");
+    uint64_t seq_stable = 0; //seq that is now stable on disk
+    uint64_t seq_next = 1;   //seq that is ongoing and not yet stable
+    // map of dirty files, files of same dirty_seq are grouped into list.
+    std::map<uint64_t, dirty_file_list_t> files;
+  } dirty;
 
   ceph::condition_variable log_cond;                             ///< used for state control between log flush / log compaction
-  ceph::mutex cond_lock = ceph::make_mutex("BlueFS::cond_lock"); ///< ....
   std::atomic<bool> log_is_compacting{false};                    ///< signals that bluefs log is already ongoing compaction
   std::atomic<bool> log_forbidden_to_expand{false};              ///< used to signal that async compaction is in state
                                                                  ///  that prohibits expansion of bluefs log

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -309,9 +309,6 @@ public:
   };
 
 private:
-  ceph::mutex log_lock = ceph::make_mutex("BlueFS::log_lock");
-  ceph::mutex dirs_lock = ceph::make_mutex("BlueFS::dirs_lock");
-  ceph::mutex dirty_lock = ceph::make_mutex("BlueFS::dirty_lock");
   PerfCounters *logger = nullptr;
 
   uint64_t max_bytes[MAX_BDEV] = {0};

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -121,6 +121,11 @@ public:
     std::atomic_int num_reading;
 
     void* vselector_hint = nullptr;
+    /* lock protects fnode and other the parts that can be modified during read & write operations.
+       Does not protect values that are fixed
+       Does not need to be taken when doing one-time operations:
+       _replay, device_migrate_to_existing, device_migrate_to_new */
+    ceph::mutex lock = ceph::make_mutex("BlueFS::File::lock");
 
   private:
     FRIEND_MAKE_REF(File);
@@ -304,8 +309,9 @@ public:
   };
 
 private:
-  ceph::mutex lock = ceph::make_mutex("BlueFS::lock");
-
+  ceph::mutex log_lock = ceph::make_mutex("BlueFS::log_lock");
+  ceph::mutex dirs_lock = ceph::make_mutex("BlueFS::dirs_lock");
+  ceph::mutex dirty_lock = ceph::make_mutex("BlueFS::dirty_lock");
   PerfCounters *logger = nullptr;
 
   uint64_t max_bytes[MAX_BDEV] = {0};
@@ -329,13 +335,12 @@ private:
   FileWriter *log_writer = 0;  ///< writer for the log
   bluefs_transaction_t log_t;  ///< pending, unwritten log transaction
   bool log_flushing = false;   ///< true while flushing the log
-  ceph::condition_variable log_cond;
 
-  uint64_t new_log_jump_to = 0;
-  uint64_t old_log_jump_to = 0;
-  FileRef new_log = nullptr;
-  FileWriter *new_log_writer = nullptr;
-
+  ceph::condition_variable log_cond;                             ///< used for state control between log flush / log compaction
+  ceph::mutex cond_lock = ceph::make_mutex("BlueFS::cond_lock"); ///< ....
+  std::atomic<bool> log_is_compacting{false};                    ///< signals that bluefs log is already ongoing compaction
+  std::atomic<bool> log_forbidden_to_expand{false};              ///< used to signal that async compaction is in state
+                                                                 ///  that prohibits expansion of bluefs log
   /*
    * There are up to 3 block devices:
    *
@@ -349,6 +354,11 @@ private:
   std::vector<Allocator*> alloc;                   ///< allocators for bdevs
   std::vector<uint64_t> alloc_size;                ///< alloc size for each device
   std::vector<interval_set<uint64_t>> pending_release; ///< extents to release
+  // TODO: it should be examined what makes pending_release immune to
+  // eras in a way similar to dirty_files. Hints:
+  // 1) we have actually only 2 eras: log_seq and log_seq+1
+  // 2) we usually not remove extents from files. And when we do, we force log-syncing.
+
   //std::vector<interval_set<uint64_t>> block_unused_too_granular;
 
   BlockDevice::aio_callback_t discard_cb[3]; //discard callbacks for each dev
@@ -395,10 +405,9 @@ private:
   int _signal_dirty_to_log(FileWriter *h);
   int _flush_range(FileWriter *h, uint64_t offset, uint64_t length);
   int _flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered);
-  int _flush(FileWriter *h, bool force, std::unique_lock<ceph::mutex>& l);
   int _flush(FileWriter *h, bool force, bool *flushed = nullptr);
   int _flush_special(FileWriter *h);
-  int _fsync(FileWriter *h, std::unique_lock<ceph::mutex>& l);
+  int _fsync(FileWriter *h);
 
 #ifdef HAVE_LIBAIO
   void _claim_completed_aios(FileWriter *h, std::list<aio_t> *ls);
@@ -414,11 +423,10 @@ private:
   void _flush_and_sync_log_core(int64_t available_runway);
   int _flush_and_sync_log_jump(uint64_t jump_to,
 			       int64_t available_runway);
-  int _flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
-			  uint64_t want_seq = 0);
+  int flush_and_sync_log(uint64_t want_seq = 0);
 
-  uint64_t _estimate_log_size();
-  bool _should_compact_log();
+  uint64_t estimate_log_size();
+  bool should_start_compact_log();
 
   enum {
     REMOVE_DB = 1,
@@ -426,12 +434,12 @@ private:
     RENAME_SLOW2DB = 4,
     RENAME_DB2SLOW = 8,
   };
-  void _compact_log_dump_metadata(bluefs_transaction_t *t,
-				  int flags);
-  void _compact_log_sync();
-  void _compact_log_async(std::unique_lock<ceph::mutex>& l);
+  void compact_log_dump_metadata(bluefs_transaction_t *t,
+				 int flags);
+  void compact_log_sync();
+  void compact_log_async();
 
-  void _rewrite_log_and_layout_sync(bool allocate_with_fallback,
+  void rewrite_log_and_layout_sync(bool allocate_with_fallback,
 				    int super_dev,
 				    int log_dev,
 				    int new_log_dev,
@@ -440,7 +448,7 @@ private:
 
   //void _aio_finish(void *priv);
 
-  void _flush_bdev_safely(FileWriter *h);
+  void _flush_bdev(FileWriter *h);
   void flush_bdev();  // this is safe to call without a lock
   void flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs);  // this is safe to call without a lock
 
@@ -459,8 +467,6 @@ private:
     uint64_t len,    ///< [in] this many bytes
     char *out);      ///< [out] optional: or copy it here
 
-  void _invalidate_cache(FileRef f, uint64_t offset, uint64_t length);
-
   int _open_super();
   int _write_super(int dev);
   int _check_allocations(const bluefs_fnode_t& fnode,
@@ -473,6 +479,7 @@ private:
   int _replay(bool noop, bool to_stdout = false); ///< replay journal
 
   FileWriter *_create_writer(FileRef f);
+  void _drain_writer(FileWriter *h);
   void _close_writer(FileWriter *h);
 
   // always put the super in the second 4k block.  FIXME should this be
@@ -538,10 +545,8 @@ public:
     FileReader **h,
     bool random = false);
 
-  void close_writer(FileWriter *h) {
-    std::lock_guard l(lock);
-    _close_writer(h);
-  }
+  // data added after last fsync() is lost
+  void close_writer(FileWriter *h);
 
   int rename(std::string_view old_dir, std::string_view old_file,
 	     std::string_view new_dir, std::string_view new_file);
@@ -565,7 +570,7 @@ public:
   /// sync any uncommitted state to disk
   void sync_metadata(bool avoid_compact);
   /// test and compact log, if necessary
-  void _maybe_compact_log(std::unique_lock<ceph::mutex>& l);
+  void maybe_compact_log();
 
   void set_volume_selector(BlueFSVolumeSelector* s) {
     vselector.reset(s);
@@ -587,42 +592,11 @@ public:
   // handler for discard event
   void handle_discard(unsigned dev, interval_set<uint64_t>& to_release);
 
-  void flush(FileWriter *h, bool force = false) {
-    std::unique_lock l(lock);
-    int r = _flush(h, force, l);
-    ceph_assert(r == 0);
-  }
+  void flush(FileWriter *h, bool force = false);
 
-  void append_try_flush(FileWriter *h, const char* buf, size_t len) {
-    size_t max_size = 1ull << 30; // cap to 1GB
-    while (len > 0) {
-      bool need_flush = true;
-      auto l0 = h->get_buffer_length();
-      if (l0 < max_size) {
-	size_t l = std::min(len, max_size - l0);
-	h->append(buf, l);
-	buf += l;
-	len -= l;
-	need_flush = h->get_buffer_length() >= cct->_conf->bluefs_min_flush_size;
-      }
-      if (need_flush) {
-	flush(h, true);
-	// make sure we've made any progress with flush hence the
-	// loop doesn't iterate forever
-	ceph_assert(h->get_buffer_length() < max_size);
-      }
-    }
-  }
-  void flush_range(FileWriter *h, uint64_t offset, uint64_t length) {
-    std::lock_guard l(lock);
-    _flush_range(h, offset, length);
-  }
-  int fsync(FileWriter *h) {
-    std::unique_lock l(lock);
-    int r = _fsync(h, l);
-    _maybe_compact_log(l);
-    return r;
-  }
+  void append_try_flush(FileWriter *h, const char* buf, size_t len);
+  void flush_range(FileWriter *h, uint64_t offset, uint64_t length);
+  int fsync(FileWriter *h);
   int64_t read(FileReader *h, uint64_t offset, size_t len,
 	   ceph::buffer::list *outbl, char *out) {
     // no need to hold the global lock here; we only touch h and
@@ -637,18 +611,9 @@ public:
     // atomics and asserts).
     return _read_random(h, offset, len, out);
   }
-  void invalidate_cache(FileRef f, uint64_t offset, uint64_t len) {
-    std::lock_guard l(lock);
-    _invalidate_cache(f, offset, len);
-  }
-  int preallocate(FileRef f, uint64_t offset, uint64_t len) {
-    std::lock_guard l(lock);
-    return _preallocate(f, offset, len);
-  }
-  int truncate(FileWriter *h, uint64_t offset) {
-    std::lock_guard l(lock);
-    return _truncate(h, offset);
-  }
+  void invalidate_cache(FileRef f, uint64_t offset, uint64_t len);
+  int preallocate(FileRef f, uint64_t offset, uint64_t len);
+  int truncate(FileWriter *h, uint64_t offset);
   int do_replay_recovery_read(FileReader *log,
 			      size_t log_pos,
 			      size_t read_offset,

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -333,7 +333,8 @@ private:
 
   struct {
     ceph::mutex lock = ceph::make_mutex("BlueFS::log.lock");
-    uint64_t seq_live = 0; //seq that log is currently writing to
+    //uint64_t seq_stable = 0; //seq that is now stable on disk    AK - consider also mirroring this
+    uint64_t seq_live = 1;   //seq that log is currently writing to; mirrors dirty.seq_live
     FileWriter *writer = 0;
     bluefs_transaction_t t;
   } log;
@@ -341,7 +342,7 @@ private:
   struct {
     ceph::mutex lock = ceph::make_mutex("BlueFS::dirty.lock");
     uint64_t seq_stable = 0; //seq that is now stable on disk
-    uint64_t seq_next = 1;   //seq that is ongoing and not yet stable
+    uint64_t seq_live = 1;   //seq that is ongoing and dirty files will be written to
     // map of dirty files, files of same dirty_seq are grouped into list.
     std::map<uint64_t, dirty_file_list_t> files;
   } dirty;
@@ -425,9 +426,10 @@ private:
 
   int64_t _maybe_extend_log();
   void _extend_log();
-  uint64_t _consume_dirty();
-  void _clear_dirty_set_stable(uint64_t seq_stable);
-  void _release_pending_allocations(std::vector<interval_set<uint64_t>>& to_release);
+  uint64_t _log_advance_seq();
+  void _consume_dirty(uint64_t seq);
+  void clear_dirty_set_stable(uint64_t seq_stable);
+  void release_pending_allocations(std::vector<interval_set<uint64_t>>& to_release);
 
   void _flush_and_sync_log_core(int64_t available_runway);
   int _flush_and_sync_log_jump(uint64_t jump_to,


### PR DESCRIPTION
This work is about splitting one BlueFS lock into 5 small ones.
The target for it is the case when writing during compaction is in collision with writing to WAL.
Such behaviour can be observed when bluefs_buffered_io = true.


First 2 commits do refactor BlueFS internals, but do not introduce new logic.
Third commit actually splits BlueFS lock.
Commits 4-7 are cleanups.
Commits 8-10 are modifying locking order to avoid deadlocks.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
