### PR TITLE
crimson: introduce assert_moveable().

### DIFF
--- a/src/crimson/common/utility.h
+++ b/src/crimson/common/utility.h
@@ -1,0 +1,16 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab expandtab
+
+#pragma once
+
+#include <type_traits>
+
+template <class T>
+void assert_moveable(T& t) {
+    // It's fine
+}
+template <class T>
+void assert_moveable(const T& t) {
+    static_assert(always_false<T>::value, "unable to move-out from T");
+}
+

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -8,6 +8,7 @@
 #include <sstream>
 
 #include "common/likely.h"
+#include "crimson/common/utility.h"
 #include "crimson/os/seastore/logging.h"
 
 #include "node_extent_manager.h"
@@ -1828,6 +1829,7 @@ LeafNode::erase(context_t c, const search_position_t& pos, bool get_next)
     }
     return seastar::now().then(
         [c, &pos, this_ref = std::move(this_ref), this, FNAME] () mutable {
+      assert_moveable(this_ref);
 #ifndef NDEBUG
       assert(!impl->is_keys_empty());
       if (impl->has_single_value()) {


### PR DESCRIPTION
In C++ `std::moving` a `const`-qualified value yields a constant r-value reference (`const T&&`) which won't be matched with a callable taking non-constant r-value reference (like move constructors) but can play with one taking a constant l-value reference (like copy constructors do). This behaviour is surprising especially in lambas where adding or removing the `mutable` specifier may lead to different behaviour. The problem isn't obvious and it's easy to wrongly drop the `mutable` druing a clean-up. Therefore introducing a tool for developers to fail at compile-time if that happens seems desired.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
