### PR TITLE
crimson/seastore: enforce per-collection transaction ordering

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -120,6 +120,11 @@ public:
     return ret;
   }
 
+  /// Resets transaction preserving
+  void reset_transaction_preserve_handle(Transaction &t) {
+    t.reset_preserve_handle(last_commit);
+  }
+
   /**
    * drop_from_cache
    *

--- a/src/crimson/os/seastore/ordering_handle.h
+++ b/src/crimson/os/seastore/ordering_handle.h
@@ -56,16 +56,16 @@ inline OrderingHandle get_dummy_ordering_handle() {
 
 struct WritePipeline {
   OrderedExclusivePhase wait_throttle{
-    "TransactionManager::wait_throttle"
+    "WritePipeline::wait_throttle_phase"
   };
   OrderedExclusivePhase prepare{
-    "TransactionManager::prepare_phase"
+    "WritePipeline::prepare_phase"
   };
   OrderedConcurrentPhase device_submission{
-    "TransactionManager::journal_phase"
+    "WritePipeline::device_submission_phase"
   };
   OrderedExclusivePhase finalize{
-    "TransactionManager::finalize_phase"
+    "WritePipeline::finalize_phase"
   };
 };
 

--- a/src/crimson/os/seastore/ordering_handle.h
+++ b/src/crimson/os/seastore/ordering_handle.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <seastar/core/shared_mutex.hh>
+
 #include "crimson/common/operation.h"
 
 namespace crimson::os::seastore {
@@ -35,6 +37,27 @@ private:
 struct OrderingHandle {
   OperationRef op;
   PipelineHandle phase_handle;
+  seastar::shared_mutex *collection_ordering_lock = nullptr;
+
+  OrderingHandle(OperationRef &&op) : op(std::move(op)) {}
+  OrderingHandle(OrderingHandle &&other)
+    : op(std::move(other.op)), phase_handle(std::move(other.phase_handle)),
+      collection_ordering_lock(other.collection_ordering_lock) {
+    other.collection_ordering_lock = nullptr;
+  }
+
+  seastar::future<> take_collection_lock(seastar::shared_mutex &mutex) {
+    ceph_assert(!collection_ordering_lock);
+    collection_ordering_lock = &mutex;
+    return collection_ordering_lock->lock();
+  }
+
+  void maybe_release_collection_lock() {
+    if (collection_ordering_lock) {
+      collection_ordering_lock->unlock();
+      collection_ordering_lock = nullptr;
+    }
+  }
 
   template <typename T>
   seastar::future<> enter(T &t) {
@@ -48,16 +71,17 @@ struct OrderingHandle {
   seastar::future<> complete() {
     return phase_handle.complete();
   }
+
+  ~OrderingHandle() {
+    maybe_release_collection_lock();
+  }
 };
 
 inline OrderingHandle get_dummy_ordering_handle() {
-  return OrderingHandle{new PlaceholderOperation, {}};
+  return OrderingHandle{new PlaceholderOperation};
 }
 
 struct WritePipeline {
-  OrderedExclusivePhase wait_throttle{
-    "WritePipeline::wait_throttle_phase"
-  };
   OrderedExclusivePhase prepare{
     "WritePipeline::prepare_phase"
   };

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -25,10 +25,18 @@
 
 namespace crimson::os::seastore {
 
-class SeastoreCollection;
 class Onode;
 using OnodeRef = boost::intrusive_ptr<Onode>;
 class TransactionManager;
+
+class SeastoreCollection final : public FuturizedCollection {
+public:
+  template <typename... T>
+  SeastoreCollection(T&&... args) :
+    FuturizedCollection(std::forward<T>(args)...) {}
+
+  seastar::shared_mutex ordering_lock;
+};
 
 class SeaStore final : public FuturizedStore {
 public:
@@ -128,8 +136,10 @@ private:
 
     internal_context_t(
       CollectionRef ch,
-      ceph::os::Transaction &&_ext_transaction)
+      ceph::os::Transaction &&_ext_transaction,
+      TransactionRef &&transaction)
       : ch(ch), ext_transaction(std::move(_ext_transaction)),
+	transaction(std::move(transaction)),
 	iter(ext_transaction.begin()) {}
 
     TransactionRef transaction;
@@ -158,15 +168,19 @@ private:
 	transaction_manager->create_transaction()),
       std::forward<F>(f),
       [this](auto &ctx, auto &f) {
-	return repeat_eagain([&]() {
-	  ctx.reset_preserve_handle(transaction_manager);
-	  return std::invoke(f, ctx);
-	}).handle_error(
-	  crimson::ct_error::eagain::pass_further{},
-	  crimson::ct_error::all_same_way([&ctx](auto e) {
-	    on_error(ctx.ext_transaction);
-	  })
-	);
+	return ctx.transaction->get_handle().take_collection_lock(
+	  static_cast<SeastoreCollection&>(*(ctx.ch)).ordering_lock
+	).then([&, this] {
+	  return repeat_eagain([&, this] {
+	    ctx.reset_preserve_handle(transaction_manager);
+	    return std::invoke(f, ctx);
+	  }).handle_error(
+	    crimson::ct_error::eagain::pass_further{},
+	    crimson::ct_error::all_same_way([&ctx](auto e) {
+	      on_error(ctx.ext_transaction);
+	    })
+	  );
+	});
       });
   }
 

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -144,6 +144,20 @@ public:
   friend class crimson::os::seastore::SeaStore;
   friend class TransactionConflictCondition;
 
+  void reset_preserve_handle(journal_seq_t initiated_after) {
+    root.reset();
+    offset = 0;
+    read_set.clear();
+    write_set.clear();
+    fresh_block_list.clear();
+    mutated_block_list.clear();
+    retired_set.clear();
+    to_release = NULL_SEG_ID;
+    retired_uncached.clear();
+    retired_gate_token.reset(initiated_after);
+    conflicted = false;
+  }
+
 private:
   friend class Cache;
   friend Ref make_test_transaction();

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -148,8 +148,6 @@ private:
 
   std::vector<std::pair<paddr_t, extent_len_t>> retired_uncached;
 
-  journal_seq_t initiated_after;
-
   retired_extent_gate_t::token_t retired_gate_token;
 
   bool conflicted = false;

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -224,7 +224,7 @@ TransactionManager::submit_transaction(
   LOG_PREFIX(TransactionManager::submit_transaction);
   DEBUGT("about to await throttle", t);
   return trans_intr::make_interruptible(
-    t.handle.enter(write_pipeline.wait_throttle)
+    t.get_handle().enter(write_pipeline.wait_throttle)
   ).then_interruptible([this] {
     return trans_intr::make_interruptible(segment_cleaner->await_hard_limits());
   }).then_interruptible([this, &t]() {
@@ -239,7 +239,7 @@ TransactionManager::submit_transaction_direct(
   LOG_PREFIX(TransactionManager::submit_transaction_direct);
   DEBUGT("about to prepare", tref);
   return trans_intr::make_interruptible(
-    tref.handle.enter(write_pipeline.prepare)
+    tref.get_handle().enter(write_pipeline.prepare)
   ).then_interruptible([this, FNAME, &tref]() mutable
 		       -> submit_transaction_iertr::future<> {
     auto record = cache->try_construct_record(tref);
@@ -247,7 +247,7 @@ TransactionManager::submit_transaction_direct(
 
     DEBUGT("about to submit to journal", tref);
 
-    return journal->submit_record(std::move(*record), tref.handle
+    return journal->submit_record(std::move(*record), tref.get_handle()
     ).safe_then([this, FNAME, &tref](auto p) mutable {
       auto [addr, journal_seq] = p;
       DEBUGT("journal commit to {} seq {}", tref, addr, journal_seq);
@@ -266,14 +266,14 @@ TransactionManager::submit_transaction_direct(
 	return SegmentManager::release_ertr::now();
       }
     }).safe_then([&tref] {
-      return tref.handle.complete();
+      return tref.get_handle().complete();
     }).handle_error(
       submit_transaction_iertr::pass_further{},
       crimson::ct_error::all_same_way([](auto e) {
 	ceph_assert(0 == "Hit error submitting to journal");
       }));
     }).finally([&tref]() {
-      tref.handle.exit();
+      tref.get_handle().exit();
     });
 }
 

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -116,6 +116,11 @@ public:
     return cache->create_weak_transaction();
   }
 
+  /// Resets transaction
+  void reset_transaction_preserve_handle(Transaction &t) {
+    return cache->reset_transaction_preserve_handle(t);
+  }
+
   /**
    * get_pin
    *
@@ -612,6 +617,7 @@ public:
   FORWARD(close)
   FORWARD(create_transaction)
   FORWARD(create_weak_transaction)
+  FORWARD(reset_transaction_preserve_handle)
   INT_FORWARD(get_pin)
   INT_FORWARD(get_pins)
   PARAM_INT_FORWARD(pin_to_extent)

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -63,7 +63,7 @@ struct btree_lba_manager_test :
       ceph_assert(0 == "cannot fail");
     }
 
-    return journal.submit_record(std::move(*record), t->handle).safe_then(
+    return journal.submit_record(std::move(*record), t->get_handle()).safe_then(
       [this, t=std::move(t)](auto p) mutable {
 	auto [addr, seq] = p;
 	cache.complete_commit(*t, addr, seq);


### PR DESCRIPTION
Adds a mutex to SeastoreCollection to enforce transaction ordering per collection.  Note that no ordering is enforced between transactions on different collections (different pgs), so conflicts aren't really less likely.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
