### PR TITLE
rgw: expose RADOS cluster_fsid via adminops

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -10,6 +10,54 @@ mechanism. Some operations require that the user holds special administrative ca
 The response entity type (XML or JSON) may be specified as the 'format' option in the
 request and defaults to JSON if not specified.
 
+Info
+====
+
+Get RGW cluster/endpoint information.
+
+:caps: info=read
+
+
+Syntax
+~~~~~~
+
+::
+
+	GET /{admin}/info?format=json HTTP/1.1
+	Host: {fqdn}
+
+
+Request Parameters
+~~~~~~~~~~~~~~~~~~
+
+None.
+
+
+Response Entities
+~~~~~~~~~~~~~~~~~
+
+If successful, the response contains an ``info`` section.
+
+``info``
+
+:Description: A container for all returned information.
+:Type: Container
+
+``cluster_id``
+
+:Description: The (typically unique) identifier for the controlling
+	      backing store for the RGW cluster.  In the typical case,
+	      this is value returned from librados::rados::cluster_fsid().
+:Type: String
+:Parent: ``info``
+
+
+Special Error Responses
+~~~~~~~~~~~~~~~~~~~~~~~
+
+None.
+
+
 Get Usage
 =========
 

--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -32,7 +32,7 @@ def rgwadmin_rest(connection, cmd, params=None, headers=None, raw=False):
     put_cmds = ['create', 'link', 'add']
     post_cmds = ['unlink', 'modify']
     delete_cmds = ['trim', 'rm', 'process']
-    get_cmds = ['check', 'info', 'show', 'list']
+    get_cmds = ['check', 'info', 'show', 'list', '']
 
     bucket_sub_resources = ['object', 'policy', 'index']
     user_sub_resources = ['subuser', 'key', 'caps']
@@ -722,11 +722,15 @@ def task(ctx, config):
     (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' :  user1})
     assert ret == 404
 
-    # TESTCASE 'info' 'info' 'show' 'display info' 'succeeds'
+    # TESTCASE 'info' 'display info' 'succeeds'
     (ret, out) = rgwadmin_rest(admin_conn, ['info', ''])
     assert ret == 200
     info = out['info']
-    # currently, cluster_id is the only element in the info section
-    fsid = info['cluster_id']
+    backends = info['storage_backends']
+    name = backends[0]['name']
+    fsid = backends[0]['cluster_id']
+    # name is always "rados" at time of writing, but zipper would allow
+    # other backends, at some point
+    assert len(name) > 0
     # fsid is a uuid, but I'm not going to try to parse it
     assert len(fsid) > 0

--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -16,6 +16,7 @@ import boto.s3.acl
 
 import requests
 import time
+import json
 
 from boto.connection import AWSAuthConnection
 from teuthology import misc as teuthology
@@ -67,6 +68,8 @@ def rgwadmin_rest(connection, cmd, params=None, headers=None, raw=False):
                 return 'user', cmd[0]
         elif cmd[0] == 'usage':
             return 'usage', ''
+        elif cmd[0] == 'info':
+            return 'info', ''
         elif cmd[0] == 'zone' or cmd[0] in zone_sub_resources:
             if cmd[0] == 'zone':
                 return 'zone', ''
@@ -137,7 +140,7 @@ def task(ctx, config):
     admin_display_name = 'Ms. Admin User'
     admin_access_key = 'MH1WC2XQ1S8UISFDZC8W'
     admin_secret_key = 'dQyrTPA0s248YeN5bBv4ukvKU0kh54LWWywkrpoG'
-    admin_caps = 'users=read, write; usage=read, write; buckets=read, write; zone=read, write'
+    admin_caps = 'users=read, write; usage=read, write; buckets=read, write; zone=read, write; info=read'
 
     user1 = 'foo'
     user2 = 'fud'
@@ -719,3 +722,11 @@ def task(ctx, config):
     (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' :  user1})
     assert ret == 404
 
+    # TESTCASE 'info' 'info' 'show' 'display info' 'succeeds'
+    (ret, out) = rgwadmin_rest(admin_conn, ['info', ''])
+    assert ret == 200
+    info = out['info']
+    # currently, cluster_id is the only element in the info section
+    fsid = info['cluster_id']
+    # fsid is a uuid, but I'm not going to try to parse it
+    assert len(fsid) > 0

--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -16,7 +16,6 @@ import boto.s3.acl
 
 import requests
 import time
-import json
 
 from boto.connection import AWSAuthConnection
 from teuthology import misc as teuthology

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -270,6 +270,7 @@ set(rgw_a_srcs
   rgw_rest_realm.cc
   rgw_rest_swift.cc
   rgw_rest_usage.cc
+  rgw_rest_info.cc
   rgw_rest_user.cc
   rgw_swift_auth.cc
   rgw_usage.cc

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2007,6 +2007,7 @@ bool RGWUserCaps::is_valid_cap_type(const string& tp)
                                     "users",
                                     "buckets",
                                     "metadata",
+                                    "info",
                                     "usage",
                                     "zone",
                                     "bilog",

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -23,6 +23,7 @@
 #include "rgw_rest_s3.h"
 #include "rgw_rest_swift.h"
 #include "rgw_rest_admin.h"
+#include "rgw_rest_info.h"
 #include "rgw_rest_usage.h"
 #include "rgw_rest_user.h"
 #include "rgw_rest_bucket.h"
@@ -499,6 +500,7 @@ int radosgw_Main(int argc, const char **argv)
 
   if (apis_map.count("admin") > 0) {
     RGWRESTMgr_Admin *admin_resource = new RGWRESTMgr_Admin;
+    admin_resource->register_resource("info", new RGWRESTMgr_Info);
     admin_resource->register_resource("usage", new RGWRESTMgr_Usage);
     admin_resource->register_resource("user", new RGWRESTMgr_User);
     /* XXX dang part of this is RADOS specific */

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2420,6 +2420,11 @@ bool RGWRados::obj_to_raw(const rgw_placement_rule& placement_rule, const rgw_ob
   return get_obj_data_pool(placement_rule, obj, &raw_obj->pool);
 }
 
+std::string RGWRados::get_cluster_fsid(const DoutPrefixProvider *dpp, optional_yield y)
+{
+  return svc.rados->cluster_fsid();
+}
+
 int RGWRados::get_obj_head_ioctx(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::IoCtx *ioctx)
 {
   string oid, key;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -395,6 +395,8 @@ class RGWRados
   // This field represents the number of bucket index object shards
   uint32_t bucket_index_max_shards;
 
+  std::string get_cluster_fsid(const DoutPrefixProvider *dpp, optional_yield y);
+
   int get_obj_head_ref(const DoutPrefixProvider *dpp, const rgw_placement_rule& target_placement_rule, const rgw_obj& obj, rgw_rados_ref *ref);
   int get_obj_head_ref(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_rados_ref *ref);
   int get_system_obj_ref(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, rgw_rados_ref *ref);

--- a/src/rgw/rgw_rest_info.cc
+++ b/src/rgw/rgw_rest_info.cc
@@ -1,0 +1,40 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#include "rgw_op.h"
+#include "rgw_rest_info.h"
+#include "rgw_sal.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+class RGWOp_Info_Get : public RGWRESTOp {
+
+public:
+  RGWOp_Info_Get() {}
+
+  int check_caps(const RGWUserCaps& caps) override {
+    return caps.check_cap("info", RGW_CAP_READ);
+  }
+  void execute(optional_yield y) override;
+
+  const char* name() const override { return "get_info"; }
+};
+
+void RGWOp_Info_Get::execute(optional_yield y) {
+  Formatter *formatter = flusher.get_formatter();
+  flusher.start(0);
+
+  // extensible array of general info sections
+  formatter->open_object_section("dummy");
+  formatter->open_object_section("info");
+  formatter->dump_string("cluster_id", store->get_cluster_id(this, y));
+  formatter->close_section();
+  formatter->close_section();
+
+  flusher.flush();
+} /* RGWOp_Info_Get::execute */
+
+RGWOp *RGWHandler_Info::op_get()
+{
+  return new RGWOp_Info_Get;
+}

--- a/src/rgw/rgw_rest_info.cc
+++ b/src/rgw/rgw_rest_info.cc
@@ -24,10 +24,19 @@ void RGWOp_Info_Get::execute(optional_yield y) {
   Formatter *formatter = flusher.get_formatter();
   flusher.start(0);
 
-  // extensible array of general info sections
+  /* extensible array of general info sections, currently only
+   * storage backend is defined:
+   * {"info":{"storage_backends":[{"name":"rados","cluster_id":"75d1938b-2949-4933-8386-fb2d1449ff03"}]}}
+   */
   formatter->open_object_section("dummy");
   formatter->open_object_section("info");
+  formatter->open_array_section("storage_backends");
+  // for now, just return the backend that is accessible
+  formatter->open_object_section("dummy");
+  formatter->dump_string("name", store->get_name());
   formatter->dump_string("cluster_id", store->get_cluster_id(this, y));
+  formatter->close_section();
+  formatter->close_section();
   formatter->close_section();
   formatter->close_section();
 

--- a/src/rgw/rgw_rest_info.h
+++ b/src/rgw/rgw_rest_info.h
@@ -1,0 +1,33 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#pragma once
+
+#include "rgw_rest.h"
+#include "rgw_rest_s3.h"
+
+
+class RGWHandler_Info : public RGWHandler_Auth_S3 {
+protected:
+  RGWOp *op_get() override;
+public:
+  using RGWHandler_Auth_S3::RGWHandler_Auth_S3;
+  ~RGWHandler_Info() override = default;
+
+  int read_permissions(RGWOp*, optional_yield) override {
+    return 0;
+  }
+};
+
+class RGWRESTMgr_Info : public RGWRESTMgr {
+public:
+  RGWRESTMgr_Info() = default;
+  ~RGWRESTMgr_Info() override = default;
+
+  RGWHandler_REST* get_handler(rgw::sal::Store* store,
+			       struct req_state*,
+                               const rgw::auth::StrategyRegistry& auth_registry,
+                               const std::string&) override {
+    return new RGWHandler_Info(auth_registry);
+  }
+};

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -244,6 +244,8 @@ class Store {
     Store() {}
     virtual ~Store() = default;
 
+    /** Name of this store provider (e.g., RADOS") */
+    virtual const char* get_name() const = 0;
     /** Get cluster unique identifier */
     virtual std::string get_cluster_id(const DoutPrefixProvider* dpp,  optional_yield y) = 0;
     /** Get a User from a rgw_user.  Does not query store for user info, so quick */

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -244,6 +244,8 @@ class Store {
     Store() {}
     virtual ~Store() = default;
 
+    /** Get cluster unique identifier */
+    virtual std::string get_cluster_id(const DoutPrefixProvider* dpp,  optional_yield y) = 0;
     /** Get a User from a rgw_user.  Does not query store for user info, so quick */
     virtual std::unique_ptr<User> get_user(const rgw_user& u) = 0;
     /** Lookup a User by access key.  Queries store for user info. */

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1103,6 +1103,11 @@ namespace rgw::sal {
     return 0;
   }
 
+  std::string DBStore::get_cluster_id(const DoutPrefixProvider* dpp,  optional_yield y)
+  {
+    return "PLACEHOLDER"; // for instance unique identifier
+  }
+
   std::unique_ptr<Object> DBStore::get_object(const rgw_obj_key& k)
   {
     return std::make_unique<DBObject>(this, k);

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -511,6 +511,7 @@ protected:
       virtual int get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user) override;
       virtual int get_user_by_swift(const DoutPrefixProvider *dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user) override;
       virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) override;
+      virtual std::string get_cluster_id(const DoutPrefixProvider* dpp, optional_yield y);
       virtual int get_bucket(const DoutPrefixProvider *dpp, User* u, const rgw_bucket& b, std::unique_ptr<Bucket>* bucket, optional_yield y) override;
       virtual int get_bucket(User* u, const RGWBucketInfo& i, std::unique_ptr<Bucket>* bucket) override;
       virtual int get_bucket(const DoutPrefixProvider *dpp, User* u, const std::string& tenant, const std::string&name, std::unique_ptr<Bucket>* bucket, optional_yield y) override;

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -506,6 +506,11 @@ protected:
       }
 
       int initialize(CephContext *cct, const DoutPrefixProvider *dpp);
+
+      virtual const char* get_name() const override {
+        return "dbstore";
+      }
+
       virtual std::unique_ptr<User> get_user(const rgw_user& u) override;
       virtual int get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) override;
       virtual int get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user) override;

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -977,6 +977,11 @@ std::unique_ptr<User> RadosStore::get_user(const rgw_user &u)
   return std::make_unique<RadosUser>(this, u);
 }
 
+std::string RadosStore::get_cluster_id(const DoutPrefixProvider* dpp,  optional_yield y)
+{
+  return getRados()->get_cluster_fsid(dpp, y);
+}
+
 int RadosStore::get_user_by_access_key(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user)
 {
   RGWUserInfo uinfo;

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -374,6 +374,7 @@ class RadosStore : public Store {
     }
 
     virtual std::unique_ptr<User> get_user(const rgw_user& u) override;
+    virtual std::string get_cluster_id(const DoutPrefixProvider* dpp,  optional_yield y) override;
     virtual int get_user_by_access_key(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) override;
     virtual int get_user_by_email(const DoutPrefixProvider* dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user) override;
     virtual int get_user_by_swift(const DoutPrefixProvider* dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user) override;

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -373,6 +373,10 @@ class RadosStore : public Store {
       delete rados;
     }
 
+    virtual const char* get_name() const override {
+			return "rados";
+	}
+
     virtual std::unique_ptr<User> get_user(const rgw_user& u) override;
     virtual std::string get_cluster_id(const DoutPrefixProvider* dpp,  optional_yield y) override;
     virtual int get_user_by_access_key(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) override;

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -52,6 +52,13 @@ librados::Rados* RGWSI_RADOS::get_rados_handle()
   return &rados;
 }
 
+std::string RGWSI_RADOS::cluster_fsid()
+{
+  std::string fsid;
+  (void) get_rados_handle()->cluster_fsid(&fsid);
+  return fsid;
+}
+
 uint64_t RGWSI_RADOS::instance_id()
 {
   return get_rados_handle()->get_instance_id();

--- a/src/rgw/services/svc_rados.h
+++ b/src/rgw/services/svc_rados.h
@@ -67,6 +67,7 @@ public:
   void init() {}
   void shutdown() override;
 
+  std::string cluster_fsid();
   uint64_t instance_id();
   bool check_secure_mon_conn(const DoutPrefixProvider *dpp) const;
 


### PR DESCRIPTION
rgw: expose RADOS cluster_fsid as /{admin}/info api resource
    
The new "info" resource returns an array of informational data, which
currently consists of the RADOS cluster fsid as "cluster_fsid."
    
Fixes: https://tracker.ceph.com/issues/51432
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
