### PR TITLE
doc/cephadm: improve "Potential Problems"

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -91,22 +91,27 @@ There are a few health alerts that can arise during the upgrade process.
 UPGRADE_NO_STANDBY_MGR
 ----------------------
 
-This alert means that Ceph requires an active and standby manager daemon in
-order to proceed, but there is currently no standby.
+This alert (``UPGRADE_NO_STANDBY_MGR``) means that Ceph does not detect an
+active standby manager daemon. In order to proceed with the upgrade, Ceph
+requires an active standby manager daemon (which you can think of in this
+context as "a second manager").
 
-You can ensure that Cephadm is configured to run 2 (or more) managers by running the following command:
+You can ensure that Cephadm is configured to run 2 (or more) managers by
+running the following command:
 
 .. prompt:: bash #
 
   ceph orch apply mgr 2  # or more
 
-You can check the status of existing mgr daemons by running the following command:
+You can check the status of existing mgr daemons by running the following
+command:
 
 .. prompt:: bash #
 
   ceph orch ps --daemon-type mgr
 
-If an existing mgr daemon has stopped, you can try to restart it by running the following command: 
+If an existing mgr daemon has stopped, you can try to restart it by running the
+following command: 
 
 .. prompt:: bash #
 
@@ -115,12 +120,13 @@ If an existing mgr daemon has stopped, you can try to restart it by running the 
 UPGRADE_FAILED_PULL
 -------------------
 
-This alert means that Ceph was unable to pull the container image for the
-target version. This can happen if you specify a version or container image
-that does not exist (e.g. "1.2.3"), or if the container registry can not
-be reached by one or more hosts in the cluster.
+This alert (``UPGRADE_FAILED_PULL``) means that Ceph was unable to pull the
+container image for the target version. This can happen if you specify a
+version or container image that does not exist (e.g. "1.2.3"), or if the
+container registry can not be reached by one or more hosts in the cluster.
 
-To cancel the existing upgrade and to specify a different target version, run the following commands: 
+To cancel the existing upgrade and to specify a different target version, run
+the following commands: 
 
 .. prompt:: bash #
 


### PR DESCRIPTION
This PR makes some improvements to the "Potential
Problems" section of the "Upgrading Ceph" chapter
of the cephadm documentation.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
