### PR TITLE
doc/rbd/iscsi-initiator-linux: set "product" in multipath.conf

### DIFF
--- a/doc/rbd/iscsi-initiator-linux.rst
+++ b/doc/rbd/iscsi-initiator-linux.rst
@@ -33,6 +33,7 @@ Install the iSCSI initiator and multipath tools:
        devices {
                device {
                        vendor                 "LIO-ORG"
+                       product                "TCMU device"
                        hardware_handler       "1 alua"
                        path_grouping_policy   "failover"
                        path_selector          "queue-length 0"


### PR DESCRIPTION
docs: add missing product in multipath conf

Adding missing parameter in multipath configuration.
See also https://bugzilla.redhat.com/show_bug.cgi?id=1769135

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>

## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
