### PR TITLE
pacific: mgr/dashboard: Fix bucket name input allowing space in the value 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
@@ -136,6 +136,10 @@ describe('RgwBucketFormComponent', () => {
       testValidator('bucket-name-is-unique', true);
     }));
 
+    it('bucket names must not contain spaces', fakeAsync(() => {
+      testValidator('bucket name  with   spaces', false, 'onlyLowerCaseAndNumbers');
+    }));
+
     it('should get zonegroup and placement targets', () => {
       const payload: Record<string, any> = {
         zonegroup: 'default',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -282,7 +282,7 @@ export class RgwBucketFormComponent extends CdForm implements OnInit {
             return false;
           }
           // Bucket names can contain lowercase letters, numbers, and hyphens.
-          if (!/[0-9a-z-]/.test(label)) {
+          if (!/^\S*$/.test(name) || !/[0-9a-z-]/.test(label)) {
             errorName = 'onlyLowerCaseAndNumbers';
             return false;
           }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51447

---

backport of https://github.com/ceph/ceph/pull/42026
parent tracker: https://tracker.ceph.com/issues/51368

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh