### PR TITLE
rgw: modify realm entities init resolution

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1180,6 +1180,16 @@ options:
   - rgw_zonegroup
   - rgw_realm
   with_legacy: true
+- name: rgw_zone_id
+  type: str
+  level: advanced
+  desc: Zone ID
+  services:
+  - rgw
+  see_also:
+  - rgw_zone
+  - rgw_zonegroup
+  - rgw_realm
 - name: rgw_zone_root_pool
   type: str
   level: advanced
@@ -1248,6 +1258,16 @@ options:
   - rgw_zone
   - rgw_realm
   with_legacy: true
+- name: rgw_zonegroup_id
+  type: str
+  level: advanced
+  desc: Zonegroup ID
+  services:
+  - rgw
+  see_also:
+  - rgw_zone
+  - rgw_zonegroup
+  - rgw_realm
 - name: rgw_zonegroup_root_pool
   type: str
   level: advanced
@@ -1278,6 +1298,11 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_realm_id
+  type: str
+  level: advanced
+  services:
+  - rgw
 - name: rgw_realm_root_pool
   type: str
   level: advanced

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5140,17 +5140,12 @@ int main(int argc, const char **argv)
       break;
     case OPT::ZONE_DEFAULT:
       {
-	RGWZoneGroup zonegroup(zonegroup_id,zonegroup_name);
-	int ret = zonegroup.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
-	if (ret < 0) {
-	  cerr << "WARNING: failed to initialize zonegroup " << zonegroup_name << std::endl;
-	}
 	if (zone_id.empty() && zone_name.empty()) {
 	  cerr << "no zone name or id provided" << std::endl;
 	  return EINVAL;
 	}
 	RGWZoneParams zone(zone_id, zone_name);
-	ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
+	int ret = zone.init(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, null_yield);
 	if (ret < 0) {
 	  cerr << "unable to initialize zone: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -166,6 +166,10 @@ const string& RGWZoneGroup::get_names_oid_prefix() const
   return zonegroup_names_oid_prefix;
 }
 
+string RGWZoneGroup::get_predefined_id(CephContext *cct) const {
+  return cct->_conf.get_val<string>("rgw_zonegroup_id");
+}
+
 const string& RGWZoneGroup::get_predefined_name(CephContext *cct) const {
   return cct->_conf->rgw_zonegroup;
 }
@@ -371,6 +375,10 @@ int RGWSystemMetaObj::init(const DoutPrefixProvider *dpp, CephContext *_cct, RGW
 
   if (old_format && id.empty()) {
     id = name;
+  }
+
+  if (id.empty()) {
+    id = get_predefined_id(cct);
   }
 
   if (id.empty()) {
@@ -707,6 +715,10 @@ RGWRealm::~RGWRealm() {}
 RGWRemoteMetaLog::~RGWRemoteMetaLog()
 {
   delete error_logger;
+}
+
+string RGWRealm::get_predefined_id(CephContext *cct) const {
+  return cct->_conf.get_val<string>("rgw_realm_id");
 }
 
 const string& RGWRealm::get_predefined_name(CephContext *cct) const {
@@ -1791,6 +1803,10 @@ const string& RGWZoneParams::get_names_oid_prefix() const
 const string& RGWZoneParams::get_info_oid_prefix(bool old_format) const
 {
   return zone_info_oid_prefix;
+}
+
+string RGWZoneParams::get_predefined_id(CephContext *cct) const {
+  return cct->_conf.get_val<string>("rgw_zone_id");
 }
 
 const string& RGWZoneParams::get_predefined_name(CephContext *cct) const {

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -880,6 +880,35 @@ int RGWRealm::notify_new_period(const DoutPrefixProvider *dpp, const RGWPeriod& 
   return notify_zone(dpp, bl, y);
 }
 
+
+int RGWRealm::find_zone(const DoutPrefixProvider *dpp,
+                        const rgw_zone_id& zid,
+                        RGWPeriod *pperiod,
+                        RGWZoneGroup *pzonegroup,
+                        bool *pfound,
+                        optional_yield y) const
+{
+  auto& found = *pfound;
+
+  found = false;
+
+  string period_id;
+  epoch_t epoch = 0;
+
+  RGWPeriod period(period_id, epoch);
+  int r = period.init(dpp, cct, sysobj_svc, get_id(), y, get_name());
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "WARNING: period init failed: " << cpp_strerror(-r) << " ... skipping" << dendl;
+    return r;
+  }
+
+  found = period.find_zone(dpp, zid, pzonegroup, y);
+  if (found) {
+    *pperiod = period;
+  }
+  return 0;
+}
+
 std::string RGWPeriodConfig::get_oid(const std::string& realm_id)
 {
   if (realm_id.empty()) {
@@ -1003,6 +1032,22 @@ int RGWPeriod::get_zonegroup(RGWZoneGroup& zonegroup,
   }
 
   return -ENOENT;
+}
+
+bool RGWPeriod::find_zone(const DoutPrefixProvider *dpp,
+                          const rgw_zone_id& zid,
+                          RGWZoneGroup *pzonegroup,
+                          optional_yield y) const
+{
+  RGWZoneGroup zg;
+  RGWZone zone;
+
+  bool found = period_map.find_zone_by_id(zid, &zg, &zone);
+  if (found) {
+    *pzonegroup = zg;
+  }
+
+  return found;
 }
 
 const string& RGWPeriod::get_latest_epoch_oid() const
@@ -1908,6 +1953,44 @@ uint32_t RGWPeriodMap::get_zone_short_id(const string& zone_id) const
     return 0;
   }
   return i->second;
+}
+
+bool RGWPeriodMap::find_zone_by_id(const rgw_zone_id& zone_id,
+                                   RGWZoneGroup *zonegroup,
+                                   RGWZone *zone) const
+{
+  for (auto& iter : zonegroups) {
+    auto& zg = iter.second;
+
+    auto ziter = zg.zones.find(zone_id);
+    if (ziter != zg.zones.end()) {
+      *zonegroup = zg;
+      *zone = ziter->second;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool RGWPeriodMap::find_zone_by_name(const string& zone_name,
+                                     RGWZoneGroup *zonegroup,
+                                     RGWZone *zone) const
+{
+  for (auto& iter : zonegroups) {
+    auto& zg = iter.second;
+    for (auto& ziter : zg.zones) {
+      auto& z = ziter.second;
+
+      if (z.name == zone_name) {
+        *zonegroup = zg;
+        *zone = z;
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 int RGWZoneGroupMap::read(const DoutPrefixProvider *dpp, CephContext *cct, RGWSI_SysObj *sysobj_svc, optional_yield y)

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -151,6 +151,7 @@ public:
   virtual const std::string get_default_oid(bool old_format = false) const = 0;
   virtual const std::string& get_names_oid_prefix() const = 0;
   virtual const std::string& get_info_oid_prefix(bool old_format = false) const = 0;
+  virtual std::string get_predefined_id(CephContext *cct) const = 0;
   virtual const std::string& get_predefined_name(CephContext *cct) const = 0;
 
   void dump(Formatter *f) const;
@@ -399,6 +400,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
   const std::string get_default_oid(bool old_format = false) const override;
   const std::string& get_names_oid_prefix() const override;
   const std::string& get_info_oid_prefix(bool old_format = false) const override;
+  std::string get_predefined_id(CephContext *cct) const override;
   const std::string& get_predefined_name(CephContext *cct) const override;
 
   int init(const DoutPrefixProvider *dpp, 
@@ -831,6 +833,7 @@ struct RGWZoneGroup : public RGWSystemMetaObj {
   const std::string get_default_oid(bool old_region_format = false) const override;
   const std::string& get_info_oid_prefix(bool old_region_format = false) const override;
   const std::string& get_names_oid_prefix() const override;
+  std::string get_predefined_id(CephContext *cct) const override;
   const std::string& get_predefined_name(CephContext *cct) const override;
 
   void dump(Formatter *f) const;
@@ -984,6 +987,7 @@ public:
   const std::string get_default_oid(bool old_format = false) const override;
   const std::string& get_names_oid_prefix() const override;
   const std::string& get_info_oid_prefix(bool old_format = false) const override;
+  std::string get_predefined_id(CephContext *cct) const override;
   const std::string& get_predefined_name(CephContext *cct) const override;
 
   using RGWSystemMetaObj::read_id; // expose as public for radosgw-admin

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -863,6 +863,13 @@ struct RGWPeriodMap
   }
 
   uint32_t get_zone_short_id(const std::string& zone_id) const;
+
+  bool find_zone_by_id(const rgw_zone_id& zone_id,
+                       RGWZoneGroup *zonegroup,
+                       RGWZone *zone) const;
+  bool find_zone_by_name(const string& zone_id,
+                       RGWZoneGroup *zonegroup,
+                       RGWZone *zone) const;
 };
 WRITE_CLASS_ENCODER(RGWPeriodMap)
 
@@ -1000,6 +1007,13 @@ public:
   int notify_zone(const DoutPrefixProvider *dpp, bufferlist& bl, optional_yield y);
   /// notify the zone of a new period
   int notify_new_period(const DoutPrefixProvider *dpp, const RGWPeriod& period, optional_yield y);
+
+  int find_zone(const DoutPrefixProvider *dpp,
+                const rgw_zone_id& zid,
+                RGWPeriod *pperiod,
+                RGWZoneGroup *pzonegroup,
+                bool *pfound,
+                optional_yield y) const;
 };
 WRITE_CLASS_ENCODER(RGWRealm)
 
@@ -1150,6 +1164,11 @@ public:
     }
     return false;
   }
+
+  bool find_zone(const DoutPrefixProvider *dpp,
+                const rgw_zone_id& zid,
+                RGWZoneGroup *pzonegroup,
+                optional_yield y) const;
 
   int get_latest_epoch(const DoutPrefixProvider *dpp, epoch_t& epoch, optional_yield y);
   int set_latest_epoch(const DoutPrefixProvider *dpp, optional_yield y,

--- a/src/rgw/services/svc_zone.h
+++ b/src/rgw/services/svc_zone.h
@@ -65,11 +65,22 @@ class RGWSI_Zone : public RGWServiceInstance
   void shutdown() override;
 
   int replace_region_with_zonegroup(const DoutPrefixProvider *dpp, optional_yield y);
-  int init_zg_from_period(const DoutPrefixProvider *dpp, bool *initialized, optional_yield y);
-  int init_zg_from_local(const DoutPrefixProvider *dpp, bool *creating_defaults, optional_yield y);
+  int init_zg_from_period(const DoutPrefixProvider *dpp, optional_yield y);
+  int init_zg_from_local(const DoutPrefixProvider *dpp, optional_yield y);
   int convert_regionmap(const DoutPrefixProvider *dpp, optional_yield y);
 
   int update_placement_map(const DoutPrefixProvider *dpp, optional_yield y);
+
+  int create_default_zg(const DoutPrefixProvider *dpp, optional_yield y);
+  int init_default_zone(const DoutPrefixProvider *dpp, optional_yield y);
+
+  int search_realm_with_zone(const DoutPrefixProvider *dpp,
+                             const rgw_zone_id& zid,
+                             RGWRealm *prealm,
+                             RGWPeriod *pperiod,
+                             RGWZoneGroup *pzonegroup,
+                             bool *pfound,
+                             optional_yield y);
 public:
   RGWSI_Zone(CephContext *cct);
   ~RGWSI_Zone();


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
 - Try to identify on initialization (`radosgw`, `radosgw-admin`)  the correct realm and zonegroup if only zone is provided. Do it even if default realm and zonegroups are configured and make sure that provided params are consistent -- don't allow zone to run under the wrong zonegroup.
 - Add new configurables that to be able to start `radosgw` using explicit entity IDs (`rgw_zone_id`, `rgw_zonegroup_id`, `rgw_realm_id`). These apply to `radosgw-admin` too, but old params that were previously used there are retained for backward compatibility.
 - Simplify `svc.zone` initialization
 - Require explicit params for certain realm/zonegroup/zone operations (don't rely on defaults)

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
