### PR TITLE
doc/dev/continuous-integration: use ceph repos

### DIFF
--- a/doc/dev/continuous-integration.rst
+++ b/doc/dev/continuous-integration.rst
@@ -129,7 +129,7 @@ libboost
     .. prompt:: bash $
 
        tar xjf boost_1_76_0.tar.bz2
-       git clone https://github.com/tchaikov/ceph-boost
+       git clone https://github.com/ceph/ceph-boost
        cp -ra ceph-boost/debian boost_1_76_0/
        export DEB_BUILD_OPTIONS='parallel=6 nodoc'
        dpkg-buildpackage -us -uc -b
@@ -140,7 +140,7 @@ libzbd
 libpmem
     packages `pmdk`_ . Please note, ``ndctl`` is one of the build dependencies of
     pmdk, for an updated debian packaging, please see
-    https://github.com/tchaikov/ceph-ndctl .
+    https://github.com/ceph/ceph-ndctl .
 
 .. _boost: https://www.boost.org
 .. _libzbd: https://github.com/westerndigitalcorporation/libzbd


### PR DESCRIPTION
since the reference repos have been forked under ceph organization,
let's use their new addresses.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
