### PR TITLE
osd: Add mechanism to avoid running OSD bench on every OSD init when mclock_scheduler is enabled

### DIFF
--- a/qa/standalone/erasure-code/test-erasure-eio.sh
+++ b/qa/standalone/erasure-code/test-erasure-eio.sh
@@ -26,6 +26,7 @@ function run() {
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--osd-mclock-profile=high_recovery_ops "
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do
@@ -548,7 +549,7 @@ function TEST_ec_backfill_unfound() {
 
     sleep 15
 
-    for tmp in $(seq 1 100); do
+    for tmp in $(seq 1 240); do
       state=$(get_state 2.0)
       echo $state | grep backfill_unfound
       if [ "$?" = "0" ]; then

--- a/qa/standalone/misc/ver-health.sh
+++ b/qa/standalone/misc/ver-health.sh
@@ -38,7 +38,7 @@ function run() {
 
 function wait_for_health_string() {
     local grep_string=$1
-    local seconds=${2:-10}
+    local seconds=${2:-20}
 
     # Allow mon to notice version difference
     set -o pipefail

--- a/qa/standalone/osd-backfill/osd-backfill-prio.sh
+++ b/qa/standalone/osd-backfill/osd-backfill-prio.sh
@@ -27,6 +27,9 @@ function run() {
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON --osd_max_backfills=1 --debug_reserver=20 "
     CEPH_ARGS+="--osd_min_pg_log_entries=5 --osd_max_pg_log_entries=10 "
+    # Set osd op queue = wpq for the tests. Backfill priority is not
+    # considered by mclock_scheduler leading to unexpected results.
+    CEPH_ARGS+="--osd-op-queue=wpq "
     export objects=50
     export poolprefix=test
     export FORCE_PRIO="254"     # See OSD_BACKFILL_PRIORITY_FORCED

--- a/qa/standalone/osd-backfill/osd-backfill-space.sh
+++ b/qa/standalone/osd-backfill/osd-backfill-space.sh
@@ -28,6 +28,7 @@ function run() {
     CEPH_ARGS+="--osd_min_pg_log_entries=5 --osd_max_pg_log_entries=10 "
     CEPH_ARGS+="--fake_statfs_for_testing=3686400 "
     CEPH_ARGS+="--osd_max_backfills=10 "
+    CEPH_ARGS+="--osd_mclock_profile=high_recovery_ops "
     export objects=600
     export poolprefix=test
 
@@ -149,7 +150,7 @@ function TEST_backfill_test_simple() {
     done
     sleep 30
 
-    wait_for_not_backfilling 240 || return 1
+    wait_for_not_backfilling 1200 || return 1
     wait_for_not_activating 60 || return 1
 
     ERRORS=0
@@ -228,7 +229,7 @@ function TEST_backfill_test_multi() {
     done
     sleep 30
 
-    wait_for_not_backfilling 240 || return 1
+    wait_for_not_backfilling 1200 || return 1
     wait_for_not_activating 60 || return 1
 
     ERRORS=0
@@ -380,7 +381,7 @@ function TEST_backfill_test_sametarget() {
     ceph osd pool set $pool2 size 2
     sleep 30
 
-    wait_for_not_backfilling 240 || return 1
+    wait_for_not_backfilling 1200 || return 1
     wait_for_not_activating 60 || return 1
 
     ERRORS=0
@@ -512,7 +513,7 @@ function TEST_backfill_multi_partial() {
     ceph osd in osd.$fillosd
     sleep 30
 
-    wait_for_not_backfilling 240 || return 1
+    wait_for_not_backfilling 1200 || return 1
     wait_for_not_activating 60 || return 1
 
     flush_pg_stats || return 1
@@ -695,7 +696,7 @@ function TEST_ec_backfill_simple() {
 
     ceph pg dump pgs
 
-    wait_for_not_backfilling 240 || return 1
+    wait_for_not_backfilling 1200 || return 1
     wait_for_not_activating 60 || return 1
 
     ceph pg dump pgs
@@ -819,7 +820,7 @@ function TEST_ec_backfill_multi() {
 
     sleep 30
 
-    wait_for_not_backfilling 240 || return 1
+    wait_for_not_backfilling 1200 || return 1
     wait_for_not_activating 60 || return 1
 
     ceph pg dump pgs
@@ -958,7 +959,7 @@ function SKIP_TEST_ec_backfill_multi_partial() {
     sleep 30
     ceph pg dump pgs
 
-    wait_for_not_backfilling 240 || return 1
+    wait_for_not_backfilling 1200 || return 1
     wait_for_not_activating 60 || return 1
 
     ceph pg dump pgs
@@ -1066,7 +1067,7 @@ function SKIP_TEST_ec_backfill_multi_partial() {
     ceph osd in osd.$fillosd
     sleep 30
 
-    wait_for_not_backfilling 240 || return 1
+    wait_for_not_backfilling 1200 || return 1
     wait_for_not_activating 60 || return 1
 
     ERRORS=0

--- a/qa/standalone/osd-backfill/osd-backfill-stats.sh
+++ b/qa/standalone/osd-backfill/osd-backfill-stats.sh
@@ -27,6 +27,8 @@ function run() {
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
     CEPH_ARGS+="--osd_min_pg_log_entries=5 --osd_max_pg_log_entries=10 "
+    # Use "high_recovery_ops" profile if mclock_scheduler is enabled.
+    CEPH_ARGS+="--osd-mclock-profile=high_recovery_ops "
     export margin=10
     export objects=200
     export poolname=test
@@ -674,13 +676,13 @@ function TEST_backfill_ec_down_all_out() {
       break
     done
     ceph pg dump pgs
-    for i in $(seq 1 60)
+    for i in $(seq 1 240)
     do
       if ceph pg dump pgs | grep ^$PG | grep -qv backfilling
       then
           break
       fi
-      if [ $i = "60" ];
+      if [ $i = "240" ];
       then
           echo "Timeout waiting for recovery to finish"
           return 1

--- a/qa/standalone/osd/osd-recovery-prio.sh
+++ b/qa/standalone/osd/osd-recovery-prio.sh
@@ -25,7 +25,10 @@ function run() {
     export CEPH_MON="127.0.0.1:7114" # git grep '\<7114\>' : there must be only one
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
-    CEPH_ARGS+="--mon-host=$CEPH_MON --osd_max_backfills=1 --debug_reserver=20"
+    CEPH_ARGS+="--mon-host=$CEPH_MON --osd_max_backfills=1 --debug_reserver=20 "
+    # Set osd op queue = wpq for the tests. Recovery priority is not
+    # considered by mclock_scheduler leading to unexpected results.
+    CEPH_ARGS+="--osd-op-queue=wpq "
     export objects=200
     export poolprefix=test
     export FORCE_PRIO="255"    # See OSD_RECOVERY_PRIORITY_FORCED

--- a/qa/standalone/osd/osd-recovery-stats.sh
+++ b/qa/standalone/osd/osd-recovery-stats.sh
@@ -28,6 +28,8 @@ function run() {
     CEPH_ARGS+="--mon-host=$CEPH_MON "
     # so we will not force auth_log_shard to be acting_primary
     CEPH_ARGS+="--osd_force_auth_primary_missing_objects=1000000 "
+    # Use "high_recovery_ops" profile if mclock_scheduler is enabled.
+    CEPH_ARGS+="--osd-mclock-profile=high_recovery_ops "
     export margin=10
     export objects=200
     export poolname=test
@@ -347,13 +349,13 @@ function TEST_recovery_undersized() {
     # Wait for recovery to finish
     # Can't use wait_for_clean() because state goes from active+recovering+undersized+degraded
     # to  active+undersized+degraded
-    for i in $(seq 1 60)
+    for i in $(seq 1 300)
     do
       if ceph pg dump pgs | grep ^$PG | grep -qv recovering
       then
           break
       fi
-      if [ $i = "60" ];
+      if [ $i = "300" ];
       then
           echo "Timeout waiting for recovery to finish"
           return 1

--- a/qa/standalone/osd/osd-rep-recov-eio.sh
+++ b/qa/standalone/osd/osd-rep-recov-eio.sh
@@ -29,6 +29,7 @@ function run() {
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--osd-mclock-profile=high_recovery_ops "
 
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
@@ -301,7 +302,7 @@ function TEST_rep_backfill_unfound() {
 
     sleep 15
 
-    for tmp in $(seq 1 100); do
+    for tmp in $(seq 1 360); do
       state=$(get_state 2.0)
       echo $state | grep backfill_unfound
       if [ "$?" = "0" ]; then

--- a/qa/standalone/osd/repeer-on-acting-back.sh
+++ b/qa/standalone/osd/repeer-on-acting-back.sh
@@ -34,6 +34,7 @@ function run() {
     CEPH_ARGS+="--osd_force_auth_primary_missing_objects=1000000 "
     # use small pg_log settings, so we always do backfill instead of recovery
     CEPH_ARGS+="--osd_min_pg_log_entries=$loglen --osd_max_pg_log_entries=$loglen --osd_pg_log_trim_min=$trim "
+    CEPH_ARGS+="--osd_mclock_profile=high_recovery_ops "
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do

--- a/qa/standalone/scrub/osd-scrub-dump.sh
+++ b/qa/standalone/scrub/osd-scrub-dump.sh
@@ -24,7 +24,6 @@ POOL_SIZE=3
 function run() {
     local dir=$1
     shift
-    local SLEEP=0
     local CHUNK_MAX=5
 
     export CEPH_MON="127.0.0.1:7184" # git grep '\<7184\>' : there must be only one
@@ -32,10 +31,13 @@ function run() {
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
     CEPH_ARGS+="--osd_max_scrubs=$MAX_SCRUBS "
-    CEPH_ARGS+="--osd_scrub_sleep=$SLEEP "
     CEPH_ARGS+="--osd_scrub_chunk_max=$CHUNK_MAX "
     CEPH_ARGS+="--osd_scrub_sleep=$SCRUB_SLEEP "
     CEPH_ARGS+="--osd_pool_default_size=$POOL_SIZE "
+    # Set scheduler to "wpq" until there's a reliable way to query scrub states
+    # with "--osd-scrub-sleep" set to 0. The "mclock_scheduler" overrides the
+    # scrub sleep to 0 and as a result the checks in the test fail.
+    CEPH_ARGS+="--osd_op_queue=wpq "
 
     export -n CEPH_CLI_TEST_DUP_COMMAND
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
@@ -91,10 +93,9 @@ function TEST_recover_unexpected() {
     ceph pg dump pgs
 
     max=$(CEPH_ARGS='' ceph daemon $(get_asok_path osd.0) dump_scrub_reservations | jq '.osd_max_scrubs')
-    if [ $max != $MAX_SCRUBS];
-    then
-	echo "ERROR: Incorrect osd_max_scrubs from dump_scrub_reservations"
-	return 1
+    if [ $max != $MAX_SCRUBS ]; then
+        echo "ERROR: Incorrect osd_max_scrubs from dump_scrub_reservations"
+        return 1
     fi
 
     ceph osd unset noscrub

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -390,9 +390,13 @@ function TEST_auto_repair_bluestore_tag() {
     # Launch a cluster with 3 seconds scrub interval
     run_mon $dir a || return 1
     run_mgr $dir x || return 1
+    # Set scheduler to "wpq" until there's a reliable way to query scrub states
+    # with "--osd-scrub-sleep" set to 0. The "mclock_scheduler" overrides the
+    # scrub sleep to 0 and as a result the checks in the test fail.
     local ceph_osd_args="--osd-scrub-auto-repair=true \
             --osd_deep_scrub_randomize_ratio=0 \
-            --osd-scrub-interval-randomize-ratio=0"
+            --osd-scrub-interval-randomize-ratio=0 \
+            --osd-op-queue=wpq"
     for id in $(seq 0 2) ; do
         run_osd $dir $id $ceph_osd_args || return 1
     done

--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -301,10 +301,15 @@ function _scrub_abort() {
     run_mgr $dir x || return 1
     for osd in $(seq 0 $(expr $OSDS - 1))
     do
-      run_osd $dir $osd --osd_pool_default_pg_autoscale_mode=off \
-	      --osd_deep_scrub_randomize_ratio=0.0 \
-	      --osd_scrub_sleep=5.0 \
-	      --osd_scrub_interval_randomize_ratio=0  || return 1
+        # Set scheduler to "wpq" until there's a reliable way to query scrub
+        # states with "--osd-scrub-sleep" set to 0. The "mclock_scheduler"
+        # overrides the scrub sleep to 0 and as a result the checks in the
+        # test fail.
+        run_osd $dir $osd --osd_pool_default_pg_autoscale_mode=off \
+            --osd_deep_scrub_randomize_ratio=0.0 \
+            --osd_scrub_sleep=5.0 \
+            --osd_scrub_interval_randomize_ratio=0 \
+            --osd_op_queue=wpq || return 1
     done
 
     # Create a pool with a single pg

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1024,6 +1024,16 @@ void md_config_t::get_config_bl(
   }
 }
 
+std::optional<std::string> md_config_t::get_val_default(std::string_view key)
+{
+  std::string val;
+  const Option *opt = find_option(key);
+  if (opt && (conf_stringify(_get_val_default(*opt), &val) == 0)) {
+    return std::make_optional(std::move(val));
+  }
+  return std::nullopt;
+}
+
 int md_config_t::get_val(const ConfigValues& values,
 			 const std::string_view key, char **buf, int len) const
 {

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -192,6 +192,9 @@ public:
   /// get encoded map<string,string> of compiled-in defaults
   void get_defaults_bl(const ConfigValues& values, ceph::buffer::list *bl);
 
+  /// Get the default value of a configuration option
+  std::optional<std::string> get_val_default(std::string_view key);
+
   // Get a configuration value.
   // No metavariables will be returned (they will have already been expanded)
   int get_val(const ConfigValues& values, const std::string_view key, char **buf, int len) const;

--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -344,6 +344,9 @@ public:
   const std::string& get_conf_path() const {
     return config.get_conf_path();
   }
+  std::optional<std::string> get_val_default(std::string_view key) {
+    return config.get_val_default(key);
+  }
 };
 
 }

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -1045,6 +1045,22 @@ options:
   default: 21500
   flags:
   - runtime
+- name: osd_mclock_force_run_benchmark_on_init
+  type: bool
+  level: advanced
+  desc: Force run the OSD benchmark on OSD initialization/boot-up
+  long_desc: This option specifies whether the OSD benchmark must be run during
+    the OSD boot-up sequence even if historical data about the OSD iops capacity
+    is available in the MON config store. Enable this to refresh the OSD iops
+    capacity if the underlying device's performance characteristics have changed
+    significantly. Only considered for osd_op_queue = mclock_scheduler.
+  fmt_desc: Force run the OSD benchmark on OSD initialization/boot-up
+  default: false
+  see_also:
+  - osd_mclock_max_capacity_iops_hdd
+  - osd_mclock_max_capacity_iops_ssd
+  flags:
+  - startup
 - name: osd_mclock_profile
   type: str
   level: advanced

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10206,12 +10206,50 @@ void OSD::maybe_override_max_osd_capacity_for_qos()
   // osd capacity with the value obtained from running the
   // osd bench test. This is later used to setup mclock.
   if (cct->_conf.get_val<std::string>("osd_op_queue") == "mclock_scheduler") {
-    // Write 200 4MiB objects with blocksize 4KiB
+    std::string max_capacity_iops_config;
+    bool force_run_benchmark = false;
+
+    if (store_is_rotational) {
+      max_capacity_iops_config = "osd_mclock_max_capacity_iops_hdd";
+    } else {
+      max_capacity_iops_config = "osd_mclock_max_capacity_iops_ssd";
+    }
+
+    if (!force_run_benchmark) {
+      double default_iops = 0.0;
+
+      // Get the current osd iops capacity
+      double cur_iops = cct->_conf.get_val<double>(max_capacity_iops_config);
+
+      // Get the default max iops capacity
+      auto val = cct->_conf.get_val_default(max_capacity_iops_config);
+      if (!val.has_value()) {
+        derr << __func__ << " Unable to determine default value of "
+            << max_capacity_iops_config << dendl;
+        // Cannot determine default iops. Force a run of the OSD benchmark.
+        force_run_benchmark = true;
+      } else {
+        // Default iops
+        default_iops = std::stod(val.value());
+      }
+
+      // Determine if we really need to run the osd benchmark
+      if (!force_run_benchmark && (default_iops != cur_iops)) {
+        dout(1) << __func__ << std::fixed << std::setprecision(2)
+                << " default_iops: " << default_iops
+                << " cur_iops: " << cur_iops
+                << ". Skip OSD benchmark test." << dendl;
+        return;
+      }
+    }
+
+    // Run osd bench: write 100 4MiB objects with blocksize 4KiB
     int64_t count = 12288000; // Count of bytes to write
     int64_t bsize = 4096;     // Block size
     int64_t osize = 4194304;  // Object size
     int64_t onum = 100;       // Count of objects to write
     double elapsed = 0.0;     // Time taken to complete the test
+    double iops = 0.0;
     stringstream ss;
     int ret = run_osd_bench_test(count, bsize, osize, onum, &elapsed, ss);
     if (ret != 0) {
@@ -10219,30 +10257,29 @@ void OSD::maybe_override_max_osd_capacity_for_qos()
            << " osd bench err: " << ret
            << " osd bench errstr: " << ss.str()
            << dendl;
-    } else {
-      double rate = count / elapsed;
-      double iops = rate / bsize;
-      dout(1) << __func__
-              << " osd bench result -"
-              << std::fixed << std::setprecision(3)
-              << " bandwidth (MiB/sec): " << rate / (1024 * 1024)
-              << " iops: " << iops
-              << " elapsed_sec: " << elapsed
-              << dendl;
+      return;
+    }
 
-      // Override the appropriate config option
-      if (store_is_rotational) {
-        cct->_conf.set_val(
-          "osd_mclock_max_capacity_iops_hdd", std::to_string(iops));
-      } else {
-        cct->_conf.set_val(
-          "osd_mclock_max_capacity_iops_ssd", std::to_string(iops));
-      }
+    double rate = count / elapsed;
+    iops = rate / bsize;
+    dout(1) << __func__
+            << " osd bench result -"
+            << std::fixed << std::setprecision(3)
+            << " bandwidth (MiB/sec): " << rate / (1024 * 1024)
+            << " iops: " << iops
+            << " elapsed_sec: " << elapsed
+            << dendl;
 
-      // Override the max osd capacity for all shards
-      for (auto& shard : shards) {
-        shard->update_scheduler_config();
-      }
+    // Persist iops to the MON store
+    ret = mon_cmd_set_config(max_capacity_iops_config, std::to_string(iops));
+    if (ret < 0) {
+      // Fallback to setting the config within the in-memory "values" map.
+      cct->_conf.set_val(max_capacity_iops_config, std::to_string(iops));
+    }
+
+    // Override the max osd capacity for all shards
+    for (auto& shard : shards) {
+      shard->update_scheduler_config();
     }
   }
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10207,7 +10207,8 @@ void OSD::maybe_override_max_osd_capacity_for_qos()
   // osd bench test. This is later used to setup mclock.
   if (cct->_conf.get_val<std::string>("osd_op_queue") == "mclock_scheduler") {
     std::string max_capacity_iops_config;
-    bool force_run_benchmark = false;
+    bool force_run_benchmark =
+      cct->_conf.get_val<bool>("osd_mclock_force_run_benchmark_on_init");
 
     if (store_is_rotational) {
       max_capacity_iops_config = "osd_mclock_max_capacity_iops_hdd";

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10295,6 +10295,32 @@ bool OSD::maybe_override_options_for_qos()
   return false;
 }
 
+int OSD::mon_cmd_set_config(const std::string &key, const std::string &val)
+{
+  std::string cmd =
+    "{"
+      "\"prefix\": \"config set\", "
+      "\"who\": \"osd." + std::to_string(whoami) + "\", "
+      "\"name\": \"" + key + "\", "
+      "\"value\": \"" + val + "\""
+    "}";
+
+  vector<std::string> vcmd{cmd};
+  bufferlist inbl;
+  std::string outs;
+  C_SaferCond cond;
+  monc->start_mon_command(vcmd, inbl, nullptr, &outs, &cond);
+  int r = cond.wait();
+  if (r < 0) {
+    derr << __func__ << " Failed to set config key " << key
+         << " err: " << cpp_strerror(r)
+         << " errstr: " << outs << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
 void OSD::update_log_config()
 {
   map<string,string> log_to_monitors;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2107,6 +2107,7 @@ private:
                          int64_t onum,
                          double *elapsed,
                          std::ostream& ss);
+  int mon_cmd_set_config(const std::string &key, const std::string &val);
 
   void scrub_purged_snaps();
   void probe_smart(const std::string& devid, std::ostream& ss);


### PR DESCRIPTION
The change-set implements the following to help avoid running OSD benchmark tests on every OSD init
with mclock_scheduler enabled:

- Implement helper method to store config option key/value to the MON store.
- Implement ConfigProxy and md_config_t methods to return the default value of a config option.
- Use the above introduced methods to implement the logic to avoid running the benchmark everytime.
- Introduce a new config option to help force-run the OSD benchmark when required.
- A set of commits to address the standalone failures observed with mclock_scheduler. (Added July 12, 2021)

Fixes: https://tracker.ceph.com/issues/51464
Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
