### PR TITLE
crimson/os/seastore: convert omap and collection_manager to interruptible future

### DIFF
--- a/src/crimson/os/seastore/collection_manager.cc
+++ b/src/crimson/os/seastore/collection_manager.cc
@@ -7,7 +7,7 @@
 
 namespace crimson::os::seastore::collection_manager {
 
-CollectionManagerRef create_coll_manager(InterruptedTransactionManager trans_manager) {
+CollectionManagerRef create_coll_manager(TransactionManager &trans_manager) {
   return CollectionManagerRef(new FlatCollectionManager(trans_manager));
 }
 

--- a/src/crimson/os/seastore/collection_manager.h
+++ b/src/crimson/os/seastore/collection_manager.h
@@ -26,19 +26,17 @@ struct coll_info_t {
 /// Interface for maintaining set of collections
 class CollectionManager {
 public:
-  using base_ertr = with_trans_ertr<
-    TransactionManager::read_extent_iertr>;
+  using base_iertr = TransactionManager::read_extent_iertr;
 
     /// Initialize collection manager instance for an empty store
-  using mkfs_ertr = with_trans_ertr<
-    TransactionManager::alloc_extent_iertr>;
-  using mkfs_ret = mkfs_ertr::future<coll_root_t>;
+  using mkfs_iertr = TransactionManager::alloc_extent_iertr;
+  using mkfs_ret = mkfs_iertr::future<coll_root_t>;
   virtual mkfs_ret mkfs(
     Transaction &t) = 0;
 
   /// Create collection
-  using create_ertr = base_ertr;
-  using create_ret = create_ertr::future<>;
+  using create_iertr = base_iertr;
+  using create_ret = create_iertr::future<>;
   virtual create_ret create(
     coll_root_t &root,
     Transaction &t,
@@ -47,24 +45,24 @@ public:
   ) = 0;
 
   /// List collections with info
-  using list_ertr = base_ertr;
+  using list_iertr = base_iertr;
   using list_ret_bare = std::vector<std::pair<coll_t, coll_info_t>>;
-  using list_ret = list_ertr::future<list_ret_bare>;
+  using list_ret = list_iertr::future<list_ret_bare>;
   virtual list_ret list(
     const coll_root_t &root,
     Transaction &t) = 0;
 
   /// Remove cid
-  using remove_ertr = base_ertr;
-  using remove_ret = remove_ertr::future<>;
+  using remove_iertr = base_iertr;
+  using remove_ret = remove_iertr::future<>;
   virtual remove_ret remove(
     const coll_root_t &coll_root,
     Transaction &t,
     coll_t cid) = 0;
 
   /// Update info for cid
-  using update_ertr = base_ertr;
-  using update_ret = base_ertr::future<>;
+  using update_iertr = base_iertr;
+  using update_ret = base_iertr::future<>;
   virtual update_ret update(
     const coll_root_t &coll_root,
     Transaction &t,
@@ -79,7 +77,7 @@ using CollectionManagerRef = std::unique_ptr<CollectionManager>;
 namespace collection_manager {
 /* creat CollectionMapManager for Collection  */
 CollectionManagerRef create_coll_manager(
-  InterruptedTransactionManager trans_manager);
+  TransactionManager &trans_manager);
 
 }
 

--- a/src/crimson/os/seastore/collection_manager/collection_flat_node.cc
+++ b/src/crimson/os/seastore/collection_manager/collection_flat_node.cc
@@ -53,7 +53,7 @@ CollectionNode::list()
     list_result.emplace_back(coll, bits);
   }
   return list_ret(
-    list_ertr::ready_future_marker{},
+    interruptible::ready_future_marker{},
     std::move(list_result));
 }
 
@@ -72,7 +72,7 @@ CollectionNode::create(coll_context_t cc, coll_t coll, unsigned bits)
   if (encoded_sizeof((base_coll_map_t&)decoded) > get_bptr().length()) {
     decoded.erase(iter);
     return create_ret(
-      create_ertr::ready_future_marker{},
+      interruptible::ready_future_marker{},
       create_result_t::OVERFLOW);
   } else {
     if (auto buffer = maybe_get_delta_buffer(); buffer) {
@@ -80,7 +80,7 @@ CollectionNode::create(coll_context_t cc, coll_t coll, unsigned bits)
     }
     copy_to_node();
     return create_ret(
-      create_ertr::ready_future_marker{},
+      interruptible::ready_future_marker{},
       create_result_t::SUCCESS);
   }
 }

--- a/src/crimson/os/seastore/collection_manager/collection_flat_node.h
+++ b/src/crimson/os/seastore/collection_manager/collection_flat_node.h
@@ -9,7 +9,7 @@
 
 namespace crimson::os::seastore::collection_manager {
 struct coll_context_t {
-  InterruptedTransactionManager tm;
+  TransactionManager &tm;
   Transaction &t;
 };
 
@@ -115,7 +115,7 @@ struct CollectionNode
     return is_mutation_pending() ? &delta_buffer : nullptr;
   }
 
-  using list_ertr = CollectionManager::list_ertr;
+  using list_iertr = CollectionManager::list_iertr;
   using list_ret = CollectionManager::list_ret;
   list_ret list();
 
@@ -124,15 +124,15 @@ struct CollectionNode
     SUCCESS,
     OVERFLOW
   };
-  using create_ertr = CollectionManager::create_ertr;
-  using create_ret = create_ertr::future<create_result_t>;
+  using create_iertr = CollectionManager::create_iertr;
+  using create_ret = create_iertr::future<create_result_t>;
   create_ret create(coll_context_t cc, coll_t coll, unsigned bits);
 
-  using remove_ertr = CollectionManager::remove_ertr;
+  using remove_iertr = CollectionManager::remove_iertr;
   using remove_ret = CollectionManager::remove_ret;
   remove_ret remove(coll_context_t cc, coll_t coll);
 
-  using update_ertr = CollectionManager::update_ertr;
+  using update_iertr = CollectionManager::update_iertr;
   using update_ret = CollectionManager::update_ret;
   update_ret update(coll_context_t cc, coll_t coll, unsigned bits);
 

--- a/src/crimson/os/seastore/collection_manager/flat_collection_manager.cc
+++ b/src/crimson/os/seastore/collection_manager/flat_collection_manager.cc
@@ -22,7 +22,7 @@ constexpr static segment_off_t MIN_FLAT_BLOCK_SIZE = 4<<10;
 [[maybe_unused]] constexpr static segment_off_t MAX_FLAT_BLOCK_SIZE = 4<<20;
 
 FlatCollectionManager::FlatCollectionManager(
-  InterruptedTransactionManager tm)
+  TransactionManager &tm)
   : tm(tm) {}
 
 FlatCollectionManager::mkfs_ret
@@ -32,12 +32,12 @@ FlatCollectionManager::mkfs(Transaction &t)
   logger().debug("FlatCollectionManager: {}", __func__);
   return tm.alloc_extent<CollectionNode>(
     t, L_ADDR_MIN, MIN_FLAT_BLOCK_SIZE
-  ).safe_then([](auto&& root_extent) {
+  ).si_then([](auto&& root_extent) {
     coll_root_t coll_root = coll_root_t(
       root_extent->get_laddr(),
       MIN_FLAT_BLOCK_SIZE
     );
-    return mkfs_ertr::make_ready_future<coll_root_t>(coll_root);
+    return mkfs_iertr::make_ready_future<coll_root_t>(coll_root);
   });
 }
 
@@ -51,8 +51,8 @@ FlatCollectionManager::get_coll_root(const coll_root_t &coll_root, Transaction &
     cc.t,
     coll_root.get_location(),
     coll_root.get_size()
-  ).safe_then([](auto&& e) {
-    return get_root_ertr::make_ready_future<CollectionNodeRef>(std::move(e));
+  ).si_then([](auto&& e) {
+    return get_root_iertr::make_ready_future<CollectionNodeRef>(std::move(e));
   });
 }
 
@@ -62,10 +62,10 @@ FlatCollectionManager::create(coll_root_t &coll_root, Transaction &t,
 {
   logger().debug("FlatCollectionManager: {}", __func__);
   return get_coll_root(coll_root, t
-  ).safe_then([=, &coll_root, &t] (auto &&extent) {
+  ).si_then([=, &coll_root, &t] (auto &&extent) {
     return extent->create(
       get_coll_context(t), cid, info.split_bits
-    ).safe_then([=, &coll_root, &t] (auto ret) {
+    ).si_then([=, &coll_root, &t] (auto ret) {
       switch (ret) {
       case CollectionNode::create_result_t::OVERFLOW: {
         logger().debug("FlatCollectionManager: {} overflow!", __func__);
@@ -76,23 +76,23 @@ FlatCollectionManager::create(coll_root_t &coll_root, Transaction &t,
 	assert(new_size < MAX_FLAT_BLOCK_SIZE);
         return tm.alloc_extent<CollectionNode>(
 	  t, L_ADDR_MIN, new_size
-	).safe_then([=, &coll_root, &t] (auto &&root_extent) {
+	).si_then([=, &coll_root, &t] (auto &&root_extent) {
           coll_root.update(root_extent->get_laddr(), root_extent->get_length());
 
 	  root_extent->decoded = extent->decoded;
 	  root_extent->loaded = true;
 	  return root_extent->create(
 	    get_coll_context(t), cid, info.split_bits
-	  ).safe_then([=, &t](auto result) {
+	  ).si_then([=, &t](auto result) {
 	    assert(result == CollectionNode::create_result_t::SUCCESS);
 	    return tm.dec_ref(t, extent->get_laddr());
-	  }).safe_then([] (auto) {
-            return create_ertr::make_ready_future<>();
+	  }).si_then([] (auto) {
+            return create_iertr::make_ready_future<>();
           });
         });
       }
       case CollectionNode::create_result_t::SUCCESS: {
-        return create_ertr::make_ready_future<>();
+        return create_iertr::make_ready_future<>();
       }
       }
       __builtin_unreachable();
@@ -105,7 +105,7 @@ FlatCollectionManager::list(const coll_root_t &coll_root, Transaction &t)
 {
   logger().debug("FlatCollectionManager: {}", __func__);
   return get_coll_root(coll_root, t)
-    .safe_then([] (auto extent) {
+    .si_then([] (auto extent) {
     return extent->list();
   });
 }
@@ -116,7 +116,7 @@ FlatCollectionManager::update(const coll_root_t &coll_root, Transaction &t,
 {
   logger().debug("FlatCollectionManager: {}", __func__);
   return get_coll_root(coll_root, t)
-    .safe_then([this, &t, cid, info] (auto extent) {
+    .si_then([this, &t, cid, info] (auto extent) {
       return extent->update(get_coll_context(t), cid, info.split_bits);
   });
 }
@@ -126,7 +126,7 @@ FlatCollectionManager::remove(const coll_root_t &coll_root, Transaction &t,
                               coll_t cid )
 {
   logger().debug("FlatCollectionManager: {}", __func__);
-  return get_coll_root(coll_root, t).safe_then([this, &t, cid] (auto extent) {
+  return get_coll_root(coll_root, t).si_then([this, &t, cid] (auto extent) {
     return extent->remove(get_coll_context(t), cid);
   });
 }

--- a/src/crimson/os/seastore/collection_manager/flat_collection_manager.h
+++ b/src/crimson/os/seastore/collection_manager/flat_collection_manager.h
@@ -13,18 +13,18 @@
 namespace crimson::os::seastore::collection_manager {
 
 class FlatCollectionManager : public CollectionManager {
-  InterruptedTransactionManager tm;
+  TransactionManager &tm;
 
   coll_context_t get_coll_context(Transaction &t) {
     return coll_context_t{tm, t};
   }
 
-  using get_root_ertr = base_ertr;
-  using get_root_ret = get_root_ertr::future<CollectionNodeRef>;
+  using get_root_iertr = base_iertr;
+  using get_root_ret = get_root_iertr::future<CollectionNodeRef>;
   get_root_ret get_coll_root(const coll_root_t &coll_root, Transaction &t);
 
 public:
-  explicit FlatCollectionManager(InterruptedTransactionManager tm);
+  explicit FlatCollectionManager(TransactionManager &tm);
 
   mkfs_ret mkfs(Transaction &t) final;
 

--- a/src/crimson/os/seastore/omap_manager.cc
+++ b/src/crimson/os/seastore/omap_manager.cc
@@ -9,8 +9,7 @@
 
 namespace crimson::os::seastore::omap_manager {
 
-OMapManagerRef create_omap_manager(
-  InterruptedTransactionManager trans_manager) {
+OMapManagerRef create_omap_manager(TransactionManager &trans_manager) {
   return OMapManagerRef(new BtreeOMapManager(trans_manager));
 }
 

--- a/src/crimson/os/seastore/omap_manager.h
+++ b/src/crimson/os/seastore/omap_manager.h
@@ -27,7 +27,7 @@ class OMapManager {
   * until these functions future resolved.
   */
 public:
-  using base_ertr = with_trans_ertr<TransactionManager::base_iertr>;
+  using base_iertr = TransactionManager::base_iertr;
 
   /**
    * allocate omap tree root node
@@ -35,8 +35,8 @@ public:
    * @param Transaction &t, current transaction
    * @retval return the omap_root_t structure.
    */
-  using initialize_omap_ertr = base_ertr;
-  using initialize_omap_ret = initialize_omap_ertr::future<omap_root_t>;
+  using initialize_omap_iertr = base_iertr;
+  using initialize_omap_ret = initialize_omap_iertr::future<omap_root_t>;
   virtual initialize_omap_ret initialize_omap(Transaction &t) = 0;
 
   /**
@@ -47,8 +47,8 @@ public:
    * @param string &key, omap string key
    * @retval return string key->string value mapping pair.
    */
-  using omap_get_value_ertr = base_ertr;
-  using omap_get_value_ret = omap_get_value_ertr::future<
+  using omap_get_value_iertr = base_iertr;
+  using omap_get_value_ret = omap_get_value_iertr::future<
     std::optional<bufferlist>>;
   virtual omap_get_value_ret omap_get_value(
     const omap_root_t &omap_root,
@@ -63,16 +63,16 @@ public:
    * @param string &key, omap string key
    * @param string &value, mapped value corresponding key
    */
-  using omap_set_key_ertr = base_ertr;
-  using omap_set_key_ret = omap_set_key_ertr::future<>;
+  using omap_set_key_iertr = base_iertr;
+  using omap_set_key_ret = omap_set_key_iertr::future<>;
   virtual omap_set_key_ret omap_set_key(
     omap_root_t &omap_root,
     Transaction &t,
     const std::string &key,
     const ceph::bufferlist &value) = 0;
 
-  using omap_set_keys_ertr = base_ertr;
-  using omap_set_keys_ret = omap_set_keys_ertr::future<>;
+  using omap_set_keys_iertr = base_iertr;
+  using omap_set_keys_ret = omap_set_keys_iertr::future<>;
   virtual omap_set_keys_ret omap_set_keys(
     omap_root_t &omap_root,
     Transaction &t,
@@ -85,8 +85,8 @@ public:
    * @param Transaction &t,  current transaction
    * @param string &key, omap string key
    */
-  using omap_rm_key_ertr = base_ertr;
-  using omap_rm_key_ret = omap_rm_key_ertr::future<>;
+  using omap_rm_key_iertr = base_iertr;
+  using omap_rm_key_ret = omap_rm_key_iertr::future<>;
   virtual omap_rm_key_ret omap_rm_key(
     omap_root_t &omap_root,
     Transaction &t,
@@ -142,11 +142,11 @@ public:
       );
     }
   };
-  using omap_list_ertr = base_ertr;
+  using omap_list_iertr = base_iertr;
   using omap_list_bare_ret = std::tuple<
     bool,
     std::map<std::string, bufferlist, std::less<>>>;
-  using omap_list_ret = omap_list_ertr::future<omap_list_bare_ret>;
+  using omap_list_ret = omap_list_iertr::future<omap_list_bare_ret>;
   virtual omap_list_ret omap_list(
     const omap_root_t &omap_root,
     Transaction &t,
@@ -159,8 +159,8 @@ public:
    * @param omap_root_t &omap_root,  omap btree root information
    * @param Transaction &t,  current transaction
    */
-  using omap_clear_ertr = base_ertr;
-  using omap_clear_ret = omap_clear_ertr::future<>;
+  using omap_clear_iertr = base_iertr;
+  using omap_clear_ret = omap_clear_iertr::future<>;
   virtual omap_clear_ret omap_clear(omap_root_t &omap_root, Transaction &t) = 0;
 
   virtual ~OMapManager() {}
@@ -170,7 +170,7 @@ using OMapManagerRef = std::unique_ptr<OMapManager>;
 namespace omap_manager {
 
 OMapManagerRef create_omap_manager (
-  InterruptedTransactionManager trans_manager);
+  TransactionManager &trans_manager);
 }
 
 }

--- a/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
@@ -21,23 +21,19 @@ BtreeOMapManager::BtreeOMapManager(
   TransactionManager &tm)
   : tm(tm) {}
 
-BtreeOMapManager::BtreeOMapManager(
-  InterruptedTransactionManager tm)
-  : tm(tm) {}
-
 BtreeOMapManager::initialize_omap_ret
 BtreeOMapManager::initialize_omap(Transaction &t)
 {
 
   logger().debug("{}", __func__);
   return tm.alloc_extent<OMapLeafNode>(t, L_ADDR_MIN, OMAP_BLOCK_SIZE)
-    .safe_then([](auto&& root_extent) {
+    .si_then([](auto&& root_extent) {
       root_extent->set_size(0);
       omap_node_meta_t meta{1};
       root_extent->set_meta(meta);
       omap_root_t omap_root;
       omap_root.update(root_extent->get_laddr(), 1);
-      return initialize_omap_ertr::make_ready_future<omap_root_t>(omap_root);
+      return initialize_omap_iertr::make_ready_future<omap_root_t>(omap_root);
   });
 }
 
@@ -56,7 +52,7 @@ BtreeOMapManager::handle_root_split(
   const OMapNode::mutation_result_t& mresult)
 {
   return oc.tm.alloc_extent<OMapInnerNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE)
-    .safe_then([&omap_root, mresult](auto&& nroot) -> handle_root_split_ret {
+    .si_then([&omap_root, mresult](auto&& nroot) -> handle_root_split_ret {
     auto [left, right, pivot] = *(mresult.split_tuple);
     omap_node_meta_t meta{omap_root.depth + 1};
     nroot->set_meta(meta);
@@ -81,10 +77,10 @@ BtreeOMapManager::handle_root_merge(
     iter->get_val(),
     omap_root.depth -= 1);
   return oc.tm.dec_ref(oc.t, root->get_laddr()
-  ).safe_then([](auto &&ret) -> handle_root_merge_ret {
+  ).si_then([](auto &&ret) -> handle_root_merge_ret {
     return seastar::now();
-  }).handle_error(
-    handle_root_merge_ertr::pass_further{},
+  }).handle_error_interruptible(
+    handle_root_merge_iertr::pass_further{},
     crimson::ct_error::assert_all{
       "Invalid error in handle_root_merge"
     }
@@ -101,11 +97,11 @@ BtreeOMapManager::omap_get_value(
   return get_omap_root(
     get_omap_context(t),
     omap_root
-  ).safe_then([this, &t, &key](auto&& extent) {
+  ).si_then([this, &t, &key](auto&& extent) {
     return extent->get_value(get_omap_context(t), key);
-  }).safe_then([](auto &&e) {
+  }).si_then([](auto &&e) {
     return omap_get_value_ret(
-        omap_get_value_ertr::ready_future_marker{},
+        interruptible::ready_future_marker{},
         std::move(e));
   });
 }
@@ -117,7 +113,7 @@ BtreeOMapManager::omap_set_keys(
   std::map<std::string, ceph::bufferlist>&& keys)
 {
   return seastar::do_with(std::move(keys), [&, this](auto& keys) {
-    return crimson::do_for_each(
+    return trans_intr::do_for_each(
       keys.begin(),
       keys.end(),
       [&, this](auto &p) {
@@ -137,9 +133,9 @@ BtreeOMapManager::omap_set_key(
   return get_omap_root(
     get_omap_context(t),
     omap_root
-  ).safe_then([this, &t, &key, &value](auto root) {
+  ).si_then([this, &t, &key, &value](auto root) {
     return root->insert(get_omap_context(t), key, value);
-  }).safe_then([this, &omap_root, &t](auto mresult) -> omap_set_key_ret {
+  }).si_then([this, &omap_root, &t](auto mresult) -> omap_set_key_ret {
     if (mresult.status == mutation_status_t::SUCCESS)
       return seastar::now();
     else if (mresult.status == mutation_status_t::WAS_SPLIT)
@@ -159,9 +155,9 @@ BtreeOMapManager::omap_rm_key(
   return get_omap_root(
     get_omap_context(t),
     omap_root
-  ).safe_then([this, &t, &key](auto root) {
+  ).si_then([this, &t, &key](auto root) {
     return root->rm_key(get_omap_context(t), key);
-  }).safe_then([this, &omap_root, &t](auto mresult) -> omap_rm_key_ret {
+  }).si_then([this, &omap_root, &t](auto mresult) -> omap_rm_key_ret {
     if (mresult.status == mutation_status_t::SUCCESS) {
       return seastar::now();
     } else if (mresult.status == mutation_status_t::WAS_SPLIT) {
@@ -191,7 +187,7 @@ BtreeOMapManager::omap_list(
   return get_omap_root(
     get_omap_context(t),
     omap_root
-  ).safe_then([this, config, &t, &start](auto extent) {
+  ).si_then([this, config, &t, &start](auto extent) {
     return extent->list(
       get_omap_context(t),
       start,
@@ -208,19 +204,19 @@ BtreeOMapManager::omap_clear(
   return get_omap_root(
     get_omap_context(t),
     omap_root
-  ).safe_then([this, &t](auto extent) {
+  ).si_then([this, &t](auto extent) {
     return extent->clear(get_omap_context(t));
-  }).safe_then([this, &omap_root, &t] {
+  }).si_then([this, &omap_root, &t] {
     return tm.dec_ref(
       t, omap_root.get_location()
-    ).safe_then([&omap_root] (auto ret) {
+    ).si_then([&omap_root] (auto ret) {
       omap_root.update(
 	L_ADDR_NULL,
 	0);
-      return omap_clear_ertr::now();
+      return omap_clear_iertr::now();
     });
-  }).handle_error(
-    omap_clear_ertr::pass_further{},
+  }).handle_error_interruptible(
+    omap_clear_iertr::pass_further{},
     crimson::ct_error::assert_all{
       "Invalid error in BtreeOMapManager::omap_clear"
     }

--- a/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.h
+++ b/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.h
@@ -23,7 +23,7 @@ namespace crimson::os::seastore::omap_manager {
  */
 
 class BtreeOMapManager : public OMapManager {
-  InterruptedTransactionManager tm;
+  TransactionManager &tm;
 
   omap_context_t get_omap_context(
     Transaction &t) {
@@ -34,8 +34,8 @@ class BtreeOMapManager : public OMapManager {
    *
    * load omap tree root node
    */
-  using get_root_ertr = base_ertr;
-  using get_root_ret = get_root_ertr::future<OMapNodeRef>;
+  using get_root_iertr = base_iertr;
+  using get_root_ret = get_root_iertr::future<OMapNodeRef>;
   static get_root_ret get_omap_root(
     omap_context_t c,
     const omap_root_t &omap_root);
@@ -44,8 +44,8 @@ class BtreeOMapManager : public OMapManager {
    *
    * root has been split and needs to update omap_root_t
    */
-  using handle_root_split_ertr = base_ertr;
-  using handle_root_split_ret = handle_root_split_ertr::future<>;
+  using handle_root_split_iertr = base_iertr;
+  using handle_root_split_ret = handle_root_split_iertr::future<>;
   handle_root_split_ret handle_root_split(
     omap_context_t c,
     omap_root_t &omap_root,
@@ -55,15 +55,14 @@ class BtreeOMapManager : public OMapManager {
    *
    * root node has only one item and it is not leaf node, need remove a layer
    */
-  using handle_root_merge_ertr = base_ertr;
-  using handle_root_merge_ret = handle_root_merge_ertr::future<>;
+  using handle_root_merge_iertr = base_iertr;
+  using handle_root_merge_ret = handle_root_merge_iertr::future<>;
   handle_root_merge_ret handle_root_merge(
     omap_context_t oc,
     omap_root_t &omap_root, 
     OMapNode:: mutation_result_t mresult);
 
 public:
-  explicit BtreeOMapManager(InterruptedTransactionManager tm);
   explicit BtreeOMapManager(TransactionManager &tm);
 
   initialize_omap_ret initialize_omap(Transaction &t) final;

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node.h
@@ -16,7 +16,7 @@
 namespace crimson::os::seastore::omap_manager{
 
 struct omap_context_t {
-  InterruptedTransactionManager tm;
+  TransactionManager &tm;
   Transaction &t;
 };
 
@@ -28,7 +28,7 @@ enum class mutation_status_t : uint8_t {
 };
 
 struct OMapNode : LogicalCachedExtent {
-  using base_ertr = OMapManager::base_ertr;
+  using base_iertr = OMapManager::base_iertr;
 
   using OMapNodeRef = TCachedExtentRef<OMapNode>;
 
@@ -51,27 +51,27 @@ struct OMapNode : LogicalCachedExtent {
   OMapNode(const OMapNode &other)
   : LogicalCachedExtent(other) {}
 
-  using get_value_ertr = base_ertr;
+  using get_value_iertr = base_iertr;
   using get_value_ret = OMapManager::omap_get_value_ret;
   virtual get_value_ret get_value(
     omap_context_t oc,
     const std::string &key) = 0;
 
-  using insert_ertr = base_ertr;
-  using insert_ret = insert_ertr::future<mutation_result_t>;
+  using insert_iertr = base_iertr;
+  using insert_ret = insert_iertr::future<mutation_result_t>;
   virtual insert_ret insert(
     omap_context_t oc,
     const std::string &key,
     const ceph::bufferlist &value) = 0;
 
-  using rm_key_ertr = base_ertr;
-  using rm_key_ret = rm_key_ertr::future<mutation_result_t>;
+  using rm_key_iertr = base_iertr;
+  using rm_key_ret = rm_key_iertr::future<mutation_result_t>;
   virtual rm_key_ret rm_key(
     omap_context_t oc,
     const std::string &key) = 0;
 
   using omap_list_config_t = OMapManager::omap_list_config_t;
-  using list_ertr = base_ertr;
+  using list_iertr = base_iertr;
   using list_bare_ret = OMapManager::omap_list_bare_ret;
   using list_ret = OMapManager::omap_list_ret;
   virtual list_ret list(
@@ -79,18 +79,18 @@ struct OMapNode : LogicalCachedExtent {
     const std::optional<std::string> &start,
     omap_list_config_t config) = 0;
 
-  using clear_ertr = base_ertr;
-  using clear_ret = clear_ertr::future<>;
+  using clear_iertr = base_iertr;
+  using clear_ret = clear_iertr::future<>;
   virtual clear_ret clear(omap_context_t oc) = 0;
 
-  using full_merge_ertr = base_ertr;
-  using full_merge_ret = full_merge_ertr::future<OMapNodeRef>;
+  using full_merge_iertr = base_iertr;
+  using full_merge_ret = full_merge_iertr::future<OMapNodeRef>;
   virtual full_merge_ret make_full_merge(
     omap_context_t oc,
     OMapNodeRef right) = 0;
 
-  using make_balanced_ertr = base_ertr;
-  using make_balanced_ret = make_balanced_ertr::future
+  using make_balanced_iertr = base_iertr;
+  using make_balanced_ret = make_balanced_iertr::future
           <std::tuple<OMapNodeRef, OMapNodeRef, std::string>>;
   virtual make_balanced_ret make_balanced(
     omap_context_t oc,
@@ -108,8 +108,8 @@ struct OMapNode : LogicalCachedExtent {
 
 using OMapNodeRef = OMapNode::OMapNodeRef;
 
-using omap_load_extent_ertr = OMapNode::base_ertr;
-omap_load_extent_ertr::future<OMapNodeRef>
+using omap_load_extent_iertr = OMapNode::base_iertr;
+omap_load_extent_iertr::future<OMapNodeRef>
 omap_load_extent(omap_context_t oc, laddr_t laddr, depth_t depth);
 
 }

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -36,16 +36,16 @@ std::ostream &OMapInnerNode::print_detail_l(std::ostream &out) const
 	     << ", depth=" << get_meta().depth;
 }
 
-using dec_ref_ertr = OMapInnerNode::base_ertr;
-using dec_ref_ret = dec_ref_ertr::future<>;
+using dec_ref_iertr = OMapInnerNode::base_iertr;
+using dec_ref_ret = dec_ref_iertr::future<>;
 template <typename T>
 dec_ref_ret dec_ref(omap_context_t oc, T&& addr) {
-  return oc.tm.dec_ref(oc.t, std::forward<T>(addr)).handle_error(
-    dec_ref_ertr::pass_further{},
+  return oc.tm.dec_ref(oc.t, std::forward<T>(addr)).handle_error_interruptible(
+    dec_ref_iertr::pass_further{},
     crimson::ct_error::assert_all{
       "Invalid error in OMapInnerNode helper dec_ref"
     }
-  ).safe_then([](auto &&e) {});
+  ).si_then([](auto &&e) {});
 }
 
 /**
@@ -61,7 +61,7 @@ OMapInnerNode::make_split_insert(
   std::string key,
   laddr_t laddr)
 {
-  return make_split_children(oc).safe_then([=] (auto tuple) {
+  return make_split_children(oc).si_then([=] (auto tuple) {
     auto [left, right, pivot] = tuple;
     if (pivot > key) {
       auto liter = left->iter_idx(iter.get_index());
@@ -73,7 +73,7 @@ OMapInnerNode::make_split_insert(
                                   right->maybe_get_delta_buffer());
     }
     return make_split_insert_ret(
-           make_split_insert_ertr::ready_future_marker{},
+           interruptible::ready_future_marker{},
            mutation_result_t(mutation_status_t::WAS_SPLIT, tuple, std::nullopt));
   });
 
@@ -100,15 +100,15 @@ OMapInnerNode::handle_split(
     journal_inner_insert(iter + 1, right->get_laddr(), pivot,
                          maybe_get_delta_buffer());
     return insert_ret(
-           insert_ertr::ready_future_marker{},
+           interruptible::ready_future_marker{},
            mutation_result_t(mutation_status_t::SUCCESS, std::nullopt, std::nullopt));
   } else {
     return make_split_insert(oc, iter + 1, pivot, right->get_laddr())
-      .safe_then([this, oc] (auto m_result) {
+      .si_then([this, oc] (auto m_result) {
        return dec_ref(oc, get_laddr())
-         .safe_then([m_result = std::move(m_result)] {
+         .si_then([m_result = std::move(m_result)] {
           return insert_ret(
-                 insert_ertr::ready_future_marker{},
+                 interruptible::ready_future_marker{},
                  m_result);
        });
    });
@@ -124,7 +124,7 @@ OMapInnerNode::get_value(
   auto child_pt = get_containing_child(key);
   assert(child_pt != iter_end());
   auto laddr = child_pt->get_val();
-  return omap_load_extent(oc, laddr, get_meta().depth - 1).safe_then(
+  return omap_load_extent(oc, laddr, get_meta().depth - 1).si_then(
     [oc, &key] (auto extent) {
     return extent->get_value(oc, key);
   }).finally([ref = OMapNodeRef(this)] {});
@@ -140,17 +140,17 @@ OMapInnerNode::insert(
   auto child_pt = get_containing_child(key);
   assert(child_pt != iter_end());
   auto laddr = child_pt->get_val();
-  return omap_load_extent(oc, laddr, get_meta().depth - 1).safe_then(
+  return omap_load_extent(oc, laddr, get_meta().depth - 1).si_then(
     [oc, &key, &value] (auto extent) {
     return extent->insert(oc, key, value);
-  }).safe_then([this, oc, child_pt] (auto mresult) {
+  }).si_then([this, oc, child_pt] (auto mresult) {
     if (mresult.status == mutation_status_t::SUCCESS) {
-      return insert_ertr::make_ready_future<mutation_result_t>(mresult);
+      return insert_iertr::make_ready_future<mutation_result_t>(mresult);
     } else if (mresult.status == mutation_status_t::WAS_SPLIT) {
       return handle_split(oc, child_pt, mresult);
     } else {
      return insert_ret(
-            insert_ertr::ready_future_marker{},
+            interruptible::ready_future_marker{},
             mutation_result_t(mutation_status_t::SUCCESS, std::nullopt, std::nullopt));
     }
   });
@@ -163,27 +163,27 @@ OMapInnerNode::rm_key(omap_context_t oc, const std::string &key)
   auto child_pt = get_containing_child(key);
   assert(child_pt != iter_end());
   auto laddr = child_pt->get_val();
-  return omap_load_extent(oc, laddr, get_meta().depth - 1).safe_then(
+  return omap_load_extent(oc, laddr, get_meta().depth - 1).si_then(
     [this, oc, &key, child_pt] (auto extent) {
     return extent->rm_key(oc, key)
-      .safe_then([this, oc, child_pt, extent = std::move(extent)] (auto mresult) {
+      .si_then([this, oc, child_pt, extent = std::move(extent)] (auto mresult) {
       switch (mresult.status) {
         case mutation_status_t::SUCCESS:
         case mutation_status_t::FAIL:
-          return rm_key_ertr::make_ready_future<mutation_result_t>(mresult);
+          return rm_key_iertr::make_ready_future<mutation_result_t>(mresult);
         case mutation_status_t::NEED_MERGE: {
           if (get_node_size() >1)
             return merge_entry(oc, child_pt, *(mresult.need_merge));
           else
             return rm_key_ret(
-                   rm_key_ertr::ready_future_marker{},
+                   interruptible::ready_future_marker{},
                    mutation_result_t(mutation_status_t::SUCCESS,
                                      std::nullopt, std::nullopt));
         }
         case mutation_status_t::WAS_SPLIT:
           return handle_split(oc, child_pt, mresult);
         default:
-          return rm_key_ertr::make_ready_future<mutation_result_t>(mresult);
+          return rm_key_iertr::make_ready_future<mutation_result_t>(mresult);
       }
     });
   });
@@ -209,23 +209,23 @@ OMapInnerNode::list(
     [=, &start](auto &biter, auto &eiter, auto &ret) {
       auto &complete = std::get<0>(ret);
       auto &result = std::get<1>(ret);
-      return crimson::repeat(
-	[&, config, oc, this]() -> list_ertr::future<seastar::stop_iteration> {
+      return trans_intr::repeat(
+	[&, config, oc, this]() -> list_iertr::future<seastar::stop_iteration> {
 	  if (biter == eiter  || result.size() == config.max_result_size) {
 	    complete = biter == eiter;
-	    return list_ertr::make_ready_future<seastar::stop_iteration>(
+	    return list_iertr::make_ready_future<seastar::stop_iteration>(
 	      seastar::stop_iteration::yes);
 	  }
 	  auto laddr = biter->get_val();
 	  return omap_load_extent(
 	    oc, laddr,
 	    get_meta().depth - 1
-	  ).safe_then([&, config, oc] (auto &&extent) {
+	  ).si_then([&, config, oc] (auto &&extent) {
 	    return extent->list(
 	      oc,
 	      start,
 	      config.with_reduced_max(result.size())
-	    ).safe_then([&, config](auto &&child_ret) mutable {
+	    ).si_then([&, config](auto &&child_ret) mutable {
 	      auto &[child_complete, child_result] = child_ret;
 	      if (result.size() && child_result.size()) {
 		assert(child_result.begin()->first > result.rbegin()->first);
@@ -236,12 +236,12 @@ OMapInnerNode::list(
 	      result.merge(std::move(child_result));
 	      ++biter;
 	      assert(child_complete || result.size() == config.max_result_size);
-	      return list_ertr::make_ready_future<seastar::stop_iteration>(
+	      return list_iertr::make_ready_future<seastar::stop_iteration>(
 		seastar::stop_iteration::no);
 	    });
 	  });
-	}).safe_then([&ret, ref = OMapNodeRef(this)] {
-	  return list_ertr::make_ready_future<list_bare_ret>(std::move(ret));
+	}).si_then([&ret, ref = OMapNodeRef(this)] {
+	  return list_iertr::make_ready_future<list_bare_ret>(std::move(ret));
 	});
     });
 }
@@ -250,15 +250,15 @@ OMapInnerNode::clear_ret
 OMapInnerNode::clear(omap_context_t oc)
 {
   logger().debug("OMapInnerNode: {}", __func__);
-  return crimson::do_for_each(iter_begin(), iter_end(), [this, oc] (auto iter) {
+  return trans_intr::do_for_each(iter_begin(), iter_end(), [this, oc] (auto iter) {
     auto laddr = iter->get_val();
-    return omap_load_extent(oc, laddr, get_meta().depth - 1).safe_then(
+    return omap_load_extent(oc, laddr, get_meta().depth - 1).si_then(
       [oc] (auto &&extent) {
       return extent->clear(oc);
-    }).safe_then([oc, laddr] {
+    }).si_then([oc, laddr] {
       return dec_ref(oc, laddr);
-    }).safe_then([ref = OMapNodeRef(this)] {
-      return clear_ertr::now();
+    }).si_then([ref = OMapNodeRef(this)] {
+      return clear_iertr::now();
     });
   });
 }
@@ -268,11 +268,11 @@ OMapInnerNode:: make_split_children(omap_context_t oc)
 {
   logger().debug("OMapInnerNode: {}", __func__);
   return oc.tm.alloc_extents<OMapInnerNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE, 2)
-    .safe_then([this] (auto &&ext_pair) {
+    .si_then([this] (auto &&ext_pair) {
       auto left = ext_pair.front();
       auto right = ext_pair.back();
       return split_children_ret(
-             split_children_ertr::ready_future_marker{},
+             interruptible::ready_future_marker{},
              std::make_tuple(left, right, split_into(*left, *right)));
   });
 }
@@ -282,10 +282,10 @@ OMapInnerNode::make_full_merge(omap_context_t oc, OMapNodeRef right)
 {
   logger().debug("OMapInnerNode: {}", __func__);
   return oc.tm.alloc_extent<OMapInnerNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE)
-    .safe_then([this, right] (auto &&replacement) {
+    .si_then([this, right] (auto &&replacement) {
       replacement->merge_from(*this, *right->cast<OMapInnerNode>());
       return full_merge_ret(
-        full_merge_ertr::ready_future_marker{},
+        interruptible::ready_future_marker{},
         std::move(replacement));
   });
 }
@@ -296,12 +296,12 @@ OMapInnerNode::make_balanced(omap_context_t oc, OMapNodeRef _right)
   logger().debug("OMapInnerNode: {}", __func__);
   ceph_assert(_right->get_type() == type);
   return oc.tm.alloc_extents<OMapInnerNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE, 2)
-    .safe_then([this, _right] (auto &&replacement_pair){
+    .si_then([this, _right] (auto &&replacement_pair){
       auto replacement_left = replacement_pair.front();
       auto replacement_right = replacement_pair.back();
       auto &right = *_right->cast<OMapInnerNode>();
       return make_balanced_ret(
-             make_balanced_ertr::ready_future_marker{},
+             interruptible::ready_future_marker{},
              std::make_tuple(replacement_left, replacement_right,
                              balance_into_new_nodes(*this, right,
                                *replacement_left, *replacement_right)));
@@ -323,7 +323,7 @@ OMapInnerNode::merge_entry(
   auto is_left = (iter + 1) == iter_end();
   auto donor_iter = is_left ? iter - 1 : iter + 1;
   return omap_load_extent(oc, donor_iter->get_val(), get_meta().depth - 1)
-    .safe_then([=] (auto &&donor) mutable {
+    .si_then([=] (auto &&donor) mutable {
     auto [l, r] = is_left ?
       std::make_pair(donor, entry) : std::make_pair(entry, donor);
     auto [liter, riter] = is_left ?
@@ -331,28 +331,28 @@ OMapInnerNode::merge_entry(
     if (donor->extent_is_below_min()) {
       logger().debug("{}::merge_entry make_full_merge l {} r {}", __func__, *l, *r);
       assert(entry->extent_is_below_min());
-      return l->make_full_merge(oc, r).safe_then([liter=liter, riter=riter,
+      return l->make_full_merge(oc, r).si_then([liter=liter, riter=riter,
                                                   l=l, r=r, oc, this] (auto &&replacement){
         journal_inner_update(liter, replacement->get_laddr(), maybe_get_delta_buffer());
         journal_inner_remove(riter, maybe_get_delta_buffer());
         //retire extent
         std::vector<laddr_t> dec_laddrs {l->get_laddr(), r->get_laddr()};
-        return dec_ref(oc, dec_laddrs).safe_then([this] {
+        return dec_ref(oc, dec_laddrs).si_then([this] {
           if (extent_is_below_min()) {
             return merge_entry_ret(
-                   merge_entry_ertr::ready_future_marker{},
+                   interruptible::ready_future_marker{},
                    mutation_result_t(mutation_status_t::NEED_MERGE, std::nullopt,
                                     this));
           } else {
             return merge_entry_ret(
-                   merge_entry_ertr::ready_future_marker{},
+                   interruptible::ready_future_marker{},
                    mutation_result_t(mutation_status_t::SUCCESS, std::nullopt, std::nullopt));
           }
         });
       });
     } else {
       logger().debug("{}::merge_entry balanced l {} r {}", __func__, *l, *r);
-      return l->make_balanced(oc, r).safe_then([liter=liter, riter=riter,
+      return l->make_balanced(oc, r).si_then([liter=liter, riter=riter,
                                                 l=l, r=r, oc, this] (auto tuple) {
         auto [replacement_l, replacement_r, replacement_pivot] = tuple;
         //update operation will not cuase node overflow, so we can do it first
@@ -366,9 +366,9 @@ OMapInnerNode::merge_entry(
 	    replacement_pivot,
 	    maybe_get_delta_buffer());
           std::vector<laddr_t> dec_laddrs{l->get_laddr(), r->get_laddr()};
-          return dec_ref(oc, dec_laddrs).safe_then([] {
+          return dec_ref(oc, dec_laddrs).si_then([] {
             return merge_entry_ret(
-                   merge_entry_ertr::ready_future_marker{},
+                   interruptible::ready_future_marker{},
                    mutation_result_t(mutation_status_t::SUCCESS, std::nullopt, std::nullopt));
           });
         } else {
@@ -377,12 +377,12 @@ OMapInnerNode::merge_entry(
           //remove operation will not cause node split, so we can do it first
           journal_inner_remove(riter, maybe_get_delta_buffer());
           return make_split_insert(oc, riter, replacement_pivot, replacement_r->get_laddr())
-            .safe_then([this, oc, l = l, r = r] (auto mresult) {
+            .si_then([this, oc, l = l, r = r] (auto mresult) {
             std::vector<laddr_t> dec_laddrs{l->get_laddr(), r->get_laddr(), get_laddr()};
             return dec_ref(oc, dec_laddrs)
-              .safe_then([mresult = std::move(mresult)] {
+              .si_then([mresult = std::move(mresult)] {
               return merge_entry_ret(
-                     merge_entry_ertr::ready_future_marker{},
+                     interruptible::ready_future_marker{},
                      mresult);
             });
           });
@@ -415,11 +415,11 @@ OMapLeafNode::get_value(omap_context_t oc, const std::string &key)
   if (ite != iter_end()) {
     auto value = ite->get_val();
     return get_value_ret(
-      get_value_ertr::ready_future_marker{},
+      interruptible::ready_future_marker{},
       value);
   } else {
     return get_value_ret(
-      get_value_ertr::ready_future_marker{},
+      interruptible::ready_future_marker{},
       std::nullopt);
   }
 }
@@ -449,10 +449,10 @@ OMapLeafNode::insert(
         insert_pt.get_key());
     }
     return insert_ret(
-           insert_ertr::ready_future_marker{},
+           interruptible::ready_future_marker{},
            mutation_result_t(mutation_status_t::SUCCESS, std::nullopt, std::nullopt));
   } else {
-    return make_split_children(oc).safe_then([this, oc, &key, &value] (auto tuple) {
+    return make_split_children(oc).si_then([this, oc, &key, &value] (auto tuple) {
       auto [left, right, pivot] = tuple;
       auto replace_pt = find_string_key(key);
       if (replace_pt != iter_end()) {
@@ -474,9 +474,9 @@ OMapLeafNode::insert(
         }
       }
       return dec_ref(oc, get_laddr())
-        .safe_then([tuple = std::move(tuple)] {
+        .si_then([tuple = std::move(tuple)] {
         return insert_ret(
-               insert_ertr::ready_future_marker{},
+               interruptible::ready_future_marker{},
                mutation_result_t(mutation_status_t::WAS_SPLIT, tuple, std::nullopt));
       });
     });
@@ -497,17 +497,17 @@ OMapLeafNode::rm_key(omap_context_t oc, const std::string &key)
     journal_leaf_remove(rm_pt, maybe_get_delta_buffer());
     if (extent_is_below_min()) {
       return rm_key_ret(
-	rm_key_ertr::ready_future_marker{},
+	interruptible::ready_future_marker{},
 	mutation_result_t(mutation_status_t::NEED_MERGE, std::nullopt,
 			  this->cast<OMapNode>()));
     } else {
       return rm_key_ret(
-	rm_key_ertr::ready_future_marker{},
+	interruptible::ready_future_marker{},
 	mutation_result_t(mutation_status_t::SUCCESS, std::nullopt, std::nullopt));
     }
   } else {
     return rm_key_ret(
-      rm_key_ertr::ready_future_marker{},
+      interruptible::ready_future_marker{},
       mutation_result_t(mutation_status_t::FAIL, std::nullopt, std::nullopt));
   }
 
@@ -540,14 +540,14 @@ OMapLeafNode::list(
 
   complete = (iter == iter_end());
 
-  return list_ertr::make_ready_future<list_bare_ret>(
+  return list_iertr::make_ready_future<list_bare_ret>(
     std::move(ret));
 }
 
 OMapLeafNode::clear_ret
 OMapLeafNode::clear(omap_context_t oc)
 {
-  return clear_ertr::now();
+  return clear_iertr::now();
 }
 
 OMapLeafNode::split_children_ret
@@ -555,11 +555,11 @@ OMapLeafNode::make_split_children(omap_context_t oc)
 {
   logger().debug("OMapLeafNode: {}", __func__);
   return oc.tm.alloc_extents<OMapLeafNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE, 2)
-    .safe_then([this] (auto &&ext_pair) {
+    .si_then([this] (auto &&ext_pair) {
       auto left = ext_pair.front();
       auto right = ext_pair.back();
       return split_children_ret(
-             split_children_ertr::ready_future_marker{},
+             interruptible::ready_future_marker{},
              std::make_tuple(left, right, split_into(*left, *right)));
   });
 }
@@ -570,10 +570,10 @@ OMapLeafNode::make_full_merge(omap_context_t oc, OMapNodeRef right)
   ceph_assert(right->get_type() == type);
   logger().debug("OMapLeafNode: {}", __func__);
   return oc.tm.alloc_extent<OMapLeafNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE)
-    .safe_then([this, right] (auto &&replacement) {
+    .si_then([this, right] (auto &&replacement) {
       replacement->merge_from(*this, *right->cast<OMapLeafNode>());
       return full_merge_ret(
-        full_merge_ertr::ready_future_marker{},
+        interruptible::ready_future_marker{},
         std::move(replacement));
   });
 }
@@ -584,12 +584,12 @@ OMapLeafNode::make_balanced(omap_context_t oc, OMapNodeRef _right)
   ceph_assert(_right->get_type() == type);
   logger().debug("OMapLeafNode: {}",  __func__);
   return oc.tm.alloc_extents<OMapLeafNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE, 2)
-    .safe_then([this, _right] (auto &&replacement_pair) {
+    .si_then([this, _right] (auto &&replacement_pair) {
       auto replacement_left = replacement_pair.front();
       auto replacement_right = replacement_pair.back();
       auto &right = *_right->cast<OMapLeafNode>();
       return make_balanced_ret(
-             make_balanced_ertr::ready_future_marker{},
+             interruptible::ready_future_marker{},
              std::make_tuple(
                replacement_left, replacement_right,
                balance_into_new_nodes(
@@ -599,25 +599,25 @@ OMapLeafNode::make_balanced(omap_context_t oc, OMapNodeRef _right)
 }
 
 
-omap_load_extent_ertr::future<OMapNodeRef>
+omap_load_extent_iertr::future<OMapNodeRef>
 omap_load_extent(omap_context_t oc, laddr_t laddr, depth_t depth)
 {
   ceph_assert(depth > 0);
   if (depth > 1) {
     return oc.tm.read_extent<OMapInnerNode>(oc.t, laddr, OMAP_BLOCK_SIZE
-    ).handle_error(
-      omap_load_extent_ertr::pass_further{},
+    ).handle_error_interruptible(
+      omap_load_extent_iertr::pass_further{},
       crimson::ct_error::assert_all{ "Invalid error in omap_load_extent" }
-    ).safe_then(
+    ).si_then(
       [](auto&& e) {
       return seastar::make_ready_future<OMapNodeRef>(std::move(e));
     });
   } else {
     return oc.tm.read_extent<OMapLeafNode>(oc.t, laddr, OMAP_BLOCK_SIZE
-    ).handle_error(
-      omap_load_extent_ertr::pass_further{},
+    ).handle_error_interruptible(
+      omap_load_extent_iertr::pass_further{},
       crimson::ct_error::assert_all{ "Invalid error in omap_load_extent" }
-    ).safe_then(
+    ).si_then(
       [](auto&& e) {
       return seastar::make_ready_future<OMapNodeRef>(std::move(e));
     });

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
@@ -73,8 +73,8 @@ struct OMapInnerNode
 
   clear_ret clear(omap_context_t oc) final;
 
-  using split_children_ertr = base_ertr;
-  using split_children_ret = split_children_ertr::future
+  using split_children_iertr = base_iertr;
+  using split_children_ret = split_children_iertr::future
           <std::tuple<OMapInnerNodeRef, OMapInnerNodeRef, std::string>>;
   split_children_ret make_split_children(omap_context_t oc);
 
@@ -84,20 +84,20 @@ struct OMapInnerNode
   make_balanced_ret make_balanced(
     omap_context_t oc, OMapNodeRef right) final;
 
-  using make_split_insert_ertr = base_ertr; 
-  using make_split_insert_ret = make_split_insert_ertr::future<mutation_result_t>;
+  using make_split_insert_iertr = base_iertr; 
+  using make_split_insert_ret = make_split_insert_iertr::future<mutation_result_t>;
   make_split_insert_ret make_split_insert(
     omap_context_t oc, internal_iterator_t iter,
     std::string key, laddr_t laddr);
 
-  using merge_entry_ertr = base_ertr;
-  using merge_entry_ret = merge_entry_ertr::future<mutation_result_t>;
+  using merge_entry_iertr = base_iertr;
+  using merge_entry_ret = merge_entry_iertr::future<mutation_result_t>;
   merge_entry_ret merge_entry(
     omap_context_t oc,
     internal_iterator_t iter, OMapNodeRef entry);
 
-  using handle_split_ertr = base_ertr;
-  using handle_split_ret = handle_split_ertr::future<mutation_result_t>;
+  using handle_split_iertr = base_iertr;
+  using handle_split_ret = handle_split_iertr::future<mutation_result_t>;
   handle_split_ret handle_split(
     omap_context_t oc, internal_iterator_t iter,
     mutation_result_t mresult);
@@ -188,8 +188,8 @@ struct OMapLeafNode
   clear_ret clear(
     omap_context_t oc) final;
 
-  using split_children_ertr = base_ertr;
-  using split_children_ret = split_children_ertr::future
+  using split_children_iertr = base_iertr;
+  using split_children_ret = split_children_iertr::future
           <std::tuple<OMapLeafNodeRef, OMapLeafNodeRef, std::string>>;
   split_children_ret make_split_children(
     omap_context_t oc);

--- a/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
+++ b/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
@@ -322,6 +322,7 @@ public:
       return iter_t<!is_const>(node, index);
     }
 
+    using reference = iter_t&;
     iter_t &operator*() { return *this; }
     iter_t *operator->() { return this; }
 

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -367,21 +367,25 @@ SeaStore::_omap_get_value_ret SeaStore::_omap_get_value(
   std::string_view key) const
 {
   return seastar::do_with(
-    BtreeOMapManager(*transaction_manager),
+    BtreeOMapManager(transaction_manager->get_tm()),
     std::move(root),
     std::string(key),
     [&t](auto &manager, auto& root, auto& key) -> _omap_get_value_ret {
       if (root.is_null()) {
 	return crimson::ct_error::enodata::make();
       }
-      return manager.omap_get_value(
-	root, t, key
-      ).safe_then([](auto opt) -> _omap_get_value_ret {
-	if (!opt) {
-	  return crimson::ct_error::enodata::make();
-	}
-	return seastar::make_ready_future<ceph::bufferlist>(std::move(*opt));
-      });
+      return with_trans_intr(
+	t,
+	[&](auto &t) {
+	  return manager.omap_get_value(
+	    root, t, key
+	  );
+	}).safe_then([](auto opt) -> _omap_get_value_ret {
+	  if (!opt) {
+	    return crimson::ct_error::enodata::make();
+	  }
+	  return seastar::make_ready_future<ceph::bufferlist>(std::move(*opt));
+	});
     });
 }
 
@@ -394,31 +398,35 @@ SeaStore::_omap_get_values_ret SeaStore::_omap_get_values(
     return seastar::make_ready_future<omap_values_t>();
   }
   return seastar::do_with(
-    BtreeOMapManager(*transaction_manager),
+    BtreeOMapManager(transaction_manager->get_tm()),
     std::move(omap_root),
     omap_values_t(),
     [&](auto &manager, auto &root, auto &ret) {
-      return crimson::do_for_each(
-	keys.begin(),
-	keys.end(),
-	[&](auto &key) {
-	  return manager.omap_get_value(
-	    root,
-	    t,
-	    key
-	  ).safe_then([&ret, &key](auto &&p) {
-	    if (p) {
-	      bufferlist bl;
-	      bl.append(*p);
-	      ret.emplace(
-		std::make_pair(
-		  std::move(key),
-		  std::move(bl)));
-	    }
-	    return seastar::now();
-	  });
-	}).safe_then([&ret] {
-	  return std::move(ret);
+      return with_trans_intr(
+	t,
+	[&, this](auto &t) {
+	  return trans_intr::do_for_each(
+	    keys.begin(),
+	    keys.end(),
+	    [&](auto &key) {
+	      return manager.omap_get_value(
+		root,
+		t,
+		key
+	      ).si_then([&ret, &key](auto &&p) {
+		if (p) {
+		  bufferlist bl;
+		  bl.append(*p);
+		  ret.emplace(
+		    std::make_pair(
+		      std::move(key),
+		      std::move(bl)));
+		}
+		return seastar::now();
+	      });
+	    }).si_then([&ret] {
+	      return std::move(ret);
+	    });
 	});
     });
 }
@@ -436,12 +444,16 @@ SeaStore::_omap_list_ret SeaStore::_omap_list(
     );
   }
   return seastar::do_with(
-    BtreeOMapManager(*transaction_manager),
+    BtreeOMapManager(transaction_manager->get_tm()),
     root,
     start,
     [&t, config](auto &manager, auto& root, auto& start) {
-    return manager.omap_list(root, t, start, config);
-  });
+      return with_trans_intr(
+	t,
+	[&](auto &t) {
+	  return manager.omap_list(root, t, start, config);
+	});
+    });
 }
 
 SeaStore::omap_get_values_ret_t SeaStore::omap_list(
@@ -815,28 +827,32 @@ SeaStore::_omap_set_kvs(
   std::map<std::string, ceph::bufferlist>&& kvs)
 {
   return seastar::do_with(
-    BtreeOMapManager(*transaction_manager),
+    BtreeOMapManager(transaction_manager->get_tm()),
     omap_root.get(),
-    [&t, keys=std::move(kvs)](auto &omap_manager, auto &root) {
-    tm_ertr::future<> maybe_create_root =
-      !root.is_null() ?
-      tm_ertr::now() :
-      omap_manager.initialize_omap(t)
-      .safe_then([&root](auto new_root) {
-	root = new_root;
-      });
-
-    return maybe_create_root.safe_then(
-      [&, keys=std::move(keys)]() mutable {
-      return omap_manager.omap_set_keys(root, t, std::move(keys));
-    }).safe_then([&] {
-      return tm_ertr::make_ready_future<omap_root_t>(std::move(root));
+    [&, keys=std::move(kvs)](auto &omap_manager, auto &root) {
+      return with_trans_intr(
+	t,
+	[&](auto &t) {
+	  tm_iertr::future<> maybe_create_root =
+	    !root.is_null() ?
+	    tm_iertr::now() :
+	    omap_manager.initialize_omap(
+	      t
+	    ).si_then([&root](auto new_root) {
+	      root = new_root;
+	    });
+	  return maybe_create_root.si_then(
+	    [&, keys=std::move(keys)]() mutable {
+	      return omap_manager.omap_set_keys(root, t, std::move(keys));
+	    }).si_then([&] {
+	      return tm_iertr::make_ready_future<omap_root_t>(std::move(root));
+	    }).si_then([&mutable_omap_root](auto root) {
+	      if (root.must_update()) {
+		mutable_omap_root.update(root);
+	      }
+	    });
+	});
     });
-  }).safe_then([&mutable_omap_root](auto root) {
-    if (root.must_update()) {
-      mutable_omap_root.update(root);
-    }
-  });
 }
 
 SeaStore::tm_ret SeaStore::_omap_set_values(
@@ -876,26 +892,30 @@ SeaStore::tm_ret SeaStore::_omap_rmkeys(
     return seastar::now();
   } else {
     return seastar::do_with(
-      BtreeOMapManager(*transaction_manager),
+      BtreeOMapManager(transaction_manager->get_tm()),
       onode->get_layout().omap_root.get(),
       std::move(keys),
       [&ctx, &onode](
 	auto &omap_manager,
 	auto &omap_root,
 	auto &keys) {
-	return crimson::do_for_each(
-	  keys.begin(),
-	  keys.end(),
-	  [&](auto &p) {
-	    return omap_manager.omap_rm_key(
-	      omap_root,
-	      *ctx.transaction,
-	      p);
-	  }).safe_then([&] {
-	    if (omap_root.must_update()) {
-	      onode->get_mutable_layout(*ctx.transaction
-	      ).omap_root.update(omap_root);
-	    }
+	return with_trans_intr(
+	  *ctx.transaction,
+	  [&](auto &t) {
+	    return trans_intr::do_for_each(
+	      keys.begin(),
+	      keys.end(),
+	      [&](auto &p) {
+		return omap_manager.omap_rm_key(
+		  omap_root,
+		  *ctx.transaction,
+		  p);
+	      }).si_then([&] {
+		if (omap_root.must_update()) {
+		  onode->get_mutable_layout(*ctx.transaction
+		  ).omap_root.update(omap_root);
+		}
+	      });
 	  });
       });
   }

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -212,7 +212,7 @@ private:
       });
   }
 
-  using _omap_get_value_ertr = OMapManager::base_ertr::extend<
+  using _omap_get_value_ertr = with_trans_ertr<OMapManager::base_iertr>::extend<
     crimson::ct_error::enodata
     >;
   using _omap_get_value_ret = _omap_get_value_ertr::future<ceph::bufferlist>;
@@ -221,7 +221,7 @@ private:
     omap_root_t &&root,
     std::string_view key) const;
 
-  using _omap_get_values_ertr = OMapManager::base_ertr;
+  using _omap_get_values_ertr = with_trans_ertr<OMapManager::base_iertr>;
   using _omap_get_values_ret = _omap_get_values_ertr::future<omap_values_t>;
   _omap_get_values_ret _omap_get_values(
     Transaction &t,
@@ -229,7 +229,8 @@ private:
     const omap_keys_t &keys) const;
 
   using _omap_list_bare_ret = OMapManager::omap_list_bare_ret;
-  using _omap_list_ret = OMapManager::omap_list_ret;
+  using _omap_list_ret =
+    _omap_get_values_ertr::future<OMapManager::omap_list_bare_ret>;
   _omap_list_ret _omap_list(
     const omap_root_le_t& omap_root,
     Transaction& t,
@@ -248,7 +249,8 @@ private:
   CollectionManagerRef collection_manager;
   OnodeManagerRef onode_manager;
 
-  using tm_ertr = with_trans_ertr<TransactionManager::base_iertr>;
+  using tm_iertr = TransactionManager::base_iertr;
+  using tm_ertr = with_trans_ertr<tm_iertr>;
   using tm_ret = tm_ertr::future<>;
   tm_ret _do_transaction_step(
     internal_context_t &ctx,

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -618,6 +618,8 @@ public:
   InterruptedTransactionManager &operator=(
     InterruptedTransactionManager &&) = default;
 
+  TransactionManager &get_tm() const { return *tm; }
+
   FORWARD(mkfs)
   FORWARD(mount)
   FORWARD(close)

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -71,7 +71,7 @@ struct fltree_onode_manager_test_t
 
   virtual void _init() final {
     TMTestState::_init();
-    manager.reset(new FLTreeOnodeManager(*tm));
+    manager.reset(new FLTreeOnodeManager(itm));
   }
 
   virtual void _destroy() final {
@@ -89,7 +89,7 @@ struct fltree_onode_manager_test_t
 	  [this](auto &t) {
 	    return manager->mkfs(*t
 	    ).safe_then([this, &t] {
-	      return tm->submit_transaction(*t);
+	      return submit_transaction_fut(*t);
 	    });
 	  });
       }).safe_then([this] {

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1528,7 +1528,7 @@ TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
         {8, 11,  64, 256, 301, 320},
         {8, 16, 128, 512, 576, 640},
         {0, 16}, {0, 10}, {0, 4});
-    auto moved_nm = (TEST_SEASTORE ? NodeExtentManager::create_seastore(*tm)
+    auto moved_nm = (TEST_SEASTORE ? NodeExtentManager::create_seastore(itm)
                                    : NodeExtentManager::create_dummy(IS_DUMMY_SYNC));
     auto p_nm = moved_nm.get();
     auto tree = std::make_unique<TreeBuilder<TRACK_CURSORS, BoundedValue>>(
@@ -1554,7 +1554,7 @@ TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
     if constexpr (TEST_SEASTORE) {
       logger().info("seastore replay insert begin");
       restart();
-      tree->reload(NodeExtentManager::create_seastore(*tm));
+      tree->reload(NodeExtentManager::create_seastore(itm));
       logger().info("seastore replay insert end");
     }
     {
@@ -1577,7 +1577,7 @@ TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
     if constexpr (TEST_SEASTORE) {
       logger().info("seastore replay erase-1 begin");
       restart();
-      tree->reload(NodeExtentManager::create_seastore(*tm));
+      tree->reload(NodeExtentManager::create_seastore(itm));
       logger().info("seastore replay erase-1 end");
     }
     {
@@ -1599,7 +1599,7 @@ TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
     if constexpr (TEST_SEASTORE) {
       logger().info("seastore replay erase-2 begin");
       restart();
-      tree->reload(NodeExtentManager::create_seastore(*tm));
+      tree->reload(NodeExtentManager::create_seastore(itm));
       logger().info("seastore replay erase-2 end");
     }
     {
@@ -1627,7 +1627,7 @@ TEST_F(d_seastore_tm_test_t, 7_tree_insert_erase_eagain)
         {8, 16, 128, 576,  992, 1200},
         {0, 8}, {0, 10}, {0, 4});
     auto moved_nm = NodeExtentManager::create_seastore(
-        *tm, L_ADDR_MIN, EAGAIN_PROBABILITY);
+        itm, L_ADDR_MIN, EAGAIN_PROBABILITY);
     auto p_nm = static_cast<SeastoreNodeExtentManager<true>*>(moved_nm.get());
     auto tree = std::make_unique<TreeBuilder<TRACK_CURSORS, ExtendedValue>>(
         kvs, std::move(moved_nm));
@@ -1643,7 +1643,7 @@ TEST_F(d_seastore_tm_test_t, 7_tree_insert_erase_eagain)
 	[this, &tree](auto &t) {
 	  return tree->bootstrap(*t
 	  ).safe_then([this, &t] {
-	    return tm->submit_transaction(*t);
+	    return submit_transaction_fut(*t);
 	  });
 	});
     }).unsafe_get0();
@@ -1663,7 +1663,7 @@ TEST_F(d_seastore_tm_test_t, 7_tree_insert_erase_eagain)
 	      return tree->insert_one(*t, iter
 	      ).safe_then([this, &t](auto cursor) {
 		cursor.invalidate();
-		return tm->submit_transaction(*t);
+		return submit_transaction_fut(*t);
 	      });
 	    });
         }).unsafe_get0();
@@ -1709,7 +1709,7 @@ TEST_F(d_seastore_tm_test_t, 7_tree_insert_erase_eagain)
 	    [this, &tree, &iter](auto &t) {
 	      return tree->erase_one(*t, iter
 	      ).safe_then([this, &t] () mutable {
-		return tm->submit_transaction(*t);
+		return submit_transaction_fut(*t);
 	      });
 	    });
         }).unsafe_get0();

--- a/src/test/crimson/seastore/test_collection_manager.cc
+++ b/src/test/crimson/seastore/test_collection_manager.cc
@@ -23,6 +23,21 @@ namespace {
 }
 
 
+#define TEST_COLL_FORWARD(METHOD)					\
+  template <typename... Args>				\
+  auto METHOD(coll_root_t &root, Transaction &t, Args&&... args) const { \
+    return with_trans_intr(						\
+    t,									\
+    [this](auto &t, auto &root, auto&&... args) {			\
+      return collection_manager->METHOD(				\
+        root,								\
+        t,								\
+        std::forward<decltype(args)>(args)...);				\
+      },								\
+      root,								\
+      std::forward<Args>(args)...).unsafe_get0();			\
+  }
+
 struct collection_manager_test_t :
   public seastar_test_suite_t,
   TMTestState {
@@ -55,8 +70,24 @@ struct collection_manager_test_t :
     logger().debug("{}: end", __func__);
   }
 
+  auto get_root() {
+    auto tref = tm->create_transaction();
+    auto coll_root = with_trans_intr(
+      *tref,
+      [this](auto &t) {
+	return collection_manager->mkfs(t);
+      }).unsafe_get0();
+    submit_transaction(std::move(tref));
+    return coll_root;
+  }
+
+  TEST_COLL_FORWARD(remove)
+  TEST_COLL_FORWARD(list)
+  TEST_COLL_FORWARD(create)
+  TEST_COLL_FORWARD(update)
+
   void checking_mappings(coll_root_t &coll_root, Transaction &t) {
-    auto coll_list = collection_manager->list(coll_root, t).unsafe_get0();
+    auto coll_list = list(coll_root, t);
     EXPECT_EQ(test_coll_mappings.size(), coll_list.size());
     for (std::pair<coll_t, coll_info_t> p : test_coll_mappings) {
       EXPECT_NE(
@@ -74,17 +105,12 @@ struct collection_manager_test_t :
 TEST_F(collection_manager_test_t, basic)
 {
   run_async([this] {
-    coll_root_t coll_root;
-    {
-      auto t = tm->create_transaction();
-      coll_root = collection_manager->mkfs(*t).unsafe_get0();
-      submit_transaction(std::move(t));
-    }
+    coll_root_t coll_root = get_root();
     {
       auto t = tm->create_transaction();
       for (int i = 0; i < 20; i++) {
         coll_t cid(spg_t(pg_t(i+1,i+2), shard_id_t::NO_SHARD));
-        collection_manager->create(coll_root, *t, cid, coll_info_t(i)).unsafe_get0();
+        create(coll_root, *t, cid, coll_info_t(i));
         test_coll_mappings.emplace(cid, coll_info_t(i));
       }
       checking_mappings(coll_root, *t);
@@ -97,7 +123,7 @@ TEST_F(collection_manager_test_t, basic)
     {
       auto t = tm->create_transaction();
       for (auto& ite : test_coll_mappings) {
-        collection_manager->remove(coll_root, *t, ite.first).unsafe_get0();
+        remove(coll_root, *t, ite.first);
         test_coll_mappings.erase(ite.first);
       }
       submit_transaction(std::move(t));
@@ -105,7 +131,7 @@ TEST_F(collection_manager_test_t, basic)
     replay();
     {
       auto t = tm->create_transaction();
-      auto list_ret = collection_manager->list(coll_root, *t).unsafe_get0();
+      auto list_ret = list(coll_root, *t);
       submit_transaction(std::move(t));
       EXPECT_EQ(list_ret.size(), test_coll_mappings.size());
     }
@@ -115,18 +141,13 @@ TEST_F(collection_manager_test_t, basic)
 TEST_F(collection_manager_test_t, overflow)
 {
   run_async([this] {
-    coll_root_t coll_root;
-    {
-      auto t = tm->create_transaction();
-      coll_root = collection_manager->mkfs(*t).unsafe_get0();
-      submit_transaction(std::move(t));
-    }
+    coll_root_t coll_root = get_root();
     auto old_location = coll_root.get_location();
 
     auto t = tm->create_transaction();
     for (int i = 0; i < 412; i++) {
       coll_t cid(spg_t(pg_t(i+1,i+2), shard_id_t::NO_SHARD));
-      collection_manager->create(coll_root, *t, cid, coll_info_t(i)).unsafe_get0();
+      create(coll_root, *t, cid, coll_info_t(i));
       test_coll_mappings.emplace(cid, coll_info_t(i));
     }
     submit_transaction(std::move(t));
@@ -141,17 +162,12 @@ TEST_F(collection_manager_test_t, overflow)
 TEST_F(collection_manager_test_t, update)
 {
   run_async([this] {
-    coll_root_t coll_root;
-    {
-      auto t = tm->create_transaction();
-      coll_root = collection_manager->mkfs(*t).unsafe_get0();
-      submit_transaction(std::move(t));
-    }
+    coll_root_t coll_root = get_root();
     {
       auto t = tm->create_transaction();
       for (int i = 0; i < 2; i++) {
         coll_t cid(spg_t(pg_t(1,i+1), shard_id_t::NO_SHARD));
-        collection_manager->create(coll_root, *t, cid, coll_info_t(i)).unsafe_get0();
+	create(coll_root, *t, cid, coll_info_t(i));
         test_coll_mappings.emplace(cid, coll_info_t(i));
       }
       submit_transaction(std::move(t));
@@ -161,7 +177,7 @@ TEST_F(collection_manager_test_t, update)
        auto iter2 = std::next(test_coll_mappings.begin(), 1);
        EXPECT_NE(iter1->second.split_bits, iter2->second.split_bits);
        auto t = tm->create_transaction();
-       collection_manager->update(coll_root, *t, iter1->first, iter2->second).unsafe_get0();
+       update(coll_root, *t, iter1->first, iter2->second);
        submit_transaction(std::move(t));
        iter1->second.split_bits = iter2->second.split_bits;
     }

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -43,13 +43,6 @@ struct object_data_handler_test_t:
 
   object_data_handler_test_t() {}
 
-  auto submit_transaction(TransactionRef &&t) {
-    return tm->submit_transaction(*t
-    ).safe_then([this] {
-      return segment_cleaner->run_until_halt();
-    });
-  }
-
   void write(Transaction &t, objaddr_t offset, extent_len_t len, char fill) {
     ceph_assert(offset + len <= known_contents.length());
     size = std::max<extent_len_t>(size, offset + len);
@@ -65,7 +58,7 @@ struct object_data_handler_test_t:
 	len));
     return ObjectDataHandler().write(
       ObjectDataHandler::context_t{
-	*tm,
+	itm,
 	t,
 	*onode,
       },
@@ -75,7 +68,7 @@ struct object_data_handler_test_t:
   void write(objaddr_t offset, extent_len_t len, char fill) {
     auto t = tm->create_transaction();
     write(*t, offset, len, fill);
-    return submit_transaction(std::move(t)).unsafe_get0();
+    return submit_transaction(std::move(t));
   }
 
   void truncate(Transaction &t, objaddr_t offset) {
@@ -86,7 +79,7 @@ struct object_data_handler_test_t:
 	size - offset);
       ObjectDataHandler().truncate(
 	ObjectDataHandler::context_t{
-	  *tm,
+	  itm,
 	  t,
 	  *onode
 	},
@@ -97,13 +90,13 @@ struct object_data_handler_test_t:
   void truncate(objaddr_t offset) {
     auto t = tm->create_transaction();
     truncate(*t, offset);
-    return submit_transaction(std::move(t)).unsafe_get0();
+    return submit_transaction(std::move(t));
   }
 
   void read(Transaction &t, objaddr_t offset, extent_len_t len) {
     bufferlist bl = ObjectDataHandler().read(
       ObjectDataHandler::context_t{
-	*tm,
+	itm,
 	t,
 	*onode
       },

--- a/src/test/crimson/seastore/test_omap_manager.cc
+++ b/src/test/crimson/seastore/test_omap_manager.cc
@@ -55,7 +55,7 @@ struct omap_manager_test_t :
 
   seastar::future<> set_up_fut() final {
     return tm_setup().then([this] {
-      omap_manager = omap_manager::create_omap_manager(*tm);
+      omap_manager = omap_manager::create_omap_manager(itm);
       return seastar::now();
     });
   }
@@ -190,7 +190,7 @@ struct omap_manager_test_t :
   void replay() {
     logger().debug("{}: begin", __func__);
     restart();
-    omap_manager = omap_manager::create_omap_manager(*tm);
+    omap_manager = omap_manager::create_omap_manager(itm);
     logger().debug("{}: end", __func__);
   }
 };

--- a/src/test/crimson/seastore/test_omap_manager.cc
+++ b/src/test/crimson/seastore/test_omap_manager.cc
@@ -55,7 +55,7 @@ struct omap_manager_test_t :
 
   seastar::future<> set_up_fut() final {
     return tm_setup().then([this] {
-      omap_manager = omap_manager::create_omap_manager(itm);
+      omap_manager = omap_manager::create_omap_manager(*tm);
       return seastar::now();
     });
   }
@@ -75,7 +75,11 @@ struct omap_manager_test_t :
     Transaction &t,
     const string &key,
     const bufferlist &val) {
-    omap_manager->omap_set_key(omap_root, t, key, val).unsafe_get0();
+    with_trans_intr(
+      t,
+      [&, this](auto &t) {
+	return omap_manager->omap_set_key(omap_root, t, key, val);
+      }).unsafe_get0();
     test_omap_mappings[key] = val;
   }
 
@@ -105,7 +109,11 @@ struct omap_manager_test_t :
     omap_root_t &omap_root,
     Transaction &t,
     const string &key) {
-    auto ret = omap_manager->omap_get_value(omap_root, t, key).unsafe_get0();
+    auto ret = with_trans_intr(
+      t,
+      [&, this](auto &t) {
+	return omap_manager->omap_get_value(omap_root, t, key);
+      }).unsafe_get0();
     auto iter = test_omap_mappings.find(key);
     if (iter == test_omap_mappings.end()) {
       EXPECT_FALSE(ret);
@@ -121,7 +129,11 @@ struct omap_manager_test_t :
     omap_root_t &omap_root,
     Transaction &t,
     const string &key) {
-    omap_manager->omap_rm_key(omap_root, t, key).unsafe_get0();
+    with_trans_intr(
+      t,
+      [&, this](auto &t) {
+	return omap_manager->omap_rm_key(omap_root, t, key);
+      }).unsafe_get0();
     test_omap_mappings.erase(test_omap_mappings.find(key));
   }
 
@@ -139,9 +151,12 @@ struct omap_manager_test_t :
 
     auto config = OMapManager::omap_list_config_t::with_max(max);
     config.max_result_size = max;
-    auto [complete, results] = omap_manager->omap_list(
-      omap_root, t, start, config
-    ).unsafe_get0();
+
+    auto [complete, results] = with_trans_intr(
+      t,
+      [&, this](auto &t) {
+	return omap_manager->omap_list(omap_root, t, start, config);
+      }).unsafe_get0();
 
     auto it = start ?
       test_omap_mappings.upper_bound(*start) :
@@ -164,7 +179,11 @@ struct omap_manager_test_t :
   void clear(
     omap_root_t &omap_root,
     Transaction &t) {
-    omap_manager->omap_clear(omap_root, t).unsafe_get0();
+    with_trans_intr(
+      t,
+      [&, this](auto &t) {
+	return omap_manager->omap_clear(omap_root, t);
+      }).unsafe_get0();
     EXPECT_EQ(omap_root.get_location(), L_ADDR_NULL);
   }
 
@@ -187,23 +206,30 @@ struct omap_manager_test_t :
     }
     return mkeys;
   }
+
   void replay() {
     logger().debug("{}: begin", __func__);
     restart();
-    omap_manager = omap_manager::create_omap_manager(itm);
+    omap_manager = omap_manager::create_omap_manager(*tm);
     logger().debug("{}: end", __func__);
+  }
+
+  auto initialize() {
+    auto t = tm->create_transaction();
+    omap_root_t omap_root = with_trans_intr(
+      *t,
+      [this](auto &t) {
+	return omap_manager->initialize_omap(t);
+      }).unsafe_get0();
+    submit_transaction(std::move(t));
+    return omap_root;
   }
 };
 
 TEST_F(omap_manager_test_t, basic)
 {
   run_async([this] {
-    omap_root_t omap_root(L_ADDR_NULL, 0);
-    {
-      auto t = tm->create_transaction();
-      omap_root = omap_manager->initialize_omap(*t).unsafe_get0();
-      submit_transaction(std::move(t));
-    }
+    omap_root_t omap_root = initialize();
 
     string key = "owner";
     string val = "test";
@@ -235,12 +261,8 @@ TEST_F(omap_manager_test_t, basic)
 TEST_F(omap_manager_test_t, force_leafnode_split)
 {
   run_async([this] {
-    omap_root_t omap_root(L_ADDR_NULL, 0);
-    {
-      auto t = tm->create_transaction();
-      omap_root = omap_manager->initialize_omap(*t).unsafe_get0();
-      submit_transaction(std::move(t));
-    }
+    omap_root_t omap_root = initialize();
+
     for (unsigned i = 0; i < 40; i++) {
       auto t = tm->create_transaction();
       logger().debug("opened transaction");
@@ -260,12 +282,7 @@ TEST_F(omap_manager_test_t, force_leafnode_split)
 TEST_F(omap_manager_test_t, force_leafnode_split_merge)
 {
   run_async([this] {
-    omap_root_t omap_root(L_ADDR_NULL, 0);
-    {
-      auto t = tm->create_transaction();
-      omap_root = omap_manager->initialize_omap(*t).unsafe_get0();
-      submit_transaction(std::move(t));
-    }
+    omap_root_t omap_root = initialize();
 
     for (unsigned i = 0; i < 80; i++) {
       auto t = tm->create_transaction();
@@ -308,12 +325,7 @@ TEST_F(omap_manager_test_t, force_leafnode_split_merge)
 TEST_F(omap_manager_test_t, force_leafnode_split_merge_fullandbalanced)
 {
   run_async([this] {
-    omap_root_t omap_root(L_ADDR_NULL, 0);
-    {
-      auto t = tm->create_transaction();
-      omap_root = omap_manager->initialize_omap(*t).unsafe_get0();
-      submit_transaction(std::move(t));
-    }
+    omap_root_t omap_root = initialize();
 
     for (unsigned i = 0; i < 50; i++) {
       auto t = tm->create_transaction();
@@ -359,12 +371,8 @@ TEST_F(omap_manager_test_t, force_leafnode_split_merge_fullandbalanced)
 TEST_F(omap_manager_test_t, force_split_listkeys_list_clear)
 {
   run_async([this] {
-    omap_root_t omap_root(L_ADDR_NULL, 0);
-    {
-      auto t = tm->create_transaction();
-      omap_root = omap_manager->initialize_omap(*t).unsafe_get0();
-      submit_transaction(std::move(t));
-    }
+    omap_root_t omap_root = initialize();
+
     string temp;
     for (unsigned i = 0; i < 40; i++) {
       auto t = tm->create_transaction();
@@ -403,12 +411,8 @@ TEST_F(omap_manager_test_t, force_split_listkeys_list_clear)
 TEST_F(omap_manager_test_t, internal_force_split)
 {
   run_async([this] {
-    omap_root_t omap_root(L_ADDR_NULL, 0);
-    {
-      auto t = tm->create_transaction();
-      omap_root = omap_manager->initialize_omap(*t).unsafe_get0();
-      submit_transaction(std::move(t));
-    }
+    omap_root_t omap_root = initialize();
+
     for (unsigned i = 0; i < 10; i++) {
       logger().debug("opened split transaction");
       auto t = tm->create_transaction();
@@ -429,12 +433,7 @@ TEST_F(omap_manager_test_t, internal_force_split)
 TEST_F(omap_manager_test_t, internal_force_merge_fullandbalanced)
 {
   run_async([this] {
-    omap_root_t omap_root(L_ADDR_NULL, 0);
-    {
-      auto t = tm->create_transaction();
-      omap_root = omap_manager->initialize_omap(*t).unsafe_get0();
-      submit_transaction(std::move(t));
-    }
+    omap_root_t omap_root = initialize();
 
     for (unsigned i = 0; i < 8; i++) {
       logger().debug("opened split transaction");
@@ -474,13 +473,7 @@ TEST_F(omap_manager_test_t, internal_force_merge_fullandbalanced)
 TEST_F(omap_manager_test_t, replay)
 {
   run_async([this] {
-    omap_root_t omap_root(L_ADDR_NULL, 0);
-    {
-      auto t = tm->create_transaction();
-      omap_root = omap_manager->initialize_omap(*t).unsafe_get0();
-      submit_transaction(std::move(t));
-      replay();
-    }
+    omap_root_t omap_root = initialize();
 
     for (unsigned i = 0; i < 8; i++) {
       logger().debug("opened split transaction");
@@ -527,12 +520,7 @@ TEST_F(omap_manager_test_t, replay)
 TEST_F(omap_manager_test_t, internal_force_split_to_root)
 {
   run_async([this] {
-    omap_root_t omap_root(L_ADDR_NULL, 0);
-    {
-      auto t = tm->create_transaction();
-      omap_root = omap_manager->initialize_omap(*t).unsafe_get0();
-      submit_transaction(std::move(t));
-    }
+    omap_root_t omap_root = initialize();
 
     logger().debug("set big keys");
     for (unsigned i = 0; i < 53; i++) {

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -100,7 +100,8 @@ auto get_seastore(SegmentManagerRef sm) {
 
 class TMTestState : public EphemeralTestState {
 protected:
-  InterruptedTMRef tm;
+  TransactionManagerRef tm;
+  InterruptedTransactionManager itm;
   LBAManager *lba_manager;
   SegmentCleaner *segment_cleaner;
 
@@ -108,6 +109,7 @@ protected:
 
   virtual void _init() {
     tm = get_transaction_manager(*segment_manager);
+    itm = InterruptedTransactionManager(*tm);
     segment_cleaner = tm->get_segment_cleaner();
     lba_manager = tm->get_lba_manager();
   }
@@ -115,6 +117,7 @@ protected:
   virtual void _destroy() {
     segment_cleaner = nullptr;
     lba_manager = nullptr;
+    itm.reset();
     tm.reset();
   }
 
@@ -145,8 +148,16 @@ protected:
     );
   }
 
+  auto submit_transaction_fut(Transaction &t) {
+    return with_trans_intr(
+      t,
+      [this](auto &t) {
+	return tm->submit_transaction(t);
+      });
+  }
+
   void submit_transaction(TransactionRef t) {
-    tm->submit_transaction(*t).unsafe_get0();
+    submit_transaction_fut(*t).unsafe_get0();
     segment_cleaner->run_until_halt().get0();
   }
 };


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
