### PR TITLE
librbd/cache/pwl: avoid stack overflow caused by nested shared_ptr destruction

### DIFF
--- a/src/librbd/cache/pwl/LogOperation.cc
+++ b/src/librbd/cache/pwl/LogOperation.cc
@@ -70,9 +70,10 @@ std::vector<Context*> SyncPointLogOperation::append_sync_point() {
 void SyncPointLogOperation::clear_earlier_sync_point() {
   std::lock_guard locker(m_lock);
   ceph_assert(sync_point->later_sync_point);
-  ceph_assert(sync_point->later_sync_point->earlier_sync_point ==
-              sync_point);
+  ceph_assert(sync_point->later_sync_point->earlier_sync_point == sync_point);
   sync_point->later_sync_point->earlier_sync_point = nullptr;
+  sync_point->later_sync_point = nullptr;
+  sync_point->log_entry->next_sync_point_entry = nullptr;
 }
 
 std::vector<Context*> SyncPointLogOperation::swap_on_sync_point_persisted() {


### PR DESCRIPTION
Destruction of nested `shared_ptr` will cause stack overflow.
With the explicit assignment to `nullptr`, the deleted node
is completely disconnected from the current linked list

Fixes: https://tracker.ceph.com/issues/51418

Signed-off-by: Hualong Feng <hualong.feng@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
