### PR TITLE
crimson/seastore: fix lba add_pin impossible assert

### DIFF
--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.h
@@ -275,6 +275,15 @@ struct LBAInternalNode
     return std::make_pair(retl, retr);
   }
 
+  internal_iterator_t right_end(laddr_t r){
+    auto retr = begin();
+    for (; retr != end(); ++retr) {
+      if (retr->get_key() >= r)
+        break;
+    }
+    return retr;
+  }
+
   using split_iertr = base_iertr;
   using split_ret = split_iertr::future<LBANodeRef>;
   split_ret split_entry(


### PR DESCRIPTION
when lba internal node find hole, it got the ub=L_ADDR_MAX when iter is the last one.
but before search child node, the node do split and child node split into two.
so child node find hole get laddr equal to next child first laddr, and it got an
existing laddr, there are two alloc extents got the same exiting laddr, when do
add_pin, two extents have same begin and end meta. so confilict

so need check the gotten laddr != meta.end, means it is not the next child begin.
and repeate  [begin, end] =  bound(min, max), to update end iter when split happend.

Fixes: https://tracker.ceph.com/issues/51436
Signed-off-by: chunmei-liu <chunmei.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
