### PR TITLE
rgw: cls_bucket_list_unordered() might return one redundent entry every time is_truncated is true

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8713,21 +8713,19 @@ int RGWRados::cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
     } else {
       // so now we have the key used to compute the bucket index shard
       // and can extract the specific shard from it
+      string index_hash_source = obj_key.name;
       if (obj_key.ns == RGW_OBJ_NS_MULTIPART) {
         // Use obj_key.ns == RGW_OBJ_NS_MULTIPART instead of
         // the implementation relying on MultipartMetaFilter
         // because MultipartMetaFilter only checks .meta suffix, which may
         // exclude data multiparts but include some regular objects with .meta suffix
         // by mistake.
-        string index_hash_source;
         r = parse_index_hash_source(obj_key.name, &index_hash_source);
         if (r < 0) {
           return r;
         }
-        current_shard = svc.bi_rados->bucket_shard_index(index_hash_source, num_shards);
-      } else {
-        current_shard = svc.bi_rados->bucket_shard_index(obj_key.name, num_shards);
-      }
+      } 
+      current_shard = svc.bi_rados->bucket_shard_index(index_hash_source, num_shards);
     }
   }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8780,6 +8780,7 @@ int RGWRados::cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
 	  ent_list.emplace_back(std::move(dirent));
 	  ++count;
 	} else {
+	  last_added_entry = dirent.key;
 	  *is_truncated = true;
 	  goto check_updates;
 	}


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

cls_bucket_list_unordered() might return one redundent entry, which is returned last loop when number of incomplete multipart upload in index shards exceeds 1100. This is because when count == num_entries, last_added_entries is not updated. This is really easy to reproduce. And it could be observed in rgw's log that start_after entry for next loop is not the last entry returned last loop. Although this is not fatal but it still turns out that the code is not working as expected.

Fixes: https://tracker.ceph.com/issues/51466
Signed-off-by: Peng Zhang <zhangpeng@vclusters.com>
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
