### PR TITLE
common/options: Set osd_client_message_cap to 256.

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -629,7 +629,7 @@ options:
   type: uint
   level: advanced
   desc: maximum number of in-flight client requests
-  default: 0
+  default: 256
   with_legacy: true
 - name: osd_crush_update_on_start
   type: bool


### PR DESCRIPTION
This seems like a reasonable default value based on testing results here:

https://docs.google.com/spreadsheets/d/1dwKcxFKpAOWzDPekgojrJhfiCtPgiIf8CGGMG1rboRU/edit?usp=sharing

Eventually we may want to rethink how the throttles and even how flow control works, but this at least gives us some basic limits now ( a little higher than the old value of 100 that we used for many years).

Signed-off-by: Mark Nelson <mnelson@redhat.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
