### PR TITLE
pacific: qa: FileNotFoundError: [Errno 2] No such file or directory: '/sys/kernel/debug/ceph/3fab6bea-f243-47a4-a956-8c03a62b61b5.client4721/mds_sessions'

### DIFF
--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -135,9 +135,11 @@ class TestClientRecovery(CephFSTestCase):
         # =================
         # Check that if I stop an MDS and a client goes away, the MDS waits
         # for the reconnect period
-        self.fs.fail()
 
         mount_a_client_id = self.mount_a.get_global_id()
+
+        self.fs.fail()
+
         self.mount_a.umount_wait(force=True)
 
         self.fs.set_joinable()


### PR DESCRIPTION
https://tracker.ceph.com/issues/51500