### PR TITLE
mgr/dashboard: Routable Modal for Add Host Form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
@@ -2,7 +2,7 @@ import { PageHelper } from '../page-helper.po';
 
 const pages = {
   index: { url: '#/hosts', id: 'cd-hosts' },
-  create: { url: '#/hosts/create', id: 'cd-host-form' }
+  add: { url: '#/hosts/(modal:add)', id: 'cd-host-form' }
 };
 
 export class HostsPageHelper extends PageHelper {
@@ -49,21 +49,20 @@ export class HostsPageHelper extends PageHelper {
     });
   }
 
-  @PageHelper.restrictTo(pages.create.url)
+  @PageHelper.restrictTo(pages.add.url)
   add(hostname: string, exist?: boolean, maintenance?: boolean) {
-    cy.get(`${this.pages.create.id}`).within(() => {
+    cy.get(`${this.pages.add.id}`).within(() => {
       cy.get('#hostname').type(hostname);
       if (maintenance) {
         cy.get('label[for=maintenance]').click();
       }
+      if (exist) {
+        cy.get('#hostname').should('have.class', 'ng-invalid');
+      }
       cy.get('cd-submit-button').click();
     });
-    if (exist) {
-      cy.get('#hostname').should('have.class', 'ng-invalid');
-    } else {
-      // back to host list
-      cy.get(`${this.pages.index.id}`);
-    }
+    // back to host list
+    cy.get(`${this.pages.index.id}`);
   }
 
   @PageHelper.restrictTo(pages.index.url)

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/01-hosts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/01-hosts.e2e-spec.ts
@@ -17,7 +17,7 @@ describe('Hosts page', () => {
 
     it('should not add an exsiting host', function () {
       const hostname = Cypress._.sample(this.hosts).name;
-      hosts.navigateTo('create');
+      hosts.navigateTo('add');
       hosts.add(hostname, true);
     });
 
@@ -26,7 +26,7 @@ describe('Hosts page', () => {
       hosts.delete(host);
 
       // add it back
-      hosts.navigateTo('create');
+      hosts.navigateTo('add');
       hosts.add(host);
       hosts.checkExist(host, true);
     });

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/01-hosts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/01-hosts.e2e-spec.ts
@@ -4,7 +4,7 @@ describe('Hosts page', () => {
   const hosts = new HostsPageHelper();
   const hostnames = ['ceph-node-00.cephlab.com', 'ceph-node-01.cephlab.com'];
   const addHost = (hostname: string, exist?: boolean, maintenance?: boolean) => {
-    hosts.navigateTo('create');
+    hosts.navigateTo('add');
     hosts.add(hostname, exist, maintenance);
     hosts.checkExist(hostname, true);
   };
@@ -37,7 +37,7 @@ describe('Hosts page', () => {
     });
 
     it('should not add an existing host', function () {
-      hosts.navigateTo('create');
+      hosts.navigateTo('add');
       hosts.add(hostnames[0], true);
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -105,13 +105,13 @@ const routes: Routes = [
       },
       {
         path: 'hosts',
+        component: HostsComponent,
         data: { breadcrumbs: 'Cluster/Hosts' },
         children: [
-          { path: '', component: HostsComponent },
           {
-            path: URLVerbs.CREATE,
+            path: URLVerbs.ADD,
             component: HostFormComponent,
-            data: { breadcrumbs: ActionLabels.CREATE }
+            outlet: 'modal'
           }
         ]
       },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
@@ -1,91 +1,94 @@
-<div class="cd-col-form"
-     *cdFormLoading="loading">
-  <form name="hostForm"
-        #formDir="ngForm"
-        [formGroup]="hostForm"
-        novalidate>
-    <div class="card">
-      <div i18n="form title|Example: Create Pool@@formTitle"
-           class="card-header">{{ action | titlecase }} {{ resource | upperFirst }}</div>
+<cd-modal pageURL="hosts">
+  <span class="modal-title"
+        i18n>{{ action | titlecase }} {{ resource | upperFirst }}</span>
 
-      <div class="card-body">
+  <ng-container class="modal-content">
 
-        <!-- Hostname -->
-        <div class="form-group row">
-          <label class="cd-col-form-label required"
-                 for="hostname"
-                 i18n>Hostname</label>
-          <div class="cd-col-form-input">
-            <input class="form-control"
-                   type="text"
-                   placeholder="mon-123"
-                   id="hostname"
-                   name="hostname"
-                   formControlName="hostname"
-                   autofocus>
-            <span class="invalid-feedback"
-                  *ngIf="hostForm.showError('hostname', formDir, 'required')"
-                  i18n>This field is required.</span>
-            <span class="invalid-feedback"
-                  *ngIf="hostForm.showError('hostname', formDir, 'uniqueName')"
-                  i18n>The chosen hostname is already in use.</span>
+    <div *cdFormLoading="loading">
+      <form name="hostForm"
+            #formDir="ngForm"
+            [formGroup]="hostForm"
+            novalidate>
+
+        <div class="modal-body">
+
+          <!-- Hostname -->
+          <div class="form-group row">
+            <label class="cd-col-form-label required"
+                   for="hostname"
+                   i18n>Hostname</label>
+            <div class="cd-col-form-input">
+              <input class="form-control"
+                     type="text"
+                     placeholder="mon-123"
+                     id="hostname"
+                     name="hostname"
+                     formControlName="hostname"
+                     autofocus>
+              <span class="invalid-feedback"
+                    *ngIf="hostForm.showError('hostname', formDir, 'required')"
+                    i18n>This field is required.</span>
+              <span class="invalid-feedback"
+                    *ngIf="hostForm.showError('hostname', formDir, 'uniqueName')"
+                    i18n>The chosen hostname is already in use.</span>
+            </div>
           </div>
-        </div>
 
-        <!-- Address -->
-        <div class="form-group row">
-          <label class="cd-col-form-label"
-                 for="addr"
-                 i18n>Nework address</label>
-          <div class="cd-col-form-input">
-            <input class="form-control"
-                   type="text"
-                   placeholder="192.168.0.1"
-                   id="addr"
-                   name="addr"
-                   formControlName="addr">
-            <span class="invalid-feedback"
-                  *ngIf="hostForm.showError('addr', formDir, 'pattern')"
-                  i18n>The value is not a valid IP address.</span>
+          <!-- Address -->
+          <div class="form-group row">
+            <label class="cd-col-form-label"
+                   for="addr"
+                   i18n>Nework address</label>
+            <div class="cd-col-form-input">
+              <input class="form-control"
+                     type="text"
+                     placeholder="192.168.0.1"
+                     id="addr"
+                     name="addr"
+                     formControlName="addr">
+              <span class="invalid-feedback"
+                    *ngIf="hostForm.showError('addr', formDir, 'pattern')"
+                    i18n>The value is not a valid IP address.</span>
+            </div>
           </div>
-        </div>
 
-        <!-- Labels -->
-        <div class="form-group row">
-          <label i18n
-                 for="labels"
-                 class="cd-col-form-label">Labels</label>
-          <div class="cd-col-form-input">
-            <cd-select-badges id="labels"
-                              [data]="hostForm.controls.labels.value"
-                              [customBadges]="true"
-                              [messages]="messages">
-            </cd-select-badges>
+          <!-- Labels -->
+          <div class="form-group row">
+            <label i18n
+                   for="labels"
+                   class="cd-col-form-label">Labels</label>
+            <div class="cd-col-form-input">
+              <cd-select-badges id="labels"
+                                [data]="hostForm.controls.labels.value"
+                                [customBadges]="true"
+                                [messages]="messages">
+              </cd-select-badges>
+            </div>
           </div>
-        </div>
 
-        <!-- Maintenance Mode -->
-        <div class="form-group row">
-          <div class="cd-col-form-offset">
-            <div class="custom-control custom-checkbox">
-              <input class="custom-control-input"
-                     id="maintenance"
-                     type="checkbox"
-                     formControlName="maintenance">
-              <label class="custom-control-label"
-                     for="maintenance"
-                     i18n>Maintenance Mode</label>
+          <!-- Maintenance Mode -->
+          <div class="form-group row">
+            <div class="cd-col-form-offset">
+              <div class="custom-control custom-checkbox">
+                <input class="custom-control-input"
+                       id="maintenance"
+                       type="checkbox"
+                       formControlName="maintenance">
+                <label class="custom-control-label"
+                       for="maintenance"
+                       i18n>Maintenance Mode</label>
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <div class="card-footer">
-        <cd-form-button-panel (submitActionEvent)="submit()"
-                              [form]="hostForm"
-                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                              wrappingClass="text-right"></cd-form-button-panel>
-      </div>
+        <div class="modal-footer">
+          <cd-form-button-panel (submitActionEvent)="submit()"
+                                [form]="hostForm"
+                                [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                                wrappingClass="text-right"></cd-form-button-panel>
+        </div>
+      </form>
     </div>
-  </form>
-</div>
+  </ng-container>
+</cd-modal>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
@@ -39,7 +39,7 @@ export class HostFormComponent extends CdForm implements OnInit {
   ) {
     super();
     this.resource = $localize`host`;
-    this.action = this.actionLabels.CREATE;
+    this.action = this.actionLabels.ADD;
     this.createForm();
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
@@ -66,3 +66,4 @@
   <ng-container i18n
                 *ngIf="showSubmit">Are you sure you want to continue?</ng-container>
 </ng-template>
+<router-outlet name="modal"></router-outlet>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -182,7 +182,7 @@ describe('HostsComponent', () => {
       const tests = [
         {
           expectResults: {
-            Create: { disabled: false, disableDesc: '' },
+            Add: { disabled: false, disableDesc: '' },
             Edit: { disabled: true, disableDesc: '' },
             Delete: { disabled: true, disableDesc: '' }
           }
@@ -190,7 +190,7 @@ describe('HostsComponent', () => {
         {
           selectRow: fakeHosts[0], // non-orchestrator host
           expectResults: {
-            Create: { disabled: false, disableDesc: '' },
+            Add: { disabled: false, disableDesc: '' },
             Edit: { disabled: true, disableDesc: component.messages.nonOrchHost },
             Delete: { disabled: true, disableDesc: component.messages.nonOrchHost }
           }
@@ -198,7 +198,7 @@ describe('HostsComponent', () => {
         {
           selectRow: fakeHosts[1], // orchestrator host
           expectResults: {
-            Create: { disabled: false, disableDesc: '' },
+            Add: { disabled: false, disableDesc: '' },
             Edit: { disabled: false, disableDesc: '' },
             Delete: { disabled: false, disableDesc: '' }
           }
@@ -222,7 +222,7 @@ describe('HostsComponent', () => {
       const tests = [
         {
           expectResults: {
-            Create: resultNoOrchestrator,
+            Add: resultNoOrchestrator,
             Edit: { disabled: true, disableDesc: '' },
             Delete: { disabled: true, disableDesc: '' }
           }
@@ -230,7 +230,7 @@ describe('HostsComponent', () => {
         {
           selectRow: fakeHosts[0], // non-orchestrator host
           expectResults: {
-            Create: resultNoOrchestrator,
+            Add: resultNoOrchestrator,
             Edit: { disabled: true, disableDesc: component.messages.nonOrchHost },
             Delete: { disabled: true, disableDesc: component.messages.nonOrchHost }
           }
@@ -238,7 +238,7 @@ describe('HostsComponent', () => {
         {
           selectRow: fakeHosts[1], // orchestrator host
           expectResults: {
-            Create: resultNoOrchestrator,
+            Add: resultNoOrchestrator,
             Edit: resultNoOrchestrator,
             Delete: resultNoOrchestrator
           }
@@ -255,7 +255,7 @@ describe('HostsComponent', () => {
       const tests = [
         {
           expectResults: {
-            Create: resultMissingFeatures,
+            Add: resultMissingFeatures,
             Edit: { disabled: true, disableDesc: '' },
             Delete: { disabled: true, disableDesc: '' }
           }
@@ -263,7 +263,7 @@ describe('HostsComponent', () => {
         {
           selectRow: fakeHosts[0], // non-orchestrator host
           expectResults: {
-            Create: resultMissingFeatures,
+            Add: resultMissingFeatures,
             Edit: { disabled: true, disableDesc: component.messages.nonOrchHost },
             Delete: { disabled: true, disableDesc: component.messages.nonOrchHost }
           }
@@ -271,7 +271,7 @@ describe('HostsComponent', () => {
         {
           selectRow: fakeHosts[1], // orchestrator host
           expectResults: {
-            Create: resultMissingFeatures,
+            Add: resultMissingFeatures,
             Edit: resultMissingFeatures,
             Delete: resultMissingFeatures
           }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -11,7 +11,7 @@ import { ConfirmationModalComponent } from '~/app/shared/components/confirmation
 import { CriticalConfirmationModalComponent } from '~/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
 import { FormModalComponent } from '~/app/shared/components/form-modal/form-modal.component';
 import { SelectMessages } from '~/app/shared/components/select/select-messages.model';
-import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { TableComponent } from '~/app/shared/datatable/table/table.component';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
 import { Icons } from '~/app/shared/enum/icons.enum';
@@ -67,7 +67,7 @@ export class HostsComponent extends ListWithDetails implements OnInit {
 
   orchStatus: OrchestratorStatus;
   actionOrchFeatures = {
-    create: [OrchestratorFeature.HOST_CREATE],
+    add: [OrchestratorFeature.HOST_CREATE],
     edit: [OrchestratorFeature.HOST_LABEL_ADD, OrchestratorFeature.HOST_LABEL_REMOVE],
     delete: [OrchestratorFeature.HOST_DELETE],
     maintenance: [
@@ -80,7 +80,6 @@ export class HostsComponent extends ListWithDetails implements OnInit {
     private authStorageService: AuthStorageService,
     private hostService: HostService,
     private cephShortVersionPipe: CephShortVersionPipe,
-    private urlBuilder: URLBuilderService,
     private actionLabels: ActionLabelsI18n,
     private modalService: ModalService,
     private taskWrapper: TaskWrapperService,
@@ -92,11 +91,11 @@ export class HostsComponent extends ListWithDetails implements OnInit {
     this.permissions = this.authStorageService.getPermissions();
     this.tableActions = [
       {
-        name: this.actionLabels.CREATE,
+        name: this.actionLabels.ADD,
         permission: 'create',
         icon: Icons.add,
-        click: () => this.router.navigate([this.urlBuilder.getCreate()]),
-        disable: (selection: CdTableSelection) => this.getDisable('create', selection)
+        click: () => this.router.navigate([BASE_URL, { outlets: { modal: [URLVerbs.ADD] } }]),
+        disable: (selection: CdTableSelection) => this.getDisable('add', selection)
       },
       {
         name: this.actionLabels.EDIT,
@@ -287,7 +286,7 @@ export class HostsComponent extends ListWithDetails implements OnInit {
   }
 
   getDisable(
-    action: 'create' | 'edit' | 'delete' | 'maintenance',
+    action: 'add' | 'edit' | 'delete' | 'maintenance',
     selection: CdTableSelection
   ): boolean | string {
     if (action === 'delete' || action === 'edit' || action === 'maintenance') {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.html
@@ -1,13 +1,19 @@
-<div class="modal-header">
-  <h4 class="modal-title float-left">
-    <ng-content select=".modal-title"></ng-content>
-  </h4>
-  <button type="button"
-          class="close float-right"
-          aria-label="Close"
-          (click)="close()">
-    <span aria-hidden="true">&times;</span>
-  </button>
-</div>
+<div [ngClass]="pageURL ? 'modal' : ''">
+  <div [ngClass]="pageURL ? 'modal-dialog' : ''">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title float-left">
+          <ng-content select=".modal-title"></ng-content>
+        </h4>
+        <button type="button"
+                class="close float-right"
+                aria-label="Close"
+                (click)="close()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
 
-<ng-content select=".modal-content"></ng-content>
+      <ng-content select=".modal-content"></ng-content>
+    </div>
+  </div>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
@@ -8,14 +10,18 @@ import { ModalComponent } from './modal.component';
 describe('ModalComponent', () => {
   let component: ModalComponent;
   let fixture: ComponentFixture<ModalComponent>;
+  let routerNavigateSpy: jasmine.Spy;
 
   configureTestBed({
-    declarations: [ModalComponent]
+    declarations: [ModalComponent],
+    imports: [RouterTestingModule]
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ModalComponent);
     component = fixture.componentInstance;
+    routerNavigateSpy = spyOn(TestBed.inject(Router), 'navigate');
+    routerNavigateSpy.and.returnValue(true);
     fixture.detectChanges();
   });
 
@@ -37,5 +43,12 @@ describe('ModalComponent', () => {
     spyOn(component.modalRef, 'close');
     component.close();
     expect(component.modalRef.close).toHaveBeenCalled();
+  });
+
+  it('should hide the routed modal', () => {
+    component.pageURL = 'hosts';
+    component.close();
+    expect(routerNavigateSpy).toHaveBeenCalledTimes(1);
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['hosts', { outlets: { modal: null } }]);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
@@ -10,6 +11,8 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 export class ModalComponent {
   @Input()
   modalRef: NgbActiveModal;
+  @Input()
+  pageURL: string;
 
   /**
    * Should be a function that is triggered when the modal is hidden.
@@ -17,8 +20,12 @@ export class ModalComponent {
   @Output()
   hide = new EventEmitter();
 
+  constructor(private router: Router) {}
+
   close() {
-    this.modalRef?.close();
+    this.pageURL
+      ? this.router.navigate([this.pageURL, { outlets: { modal: null } }])
+      : this.modalRef?.close();
     this.hide.emit();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_forms.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_forms.scss
@@ -53,6 +53,17 @@
 }
 
 cd-modal {
+  .modal {
+    /* stylelint-disable */
+    background-color: rgba(0, 0, 0, 0.4);
+    /* stylelint-enable */
+    display: block;
+  }
+
+  .modal-dialog {
+    max-width: 70vh;
+  }
+
   .cd-col-form-label {
     @extend .col-lg-4;
   }


### PR DESCRIPTION
- Used routed modal for host Additon form
- Renamed the Create to Add in Host Form

![host-add](https://user-images.githubusercontent.com/71764184/124423566-09373780-dd83-11eb-9aa7-f11036415a2f.png)

Fixes: https://tracker.ceph.com/issues/51517
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
