### PR TITLE
rgw: remove the three-character limit when creating a container with swift interface

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2856,10 +2856,6 @@ int RGWHandler_REST_SWIFT::validate_bucket_name(const string& bucket)
     return -ERR_INVALID_BUCKET_NAME;
   }
 
-  const auto ret = RGWHandler_REST::validate_bucket_name(bucket);
-  if (ret < 0) {
-    return ret;
-  }
 
   if (len == 0)
     return 0;


### PR DESCRIPTION
rgw: remove the three-character limit when creating a container with swift interface

According to the swift interface documentation, the length of the container name must be 1 to 256 characters

Fixes: https://tracker.ceph.com/issues/51534

Signed-off-by: wangtengfei <wangtengfei@inspur.com>
