### PR TITLE
crimson/os/seastore: fix lambda capture issue in Journal::scan_extents()

### DIFF
--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -655,11 +655,11 @@ Journal::scan_extents_ret Journal::scan_extents(
     crimson::ct_error::assert_all{
       "Invalid error in Journal::scan_extents"
     }
-  ).safe_then([&](auto segment_header) {
+  ).safe_then([&, bytes_to_read](auto segment_header) {
     auto segment_nonce = segment_header.segment_nonce;
     return seastar::do_with(
       found_record_handler_t(
-	[&](
+	[&, bytes_to_read](
 	  paddr_t base,
 	  const record_header_t &header,
 	  const bufferlist &mdbuf) mutable {


### PR DESCRIPTION
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
