### PR TITLE
crimson/os/seastore: use discard_result() to discard futurized value

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -372,7 +372,7 @@ private:
     // any `seastar::futurize` specialization must be able to access the base.
     // see : `satisfy_with_result_of()` far below.
     template <typename>
-    friend class seastar::futurize;
+    friend struct seastar::futurize;
 
     template <typename T1, typename T2, typename... More>
     friend auto seastar::internal::do_with_impl(T1&& rv1, T2&& rv2, More&&... more);

--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -641,6 +641,11 @@ private:
       });
     }
 
+    _future<::crimson::errorated_future_marker<void>>
+    discard_result() noexcept {
+      return safe_then([](auto&&) {});
+    }
+
     // taking ErrorFuncOne and ErrorFuncTwo separately from ErrorFuncTail
     // to avoid SFINAE
     template <class ValueFunc,

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -687,7 +687,7 @@ Journal::scan_extents_ret Journal::scan_extents(
 	  cursor,
 	  segment_nonce,
 	  bytes_to_read,
-	  dhandler).safe_then([](auto){});
+	  dhandler).discard_result();
       });
   }).safe_then([ret=std::move(ret)] {
     return std::move(*ret);


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
