### PR TITLE
rgw: remove unused store variable

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5630,7 +5630,6 @@ int RGWRados::Object::Stat::finish(const DoutPrefixProvider *dpp)
       result.manifest.emplace();
       decode(*result.manifest, biter);
     } catch (buffer::error& err) {
-      RGWRados *store = source->get_store();
       ldpp_dout(dpp, 0) << "ERROR: " << __func__ << ": failed to decode manifest"  << dendl;
       return -EIO;
     }


### PR DESCRIPTION
A recent change made the store variable unnecessary and now compiling
generates a warning. Clean up.

Compilation is sufficient; no testing is necessary.
No backports necessary.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>