### PR TITLE
mon/PGMap: map reduced PG availability to HEALTH_ERR severity

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2589,7 +2589,7 @@ void PGMap::get_health_checks(
     switch(i.first) {
       case UNAVAILABLE:
         health_code = "PG_AVAILABILITY";
-        sev = HEALTH_WARN;
+        sev = HEALTH_ERR;
         summary = "Reduced data availability: ";
         break;
       case DEGRADED:


### PR DESCRIPTION
Unavailable PGs is one of the most disruptive conditions that can
occur in a ceph cluster. Mark this with HEALTH_ERR so that operators
and tooling can easily understand the severity of the problem.

Fixes: https://tracker.ceph.com/issues/23565
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>