### PR TITLE
mds: add debugging when rejecting mksnap with EPERM

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -10256,6 +10256,7 @@ void Server::handle_client_mksnap(MDRequestRef& mdr)
   }
   if (!mds->mdsmap->allows_snaps()) {
     // you can't make snapshots until you set an option right now
+    dout(5) << "new snapshots are disabled for this fs" << dendl;
     respond_to_request(mdr, -CEPHFS_EPERM);
     return;
   }
@@ -10271,6 +10272,7 @@ void Server::handle_client_mksnap(MDRequestRef& mdr)
   }
   if (diri->is_system() && !diri->is_root()) {
     // no snaps in system dirs (root is ok)
+    dout(5) << "is an internal system dir" << dendl;
     respond_to_request(mdr, -CEPHFS_EPERM);
     return;
   }
@@ -10304,6 +10306,7 @@ void Server::handle_client_mksnap(MDRequestRef& mdr)
 
   if (inodeno_t subvol_ino = diri->find_snaprealm()->get_subvolume_ino();
       (subvol_ino && subvol_ino != diri->ino())) {
+    dout(5) << "is a descendent of a subvolume dir" << dendl;
     respond_to_request(mdr, -CEPHFS_EPERM);
     return;
   }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/51543
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
