### PR TITLE
qa: fold frag confs into conf/mds.yaml

### DIFF
--- a/qa/cephfs/conf/mds.yaml
+++ b/qa/cephfs/conf/mds.yaml
@@ -4,6 +4,10 @@ overrides:
       mds:
         debug mds: 20
         debug ms: 1
+        mds bal fragment size max: 10000
+        mds bal merge size: 5
+        mds bal split bits: 3
+        mds bal split size: 100
         mds debug frag: true
         mds debug scatterstat: true
         mds op complaint time: 180

--- a/qa/cephfs/overrides/frag_enable.yaml
+++ b/qa/cephfs/overrides/frag_enable.yaml
@@ -1,9 +1,0 @@
-overrides:
-  ceph:
-    conf:
-      mds:
-        mds bal frag: true
-        mds bal fragment size max: 10000
-        mds bal split size: 100
-        mds bal merge size: 5
-        mds bal split bits: 3

--- a/qa/suites/fs/32bits/overrides/frag_enable.yaml
+++ b/qa/suites/fs/32bits/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/bugs/client_trim_caps/overrides/frag_enable.yaml
+++ b/qa/suites/fs/bugs/client_trim_caps/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/full/overrides/frag_enable.yaml
+++ b/qa/suites/fs/full/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/functional/overrides/frag_enable.yaml
+++ b/qa/suites/fs/functional/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/libcephfs/overrides/frag_enable.yaml
+++ b/qa/suites/fs/libcephfs/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/mixed-clients/overrides/frag_enable.yaml
+++ b/qa/suites/fs/mixed-clients/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/multiclient/overrides/frag_enable.yaml
+++ b/qa/suites/fs/multiclient/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/multifs/overrides/frag_enable.yaml
+++ b/qa/suites/fs/multifs/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/permission/overrides/frag_enable.yaml
+++ b/qa/suites/fs/permission/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/shell/overrides/frag_enable.yaml
+++ b/qa/suites/fs/shell/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/snaps/overrides/frag_enable.yaml
+++ b/qa/suites/fs/snaps/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/thrash/multifs/overrides/frag_enable.yaml
+++ b/qa/suites/fs/thrash/multifs/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/thrash/workloads/overrides/frag_enable.yaml
+++ b/qa/suites/fs/thrash/workloads/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/traceless/overrides/frag_enable.yaml
+++ b/qa/suites/fs/traceless/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/upgrade/featureful_client/old_client/overrides/frag_enable.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/overrides/frag_enable.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/verify/overrides/frag_enable.yaml
+++ b/qa/suites/fs/verify/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/volumes/overrides/frag_enable.yaml
+++ b/qa/suites/fs/volumes/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml

--- a/qa/suites/fs/workload/overrides/frag_enable.yaml
+++ b/qa/suites/fs/workload/overrides/frag_enable.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/overrides/frag_enable.yaml


### PR DESCRIPTION
These overrides are standard for all configurations. The config to
enable fragmentation is also long removed.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
