### PR TITLE
crimson/os/seastore: implement label-based profiling with metrics

### DIFF
--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -218,7 +218,7 @@ public:
       }
       for (const auto& [labels, metric] : metric_family) {
         if (metric && metric->is_enabled()) {
-          dump_metric_value(f.get(), full_name, *metric);
+          dump_metric_value(f.get(), full_name, *metric, labels);
         }
       }
     }
@@ -231,20 +231,26 @@ private:
 
   static void dump_metric_value(Formatter* f,
                                 string_view full_name,
-                                const registered_metric& metric)
+                                const registered_metric& metric,
+                                const seastar::metrics::impl::labels_type& labels)
   {
+    f->open_object_section(full_name);
+    for (const auto& [key, value] : labels) {
+      f->dump_string(key, value);
+    }
+    auto value_name = "value";
     switch (auto v = metric(); v.type()) {
     case data_type::GAUGE:
-      f->dump_float(full_name, v.d());
+      f->dump_float(value_name, v.d());
       break;
     case data_type::COUNTER:
-      f->dump_unsigned(full_name, v.ui());
+      f->dump_unsigned(value_name, v.ui());
       break;
     case data_type::DERIVE:
-      f->dump_int(full_name, v.i());
+      f->dump_int(value_name, v.i());
       break;
     case data_type::HISTOGRAM: {
-      f->open_object_section(full_name);
+      f->open_object_section(value_name);
       auto&& h = v.get_histogram();
       f->dump_float("sum", h.sample_sum);
       f->dump_unsigned("count", h.sample_count);
@@ -262,13 +268,14 @@ private:
         f->close_section();
       }
       f->close_section(); // "buckets"
-      f->close_section(); // full_name
+      f->close_section(); // value_name
     }
       break;
     default:
       std::abort();
       break;
     }
+    f->close_section(); // full_name
   }
 };
 template std::unique_ptr<AdminSocketHook> make_asok_hook<DumpMetricsHook>();

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -351,7 +351,7 @@ void Cache::invalidate(CachedExtent &extent) {
   DEBUG("invalidate begin -- extent {}", extent);
   for (auto &&i: extent.transactions) {
     if (!i.t->conflicted) {
-      DEBUGT("", i.t);
+      DEBUGT("set conflict", *i.t);
       i.t->conflicted = true;
       assert(!i.t->is_weak());
       auto m_key = std::make_pair(i.t->get_src(), extent.get_type());

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -94,29 +94,33 @@ public:
 
   retired_extent_gate_t retired_extent_gate;
 
-  /// Creates empty transaction
-  TransactionRef create_transaction() {
+  /// Creates empty transaction by source
+  TransactionRef create_transaction(
+      Transaction::src_t src) {
     LOG_PREFIX(Cache::create_transaction);
     auto ret = std::make_unique<Transaction>(
       get_dummy_ordering_handle(),
       false,
+      src,
       last_commit
     );
     retired_extent_gate.add_token(ret->retired_gate_token);
-    DEBUGT("created", *ret);
+    DEBUGT("created source={}", *ret, src);
     return ret;
   }
 
-  /// Creates empty weak transaction
-  TransactionRef create_weak_transaction() {
+  /// Creates empty weak transaction by source
+  TransactionRef create_weak_transaction(
+      Transaction::src_t src) {
     LOG_PREFIX(Cache::create_weak_transaction);
     auto ret = std::make_unique<Transaction>(
       get_dummy_ordering_handle(),
       true,
+      src,
       last_commit
     );
     retired_extent_gate.add_token(ret->retired_gate_token);
-    DEBUGT("created", *ret);
+    DEBUGT("created source={}", *ret, src);
     return ret;
   }
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -134,10 +134,12 @@ public:
 
   /// Resets transaction preserving
   void reset_transaction_preserve_handle(Transaction &t) {
+    LOG_PREFIX(Cache::reset_transaction_preserve_handle);
     if (t.did_reset()) {
       ++(get_counter(stats.trans_created_by_src, t.get_src()));
     }
     t.reset_preserve_handle(last_commit);
+    DEBUGT("reset", t);
   }
 
   /**

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -574,6 +574,7 @@ private:
 
   struct {
     std::array<uint64_t, Transaction::SRC_MAX> trans_created_by_src;
+    std::array<uint64_t, Transaction::SRC_MAX> trans_committed_by_src;
   } stats;
   uint64_t& get_counter(
       std::array<uint64_t, Transaction::SRC_MAX>& counters_by_src,

--- a/src/crimson/os/seastore/collection_manager/collection_flat_node.h
+++ b/src/crimson/os/seastore/collection_manager/collection_flat_node.h
@@ -173,8 +173,9 @@ struct CollectionNode
     copy_to_node();
   }
 
+  static constexpr extent_types_t TYPE = extent_types_t::COLL_BLOCK;
   extent_types_t get_type() const final {
-    return type;
+    return TYPE;
   }
 
   std::ostream &print_detail_l(std::ostream &out) const final;

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.h
@@ -78,7 +78,7 @@ struct LBAInternalNode
     LBANode(std::forward<T>(t)...),
     FixedKVNodeLayout(get_bptr().c_str()) {}
 
-  static constexpr extent_types_t type = extent_types_t::LADDR_INTERNAL;
+  static constexpr extent_types_t TYPE = extent_types_t::LADDR_INTERNAL;
 
   lba_node_meta_t get_node_meta() const final { return get_meta(); }
 
@@ -170,7 +170,7 @@ struct LBAInternalNode
     op_context_t c,
     LBANodeRef &_right,
     bool prefer_left) final {
-    ceph_assert(_right->get_type() == type);
+    ceph_assert(_right->get_type() == TYPE);
     auto &right = *_right->cast<LBAInternalNode>();
     auto replacement_left = c.cache.alloc_new_extent<LBAInternalNode>(
       c.trans, LBA_BLOCK_SIZE);
@@ -224,7 +224,7 @@ struct LBAInternalNode
   }
 
   extent_types_t get_type() const final {
-    return type;
+    return TYPE;
   }
 
   std::ostream &print_detail(std::ostream &out) const final;
@@ -352,7 +352,7 @@ struct LBALeafNode
     LBANode(std::forward<T>(t)...),
     FixedKVNodeLayout(get_bptr().c_str()) {}
 
-  static constexpr extent_types_t type = extent_types_t::LADDR_LEAF;
+  static constexpr extent_types_t TYPE = extent_types_t::LADDR_LEAF;
 
   lba_node_meta_t get_node_meta() const final { return get_meta(); }
 
@@ -449,7 +449,7 @@ struct LBALeafNode
     op_context_t c,
     LBANodeRef &_right,
     bool prefer_left) final {
-    ceph_assert(_right->get_type() == type);
+    ceph_assert(_right->get_type() == TYPE);
     auto &right = *_right->cast<LBALeafNode>();
     auto replacement_left = c.cache.alloc_new_extent<LBALeafNode>(
       c.trans, LBA_BLOCK_SIZE);
@@ -521,7 +521,7 @@ struct LBALeafNode
   }
 
   extent_types_t get_type() const final {
-    return type;
+    return TYPE;
   }
 
   std::ostream &print_detail(std::ostream &out) const final;

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -294,7 +294,7 @@ OMapInnerNode::make_balanced_ret
 OMapInnerNode::make_balanced(omap_context_t oc, OMapNodeRef _right)
 {
   logger().debug("OMapInnerNode: {}", __func__);
-  ceph_assert(_right->get_type() == type);
+  ceph_assert(_right->get_type() == TYPE);
   return oc.tm.alloc_extents<OMapInnerNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE, 2)
     .si_then([this, _right] (auto &&replacement_pair){
       auto replacement_left = replacement_pair.front();
@@ -567,7 +567,7 @@ OMapLeafNode::make_split_children(omap_context_t oc)
 OMapLeafNode::full_merge_ret
 OMapLeafNode::make_full_merge(omap_context_t oc, OMapNodeRef right)
 {
-  ceph_assert(right->get_type() == type);
+  ceph_assert(right->get_type() == TYPE);
   logger().debug("OMapLeafNode: {}", __func__);
   return oc.tm.alloc_extent<OMapLeafNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE)
     .si_then([this, right] (auto &&replacement) {
@@ -581,7 +581,7 @@ OMapLeafNode::make_full_merge(omap_context_t oc, OMapNodeRef right)
 OMapLeafNode::make_balanced_ret
 OMapLeafNode::make_balanced(omap_context_t oc, OMapNodeRef _right)
 {
-  ceph_assert(_right->get_type() == type);
+  ceph_assert(_right->get_type() == TYPE);
   logger().debug("OMapLeafNode: {}",  __func__);
   return oc.tm.alloc_extents<OMapLeafNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE, 2)
     .si_then([this, _right] (auto &&replacement_pair) {

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
@@ -36,8 +36,6 @@ struct OMapInnerNode
     OMapNode(std::forward<T>(t)...),
     StringKVInnerNodeLayout(get_bptr().c_str()) {}
 
-  static constexpr extent_types_t type = extent_types_t::OMAP_INNER;
-
   omap_node_meta_t get_node_meta() const final { return get_meta(); }
   bool extent_will_overflow(size_t ksize, std::optional<size_t> vsize) const {
     return is_overflow(ksize);
@@ -104,8 +102,9 @@ struct OMapInnerNode
 
   std::ostream &print_detail_l(std::ostream &out) const final;
 
+  static constexpr extent_types_t TYPE = extent_types_t::OMAP_INNER;
   extent_types_t get_type() const final {
-    return type;
+    return TYPE;
   }
 
   ceph::bufferlist get_delta() final {
@@ -148,8 +147,6 @@ struct OMapLeafNode
   OMapLeafNode(T&&... t) :
     OMapNode(std::forward<T>(t)...),
     StringKVLeafNodeLayout(get_bptr().c_str()) {}
-
-  static constexpr extent_types_t type = extent_types_t::OMAP_LEAF;
 
   omap_node_meta_t get_node_meta() const final { return get_meta(); }
   bool extent_will_overflow(
@@ -202,8 +199,9 @@ struct OMapLeafNode
     omap_context_t oc,
     OMapNodeRef _right) final;
 
+  static constexpr extent_types_t TYPE = extent_types_t::OMAP_LEAF;
   extent_types_t get_type() const final {
-    return type;
+    return TYPE;
   }
 
   ceph::bufferlist get_delta() final {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -46,6 +46,12 @@ class SeastoreNodeExtent final: public NodeExtent {
   SeastoreNodeExtent(const SeastoreNodeExtent& other)
     : NodeExtent(other) {}
   ~SeastoreNodeExtent() override = default;
+
+  constexpr static extent_types_t TYPE = extent_types_t::ONODE_BLOCK_STAGED;
+  extent_types_t get_type() const override {
+    return TYPE;
+  }
+
  protected:
   NodeExtentRef mutate(context_t, DeltaRecorderURef&&) override;
 
@@ -56,14 +62,12 @@ class SeastoreNodeExtent final: public NodeExtent {
   CachedExtentRef duplicate_for_write() override {
     return CachedExtentRef(new SeastoreNodeExtent(*this));
   }
-  extent_types_t get_type() const override {
-    return extent_types_t::ONODE_BLOCK_STAGED;
-  }
   ceph::bufferlist get_delta() override {
     assert(recorder);
     return recorder->get_delta();
   }
   void apply_delta(const ceph::bufferlist&) override;
+
  private:
   DeltaRecorderURef recorder;
 };

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -713,6 +713,18 @@ struct rbm_alloc_delta_t {
 
 }
 
+namespace std {
+
+template<>
+struct hash<::crimson::os::seastore::extent_types_t> {
+  std::size_t operator()(
+      const ::crimson::os::seastore::extent_types_t& type) const noexcept {
+    return std::hash<uint8_t>{}((uint8_t)type);
+  }
+};
+
+}
+
 WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::seastore_meta_t)
 WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::paddr_t)
 WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::journal_seq_t)

--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -284,7 +284,7 @@ SegmentCleaner::gc_trim_journal_ret SegmentCleaner::gc_trim_journal()
   return repeat_eagain(
     [this] {
       return seastar::do_with(
-	ecb->create_transaction(),
+	ecb->create_transaction(Transaction::src_t::CLEANER),
 	[this](auto &tref) {
 	  return with_trans_intr(*tref, [this](auto &t) {
 	    return rewrite_dirty(t, get_dirty_tail()
@@ -330,7 +330,7 @@ SegmentCleaner::gc_reclaim_space_ret SegmentCleaner::gc_reclaim_space()
 	    "SegmentCleaner::gc_reclaim_space: processing {} extents",
 	    extents.size());
 	  return seastar::do_with(
-	    ecb->create_transaction(),
+	    ecb->create_transaction(Transaction::src_t::CLEANER),
 	    [this, &extents](auto &tref) mutable {
 	      return with_trans_intr(*tref, [this, &extents](auto &t) {
 		return trans_intr::do_for_each(

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -246,7 +246,7 @@ public:
   public:
     virtual ~ExtentCallbackInterface() = default;
 
-    virtual TransactionRef create_transaction() = 0;
+    virtual TransactionRef create_transaction(Transaction::src_t) = 0;
 
     /**
      * get_next_dirty_extent

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -201,6 +201,13 @@ public:
     to_release = NULL_SEG_ID;
     retired_gate_token.reset(initiated_after);
     conflicted = false;
+    if (!has_reset) {
+      has_reset = true;
+    }
+  }
+
+  bool did_reset() const {
+    return has_reset;
   }
 
 private:
@@ -231,6 +238,8 @@ private:
   retired_extent_gate_t::token_t retired_gate_token;
 
   bool conflicted = false;
+
+  bool has_reset = false;
 
   OrderingHandle handle;
 
@@ -322,5 +331,17 @@ auto with_trans_intr(Transaction &t, F &&f, Args&&... args) {
 
 template <typename T>
 using with_trans_ertr = typename T::base_ertr::template extend<crimson::ct_error::eagain>;
+
+}
+
+namespace std {
+
+template<>
+struct hash<::crimson::os::seastore::Transaction::src_t> {
+  std::size_t operator()(
+      const ::crimson::os::seastore::Transaction::src_t& src) const noexcept {
+    return std::hash<uint8_t>{}((uint8_t)src);
+  }
+};
 
 }

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -36,7 +36,7 @@ TransactionManager::mkfs_ertr::future<> TransactionManager::mkfs()
     DEBUG("about to do_with");
     segment_cleaner->init_mkfs(addr);
     return seastar::do_with(
-      create_transaction(),
+      create_transaction(Transaction::src_t::INIT),
       [this, FNAME](auto &transaction) {
 	DEBUGT(
 	  "about to cache->mkfs",
@@ -78,7 +78,7 @@ TransactionManager::mount_ertr::future<> TransactionManager::mount()
   }).safe_then([this, FNAME](auto addr) {
     segment_cleaner->set_journal_head(addr);
     return seastar::do_with(
-      create_weak_transaction(),
+      create_weak_transaction(Transaction::src_t::INIT),
       [this, FNAME](auto &tref) {
 	return with_trans_intr(
 	  *tref,

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -107,13 +107,15 @@ public:
   close_ertr::future<> close();
 
   /// Creates empty transaction
-  TransactionRef create_transaction() final {
-    return cache->create_transaction();
+  TransactionRef create_transaction(
+      Transaction::src_t src) final {
+    return cache->create_transaction(src);
   }
 
   /// Creates empty weak transaction
-  TransactionRef create_weak_transaction() {
-    return cache->create_weak_transaction();
+  TransactionRef create_weak_transaction(
+      Transaction::src_t src) {
+    return cache->create_weak_transaction(src);
   }
 
   /// Resets transaction

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -23,7 +23,7 @@ seastar::future<> TMDriver::write(
   assert((ptr.length() % (size_t)segment_manager->get_block_size()) == 0);
   return repeat_eagain([this, offset, ptr=std::move(ptr)] {
     return seastar::do_with(
-      tm->create_transaction(),
+      tm->create_transaction(Transaction::src_t::MUTATE),
       ptr,
       [this, offset](auto &t, auto &ptr) mutable {
 	return tm->dec_ref(
@@ -101,7 +101,7 @@ seastar::future<bufferlist> TMDriver::read(
   auto &blret = *blptrret;
   return repeat_eagain([=, &blret] {
     return seastar::do_with(
-      tm->create_transaction(),
+      tm->create_transaction(Transaction::src_t::READ),
       [=, &blret](auto &t) {
 	return read_extents(*t, offset, size
 	).safe_then([=, &blret](auto ext_list) mutable {

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -85,7 +85,7 @@ struct fltree_onode_manager_test_t
       return tm->mount(
       ).safe_then([this] {
 	return seastar::do_with(
-	  tm->create_transaction(),
+	  create_mutate_transaction(),
 	  [this](auto &t) {
 	    return manager->mkfs(*t
 	    ).safe_then([this, &t] {
@@ -102,7 +102,7 @@ struct fltree_onode_manager_test_t
 
   template <typename F>
   void with_transaction(F&& f) {
-    auto t = tm->create_transaction();
+    auto t = create_mutate_transaction();
     std::invoke(f, *t);
     submit_transaction(std::move(t));
     segment_cleaner->run_until_halt().get0();

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -73,7 +73,7 @@ struct btree_lba_manager_test :
       return journal.open_for_write();
     }).safe_then([this](auto addr) {
       return seastar::do_with(
-	cache.create_transaction(),
+	cache.create_transaction(Transaction::src_t::MUTATE),
 	[this](auto &transaction) {
 	  cache.init();
 	  return cache.mkfs(*transaction
@@ -116,7 +116,7 @@ struct btree_lba_manager_test :
 
   auto create_transaction() {
     auto t = test_transaction_t{
-      cache.create_transaction(),
+      cache.create_transaction(Transaction::src_t::MUTATE),
       test_lba_mappings
     };
     cache.alloc_new_extent<TestBlockPhysical>(*t.t, TestBlockPhysical::SIZE);
@@ -125,7 +125,7 @@ struct btree_lba_manager_test :
 
   auto create_weak_transaction() {
     auto t = test_transaction_t{
-      cache.create_weak_transaction(),
+      cache.create_weak_transaction(Transaction::src_t::READ),
       test_lba_mappings
     };
     return t;

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -66,7 +66,7 @@ struct object_data_handler_test_t:
       bl).unsafe_get0();
   }
   void write(objaddr_t offset, extent_len_t len, char fill) {
-    auto t = tm->create_transaction();
+    auto t = create_mutate_transaction();
     write(*t, offset, len, fill);
     return submit_transaction(std::move(t));
   }
@@ -88,7 +88,7 @@ struct object_data_handler_test_t:
     size = offset;
   }
   void truncate(objaddr_t offset) {
-    auto t = tm->create_transaction();
+    auto t = create_mutate_transaction();
     truncate(*t, offset);
     return submit_transaction(std::move(t));
   }
@@ -112,7 +112,7 @@ struct object_data_handler_test_t:
     EXPECT_EQ(bl, known);
   }
   void read(objaddr_t offset, extent_len_t len) {
-    auto t = tm->create_transaction();
+    auto t = create_read_transaction();
     read(*t, offset, len);
   }
   void read_near(objaddr_t offset, extent_len_t len, extent_len_t fuzz) {

--- a/src/test/crimson/seastore/test_randomblock_manager.cc
+++ b/src/test/crimson/seastore/test_randomblock_manager.cc
@@ -103,7 +103,7 @@ struct rbm_test_t : public  seastar_test_suite_t,
   }
 
   auto alloc_extent(rbm_transaction &t, size_t size) {
-    auto tt = tm->create_transaction(); // dummy transaction
+    auto tt = create_mutate_transaction(); // dummy transaction
     auto extent = rbm_manager->find_free_block(*tt, size).unsafe_get0();
     if (!extent.empty()) {
       rbm_alloc_delta_t alloc_info {

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -62,7 +62,7 @@ struct cache_test_t : public seastar_test_suite_t {
   }
 
   auto get_transaction() {
-    return cache.create_transaction();
+    return cache.create_transaction(Transaction::src_t::MUTATE);
   }
 
   template <typename T, typename... Args>
@@ -80,7 +80,7 @@ struct cache_test_t : public seastar_test_suite_t {
     ).safe_then(
       [this] {
 	return seastar::do_with(
-	  cache.create_transaction(),
+	  get_transaction(),
 	  [this](auto &transaction) {
 	    cache.init();
 	    return cache.mkfs(*transaction).safe_then(

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -351,11 +351,11 @@ struct transaction_manager_test_t :
   };
 
   test_transaction_t create_transaction() {
-    return { itm.create_transaction(), {} };
+    return { create_mutate_transaction(), {} };
   }
 
-  test_transaction_t create_weak_transaction() {
-    return { itm.create_weak_transaction(), {} };
+  test_transaction_t create_weak_test_transaction() {
+    return { create_weak_transaction(), {} };
   }
 
   TestBlockRef alloc_extent(
@@ -386,7 +386,7 @@ struct transaction_manager_test_t :
   }
 
   bool check_usage() {
-    auto t = create_weak_transaction();
+    auto t = create_weak_test_transaction();
     SpaceTrackerIRef tracker(segment_cleaner->get_empty_space_tracker());
     with_trans_intr(
       *t.t,
@@ -416,7 +416,7 @@ struct transaction_manager_test_t :
   }
 
   void check_mappings() {
-    auto t = create_weak_transaction();
+    auto t = create_weak_test_transaction();
     check_mappings(t);
   }
 

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -148,6 +148,18 @@ protected:
     );
   }
 
+  auto create_mutate_transaction() {
+    return tm->create_transaction(Transaction::src_t::MUTATE);
+  }
+
+  auto create_read_transaction() {
+    return tm->create_transaction(Transaction::src_t::READ);
+  }
+
+  auto create_weak_transaction() {
+    return tm->create_weak_transaction(Transaction::src_t::READ);
+  }
+
   auto submit_transaction_fut(Transaction &t) {
     return with_trans_intr(
       t,

--- a/src/tools/crimson/perf_staged_fltree.cc
+++ b/src/tools/crimson/perf_staged_fltree.cc
@@ -34,12 +34,12 @@ class PerfTree : public TMTestState {
             (is_dummy ? NodeExtentManager::create_dummy(true)
                       : NodeExtentManager::create_seastore(*tm)));
         {
-          auto t = tm->create_transaction();
+          auto t = create_mutate_transaction();
           tree->bootstrap(*t).unsafe_get();
           submit_transaction(std::move(t));
         }
         {
-          auto t = tm->create_transaction();
+          auto t = create_mutate_transaction();
           tree->insert(*t).unsafe_get();
           auto start_time = mono_clock::now();
           submit_transaction(std::move(t));
@@ -47,18 +47,18 @@ class PerfTree : public TMTestState {
           logger().warn("submit_transaction() done! {}s", duration.count());
         }
         {
-          // Note: tm->create_weak_transaction() can also work, but too slow.
-          auto t = tm->create_transaction();
+          // Note: create_weak_transaction() can also work, but too slow.
+          auto t = create_read_transaction();
           tree->get_stats(*t).unsafe_get();
           tree->validate(*t).unsafe_get();
         }
         {
-          auto t = tm->create_transaction();
+          auto t = create_mutate_transaction();
           tree->erase(*t, kvs.size() * erase_ratio).unsafe_get();
           submit_transaction(std::move(t));
         }
         {
-          auto t = tm->create_transaction();
+          auto t = create_read_transaction();
           tree->get_stats(*t).unsafe_get();
           tree->validate(*t).unsafe_get();
         }


### PR DESCRIPTION
TODOs:
* Cache hit;
* Disk I/O;
* Transaction usage;

After 15 seconds rados bench write:
```
    "cache_trans_committed(shard=0, src=ALL)": 1322,
    "cache_trans_committed(shard=0, src=CLEANER)": 1,
    "cache_trans_committed(shard=0, src=SEASTORE)": 1321,
    "cache_trans_committed(shard=0, src=TEST)": 0,
    "cache_trans_created(shard=0, src=ALL)": 5175,
    "cache_trans_created(shard=0, src=CLEANER)": 1,
    "cache_trans_created(shard=0, src=SEASTORE)": 3469,
    "cache_trans_created(shard=0, src=SEASTORE_READ)": 1704,
    "cache_trans_created(shard=0, src=TEST)": 0,
    "cache_trans_created(shard=0, src=WEAK)": 1,
    "cache_trans_invalidated(ext=COLL_BLOCK, shard=0, src=CLEANER)": 0,
    "cache_trans_invalidated(ext=COLL_BLOCK, shard=0, src=SEASTORE)": 0,
    "cache_trans_invalidated(ext=COLL_BLOCK, shard=0, src=SEASTORE_READ)": 0,
    "cache_trans_invalidated(ext=COLL_BLOCK, shard=0, src=TEST)": 0,
    "cache_trans_invalidated(ext=LADDR_INTERNAL, shard=0, src=CLEANER)": 0,
    "cache_trans_invalidated(ext=LADDR_INTERNAL, shard=0, src=SEASTORE)": 62,
    "cache_trans_invalidated(ext=LADDR_INTERNAL, shard=0, src=SEASTORE_READ)": 19,
    "cache_trans_invalidated(ext=LADDR_INTERNAL, shard=0, src=TEST)": 0,
    "cache_trans_invalidated(ext=LADDR_LEAF, shard=0, src=CLEANER)": 0,
    "cache_trans_invalidated(ext=LADDR_LEAF, shard=0, src=SEASTORE)": 1121,
    "cache_trans_invalidated(ext=LADDR_LEAF, shard=0, src=SEASTORE_READ)": 406,
    "cache_trans_invalidated(ext=LADDR_LEAF, shard=0, src=TEST)": 0,
    "cache_trans_invalidated(ext=OBJECT_DATA_BLOCK, shard=0, src=CLEANER)": 0,
    "cache_trans_invalidated(ext=OBJECT_DATA_BLOCK, shard=0, src=SEASTORE)": 0,
    "cache_trans_invalidated(ext=OBJECT_DATA_BLOCK, shard=0, src=SEASTORE_READ)": 0,
    "cache_trans_invalidated(ext=OBJECT_DATA_BLOCK, shard=0, src=TEST)": 0,
    "cache_trans_invalidated(ext=OMAP_INNER, shard=0, src=CLEANER)": 0,
    "cache_trans_invalidated(ext=OMAP_INNER, shard=0, src=SEASTORE)": 0,
    "cache_trans_invalidated(ext=OMAP_INNER, shard=0, src=SEASTORE_READ)": 0,
    "cache_trans_invalidated(ext=OMAP_INNER, shard=0, src=TEST)": 0,
    "cache_trans_invalidated(ext=ONODE_BLOCK_STAGED, shard=0, src=CLEANER)": 0,
    "cache_trans_invalidated(ext=ONODE_BLOCK_STAGED, shard=0, src=SEASTORE)": 368,
    "cache_trans_invalidated(ext=ONODE_BLOCK_STAGED, shard=0, src=SEASTORE_READ)": 40,
    "cache_trans_invalidated(ext=ONODE_BLOCK_STAGED, shard=0, src=TEST)": 0,
    "cache_trans_invalidated(ext=RBM_ALLOC_INFO, shard=0, src=CLEANER)": 0,
    "cache_trans_invalidated(ext=RBM_ALLOC_INFO, shard=0, src=SEASTORE)": 0,
    "cache_trans_invalidated(ext=RBM_ALLOC_INFO, shard=0, src=SEASTORE_READ)": 0,
    "cache_trans_invalidated(ext=RBM_ALLOC_INFO, shard=0, src=TEST)": 0,
    "cache_trans_invalidated(ext=RETIRED_PLACEHOLDER, shard=0, src=CLEANER)": 0,
    "cache_trans_invalidated(ext=RETIRED_PLACEHOLDER, shard=0, src=SEASTORE)": 0,
    "cache_trans_invalidated(ext=RETIRED_PLACEHOLDER, shard=0, src=SEASTORE_READ)": 0,
    "cache_trans_invalidated(ext=RETIRED_PLACEHOLDER, shard=0, src=TEST)": 0,
    "cache_trans_invalidated(ext=ROOT, shard=0, src=CLEANER)": 0,
    "cache_trans_invalidated(ext=ROOT, shard=0, src=SEASTORE)": 0,
    "cache_trans_invalidated(ext=ROOT, shard=0, src=SEASTORE_READ)": 1,
    "cache_trans_invalidated(ext=ROOT, shard=0, src=TEST)": 0,
    "cache_trans_invalidated(ext=TEST_BLOCK, shard=0, src=CLEANER)": 0,
    "cache_trans_invalidated(ext=TEST_BLOCK, shard=0, src=SEASTORE)": 0,
    "cache_trans_invalidated(ext=TEST_BLOCK, shard=0, src=SEASTORE_READ)": 0,
    "cache_trans_invalidated(ext=TEST_BLOCK, shard=0, src=TEST)": 0,
    "cache_trans_invalidated(ext=TEST_BLOCK_PHYSICAL, shard=0, src=CLEANER)": 0,
    "cache_trans_invalidated(ext=TEST_BLOCK_PHYSICAL, shard=0, src=SEASTORE)": 0,
    "cache_trans_invalidated(ext=TEST_BLOCK_PHYSICAL, shard=0, src=SEASTORE_READ)": 0,
    "cache_trans_invalidated(ext=TEST_BLOCK_PHYSICAL, shard=0, src=TEST)": 0,
    "cache_trans_invalidated(shard=0, src=ALL)": 2017,
```
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
