### PR TITLE
common/hobject: a minor fix and performance gain to hobjects listing

### DIFF
--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -211,13 +211,14 @@ void hobject_t::generate_test_instances(list<hobject_t*>& o)
 static void append_out_escaped(const string &in, string *out)
 {
   for (string::const_iterator i = in.begin(); i != in.end(); ++i) {
-    if (*i == '%' || *i == ':' || *i == '/' || *i < 32 || *i >= 127) {
+    int k = (int)(unsigned char)(*i);
+    if (k == '%' || k == ':' || k == '/' || k < 32 || k >= 127) {
       out->push_back('%');
       char buf[3];
-      snprintf(buf, sizeof(buf), "%02x", (int)(unsigned char)*i);
+      snprintf(buf, sizeof(buf), "%02x", (int)(unsigned char)k);
       out->append(buf);
     } else {
-      out->push_back(*i);
+      out->push_back(k);
     }
   }
 }

--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <charconv>
+
 #include "hobject.h"
 #include "common/Formatter.h"
 
@@ -210,15 +212,18 @@ void hobject_t::generate_test_instances(list<hobject_t*>& o)
 
 static void append_out_escaped(const string &in, string *out)
 {
-  for (string::const_iterator i = in.begin(); i != in.end(); ++i) {
-    int k = (int)(unsigned char)(*i);
-    if (k == '%' || k == ':' || k == '/' || k < 32 || k >= 127) {
-      out->push_back('%');
-      char buf[3];
-      snprintf(buf, sizeof(buf), "%02x", (int)(unsigned char)k);
+  for (auto c : in) {
+    int i = (int)(unsigned char)(c);
+    if (i <= 0x0f) {
+      char buf[4] = {'%', '0'};
+      std::to_chars(buf + 2, buf + 3, i, 16);
+      out->append(buf);
+    } else if (i < 32 || i >= 127 || i == '%' || i == ':' || i == '/') {
+      char buf[4] = {'%'};
+      std::to_chars(buf + 1, buf + 3, i, 16);
       out->append(buf);
     } else {
-      out->push_back(k);
+      out->push_back(c);
     }
   }
 }


### PR DESCRIPTION
The fix: the 'char >= 127' test was always(*) false.
    (*) ostensibly - compiler dependent

Speedup:     
   Using charconv::to_chars().
    Anecdotal speedup handling an assorted mix of strings: 2.4X
    (tested on my laptop)
 
Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
Reviewed-by: Kefu Chai <kchai@redhat.com>
Reviewed-by: Josh Durgin <jdurgin@redhat.com>