### PR TITLE
common/options: global.yaml: change ms_bind_port_max to 7568

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1127,7 +1127,7 @@ options:
   level: advanced
   desc: Highest port number to bind daemon(s) to
   fmt_desc: The maximum port number to which an OSD or MDS daemon will bind.
-  default: 7300
+  default: 7568
   with_legacy: true
 # FreeBSD does not use SO_REAUSEADDR so allow for a bit more time per default
 - name: ms_bind_retry_count


### PR DESCRIPTION
If the cluster is set to have very dense nodes (>60 OSDs per host)
we have to make sure to assign sufficient ports for Ceph OSDs. The
current default (6800-7300) currently allows for no more than 62 OSDs
per host. For cluster with dense nodes like this we have to adjust the
setting "ms_bind_port_max" to a suitable value. Each OSD will consume
8 additional ports. For example, given a host that is set to run 96 OSDs,
768 ports will be needed. "ms_bind_port_max" should be set at least to
7568.

Fixes: https://tracker.ceph.com/issues/48292
Signed-off-by: Sebastian Wagner <sewagner@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
