### PR TITLE
rgw: Use signaling compatible with POSIX

### DIFF
--- a/src/rgw/rgw_d3n_cacherequest.h
+++ b/src/rgw/rgw_d3n_cacherequest.h
@@ -76,7 +76,7 @@ struct D3nL1CacheRequest {
       return 0;
     }
 
-    static void libaio_cb_aio_dispatch(sigval_t sigval) {
+    static void libaio_cb_aio_dispatch(sigval sigval) {
       lsubdout(g_ceph_context, rgw_datacache, 20) << "D3nDataCache: " << __func__ << "()" << dendl;
       auto p = std::unique_ptr<Completion>{static_cast<Completion*>(sigval.sival_ptr)};
       auto op = std::move(p->user_data);

--- a/src/rgw/rgw_d3n_datacache.cc
+++ b/src/rgw/rgw_d3n_datacache.cc
@@ -144,7 +144,7 @@ int D3nDataCache::d3n_io_write(bufferlist& bl, unsigned int len, std::string oid
   return r;
 }
 
-void d3n_libaio_write_cb(sigval_t sigval)
+void d3n_libaio_write_cb(sigval sigval)
 {
   lsubdout(g_ceph_context, rgw_datacache, 30) << "D3nDataCache: " << __func__ << "()" << dendl;
   D3nCacheAioWriteRequest* c = static_cast<D3nCacheAioWriteRequest*>(sigval.sival_ptr);


### PR DESCRIPTION
FreeBSD does not have signal_t.
Linux specifies also to use `sigval` as POSIX compliant.

```
In file included from /home/jenkins/workspace/ceph-master-compile/src/rgw/rgw_rados.h:30:
/home/jenkins/workspace/ceph-master-compile/src/rgw/rgw_d3n_cacherequest.h:79:40: error: unknown type name 'sigval_t'; did you mean 'sigval'?
    static void libaio_cb_aio_dispatch(sigval_t sigval) {
                                       ^~~~~~~~
                                       sigval
/usr/include/sys/signal.h:171:7: note: 'sigval' declared here
union sigval {
      ^
1 error generated.
```
occurs after merging: https://github.com/ceph/ceph/pull/36266

Fixes: https://tracker.ceph.com/issues/51610

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>