### PR TITLE
pacific: radosgw: include realm_{id,name} in service map

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1136,6 +1136,8 @@ int RGWRados::register_to_service_map(const string& daemon_type, const map<strin
   metadata["zonegroup_name"] = svc.zone->get_zonegroup().get_name();
   metadata["zone_name"] = svc.zone->zone_name();
   metadata["zone_id"] = svc.zone->zone_id().id;
+  metadata["realm_name"] = svc.zone->get_realm().get_name();
+  metadata["realm_id"] = svc.zone->get_realm().get_id();
   metadata["id"] = name;
   int ret = rados.service_daemon_register(
     daemon_type,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51542

---

backport of https://github.com/ceph/ceph/pull/41739
parent tracker: https://tracker.ceph.com/issues/51303

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh