### PR TITLE
cephadm: ISCSI: Allow unlimited number of threads

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -631,6 +631,11 @@ class CephIscsi(object):
         # remove extra container args for tcmu container.
         # extra args could cause issue with forking service type
         tcmu_container.container_args = []
+        # Set unlimited pids limit. Othweise the container isn't able run enough
+        # threads
+        pids_unlimited = '0' if not isinstance(self.ctx.container_engine, Docker) else '-1'
+        tcmu_container.container_args.extend(['--pids-limit={}'.format(pids_unlimited)])
+
         return tcmu_container
 
 ##################################

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1235,3 +1235,33 @@ class TestBootstrap(object):
             else:
                 retval = cd.command_bootstrap(ctx)
                 assert retval == 0
+
+class TestIscsi:
+    def test_get_tcmu_runner_container(self, cephadm_fs):
+        with with_cephadm_ctx(['--image=ceph/ceph'], list_networks={}) as ctx:
+            iscsi = cd.CephIscsi(ctx, '9b9d7609-f4d5-4aba-94c8-effa764d96c9', 'daemon_id', {
+                'files': {'iscsi-gateway.cfg': ''}
+            })
+            c = iscsi.get_tcmu_runner_container()
+            assert c.run_cmd() == [
+                '/usr/bin/podman', 'run', '--rm',
+                '--ipc=host', '--stop-signal=SIGTERM', '--net=host',
+                '--entrypoint', '/usr/bin/tcmu-runner',
+                '--privileged', '--group-add=disk',
+                '--init',
+                '--name', 'ceph-9b9d7609-f4d5-4aba-94c8-effa764d96c9-iscsi.daemon_id-tcmu',
+                '--pids-limit=0',
+                '-e', 'CONTAINER_IMAGE=ceph/ceph',
+                '-e', 'NODE_NAME=host1',
+                '-e', 'CEPH_USE_RANDOM_NONCE=1',
+                '-e', 'TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=134217728',
+                '-v', '/var/lib/ceph/9b9d7609-f4d5-4aba-94c8-effa764d96c9/iscsi.daemon_id/config:/etc/ceph/ceph.conf:z',
+                '-v', '/var/lib/ceph/9b9d7609-f4d5-4aba-94c8-effa764d96c9/iscsi.daemon_id/keyring:/etc/ceph/keyring:z',
+                '-v', '/var/lib/ceph/9b9d7609-f4d5-4aba-94c8-effa764d96c9/iscsi.daemon_id/iscsi-gateway.cfg:/etc/ceph/iscsi-gateway.cfg:z',
+                '-v', '/var/lib/ceph/9b9d7609-f4d5-4aba-94c8-effa764d96c9/iscsi.daemon_id/configfs:/sys/kernel/config',
+                '-v', '/var/log/ceph/9b9d7609-f4d5-4aba-94c8-effa764d96c9:/var/log/rbd-target-api:z',
+                '-v', '/dev:/dev',
+                '--mount', 'type=bind,source=/lib/modules,destination=/lib/modules,ro=true',
+                'ceph/ceph'
+            ]
+            


### PR DESCRIPTION
Otherwise we're not able to create max luns per target.

Signed-off-by: Sebastian Wagner <sewagner@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
