### PR TITLE
monitoring: fix Physical Device Latency unit

### DIFF
--- a/monitoring/grafana/dashboards/osd-device-details.json
+++ b/monitoring/grafana/dashboards/osd-device-details.json
@@ -423,7 +423,7 @@
       },
       "yaxes": [
         {
-          "format": "ms",
+          "format": "s",
           "label": "Read (-) / Write (+)",
           "logBase": 1,
           "max": null,


### PR DESCRIPTION
Based on the expr it should be seconds

Fixes: https://tracker.ceph.com/issues/51565
Signed-off-by: Seena Fallah <seenafallah@gmail.com>