### PR TITLE
pacific: common/Formatter: include used header

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -19,6 +19,7 @@
 #include "include/buffer.h"
 
 #include <fmt/format.h>
+#include <algorithm>
 #include <set>
 #include <limits>
 

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -39,6 +39,7 @@
 #include <boost/intrusive/set.hpp>
 #include <boost/optional.hpp>
 
+#include "include/compat.h"
 #include "include/intarith.h"
 #include "include/int_types.h"
 #include "include/scope_guard.h"

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3690,7 +3690,7 @@ void Monitor::handle_command(MonOpRequestRef op)
     rs = ss2.str();
     r = 0;
   } else if (prefix == "osd last-stat-seq") {
-    int64_t osd;
+    int64_t osd = 0;
     cmd_getval(cmdmap, "id", osd);
     uint64_t seq = mgrstatmon()->get_last_osd_stat_seq(osd);
     if (f) {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1596,12 +1596,12 @@ public:
   }
 
   int64_t get_dedup_tier() const {
-    int64_t tier_id;
+    int64_t tier_id = 0;
     opts.get(pool_opts_t::DEDUP_TIER, &tier_id);
     return tier_id;
   }
   int64_t get_dedup_cdc_chunk_size() const {
-    int64_t chunk_size;
+    int64_t chunk_size = 0;
     opts.get(pool_opts_t::DEDUP_CDC_CHUNK_SIZE, &chunk_size);
     return chunk_size;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51579

---

backport of https://github.com/ceph/ceph/pull/40807
parent tracker: https://tracker.ceph.com/issues/51578

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh