### PR TITLE
nautilus: osd: move down peers out from peer_purged

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -990,11 +990,21 @@ void PG::remove_down_peer_info(const OSDMapRef osdmap)
       peer_missing.erase(p->first);
       peer_log_requested.erase(p->first);
       peer_missing_requested.erase(p->first);
-      peer_purged.erase(p->first); // so we can re-purge if necessary
       peer_info.erase(p++);
       removed = true;
     } else
       ++p;
+  }
+
+  // Remove any downed osds from peer_purged so we can re-purge if necessary
+  auto it = peer_purged.begin();
+  while (it != peer_purged.end()) {
+    if (!osdmap->is_up(it->osd)) {
+      dout(10) << " dropping down osd." << *it << " from peer_purged" << dendl;
+      peer_purged.erase(it++);
+    } else {
+      ++it;
+    }
   }
 
   // if we removed anyone, update peers (which include peer_info)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51583

---

backport of https://github.com/ceph/ceph/pull/42141
parent tracker: https://tracker.ceph.com/issues/38931

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh