### PR TITLE
rgw: cleanup virtual dtor decls and defns

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -191,6 +191,14 @@ stringstream& RGWCoroutine::Status::set_status()
   return status;
 }
 
+RGWCoroutinesManager::~RGWCoroutinesManager() {
+  stop();
+  completion_mgr->put();
+  if (cr_registry) {
+    cr_registry->remove(this);
+  }
+}
+
 int64_t RGWCoroutinesManager::get_next_io_id()
 {
   return (int64_t)++max_io_id;

--- a/src/rgw/rgw_coroutine.h
+++ b/src/rgw/rgw_coroutine.h
@@ -276,7 +276,7 @@ protected:
   }
 public:
   RGWCoroutine(CephContext *_cct) : status(_cct), _yield_ret(false), cct(_cct), stack(NULL), retcode(0), state(RGWCoroutine_Run) {}
-  ~RGWCoroutine() override;
+  virtual ~RGWCoroutine() override;
 
   virtual int operate(const DoutPrefixProvider *dpp) = 0;
 
@@ -606,7 +606,7 @@ class RGWCoroutinesManagerRegistry : public RefCountedObject, public AdminSocket
 
 public:
   explicit RGWCoroutinesManagerRegistry(CephContext *_cct) : cct(_cct) {}
-  ~RGWCoroutinesManagerRegistry() override;
+  virtual ~RGWCoroutinesManagerRegistry() override;
 
   void add(RGWCoroutinesManager *mgr);
   void remove(RGWCoroutinesManager *mgr);
@@ -654,13 +654,7 @@ public:
       cr_registry->add(this);
     }
   }
-  virtual ~RGWCoroutinesManager() {
-    stop();
-    completion_mgr->put();
-    if (cr_registry) {
-      cr_registry->remove(this);
-    }
-  }
+  virtual ~RGWCoroutinesManager();
 
   int run(const DoutPrefixProvider *dpp, list<RGWCoroutinesStack *>& ops);
   int run(const DoutPrefixProvider *dpp, RGWCoroutine *op);

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -1320,6 +1320,8 @@ public:
     interval(_interval), caller(_caller)
   {}
 
+  virtual ~RGWContinuousLeaseCR() override;
+
   int operate(const DoutPrefixProvider *dpp) override;
 
   bool is_locked() const {

--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -53,6 +53,7 @@ bool RGWMultiCompleteUpload::xml_end(const char *el) {
   return true;
 }
 
+RGWMultiXMLParser::~RGWMultiXMLParser() {}
 
 XMLObj *RGWMultiXMLParser::alloc_obj(const char *el) {
   XMLObj *obj = NULL;

--- a/src/rgw/rgw_multi.h
+++ b/src/rgw/rgw_multi.h
@@ -104,7 +104,7 @@ class RGWMultiXMLParser : public RGWXMLParser
   XMLObj *alloc_obj(const char *el) override;
 public:
   RGWMultiXMLParser() {}
-  ~RGWMultiXMLParser() override {}
+  virtual ~RGWMultiXMLParser() override;
 };
 
 extern bool is_v2_upload_id(const string& upload_id);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -958,6 +958,8 @@ int RGWGetObj::verify_permission(optional_yield y)
   return 0;
 }
 
+RGWOp::~RGWOp(){};
+
 int RGWOp::verify_op_mask()
 {
   uint32_t required_mask = op_mask();

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -215,7 +215,7 @@ public:
       op_ret(0) {
   }
 
-  virtual ~RGWOp() = default;
+  virtual ~RGWOp() override;
 
   int get_ret() const { return op_ret; }
 

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -46,6 +46,8 @@
 
 namespace rgw::sal {
 
+RadosObject::~RadosObject() {}
+
 static int decode_policy(CephContext* cct,
                          bufferlist& bl,
                          RGWAccessControlPolicy* policy)
@@ -214,6 +216,8 @@ Object* RadosBucket::create_object(const rgw_obj_key &key)
 {
   return nullptr;
 }
+
+RadosBucket::~RadosBucket() {}
 
 int RadosBucket::remove_bucket(const DoutPrefixProvider* dpp,
 			       bool delete_children,

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -151,6 +151,8 @@ class RadosObject : public Object {
     }
     RadosObject(RadosObject& _o) = default;
 
+    virtual ~RadosObject();
+
     virtual int delete_object(const DoutPrefixProvider* dpp, RGWObjectCtx* obj_ctx,
 			      optional_yield y, bool prevent_versioning) override;
     virtual int delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate, Completions* aio,
@@ -286,7 +288,7 @@ class RadosBucket : public Bucket {
         acls() {
     }
 
-    ~RadosBucket() { }
+    virtual ~RadosBucket();
 
     virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) override;
     virtual int list(const DoutPrefixProvider* dpp, ListParams&, int, ListResults&, optional_yield y) override;

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -315,6 +315,8 @@ int RGWServices::do_init(CephContext *_cct, bool have_cache, bool raw, bool run_
   return 0;
 }
 
+RGWServiceInstance::~RGWServiceInstance() {}
+
 int RGWServiceInstance::start(optional_yield y, const DoutPrefixProvider *dpp)
 {
   if (start_state != StateInit) {

--- a/src/rgw/rgw_service.h
+++ b/src/rgw/rgw_service.h
@@ -34,7 +34,7 @@ protected:
   }
 public:
   RGWServiceInstance(CephContext *_cct) : cct(_cct) {}
-  virtual ~RGWServiceInstance() {}
+  virtual ~RGWServiceInstance();
 
   int start(optional_yield y, const DoutPrefixProvider *dpp);
   bool is_started() {

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -40,6 +40,8 @@ static string mdlog_sync_status_oid = "mdlog.sync-status";
 static string mdlog_sync_status_shard_prefix = "mdlog.sync-status.shard";
 static string mdlog_sync_full_sync_index_prefix = "meta.full-sync.index";
 
+RGWContinuousLeaseCR::~RGWContinuousLeaseCR() {}
+
 RGWSyncErrorLogger::RGWSyncErrorLogger(rgw::sal::RadosStore* _store, const string &oid_prefix, int _num_shards) : store(_store), num_shards(_num_shards) {
   for (int i = 0; i < num_shards; i++) {
     oids.push_back(get_shard_oid(oid_prefix, i));
@@ -232,11 +234,6 @@ public:
   }
   bool spawn_next() override;
 };
-
-RGWRemoteMetaLog::~RGWRemoteMetaLog()
-{
-  delete error_logger;
-}
 
 int RGWRemoteMetaLog::read_log_info(const DoutPrefixProvider *dpp, rgw_mdlog_info *log_info)
 {

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -225,7 +225,7 @@ public:
       http_manager(store->ctx(), completion_mgr),
       status_manager(_sm) {}
 
-  ~RGWRemoteMetaLog() override;
+  virtual ~RGWRemoteMetaLog() override;
 
   int init();
   void finish();
@@ -274,6 +274,9 @@ public:
   RGWMetaSyncStatusManager(rgw::sal::RadosStore* _store, RGWAsyncRadosProcessor *async_rados)
     : store(_store), master_log(this, store, async_rados, this)
   {}
+
+  virtual ~RGWMetaSyncStatusManager() override;
+
   int init(const DoutPrefixProvider *dpp);
 
   int read_sync_status(const DoutPrefixProvider *dpp, rgw_meta_sync_status *sync_status) {

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -43,6 +43,8 @@ std::string default_storage_pool_suffix = "rgw.buckets.data";
 
 using namespace rgw_zone_defaults;
 
+RGWMetaSyncStatusManager::~RGWMetaSyncStatusManager(){}
+
 #define FIRST_EPOCH 1
 
 void RGWDefaultZoneGroupInfo::dump(Formatter *f) const {
@@ -699,6 +701,13 @@ int RGWSystemMetaObj::write(const DoutPrefixProvider *dpp, bool exclusive, optio
   return 0;
 }
 
+
+RGWRealm::~RGWRealm() {}
+
+RGWRemoteMetaLog::~RGWRemoteMetaLog()
+{
+  delete error_logger;
+}
 
 const string& RGWRealm::get_predefined_name(CephContext *cct) const {
   return cct->_conf->rgw_realm;

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -953,6 +953,7 @@ public:
   RGWRealm(const std::string& _id, const std::string& _name = "") : RGWSystemMetaObj(_id, _name) {}
   RGWRealm(CephContext *_cct, RGWSI_SysObj *_sysobj_svc): RGWSystemMetaObj(_cct, _sysobj_svc) {}
   RGWRealm(const std::string& _name, CephContext *_cct, RGWSI_SysObj *_sysobj_svc): RGWSystemMetaObj(_name, _cct, _sysobj_svc){}
+  virtual ~RGWRealm() override;
 
   void encode(bufferlist& bl) const override {
     ENCODE_START(1, 1, bl);

--- a/src/rgw/services/svc_config_key_rados.cc
+++ b/src/rgw/services/svc_config_key_rados.cc
@@ -2,6 +2,8 @@
 #include "svc_rados.h"
 #include "svc_config_key_rados.h"
 
+RGWSI_ConfigKey_RADOS::~RGWSI_ConfigKey_RADOS(){}
+
 int RGWSI_ConfigKey_RADOS::do_start(optional_yield, const DoutPrefixProvider *dpp)
 {
   maybe_insecure_mon_conn = !svc.rados->check_secure_mon_conn(dpp);

--- a/src/rgw/services/svc_config_key_rados.h
+++ b/src/rgw/services/svc_config_key_rados.h
@@ -46,6 +46,8 @@ public:
 
   RGWSI_ConfigKey_RADOS(CephContext *cct) : RGWSI_ConfigKey(cct) {}
 
+  virtual ~RGWSI_ConfigKey_RADOS() override;
+
   int get(const string& key, bool secure, bufferlist *result) override;
 };
 

--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -16,6 +16,12 @@
 
 static string notify_oid_prefix = "notify";
 
+RGWSI_Notify::~RGWSI_Notify()
+{
+  shutdown();
+}
+
+
 class RGWWatcher : public DoutPrefixProvider , public librados::WatchCtx2 {
   CephContext *cct;
   RGWSI_Notify *svc;
@@ -291,11 +297,6 @@ void RGWSI_Notify::shutdown()
   delete shutdown_cb;
 
   finalized = true;
-}
-
-RGWSI_Notify::~RGWSI_Notify()
-{
-  shutdown();
 }
 
 int RGWSI_Notify::unwatch(RGWSI_RADOS::Obj& obj, uint64_t watch_handle)

--- a/src/rgw/services/svc_notify.h
+++ b/src/rgw/services/svc_notify.h
@@ -85,7 +85,8 @@ private:
   void schedule_context(Context *c);
 public:
   RGWSI_Notify(CephContext *cct): RGWServiceInstance(cct) {}
-  ~RGWSI_Notify();
+
+  virtual ~RGWSI_Notify() override;
 
   class CB {
     public:

--- a/src/rgw/services/svc_tier_rados.cc
+++ b/src/rgw/services/svc_tier_rados.cc
@@ -5,6 +5,8 @@
 
 const std::string MP_META_SUFFIX = ".meta";
 
+MultipartMetaFilter::~MultipartMetaFilter() {}
+
 bool MultipartMetaFilter::filter(const string& name, string& key) {
   // the length of the suffix so we can skip past it
   static const size_t MP_META_SUFFIX_LEN = MP_META_SUFFIX.length();

--- a/src/rgw/services/svc_tier_rados.h
+++ b/src/rgw/services/svc_tier_rados.h
@@ -107,6 +107,8 @@ class MultipartMetaFilter : public RGWAccessListFilter {
 public:
   MultipartMetaFilter() {}
 
+  virtual ~MultipartMetaFilter() override;
+
   /**
    * @param name [in] The object name as it appears in the bucket index.
    * @param key [out] An output parameter that will contain the bucket


### PR DESCRIPTION
working on zipper loadable modules reveals issues with dtors in several classes.

These manifest as undefined references to vtable and typeinfo when linking librgw.so.

(Note: you won't see these until more zipper work is merged.)
This is due to:

    some classes don't declare a dtor at all
    some classes don't declare the dtor as virtual
    some classes define the dtor inline in the decl in the .h
    some classes don't have a defn at all
    etc.

https://tracker.ceph.com/issues/51599
Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
