### PR TITLE
rgw: Robustly Invalidate

### DIFF
--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -212,7 +212,9 @@ void ObjectCache::put(const DoutPrefixProvider *dpp, const string& name, ObjectC
     target.version = info.version;
 }
 
-bool ObjectCache::remove(const DoutPrefixProvider *dpp, const string& name)
+// WARNING: This function /must not/ be modified to cache a
+// negative lookup. It must only invalidate.
+bool ObjectCache::invalidate_remove(const DoutPrefixProvider *dpp, const string& name)
 {
   std::unique_lock l{lock};
 

--- a/src/rgw/rgw_cache.h
+++ b/src/rgw/rgw_cache.h
@@ -125,6 +125,11 @@ struct RGWCacheNotifyInfo {
   static void generate_test_instances(list<RGWCacheNotifyInfo*>& o);
 };
 WRITE_CLASS_ENCODER(RGWCacheNotifyInfo)
+inline std::ostream& operator <<(std::ostream& m, const RGWCacheNotifyInfo& cni) {
+  return m << "[op: " << cni.op << ", obj: " << cni.obj
+	   << ", ofs" << cni.ofs << ", ns" << cni.ns << "]";
+}
+
 
 class RGWChainedCache {
 public:

--- a/src/rgw/rgw_cache.h
+++ b/src/rgw/rgw_cache.h
@@ -17,7 +17,7 @@
 
 enum {
   UPDATE_OBJ,
-  REMOVE_OBJ,
+  INVALIDATE_OBJ,
 };
 
 #define CACHE_FLAG_DATA           0x01
@@ -204,7 +204,7 @@ public:
   }
 
   void put(const DoutPrefixProvider *dpp, const std::string& name, ObjectCacheInfo& bl, rgw_cache_entry_info *cache_info);
-  bool remove(const DoutPrefixProvider *dpp, const std::string& name);
+  bool invalidate_remove(const DoutPrefixProvider *dpp, const std::string& name);
   void set_ctx(CephContext *_cct) {
     cct = _cct;
     lru_window = cct->_conf->rgw_cache_lru_size / 2;

--- a/src/rgw/services/svc_notify.h
+++ b/src/rgw/services/svc_notify.h
@@ -15,6 +15,7 @@ class RGWSI_Finisher;
 
 class RGWWatcher;
 class RGWSI_Notify_ShutdownCB;
+struct RGWCacheNotifyInfo;
 
 class RGWSI_Notify : public RGWServiceInstance
 {
@@ -78,9 +79,8 @@ private:
   void _set_enabled(bool status);
   void set_enabled(bool status);
 
-  int robust_notify(const DoutPrefixProvider *dpp, 
-                    RGWSI_RADOS::Obj& notify_obj, bufferlist& bl,
-                    optional_yield y);
+  int robust_notify(const DoutPrefixProvider *dpp, RGWSI_RADOS::Obj& notify_obj,
+		    const RGWCacheNotifyInfo& bl, optional_yield y);
 
   void schedule_context(Context *c);
 public:
@@ -98,7 +98,8 @@ public:
       virtual void set_enabled(bool status) = 0;
   };
 
-  int distribute(const DoutPrefixProvider *dpp, const string& key, bufferlist& bl, optional_yield y);
+  int distribute(const DoutPrefixProvider *dpp, const string& key, const RGWCacheNotifyInfo& bl,
+		 optional_yield y);
 
   void register_watch_cb(CB *cb);
 };

--- a/src/rgw/services/svc_notify.h
+++ b/src/rgw/services/svc_notify.h
@@ -42,7 +42,7 @@ private:
   bool enabled{false};
 
   double inject_notify_timeout_probability{0};
-  unsigned max_notify_retries{0};
+  static constexpr unsigned max_notify_retries = 10;
 
   string get_control_oid(int i);
   RGWSI_RADOS::Obj pick_control_obj(const string& key);

--- a/src/rgw/services/svc_sys_obj_cache.cc
+++ b/src/rgw/services/svc_sys_obj_cache.cc
@@ -94,10 +94,10 @@ int RGWSI_SysObj_Cache::remove(const DoutPrefixProvider *dpp,
   normalize_pool_and_obj(obj.pool, obj.oid, pool, oid);
 
   string name = normal_name(pool, oid);
-  cache.remove(dpp, name);
+  cache.invalidate_remove(dpp, name);
 
   ObjectCacheInfo info;
-  int r = distribute_cache(dpp, name, obj, info, REMOVE_OBJ, y);
+  int r = distribute_cache(dpp, name, obj, info, INVALIDATE_OBJ, y);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "ERROR: " << __func__ << "(): failed to distribute cache: r=" << r << dendl;
   }
@@ -270,7 +270,7 @@ int RGWSI_SysObj_Cache::set_attrs(const DoutPrefixProvider *dpp,
     if (r < 0)
       ldpp_dout(dpp, 0) << "ERROR: failed to distribute cache for " << obj << dendl;
   } else {
-    cache.remove(dpp, name);
+    cache.invalidate_remove(dpp, name);
   }
 
   return ret;
@@ -314,7 +314,7 @@ int RGWSI_SysObj_Cache::write(const DoutPrefixProvider *dpp,
     if (r < 0)
       ldpp_dout(dpp, 0) << "ERROR: failed to distribute cache for " << obj << dendl;
   } else {
-    cache.remove(dpp, name);
+    cache.invalidate_remove(dpp, name);
   }
 
   return ret;
@@ -349,7 +349,7 @@ int RGWSI_SysObj_Cache::write_data(const DoutPrefixProvider *dpp,
     if (r < 0)
       ldpp_dout(dpp, 0) << "ERROR: failed to distribute cache for " << obj << dendl;
   } else {
-    cache.remove(dpp, name);
+    cache.invalidate_remove(dpp, name);
   }
 
   return ret;
@@ -461,8 +461,8 @@ int RGWSI_SysObj_Cache::watch_cb(const DoutPrefixProvider *dpp,
   case UPDATE_OBJ:
     cache.put(dpp, name, info.obj_info, NULL);
     break;
-  case REMOVE_OBJ:
-    cache.remove(dpp, name);
+  case INVALIDATE_OBJ:
+    cache.invalidate_remove(dpp, name);
     break;
   default:
     ldpp_dout(dpp, 0) << "WARNING: got unknown notification op: " << info.op << dendl;
@@ -633,7 +633,7 @@ int RGWSI_SysObj_Cache::ASocketHandler::call_inspect(const std::string& target, 
 
 int RGWSI_SysObj_Cache::ASocketHandler::call_erase(const std::string& target)
 {
-  return svc->cache.remove(dpp, target);
+  return svc->cache.invalidate_remove(dpp, target);
 }
 
 int RGWSI_SysObj_Cache::ASocketHandler::call_zap()

--- a/src/rgw/services/svc_sys_obj_cache.cc
+++ b/src/rgw/services/svc_sys_obj_cache.cc
@@ -430,9 +430,7 @@ int RGWSI_SysObj_Cache::distribute_cache(const DoutPrefixProvider *dpp,
   info.op = op;
   info.obj_info = obj_info;
   info.obj = obj;
-  bufferlist bl;
-  encode(info, bl);
-  return notify_svc->distribute(dpp, normal_name, bl, y);
+  return notify_svc->distribute(dpp, normal_name, info, y);
 }
 
 int RGWSI_SysObj_Cache::watch_cb(const DoutPrefixProvider *dpp,


### PR DESCRIPTION
When notify fails, simply blow out the cached object in our peers. Avoid a potential race condition arising from a delayed update.

Also print the object name on notify error so we can get some visibility into exactly what operation is failing.