### PR TITLE
mgr/dashboard,cephadm: automate setup of RGW credentials for dashboard

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -376,51 +376,14 @@ password.
 Enabling the Object Gateway Management Frontend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To use the Object Gateway management functionality of the dashboard, you will
-need to provide the login credentials of a user with the ``system`` flag
-enabled. If you do not have a ``system`` user already, you must create one::
+When RGW is deployed with cephadm, the RGW credentials used by the
+dashboard will be automatically created.  You can also manually force the
+credentials to be created with::
 
-  $ radosgw-admin user create --uid=<user_id> --display-name=<display_name> \
-      --system
+  $ ceph dashboard connect-rgw
 
-Take note of the keys ``access_key`` and ``secret_key`` in the output.
-
-To obtain the credentials of an existing user via `radosgw-admin`::
-
-  $ radosgw-admin user info --uid=<user_id>
-
-In case of having several Object Gateways, you will need the required users' credentials
-to connect to each Object Gateway.
-Finally, provide these credentials to the dashboard::
-
-  $ echo -n "{'<daemon1.id>': '<user1-access-key>', '<daemon2.id>': '<user2-access-key>', ...}" > <file-containing-access-key>
-  $ echo -n "{'<daemon1.id>': '<user1-secret-key>', '<daemon2.id>': '<user2-secret-key>', ...}" > <file-containing-secret-key>
-  $ ceph dashboard set-rgw-api-access-key -i <file-containing-access-key>
-  $ ceph dashboard set-rgw-api-secret-key -i <file-containing-secret-key>
-
-.. note::
-
-  Legacy way of providing credentials (connect to single Object Gateway)::
-
-  $ echo -n "<access-key>" > <file-containing-access-key>
-  $ echo -n "<secret-key>" > <file-containing-secret-key>
-
-In a simple configuration with a single RGW endpoint, this is all you
-have to do to get the Object Gateway management functionality working. The
-dashboard will try to automatically determine the host and port
-from the Ceph Manager's service map.
-
-In case of having several Object Gateways, you might want to set
-the default one by setting its host and port manually::
-
-  $ ceph dashboard set-rgw-api-host <host>
-  $ ceph dashboard set-rgw-api-port <port>
-
-In addition to the settings mentioned so far, the following settings do also
-exist and you may find yourself in the situation that you have to use them::
-
-  $ ceph dashboard set-rgw-api-scheme <scheme>  # http or https
-  $ ceph dashboard set-rgw-api-admin-resource <admin_resource>
+This will create an RGW user with uid ``dashboard`` for each realm in
+the system.
 
 If you are using a self-signed certificate in your Object Gateway setup,
 you should disable certificate verification in the dashboard to avoid refused

--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -377,13 +377,17 @@ Enabling the Object Gateway Management Frontend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When RGW is deployed with cephadm, the RGW credentials used by the
-dashboard will be automatically created.  You can also manually force the
-credentials to be created with::
+dashboard will be automatically configured. You can also manually force the
+credentials to be set up with::
 
-  $ ceph dashboard connect-rgw
+  $ ceph dashboard set-rgw-credentials
 
 This will create an RGW user with uid ``dashboard`` for each realm in
 the system.
+
+If you've configured a custom 'admin' resource in your RGW admin API, you should set it here also::
+
+  $ ceph dashboard set-rgw-api-admin-resource <admin_resource>
 
 If you are using a self-signed certificate in your Object Gateway setup,
 you should disable certificate verification in the dashboard to avoid refused

--- a/qa/tasks/mgr/dashboard/test_rgw.py
+++ b/qa/tasks/mgr/dashboard/test_rgw.py
@@ -77,22 +77,22 @@ class RgwApiCredentialsTest(RgwTestCase):
         self.logout()
         self._ceph_cmd(['mgr', 'module', 'disable', 'dashboard'])
         self._ceph_cmd(['mgr', 'module', 'enable', 'dashboard', '--force'])
-        # Set the default credentials.
-        self._ceph_cmd_with_secret(['dashboard', 'set-rgw-api-secret-key'], 'admin')
-        self._ceph_cmd_with_secret(['dashboard', 'set-rgw-api-access-key'], 'admin')
         super(RgwApiCredentialsTest, self).setUp()
 
-    def test_no_access_secret_key(self):
-        self._ceph_cmd(['dashboard', 'reset-rgw-api-secret-key'])
-        self._ceph_cmd(['dashboard', 'reset-rgw-api-access-key'])
+    def test_invalid_credentials(self):
+        self._ceph_cmd_with_secret(['dashboard', 'set-rgw-api-secret-key'], 'invalid')
+        self._ceph_cmd_with_secret(['dashboard', 'set-rgw-api-access-key'], 'invalid')
         resp = self._get('/api/rgw/user')
         self.assertStatus(500)
         self.assertIn('detail', resp)
         self.assertIn('component', resp)
-        self.assertIn('No RGW credentials found', resp['detail'])
+        self.assertIn('Error connecting to Object Gateway', resp['detail'])
         self.assertEqual(resp['component'], 'rgw')
 
     def test_success(self):
+        # Set the default credentials.
+        self._ceph_cmd_with_secret(['dashboard', 'set-rgw-api-secret-key'], 'admin')
+        self._ceph_cmd_with_secret(['dashboard', 'set-rgw-api-access-key'], 'admin')
         data = self._get('/api/rgw/status')
         self.assertStatus(200)
         self.assertIn('available', data)

--- a/qa/tasks/mgr/dashboard/test_rgw.py
+++ b/qa/tasks/mgr/dashboard/test_rgw.py
@@ -70,20 +70,11 @@ class RgwApiCredentialsTest(RgwTestCase):
 
     AUTH_ROLES = ['rgw-manager']
 
-    def setUp(self):
-        super(RgwApiCredentialsTest, self).setUp()
-        # Restart the Dashboard module to ensure that the connection to the
-        # RGW Admin Ops API is re-established with the new credentials.
-        self.logout()
-        self._ceph_cmd(['mgr', 'module', 'disable', 'dashboard'])
-        self._ceph_cmd(['mgr', 'module', 'enable', 'dashboard', '--force'])
-        super(RgwApiCredentialsTest, self).setUp()
-
     def test_invalid_credentials(self):
         self._ceph_cmd_with_secret(['dashboard', 'set-rgw-api-secret-key'], 'invalid')
         self._ceph_cmd_with_secret(['dashboard', 'set-rgw-api-access-key'], 'invalid')
         resp = self._get('/api/rgw/user')
-        self.assertStatus(500)
+        self.assertStatus(404)
         self.assertIn('detail', resp)
         self.assertIn('component', resp)
         self.assertIn('Error connecting to Object Gateway', resp['detail'])

--- a/qa/tasks/mgr/dashboard/test_settings.py
+++ b/qa/tasks/mgr/dashboard/test_settings.py
@@ -51,15 +51,15 @@ class SettingsTest(DashboardTestCase):
 
     def test_bulk_set(self):
         self._put('/api/settings', {
-            'USER_PWD_EXPIRATION_WARNING_1': 12,
-            'USER_PWD_EXPIRATION_WARNING_2': 6,
+            'RGW_API_ACCESS_KEY': 'dummy-key',
+            'RGW_API_SECRET_KEY': 'dummy-secret',
         })
         self.assertStatus(200)
 
-        host = self._get('/api/settings/rgw-api-host')['value']
+        access_key = self._get('/api/settings/rgw-api-access-key')['value']
         self.assertStatus(200)
-        self.assertEqual('somehost', host)
+        self.assertEqual('dummy-key', access_key)
 
-        port = self._get('/api/settings/rgw-api-port')['value']
+        secret_key = self._get('/api/settings/rgw-api-secret-key')['value']
         self.assertStatus(200)
-        self.assertEqual(7777, port)
+        self.assertEqual('dummy-secret', secret_key)

--- a/qa/tasks/mgr/dashboard/test_settings.py
+++ b/qa/tasks/mgr/dashboard/test_settings.py
@@ -51,8 +51,8 @@ class SettingsTest(DashboardTestCase):
 
     def test_bulk_set(self):
         self._put('/api/settings', {
-            'RGW_API_HOST': 'somehost',
-            'RGW_API_PORT': 7777,
+            'USER_PWD_EXPIRATION_WARNING_1': 12,
+            'USER_PWD_EXPIRATION_WARNING_2': 6,
         })
         self.assertStatus(200)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -467,6 +467,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self.template = TemplateMgr(self)
 
         self.requires_post_actions: Set[str] = set()
+        self.need_connect_dashboard_rgw = False
 
         self.config_checker = CephadmConfigChecks(self)
 
@@ -2611,3 +2612,7 @@ Then run the following:
             daemons_table += "{:<20} {:<15}\n".format(d.daemon_type, d.daemon_id)
 
         return "Scheduled to remove the following daemons from host '{}'\n{}".format(hostname, daemons_table)
+
+    def trigger_connect_dashboard_rgw(self) -> None:
+        self.need_connect_dashboard_rgw = True
+        self.event.set()

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -85,7 +85,7 @@ class CephadmServe:
                     self.mgr.need_connect_dashboard_rgw = False
                     if 'dashboard' in self.mgr.get('mgr_map')['modules']:
                         self.log.info('Checking dashboard <-> RGW credentials')
-                        self.mgr.remote('dashboard', 'connect_rgw')
+                        self.mgr.remote('dashboard', 'set_rgw_credentials')
 
                 if not self.mgr.paused:
                     self.mgr.to_remove_osds.process_removal_queue()

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -795,6 +795,7 @@ class RgwService(CephService):
         logger.info('Saving service %s spec with placement %s' % (
             spec.service_name(), spec.placement.pretty_str()))
         self.mgr.spec_store.save(spec)
+        self.mgr.trigger_connect_dashboard_rgw()
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
@@ -874,6 +875,7 @@ class RgwService(CephService):
             'prefix': 'config-key rm',
             'key': f'rgw/cert/{service_name}',
         })
+        self.mgr.trigger_connect_dashboard_rgw()
 
     def post_remove(self, daemon: DaemonDescription) -> None:
         super().post_remove(daemon)
@@ -917,6 +919,9 @@ class RgwService(CephService):
         # Provide warning
         warn_message = "WARNING: Removing RGW daemons can cause clients to lose connectivity. "
         return HandleCommandResult(-errno.EBUSY, '', warn_message)
+
+    def config_dashboard(self, daemon_descrs: List[DaemonDescription]) -> None:
+        self.mgr.trigger_connect_dashboard_rgw()
 
 
 class RbdMirrorService(CephService):

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/mgr-modules.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/mgr-modules.e2e-spec.ts
@@ -30,11 +30,6 @@ describe('Manager modules page', () => {
     it('should test editing on dashboard module', () => {
       const dashboardArr: Input[] = [
         {
-          id: 'RGW_API_USER_ID',
-          newValue: 'rq',
-          oldValue: ''
-        },
-        {
           id: 'GRAFANA_API_PASSWORD',
           newValue: 'rafa',
           oldValue: ''

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -77,7 +77,7 @@
                   i18n>This field is required.</span>
             <span class="invalid-feedback"
                   *ngIf="serviceForm.showError('service_id', frm, 'rgwPattern')"
-                  i18n>The value does not match the pattern <strong>&lt;realm_name&gt;.&lt;zone_name&gt;[.&lt;subcluster&gt;]</strong>.</span>
+                  i18n>The value does not match the pattern <strong>&lt;service_id&gt;[.&lt;realm_name&gt;.&lt;zone_name&gt;]</strong>.</span>
           </div>
         </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -27,6 +27,7 @@ import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
   styleUrls: ['./service-form.component.scss']
 })
 export class ServiceFormComponent extends CdForm implements OnInit {
+  readonly RGW_SVC_ID_PATTERN = /^([^.]+)(\.([^.]+)\.([^.]+))?$/;
   @ViewChild(NgbTypeahead, { static: false })
   typeahead: NgbTypeahead;
 
@@ -91,7 +92,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
                 if (_.isEmpty(value)) {
                   return false;
                 }
-                return !/^[^.]+\.[^.]+(\.[^.]+)?$/.test(value);
+                return !this.RGW_SVC_ID_PATTERN.test(value);
               })
             ]
           )
@@ -283,13 +284,24 @@ export class ServiceFormComponent extends CdForm implements OnInit {
   onSubmit() {
     const self = this;
     const values: object = this.serviceForm.value;
-    const serviceId: string = values['service_id'];
     const serviceType: string = values['service_type'];
     const serviceSpec: object = {
       service_type: serviceType,
       placement: {},
       unmanaged: values['unmanaged']
     };
+    let svcId: string;
+    if (serviceType === 'rgw') {
+      const svcIdMatch = values['service_id'].match(this.RGW_SVC_ID_PATTERN);
+      svcId = svcIdMatch[1];
+      if (svcIdMatch[3]) {
+        serviceSpec['rgw_realm'] = svcIdMatch[3];
+        serviceSpec['rgw_zone'] = svcIdMatch[4];
+      }
+    } else {
+      svcId = values['service_id'];
+    }
+    const serviceId: string = svcId;
     let serviceName: string = serviceType;
     if (_.isString(serviceId) && !_.isEmpty(serviceId)) {
       serviceName = `${serviceType}.${serviceId}`;

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -29,6 +29,7 @@ from .controllers import generate_routes, json_error_page
 from .grafana import push_local_dashboards
 from .services.auth import AuthManager, AuthManagerTool, JwtManager
 from .services.exception import dashboard_exception_handler
+from .services.rgw_client import configure_rgw_users
 from .services.sso import SSO_COMMANDS, handle_sso_command
 from .settings import handle_option_command, options_command_list, options_schema_list
 from .tools import NotificationQueue, RequestLoggingTool, TaskManager, \
@@ -405,6 +406,11 @@ class Module(MgrModule, CherryPyConfig):
         if result.retval != 0:
             return result
         return 0, 'Self-signed certificate created', ''
+
+    @CLIWriteCommand("dashboard connect-rgw")
+    def connect_rgw(self):
+        configure_rgw_users()
+        return 0, '', ''
 
     def handle_command(self, inbuf, cmd):
         # pylint: disable=too-many-return-statements

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -29,7 +29,7 @@ from .controllers import generate_routes, json_error_page
 from .grafana import push_local_dashboards
 from .services.auth import AuthManager, AuthManagerTool, JwtManager
 from .services.exception import dashboard_exception_handler
-from .services.rgw_client import configure_rgw_users
+from .services.rgw_client import configure_rgw_credentials
 from .services.sso import SSO_COMMANDS, handle_sso_command
 from .settings import handle_option_command, options_command_list, options_schema_list
 from .tools import NotificationQueue, RequestLoggingTool, TaskManager, \
@@ -409,8 +409,13 @@ class Module(MgrModule, CherryPyConfig):
 
     @CLIWriteCommand("dashboard connect-rgw")
     def connect_rgw(self):
-        configure_rgw_users()
-        return 0, '', ''
+        try:
+            configure_rgw_credentials()
+        except Exception as error:
+            logger.exception(error)
+            return -errno.EINVAL, '', str(error)
+
+        return 0, 'RGW credentials configured', ''
 
     def handle_command(self, inbuf, cmd):
         # pylint: disable=too-many-return-statements

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -407,12 +407,11 @@ class Module(MgrModule, CherryPyConfig):
             return result
         return 0, 'Self-signed certificate created', ''
 
-    @CLIWriteCommand("dashboard connect-rgw")
-    def connect_rgw(self):
+    @CLIWriteCommand("dashboard set-rgw-credentials")
+    def set_rgw_credentials(self):
         try:
             configure_rgw_credentials()
         except Exception as error:
-            logger.exception(error)
             return -errno.EINVAL, '', str(error)
 
         return 0, 'RGW credentials configured', ''

--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -43,7 +43,7 @@ setup_teuthology() {
 
     ${TEUTHOLOGY_PYTHON_BIN:-/usr/bin/python3} -m venv venv
     source venv/bin/activate
-    pip install 'setuptools >= 12'
+    pip install -U pip 'setuptools >= 12'
     pip install git+https://github.com/ceph/teuthology#egg=teuthology[test]
     pushd $CURR_DIR
     pip install -r requirements.txt -c constraints.txt

--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -8,10 +8,10 @@ start_ceph() {
     MGR=2 RGW=1 ../src/vstart.sh -n -d
     sleep 10
 
+    set -x
+
     # Create an Object Gateway User
     ./bin/radosgw-admin user create --uid=dev --display-name=Developer --system
-    # Set the user-id
-    ./bin/ceph dashboard set-rgw-api-user-id dev
     # Obtain and set access and secret key for the previously created user. $() is safer than backticks `..`
     RGW_ACCESS_KEY_FILE="/tmp/rgw-user-access-key.txt"
     printf "$(./bin/radosgw-admin user info --uid=dev | jq -r .keys[0].access_key)" > "${RGW_ACCESS_KEY_FILE}"
@@ -23,6 +23,8 @@ start_ceph() {
     ./bin/ceph dashboard set-rgw-api-ssl-verify False
 
     CYPRESS_BASE_URL=$(./bin/ceph mgr services | jq -r .dashboard)
+
+    set +x
 }
 
 stop() {

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -4,9 +4,9 @@ import ipaddress
 import json
 import logging
 import re
-import subprocess
 import xml.etree.ElementTree as ET  # noqa: N814
 from distutils.util import strtobool
+from subprocess import SubprocessError
 
 from .. import mgr
 from ..awsauth import S3Auth
@@ -28,7 +28,7 @@ class NoRgwDaemonsException(Exception):
         super().__init__('No RGW service is running.')
 
 
-class NoCredentialsException(RequestException):
+class NoCredentialsException(Exception):
     def __init__(self):
         super(NoCredentialsException, self).__init__(
             'No RGW credentials found, '
@@ -193,86 +193,76 @@ def _parse_frontend_config(config) -> Tuple[int, bool]:
     raise LookupError('Failed to determine RGW port from "{}"'.format(config))
 
 
-def _radosgw_admin(args: List[str]) -> Tuple[int, str, str]:
-    try:
-        result = subprocess.run(  # pylint: disable=subprocess-run-check
-            [
-                'radosgw-admin',
-                '-c', str(mgr.get_ceph_conf_path()),
-                '-k', str(mgr.get_ceph_option('keyring')),
-                '-n', f'mgr.{mgr.get_mgr_id()}',
-            ] + args,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            timeout=10,
-        )
-        return result.returncode, result.stdout.decode('utf-8'), result.stderr.decode('utf-8')
-    except subprocess.CalledProcessError as ex:
-        mgr.log.error(f'Error executing radosgw-admin {ex.cmd}: {ex.output}')
-        raise
-    except subprocess.TimeoutExpired as ex:
-        mgr.log.error(f'Timeout (10s) executing radosgw-admin {ex.cmd}')
-        raise
-
-
-def _parse_secrets(user: str, payload: str) -> Tuple[Optional[str], Optional[str]]:
-    data = json.loads(payload)
+def _parse_secrets(user: str, data: dict) -> Tuple[str, str]:
     for key in data.get('keys', []):
         if key.get('user') == user and data.get('system') in ['true', True]:
             access_key = key.get('access_key')
             secret_key = key.get('secret_key')
             return access_key, secret_key
-    return None, None
+    return '', ''
 
 
 def _get_user_keys(user: str, realm: Optional[str] = None) -> Tuple[str, str]:
-    cmd = ['user', 'info', '--uid', user]
+    access_key = ''
+    secret_key = ''
+    rgw_user_info_cmd = ['user', 'info', '--uid', user]
     cmd_realm_option = ['--rgw-realm', realm] if realm else []
     if realm:
-        cmd += cmd_realm_option
-    rc, out, err = _radosgw_admin(cmd)
-    access_key = None
-    secret_key = None
-    if not rc:
-        access_key, secret_key = _parse_secrets(user, out)
-    if not access_key:
-        rgw_create_user_cmd = [
-            'user', 'create',
-            '--uid', user,
-            '--display-name', 'Ceph Dashboard',
-            '--system',
-        ] + cmd_realm_option
-        rc, out, err = _radosgw_admin(rgw_create_user_cmd)
-        if not rc:
+        rgw_user_info_cmd += cmd_realm_option
+    try:
+        _, out, err = mgr.send_rgwadmin_command(rgw_user_info_cmd)
+        if out:
             access_key, secret_key = _parse_secrets(user, out)
-    if not access_key:
-        mgr.log.error(f'Unable to create rgw {user} user: {err}')
-    assert access_key
-    assert secret_key
+        if not access_key:
+            rgw_create_user_cmd = [
+                'user', 'create',
+                '--uid', user,
+                '--display-name', 'Ceph Dashboard',
+                '--system',
+            ] + cmd_realm_option
+            _, out, err = mgr.send_rgwadmin_command(rgw_create_user_cmd)
+            if out:
+                access_key, secret_key = _parse_secrets(user, out)
+        if not access_key:
+            logger.error('Unable to create rgw user "%s": %s', user, err)
+    except SubprocessError as error:
+        logger.exception(error)
+
     return access_key, secret_key
 
 
 def configure_rgw_credentials():
-    mgr.log.info('Configuring dashboard RGW credentials')
+    logger.info('Configuring dashboard RGW credentials')
     user = 'dashboard'
-    rc, out, err = _radosgw_admin(['realm', 'list'])
-    if rc:
-        error = RgwAdminException(f'Unable to list RGW realms: {err}')
-        mgr.log.exception(error)
-        raise error
-    j = json.loads(out)
-    realms = j.get('realms', [])
-    if realms:
-        access_keys = {}
-        secret_keys = {}
-        for realm in realms:
-            access_keys[realm], secret_keys[realm] = _get_user_keys(user, realm)
-        access_key = json.dumps(access_keys)
-        secret_key = json.dumps(secret_keys)
-    else:
-        access_key, secret_key = _get_user_keys(user)
-    Settings.RGW_API_ACCESS_KEY = access_key
-    Settings.RGW_API_SECRET_KEY = secret_key
+    realms = []
+    access_key = ''
+    secret_key = ''
+    try:
+        _, out, err = mgr.send_rgwadmin_command(['realm', 'list'])
+        if out:
+            realms = out.get('realms', [])
+        if err:
+            logger.error('Unable to list RGW realms: %s', err)
+        if realms:
+            realm_access_keys = {}
+            realm_secret_keys = {}
+            for realm in realms:
+                realm_access_key, realm_secret_key = _get_user_keys(user, realm)
+                if realm_access_key:
+                    realm_access_keys[realm] = realm_access_key
+                    realm_secret_keys[realm] = realm_secret_key
+            if realm_access_keys:
+                access_key = json.dumps(realm_access_keys)
+                secret_key = json.dumps(realm_secret_keys)
+        else:
+            access_key, secret_key = _get_user_keys(user)
+
+        assert access_key and secret_key
+        Settings.RGW_API_ACCESS_KEY = access_key
+        Settings.RGW_API_SECRET_KEY = secret_key
+    except (AssertionError, SubprocessError) as error:
+        logger.exception(error)
+        raise NoCredentialsException
 
 
 class RgwClient(RestClient):
@@ -317,12 +307,9 @@ class RgwClient(RestClient):
 
     @staticmethod
     def _rgw_settings():
-        return (Settings.RGW_API_HOST,
-                Settings.RGW_API_PORT,
-                Settings.RGW_API_ACCESS_KEY,
+        return (Settings.RGW_API_ACCESS_KEY,
                 Settings.RGW_API_SECRET_KEY,
                 Settings.RGW_API_ADMIN_RESOURCE,
-                Settings.RGW_API_SCHEME,
                 Settings.RGW_API_SSL_VERIFY)
 
     @staticmethod
@@ -334,30 +321,11 @@ class RgwClient(RestClient):
 
         # The API access key and secret key are mandatory for a minimal configuration.
         if not (Settings.RGW_API_ACCESS_KEY and Settings.RGW_API_SECRET_KEY):
-            try:
-                configure_rgw_credentials()
-            except Exception as error:
-                logger.exception(error)
-                raise NoCredentialsException()
+            configure_rgw_credentials()
 
         if not daemon_name:
-            # Select default daemon if configured in settings:
-            if Settings.RGW_API_HOST and Settings.RGW_API_PORT:
-                for daemon in RgwClient._daemons.values():
-                    if daemon.host == Settings.RGW_API_HOST \
-                            and daemon.port == Settings.RGW_API_PORT:
-                        daemon_name = daemon.name
-                        break
-                if not daemon_name:
-                    raise DashboardException(
-                        msg='No RGW daemon found with user-defined host: {}, port: {}'.format(
-                            Settings.RGW_API_HOST,
-                            Settings.RGW_API_PORT),
-                        http_status_code=404,
-                        component='rgw')
             # Select 1st daemon:
-            else:
-                daemon_name = next(iter(RgwClient._daemons.keys()))
+            daemon_name = next(iter(RgwClient._daemons.keys()))
 
         # Discard all cached instances if any rgw setting has changed
         if RgwClient._rgw_settings_snapshot != RgwClient._rgw_settings():
@@ -443,6 +411,7 @@ class RgwClient(RestClient):
             self.userid = self._get_user_id(self.admin_path) if self.got_keys_from_config \
                 else user_id
         except RequestException as error:
+            logger.exception(error)
             msg = 'Error connecting to Object Gateway'
             if error.status_code == 404:
                 msg = '{}: {}'.format(msg, str(error))

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -36,13 +36,19 @@ class NoCredentialsException(RequestException):
             'the dashboard.')
 
 
+class RgwAdminException(Exception):
+    pass
+
+
 class RgwDaemon:
     """Simple representation of a daemon."""
     host: str
     name: str
     port: int
     ssl: bool
+    realm_name: str
     zonegroup_name: str
+    zone_name: str
 
 
 def _get_daemons() -> Dict[str, RgwDaemon]:
@@ -59,7 +65,9 @@ def _get_daemons() -> Dict[str, RgwDaemon]:
         if dict_contains_path(daemon_map[key], ['metadata', 'frontend_config#0']):
             daemon = _determine_rgw_addr(daemon_map[key])
             daemon.name = daemon_map[key]['metadata']['id']
+            daemon.realm_name = daemon_map[key]['metadata']['realm_name']
             daemon.zonegroup_name = daemon_map[key]['metadata']['zonegroup_name']
+            daemon.zone_name = daemon_map[key]['metadata']['zone_name']
             daemons[daemon.name] = daemon
             logger.info('Found RGW daemon with configuration: host=%s, port=%d, ssl=%s',
                         daemon.host, daemon.port, str(daemon.ssl))
@@ -185,9 +193,9 @@ def _parse_frontend_config(config) -> Tuple[int, bool]:
     raise LookupError('Failed to determine RGW port from "{}"'.format(config))
 
 
-def radosgw_admin(args: List[str]) -> Tuple[int, str, str]:
+def _radosgw_admin(args: List[str]) -> Tuple[int, str, str]:
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # pylint: disable=subprocess-run-check
             [
                 'radosgw-admin',
                 '-c', str(mgr.get_ceph_conf_path()),
@@ -207,60 +215,62 @@ def radosgw_admin(args: List[str]) -> Tuple[int, str, str]:
         raise
 
 
-def configure_rgw_users():
-    mgr.log.info('Configuring dashboard RGW credentials')
-    user = 'dashboard'
+def _parse_secrets(user: str, payload: str) -> Tuple[Optional[str], Optional[str]]:
+    data = json.loads(payload)
+    for key in data.get('keys', []):
+        if key.get('user') == user and data.get('system') in ['true', True]:
+            access_key = key.get('access_key')
+            secret_key = key.get('secret_key')
+            return access_key, secret_key
+    return None, None
 
-    def parse_secrets(user: str, out: str) -> Tuple[Optional[str], Optional[str]]:
-        r = json.loads(out)
-        for k in r.get('keys', []):
-            if k.get('user') == user and r.get('system') in ['true', True]:
-                access_key = k.get('access_key')
-                secret_key = k.get('secret_key')
-                return access_key, secret_key
-        return None, None
 
-    def get_keys(realm: Optional[str]) -> Tuple[str, str]:
-        cmd = ['user', 'info', '--uid', user]
-        if realm:
-            cmd += ['--rgw-realm', realm]
-        rc, out, _ = radosgw_admin(cmd)
-        access_key = None
-        secret_key = None
-        if not rc:
-            access_key, secret_key = parse_secrets(user, out)
-        if not access_key:
-            rc, out, err = radosgw_admin([
-                'user', 'create',
-                '--uid', user,
-                '--display-name', 'Ceph Dashboard',
-                '--system',
-            ])
-            if not rc:
-                access_key, secret_key = parse_secrets(user, out)
-        if not access_key:
-            mgr.log.error(f'Unable to create rgw {user} user: {err}')
-        assert access_key
-        assert secret_key
-        return access_key, secret_key
-
-    rc, out, err = radosgw_admin(['realm', 'list'])
-    if rc:
-        mgr.log.error(f'Unable to list RGW realms: {err}')
-        return
-    j = json.loads(out)
-    realms = j.get('realms', [])
+def _get_user_keys(user: str, realm: Optional[str] = None) -> Tuple[str, str]:
+    cmd = ['user', 'info', '--uid', user]
+    cmd_realm_option = ['--rgw-realm', realm] if realm else []
+    if realm:
+        cmd += cmd_realm_option
+    rc, out, err = _radosgw_admin(cmd)
     access_key = None
     secret_key = None
+    if not rc:
+        access_key, secret_key = _parse_secrets(user, out)
+    if not access_key:
+        rgw_create_user_cmd = [
+            'user', 'create',
+            '--uid', user,
+            '--display-name', 'Ceph Dashboard',
+            '--system',
+        ] + cmd_realm_option
+        rc, out, err = _radosgw_admin(rgw_create_user_cmd)
+        if not rc:
+            access_key, secret_key = _parse_secrets(user, out)
+    if not access_key:
+        mgr.log.error(f'Unable to create rgw {user} user: {err}')
+    assert access_key
+    assert secret_key
+    return access_key, secret_key
+
+
+def configure_rgw_credentials():
+    mgr.log.info('Configuring dashboard RGW credentials')
+    user = 'dashboard'
+    rc, out, err = _radosgw_admin(['realm', 'list'])
+    if rc:
+        error = RgwAdminException(f'Unable to list RGW realms: {err}')
+        mgr.log.exception(error)
+        raise error
+    j = json.loads(out)
+    realms = j.get('realms', [])
     if realms:
-        als = {}
-        sls = {}
+        access_keys = {}
+        secret_keys = {}
         for realm in realms:
-            als[realm], sls[realm] = get_keys(realm)
-        access_key = json.dumps(als)
-        secret_key = json.dumps(sls)
+            access_keys[realm], secret_keys[realm] = _get_user_keys(user, realm)
+        access_key = json.dumps(access_keys)
+        secret_key = json.dumps(secret_keys)
     else:
-        access_key, secret_key = get_keys(None)
+        access_key, secret_key = _get_user_keys(user)
     Settings.RGW_API_ACCESS_KEY = access_key
     Settings.RGW_API_SECRET_KEY = secret_key
 
@@ -285,8 +295,9 @@ class RgwClient(RestClient):
     @staticmethod
     def _get_daemon_connection_info(daemon_name: str) -> dict:
         try:
-            access_key = Settings.RGW_API_ACCESS_KEY[daemon_name]
-            secret_key = Settings.RGW_API_SECRET_KEY[daemon_name]
+            realm_name = RgwClient._daemons[daemon_name].realm_name
+            access_key = Settings.RGW_API_ACCESS_KEY[realm_name]
+            secret_key = Settings.RGW_API_SECRET_KEY[realm_name]
         except TypeError:
             # Legacy string values.
             access_key = Settings.RGW_API_ACCESS_KEY
@@ -323,10 +334,11 @@ class RgwClient(RestClient):
 
         # The API access key and secret key are mandatory for a minimal configuration.
         if not (Settings.RGW_API_ACCESS_KEY and Settings.RGW_API_SECRET_KEY):
-            logger.warning('No credentials found, please consult the '
-                           'documentation about how to enable RGW for the '
-                           'dashboard.')
-            raise NoCredentialsException()
+            try:
+                configure_rgw_credentials()
+            except Exception as error:
+                logger.exception(error)
+                raise NoCredentialsException()
 
         if not daemon_name:
             # Select default daemon if configured in settings:

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -63,13 +63,9 @@ class Options(object):
     AUDIT_API_LOG_PAYLOAD = Setting(True, [bool])
 
     # RGW settings
-    RGW_API_HOST = Setting('', [dict, str])
-    RGW_API_PORT = Setting(80, [dict, int])
     RGW_API_ACCESS_KEY = Setting('', [dict, str])
     RGW_API_SECRET_KEY = Setting('', [dict, str])
     RGW_API_ADMIN_RESOURCE = Setting('admin', [str])
-    RGW_API_SCHEME = Setting('http', [str])
-    RGW_API_USER_ID = Setting('', [dict, str])
     RGW_API_SSL_VERIFY = Setting(True, [bool])
 
     # Grafana settings

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -297,8 +297,6 @@ class RgwStub(Stub):
     @classmethod
     def get_settings(cls):
         settings = {
-            'RGW_API_HOST': '',
-            'RGW_API_PORT': 0,
             'RGW_API_ACCESS_KEY': 'fake-access-key',
             'RGW_API_SECRET_KEY': 'fake-secret-key',
         }

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -277,6 +277,7 @@ class RgwStub(Stub):
                 'metadata': {
                     'frontend_config#0': 'beast port=8000',
                     'id': 'daemon1',
+                    'realm_name': 'realm1',
                     'zonegroup_name': 'zonegroup1',
                     'zone_name': 'zone1'
                 }
@@ -286,6 +287,7 @@ class RgwStub(Stub):
                 'metadata': {
                     'frontend_config#0': 'civetweb port=8002',
                     'id': 'daemon2',
+                    'realm_name': 'realm2',
                     'zonegroup_name': 'zonegroup2',
                     'zone_name': 'zone2'
                 }

--- a/src/pybind/mgr/dashboard/tests/test_rgw_client.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw_client.py
@@ -4,11 +4,12 @@ import errno
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
+from .. import mgr
 from ..exceptions import DashboardException
 from ..services.rgw_client import NoCredentialsException, \
     NoRgwDaemonsException, RgwClient, _parse_frontend_config
 from ..settings import Settings
-from . import CLICommandTestMixin, CmdException, RgwStub  # pylint: disable=no-name-in-module
+from . import CLICommandTestMixin, RgwStub  # pylint: disable=no-name-in-module
 
 
 @patch('dashboard.services.rgw_client.RgwClient._get_user_id', Mock(
@@ -19,19 +20,33 @@ class RgwClientTest(TestCase, CLICommandTestMixin):
     _dashboard_user_realm2_access_key = 'OMDR282VYLBC1ZYMYDL0'
     _dashboard_user_realm2_secret_key = 'N3thf7jAiwQ90PsPrhC2DIcvCFOsBXtBvPJJMdC3'
     _radosgw_admin_result_error = (-errno.EINVAL, '', 'fake error')
-    _radosgw_admin_result_no_realms = (0, '{}', '')
-    _radosgw_admin_result_realms = (0, '{"realms": ["realm1", "realm2"]}', '')
-    _radosgw_admin_result_user_realm1_payload = (
+    _radosgw_admin_result_no_realms = (0, {}, '')
+    _radosgw_admin_result_realms = (0, {"realms": ["realm1", "realm2"]}, '')
+    _radosgw_admin_result_user_realm1 = (
         0,
-        '{"keys": [{"user": "dashboard", "access_key": "'
-        f'{_dashboard_user_realm1_access_key}",'
-        f'"secret_key": "{_dashboard_user_realm1_secret_key}"}}], "system": "true"}}',
+        {
+            "keys": [
+                {
+                    "user": "dashboard",
+                    "access_key": _dashboard_user_realm1_access_key,
+                    "secret_key": _dashboard_user_realm1_secret_key
+                }
+            ],
+            "system": "true"
+        },
         '')
-    _radosgw_admin_result_user_realm2_payload = (
+    _radosgw_admin_result_user_realm2 = (
         0,
-        '{"keys": [{"user": "dashboard", "access_key": "'
-        f'{_dashboard_user_realm2_access_key}",'
-        f'"secret_key": "{_dashboard_user_realm2_secret_key}"}}], "system": "true"}}',
+        {
+            "keys": [
+                {
+                    "user": "dashboard",
+                    "access_key": _dashboard_user_realm2_access_key,
+                    "secret_key": _dashboard_user_realm2_secret_key
+                }
+            ],
+            "system": "true"
+        },
         '')
 
     def setUp(self):
@@ -42,58 +57,68 @@ class RgwClientTest(TestCase, CLICommandTestMixin):
             'RGW_API_SECRET_KEY': 'supergeheim',
         })
 
-    @patch('dashboard.services.rgw_client._radosgw_admin')
-    def test_connect_rgw(self, radosgw_admin):
-        radosgw_admin.side_effect = [
-            self._radosgw_admin_result_error,
-            self._radosgw_admin_result_no_realms,
-            self._radosgw_admin_result_user_realm1_payload
-        ]
-        with self.assertRaises(CmdException) as ctx:
-            self.exec_cmd('connect-rgw')
-        self.assertEqual(ctx.exception.retcode, -errno.EINVAL)
-        self.assertIn('Unable to list RGW realms', str(ctx.exception))
-
-        result = self.exec_cmd('connect-rgw')
-        self.assertEqual(result, 'RGW credentials configured')
-        self.assertEqual(Settings.RGW_API_ACCESS_KEY, self._dashboard_user_realm1_access_key)
-        self.assertEqual(Settings.RGW_API_SECRET_KEY, self._dashboard_user_realm1_secret_key)
-
     def test_configure_credentials_error(self):
         self.CONFIG_KEY_DICT.update({
             'RGW_API_ACCESS_KEY': '',
             'RGW_API_SECRET_KEY': '',
         })
+        # Get no realms, get no user, user creation fails.
+        mgr.send_rgwadmin_command.side_effect = [
+            self._radosgw_admin_result_error,
+            self._radosgw_admin_result_error,
+            self._radosgw_admin_result_error,
+        ]
         with self.assertRaises(NoCredentialsException) as cm:
             RgwClient.admin_instance()
         self.assertIn('No RGW credentials found', str(cm.exception))
 
-    @patch('dashboard.services.rgw_client._radosgw_admin')
-    def test_configure_credentials_with_no_realms(self, radosgw_admin):
+    def test_configure_credentials_error_with_realms(self):
         self.CONFIG_KEY_DICT.update({
             'RGW_API_ACCESS_KEY': '',
             'RGW_API_SECRET_KEY': '',
         })
-        radosgw_admin.side_effect = [
-            self._radosgw_admin_result_no_realms,
-            self._radosgw_admin_result_user_realm1_payload
+        # Get realms, get no user, user creation fails.
+        mgr.send_rgwadmin_command.side_effect = [
+            self._radosgw_admin_result_realms,
+            self._radosgw_admin_result_error,
+            self._radosgw_admin_result_error,
+            self._radosgw_admin_result_error,
+            self._radosgw_admin_result_error,
         ]
-        RgwClient.admin_instance()
+        with self.assertRaises(NoCredentialsException) as cm:
+            RgwClient.admin_instance()
+        self.assertIn('No RGW credentials found', str(cm.exception))
+
+    def test_set_rgw_credentials_command(self):
+        # Get no realms, get user.
+        mgr.send_rgwadmin_command.side_effect = [
+            self._radosgw_admin_result_error,
+            self._radosgw_admin_result_user_realm1
+        ]
+        result = self.exec_cmd('set-rgw-credentials')
+        self.assertEqual(result, 'RGW credentials configured')
         self.assertEqual(Settings.RGW_API_ACCESS_KEY, self._dashboard_user_realm1_access_key)
         self.assertEqual(Settings.RGW_API_SECRET_KEY, self._dashboard_user_realm1_secret_key)
 
-    @patch('dashboard.services.rgw_client._radosgw_admin')
-    def test_configure_credentials_with_realms(self, radosgw_admin):
-        self.CONFIG_KEY_DICT.update({
-            'RGW_API_ACCESS_KEY': '',
-            'RGW_API_SECRET_KEY': '',
-        })
-        radosgw_admin.side_effect = [
-            self._radosgw_admin_result_realms,
-            self._radosgw_admin_result_user_realm1_payload,
-            self._radosgw_admin_result_user_realm2_payload
+        # Get no realms, get no user, user creation.
+        mgr.send_rgwadmin_command.side_effect = [
+            self._radosgw_admin_result_error,
+            self._radosgw_admin_result_error,
+            self._radosgw_admin_result_user_realm1
         ]
-        RgwClient.admin_instance()
+        result = self.exec_cmd('set-rgw-credentials')
+        self.assertEqual(result, 'RGW credentials configured')
+        self.assertEqual(Settings.RGW_API_ACCESS_KEY, self._dashboard_user_realm1_access_key)
+        self.assertEqual(Settings.RGW_API_SECRET_KEY, self._dashboard_user_realm1_secret_key)
+
+        # Get realms, get users.
+        mgr.send_rgwadmin_command.side_effect = [
+            self._radosgw_admin_result_realms,
+            self._radosgw_admin_result_user_realm1,
+            self._radosgw_admin_result_user_realm2
+        ]
+        result = self.exec_cmd('set-rgw-credentials')
+        self.assertEqual(result, 'RGW credentials configured')
         self.assertEqual(Settings.RGW_API_ACCESS_KEY, {
             'realm1': self._dashboard_user_realm1_access_key,
             'realm2': self._dashboard_user_realm2_access_key
@@ -101,6 +126,42 @@ class RgwClientTest(TestCase, CLICommandTestMixin):
         self.assertEqual(Settings.RGW_API_SECRET_KEY, {
             'realm1': self._dashboard_user_realm1_secret_key,
             'realm2': self._dashboard_user_realm2_secret_key
+        })
+
+        # Get realms, get no users, users' creation.
+        mgr.send_rgwadmin_command.side_effect = [
+            self._radosgw_admin_result_realms,
+            self._radosgw_admin_result_error,
+            self._radosgw_admin_result_user_realm1,
+            self._radosgw_admin_result_error,
+            self._radosgw_admin_result_user_realm2
+        ]
+        result = self.exec_cmd('set-rgw-credentials')
+        self.assertEqual(result, 'RGW credentials configured')
+        self.assertEqual(Settings.RGW_API_ACCESS_KEY, {
+            'realm1': self._dashboard_user_realm1_access_key,
+            'realm2': self._dashboard_user_realm2_access_key
+        })
+        self.assertEqual(Settings.RGW_API_SECRET_KEY, {
+            'realm1': self._dashboard_user_realm1_secret_key,
+            'realm2': self._dashboard_user_realm2_secret_key
+        })
+
+        # Get realms, get no users, realm 2 user creation fails.
+        mgr.send_rgwadmin_command.side_effect = [
+            self._radosgw_admin_result_realms,
+            self._radosgw_admin_result_error,
+            self._radosgw_admin_result_user_realm1,
+            self._radosgw_admin_result_error,
+            self._radosgw_admin_result_error,
+        ]
+        result = self.exec_cmd('set-rgw-credentials')
+        self.assertEqual(result, 'RGW credentials configured')
+        self.assertEqual(Settings.RGW_API_ACCESS_KEY, {
+            'realm1': self._dashboard_user_realm1_access_key,
+        })
+        self.assertEqual(Settings.RGW_API_SECRET_KEY, {
+            'realm1': self._dashboard_user_realm1_secret_key,
         })
 
     def test_ssl_verify(self):
@@ -118,15 +179,6 @@ class RgwClientTest(TestCase, CLICommandTestMixin):
         with self.assertRaises(NoRgwDaemonsException) as cm:
             RgwClient.admin_instance()
         self.assertIn('No RGW service is running.', str(cm.exception))
-
-    def test_default_daemon_wrong_settings(self):
-        self.CONFIG_KEY_DICT.update({
-            'RGW_API_HOST': '172.20.0.2',
-            'RGW_API_PORT': '7990',
-        })
-        with self.assertRaises(DashboardException) as cm:
-            RgwClient.admin_instance()
-        self.assertIn('No RGW daemon found with user-defined host:', str(cm.exception))
 
     @patch.object(RgwClient, '_get_daemon_zone_info')
     def test_get_placement_targets_from_zone(self, zone_info):

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -14,6 +14,7 @@ import logging
 import errno
 import functools
 import json
+import subprocess
 import threading
 from collections import defaultdict
 from enum import IntEnum
@@ -2050,3 +2051,33 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         :param arguments: dict of key/value arguments to test
         """
         return self._ceph_is_authorized(arguments)
+
+    def send_rgwadmin_command(self, args: List[str],
+                              stdout_as_json: bool = True) -> Tuple[int, Union[str, dict], str]:
+        try:
+            cmd = [
+                    'radosgw-admin',
+                    '-c', str(self.get_ceph_conf_path()),
+                    '-k', str(self.get_ceph_option('keyring')),
+                    '-n', f'mgr.{self.get_mgr_id()}',
+                ] + args
+            self.log.debug('Executing %s', str(cmd))
+            result = subprocess.run(  # pylint: disable=subprocess-run-check
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=10,
+            )
+            stdout = result.stdout.decode('utf-8')
+            stderr = result.stderr.decode('utf-8')
+            if stdout and stdout_as_json:
+                stdout = json.loads(stdout)
+            if result.returncode:
+                self.log.debug('Error %s executing %s: %s', result.returncode, str(cmd), stderr)
+            return result.returncode, stdout, stderr
+        except subprocess.CalledProcessError as ex:
+            self.log.exception('Error executing radosgw-admin %s: %s', str(ex.cmd), str(ex.output))
+            raise
+        except subprocess.TimeoutExpired as ex:
+            self.log.error('Timeout (10s) executing radosgw-admin %s', str(ex.cmd))
+            raise


### PR DESCRIPTION
- New 'ceph dashboard connect-rgw' command to set up RGW credentials
- Trigger credential check when rgw service created or destroyed.  Note that what we *really* want is a credential check any time an RGW realm is created or destroyed, but we don't have that visibility.  We could supplement by just calling the current check every 24h or something, though.  And eventually if/when we have a mgr/rgw module that pulls some of this rgw realm management into the mgr, then we can trigger it at the right time.

@alfonsomthd UPDATE:
- Dashboard > Object Gateway: if empty credentials are detected, we trigger the credentials configuration.

Fixes: https://tracker.ceph.com/issues/44605

Related PR: https://github.com/ceph/ceph/pull/41590

TODO
- [ ] we should trigger when the dashboard module is first enabled?  or perhaps even when the dashboard loads (on every mgr startup)?
- [x] update docs