### PR TITLE
mds: update META_POP_READDIR/FETCH/STORE and cache_hit_rate

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -28,6 +28,7 @@
 #include "Locker.h"
 #include "MDLog.h"
 #include "LogSegment.h"
+#include "MDBalancer.h"
 
 #include "common/bloom_filter.hpp"
 #include "include/Context.h"
@@ -1577,6 +1578,8 @@ void CDir::fetch(MDSContext *c, std::string_view want_dn, bool ignore_authpinnab
 
   if (mdcache->mds->logger) mdcache->mds->logger->inc(l_mds_dir_fetch);
 
+  mdcache->mds->balancer->hit_dir(this, META_POP_FETCH);
+
   std::set<dentry_key_t> empty;
   _omap_fetch(NULL, empty);
 }
@@ -1601,6 +1604,8 @@ void CDir::fetch(MDSContext *c, const std::set<dentry_key_t>& keys)
 
   auth_pin(this);
   if (mdcache->mds->logger) mdcache->mds->logger->inc(l_mds_dir_fetch);
+
+  mdcache->mds->balancer->hit_dir(this, META_POP_FETCH);
 
   _omap_fetch(c, keys);
 }
@@ -2551,6 +2556,8 @@ void CDir::_commit(version_t want, int op_prio)
   }
   
   if (mdcache->mds->logger) mdcache->mds->logger->inc(l_mds_dir_commit);
+
+  mdcache->mds->balancer->hit_dir(this, META_POP_STORE);
 
   _omap_commit(op_prio);
 }

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -300,6 +300,8 @@ mds_load_t MDBalancer::get_load()
   }
 
   uint64_t num_requests = mds->get_num_requests();
+  uint64_t num_traverse = mds->logger->get(l_mds_traverse);
+  uint64_t num_traverse_hit = mds->logger->get(l_mds_traverse_hit);
 
   uint64_t cpu_time = 1;
   {
@@ -331,13 +333,17 @@ mds_load_t MDBalancer::get_load()
 	load.req_rate = (num_requests - last_num_requests) / el;
       if (cpu_time > last_cpu_time)
 	load.cpu_load_avg = (cpu_time - last_cpu_time) / el;
+      if (num_traverse > last_num_traverse && num_traverse_hit > last_num_traverse_hit)
+        load.cache_hit_rate = (double)(num_traverse_hit - last_num_traverse_hit) / (num_traverse - last_num_traverse);
     } else {
       auto p = mds_load.find(mds->get_nodeid());
       if (p != mds_load.end()) {
 	load.req_rate = p->second.req_rate;
 	load.cpu_load_avg = p->second.cpu_load_avg;
+	load.cache_hit_rate = p->second.cache_hit_rate;
       }
-      if (num_requests >= last_num_requests && cpu_time >= last_cpu_time)
+      if (num_requests >= last_num_requests && cpu_time >= last_cpu_time &&
+          num_traverse >= last_num_traverse && num_traverse_hit >= last_num_traverse_hit)
 	update_last = false;
     }
   }
@@ -346,6 +352,8 @@ mds_load_t MDBalancer::get_load()
     last_num_requests = num_requests;
     last_cpu_time = cpu_time;
     last_get_load = now;
+    last_num_traverse = num_traverse;
+    last_num_traverse_hit = num_traverse_hit;
   }
 
   dout(15) << load << dendl;

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -137,6 +137,8 @@ private:
   time last_get_load = clock::zero();
   uint64_t last_num_requests = 0;
   uint64_t last_cpu_time = 0;
+  uint64_t last_num_traverse = 0;
+  uint64_t last_num_traverse_hit = 0;
 
   // Dirfrags which are marked to be passed on to MDCache::[split|merge]_dir
   // just as soon as a delayed context comes back and triggers it.

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4760,7 +4760,7 @@ void Server::handle_client_readdir(MDRequestRef& mdr)
   mdr->reply_extra_bl = dirbl;
 
   // bump popularity.  NOTE: this doesn't quite capture it.
-  mds->balancer->hit_dir(dir, META_POP_IRD, -1, numfiles);
+  mds->balancer->hit_dir(dir, META_POP_READDIR, -1, numfiles);
   
   // reply
   mdr->tracei = diri;


### PR DESCRIPTION
I've found that decay counters related to META_POP_READDIR/FETCH/STORE and cache_hit_rate reported by 'dump loads' are not updated. If these metrics are refreshed, administrators and MDBalancer can appropriately balance (or pin) subdirectories among MDS ranks.

Fixes: https://tracker.ceph.com/issues/51600
Signed-off-by: Yongseok Oh <yongseok.oh@linecorp.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
