### PR TITLE
octopus: osd/osd_type: use f->dump_unsigned() when appropriate

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2763,8 +2763,8 @@ bool pg_stat_t::is_acting_osd(int32_t osd, bool primary) const
 void pg_stat_t::dump(Formatter *f) const
 {
   f->dump_stream("version") << version;
-  f->dump_stream("reported_seq") << reported_seq;
-  f->dump_stream("reported_epoch") << reported_epoch;
+  f->dump_unsigned("reported_seq", reported_seq);
+  f->dump_unsigned("reported_epoch", reported_epoch);
   f->dump_string("state", pg_state_string(state));
   f->dump_stream("last_fresh") << last_fresh;
   f->dump_stream("last_change") << last_change;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51456

---

backport of https://github.com/ceph/ceph/pull/41517
parent tracker: https://tracker.ceph.com/issues/51354

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh