### PR TITLE
mgr/dashboard: Review Section for the Create Cluster Workflow

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -22,6 +22,7 @@ import { CephSharedModule } from '../shared/ceph-shared.module';
 import { ConfigurationDetailsComponent } from './configuration/configuration-details/configuration-details.component';
 import { ConfigurationFormComponent } from './configuration/configuration-form/configuration-form.component';
 import { ConfigurationComponent } from './configuration/configuration.component';
+import { CreateClusterReviewComponent } from './create-cluster/create-cluster-review.component';
 import { CreateClusterComponent } from './create-cluster/create-cluster.component';
 import { CrushmapComponent } from './crushmap/crushmap.component';
 import { HostDetailsComponent } from './hosts/host-details/host-details.component';
@@ -114,7 +115,8 @@ import { TelemetryComponent } from './telemetry/telemetry.component';
     ServiceFormComponent,
     OsdFlagsIndivModalComponent,
     PlacementPipe,
-    CreateClusterComponent
+    CreateClusterComponent,
+    CreateClusterReviewComponent
   ],
   providers: [NgbActiveModal]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.html
@@ -1,0 +1,31 @@
+<div class="row">
+  <div class="col-lg-4">
+    <fieldset>
+      <legend class="cd-header"
+              i18n>Cluster Resources</legend>
+      <table class="table table-striped">
+        <tr>
+          <td i18n
+              class="bold">Hosts</td>
+          <td>{{ hostsCount }}</td>
+        </tr>
+      </table>
+    </fieldset>
+  </div>
+
+  <div class="col-lg-8">
+    <legend i18n
+            class="cd-header">Hosts by Label</legend>
+    <cd-table [data]="hostsByLabel['data']"
+              [columns]="hostsByLabel['columns']"
+              [toolHeader]="false">
+    </cd-table>
+
+    <legend i18n
+            class="cd-header">Host Details</legend>
+    <cd-table [data]="hostsDetails['data']"
+              [columns]="hostsDetails['columns']"
+              [toolHeader]="false">
+    </cd-table>
+  </div>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.spec.ts
@@ -1,0 +1,61 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import _ from 'lodash';
+import { of } from 'rxjs';
+
+import { CephModule } from '~/app/ceph/ceph.module';
+import { CoreModule } from '~/app/core/core.module';
+import { HostService } from '~/app/shared/api/host.service';
+import { SharedModule } from '~/app/shared/shared.module';
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { CreateClusterReviewComponent } from './create-cluster-review.component';
+
+describe('CreateClusterReviewComponent', () => {
+  let component: CreateClusterReviewComponent;
+  let fixture: ComponentFixture<CreateClusterReviewComponent>;
+  let hostService: HostService;
+  let hostListSpy: jasmine.Spy;
+
+  configureTestBed({
+    imports: [HttpClientTestingModule, SharedModule, CoreModule, CephModule]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CreateClusterReviewComponent);
+    component = fixture.componentInstance;
+    hostService = TestBed.inject(HostService);
+    hostListSpy = spyOn(hostService, 'list');
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should verify host metadata calculations', () => {
+    const hostnames = ['ceph.test1', 'ceph.test2'];
+    const payload = [
+      {
+        hostname: hostnames[0],
+        ceph_version: 'ceph version Development',
+        labels: ['foo', 'bar']
+      },
+      {
+        hostname: hostnames[1],
+        ceph_version: 'ceph version Development',
+        labels: ['foo1', 'bar1']
+      }
+    ];
+    hostListSpy.and.callFake(() => of(payload));
+    fixture.detectChanges();
+    expect(hostListSpy).toHaveBeenCalled();
+
+    expect(component.hostsCount).toBe(2);
+    expect(component.uniqueLabels.size).toBe(4);
+    const labels = ['foo', 'bar', 'foo1', 'bar1'];
+
+    labels.forEach((label) => {
+      expect(component.labelOccurrences[label]).toBe(1);
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.ts
@@ -1,0 +1,86 @@
+import { Component, OnInit } from '@angular/core';
+
+import _ from 'lodash';
+
+import { HostService } from '~/app/shared/api/host.service';
+import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
+
+@Component({
+  selector: 'cd-create-cluster-review',
+  templateUrl: './create-cluster-review.component.html',
+  styleUrls: ['./create-cluster-review.component.scss']
+})
+export class CreateClusterReviewComponent implements OnInit {
+  hosts: object[] = [];
+  hostsDetails: object;
+  hostsByLabel: object;
+  hostsCount: number;
+  labelOccurrences = {};
+  hostsCountPerLabel: object[] = [];
+  uniqueLabels: Set<string> = new Set();
+
+  constructor(private hostService: HostService) {}
+
+  ngOnInit() {
+    this.hostsDetails = {
+      columns: [
+        {
+          prop: 'hostname',
+          name: $localize`Host Name`,
+          flexGrow: 2
+        },
+        {
+          name: $localize`Labels`,
+          prop: 'labels',
+          flexGrow: 1,
+          cellTransformation: CellTemplate.badge,
+          customTemplateConfig: {
+            class: 'badge-dark'
+          }
+        }
+      ]
+    };
+
+    this.hostsByLabel = {
+      columns: [
+        {
+          prop: 'label',
+          name: $localize`Labels`,
+          flexGrow: 1,
+          cellTransformation: CellTemplate.badge,
+          customTemplateConfig: {
+            class: 'badge-dark'
+          }
+        },
+        {
+          name: $localize`Number of Hosts`,
+          prop: 'hosts_per_label',
+          flexGrow: 1
+        }
+      ]
+    };
+
+    this.hostService.list().subscribe((resp: object[]) => {
+      this.hosts = resp;
+      this.hostsCount = this.hosts.length;
+
+      _.forEach(this.hosts, (hostKey) => {
+        const labels = hostKey['labels'];
+        _.forEach(labels, (label) => {
+          this.labelOccurrences[label] = (this.labelOccurrences[label] || 0) + 1;
+          this.uniqueLabels.add(label);
+        });
+      });
+
+      this.uniqueLabels.forEach((label) => {
+        this.hostsCountPerLabel.push({
+          label: label,
+          hosts_per_label: this.labelOccurrences[label]
+        });
+      });
+
+      this.hostsByLabel['data'] = [...this.hostsCountPerLabel];
+      this.hostsDetails['data'] = [...this.hosts];
+    });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.html
@@ -44,10 +44,7 @@
         </div>
         <div *ngSwitchCase="'2'"
              class="ml-5">
-          <h4 class="title"
-              i18n>Review</h4>
-          <br>
-          <p>To be implemented</p>
+          <cd-create-cluster-review></cd-create-cluster-review>
         </div>
       </ng-container>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.spec.ts
@@ -90,10 +90,8 @@ describe('CreateClusterComponent', () => {
     fixture.detectChanges();
     component.onNextStep();
     fixture.detectChanges();
-    const heading = fixture.debugElement.query(By.css('.title')).nativeElement;
     expect(wizardStepServiceSpy).toHaveBeenCalledTimes(1);
-    expect(hostServiceSpy).toBeCalledTimes(1);
-    expect(heading.innerHTML).toBe('Review');
+    expect(hostServiceSpy).toBeCalledTimes(2);
   });
 
   it('should show the button labels correctly', () => {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50566
Signed-off-by: Avan Thakkar athakkar@redhat.com

Review page for create-cluster workflow:
![Screenshot from 2021-07-16 15-26-55](https://user-images.githubusercontent.com/23611106/125930022-e5068eac-4ca7-49c1-ae1d-81eb78557911.png)



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
