### PR TITLE
crimson/os/seastore: implement metrics at cache level

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -573,6 +573,7 @@ record_t Cache::prepare_record(Transaction &t)
 	});
       i->last_committed_crc = final_crc;
     }
+    assert(record.deltas.back().bl.length());
   }
 
   // Transaction is now a go, set up in-memory cache state

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -307,10 +307,7 @@ public:
 	  if (!ref->is_valid()) {
 	    LOG_PREFIX(Cache::get_extent);
 	    DEBUGT("got invalid extent: {}", t, ref);
-	    t.conflicted = true;
-	    auto m_key = std::make_pair(t.get_src(), T::TYPE);
-	    assert(stats.trans_invalidated.count(m_key));
-	    ++(stats.trans_invalidated[m_key]);
+	    invalidate(t, *ref.get());
 	    return get_extent_iertr::make_ready_future<TCachedExtentRef<T>>();
 	  } else {
 	    t.add_to_read_set(ref);
@@ -359,10 +356,7 @@ public:
         if (!ret->is_valid()) {
           LOG_PREFIX(Cache::get_extent_by_type);
           DEBUGT("got invalid extent: {}", t, ret);
-          t.conflicted = true;
-          auto m_key = std::make_pair(t.get_src(), type);
-          assert(stats.trans_invalidated.count(m_key));
-          ++(stats.trans_invalidated[m_key]);
+          invalidate(t, *ret.get());
           return get_extent_ertr::make_ready_future<CachedExtentRef>();
         } else {
           t.add_to_read_set(ret);
@@ -646,6 +640,9 @@ private:
 
   /// Invalidate extent and mark affected transactions
   void invalidate(CachedExtent &extent);
+
+  /// Mark a valid transaction as conflicted
+  void invalidate(Transaction& t, CachedExtent& conflicting_extent);
 
   template <typename T>
   get_extent_ret<T> read_extent(

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -107,7 +107,10 @@ public:
       get_dummy_ordering_handle(),
       false,
       src,
-      last_commit
+      last_commit,
+      [this](Transaction& t) {
+        return on_transaction_destruct(t);
+      }
     );
     retired_extent_gate.add_token(ret->retired_gate_token);
     DEBUGT("created source={}", *ret, src);
@@ -125,7 +128,10 @@ public:
       get_dummy_ordering_handle(),
       true,
       src,
-      last_commit
+      last_commit,
+      [this](Transaction& t) {
+        return on_transaction_destruct(t);
+      }
     );
     retired_extent_gate.add_token(ret->retired_gate_token);
     DEBUGT("created source={}", *ret, src);
@@ -644,6 +650,8 @@ private:
     std::array<trans_efforts_t, Transaction::SRC_MAX> invalidated_efforts_by_src;
     std::unordered_map<src_ext_t, query_counters_t,
                        boost::hash<src_ext_t>> cache_query;
+    uint64_t read_transactions_successful;
+    effort_t read_effort_successful;
   } stats;
 
   template <typename CounterT>
@@ -695,6 +703,9 @@ private:
 
   /// Measure efforts of a submitting/invalidating transaction
   void measure_efforts(Transaction& t, trans_efforts_t& efforts);
+
+  /// Introspect transaction when it is being destructed
+  void on_transaction_destruct(Transaction& t);
 
   template <typename T>
   get_extent_ret<T> read_extent(

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -652,6 +652,7 @@ private:
                        boost::hash<src_ext_t>> cache_query;
     uint64_t read_transactions_successful;
     effort_t read_effort_successful;
+    uint64_t dirty_bytes;
   } stats;
 
   template <typename CounterT>

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_delta_recorder.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_delta_recorder.h
@@ -29,7 +29,6 @@ class DeltaRecorder {
   }
 
   ceph::bufferlist get_delta() {
-    assert(!is_empty());
     return std::move(encoded);
   }
 

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -315,7 +315,7 @@ TransactionManager::get_extent_if_live_ret TransactionManager::get_extent_if_liv
   LOG_PREFIX(TransactionManager::get_extent_if_live);
   DEBUGT("type {}, addr {}, laddr {}, len {}", t, type, addr, laddr, len);
 
-  return cache->get_extent_if_cached(t, addr
+  return cache->get_extent_if_cached(t, addr, type
   ).si_then([this, FNAME, &t, type, addr, laddr, len](auto extent)
 	    -> get_extent_if_live_ret {
     if (extent) {

--- a/src/test/crimson/seastore/test_block.cc
+++ b/src/test/crimson/seastore/test_block.cc
@@ -22,4 +22,20 @@ void TestBlock::apply_delta(const ceph::bufferlist &bl) {
   }
 }
 
+ceph::bufferlist TestBlockPhysical::get_delta() {
+  ceph::bufferlist bl;
+  encode(delta, bl);
+  return bl;
+}
+
+void TestBlockPhysical::apply_delta_and_adjust_crc(
+    paddr_t, const ceph::bufferlist &bl) {
+  auto biter = bl.begin();
+  decltype(delta) deltas;
+  decode(deltas, biter);
+  for (auto &&d : deltas) {
+    set_contents(d.val, d.offset, d.len);
+  }
+}
+
 }

--- a/src/test/crimson/seastore/test_block.h
+++ b/src/test/crimson/seastore/test_block.h
@@ -90,7 +90,7 @@ struct TestBlockPhysical : crimson::os::seastore::CachedExtent{
 
   TestBlockPhysical(ceph::bufferptr &&ptr)
     : CachedExtent(std::move(ptr)) {}
-  TestBlockPhysical(const TestBlock &other)
+  TestBlockPhysical(const TestBlockPhysical &other)
     : CachedExtent(other) {}
 
   CachedExtentRef duplicate_for_write() final {
@@ -104,15 +104,16 @@ struct TestBlockPhysical : crimson::os::seastore::CachedExtent{
 
   void set_contents(char c, uint16_t offset, uint16_t len) {
     ::memset(get_bptr().c_str() + offset, c, len);
+    delta.push_back({c, offset, len});
   }
 
   void set_contents(char c) {
     set_contents(c, 0, get_length());
   }
 
-  ceph::bufferlist get_delta() final { return ceph::bufferlist(); }
+  ceph::bufferlist get_delta() final;
 
-  void apply_delta_and_adjust_crc(paddr_t, const ceph::bufferlist &bl) final {}
+  void apply_delta_and_adjust_crc(paddr_t, const ceph::bufferlist &bl) final;
 };
 using TestBlockPhysicalRef = TCachedExtentRef<TestBlockPhysical>;
 


### PR DESCRIPTION
This is the follow-up work of https://github.com/ceph/ceph/pull/42202

It's to profile seastore at cache layer:
* cache hit ratio at the granularity of sub-component and categorized by transaction source;
* transactional read/mutate/fresh/retire efforts that are discarded and committed;
* transactional read effort that is successful;
* dirty and cached extent usage;
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
