### PR TITLE
rgw: conditionalize d3n_datacache use of libAIO

### DIFF
--- a/src/rgw/rgw_d3n_datacache.cc
+++ b/src/rgw/rgw_d3n_datacache.cc
@@ -97,12 +97,14 @@ void D3nDataCache::init(CephContext *_cct) {
   if (conf_eviction_policy == "random")
     eviction_policy = _eviction_policy::RANDOM;
 
+#if defined(HAVE_LIBAIO)
   // libaio setup
   struct aioinit ainit{0};
-  ainit.aio_threads = cct->_conf.get_val<int64_t>("rgw_d3n_libaio_aio_threads");;
+  ainit.aio_threads = cct->_conf.get_val<int64_t>("rgw_d3n_libaio_aio_threads");
   ainit.aio_num = cct->_conf.get_val<int64_t>("rgw_d3n_libaio_aio_num");
   ainit.aio_idle_time = 120;
   aio_init(&ainit);
+#endif
 }
 
 int D3nDataCache::d3n_io_write(bufferlist& bl, unsigned int len, std::string oid)


### PR DESCRIPTION
FreeBSD dus not have libaio, but uses the POSIX aio variant.
So only include that part of  d3n_datacache when LIBAIO is available

Tracker: https://tracker.ceph.com/issues/51720
Fixes: #36266

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>