### PR TITLE
common/LogEntry: drop support of LogSummary v2 encoding scheme

### DIFF
--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -309,15 +309,7 @@ void LogSummary::build_ordered_tail_legacy(list<LogEntry> *tail) const
 
 void LogSummary::encode(bufferlist& bl, uint64_t features) const
 {
-  if (!HAVE_FEATURE(features, SERVER_MIMIC)) {
-    ENCODE_START(2, 2, bl);
-    encode(version, bl);
-    list<LogEntry> tail;
-    build_ordered_tail_legacy(&tail);
-    encode(tail, bl, features);
-    ENCODE_FINISH(bl);
-    return;
-  }
+  assert(HAVE_FEATURE(features, SERVER_MIMIC));
   ENCODE_START(4, 3, bl);
   encode(version, bl);
   encode(seq, bl);
@@ -331,19 +323,11 @@ void LogSummary::decode(bufferlist::const_iterator& bl)
 {
   DECODE_START_LEGACY_COMPAT_LEN(4, 2, 2, bl);
   decode(version, bl);
-  if (struct_v < 3) {
-    list<LogEntry> tail;
-    decode(tail, bl);
-    for (auto& i : tail) {
-      add_legacy(i);
-    }
-  } else {
-    decode(seq, bl);
-    decode(tail_by_channel, bl);
-    if (struct_v >= 4) {
-      decode(channel_info, bl);
-      recent_keys.decode(bl);
-    }
+  decode(seq, bl);
+  decode(tail_by_channel, bl);
+  if (struct_v >= 4) {
+    decode(channel_info, bl);
+    recent_keys.decode(bl);
   }
   DECODE_FINISH(bl);
   keys.clear();


### PR DESCRIPTION
LogSummary's v3 encoding scheme was introduced in
648aaf271cb02c647f046288656c11f15a7799b2, which was in turn included
by Ceph v13.1.0 and all newer releases. since LogSummary is persistented
by monitor, and it is trimmed regularly by monitor, there is no need
to read a LogSummary encoded by 2 releases older monitor.

in this change, the support of LogSummary v2 encoding scheme is dropped.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
