### PR TITLE
librbd: optimize data_object_name

### DIFF
--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -19,6 +19,7 @@ set(librbd_test
   test_ObjectMap.cc
   test_Operations.cc
   test_Trash.cc
+  test_Utils.cc
   journal/test_Entries.cc
   journal/test_Replay.cc)
 add_library(rbd_test STATIC ${librbd_test})

--- a/src/test/librbd/test_Utils.cc
+++ b/src/test/librbd/test_Utils.cc
@@ -1,0 +1,49 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_fixture.h"
+#include "test/librbd/test_support.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+
+using librbd::util::data_object_name;
+
+void register_test_utils() {
+}
+
+struct TestUtils : public TestFixture {
+  void SetUp() override {
+    TestFixture::SetUp();
+    ASSERT_EQ(0, open_image(m_image_name, &m_ictx));
+  }
+
+  void expect_data_object_name(uint64_t object_no,
+                               const std::string& expected_object_suffix) {
+    EXPECT_EQ(data_object_name(m_ictx, object_no),
+              m_ictx->object_prefix + std::string(".") +
+              expected_object_suffix);
+    }
+
+    librbd::ImageCtx *m_ictx;
+};
+
+TEST_F(TestUtils, DataObjectNameV1) {
+  REQUIRE_FORMAT_V1();
+  expect_data_object_name(0, "000000000000");
+  expect_data_object_name(1, "000000000001");
+  expect_data_object_name(0x123456789ab, "0123456789ab");
+  expect_data_object_name(0x800000000000, "800000000000");
+  expect_data_object_name(0x800000000001, "800000000001");
+  expect_data_object_name(0xffffffffffff, "ffffffffffff");
+}
+
+TEST_F(TestUtils, DataObjectNameV2) {
+  REQUIRE_FORMAT_V2();
+  expect_data_object_name(0, "0000000000000000");
+  expect_data_object_name(1, "0000000000000001");
+  expect_data_object_name(0x123456789abcdef, "0123456789abcdef");
+  expect_data_object_name(0x8000000000000000, "8000000000000000");
+  expect_data_object_name(0x8000000000000001, "8000000000000001");
+  expect_data_object_name(0xffffffffffffffff, "ffffffffffffffff");
+}
+

--- a/src/test/librbd/test_main.cc
+++ b/src/test/librbd/test_main.cc
@@ -23,6 +23,7 @@ extern void register_test_mirroring_watcher();
 extern void register_test_object_map();
 extern void register_test_operations();
 extern void register_test_trash();
+extern void register_test_utils();
 #endif // TEST_LIBRBD_INTERNALS
 
 int main(int argc, char **argv)
@@ -43,6 +44,7 @@ int main(int argc, char **argv)
   register_test_object_map();
   register_test_operations();
   register_test_trash();
+  register_test_utils();
 #endif // TEST_LIBRBD_INTERNALS
 
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
`data_object_name` function is used per each object request generated by librbd, i.e. it is very commonly called.
Currently, it's implemented using snprintf, which is not trivial in terms of cpu cycles.
I replaced the snprintf call with a simple int-to-hex conversion loop.
On my tests, I got more than X6 better performance for this function.