### PR TITLE
librbd: optimize out AsyncOpTracker from dispatchers

### DIFF
--- a/src/librbd/io/ImageDispatcher.cc
+++ b/src/librbd/io/ImageDispatcher.cc
@@ -270,8 +270,7 @@ void ImageDispatcher<I>::remap_extents(Extents& image_extents,
                                        ImageExtentsMapType type) {
   auto loop = [&image_extents, type](auto begin, auto end) {
       for (auto it = begin; it != end; ++it) {
-        auto& image_dispatch_meta = it->second;
-        auto image_dispatch = image_dispatch_meta.dispatch;
+        auto image_dispatch = it->second;
         image_dispatch->remap_extents(image_extents, type);
       }
   };

--- a/src/librbd/io/ObjectDispatcher.cc
+++ b/src/librbd/io/ObjectDispatcher.cc
@@ -165,8 +165,7 @@ void ObjectDispatcher<I>::extent_overwritten(
 
   std::shared_lock locker{this->m_lock};
   for (auto it : this->m_dispatches) {
-    auto& object_dispatch_meta = it.second;
-    auto object_dispatch = object_dispatch_meta.dispatch;
+    auto object_dispatch = it.second;
     object_dispatch->extent_overwritten(object_no, object_off, object_len,
                                         journal_tid, new_journal_tid);
   }
@@ -181,8 +180,7 @@ int ObjectDispatcher<I>::prepare_copyup(
 
   std::shared_lock locker{this->m_lock};
   for (auto it : this->m_dispatches) {
-    auto& object_dispatch_meta = it.second;
-    auto object_dispatch = object_dispatch_meta.dispatch;
+    auto object_dispatch = it.second;
     auto r = object_dispatch->prepare_copyup(
             object_no, snapshot_sparse_bufferlist);
     if (r < 0) {


### PR DESCRIPTION
There are 2 mutexes that exist to support dynamic dispatch layers in librbd.
One is in Dispatcher::m_lock, and the other is per-layer AsyncOpTracker.
This PR removes the later, and extends the use of the first instead, so that the Dispatcher m_lock is holded by the readers for longer periods.
The obvious down-side is that the writers, which are the dispatch layer mutator (register/shut-down) will take longer to acquire if many requests are still in the process.
But I think the benefit on the IO path is way more significant, than a possible minor increase in shut-down time.