### PR TITLE
common: optimize op_target_t and hobject_t constructors

### DIFF
--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -130,8 +130,8 @@ public:
     return hobject_t_max();
   }
 
-  hobject_t(object_t oid, const std::string& key, snapid_t snap, uint32_t hash,
-	    int64_t pool, std::string nspace)
+  hobject_t(const object_t& oid, const std::string& key, snapid_t snap,
+            uint32_t hash, int64_t pool, const std::string& nspace)
     : oid(oid), snap(snap), hash(hash), max(false),
       pool(pool), nspace(nspace),
       key(oid.name == key ? std::string() : key) {
@@ -139,7 +139,7 @@ public:
   }
 
   hobject_t(const sobject_t &soid, const std::string &key, uint32_t hash,
-	    int64_t pool, std::string nspace)
+	    int64_t pool, const std::string& nspace)
     : oid(soid.oid), snap(soid.snap), hash(hash), max(false),
       pool(pool), nspace(nspace),
       key(soid.oid.name == key ? std::string() : key) {

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1793,7 +1793,7 @@ public:
 
     epoch_t last_force_resend = 0;
 
-    op_target_t(object_t oid, object_locator_t oloc, int flags)
+    op_target_t(const object_t& oid, const object_locator_t& oloc, int flags)
       : flags(flags),
 	base_oid(oid),
 	base_oloc(oloc)


### PR DESCRIPTION
The oid, and oloc are already copied when initializing op_target_t members.
This seems to save a bit in the Op constructor.
Profile result of Op::Op before and after this patch:
![image](https://user-images.githubusercontent.com/17771355/125281282-b62f2880-e31e-11eb-994b-0be1a0c0680c.png)
