### PR TITLE
msg/async/ProtocolV2: optimize append_frame

### DIFF
--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -585,7 +585,7 @@ bool ProtocolV2::append_frame(F& frame) {
 
   ldout(cct, 25) << __func__ << " assembled frame " << bl.length()
                  << " bytes " << tx_frame_asm << dendl;
-  connection->outgoing_bl.append(bl);
+  connection->outgoing_bl.claim_append(bl);
   return true;
 }
 


### PR DESCRIPTION
The commonly used append_frame function currently copies
frame data, incurring expensive heap allocation and data copying.
Instead, switch to claiming the frame data, re-using it without copying.
