### PR TITLE
common: optimize objects memory allocations using pools

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(common_buffer_obj OBJECT
-  buffer.cc)
+  buffer.cc
+  buffer_pool.cc)
 
 add_library(common_texttable_obj OBJECT
   TextTable.cc)

--- a/src/common/buffer_pool.cc
+++ b/src/common/buffer_pool.cc
@@ -1,0 +1,25 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+
+#include "buffer_pool.h"
+
+#include "include/ceph_assert.h"
+
+std::array<BufferPool<void>, PooledObject::POOLED_OBJECT_MAX_SIZE> \
+        PooledObject::object_pools;
+
+void* PooledObject::operator new(std::size_t sz) {
+  if (sz >= POOLED_OBJECT_MAX_SIZE) {
+    return ::operator new(sz);
+  }
+  auto ptr = object_pools[sz].get();
+  return ptr ? ptr : ::operator new(sz);
+}
+
+void PooledObject::operator delete(void* ptr, std::size_t sz) {
+  if (sz >= POOLED_OBJECT_MAX_SIZE) {
+    ::operator delete(ptr);
+    return;
+  }
+  object_pools[sz].put(ptr);
+}

--- a/src/common/buffer_pool.h
+++ b/src/common/buffer_pool.h
@@ -1,0 +1,79 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_BUFFER_POOL_H
+#define CEPH_BUFFER_POOL_H
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+template <typename T>
+class BufferPool {
+public:
+    ~BufferPool() {
+      std::lock_guard<std::mutex> l{m_lock};
+      while (!m_buffers.empty()) {
+        auto buf = m_buffers.back();
+        ::operator delete(buf);
+        m_buffers.pop_back();
+      }
+      std::vector<T*> empty;
+      m_buffers.swap(empty);
+    }
+
+    T* get() {
+      std::lock_guard<std::mutex> l{m_lock};
+      if (m_buffers.empty()) {
+        return nullptr;
+      }
+
+      auto buf = m_buffers.back();
+      m_buffers.pop_back();
+      return buf;
+    }
+
+    void put(T* buf) {
+      std::lock_guard<std::mutex> l(m_lock);
+      m_buffers.push_back(buf);
+    }
+
+private:
+    std::mutex m_lock;
+    std::vector<T*> m_buffers;
+};
+
+class PooledObject {
+	public:
+    static void* operator new(std::size_t sz);
+    static void operator delete(void* ptr, std::size_t sz);
+
+    static constexpr int POOLED_OBJECT_MAX_SIZE = 2048;
+    static std::array<BufferPool<void>, POOLED_OBJECT_MAX_SIZE> object_pools;
+};
+
+template <typename T>
+class PooledAllocator : public std::allocator<T> {
+public:
+    PooledAllocator() {
+    }
+
+    template <typename U>
+    PooledAllocator(const PooledAllocator<U>& other) throw() {
+    };
+
+    template<typename U>
+    struct rebind {
+        typedef PooledAllocator<U> other;
+    };
+
+    T* allocate(std::size_t n) {
+      return (T*)PooledObject::operator new(n * sizeof(T));
+    }
+
+    void deallocate(T* p, std::size_t n) {
+      PooledObject::operator delete(p, n * sizeof(T));
+    }
+};
+
+#endif // CEPH_BUFFER_POOL_H

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(crimson-common STATIC
   ${PROJECT_SOURCE_DIR}/src/common/bit_str.cc
   ${PROJECT_SOURCE_DIR}/src/common/bloom_filter.cc
   ${PROJECT_SOURCE_DIR}/src/common/buffer.cc
+  ${PROJECT_SOURCE_DIR}/src/common/buffer_pool.cc
   ${PROJECT_SOURCE_DIR}/src/common/buffer_seastar.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_argparse.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_context.cc

--- a/src/include/Context.h
+++ b/src/include/Context.h
@@ -29,6 +29,7 @@
 #include "common/error_code.h"
 
 #include "include/ceph_assert.h"
+#include "common/buffer_pool.h"
 #include "common/ceph_mutex.h"
 
 #define mydout(cct, v) lgeneric_subdout(cct, context, v)
@@ -158,7 +159,7 @@ struct RunOnDelete {
 typedef std::shared_ptr<RunOnDelete> RunOnDeleteRef;
 
 template <typename T>
-class LambdaContext : public Context {
+class LambdaContext : public Context, public PooledObject {
 public:
   LambdaContext(T &&t) : t(std::forward<T>(t)) {}
   void finish(int r) override {

--- a/src/librbd/io/AioCompletion.h
+++ b/src/librbd/io/AioCompletion.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_LIBRBD_IO_AIO_COMPLETION_H
 #define CEPH_LIBRBD_IO_AIO_COMPLETION_H
 
+#include "common/buffer_pool.h"
 #include "common/ceph_time.h"
 #include "include/common_fwd.h"
 #include "include/Context.h"
@@ -37,7 +38,7 @@ namespace io {
  * within the caller's thread of execution (instead via a librados
  * context or via a thread pool context for cache read hits).
  */
-struct AioCompletion {
+struct AioCompletion : public PooledObject {
   typedef enum {
     AIO_STATE_PENDING = 0,
     AIO_STATE_CALLBACK,

--- a/src/librbd/io/ImageDispatchSpec.h
+++ b/src/librbd/io/ImageDispatchSpec.h
@@ -7,6 +7,7 @@
 #include "include/int_types.h"
 #include "include/buffer.h"
 #include "include/Context.h"
+#include "common/buffer_pool.h"
 #include "common/zipkin_trace.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/Types.h"
@@ -22,7 +23,7 @@ namespace io {
 
 struct ImageDispatcherInterface;
 
-class ImageDispatchSpec {
+class ImageDispatchSpec : public PooledObject {
 private:
   // helper to avoid extra heap allocation per object IO
   struct C_Dispatcher : public Context {

--- a/src/librbd/io/ObjectDispatchSpec.h
+++ b/src/librbd/io/ObjectDispatchSpec.h
@@ -8,6 +8,7 @@
 #include "include/buffer.h"
 #include "include/Context.h"
 #include "include/rados/librados.hpp"
+#include "common/buffer_pool.h"
 #include "common/zipkin_trace.h"
 #include "librbd/Types.h"
 #include "librbd/io/Types.h"
@@ -18,7 +19,7 @@ namespace io {
 
 struct ObjectDispatcherInterface;
 
-struct ObjectDispatchSpec {
+struct ObjectDispatchSpec : public PooledObject {
 private:
   // helper to avoid extra heap allocation per object IO
   struct C_Dispatcher : public Context {

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -8,6 +8,7 @@
 #include "include/buffer.h"
 #include "include/neorados/RADOS.hpp"
 #include "include/rados/librados.hpp"
+#include "common/buffer_pool.h"
 #include "common/zipkin_trace.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/Types.h"
@@ -34,7 +35,7 @@ template <typename> class CopyupRequest;
  * for I/O due to layering.
  */
 template <typename ImageCtxT = ImageCtx>
-class ObjectRequest {
+class ObjectRequest : public PooledObject {
 public:
   static ObjectRequest* create_write(
       ImageCtxT *ictx, uint64_t object_no, uint64_t object_off,

--- a/src/librbd/io/ReadResult.h
+++ b/src/librbd/io/ReadResult.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_LIBRBD_IO_READ_RESULT_H
 #define CEPH_LIBRBD_IO_READ_RESULT_H
 
+#include "common/buffer_pool.h"
 #include "include/common_fwd.h"
 #include "include/int_types.h"
 #include "include/buffer_fwd.h"
@@ -39,7 +40,7 @@ public:
     void finish(int r) override;
   };
 
-  struct C_ObjectReadRequest : public Context {
+  struct C_ObjectReadRequest : public Context, public PooledObject {
     AioCompletion *aio_completion;
     ReadExtents extents;
 

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.cc
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.cc
@@ -431,8 +431,9 @@ void SimpleSchedulerObjectDispatch<I>::dispatch_all_delayed_requests() {
 template <typename I>
 void SimpleSchedulerObjectDispatch<I>::register_in_flight_request(
     uint64_t object_no, const utime_t &start_time, Context **on_finish) {
+  PooledAllocator<ObjectRequests> allocator;
   auto res = m_requests.insert(
-      {object_no, std::make_shared<ObjectRequests>(object_no)});
+      {object_no, std::allocate_shared<ObjectRequests>(allocator, object_no)});
   ceph_assert(res.second);
   auto it = res.first;
 

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.h
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_LIBRBD_IO_SIMPLE_SCHEDULER_OBJECT_DISPATCH_H
 #define CEPH_LIBRBD_IO_SIMPLE_SCHEDULER_OBJECT_DISPATCH_H
 
+#include "common/buffer_pool.h"
 #include "common/ceph_mutex.h"
 #include "include/interval_set.h"
 #include "include/utime.h"
@@ -187,7 +188,9 @@ private:
   };
 
   typedef std::shared_ptr<ObjectRequests> ObjectRequestsRef;
-  typedef std::map<uint64_t, ObjectRequestsRef> Requests;
+  typedef std::map<uint64_t, ObjectRequestsRef, std::less<uint64_t>,
+                   PooledAllocator<std::pair<const uint64_t,
+                                             ObjectRequestsRef>>> Requests;
 
   ImageCtxT *m_image_ctx;
 

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -6,6 +6,7 @@
 
 #include "include/int_types.h"
 #include "include/rados/rados_types.hpp"
+#include "common/buffer_pool.h"
 #include "common/interval_map.h"
 #include "osdc/StriperTypes.h"
 #include <iosfwd>
@@ -312,7 +313,7 @@ struct ReadExtent {
     }
 };
 
-typedef std::vector<ReadExtent> ReadExtents;
+typedef std::vector<ReadExtent, PooledAllocator<ReadExtent>> ReadExtents;
 
 typedef std::map<uint64_t, uint64_t> ExtentMap;
 

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -20,6 +20,7 @@
 
 #include "MOSDFastDispatchOp.h"
 #include "include/ceph_features.h"
+#include "common/buffer_pool.h"
 #include "common/hobject.h"
 
 /*
@@ -34,7 +35,7 @@ class MOSDOpReply;
 
 namespace _mosdop {
 template<typename V>
-class MOSDOp final : public MOSDFastDispatchOp {
+class MOSDOp final : public MOSDFastDispatchOp, public PooledObject {
 private:
   static constexpr int HEAD_VERSION = 8;
   static constexpr int COMPAT_VERSION = 3;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -43,6 +43,7 @@
 
 #include "common/admin_socket.h"
 #include "common/async/completion.h"
+#include "common/buffer_pool.h"
 #include "common/ceph_time.h"
 #include "common/ceph_mutex.h"
 #include "common/ceph_timer.h"
@@ -1880,7 +1881,7 @@ public:
       return nullptr;
   }
 
-  struct Op : public RefCountedObject {
+  struct Op : public RefCountedObject, public PooledObject {
     OSDSession *session = nullptr;
     int incarnation = 0;
 


### PR DESCRIPTION
A significant time is spent in allocating memory for class objects on heap.
i.e., in calls to c++ operator new(long) and operator delete(void*).
This patch creates by-size pools to be used for allocating common objects,
which are relatively large, such as MOSDOp, Op, and librbd disaptch specs.

Implemented a meta class called PooledObject, which implements operator new and operator delete.
Then, simply make class such as MOSDOp inherit from PooledObject, and then every call to `new MOSDOp` will use the allocation implemented in PooledObject.

The classes I applied this to are upto 1K of size (most of them are just around 200 bytes).
So for example, a burst of 10000 MOSDOp's will add up to ~10MB of memory.

Also implemented Pooled Allocator for allocating memory on STL containers, currently applied only to the std::map of requests in SimpleSchedulerObjectDispatch.

See comparison of performance between the glibc operator new, and the pooled operator new:
![image](https://user-images.githubusercontent.com/17771355/125297196-b4ba2c00-e32f-11eb-8af3-416d7621d5d3.png)