### PR TITLE
cephadm: use pyfakefs during test_create_daemon_dirs_prometheus

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2196,7 +2196,9 @@ def create_daemon_dirs(ctx, fsid, daemon_type, daemon_id, uid, gid,
             f.write(keyring)
 
     if daemon_type in Monitoring.components.keys():
-        config_json: Dict[str, Any] = get_parm(ctx.config_json)
+        config_json: Dict[str, Any] = dict()
+        if 'config_json' in ctx:
+            config_json = get_parm(ctx.config_json)
 
         # Set up directories specific to the monitoring component
         config_dir = ''

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1,6 +1,7 @@
 # type: ignore
 
 import errno
+import json
 import mock
 import os
 import pytest
@@ -977,14 +978,7 @@ class TestMonitoring(object):
         version = cd.Monitoring.get_version(ctx, 'container_id', daemon_type)
         assert version == '0.16.1'
 
-    @mock.patch('cephadm.os.fchown')
-    @mock.patch('cephadm.get_parm')
-    @mock.patch('cephadm.makedirs')
-    @mock.patch('cephadm.open')
-    @mock.patch('cephadm.make_log_dir')
-    @mock.patch('cephadm.make_data_dir')
-    def test_create_daemon_dirs_prometheus(self, make_data_dir, make_log_dir, _open, makedirs,
-                                           get_parm, fchown):
+    def test_create_daemon_dirs_prometheus(self, cephadm_fs):
         """
         Ensures the required and optional files given in the configuration are
         created and mapped correctly inside the container. Tests absolute and
@@ -997,13 +991,12 @@ class TestMonitoring(object):
         daemon_id = 'home'
         ctx = cd.CephadmContext()
         ctx.data_dir = '/somedir'
-        files = {
+        ctx.config_json = json.dumps({
             'files': {
                 'prometheus.yml': 'foo',
                 '/etc/prometheus/alerting/ceph_alerts.yml': 'bar'
             }
-        }
-        get_parm.return_value = files
+        })
 
         cd.create_daemon_dirs(ctx,
                               fsid,
@@ -1020,14 +1013,17 @@ class TestMonitoring(object):
             daemon_type=daemon_type,
             daemon_id=daemon_id
         )
-        assert _open.call_args_list == [
-            mock.call('{}/etc/prometheus/prometheus.yml'.format(prefix), 'w',
-                 encoding='utf-8'),
-            mock.call('{}/etc/prometheus/alerting/ceph_alerts.yml'.format(prefix), 'w',
-                 encoding='utf-8'),
-        ]
-        assert mock.call().__enter__().write('foo') in _open.mock_calls
-        assert mock.call().__enter__().write('bar') in _open.mock_calls
+
+        expected = {
+            'etc/prometheus/prometheus.yml': 'foo',
+            'etc/prometheus/alerting/ceph_alerts.yml': 'bar',
+        }
+
+        for file,content in expected.items():
+            file = os.path.join(prefix, file)
+            assert os.path.exists(file)
+            with open(file) as f:
+                assert f.read() == content
 
 
 class TestBootstrap(object):

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -995,7 +995,7 @@ class TestMonitoring(object):
         daemon_type = 'prometheus'
         uid, gid = 50, 50
         daemon_id = 'home'
-        ctx = mock.Mock()
+        ctx = cd.CephadmContext()
         ctx.data_dir = '/somedir'
         files = {
             'files': {


### PR DESCRIPTION
convert test to use the `cephadm_fs` fixture

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
