### PR TITLE
qa/suites/upgrade: log_to_journald=false

### DIFF
--- a/qa/suites/orch/cephadm/upgrade/3-start-upgrade.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-start-upgrade.yaml
@@ -10,4 +10,5 @@ tasks:
       - sleep 120
       - ceph config set mon mon_warn_on_insecure_global_id_reclaim false --force
       - ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false --force
+      - ceph config set global log_to_journald false --force
       - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1

--- a/qa/suites/upgrade/octopus-x/parallel/upgrade-sequence.yaml
+++ b/qa/suites/upgrade/octopus-x/parallel/upgrade-sequence.yaml
@@ -5,6 +5,7 @@ upgrade-sequence:
    - cephadm.shell:
        env: [sha1]
        mon.a:
+         - ceph config set global log_to_journald false --force
          - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
          - while ceph orch upgrade status | jq '.in_progress' | grep true ; do ceph orch ps ; ceph versions ; sleep 30 ; done
          - ceph orch ps

--- a/qa/suites/upgrade/octopus-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/octopus-x/stress-split/1-start.yaml
@@ -53,6 +53,7 @@ first-half-sequence:
     env: [sha1]
     mon.a:
       - ceph config set mgr mgr/cephadm/daemon_cache_timeout 60
+      - ceph config set global log_to_journald false --force
 
       - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
       - ceph orch ps

--- a/qa/suites/upgrade/pacific-x/parallel/upgrade-sequence.yaml
+++ b/qa/suites/upgrade/pacific-x/parallel/upgrade-sequence.yaml
@@ -5,6 +5,7 @@ upgrade-sequence:
    - cephadm.shell:
        env: [sha1]
        mon.a:
+         - ceph config set global log_to_journald false --force
          - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
          - while ceph orch upgrade status | jq '.in_progress' | grep true ; do ceph orch ps ; ceph versions ; sleep 30 ; done
          - ceph orch ps

--- a/qa/suites/upgrade/pacific-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/pacific-x/stress-split/1-start.yaml
@@ -53,6 +53,7 @@ first-half-sequence:
     env: [sha1]
     mon.a:
       - ceph config set mgr mgr/cephadm/daemon_cache_timeout 60
+      - ceph config set global log_to_journald false --force
 
       - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
       - ceph orch ps


### PR DESCRIPTION
In 8b95c4b7c58e0caa6ac157b36e1cbc616803da3d we set log_to_journald=false
in the cephadm config.  However, that's not present in pre-quincy builds,
which means that when we upgrade the new daemons start spamming the
teuthology.log.  Set this (with --force, since it's not valid pre-quincy)
in the config before we start the ugprade.

Signed-off-by: Sage Weil <sage@newdream.net>