### PR TITLE
doc/cephadm: rewrite client-setup.rst

### DIFF
--- a/doc/cephadm/client-setup.rst
+++ b/doc/cephadm/client-setup.rst
@@ -1,40 +1,41 @@
 =======================
 Basic Ceph Client Setup
 =======================
-Client machines need some basic configuration in order to interact with
-a cluster. This document describes how to configure a client machine
-for cluster interaction.
+Client machines requite some basic configuration to interact with
+Ceph clusters. This section describes how to configure a client machine
+so that it can interact with a Ceph cluster.
 
-.. note:: Most client machines only need the `ceph-common` package and
-          its dependencies installed. That will supply the basic `ceph`
-          and `rados` commands, as well as other commands like
-          `mount.ceph` and `rbd`.
+.. note:: 
+   Most client machines need to install only the `ceph-common` package
+   and its dependencies. Such a setup supplies the basic `ceph` and
+   `rados` commands, as well as other commands including `mount.ceph`
+   and `rbd`.
 
 Config File Setup
 =================
-Client machines can generally get away with a smaller config file than
-a full-fledged cluster member. To generate a minimal config file, log
-into a host that is already configured as a client or running a cluster
-daemon, and then run
+Client machines usually require smaller configuration files (here
+sometimes called "config files") than do full-fledged cluster members.
+To generate a minimal config file, log into a host that has been
+configured as a client or that is running a cluster daemon, and then run the following command:
 
-.. code-block:: bash
+.. prompt:: bash #
 
-    ceph config generate-minimal-conf
+  ceph config generate-minimal-conf
 
-This will generate a minimal config file that will tell the client how to
-reach the Ceph Monitors. The contents of this file should typically be
-installed in `/etc/ceph/ceph.conf`.
+This command generates a minimal config file that tells the client how
+to reach the Ceph monitors. The contents of this file should usually 
+be installed in ``/etc/ceph/ceph.conf``.
 
 Keyring Setup
 =============
-Most Ceph clusters are run with authentication enabled, and the client will
-need keys in order to communicate with cluster machines. To generate a
-keyring file with credentials for `client.fs`, log into an extant cluster
-member and run
+Most Ceph clusters run with authentication enabled. This means that
+the client needs keys in order to communicate with the machines in the
+cluster. To generate a keyring file with credentials for `client.fs`,
+log into an running cluster member and run the following command:
 
-.. code-block:: bash
+.. prompt:: bash #
 
-    ceph auth get-or-create client.fs
+  ceph auth get-or-create client.fs
 
-The resulting output should be put into a keyring file, typically
-`/etc/ceph/ceph.keyring`.
+The resulting output is directed into a keyring file, typically
+``/etc/ceph/ceph.keyring``.


### PR DESCRIPTION
This improves the text in client-setup.rst.

We should make certain that the technical details
in this file remain current in July 2021. This
file was origingally written in November 2019.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
