### PR TITLE
mgr/dashboard: Cluster Creation Workflow followups

### DIFF
--- a/qa/suites/rados/dashboard/tasks/dashboard.yaml
+++ b/qa/suites/rados/dashboard/tasks/dashboard.yaml
@@ -39,6 +39,7 @@ tasks:
         - tasks.mgr.dashboard.test_auth
         - tasks.mgr.dashboard.test_cephfs
         - tasks.mgr.dashboard.test_cluster_configuration
+        - tasks.mgr.dashboard.test_cluster
         - tasks.mgr.dashboard.test_crush_rule
         - tasks.mgr.dashboard.test_erasure_code_profile
         - tasks.mgr.dashboard.test_ganesha

--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -284,7 +284,7 @@ class Host(RESTController):
 
     @raise_if_no_orchestrator([OrchFeature.HOST_LIST, OrchFeature.HOST_CREATE])
     @handle_orchestrator_error('host')
-    @host_task('create', {'hostname': '{hostname}'})
+    @host_task('add', {'hostname': '{hostname}'})
     @EndpointDoc('',
                  parameters={
                      'hostname': (str, 'Hostname'),

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -91,23 +91,16 @@ const routes: Routes = [
 
       // Cluster
       {
-        path: 'create-cluster',
+        path: 'expand-cluster',
         component: CreateClusterComponent,
         canActivate: [ModuleStatusGuardService],
-        children: [
-          {
-            path: URLVerbs.ADD,
-            component: HostFormComponent,
-            outlet: 'modal'
-          }
-        ],
         data: {
           moduleStatusGuardConfig: {
             apiPath: 'orchestrator',
             redirectTo: 'dashboard',
             backend: 'cephadm'
           },
-          breadcrumbs: 'Create Cluster'
+          breadcrumbs: 'Expand Cluster'
         }
       },
       {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -5,6 +5,7 @@ import { RouterModule } from '@angular/router';
 
 import { TreeModule } from '@circlon/angular-tree-component';
 import {
+  NgbActiveModal,
   NgbDatepickerModule,
   NgbDropdownModule,
   NgbNavModule,
@@ -114,6 +115,7 @@ import { TelemetryComponent } from './telemetry/telemetry.component';
     OsdFlagsIndivModalComponent,
     PlacementPipe,
     CreateClusterComponent
-  ]
+  ],
+  providers: [NgbActiveModal]
 })
 export class ClusterModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.html
@@ -11,12 +11,12 @@
 
       <div class="m-4">
         <h4 class="text-center"
-            i18n>Please proceed to complete the cluster creation</h4>
-        <div class="offset-md-3">
-          <button class="btn btn-accent m-3"
-                  name="create-cluster"
+            i18n>Please expand your cluster first</h4>
+        <div class="offset-md-2">
+          <button class="btn btn-accent m-2"
+                  name="expand-cluster"
                   (click)="createCluster()"
-                  i18n>Create Cluster</button>
+                  i18n>Expand Cluster</button>
           <button class="btn btn-light"
                   name="skip-cluster-creation"
                   (click)="skipClusterCreation()"
@@ -30,7 +30,7 @@
 <div class="card"
      *ngIf="startClusterCreation">
   <div class="card-header"
-       i18n>Create Cluster</div>
+       i18n>Expand Cluster</div>
   <div class="container-fluid">
     <cd-wizard [stepsTitle]="stepTitles"></cd-wizard>
     <div class="card-body vertical-line">
@@ -63,3 +63,11 @@
                     [name]="showCancelButtonLabel()"></cd-back-button>
   </div>
 </div>
+
+<ng-template #skipConfirmTpl>
+  <span i18n>You are about to skip the cluster expansion process.
+             You’ll need to <strong>navigate through the menu to add hosts and services.</strong></span>
+
+  <div class="mt-4"
+       i18n>Are you sure you want to continue?</div>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.scss
@@ -3,15 +3,20 @@
 .container-fluid {
   align-items: flex-start;
   display: flex;
+  padding-left: 0;
   width: 100%;
 }
 
 .card-body {
-  max-width: 90%;
+  max-width: 85%;
 }
 
 .vertical-line {
   border-left: 1px solid vv.$gray-400;
+}
+
+cd-wizard {
+  width: 15%;
 }
 
 cd-hosts {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
@@ -1,4 +1,5 @@
-<cd-modal [pageURL]="pageURL">
+<cd-modal [pageURL]="pageURL"
+          [modalRef]="activeModal">
   <span class="modal-title"
         i18n>{{ action | titlecase }} {{ resource | upperFirst }}</span>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrModule } from 'ngx-toastr';
 
 import { LoadingPanelComponent } from '~/app/shared/components/loading-panel/loading-panel.component';
@@ -24,7 +25,8 @@ describe('HostFormComponent', () => {
         ReactiveFormsModule,
         ToastrModule.forRoot()
       ],
-      declarations: [HostFormComponent]
+      declarations: [HostFormComponent],
+      providers: [NgbActiveModal]
     },
     [LoadingPanelComponent]
   );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+
 import { HostService } from '~/app/shared/api/host.service';
 import { SelectMessages } from '~/app/shared/components/select/select-messages.model';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
@@ -36,7 +38,8 @@ export class HostFormComponent extends CdForm implements OnInit {
     private router: Router,
     private actionLabels: ActionLabelsI18n,
     private hostService: HostService,
-    private taskWrapper: TaskWrapperService
+    private taskWrapper: TaskWrapperService,
+    public activeModal: NgbActiveModal
   ) {
     super();
     this.resource = $localize`host`;
@@ -44,7 +47,9 @@ export class HostFormComponent extends CdForm implements OnInit {
   }
 
   ngOnInit() {
-    this.pageURL = this.router.url.includes('hosts') ? 'hosts' : 'create-cluster';
+    if (this.router.url.includes('hosts')) {
+      this.pageURL = 'hosts';
+    }
     this.createForm();
     this.hostService.list().subscribe((resp: any[]) => {
       this.hostnames = resp.map((host) => {
@@ -80,7 +85,7 @@ export class HostFormComponent extends CdForm implements OnInit {
     this.allLabels = this.hostForm.get('labels').value;
     this.taskWrapper
       .wrapTaskAroundCall({
-        task: new FinishedTask('host/' + URLVerbs.CREATE, {
+        task: new FinishedTask('host/' + URLVerbs.ADD, {
           hostname: hostname
         }),
         call: this.hostService.create(hostname, this.addr, this.allLabels, this.status)
@@ -90,7 +95,9 @@ export class HostFormComponent extends CdForm implements OnInit {
           this.hostForm.setErrors({ cdSubmitButton: true });
         },
         complete: () => {
-          this.router.navigate([this.pageURL, { outlets: { modal: null } }]);
+          this.pageURL === 'hosts'
+            ? this.router.navigate([this.pageURL, { outlets: { modal: null } }])
+            : this.activeModal.close();
         }
       });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -30,6 +30,7 @@ import { ModalService } from '~/app/shared/services/modal.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
+import { HostFormComponent } from './host-form/host-form.component';
 
 const BASE_URL = 'hosts';
 
@@ -61,6 +62,7 @@ export class HostsComponent extends ListWithDetails implements OnInit {
   errorMessage: string;
   enableButton: boolean;
   pageURL: string;
+  bsModalRef: NgbModalRef;
 
   icons = Icons;
 
@@ -133,12 +135,14 @@ export class HostsComponent extends ListWithDetails implements OnInit {
   }
 
   ngOnInit() {
-    this.clusterCreation ? (this.pageURL = 'create-cluster') : (this.pageURL = BASE_URL);
     this.tableActions.unshift({
       name: this.actionLabels.ADD,
       permission: 'create',
       icon: Icons.add,
-      click: () => this.router.navigate([this.pageURL, { outlets: { modal: [URLVerbs.ADD] } }]),
+      click: () =>
+        this.clusterCreation
+          ? (this.bsModalRef = this.modalService.show(HostFormComponent))
+          : this.router.navigate([BASE_URL, { outlets: { modal: [URLVerbs.ADD] } }]),
       disable: (selection: CdTableSelection) => this.getDisable('add', selection)
     });
     this.columns = [

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
@@ -53,6 +53,6 @@ describe('LoginComponent', () => {
     component.login();
 
     expect(routerNavigateSpy).toHaveBeenCalledTimes(1);
-    expect(routerNavigateSpy).toHaveBeenCalledWith(['/create-cluster']);
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['/expand-cluster']);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
@@ -65,10 +65,10 @@ export class LoginComponent implements OnInit {
 
   login() {
     this.authService.login(this.model).subscribe(() => {
-      const urlPath = this.postInstalled ? '/' : '/create-cluster';
+      const urlPath = this.postInstalled ? '/' : '/expand-cluster';
       let url = _.get(this.route.snapshot.queryParams, 'returnUrl', urlPath);
       if (!this.postInstalled && this.route.snapshot.queryParams['returnUrl'] === '/dashboard') {
-        url = '/create-cluster';
+        url = '/expand-cluster';
       }
       this.router.navigate([url]);
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/wizard/wizard.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/wizard/wizard.component.html
@@ -1,21 +1,19 @@
-<div class="wizard-step-container">
-  <div class="card-body">
-    <ng-container>
-      <div class="row m-7">
-        <nav class="col">
-          <ul class="nav nav-pills flex-column"
-              *ngFor="let step of steps | async; let i = index;">
-            <li class="nav-item">
-              <a class="nav-link"
-                 (click)="onStepClick(step)">
-                <span class="circle-step"
-                      i18n>{{ step.stepIndex }}</span>
-                <span i18n>{{ stepsTitle[i] }}</span>
-              </a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </ng-container>
+<div class="card-body">
+  <div class="row m-7">
+    <nav class="col">
+      <ul class="nav nav-pills flex-column"
+          *ngFor="let step of steps | async; let i = index;">
+        <li class="nav-item">
+          <a class="nav-link"
+             (click)="onStepClick(step)"
+             [ngClass]="{active: currentStep.stepIndex === step.stepIndex}">
+            <span class="circle-step"
+                  [ngClass]="{active: currentStep.stepIndex === step.stepIndex}"
+                  i18n>{{ step.stepIndex }}</span>
+            <span i18n>{{ stepsTitle[i] }}</span>
+          </a>
+        </li>
+      </ul>
+    </nav>
   </div>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/wizard/wizard.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/wizard/wizard.component.scss
@@ -1,10 +1,7 @@
 @use './src/styles/vendor/variables' as vv;
 
-.wizard-step-container {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  width: 100%;
+.card-body {
+  padding-left: 0;
 }
 
 span.circle-step {
@@ -17,4 +14,17 @@ span.circle-step {
   margin-right: 5px;
   text-align: center;
   width: 1.6em;
+
+  &.active {
+    background-color: vv.$primary;
+  }
+}
+
+.nav-pills .nav-link {
+  background-color: vv.$white;
+  color: vv.$gray-800;
+
+  &.active {
+    color: vv.$primary;
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/wizard/wizard.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/wizard/wizard.component.ts
@@ -16,7 +16,6 @@ export class WizardComponent implements OnInit, OnDestroy {
   stepsTitle: string[];
 
   steps: Observable<WizardStepModel[]>;
-  currentSteps: Observable<WizardStepModel>;
   currentStep: WizardStepModel;
   currentStepSub: Subscription;
 
@@ -25,7 +24,6 @@ export class WizardComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.stepsService.setTotalSteps(this.stepsTitle.length);
     this.steps = this.stepsService.getSteps();
-    this.currentSteps = this.stepsService.getCurrentStep();
     this.currentStepSub = this.stepsService.getCurrentStep().subscribe((step: WizardStepModel) => {
       this.currentStep = step;
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -114,9 +114,7 @@ export class TaskMessageService {
 
   messages = {
     // Host tasks
-    'host/create': this.newTaskMessage(this.commonOperations.create, (metadata) =>
-      this.host(metadata)
-    ),
+    'host/add': this.newTaskMessage(this.commonOperations.add, (metadata) => this.host(metadata)),
     'host/delete': this.newTaskMessage(this.commonOperations.delete, (metadata) =>
       this.host(metadata)
     ),


### PR DESCRIPTION
1. Fix bug in the modal where going forward one step on the wizard and coming back opens up the add host modal.
2. Renamed Create Cluster to Expand Cluster as per the discussions
3. A skip confirmation modal to warn the user when he tries to skip the cluster creation
4. Adapted all the tests
5. Did some UI improvements like fixing and aligning the styles, colors..
![new](https://user-images.githubusercontent.com/71764184/125415143-6f687306-2348-413e-a64e-657ccdb2c90e.png)

**UI improvements**
![new](https://user-images.githubusercontent.com/71764184/126133692-fe0fc4af-f782-432b-952b-cac1a7639712.png)


**Skip Confirmation Modal**
![skipmodal](https://user-images.githubusercontent.com/71764184/125588443-398491a1-5303-4c67-970f-5c1cf044eec6.png)

Fixes: https://tracker.ceph.com/issues/51640
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
