### PR TITLE
pacific: mgr/dashboard: fix Accept-Language header parsing

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/home.py
+++ b/src/pybind/mgr/dashboard/controllers/home.py
@@ -59,7 +59,7 @@ class LanguageMixin(object):
 class HomeController(BaseController, LanguageMixin):
     LANG_TAG_SEQ_RE = re.compile(r'\s*([^,]+)\s*,?\s*')
     LANG_TAG_RE = re.compile(
-        r'^(?P<locale>[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})?)(;q=(?P<weight>[01]\.\d{0,3}))?$')
+        r'^(?P<locale>[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*|\*)(;q=(?P<weight>[01]\.\d{0,3}))?$')
     MAX_ACCEPTED_LANGS = 10
 
     @lru_cache()

--- a/src/pybind/mgr/dashboard/tests/test_home.py
+++ b/src/pybind/mgr/dashboard/tests/test_home.py
@@ -65,3 +65,10 @@ class HomeTest(ControllerTestCase, FakeFsMixin):
         self.assertStatus(200)
         logger.info(self.body)
         self.assertIn('<html lang="en">', self.body.decode('utf-8'))
+
+    @mock.patch(FakeFsMixin.builtins_open, new=FakeFsMixin.f_open)
+    @mock.patch('os.stat', new=FakeFsMixin.f_os.stat)
+    @mock.patch('os.listdir', new=FakeFsMixin.f_os.listdir)
+    def test_home_multiple_subtags_lang(self):
+        self._get('/', headers=[('Accept-Language', 'zh-Hans-CN')])
+        self.assertStatus(200)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51558

---

backport of https://github.com/ceph/ceph/pull/42183
parent tracker: https://tracker.ceph.com/issues/51528

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh