### PR TITLE
pacific: monitoring: fix Physical Device Latency unit

### DIFF
--- a/monitoring/grafana/dashboards/osd-device-details.json
+++ b/monitoring/grafana/dashboards/osd-device-details.json
@@ -423,7 +423,7 @@
       },
       "yaxes": [
         {
-          "format": "ms",
+          "format": "s",
           "label": "Read (-) / Write (+)",
           "logBase": 1,
           "max": null,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51636

---

backport of https://github.com/ceph/ceph/pull/42217
parent tracker: https://tracker.ceph.com/issues/51565

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh