### PR TITLE
crimson/osd: remote peering requests wait for OSD activation.

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -94,8 +94,7 @@ OSD::OSD(int id, uint32_t nonce,
       update_stats();
     }},
     asok{seastar::make_lw_shared<crimson::admin::AdminSocket>()},
-    osdmap_gate("OSD::osdmap_gate", std::make_optional(std::ref(shard_services))),
-    wait_for_active(std::in_place_t{})
+    osdmap_gate("OSD::osdmap_gate", std::make_optional(std::ref(shard_services)))
 {
   osdmaps[0] = boost::make_local_shared<OSDMap>();
   for (auto msgr : {std::ref(cluster_msgr), std::ref(public_msgr),
@@ -1068,9 +1067,6 @@ seastar::future<> OSD::committed_osd_maps(version_t first,
       if (state.is_booting()) {
         logger().info("osd.{}: activating...", whoami);
         state.set_active();
-        assert(wait_for_active);
-        wait_for_active->set_value();
-        wait_for_active = std::nullopt;
         beacon_timer.arm_periodic(
           std::chrono::seconds(local_conf()->osd_beacon_report_interval));
         tick_timer.arm_periodic(

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -231,7 +231,6 @@ private:
   friend class PGAdvanceMap;
 
   RemotePeeringEvent::OSDPipeline peering_request_osd_pipeline;
-  std::optional<seastar::shared_promise<>> wait_for_active;
   friend class RemotePeeringEvent;
 
 public:

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -230,6 +230,10 @@ private:
   void update_heartbeat_peers();
   friend class PGAdvanceMap;
 
+  RemotePeeringEvent::OSDPipeline peering_request_osd_pipeline;
+  std::optional<seastar::shared_promise<>> wait_for_active;
+  friend class RemotePeeringEvent;
+
 public:
   blocking_future<Ref<PG>> get_or_create_pg(
     spg_t pgid,

--- a/src/crimson/osd/osd_operations/peering_event.cc
+++ b/src/crimson/osd/osd_operations/peering_event.cc
@@ -156,11 +156,7 @@ seastar::future<Ref<PG>> RemotePeeringEvent::get_pg()
   return with_blocking_future(
     handle.enter(op().await_active)
   ).then([this] {
-    if (osd.wait_for_active) {
-      return osd.wait_for_active->get_shared_future();
-    } else {
-      return seastar::now();
-    }
+    return osd.state.when_active();
   }).then([this] {
     return with_blocking_future(handle.enter(cp().await_map));
   }).then([this] {

--- a/src/crimson/osd/osd_operations/peering_event.h
+++ b/src/crimson/osd/osd_operations/peering_event.h
@@ -99,6 +99,12 @@ protected:
   seastar::future<Ref<PG>> get_pg() final;
 
 public:
+  class OSDPipeline {
+    OrderedExclusivePhase await_active = {
+      "PeeringRequest::OSDPipeline::await_active"
+    };
+    friend class RemotePeeringEvent;
+  };
   class ConnectionPipeline {
     OrderedExclusivePhase await_map = {
       "PeeringRequest::ConnectionPipeline::await_map"
@@ -118,6 +124,7 @@ public:
 
 private:
   ConnectionPipeline &cp();
+  OSDPipeline &op();
 };
 
 class LocalPeeringEvent final : public PeeringEvent {

--- a/src/crimson/osd/state.h
+++ b/src/crimson/osd/state.h
@@ -6,6 +6,8 @@
 #include <string_view>
 #include <ostream>
 
+#include <seastar/core/shared_future.hh>
+
 class OSDMap;
 
 class OSDState {
@@ -21,6 +23,7 @@ class OSDState {
   };
 
   State state = State::INITIALIZING;
+  mutable seastar::shared_promise<> wait_for_active;
 
 public:
   bool is_initializing() const {
@@ -35,6 +38,10 @@ public:
   bool is_active() const {
     return state == State::ACTIVE;
   }
+  seastar::future<> when_active() const {
+    return is_active() ? seastar::now()
+                       : wait_for_active.get_shared_future();
+  };
   bool is_prestop() const {
     return state == State::PRESTOP;
   }
@@ -52,12 +59,16 @@ public:
   }
   void set_active() {
     state = State::ACTIVE;
+    wait_for_active.set_value();
+    wait_for_active = {};
   }
   void set_prestop() {
     state = State::PRESTOP;
   }
   void set_stopping() {
     state = State::STOPPING;
+    wait_for_active.set_exception(crimson::common::system_shutdown_exception{});
+    wait_for_active = {};
   }
   std::string_view to_string() const {
     switch (state) {


### PR DESCRIPTION
Before the patch `RemotePeeringRequest` instances were not waiting for OSD activation. This was eluding the protection from handling old, outdated peering events the `MOSDBoot` machinery offers. The net results are crashes like this one (`OSDState is booting` has been produced by a custom debug):

```
2021-07-07T18:20:23.293 INFO:journalctl@ceph.osd.2.smithi145.stdout:Jul 07 18:16:30 smithi145 conmon[71083]: DEBUG 2021-07-07 18:16:30,535 [shard 0] ms - [osd.2(cluster) v2:172.21.15.145:6802/2@62336 >> osd
.1 v2:172.21.15.145:6809/2] <== #19 === pg_lease(4.9 pg_lease(ru 60.120281219s ub 68.121276855s int 16.000000000s) e86/86) v1 (133)
2021-07-07T18:20:23.293 INFO:journalctl@ceph.osd.2.smithi145.stdout:Jul 07 18:16:30 smithi145 conmon[71083]: DEBUG 2021-07-07 18:16:30,536 [shard 0] osd - handle_peering_op on 4.9 from 1
2021-07-07T18:20:23.293 INFO:journalctl@ceph.osd.2.smithi145.stdout:Jul 07 18:16:30 smithi145 conmon[71083]: DEBUG 2021-07-07 18:16:30,536 [shard 0] osd - peering_event(id=125, detail=PeeringEvent(from=1 pg
id=4.9 sent=86 requested=86 evt=epoch_sent: 86 epoch_requested: 86 MLease epoch 86 from osd.1 pg_lease(ru 60.120281219s ub 68.121276855s int 16.000000000s))): start
2021-07-07T18:20:23.293 INFO:journalctl@ceph.osd.2.smithi145.stdout:Jul 07 18:16:30 smithi145 conmon[71083]: DEBUG 2021-07-07 18:16:30,536 [shard 0] osd - peering_event(id=125, detail=PeeringEvent(from=1 pg
id=4.9 sent=86 requested=86 evt=epoch_sent: 86 epoch_requested: 86 MLease epoch 86 from osd.1 pg_lease(ru 60.120281219s ub 68.121276855s int 16.000000000s))): got map 93
2021-07-07T18:20:23.294 INFO:journalctl@ceph.osd.2.smithi145.stdout:Jul 07 18:16:30 smithi145 conmon[71083]: DEBUG 2021-07-07 18:16:30,536 [shard 0] osd - peering_event(id=125, detail=PeeringEvent(from=1 pgid=4.9 sent=86 requested=86 evt=epoch_sent: 86 epoch_requested: 86 MLease epoch 86 from osd.1 pg_lease(ru 60.120281219s ub 68.121276855s int 16.000000000s))): OSDState is booting
2021-07-07T18:20:23.294 INFO:journalctl@ceph.osd.2.smithi145.stdout:Jul 07 18:16:30 smithi145 conmon[71083]: ERROR 2021-07-07 18:16:30,536 [shard 0] none - /home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/17.0.0-5007-g3a9abb02/rpm/el8/BUILD/ceph-17.0.0-5007-g3a9abb02/src/crimson/osd/osd_operations/peering_event.cc:165 : In function 'crimson::osd::RemotePeeringEvent::get_pg()::<lambda()>', ceph_assert(%s)
2021-07-07T18:20:23.294 INFO:journalctl@ceph.osd.2.smithi145.stdout:Jul 07 18:16:30 smithi145 conmon[71083]: osd.state.is_active()
2021-07-07T18:20:23.294 INFO:journalctl@ceph.osd.2.smithi145.stdout:Jul 07 18:16:30 smithi145 conmon[71083]: Aborting on shard 0.
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
