### PR TITLE
 crimson/osd: consider epoch_sent when ignoring old peering event. 

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -463,7 +463,8 @@ seastar::future<> PG::read_state(crimson::os::FuturizedStore* store)
 void PG::do_peering_event(
   PGPeeringEvent& evt, PeeringCtx &rctx)
 {
-  if (peering_state.pg_has_reset_since(evt.get_epoch_requested())) {
+  if (peering_state.pg_has_reset_since(evt.get_epoch_requested()) ||
+      peering_state.pg_has_reset_since(evt.get_epoch_sent())) {
     logger().debug("{} ignoring {} -- pg has reset", __func__, evt.get_desc());
   } else {
     logger().debug("{} handling {} for pg: {}", __func__, evt.get_desc(), pgid);

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -463,14 +463,14 @@ seastar::future<> PG::read_state(crimson::os::FuturizedStore* store)
 void PG::do_peering_event(
   PGPeeringEvent& evt, PeeringCtx &rctx)
 {
-  if (!peering_state.pg_has_reset_since(evt.get_epoch_requested())) {
+  if (peering_state.pg_has_reset_since(evt.get_epoch_requested())) {
+    logger().debug("{} ignoring {} -- pg has reset", __func__, evt.get_desc());
+  } else {
     logger().debug("{} handling {} for pg: {}", __func__, evt.get_desc(), pgid);
     peering_state.handle_event(
       evt.get_event(),
       &rctx);
     peering_state.write_if_dirty(rctx.transaction);
-  } else {
-    logger().debug("{} ignoring {} -- pg has reset", __func__, evt.get_desc());
   }
 }
 

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -461,21 +461,14 @@ seastar::future<> PG::read_state(crimson::os::FuturizedStore* store)
 }
 
 void PG::do_peering_event(
-  const boost::statechart::event_base &evt,
-  PeeringCtx &rctx)
-{
-  peering_state.handle_event(
-    evt,
-    &rctx);
-  peering_state.write_if_dirty(rctx.transaction);
-}
-
-void PG::do_peering_event(
   PGPeeringEvent& evt, PeeringCtx &rctx)
 {
   if (!peering_state.pg_has_reset_since(evt.get_epoch_requested())) {
     logger().debug("{} handling {} for pg: {}", __func__, evt.get_desc(), pgid);
-    do_peering_event(evt.get_event(), rctx);
+    peering_state.handle_event(
+      evt.get_event(),
+      &rctx);
+    peering_state.write_if_dirty(rctx.transaction);
   } else {
     logger().debug("{} ignoring {} -- pg has reset", __func__, evt.get_desc());
   }

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -555,9 +555,6 @@ private:
     const hobject_t &oid,
     RWState::State type);
 
-  void do_peering_event(
-    const boost::statechart::event_base &evt,
-    PeeringCtx &rctx);
   void fill_op_params_bump_pg_version(
     osd_op_params_t& osd_op_p,
     const bool user_modify);


### PR DESCRIPTION
The classical OSD does:

```
bool old_peering_evt(PGPeeringEventRef evt) {
  return old_peering_msg(evt->get_epoch_sent(), evt->get_epoch_requested());
}
```

```
bool PG::old_peering_msg(epoch_t reply_epoch, epoch_t query_epoch)
{
  if (auto last_reset = get_last_peering_reset();
      last_reset > reply_epoch || last_reset > query_epoch) {
    dout(10) << "old_peering_msg reply_epoch " << reply_epoch << " query_epoch "
             << query_epoch << " last_peering_reset " << last_reset << dendl;
    return true;
  }
  return false;
}
```

See also: https://gist.github.com/rzarzynski/e60750c279ae9d234728b0b199562c40#gistcomment-3808289.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
