### PR TITLE
osd: fix op event duration calculation

### DIFF
--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -74,14 +74,14 @@ void OpRequest::_dump(Formatter *f) const
       f->dump_string("event", i->str);
       f->dump_stream("time") << i->stamp;
 
-      auto i_next = i + 1;
+      double duration = 0;
 
-      if (i_next < events.end()) {
-	f->dump_float("duration", i_next->stamp - i->stamp);
-      } else {
-	f->dump_float("duration", events.rbegin()->stamp - get_initiated());
+      if (i != events.begin()) {
+        auto i_prev = i - 1;
+        duration = i->stamp - i_prev->stamp;
       }
 
+      f->dump_float("duration", duration);
       f->close_section();
     }
     f->close_section();


### PR DESCRIPTION
Each event is recorded with the timestamp when it's done.
Thus the time the event took is `event_timestamp - prev_event_timestamp`,
and not `next_event_timestamp - event_timestamp`, since that would be the next
event's duration.

This off-by-one is fixed by the patch.


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
