### PR TITLE
pacific: mgr/dashboard: remove usage of 'rgw_frontend_ssl_key'

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -508,7 +508,7 @@
           </div>
 
           <!-- ssl_key -->
-          <div *ngIf="serviceForm.controls.ssl.value"
+          <div *ngIf="serviceForm.controls.ssl.value && serviceForm.controls.service_type.value !== 'rgw'"
                class="form-group row">
             <label class="cd-col-form-label"
                    for="ssl_key">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
@@ -199,7 +200,6 @@ describe('ServiceFormComponent', () => {
           unmanaged: false,
           rgw_frontend_port: 1234,
           rgw_frontend_ssl_certificate: '',
-          rgw_frontend_ssl_key: '',
           ssl: true
         });
       });
@@ -243,6 +243,13 @@ describe('ServiceFormComponent', () => {
           unmanaged: false,
           ssl: false
         });
+      });
+
+      it('should not show private key field', () => {
+        formHelper.setValue('ssl', true);
+        fixture.detectChanges();
+        const ssl_key = fixture.debugElement.query(By.css('#ssl_key'));
+        expect(ssl_key).toBeNull();
       });
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -202,14 +202,6 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         [
           CdValidators.composeIf(
             {
-              service_type: 'rgw',
-              unmanaged: false,
-              ssl: true
-            },
-            [Validators.required, CdValidators.sslPrivKey()]
-          ),
-          CdValidators.composeIf(
-            {
               service_type: 'iscsi',
               unmanaged: false,
               ssl: true
@@ -331,7 +323,6 @@ export class ServiceFormComponent extends CdForm implements OnInit {
           serviceSpec['ssl'] = values['ssl'];
           if (values['ssl']) {
             serviceSpec['rgw_frontend_ssl_certificate'] = values['ssl_cert'].trim();
-            serviceSpec['rgw_frontend_ssl_key'] = values['ssl_key'].trim();
           }
           break;
         case 'iscsi':


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51657

---

backport of https://github.com/ceph/ceph/pull/42305
parent tracker: https://tracker.ceph.com/issues/51643

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh