### PR TITLE
mgr/rook: orch device ls fetch PVs from SC specified in module option

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -127,8 +127,8 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                     self.get_module_option(opt['name']))  # type: ignore
             self.log.debug(' mgr option %s = %s',
                            opt['name'], getattr(self, opt['name']))  # type: ignore
-
-        self._rook_cluster.storage_class_name = self.storage_class_name
+        assert isinstance(self.storage_class_name, str)
+        self.rook_cluster.storage_class_name = self.storage_class_name
 
     def shutdown(self) -> None:
         self._shutdown.set()

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -102,6 +102,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         self._initialized = threading.Event()
         self._k8s_CoreV1_api: Optional[client.CoreV1Api] = None
         self._k8s_BatchV1_api: Optional[client.BatchV1Api] = None
+        self._k8s_CustomObjects_api: Optional[client.CustomObjectsApi] = None
         self._rook_cluster: Optional[RookCluster] = None
         self._rook_env = RookEnv()
 
@@ -141,6 +142,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         self._k8s_CoreV1_api = client.CoreV1Api()
         self._k8s_BatchV1_api = client.BatchV1Api()
+        self._k8s_CustomObjects_api = client.CustomObjectsApi()
 
         try:
             # XXX mystery hack -- I need to do an API call from
@@ -155,6 +157,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         self._rook_cluster = RookCluster(
             self._k8s_CoreV1_api,
             self._k8s_BatchV1_api,
+            self._k8s_CustomObjects_api,
             self._rook_env)
 
         self._initialized.set()

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -177,11 +177,15 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             # Ignore here to make self.available() fail with a proper error message
             pass
 
+        assert isinstance(self.storage_class_name, str)
+
         self._rook_cluster = RookCluster(
             self._k8s_CoreV1_api,
             self._k8s_BatchV1_api,
             self._k8s_CustomObjects_api,
-            self._rook_env)
+            self._k8s_StorageV1_api,
+            self._rook_env,
+            self.storage_class_name)
 
         self._initialized.set()
 

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -109,6 +109,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         self._k8s_CoreV1_api: Optional[client.CoreV1Api] = None
         self._k8s_BatchV1_api: Optional[client.BatchV1Api] = None
         self._k8s_CustomObjects_api: Optional[client.CustomObjectsApi] = None
+        self._k8s_StorageV1_api: Optional[client.StorageV1Api] = None
         self._rook_cluster: Optional[RookCluster] = None
         self._rook_env = RookEnv()
         self.storage_class_name = self.get_module_option('storage_class_name')
@@ -164,6 +165,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         self._k8s_CoreV1_api = client.CoreV1Api()
         self._k8s_BatchV1_api = client.BatchV1Api()
         self._k8s_CustomObjects_api = client.CustomObjectsApi()
+        self._k8s_StorageV1_api = client.StorageV1Api()
 
         try:
             # XXX mystery hack -- I need to do an API call from

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -74,9 +74,9 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
     MODULE_OPTIONS: List[Option] = [
         # TODO: configure k8s API addr instead of assuming local
         Option(
-            'storage_class_name',
+            'storage_class',
             type='str',
-            default='local-sc',
+            default='local',
             desc='storage class name for LSO-discovered PVs',
         ),
     ]
@@ -112,9 +112,10 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         self._k8s_StorageV1_api: Optional[client.StorageV1Api] = None
         self._rook_cluster: Optional[RookCluster] = None
         self._rook_env = RookEnv()
-        self.storage_class_name = self.get_module_option('storage_class_name')
+        self.storage_class = self.get_module_option('storage_class')
 
         self._shutdown = threading.Event()
+        
     def config_notify(self) -> None:
         """
         This method is called whenever one of our config options is changed.
@@ -127,8 +128,8 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                     self.get_module_option(opt['name']))  # type: ignore
             self.log.debug(' mgr option %s = %s',
                            opt['name'], getattr(self, opt['name']))  # type: ignore
-        assert isinstance(self.storage_class_name, str)
-        self.rook_cluster.storage_class_name = self.storage_class_name
+        assert isinstance(self.storage_class, str)
+        self.rook_cluster.storage_class = self.storage_class
 
     def shutdown(self) -> None:
         self._shutdown.set()
@@ -177,7 +178,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             # Ignore here to make self.available() fail with a proper error message
             pass
 
-        assert isinstance(self.storage_class_name, str)
+        assert isinstance(self.storage_class, str)
 
         self._rook_cluster = RookCluster(
             self._k8s_CoreV1_api,
@@ -185,7 +186,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             self._k8s_CustomObjects_api,
             self._k8s_StorageV1_api,
             self._rook_env,
-            self.storage_class_name)
+            self.storage_class)
 
         self._initialized.set()
 

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -210,21 +210,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         for host_name, host_devs in discovered_devs.items():
             devs = []
             for d in host_devs:
-                devs.append(inventory.Device(
-                    path = d['path'],
-                    sys_api = dict(
-                        size = d['size']
-                    ),
-                    available = d['status']['state']=='Available',
-                ))
-                if 'property' in d:
-                    devs[-1].sys_api['rotational'] = '1' if d['property']=='Rotational' else '0'
-                if 'deviceID' in d and d['deviceID']:
-                    devs[-1].device_id = d['deviceID'].split('/')[-1]
-                if 'serial' in d and d['serial']:
-                    if not devs[-1].lsm_data:
-                        devs[-1].lsm_data = dict()
-                    devs[-1].lsm_data['serialNum'] = d['serial']
+                devs.append(d)
 
             result.append(orchestrator.InventoryHost(host_name, inventory.Devices(devs)))
 

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -191,10 +191,11 @@ class KubernetesResource(Generic[T]):
 class RookCluster(object):
     # import of client.CoreV1Api must be optional at import time.
     # Instead allow mgr/rook to be imported anyway.
-    def __init__(self, coreV1_api: 'client.CoreV1Api', batchV1_api: 'client.BatchV1Api', rook_env: 'RookEnv'):
+    def __init__(self, coreV1_api: 'client.CoreV1Api', batchV1_api: 'client.BatchV1Api', customObjects_api: 'client.CustomObjectsApi', rook_env: 'RookEnv'):
         self.rook_env = rook_env  # type: RookEnv
         self.coreV1_api = coreV1_api  # client.CoreV1Api
         self.batchV1_api = batchV1_api
+        self.customObjects_api = customObjects_api
 
         #  TODO: replace direct k8s calls with Rook API calls
         # when they're implemented

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -198,11 +198,13 @@ class KubernetesResource(Generic[T]):
 class RookCluster(object):
     # import of client.CoreV1Api must be optional at import time.
     # Instead allow mgr/rook to be imported anyway.
-    def __init__(self, coreV1_api: 'client.CoreV1Api', batchV1_api: 'client.BatchV1Api', customObjects_api: 'client.CustomObjectsApi', rook_env: 'RookEnv'):
+    def __init__(self, coreV1_api: 'client.CoreV1Api', batchV1_api: 'client.BatchV1Api', customObjects_api: 'client.CustomObjectsApi', storageV1_api: 'client.StorageV1Api', rook_env: 'RookEnv', storage_class_name: 'str'):
         self.rook_env = rook_env  # type: RookEnv
         self.coreV1_api = coreV1_api  # client.CoreV1Api
         self.batchV1_api = batchV1_api
         self.customObjects_api = customObjects_api
+        self.storageV1_api = storageV1_api  # client.StorageV1Api
+        self.storage_class_name = storage_class_name # type: str
 
         #  TODO: replace direct k8s calls with Rook API calls
         # when they're implemented

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -198,13 +198,13 @@ class KubernetesResource(Generic[T]):
 class RookCluster(object):
     # import of client.CoreV1Api must be optional at import time.
     # Instead allow mgr/rook to be imported anyway.
-    def __init__(self, coreV1_api: 'client.CoreV1Api', batchV1_api: 'client.BatchV1Api', customObjects_api: 'client.CustomObjectsApi', storageV1_api: 'client.StorageV1Api', rook_env: 'RookEnv', storage_class_name: 'str'):
+    def __init__(self, coreV1_api: 'client.CoreV1Api', batchV1_api: 'client.BatchV1Api', customObjects_api: 'client.CustomObjectsApi', storageV1_api: 'client.StorageV1Api', rook_env: 'RookEnv', storage_class: 'str'):
         self.rook_env = rook_env  # type: RookEnv
         self.coreV1_api = coreV1_api  # client.CoreV1Api
         self.batchV1_api = batchV1_api
         self.customObjects_api = customObjects_api
         self.storageV1_api = storageV1_api  # client.StorageV1Api
-        self.storage_class_name = storage_class_name # type: str
+        self.storage_class = storage_class # type: str
 
         #  TODO: replace direct k8s calls with Rook API calls
         # when they're implemented
@@ -262,13 +262,13 @@ class RookCluster(object):
                 return item['spec']['nodeName'] in nodenames
             else:
                 return True
-        matching_sc = [i for i in self.storage_classes.items if self.storage_class_name == i.metadata.name]
+        matching_sc = [i for i in self.storage_classes.items if self.storage_class == i.metadata.name]
         if len(matching_sc) == 0:
-            log.exception("no storage class exists matching name provided in ceph config at mgr/rook/storage_class_name")
-            raise Exception('No storage class exists matching name provided in ceph config at mgr/rook/storage_class_name')
+            log.exception("no storage class exists matching name provided in ceph config at mgr/rook/storage_class")
+            raise Exception('No storage class exists matching name provided in ceph config at mgr/rook/storage_class')
         if len(matching_sc) > 1:
-            log.exception("too many storage classes matching name provided in ceph config at mgr/rook/storage_class_name")
-            raise Exception('Too many storage classes matching name provided in ceph config at mgr/rook/storage_class_name')
+            log.exception("too many storage classes matching name provided in ceph config at mgr/rook/storage_class")
+            raise Exception('Too many storage classes matching name provided in ceph config at mgr/rook/storage_class')
         storage_class = matching_sc[0]
 
         lso_discovery_results = []
@@ -285,7 +285,7 @@ class RookCluster(object):
             drives = i['status']['discoveredDevices']
             for drive in drives:
                 lso_devices[drive['deviceID'].split('/')[-1]] = drive
-        pvs_in_sc = [i for i in self.pvs.items if i.spec.storage_class_name == self.storage_class_name]
+        pvs_in_sc = [i for i in self.pvs.items if i.spec.storage_class_name == self.storage_class]
 
         def convert_size(size_str: str) -> int:
             units = ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei")

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -280,7 +280,6 @@ class RookCluster(object):
                 log.exception("Failed to fetch device metadata")
                 raise
 
-        nodename_to_devices = {}
         lso_devices = {}
         for i in lso_discovery_results:
             drives = i['status']['discoveredDevices']
@@ -288,7 +287,7 @@ class RookCluster(object):
                 lso_devices[drive['deviceID'].split('/')[-1]] = drive
         pvs_in_sc = [i for i in self.pvs.items if i.spec.storage_class_name == self.storage_class_name]
 
-        def convert_size(size_str: str):
+        def convert_size(size_str: str) -> int:
             units = ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei")
             unit = size_str[-2:]
             try:
@@ -300,6 +299,7 @@ class RookCluster(object):
             size = coeff * (2 ** (10 * factor))
             return size
 
+        nodename_to_devices: Dict[str, Any] = {}
         for i in pvs_in_sc:
             if (not i.metadata.annotations) or ('storage.openshift.com/device-id' not in i.metadata.annotations) or (i.metadata.annotations['storage.openshift.com/device-id'] not in lso_devices):
                 size = convert_size(i.spec.capacity['storage'])

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -90,7 +90,7 @@ def threaded(f: Callable[..., None]) -> Callable[..., threading.Thread]:
 
 
 class DefaultFetcher():
-    def __init__(self, storage_class: str, coreV1_api: client.CoreV1Api):
+    def __init__(self, storage_class: str, coreV1_api: 'client.CoreV1Api'):
         self.storage_class = storage_class
         self.coreV1_api = coreV1_api
 
@@ -141,7 +141,7 @@ class DefaultFetcher():
         
 
 class LSOFetcher(DefaultFetcher):
-    def __init__(self, storage_class: str, coreV1_api: client.CoreV1Api, customObjects_api: client.CustomObjectsApi, nodenames: Optional[List[str]] = None):
+    def __init__(self, storage_class: 'str', coreV1_api: 'client.CoreV1Api', customObjects_api: 'client.CustomObjectsApi', nodenames: 'Optional[List[str]]' = None):
         super().__init__(storage_class, coreV1_api)
         self.customObjects_api = customObjects_api
         self.nodenames = nodenames
@@ -153,7 +153,7 @@ class LSOFetcher(DefaultFetcher):
                                                  version="v1alpha1",
                                                  plural="localvolumediscoveryresults")
 
-    def predicate(self, item: client.V1ConfigMapList) -> bool:
+    def predicate(self, item: 'client.V1ConfigMapList') -> bool:
             if self.nodenames is not None:
                 return item['spec']['nodeName'] in self.nodenames
             else:

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -264,11 +264,8 @@ class RookCluster(object):
                 return True
         matching_sc = [i for i in self.storage_classes.items if self.storage_class == i.metadata.name]
         if len(matching_sc) == 0:
-            log.exception("no storage class exists matching name provided in ceph config at mgr/rook/storage_class")
+            log.error(f"No storage class exists matching configured Rook orchestrator storage class which currently is <{self.storage_class}>. This storage class can be set in ceph config (mgr/rook/storage_class)")
             raise Exception('No storage class exists matching name provided in ceph config at mgr/rook/storage_class')
-        if len(matching_sc) > 1:
-            log.exception("too many storage classes matching name provided in ceph config at mgr/rook/storage_class")
-            raise Exception('Too many storage classes matching name provided in ceph config at mgr/rook/storage_class')
         storage_class = matching_sc[0]
 
         lso_discovery_results = []
@@ -277,7 +274,7 @@ class RookCluster(object):
             try:
                 lso_discovery_results = [i for i in self.discovery_results.items if predicate(i)]
             except ApiException as dummy_e:
-                log.exception("Failed to fetch device metadata")
+                log.error("Failed to fetch device metadata")
                 raise
 
         lso_devices = {}
@@ -293,7 +290,7 @@ class RookCluster(object):
             try:
                 factor = units.index(unit)
             except ValueError:
-                log.exception("PV size format invalid")
+                log.error("PV size format invalid")
                 raise
             coeff = int(size_str[:-2])
             size = coeff * (2 ** (10 * factor))

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -126,7 +126,7 @@ class DefaultFetcher():
             if len(terms) == 1 and len(terms[0].match_expressions) == 1 and terms[0].match_expressions[0].key == 'kubernetes.io/hostname' and len(terms[0].match_expressions[0].values) == 1:
                 node = terms[0].match_expressions[0].values[0]
         size = self.convert_size(i.spec.capacity['storage'])
-        path = i.spec.host_path.path if i.spec.host_path else ('/dev/' + i.metadata.annotations['storage.openshift.com/device-name']) if i.metadata.annotations['storage.openshift.com/device-name'] else ''
+        path = i.spec.host_path.path if i.spec.host_path else i.spec.local.path if i.spec.local else ('/dev/' + i.metadata.annotations['storage.openshift.com/device-name']) if i.metadata.annotations and 'storage.openshift.com/device-name' in i.metadata.annotations else ''
         state = i.spec.volume_mode == 'Block' and i.status.phase == 'Available'
         pv_name = i.metadata.name
         device = Device(


### PR DESCRIPTION
Add `storage_class` module option and to Kubernetes client-python CustomObjectsApi and StorageV1Api Rook Orchestrator.

`device ls`: fetches PVs, storage classes, and LSO DiscoveryResults. Displays information from PVs in storage class matching module option, using information from LSO if available.

`RookCluster` uses different "Fetcher" based on storage class passed by user and returns list of `Device` objects.

"Fetcher" gets required k8s resources and creates device objects accordingly.

Signed-off-by: Joseph Sawaya jsawaya@redhat.com

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
