### PR TITLE
pacific: RGW - Don't move attrs before setting them

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7375,9 +7375,6 @@ void RGWSetAttrs::execute(optional_yield y)
     rgw::sal::RGWAttrs a(attrs);
     op_ret = s->object->set_obj_attrs(this, s->obj_ctx, &a, nullptr, y);
   } else {
-    for (auto& iter : attrs) {
-      s->bucket_attrs[iter.first] = std::move(iter.second);
-    }
     op_ret = store->ctl()->bucket->set_bucket_instance_attrs(
       s->bucket->get_info(), attrs, &s->bucket->get_info().objv_tracker,
       s->yield, this);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51221

---

backport of https://github.com/ceph/ceph/pull/41761
parent tracker: https://tracker.ceph.com/issues/51159

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh