### PR TITLE
doc/mgr/telemetry: update Telemetry Module docs to include perf channel

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -46,6 +46,12 @@ the per-channel setting has no effect.)
     - cluster description
     - contact email address
 
+* **perf** (default: off): Aggregated performance counter metrics of a cluster, which can be used to
+    - reveal overall cluster health
+    - identify workload patterns
+    - troubleshoot issues with latency, throttling, memory management, etc.
+    - monitor cluster performance by daemon types
+
 The data being reported does *not* contain any sensitive
 data like pool names, object names, object contents, hostnames, or device
 serial numbers.
@@ -85,6 +91,7 @@ Individual channels can be enabled or disabled with::
   ceph config set mgr mgr/telemetry/channel_basic false
   ceph config set mgr mgr/telemetry/channel_crash false
   ceph config set mgr mgr/telemetry/channel_device false
+  ceph config set mgr mgr/telemetry/channel_perf false
   ceph telemetry show
   ceph telemetry show-device
 


### PR DESCRIPTION
PR #42074 adds a new perf channel to the Telemetry Module. With this commit, the docs will reflect that addition. Within the Telemetry Module docs, I explain the purpose of the new perf channel as well as some use cases of the metrics that will be collected under the channel.

Signed-off-by: Laura Flores <lflores@redhat.com>