### PR TITLE
pacific: rgw: require bucket name in bucket chown

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6196,6 +6196,10 @@ int main(int argc, const char **argv)
   }
 
   if (opt_cmd == OPT::BUCKET_CHOWN) {
+    if (bucket_name.empty()) {
+      cerr << "ERROR: bucket name not specified" << std::endl;
+      return EINVAL;
+    }
 
     bucket_op.set_bucket_name(bucket_name);
     bucket_op.set_new_bucket_name(new_bucket_name);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51080

---

backport of https://github.com/ceph/ceph/pull/41668
parent tracker: https://tracker.ceph.com/issues/49831

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh