### PR TITLE
rgw: Don't segfault on datalog trim

### DIFF
--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -804,6 +804,8 @@ int DataLogBackends::trim_entries(const DoutPrefixProvider *dpp, int shard_id, s
       r = -ENODATA;
     if (r == -ENODATA && be->gen_id < target_gen)
       r = 0;
+    if (be->gen_id == target_gen)
+      break;
     l.lock();
   };
   return r;


### PR DESCRIPTION
Synchronous (or yielded, basically other-than AioCompletion trim)
would try to dereference the past-the-end iterator if we were trimming
to a point in the most recent generation.