### PR TITLE
cephfs-mirror: record directory path cancel in DirRegistry

### DIFF
--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -282,7 +282,7 @@ void PeerReplayer::remove_directory(string_view dir_root) {
   if (it1 == m_registered.end()) {
     m_snap_sync_stats.erase(_dir_root);
   } else {
-    it1->second.replayer->cancel();
+    it1->second.canceled = true;
   }
   m_cond.notify_all();
 }

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -88,21 +88,13 @@ private:
       return 0;
     }
 
-    void cancel() {
-      canceled = true;
-    }
-
-    bool is_canceled() const {
-      return canceled;
-    }
-
   private:
     PeerReplayer *m_peer_replayer;
-    bool canceled = false;
   };
 
   struct DirRegistry {
     int fd;
+    bool canceled = false;
     SnapshotReplayerThread *replayer;
   };
 
@@ -244,7 +236,7 @@ private:
       return true;
     }
     auto &dr = m_registered.at(dir_root);
-    if (dr.replayer->is_canceled()) {
+    if (dr.canceled) {
       *retval = -ECANCELED;
       return true;
     }


### PR DESCRIPTION
When removing a directory path from mirroring, cephfs-mirror records
this state in a thread-local storage. The replayer thread backs-off
in midst of mirroring the directory snapshots for this directory path.
However, the state (canceled state) is never cleared causing the thread
to incorrectly assume that other directory paths (which are picked up
by this thread) need backing-off, hence, marking these directory paths
as failed (to synchronize snapshots).

Fix is to store this state in the directory specific store which is
allocated when a thread picks up a directory path for synchronization.

Fixes: http://tracker.ceph.com/issues/51666
Signed-off-by: Venky Shankar <vshankar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
