### PR TITLE
doc/man/8/ceph-volume: specify "program" for subcommands

### DIFF
--- a/doc/man/8/ceph-volume.rst
+++ b/doc/man/8/ceph-volume.rst
@@ -39,6 +39,8 @@ Commands
 inventory
 ---------
 
+.. program:: ceph-volume inventory
+
 This subcommand provides information about a host's physical disc inventory and
 reports metadata about these discs. Among this metadata one can find disc
 specific data items (like model, size, rotational or solid state) as well as
@@ -65,6 +67,8 @@ Optional arguments:
 lvm
 ---
 
+.. program:: ceph-volume lvm
+
 By making use of LVM tags, the ``lvm`` sub-command is able to store and later
 re-discover and query devices associated with OSDs so that they can later
 activated.
@@ -73,6 +77,8 @@ Subcommands:
 
 batch
 ^^^^^
+
+.. program:: ceph-volume lvm batch
 
 Creates OSDs from a list of devices using a ``filestore``
 or ``bluestore`` (default) setup. It will create all necessary volume groups
@@ -145,11 +151,14 @@ Required positional arguments:
    Full path to a raw device, like ``/dev/sda``. Multiple
    ``<DEVICE>`` paths can be passed in.
 
-.. describe:: **activate**
+activate
+^^^^^^^^
 
-   Enables a systemd unit that persists the OSD ID and its UUID (also called
-   ``fsid`` in Ceph CLI tools), so that at boot time it can understand what OSD is
-   enabled and needs to be mounted.
+.. program:: ceph-volume lvm activate
+
+Enables a systemd unit that persists the OSD ID and its UUID (also called
+``fsid`` in Ceph CLI tools), so that at boot time it can understand what OSD is
+enabled and needs to be mounted.
 
 Usage::
 
@@ -190,6 +199,8 @@ Multiple OSDs can be activated at once by using the (idempotent) ``--all`` flag:
 
 prepare
 ^^^^^^^
+
+.. program:: ceph-volume lvm prepare
 
 Prepares a logical volume to be used as an OSD and journal using a ``filestore``
 or ``bluestore`` (default) setup. It will not create or modify the logical volumes
@@ -357,6 +368,8 @@ Positional arguments:
 new-wal
 ^^^^^^^
 
+.. program:: ceph-volume lvm new-wal
+
 Attaches the given logical volume to OSD as a WAL. Logical volume
 name format is vg/lv. Fails if OSD has already got attached WAL.
 
@@ -379,6 +392,8 @@ Required arguments:
 new-db
 ^^^^^^
 
+.. program:: ceph-volume lvm new-db
+
 Attaches the given logical volume to OSD as a DB. Logical volume
 name format is vg/lv. Fails if OSD has already got attached DB.
 
@@ -400,6 +415,8 @@ Required arguments:
 
 migrate
 ^^^^^^^
+
+.. program:: ceph-volume lvm migrate
 
 Moves BlueFS data from source volume(s) to the target one, source volumes
 (except the main, i.e. data or block one) are removed on success. LVM volumes
@@ -443,6 +460,8 @@ Subcommands:
 activate
 ^^^^^^^^
 
+.. program:: ceph-volume simple activate
+
 Enables a systemd unit that persists the OSD ID and its UUID (also called
 ``fsid`` in Ceph CLI tools), so that at boot time it can understand what OSD is
 enabled and needs to be mounted, while reading information that was previously
@@ -475,6 +494,8 @@ Optional Arguments:
 
 scan
 ^^^^
+
+.. program:: ceph-volume simple scan
 
 Scan a running OSD or data device for an OSD for metadata that can later be
 used to activate and manage the OSD with ceph-volume. The scan method will


### PR DESCRIPTION
as per
https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html

> Like py:currentmodule, this directive produces no output. Instead, it
> serves to notify Sphinx that all following option directives document
> options for the program called name.
> ...
> The program name may contain spaces (in case you want to document
> subcommands like svn add and svn commit separately).

and to avoid the warnings like:

doc/man/8/ceph-volume.rst:424: WARNING: Duplicate explicit target name:
"cmdoption-ceph-volume-h".

we should specify different "program" for different set of options.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
