### PR TITLE
rgw/notifications: Change in multipart upload notification behavior

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -40,6 +40,11 @@
   If you want to return back the old behavior add 'ssl_options=' (empty) to
   ``rgw frontends`` configuration.
 
+* RGW: The behavior for Multipart Upload was modified so that only 
+  CompleteMultipartUpload notification is sent at the end of the multipart upload. 
+  The POST notification at the beginning of the upload, and PUT notifications that 
+  were sent on each part are not sent anymore.
+
 >=16.0.0
 --------
 * mgr/nfs: ``nfs`` module is moved out of volumes plugin. Prior using the

--- a/doc/radosgw/s3-notification-compatibility.rst
+++ b/doc/radosgw/s3-notification-compatibility.rst
@@ -109,6 +109,10 @@ Event Types
 
    The ``s3:ObjectRemoved:DeleteMarkerCreated`` event presents information on the latest version of the object
 
+.. note::
+
+   In case of multipart upload, an ``ObjectCreated:CompleteMultipartUpload`` notification will be sent at the end of the process.
+
 Topic Configuration
 -------------------
 In the case of bucket notifications, the topics management API will be derived from `AWS Simple Notification Service API`_. 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3810,9 +3810,11 @@ void RGWPutObj::execute(optional_yield y)
   // make reservation for notification if needed
   std::unique_ptr<rgw::sal::Notification> res = store->get_notification(s->object.get(),
 						s, rgw::notify::ObjectCreatedPut);
-  op_ret = res->publish_reserve(this, obj_tags.get());
-  if (op_ret < 0) {
-    return;
+  if(!multipart) {
+    op_ret = res->publish_reserve(this, obj_tags.get());
+    if (op_ret < 0) {
+      return;
+    }
   }
 
   // create the object processor
@@ -5994,14 +5996,6 @@ void RGWInitMultipart::execute(optional_yield y)
     return;
   }
 
-  // make reservation for notification if needed
-  std::unique_ptr<rgw::sal::Notification> res = store->get_notification(s->object.get(),
-				s, rgw::notify::ObjectCreatedPost);
-  op_ret = res->publish_reserve(this);
-  if (op_ret < 0) {
-    return;
-  }
-
   do {
     char buf[33];
     std::unique_ptr<rgw::sal::Object> obj;
@@ -6039,12 +6033,6 @@ void RGWInitMultipart::execute(optional_yield y)
     op_ret = obj_op->write_meta(this, bl.length(), 0, s->yield);
   } while (op_ret == -EEXIST);
   
-  // send request to notification manager
-  int ret = res->publish_commit(this, s->obj_size, ceph::real_clock::now(), attrs[RGW_ATTR_ETAG].to_str(), "");
-  if (ret < 0) {
-    ldpp_dout(this, 1) << "ERROR: publishing notification failed, with error: " << ret << dendl;
-    // too late to rollback operation, hence op_ret is not set here
-  }
 }
 
 int RGWCompleteMultipart::verify_permission(optional_yield y)

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -1406,7 +1406,7 @@ def ps_s3_creation_triggers_on_master(external_endpoint_address=None, ca_locatio
     # create s3 notification
     notification_name = bucket_name + NOTIFICATION_SUFFIX
     topic_conf_list = [{'Id': notification_name,'TopicArn': topic_arn,
-                        'Events': ['s3:ObjectCreated:Put', 's3:ObjectCreated:Copy']
+                        'Events': ['s3:ObjectCreated:Put', 's3:ObjectCreated:Copy', 's3:ObjectCreated:CompleteMultipartUpload']
                        }]
 
     s3_notification_conf = PSNotificationS3(conn, bucket_name, topic_conf_list)
@@ -1661,12 +1661,10 @@ def test_ps_s3_multipart_on_master():
 
     # check amqp receiver
     events = receiver1.get_and_reset_events()
-    assert_equal(len(events), 3)
+    assert_equal(len(events), 1)
 
     events = receiver2.get_and_reset_events()
-    assert_equal(len(events), 1)
-    assert_equal(events[0]['Records'][0]['eventName'], 'ObjectCreated:Post')
-    assert_equal(events[0]['Records'][0]['s3']['configurationId'], notification_name+'_2')
+    assert_equal(len(events), 0)
 
     events = receiver3.get_and_reset_events()
     assert_equal(len(events), 1)
@@ -1769,7 +1767,7 @@ def test_ps_s3_metadata_on_master():
     time.sleep(5)
     # check amqp receiver
     events = receiver.get_and_reset_events()
-    assert_equal(len(events), 4) # PUT, COPY, Multipart start, Multipart End
+    assert_equal(len(events), 3) # PUT, COPY, Multipart start, Multipart End
     for event in events:
         assert(event['Records'][0]['s3']['object']['key'] in expected_keys)
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
