### PR TITLE
doc/releases: add linkage for 15.2.13

### DIFF
--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -67,6 +67,7 @@ Release timeline
 .. _16.2.0: pacific#v16-2-0-pacific
 
 .. _Octopus: octopus
+.. _15.2.13: octopus#v15-2-13-octopus
 .. _15.2.12: octopus#v15-2-12-octopus
 .. _15.2.11: octopus#v15-2-11-octopus
 .. _15.2.10: octopus#v15-2-10-octopus

--- a/doc/releases/releases.yml
+++ b/doc/releases/releases.yml
@@ -31,6 +31,8 @@ releases:
   octopus:
     target_eol: 2022-06-01
     releases:
+      - version: 15.2.13
+        released: 2021-05-26
       - version: 15.2.12
         released: 2021-05-13
       - version: 15.2.11


### PR DESCRIPTION
Missed in https://github.com/ceph/ceph/pull/41540.