### PR TITLE
mgr/devicehealth: replace CLICommand with CLIReadCommand

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -4,7 +4,7 @@ Device health monitoring
 
 import errno
 import json
-from mgr_module import MgrModule, CommandResult, CLIRequiresDB, CLICommand, Option
+from mgr_module import MgrModule, CommandResult, CLIRequiresDB, CLICommand, CLIReadCommand, Option
 import operator
 import rados
 import re
@@ -165,8 +165,7 @@ CREATE TABLE DeviceHealthMetrics (
             return False
         return parts[0] in ('osd', 'mon')
 
-    @CLICommand('device query-daemon-health-metrics',
-                perm='r')
+    @CLIReadCommand('device query-daemon-health-metrics')
     def do_query_daemon_health_metrics(self, who: str) -> Tuple[int, str, str]:
         '''
         Get device health metrics for a given daemon
@@ -182,8 +181,7 @@ CREATE TABLE DeviceHealthMetrics (
         return result.wait()
 
     @CLIRequiresDB
-    @CLICommand('device scrape-daemon-health-metrics',
-                perm='r')
+    @CLIReadCommand('device scrape-daemon-health-metrics')
     def do_scrape_daemon_health_metrics(self, who: str) -> Tuple[int, str, str]:
         '''
         Scrape and store device health metrics for a given daemon
@@ -194,8 +192,7 @@ CREATE TABLE DeviceHealthMetrics (
         return self.scrape_daemon(daemon_type, daemon_id)
 
     @CLIRequiresDB
-    @CLICommand('device scrape-health-metrics',
-                perm='r')
+    @CLIReadCommand('device scrape-health-metrics')
     def do_scrape_health_metrics(self, devid: Optional[str] = None) -> Tuple[int, str, str]:
         '''
         Scrape and store device health metrics
@@ -206,8 +203,7 @@ CREATE TABLE DeviceHealthMetrics (
             return self.scrape_device(devid)
 
     @CLIRequiresDB
-    @CLICommand('device get-health-metrics',
-                perm='r')
+    @CLIReadCommand('device get-health-metrics')
     def do_get_health_metrics(self, devid: str, sample: Optional[str] = None) -> Tuple[int, str, str]:
         '''
         Show stored device metrics for the device
@@ -215,16 +211,14 @@ CREATE TABLE DeviceHealthMetrics (
         return self.show_device_metrics(devid, sample)
 
     @CLIRequiresDB
-    @CLICommand('device check-health',
-                perm='rw')
+    @CLICommand('device check-health')
     def do_check_health(self) -> Tuple[int, str, str]:
         '''
         Check life expectancy of devices
         '''
         return self.check_health()
 
-    @CLICommand('device monitoring on',
-                perm='rw')
+    @CLICommand('device monitoring on')
     def do_monitoring_on(self) -> Tuple[int, str, str]:
         '''
         Enable device health monitoring
@@ -233,8 +227,7 @@ CREATE TABLE DeviceHealthMetrics (
         self.event.set()
         return 0, '', ''
 
-    @CLICommand('device monitoring off',
-                perm='rw')
+    @CLICommand('device monitoring off')
     def do_monitoring_off(self) -> Tuple[int, str, str]:
         '''
         Disable device health monitoring
@@ -244,8 +237,7 @@ CREATE TABLE DeviceHealthMetrics (
         return 0, '', ''
 
     @CLIRequiresDB
-    @CLICommand('device predict-life-expectancy',
-                perm='r')
+    @CLIReadCommand('device predict-life-expectancy')
     def do_predict_life_expectancy(self, devid: str) -> Tuple[int, str, str]:
         '''
         Predict life expectancy with local predictor


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]


Fixes: https://tracker.ceph.com/issues/51631
Signed-off-by: Anamika <cseanamika3@gmail.com>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

Fixes: https://tracker.ceph.com/issues/51631
Signed-off-by: Anamika <cseanamika3@gmail.com>

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
