### PR TITLE
cls/rbd: make group_snap_list return snapshots in creation order

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -28,7 +28,9 @@
 #include "include/types.h"
 
 #include <algorithm>
+#include <functional>
 #include <errno.h>
+#include <optional>
 #include <sstream>
 
 #include "include/uuid.h"
@@ -6916,6 +6918,7 @@ int dir_remove(cls_method_context_t hctx,
 }
 
 static const string RBD_GROUP_SNAP_KEY_PREFIX = "snapshot_";
+static const string RBD_GROUP_SNAP_ORDER_KEY_PREFIX = "snap_order_";
 
 std::string snap_key(const std::string &snap_id) {
   ostringstream oss;
@@ -6923,10 +6926,120 @@ std::string snap_key(const std::string &snap_id) {
   return oss.str();
 }
 
+std::string snap_order_key(const std::string &snap_id) {
+  ostringstream oss;
+  oss << RBD_GROUP_SNAP_ORDER_KEY_PREFIX << snap_id;
+  return oss.str();
+}
+
+static const string snap_id_from_order_key(const string &key) {
+  return key.substr(RBD_GROUP_SNAP_ORDER_KEY_PREFIX.size());
+}
+
 int snap_list(cls_method_context_t hctx, cls::rbd::GroupSnapshot start_after,
               uint64_t max_return,
               std::vector<cls::rbd::GroupSnapshot> *group_snaps)
 {
+  int max_read = RBD_MAX_KEYS_READ;
+  std::map<std::string, bufferlist> vals;
+  std::string last_read = snap_key("");
+
+  group_snaps->clear();
+
+  bool more;
+  do {
+    int r = cls_cxx_map_get_vals(hctx, last_read,
+				 RBD_GROUP_SNAP_KEY_PREFIX,
+				 max_read, &vals, &more);
+    if (r < 0)
+      return r;
+
+    for (auto it = vals.begin(); it != vals.end(); ++it) {
+
+      auto iter = it->second.cbegin();
+      cls::rbd::GroupSnapshot snap;
+      try {
+	decode(snap, iter);
+      } catch (const ceph::buffer::error &err) {
+	CLS_ERR("error decoding snapshot: %s", it->first.c_str());
+	return -EIO;
+      }
+      CLS_LOG(20, "Discovered snapshot %s %s",
+	      snap.name.c_str(),
+	      snap.id.c_str());
+      group_snaps->push_back(snap);
+    }
+    if (!vals.empty()) {
+      last_read = vals.rbegin()->first;
+    } else {
+      ceph_assert(!more);
+    }
+  } while (more);
+
+  // Sort snapshots in the order they were created.
+  std::optional<uint64_t> start_after_order;
+  last_read = snap_order_key("");
+  std::map<string, uint64_t> orders;
+  do {
+    int r = cls_cxx_map_get_vals(hctx, last_read,
+                                 RBD_GROUP_SNAP_ORDER_KEY_PREFIX, max_read,
+                                 &vals, &more);
+    if (r < 0) {
+      return r;
+    }
+    for (auto &[key, bl] : vals) {
+      auto iter = bl.cbegin();
+      uint64_t order;
+      try {
+        decode(order, iter);
+      } catch (const ceph::buffer::error &err) {
+        CLS_ERR("error decoding snapshot order: %s", key.c_str());
+        return -EIO;
+      }
+      auto snap_id = snap_id_from_order_key(key);
+      orders[snap_id] = order;
+      if (snap_id == start_after.id) {
+        start_after_order = order;
+      }
+    }
+    if (!vals.empty()) {
+      last_read = vals.rbegin()->first;
+    } else {
+      ceph_assert(!more);
+    }
+  } while (more);
+
+  std::sort(group_snaps->begin(), group_snaps->end(),
+            [&orders](const cls::rbd::GroupSnapshot &a,
+                      const cls::rbd::GroupSnapshot &b) {
+              return orders[a.id] < orders[b.id];
+            });
+
+  if (!start_after_order) {
+    if (!start_after.id.empty()) {
+      CLS_LOG(5, "start_after '%s' not found", start_after.id.c_str());
+      return -ERESTART;
+    }
+  } else {
+    auto it = group_snaps->begin();
+    for (; it != group_snaps->end(); it++) {
+      if (orders[it->id] > *start_after_order) {
+        break;
+      }
+    }
+    group_snaps->erase(group_snaps->begin(), it);
+  }
+
+  if (group_snaps->size() > max_return) {
+    group_snaps->resize(max_return);
+  }
+
+  return 0;
+}
+
+int snap_list_unsorted(cls_method_context_t hctx,
+                       cls::rbd::GroupSnapshot start_after, uint64_t max_return,
+                       std::vector<cls::rbd::GroupSnapshot> *group_snaps) {
   int max_read = RBD_MAX_KEYS_READ;
   std::map<string, bufferlist> vals;
   string last_read = snap_key(start_after.id);
@@ -6956,7 +7069,11 @@ int snap_list(cls_method_context_t hctx, cls::rbd::GroupSnapshot start_after,
 	      snap.id.c_str());
       group_snaps->push_back(snap);
     }
-
+    if (!vals.empty()) {
+      last_read = vals.rbegin()->first;
+    } else {
+      ceph_assert(!more);
+    }
   } while (more && (group_snaps->size() < max_return));
 
   return 0;
@@ -6971,7 +7088,7 @@ static int check_duplicate_snap_name(cls_method_context_t hctx,
   std::vector<cls::rbd::GroupSnapshot> page;
 
   for (;;) {
-    int r = snap_list(hctx, snap_last, max_read, &page);
+    int r = snap_list_unsorted(hctx, snap_last, max_read, &page);
     if (r < 0) {
       return r;
     }
@@ -7474,6 +7591,43 @@ int group_snap_set(cls_method_context_t hctx,
     } else if (r >= 0) {
       return -EEXIST;
     }
+
+    std::string last_read = group::snap_order_key("");
+    bool more;
+    uint64_t max_order = 0;
+    std::map<string, bufferlist> vals;
+    do {
+      int r = cls_cxx_map_get_vals(hctx, last_read,
+                                   group::RBD_GROUP_SNAP_ORDER_KEY_PREFIX,
+                                   RBD_MAX_KEYS_READ, &vals, &more);
+      if (r < 0) {
+        return r;
+      }
+      for (auto &[key, bl] : vals) {
+        auto iter = bl.cbegin();
+        uint64_t order;
+        try {
+          decode(order, iter);
+        } catch (const ceph::buffer::error &err) {
+          CLS_ERR("error decoding snapshot order: %s", key.c_str());
+          return -EIO;
+        }
+        max_order = std::max(max_order, order);
+      }
+      if (!vals.empty()) {
+        last_read = vals.rbegin()->first;
+      } else {
+        ceph_assert(!more);
+      }
+    } while (more);
+
+    std::string order_key = group::snap_order_key(group_snap.id);
+    bufferlist bl;
+    encode(++max_order, bl);
+    r = cls_cxx_map_set_val(hctx, order_key, & bl);
+    if (r < 0) {
+      return r;
+    }
   }
 
   bufferlist obl;
@@ -7507,6 +7661,10 @@ int group_snap_remove(cls_method_context_t hctx,
 
   CLS_LOG(20, "removing snapshot with key %s", snap_key.c_str());
   int r = cls_cxx_map_remove_key(hctx, snap_key);
+  if (r == 0) {
+    std::string snap_order_key = group::snap_order_key(snap_id);
+    cls_cxx_map_remove_key(hctx, snap_order_key);
+  }
   return r;
 }
 

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -7581,7 +7581,10 @@ int group_snap_list(cls_method_context_t hctx,
     return -EINVAL;
   }
   std::vector<cls::rbd::GroupSnapshot> group_snaps;
-  group::snap_list(hctx, start_after, max_return, &group_snaps);
+  int r = group::snap_list(hctx, start_after, max_return, &group_snaps);
+  if (r < 0) {
+    return r;
+  }
 
   encode(group_snaps, *out);
 

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -84,13 +84,20 @@ int group_snap_list(librados::IoCtx& group_ioctx, const char *group_name,
 
   const int max_read = 1024;
   cls::rbd::GroupSnapshot snap_last;
+  cls_snaps->clear();
 
   for (;;) {
     vector<cls::rbd::GroupSnapshot> snaps_page;
 
     r = cls_client::group_snap_list(&group_ioctx, group_header_oid,
 				    snap_last, max_read, &snaps_page);
-
+    if (r == -ERESTART && !snap_last.id.empty()) {
+      ldout(cct, 20) << "invalid snap_last " << snap_last.id << ", "
+                     << "restarting listing" << dendl;
+      cls_snaps->clear();
+      snap_last = {};
+      continue;
+    }
     if (r < 0) {
       lderr(cct) << "error reading snap list from group: "
 	<< cpp_strerror(-r) << dendl;

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -2688,10 +2688,10 @@ TEST_F(TestClsRbd, group_snap_set) {
   ASSERT_EQ(0, ioctx.omap_get_keys(group_id, "", 10, &keys));
 
   auto it = keys.begin();
-  ASSERT_EQ(1U, keys.size());
+  ASSERT_EQ(2U, keys.size());
 
-  string snap_key = "snapshot_" + stringify(snap.id);
-  ASSERT_EQ(snap_key, *it);
+  ASSERT_EQ("snap_order_" + snap.id, *it++);
+  ASSERT_EQ("snapshot_" + snap.id, *it);
 }
 
 TEST_F(TestClsRbd, group_snap_list) {
@@ -2711,11 +2711,17 @@ TEST_F(TestClsRbd, group_snap_list) {
   cls::rbd::GroupSnapshot snap2 = {snap_id2, "test_snapshot2", cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE};
   ASSERT_EQ(0, group_snap_set(&ioctx, group_id, snap2));
 
+  string snap_id0 = "snap_id0";
+  cls::rbd::GroupSnapshot snap0 = {snap_id0, "test_snapshot0", cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE};
+  ASSERT_EQ(0, group_snap_set(&ioctx, group_id, snap0));
+
   std::vector<cls::rbd::GroupSnapshot> snapshots;
   ASSERT_EQ(0, group_snap_list(&ioctx, group_id, cls::rbd::GroupSnapshot(), 10, &snapshots));
-  ASSERT_EQ(2U, snapshots.size());
+  ASSERT_EQ(3U, snapshots.size());
+  // The insertion order should be preserved
   ASSERT_EQ(snap_id1, snapshots[0].id);
   ASSERT_EQ(snap_id2, snapshots[1].id);
+  ASSERT_EQ(snap_id0, snapshots[2].id);
 }
 
 static std::string hexify(int v) {
@@ -2734,12 +2740,17 @@ TEST_F(TestClsRbd, group_snap_list_max_return) {
   string group_id = "group_id_snap_list_max_return";
   ASSERT_EQ(0, ioctx.create(group_id, true));
 
-  for (int i = 0; i < 15; ++i) {
-    string snap_id = "snap_id" + hexify(i);
+  std::vector<cls::rbd::GroupSnapshot> expected_snapshots;
+  std::set<int> used_ids;
+  for (int i = 0; i < 1025; ++i) {
+    int id;
+    do { id = rand(); } while (!used_ids.insert(id).second);
+    string snap_id = "snap_id" + hexify(id);
     cls::rbd::GroupSnapshot snap = {snap_id,
 				    "test_snapshot" + hexify(i),
 				    cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE};
     ASSERT_EQ(0, group_snap_set(&ioctx, group_id, snap));
+    expected_snapshots.emplace_back(snap);
   }
 
   std::vector<cls::rbd::GroupSnapshot> snapshots;
@@ -2747,17 +2758,18 @@ TEST_F(TestClsRbd, group_snap_list_max_return) {
   ASSERT_EQ(10U, snapshots.size());
 
   for (int i = 0; i < 10; ++i) {
-    string snap_id = "snap_id" + hexify(i);
-    ASSERT_EQ(snap_id, snapshots[i].id);
+    ASSERT_EQ(expected_snapshots[i].id, snapshots[i].id);
   }
 
   cls::rbd::GroupSnapshot last_snap = *snapshots.rbegin();
+  ASSERT_EQ(0, group_snap_remove(&ioctx, group_id, last_snap.id));
+  ASSERT_EQ(-ERESTART, group_snap_list(&ioctx, group_id, last_snap, 1025, &snapshots));
 
-  ASSERT_EQ(0, group_snap_list(&ioctx, group_id, last_snap, 10, &snapshots));
-  ASSERT_EQ(5U, snapshots.size());
-  for (int i = 10; i < 15; ++i) {
-    string snap_id = "snap_id" + hexify(i);
-    ASSERT_EQ(snap_id, snapshots[i - 10].id);
+  last_snap = *(++snapshots.rbegin());
+  ASSERT_EQ(0, group_snap_list(&ioctx, group_id, last_snap, 1025, &snapshots));
+  ASSERT_EQ(1015U, snapshots.size());
+  for (int i = 10; i < 1025; ++i) {
+    ASSERT_EQ(expected_snapshots[i].id, snapshots[i - 10].id);
   }
 }
 
@@ -2779,10 +2791,10 @@ TEST_F(TestClsRbd, group_snap_remove) {
   ASSERT_EQ(0, ioctx.omap_get_keys(group_id, "", 10, &keys));
 
   auto it = keys.begin();
-  ASSERT_EQ(1U, keys.size());
+  ASSERT_EQ(2U, keys.size());
 
-  string snap_key = "snapshot_" + stringify(snap.id);
-  ASSERT_EQ(snap_key, *it);
+  ASSERT_EQ("snap_order_" + snap.id, *it++);
+  ASSERT_EQ("snapshot_" + snap.id, *it);
 
   // Remove the snapshot
 


### PR DESCRIPTION
To make this possible the snapshot order is stored on a snapshot
creation and the shapshot list result is sorted using this order
before returning to the caller.

This change adds a restriction on start_after parameter: now it
may be either the empty string id (to start at the beginning) or
an existing snapshot id. Otherwise -ERESTART is returned to inform
the caller that the "start_after" snapshot is invalid/removed and
the listing should be restarted.

Fixes: https://tracker.ceph.com/issues/51686
Signed-off-by: Mykola Golub <mgolub@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
