### PR TITLE
os/bluestore: fix bluefs log run out of space(improved)

### DIFF
--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -210,6 +210,15 @@ struct bluefs_transaction_t {
     return op_bl.length() == 0;
   }
 
+  unsigned get_cur_pos() const {
+    return op_bl.length();
+  }
+  void undo_op(unsigned pos) {
+    bufferlist tmp;
+    op_bl.splice(0, pos, &tmp);
+    op_bl.swap(tmp);
+  }
+
   void op_init() {
     using ceph::encode;
     encode((__u8)OP_INIT, op_bl);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -9139,6 +9139,22 @@ TEST_P(StoreTestSpecificAUSize, SpilloverFixed3Test) {
   );
 }
 
+TEST_P(StoreTestSpecificAUSize, SyntheticBlueFSLogRunwayOverflow) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  const char* m[][10] = {
+    { "bluestore_min_alloc_size", "8192", 0 }, // must be the first!
+    { "bluefs_alloc_size", "8192", 0 },
+    { "bluefs_max_prefetch ", "8192", 0 },
+    { "bluefs_min_log_runway ", "8192", 0 },
+    { "bluefs_max_log_runway ", "8192", 0 },
+    { "bluefs_log_compact_min_size ", "21474836480", 0 },
+    { 0 },
+  };
+  do_matrix(m, std::bind(&StoreTest::doSyntheticTest, this, _1, _2, _3, _4));
+}
+
 TEST_P(StoreTestSpecificAUSize, Ticket45195Repro) {
   if (string(GetParam()) != "bluestore")
     return;


### PR DESCRIPTION
This is an evolution of #41888. The primary driver for this patch was a desire to eliminate the need to perform redundant encodings during the initial size estimation in the initial patch. 
Additionally new patch hopefully handles a corner case : still there was no100% guarantee that the runway allocation provides enough space for the expanded log file metadata - potentially that metadata could grow above the estimated runway due to the allocation.


Fixes: https://tracker.ceph.com/issues/51217
Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
