### PR TITLE
mgr/cephadm: add agent to push metadata to mgr

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -2,6 +2,7 @@ Sphinx == 3.5.4
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
 git+https://github.com/vlasovskikh/funcparserlib.git
 breathe >= 4.20.0
+cryptography
 Jinja2
 pyyaml >= 5.1.2
 Cython

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -660,6 +660,7 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Requires:       python%{python3_pkgversion}-asyncssh
+Requires:       python%{python3_pkgversion}-cherrypy
 Requires:       cephadm = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?suse_version}
 Requires:       openssh

--- a/debian/control
+++ b/debian/control
@@ -342,7 +342,8 @@ Depends: ceph-mgr (= ${binary:Version}),
          ${misc:Depends},
          ${python:Depends},
          openssh-client,
-         python3-jinja2
+         python3-jinja2,
+         python3-cherrypy
 Description: cephadm orchestrator module for ceph-mgr
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3474,9 +3474,14 @@ class MgrListener(Thread):
         listenSocket.bind(('0.0.0.0', int(self.agent.listener_port)))
         listenSocket.settimeout(60)
         listenSocket.listen(1)
+        ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        ssl_ctx.verify_mode = ssl.CERT_REQUIRED
+        ssl_ctx.load_cert_chain(self.agent.listener_cert_path, self.agent.listener_key_path)
+        ssl_ctx.load_verify_locations(self.agent.ca_path)
+        secureListenSocket = ssl_ctx.wrap_socket(listenSocket, server_side=True)
         while not self.stop:
             try:
-                conn, _ = listenSocket.accept()
+                conn, _ = secureListenSocket.accept()
             except socket.timeout:
                 continue
             try:
@@ -3484,6 +3489,7 @@ class MgrListener(Thread):
             except Exception as e:
                 err_str = f'Failed to extract length of payload from message: {e}'
                 conn.send(err_str.encode())
+                logger.error(err_str)
             while True:
                 payload = conn.recv(length).decode()
                 if not payload:
@@ -3528,6 +3534,8 @@ class CephadmAgent():
         self.config_path = os.path.join(self.daemon_dir, 'agent.json')
         self.keyring_path = os.path.join(self.daemon_dir, 'keyring')
         self.ca_path = os.path.join(self.daemon_dir, 'root_cert.pem')
+        self.listener_cert_path = os.path.join(self.daemon_dir, 'listener.crt')
+        self.listener_key_path = os.path.join(self.daemon_dir, 'listener.key')
         self.listener_port = ''
         self.ack = -1
         self.event = threading.Event()

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3481,30 +3481,33 @@ class MgrListener(Thread):
         secureListenSocket = ssl_ctx.wrap_socket(listenSocket, server_side=True)
         while not self.stop:
             try:
-                conn, _ = secureListenSocket.accept()
-            except socket.timeout:
-                continue
-            try:
-                length: int = int(conn.recv(10).decode())
-            except Exception as e:
-                err_str = f'Failed to extract length of payload from message: {e}'
-                conn.send(err_str.encode())
-                logger.error(err_str)
-            while True:
-                payload = conn.recv(length).decode()
-                if not payload:
-                    break
                 try:
-                    data: Dict[Any, Any] = json.loads(payload)
-                    self.handle_json_payload(data)
+                    conn, _ = secureListenSocket.accept()
+                except socket.timeout:
+                    continue
+                try:
+                    length: int = int(conn.recv(10).decode())
                 except Exception as e:
-                    err_str = f'Failed to extract json payload from message: {e}'
+                    err_str = f'Failed to extract length of payload from message: {e}'
                     conn.send(err_str.encode())
                     logger.error(err_str)
-                else:
-                    conn.send(b'ACK')
-                    self.agent.wakeup()
-                    logger.debug(f'Got mgr message {data}')
+                while True:
+                    payload = conn.recv(length).decode()
+                    if not payload:
+                        break
+                    try:
+                        data: Dict[Any, Any] = json.loads(payload)
+                        self.handle_json_payload(data)
+                    except Exception as e:
+                        err_str = f'Failed to extract json payload from message: {e}'
+                        conn.send(err_str.encode())
+                        logger.error(err_str)
+                    else:
+                        conn.send(b'ACK')
+                        self.agent.wakeup()
+                        logger.debug(f'Got mgr message {data}')
+            except Exception as e:
+                logger.error(f'Mgr Listener encountered exception: {e}')
 
     def shutdown(self) -> None:
         self.stop = True
@@ -3645,8 +3648,8 @@ WantedBy=ceph-{fsid}.target
             self.mgr_listener.start()
 
         ssl_ctx = ssl.create_default_context()
-        ssl_ctx.verify_mode = ssl.CERT_REQUIRED
         ssl_ctx.check_hostname = True
+        ssl_ctx.verify_mode = ssl.CERT_REQUIRED
         ssl_ctx.load_verify_locations(self.ca_path)
 
         while not self.stop:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3540,6 +3540,7 @@ class CephadmAgent():
         self.ack = -1
         self.event = threading.Event()
         self.mgr_listener = MgrListener(self)
+        self.device_enhanced_scan = False
 
     def deploy_daemon_unit(self, config: Dict[str, str] = {}) -> None:
         if not config:
@@ -3611,6 +3612,7 @@ WantedBy=ceph-{fsid}.target
                 self.loop_interval = int(config['refresh_period'])
                 starting_port = int(config['listener_port'])
                 self.host = config['host']
+                use_lsm = config['device_enhanced_scan']
         except Exception as e:
             self.shutdown()
             raise Error(f'Failed to get agent target ip and port from config: {e}')
@@ -3623,6 +3625,10 @@ WantedBy=ceph-{fsid}.target
             raise Error(f'Failed to get agent keyring: {e}')
 
         assert self.target_ip and self.target_port
+
+        self.device_enhanced_scan = False
+        if use_lsm.lower() == 'true':
+            self.device_enhanced_scan = True
 
         try:
             for _ in range(1001):
@@ -3646,10 +3652,17 @@ WantedBy=ceph-{fsid}.target
         while not self.stop:
             ack = self.ack
 
+            try:
+                volume = self._ceph_volume(self.device_enhanced_scan)
+            except Exception as e:
+                logger.error(f'Failed to get ceph-volume metadata: {e}')
+                volume = ''
+
             data = json.dumps({'host': self.host,
                               'ls': list_daemons(self.ctx),
                                'networks': list_networks(self.ctx),
                                'facts': HostFacts(self.ctx).dump(),
+                               'volume': volume,
                                'ack': str(ack),
                                'keyring': self.keyring,
                                'port': self.listener_port})
@@ -3664,6 +3677,23 @@ WantedBy=ceph-{fsid}.target
 
             self.event.wait(self.loop_interval)
             self.event.clear()
+
+    def _ceph_volume(self, enhanced: bool = False) -> str:
+        self.ctx.command = 'inventory --format=json'.split()
+        if enhanced:
+            self.ctx.command.append('--with-lsm')
+        self.ctx.fsid = self.fsid
+
+        stream = io.StringIO()
+        with redirect_stdout(stream):
+            command_ceph_volume(self.ctx)
+
+        stdout = stream.getvalue()
+
+        if stdout:
+            return stdout
+        else:
+            raise Exception('ceph-volume returned empty value')
 
 
 def command_agent(ctx: CephadmContext) -> None:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -40,7 +40,7 @@ from configparser import ConfigParser
 from functools import wraps
 from glob import glob
 from io import StringIO
-from threading import Thread, RLock
+from threading import Thread, RLock, Event
 from urllib.error import HTTPError
 from urllib.request import urlopen, Request
 from pathlib import Path
@@ -3538,7 +3538,7 @@ class CephadmAgent():
         self.listener_key_path = os.path.join(self.daemon_dir, 'listener.key')
         self.listener_port = ''
         self.ack = -1
-        self.event = threading.Event()
+        self.event = Event()
         self.mgr_listener = MgrListener(self)
         self.device_enhanced_scan = False
 
@@ -3651,16 +3651,23 @@ WantedBy=ceph-{fsid}.target
 
         while not self.stop:
             ack = self.ack
-
             try:
                 volume = self._ceph_volume(self.device_enhanced_scan)
             except Exception as e:
                 logger.error(f'Failed to get ceph-volume metadata: {e}')
                 volume = ''
 
+            # part of the networks info is returned as a set which is not JSON
+            # serializable. The set must be converted to a list
+            networks = list_networks(self.ctx)
+            networks_list = {}
+            for key in networks.keys():
+                for k, v in networks[key].items():
+                    networks_list[key] = {k: list(v)}
+
             data = json.dumps({'host': self.host,
                               'ls': list_daemons(self.ctx),
-                               'networks': list_networks(self.ctx),
+                               'networks': networks_list,
                                'facts': HostFacts(self.ctx).dump(),
                                'volume': volume,
                                'ack': str(ack),

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3479,23 +3479,32 @@ class MgrListener(Thread):
                 conn, _ = listenSocket.accept()
             except socket.timeout:
                 continue
+            try:
+                length: int = int(conn.recv(10).decode())
+            except Exception as e:
+                err_str = f'Failed to extract length of payload from message: {e}'
+                conn.send(err_str.encode())
             while True:
-                data = conn.recv(self.agent.socket_buffer_size).decode()
-                if not data:
+                payload = conn.recv(length).decode()
+                if not payload:
                     break
                 try:
-                    self.agent.ack = int(data)
+                    data: Dict[Any, Any] = json.loads(payload)
+                    self.handle_json_payload(data)
                 except Exception as e:
-                    err_str = f'Failed to extract timestamp integer from message: {e}'
+                    err_str = f'Failed to extract json payload from message: {e}'
                     conn.send(err_str.encode())
-                    self.agent.ack = -1
+                    logger.error(err_str)
                 else:
                     conn.send(b'ACK')
-                self.agent.wakeup()
-                logger.debug(f'Got mgr message {data}')
+                    self.agent.wakeup()
+                    logger.debug(f'Got mgr message {data}')
 
     def shutdown(self) -> None:
         self.stop = True
+
+    def handle_json_payload(self, data: Dict[Any, Any]) -> None:
+        self.agent.ack = int(data['counter'])
 
 
 class CephadmAgent():
@@ -3503,7 +3512,6 @@ class CephadmAgent():
     daemon_type = 'agent'
     default_port = 8498
     loop_interval = 30
-    socket_buffer_size = 256
     stop = False
 
     required_files = ['cephadm', 'agent.json', 'keyring']

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -42,7 +42,7 @@ from glob import glob
 from io import StringIO
 from threading import Thread, RLock
 from urllib.error import HTTPError
-from urllib.request import urlopen
+from urllib.request import urlopen, Request
 from pathlib import Path
 
 FuncT = TypeVar('FuncT', bound=Callable)
@@ -1005,6 +1005,7 @@ def get_supported_daemons():
     supported_daemons.append(CephadmDaemon.daemon_type)
     supported_daemons.append(HAproxy.daemon_type)
     supported_daemons.append(Keepalived.daemon_type)
+    supported_daemons.append(CephadmAgent.daemon_type)
     assert len(supported_daemons) == len(set(supported_daemons))
     return supported_daemons
 
@@ -2093,6 +2094,9 @@ def check_units(ctx, units, enabler=None):
 
 
 def is_container_running(ctx: CephadmContext, c: 'CephContainer') -> bool:
+    if ctx.name.split('.', 1)[0] in ['agent', 'cephadm-exporter']:
+        # these are non-containerized daemon types
+        return False
     return bool(get_running_container_name(ctx, c))
 
 
@@ -2697,6 +2701,15 @@ def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
 
             cephadm_exporter = CephadmDaemon(ctx, fsid, daemon_id, port)
             cephadm_exporter.deploy_daemon_unit(config_js)
+        elif daemon_type == CephadmAgent.daemon_type:
+            if ctx.config_json == '-':
+                config_js = get_parm('-')
+            else:
+                config_js = get_parm(ctx.config_json)
+            assert isinstance(config_js, dict)
+
+            cephadm_agent = CephadmAgent(ctx, fsid, daemon_id)
+            cephadm_agent.deploy_daemon_unit(config_js)
         else:
             if c:
                 deploy_daemon_units(ctx, fsid, uid, gid, daemon_type, daemon_id,
@@ -3447,6 +3460,205 @@ class CephContainer:
                                 desc=self.entrypoint, timeout=timeout)
         return out
 
+
+#####################################
+
+class MgrListener(Thread):
+    def __init__(self, agent: 'CephadmAgent') -> None:
+        self.agent = agent
+        self.stop = False
+        super(MgrListener, self).__init__(target=self.run)
+
+    def run(self) -> None:
+        listenSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listenSocket.bind(('0.0.0.0', int(self.agent.listener_port)))
+        listenSocket.settimeout(60)
+        listenSocket.listen(1)
+        while not self.stop:
+            try:
+                conn, _ = listenSocket.accept()
+            except socket.timeout:
+                continue
+            while True:
+                data = conn.recv(self.agent.socket_buffer_size).decode()
+                if not data:
+                    break
+                try:
+                    self.agent.ack = int(data)
+                except Exception as e:
+                    err_str = f'Failed to extract timestamp integer from message: {e}'
+                    conn.send(err_str.encode())
+                    self.agent.ack = -1
+                else:
+                    conn.send(b'ACK')
+                self.agent.wakeup()
+                logger.debug(f'Got mgr message {data}')
+
+    def shutdown(self) -> None:
+        self.stop = True
+
+
+class CephadmAgent():
+
+    daemon_type = 'agent'
+    default_port = 8498
+    loop_interval = 30
+    socket_buffer_size = 256
+    stop = False
+
+    required_files = ['cephadm', 'agent.json', 'keyring']
+
+    def __init__(self, ctx: CephadmContext, fsid: str, daemon_id: Union[int, str] = ''):
+        self.ctx = ctx
+        self.fsid = fsid
+        self.daemon_id = daemon_id
+        self.target_ip = ''
+        self.target_port = ''
+        self.host = ''
+        self.daemon_dir = os.path.join(ctx.data_dir, self.fsid, f'{self.daemon_type}.{self.daemon_id}')
+        self.binary_path = os.path.join(self.daemon_dir, 'cephadm')
+        self.config_path = os.path.join(self.daemon_dir, 'agent.json')
+        self.keyring_path = os.path.join(self.daemon_dir, 'keyring')
+        self.ca_path = os.path.join(self.daemon_dir, 'root_cert.pem')
+        self.listener_port = ''
+        self.ack = -1
+        self.event = threading.Event()
+        self.mgr_listener = MgrListener(self)
+
+    def deploy_daemon_unit(self, config: Dict[str, str] = {}) -> None:
+        if not config:
+            raise Error('Agent needs a config')
+        assert isinstance(config, dict)
+
+        # Create the required config files in the daemons dir, with restricted permissions
+        for filename in config:
+            with open(os.path.join(self.daemon_dir, filename), 'w') as f:
+                f.write(config[filename])
+
+        with open(os.path.join(self.daemon_dir, 'unit.run'), 'w') as f:
+            f.write(self.unit_run())
+
+        unit_file_path = os.path.join(self.ctx.unit_dir, self.unit_name())
+        with open(unit_file_path + '.new', 'w') as f:
+            f.write(self.unit_file())
+            os.rename(unit_file_path + '.new', unit_file_path)
+
+        call_throws(self.ctx, ['systemctl', 'daemon-reload'])
+        call(self.ctx, ['systemctl', 'stop', self.unit_name()],
+             verbosity=CallVerbosity.DEBUG)
+        call(self.ctx, ['systemctl', 'reset-failed', self.unit_name()],
+             verbosity=CallVerbosity.DEBUG)
+        call_throws(self.ctx, ['systemctl', 'enable', '--now', self.unit_name()])
+
+    def unit_name(self) -> str:
+        return '{}.service'.format(get_unit_name(self.fsid, self.daemon_type, self.daemon_id))
+
+    def unit_run(self) -> str:
+        py3 = shutil.which('python3')
+        return ('set -e\n' + f'{py3} {self.binary_path} agent --fsid {self.fsid} --daemon-id {self.daemon_id} &\n')
+
+    def unit_file(self) -> str:
+        return """#generated by cephadm
+[Unit]
+Description=cephadm agent for cluster {fsid}
+
+PartOf=ceph-{fsid}.target
+Before=ceph-{fsid}.target
+
+[Service]
+Type=forking
+ExecStart=/bin/bash {data_dir}/unit.run
+Restart=on-failure
+RestartSec=10s
+
+[Install]
+WantedBy=ceph-{fsid}.target
+""".format(
+            fsid=self.fsid,
+            data_dir=self.daemon_dir
+        )
+
+    def shutdown(self) -> None:
+        self.stop = True
+        if self.mgr_listener.is_alive():
+            self.mgr_listener.shutdown()
+
+    def wakeup(self) -> None:
+        self.event.set()
+
+    def run(self) -> None:
+        try:
+            with open(self.config_path, 'r') as f:
+                config = json.load(f)
+                self.target_ip = config['target_ip']
+                self.target_port = config['target_port']
+                self.loop_interval = int(config['refresh_period'])
+                starting_port = int(config['listener_port'])
+                self.host = config['host']
+        except Exception as e:
+            self.shutdown()
+            raise Error(f'Failed to get agent target ip and port from config: {e}')
+
+        try:
+            with open(self.keyring_path, 'r') as f:
+                self.keyring = f.read()
+        except Exception as e:
+            self.shutdown()
+            raise Error(f'Failed to get agent keyring: {e}')
+
+        assert self.target_ip and self.target_port
+
+        try:
+            for _ in range(1001):
+                if not port_in_use(self.ctx, starting_port):
+                    self.listener_port = str(starting_port)
+                    break
+                starting_port += 1
+            if not self.listener_port:
+                raise Error(f'All 1000 ports starting at {str(starting_port - 1001)} taken.')
+        except Exception as e:
+            raise Error(f'Failed to pick port for agent to listen on: {e}')
+
+        if not self.mgr_listener.is_alive():
+            self.mgr_listener.start()
+
+        ssl_ctx = ssl.create_default_context()
+        ssl_ctx.verify_mode = ssl.CERT_REQUIRED
+        ssl_ctx.check_hostname = True
+        ssl_ctx.load_verify_locations(self.ca_path)
+
+        while not self.stop:
+            ack = self.ack
+
+            data = json.dumps({'host': self.host,
+                              'ls': list_daemons(self.ctx),
+                               'networks': list_networks(self.ctx),
+                               'facts': HostFacts(self.ctx).dump(),
+                               'ack': str(ack),
+                               'keyring': self.keyring,
+                               'port': self.listener_port})
+            data = data.encode('ascii')
+
+            url = f'https://{self.target_ip}:{self.target_port}/data'
+            try:
+                req = Request(url, data, {'Content-Type': 'application/json'})
+                urlopen(req, context=ssl_ctx)
+            except Exception as e:
+                logger.error(f'Failed to send metadata to mgr: {e}')
+
+            self.event.wait(self.loop_interval)
+            self.event.clear()
+
+
+def command_agent(ctx: CephadmContext) -> None:
+    agent = CephadmAgent(ctx, ctx.fsid, ctx.daemon_id)
+
+    if not os.path.isdir(agent.daemon_dir):
+        raise Error(f'Agent daemon directory {agent.daemon_dir} does not exist. Perhaps agent was never deployed?')
+
+    agent.run()
+
+
 ##################################
 
 
@@ -3542,7 +3754,7 @@ def get_image_info_from_inspect(out, image):
         'image_id': normalize_container_id(image_id)
     }  # type: Dict[str, Union[str,List[str]]]
     if digests:
-        r['repo_digests'] = list(map(normalize_image_digest, digests[1:-1].split(' ')))
+        r['repo_digests'] = list(map(normalize_image_digest, digests[1: -1].split(' ')))
     return r
 
 ##################################
@@ -3578,7 +3790,7 @@ def check_subnet(subnets: str) -> Tuple[int, List[int], str]:
 def unwrap_ipv6(address):
     # type: (str) -> str
     if address.startswith('[') and address.endswith(']'):
-        return address[1:-1]
+        return address[1: -1]
     return address
 
 
@@ -3643,7 +3855,7 @@ def prepare_mon_addresses(
             raise Error('--mon-addrv value %s must use square backets' %
                         addr_arg)
         ipv6 = addr_arg.count('[') > 1
-        for addr in addr_arg[1:-1].split(','):
+        for addr in addr_arg[1: -1].split(','):
             hasport = r.findall(addr)
             if not hasport:
                 raise Error('--mon-addrv value %s must include port number' %
@@ -4233,13 +4445,11 @@ def command_bootstrap(ctx):
     (uid, gid) = extract_uid_gid(ctx)
 
     # create some initial keys
-    (mon_key, mgr_key, admin_key, bootstrap_keyring, admin_keyring) = \
-        create_initial_keys(ctx, uid, gid, mgr_id)
+    (mon_key, mgr_key, admin_key, bootstrap_keyring, admin_keyring) = create_initial_keys(ctx, uid, gid, mgr_id)
 
     monmap = create_initial_monmap(ctx, uid, gid, fsid, mon_id, addr_arg)
-    (mon_dir, log_dir) = \
-        prepare_create_mon(ctx, uid, gid, fsid, mon_id,
-                           bootstrap_keyring.name, monmap.name)
+    (mon_dir, log_dir) = prepare_create_mon(ctx, uid, gid, fsid, mon_id,
+                                            bootstrap_keyring.name, monmap.name)
 
     with open(mon_dir + '/config', 'w') as f:
         os.fchown(f.fileno(), uid, gid)
@@ -4597,6 +4807,13 @@ def command_deploy(ctx):
 
         CephadmDaemon.validate_config(config_js)
 
+        deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, None,
+                      uid, gid, ports=daemon_ports)
+
+    elif daemon_type == CephadmAgent.daemon_type:
+        # get current user gid and uid
+        uid = os.getuid()
+        gid = os.getgid()
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, None,
                       uid, gid, ports=daemon_ports)
 
@@ -5002,8 +5219,7 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                         'systemd_unit': legacy_unit_name,
                     }
                     if detail:
-                        (val['enabled'], val['state'], _) = \
-                            check_unit(ctx, legacy_unit_name)
+                        (val['enabled'], val['state'], _) = check_unit(ctx, legacy_unit_name)
                         if not host_version:
                             try:
                                 out, err, code = call(ctx,
@@ -5034,8 +5250,7 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                     }
                     if detail:
                         # get container id
-                        (val['enabled'], val['state'], _) = \
-                            check_unit(ctx, unit_name)
+                        (val['enabled'], val['state'], _) = check_unit(ctx, unit_name)
                         container_id = None
                         image_name = None
                         image_id = None
@@ -8422,6 +8637,17 @@ def _get_parser():
         choices=['enter', 'exit'],
         help='Maintenance action - enter maintenance, or exit maintenance')
     parser_maintenance.set_defaults(func=command_maintenance)
+
+    parser_agent = subparsers.add_parser(
+        'agent', help='start cephadm agent')
+    parser_agent.set_defaults(func=command_agent)
+    parser_agent.add_argument(
+        '--fsid',
+        required=True,
+        help='cluster FSID')
+    parser_agent.add_argument(
+        '--daemon-id',
+        help='daemon id for agent')
 
     return parser
 

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -171,7 +171,6 @@ class HostData:
             if 'facts' in data and data['facts']:
                 self.mgr.cache.update_host_facts(host, json.loads(data['facts']))
             if 'volume' in data and data['volume']:
-                self.mgr.log.error(data['volume'])
                 ret = Devices.from_json(json.loads(data['volume']))
                 self.mgr.cache.update_host_devices(host, ret.devices)
 

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -1,0 +1,301 @@
+import cherrypy
+import json
+import socket
+import tempfile
+import threading
+import time
+
+from mgr_util import verify_tls_files
+from ceph.utils import datetime_now
+from ceph.deployment.service_spec import ServiceSpec, PlacementSpec
+
+from OpenSSL import crypto
+from typing import Any, Dict, Set, Tuple, TYPE_CHECKING
+from uuid import uuid4
+
+if TYPE_CHECKING:
+    from cephadm.module import CephadmOrchestrator
+
+
+class CherryPyThread(threading.Thread):
+    def __init__(self, mgr: "CephadmOrchestrator") -> None:
+        self.mgr = mgr
+        self.cherrypy_shutdown_event = threading.Event()
+        self.ssl_certs = SSLCerts(self.mgr)
+        super(CherryPyThread, self).__init__(target=self.run)
+
+    def run(self) -> None:
+        try:
+            server_addr = self.mgr.get_mgr_ip()
+            server_port = self.mgr.endpoint_port
+
+            self.ssl_certs.generate_root_cert()
+            cert, key = self.ssl_certs.generate_cert()
+
+            self.key_tmp = tempfile.NamedTemporaryFile()
+            self.key_tmp.write(key.encode('utf-8'))
+            self.key_tmp.flush()  # pkey_tmp must not be gc'ed
+            key_fname = self.key_tmp.name
+
+            self.cert_tmp = tempfile.NamedTemporaryFile()
+            self.cert_tmp.write(cert.encode('utf-8'))
+            self.cert_tmp.flush()  # cert_tmp must not be gc'ed
+            cert_fname = self.cert_tmp.name
+
+            verify_tls_files(cert_fname, key_fname)
+
+            self.mgr.set_uri('https://{0}:{1}/'.format(server_addr, server_port))
+
+            cherrypy.config.update({
+                'server.socket_host': server_addr,
+                'server.socket_port': server_port,
+                'engine.autoreload.on': False,
+                'server.ssl_module': 'builtin',
+                'server.ssl_certificate': cert_fname,
+                'server.ssl_private_key': key_fname,
+            })
+            root_conf = {'/': {'request.dispatch': cherrypy.dispatch.MethodDispatcher(),
+                               'tools.response_headers.on': True}}
+            cherrypy.tree.mount(Root(self.mgr), '/', root_conf)
+            self.mgr.log.info('Starting cherrypy engine...')
+            cherrypy.engine.start()
+            self.mgr.log.info('Cherrypy engine started.')
+            # wait for the shutdown event
+            self.cherrypy_shutdown_event.wait()
+            self.cherrypy_shutdown_event.clear()
+            cherrypy.engine.stop()
+            self.mgr.log.info('Cherrypy engine stopped.')
+        except Exception as e:
+            self.mgr.log.error(f'Failed to run cephadm cherrypy endpoint: {e}')
+
+    def shutdown(self) -> None:
+        self.mgr.log.info('Stopping cherrypy engine...')
+        self.cherrypy_shutdown_event.set()
+
+
+class Root:
+    exposed = True
+
+    def __init__(self, mgr: "CephadmOrchestrator"):
+        self.mgr = mgr
+        self.data = HostData(self.mgr)
+
+    def GET(self) -> str:
+        return '''<!DOCTYPE html>
+<html>
+<head><title>Cephadm HTTP Endpoint</title></head>
+<body>
+<p>Cephadm HTTP Endpoint is up and running</p>
+</body>
+</html>'''
+
+
+class HostData:
+    exposed = True
+
+    def __init__(self, mgr: "CephadmOrchestrator"):
+        self.mgr = mgr
+
+    @cherrypy.tools.json_in()
+    def POST(self) -> None:
+        data: Dict[str, Any] = cherrypy.request.json
+        try:
+            self.check_request_fields(data)
+        except Exception as e:
+            self.mgr.log.warning(f'Received bad metadata from an agent: {e}')
+        else:
+            self.handle_metadata(data)
+
+    def check_request_fields(self, data: Dict[str, Any]) -> None:
+        fields = '{' + ', '.join([key for key in data.keys()]) + '}'
+        if 'host' not in data:
+            raise Exception(
+                f'No host in metadata from agent ("host" field). Only received fields {fields}')
+        host = data['host']
+        if host not in self.mgr.cache.get_hosts():
+            raise Exception(f'Received metadata from agent on unknown hostname {host}')
+        if 'keyring' not in data:
+            raise Exception(
+                f'Agent on host {host} not reporting its keyring for validation ("keyring" field). Only received fields {fields}')
+        if host not in self.mgr.cache.agent_keys:
+            raise Exception(f'No agent keyring stored for host {host}. Cannot verify agent')
+        if data['keyring'] != self.mgr.cache.agent_keys[host]:
+            raise Exception(f'Got wrong keyring from agent on host {host}.')
+        if 'port' not in data:
+            raise Exception(
+                f'Agent on host {host} not reporting its listener port ("port" fields). Only received fields {fields}')
+        if 'ack' not in data:
+            raise Exception(
+                f'Agent on host {host} not reporting its counter value ("ack" field). Only received fields {fields}')
+        try:
+            int(data['ack'])
+        except Exception as e:
+            raise Exception(
+                f'Counter value from agent on host {host} could not be converted to an integer: {e}')
+        metadata_types = ['ls', 'networks', 'facts']
+        metadata_types_str = '{' + ', '.join(metadata_types) + '}'
+        if not all(item in data.keys() for item in metadata_types):
+            self.mgr.log.warning(
+                f'Agent on host {host} reported incomplete metadata. Not all of {metadata_types_str} were present. Received fields {fields}')
+
+    def handle_metadata(self, data: Dict[str, Any]) -> None:
+        try:
+            host = data['host']
+            if host not in self.mgr.cache.agent_counter:
+                self.mgr.log.debug(
+                    f'Got metadata from agent on host {host} with no known counter entry. Starting counter at 1 and requesting new metadata')
+                self.mgr.cache.agent_counter[host] = 1
+                self.mgr.agent_helpers._request_agent_acks({host})
+                return
+
+            self.mgr.cache.agent_ports[host] = int(data['port'])
+            self.mgr.cache.agent_timestamp[host] = datetime_now()
+            up_to_date = False
+
+            int_ack = int(data['ack'])
+            if int_ack == self.mgr.cache.agent_counter[host]:
+                up_to_date = True
+            else:
+                # we got old counter value with message, inform agent of new timestamp
+                self.mgr.agent_helpers._request_agent_acks({host})
+                self.mgr.log.debug(
+                    f'Received old metadata from agent on host {host}. Requested up-to-date metadata.')
+
+            if up_to_date:
+                if 'ls' in data:
+                    self.mgr._process_ls_output(host, data['ls'])
+                if 'networks' in data:
+                    self.mgr.cache.update_host_networks(host, data['networks'])
+                if 'facts' in data:
+                    self.mgr.cache.update_host_facts(host, json.loads(data['facts']))
+
+                # update timestamp of most recent up-to-date agent update
+                self.mgr.cache.metadata_up_to_date[host] = True
+                self.mgr.log.debug(
+                    f'Received up-to-date metadata from agent on host {host}.')
+
+        except Exception as e:
+            self.mgr.log.warning(
+                f'Failed to update metadata with metadata from agent on host {host}: {e}')
+
+
+class AgentMessageThread(threading.Thread):
+    def __init__(self, host: str, port: int, counter: int, mgr: "CephadmOrchestrator") -> None:
+        self.mgr = mgr
+        self.host = host
+        self.port = port
+        self.counter = counter
+        super(AgentMessageThread, self).__init__(target=self.run)
+
+    def run(self) -> None:
+        for retry_wait in [3, 5]:
+            try:
+                agent_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                agent_socket.connect((self.mgr.inventory.get_addr(self.host), self.port))
+                agent_socket.send(str(self.counter).encode())
+                agent_response = agent_socket.recv(1024).decode()
+                self.mgr.log.debug(f'Received {agent_response} from agent on host {self.host}')
+                return
+            except ConnectionError as e:
+                # if it's a connection error, possibly try to connect again.
+                # We could have just deployed agent and it might not be ready
+                self.mgr.log.debug(
+                    f'Retrying connection to agent on {self.host} in {str(retry_wait)} seconds. Connection failed with: {e}')
+                time.sleep(retry_wait)
+            except Exception as e:
+                # if it's not a connection error, something has gone wrong. Give up.
+                self.mgr.log.debug(f'Failed to contact agent on host {self.host}: {e}')
+                return
+        return
+
+
+class CephadmAgentHelpers:
+    def __init__(self, mgr: "CephadmOrchestrator"):
+        self.mgr: "CephadmOrchestrator" = mgr
+
+    def _request_agent_acks(self, hosts: Set[str]) -> None:
+        for host in hosts:
+            self.mgr.cache.metadata_up_to_date[host] = False
+            if host not in self.mgr.cache.agent_counter:
+                self.mgr.cache.agent_counter[host] = 1
+            else:
+                self.mgr.cache.agent_counter[host] = self.mgr.cache.agent_counter[host] + 1
+            message_thread = AgentMessageThread(
+                host, self.mgr.cache.agent_ports[host], self.mgr.cache.agent_counter[host], self.mgr)
+            message_thread.start()
+
+    def _agent_down(self, host: str) -> bool:
+        # if we don't have a timestamp, it's likely because of a mgr fail over.
+        # just set the timestamp to now
+        if host not in self.mgr.cache.agent_timestamp:
+            self.mgr.cache.agent_timestamp[host] = datetime_now()
+        # agent hasn't reported in 2.5 * it's refresh rate. Something is likely wrong with it.
+        time_diff = datetime_now() - self.mgr.cache.agent_timestamp[host]
+        if time_diff.total_seconds() > 2.5 * float(self.mgr.agent_refresh_rate):
+            return True
+        return False
+
+    # this function probably seems very unnecessary, but it makes it considerably easier
+    # to get the unit tests working. All unit tests that check which daemons were deployed
+    # or services setup would have to be individually changed to expect an agent service or
+    # daemons, OR we can put this in its own function then mock the function
+    def _apply_agent(self) -> None:
+        spec = ServiceSpec(
+            service_type='agent',
+            placement=PlacementSpec(host_pattern='*')
+        )
+        self.mgr.spec_store.save(spec)
+
+
+class SSLCerts:
+    def __init__(self, mgr: "CephadmOrchestrator") -> None:
+        self.mgr = mgr
+        self.root_cert: Any
+        self.root_key: Any
+        self.root_subj: Any
+
+    def generate_root_cert(self) -> Tuple[str, str]:
+        self.root_key = crypto.PKey()
+        self.root_key.generate_key(crypto.TYPE_RSA, 2048)
+
+        self.root_cert = crypto.X509()
+        self.root_cert.set_serial_number(int(uuid4()))
+
+        self.root_subj = self.root_cert.get_subject()
+        self.root_subj.commonName = "cephadm-root"
+
+        self.root_cert.set_issuer(self.root_subj)
+        self.root_cert.set_pubkey(self.root_key)
+        self.root_cert.gmtime_adj_notBefore(0)
+        self.root_cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)  # 10 years
+        self.root_cert.sign(self.root_key, 'sha256')
+
+        cert_str = crypto.dump_certificate(crypto.FILETYPE_PEM, self.root_cert).decode('utf-8')
+        key_str = crypto.dump_privatekey(crypto.FILETYPE_PEM, self.root_key).decode('utf-8')
+        return (cert_str, key_str)
+
+    def generate_cert(self) -> Tuple[str, str]:
+        key = crypto.PKey()
+        key.generate_key(crypto.TYPE_RSA, 2048)
+
+        cert = crypto.X509()
+        cert.set_serial_number(int(uuid4()))
+
+        subj = cert.get_subject()
+        subj.commonName = str(self.mgr.get_mgr_ip())
+
+        cert.set_issuer(self.root_subj)
+        cert.set_pubkey(key)
+        cert.gmtime_adj_notBefore(0)
+        cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)  # 10 years
+        cert.sign(self.root_key, 'sha256')
+
+        cert_str = crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode('utf-8')
+        key_str = crypto.dump_privatekey(crypto.FILETYPE_PEM, key).decode('utf-8')
+        return (cert_str, key_str)
+
+    def get_root_cert(self) -> str:
+        return crypto.dump_certificate(crypto.FILETYPE_PEM, self.root_cert).decode('utf-8')
+
+    def get_root_key(self) -> str:
+        return crypto.dump_privatekey(crypto.FILETYPE_PEM, self.root_key).decode('utf-8')

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -172,7 +172,7 @@ class HostData:
             else:
                 # we got old counter value with message, inform agent of new timestamp
                 self.mgr.agent_helpers._request_agent_acks({host})
-                self.mgr.log.debug(
+                self.mgr.log.info(
                     f'Received old metadata from agent on host {host}. Requested up-to-date metadata.')
 
             if 'ls' in data and data['ls']:
@@ -187,7 +187,7 @@ class HostData:
 
             if up_to_date:
                 self.mgr.cache.metadata_up_to_date[host] = True
-                self.mgr.log.debug(
+                self.mgr.log.info(
                     f'Received up-to-date metadata from agent on host {host}.')
 
         except Exception as e:
@@ -205,6 +205,7 @@ class AgentMessageThread(threading.Thread):
         super(AgentMessageThread, self).__init__(target=self.run)
 
     def run(self) -> None:
+        self.mgr.log.info(f'Sending message to agent on host {self.host}')
         try:
             assert self.mgr.cherrypy_thread
             root_cert = self.mgr.cherrypy_thread.ssl_certs.get_root_cert()
@@ -250,7 +251,7 @@ class AgentMessageThread(threading.Thread):
                 msg = (bytes_len + self.data)
                 secure_agent_socket.sendall(msg.encode('utf-8'))
                 agent_response = secure_agent_socket.recv(1024).decode()
-                self.mgr.log.debug(f'Received "{agent_response}" from agent on host {self.host}')
+                self.mgr.log.info(f'Received "{agent_response}" from agent on host {self.host}')
                 return
             except ConnectionError as e:
                 # if it's a connection error, possibly try to connect again.

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -146,6 +146,7 @@ class HostData:
     def handle_metadata(self, data: Dict[str, Any]) -> None:
         try:
             host = data['host']
+            self.mgr.cache.agent_ports[host] = int(data['port'])
             if host not in self.mgr.cache.agent_counter:
                 self.mgr.log.debug(
                     f'Got metadata from agent on host {host} with no known counter entry. Starting counter at 1 and requesting new metadata')
@@ -153,7 +154,6 @@ class HostData:
                 self.mgr.agent_helpers._request_agent_acks({host})
                 return
 
-            self.mgr.cache.agent_ports[host] = int(data['port'])
             # update timestamp of most recent agent update
             self.mgr.cache.agent_timestamp[host] = datetime_now()
             up_to_date = False

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -187,7 +187,12 @@ class HostData:
                 self.mgr.cache.update_host_devices(host, ret.devices)
 
             if up_to_date:
+                was_out_of_date = not self.mgr.cache.all_host_metadata_up_to_date()
                 self.mgr.cache.metadata_up_to_date[host] = True
+                if was_out_of_date and self.mgr.cache.all_host_metadata_up_to_date():
+                    self.mgr.log.info(
+                        'New metadata from agent has made all hosts up to date. Kicking serve loop')
+                    self.mgr._kick_serve_loop()
                 self.mgr.log.info(
                     f'Received up-to-date metadata from agent on host {host}.')
 

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -350,7 +350,13 @@ class SSLCerts:
         return (cert_str, key_str)
 
     def get_root_cert(self) -> str:
-        return crypto.dump_certificate(crypto.FILETYPE_PEM, self.root_cert).decode('utf-8')
+        try:
+            return crypto.dump_certificate(crypto.FILETYPE_PEM, self.root_cert).decode('utf-8')
+        except AttributeError:
+            return ''
 
     def get_root_key(self) -> str:
-        return crypto.dump_privatekey(crypto.FILETYPE_PEM, self.root_key).decode('utf-8')
+        try:
+            return crypto.dump_certificate(crypto.FILETYPE_PEM, self.root_key).decode('utf-8')
+        except AttributeError:
+            return ''

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -438,10 +438,12 @@ class HostCache():
         self.osdspec_previews = {}     # type: Dict[str, List[Dict[str, Any]]]
         self.osdspec_last_applied = {}  # type: Dict[str, Dict[str, datetime.datetime]]
         self.networks = {}             # type: Dict[str, Dict[str, Dict[str, List[str]]]]
+        self.last_network_update = {}   # type: Dict[str, datetime.datetime]
         self.last_device_update = {}   # type: Dict[str, datetime.datetime]
         self.last_device_change = {}   # type: Dict[str, datetime.datetime]
         self.daemon_refresh_queue = []  # type: List[str]
         self.device_refresh_queue = []  # type: List[str]
+        self.network_refresh_queue = []  # type: List[str]
         self.osdspec_previews_refresh_queue = []  # type: List[str]
 
         # host -> daemon name -> dict
@@ -452,6 +454,12 @@ class HostCache():
         self.registry_login_queue: Set[str] = set()
 
         self.scheduled_daemon_actions: Dict[str, Dict[str, str]] = {}
+
+        self.agent_counter = {}  # type: Dict[str, int]
+        self.agent_timestamp = {}  # type: Dict[str, datetime.datetime]
+        self.metadata_up_to_date = {}  # type: Dict[str, bool]
+        self.agent_keys = {}  # type: Dict[str, str]
+        self.agent_ports = {}  # type: Dict[str, int]
 
     def load(self):
         # type: () -> None
@@ -472,6 +480,7 @@ class HostCache():
                 # for services, we ignore the persisted last_*_update
                 # and always trigger a new scrape on mgr restart.
                 self.daemon_refresh_queue.append(host)
+                self.network_refresh_queue.append(host)
                 self.daemons[host] = {}
                 self.osdspec_previews[host] = []
                 self.osdspec_last_applied[host] = {}
@@ -498,6 +507,10 @@ class HostCache():
                     self.last_host_check[host] = str_to_datetime(j['last_host_check'])
                 self.registry_login_queue.add(host)
                 self.scheduled_daemon_actions[host] = j.get('scheduled_daemon_actions', {})
+
+                self.agent_counter[host] = int(j.get('agent_counter', 1))
+                self.metadata_up_to_date[host] = False
+                self.agent_keys[host] = str(j.get('agent_keys', ''))
 
                 self.mgr.log.debug(
                     'HostCache.load: host %s has %d daemons, '
@@ -537,11 +550,10 @@ class HostCache():
             return True
         return False
 
-    def update_host_devices_networks(
+    def update_host_devices(
             self,
             host: str,
             dls: List[inventory.Device],
-            nets: Dict[str, Dict[str, List[str]]]
     ) -> None:
         if (
                 host not in self.devices
@@ -551,7 +563,14 @@ class HostCache():
             self.last_device_change[host] = datetime_now()
         self.last_device_update[host] = datetime_now()
         self.devices[host] = dls
+
+    def update_host_networks(
+            self,
+            host: str,
+            nets: Dict[str, Dict[str, List[str]]]
+    ) -> None:
         self.networks[host] = nets
+        self.last_network_update[host] = datetime_now()
 
     def update_daemon_config_deps(self, host: str, name: str, deps: List[str], stamp: datetime.datetime) -> None:
         self.daemon_config_deps[host][name] = {
@@ -598,6 +617,7 @@ class HostCache():
         self.daemon_config_deps[host] = {}
         self.daemon_refresh_queue.append(host)
         self.device_refresh_queue.append(host)
+        self.network_refresh_queue.append(host)
         self.osdspec_previews_refresh_queue.append(host)
         self.registry_login_queue.add(host)
         self.last_client_files[host] = {}
@@ -616,6 +636,13 @@ class HostCache():
             del self.last_device_update[host]
         self.mgr.event.set()
 
+    def invalidate_host_networks(self, host):
+        # type: (str) -> None
+        self.network_refresh_queue.append(host)
+        if host in self.last_network_update:
+            del self.last_network_update[host]
+        self.mgr.event.set()
+
     def distribute_new_registry_login_info(self) -> None:
         self.registry_login_queue = set(self.mgr.inventory.keys())
 
@@ -631,6 +658,8 @@ class HostCache():
             j['last_daemon_update'] = datetime_to_str(self.last_daemon_update[host])
         if host in self.last_device_update:
             j['last_device_update'] = datetime_to_str(self.last_device_update[host])
+        if host in self.last_network_update:
+            j['last_network_update'] = datetime_to_str(self.last_network_update[host])
         if host in self.last_device_change:
             j['last_device_change'] = datetime_to_str(self.last_device_change[host])
         if host in self.daemons:
@@ -661,6 +690,11 @@ class HostCache():
         if host in self.scheduled_daemon_actions:
             j['scheduled_daemon_actions'] = self.scheduled_daemon_actions[host]
 
+        if host in self.agent_counter:
+            j['agent_counter'] = self.agent_counter[host]
+        if host in self.agent_keys:
+            j['agent_keys'] = self.agent_keys[host]
+
         self.mgr.set_store(HOST_CACHE_PREFIX + host, json.dumps(j))
 
     def rm_host(self, host):
@@ -687,6 +721,8 @@ class HostCache():
             del self.last_daemon_update[host]
         if host in self.last_device_update:
             del self.last_device_update[host]
+        if host in self.last_network_update:
+            del self.last_network_update[host]
         if host in self.last_device_change:
             del self.last_device_change[host]
         if host in self.daemon_config_deps:
@@ -852,6 +888,20 @@ class HostCache():
             return True
         return False
 
+    def host_needs_network_refresh(self, host):
+        # type: (str) -> bool
+        if host in self.mgr.offline_hosts:
+            logger.debug(f'Host "{host}" marked as offline. Skipping network refresh')
+            return False
+        if host in self.network_refresh_queue:
+            self.network_refresh_queue.remove(host)
+            return True
+        cutoff = datetime_now() - datetime.timedelta(
+            seconds=self.mgr.device_cache_timeout)
+        if host not in self.last_network_update or self.last_network_update[host] < cutoff:
+            return True
+        return False
+
     def host_needs_osdspec_preview_refresh(self, host: str) -> bool:
         if host in self.mgr.offline_hosts:
             logger.debug(f'Host "{host}" marked as offline. Skipping osdspec preview refresh')
@@ -890,6 +940,16 @@ class HostCache():
             self.registry_login_queue.remove(host)
             return True
         return False
+
+    def host_metadata_up_to_date(self, host: str) -> bool:
+        if host not in self.metadata_up_to_date or not self.metadata_up_to_date[host]:
+            return False
+        return True
+
+    def all_host_metadata_up_to_date(self) -> bool:
+        if [h for h in self.get_hosts() if not self.host_metadata_up_to_date(h)]:
+            return False
+        return True
 
     def add_daemon(self, host, dd):
         # type: (str, orchestrator.DaemonDescription) -> None

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -947,7 +947,12 @@ class HostCache():
         return True
 
     def all_host_metadata_up_to_date(self) -> bool:
-        if [h for h in self.get_hosts() if not self.host_metadata_up_to_date(h)]:
+        unreachables = [h.hostname for h in self.mgr._unreachable_hosts()]
+        if [h for h in self.get_hosts() if (not self.host_metadata_up_to_date(h) and h not in unreachables)]:
+            # this function is primarily for telling if it's safe to try and apply a service
+            # spec. Since offline/maintenance hosts aren't considered in that process anyway
+            # we don't want to return False if the host without up-to-date metadata is in one
+            # of those two categories.
             return False
         return True
 

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -460,6 +460,7 @@ class HostCache():
         self.metadata_up_to_date = {}  # type: Dict[str, bool]
         self.agent_keys = {}  # type: Dict[str, str]
         self.agent_ports = {}  # type: Dict[str, int]
+        self.sending_agent_message = {}  # type: Dict[str, bool]
 
     def load(self):
         # type: () -> None
@@ -940,6 +941,11 @@ class HostCache():
             self.registry_login_queue.remove(host)
             return True
         return False
+
+    def messaging_agent(self, host: str) -> bool:
+        if host not in self.sending_agent_message or not self.sending_agent_message[host]:
+            return False
+        return True
 
     def host_metadata_up_to_date(self, host: str) -> bool:
         if host not in self.metadata_up_to_date or not self.metadata_up_to_date[host]:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2268,8 +2268,8 @@ Then run the following:
                 root_cert = self.cherrypy_thread.ssl_certs.get_root_cert()
             except Exception:
                 pass
-            deps = sorted([self.get_mgr_ip(), str(self.endpoint_port), root_cert,
-                          str(self.get_module_option('device_enhanced_scan'))])
+            deps = sorted([self.get_mgr_ip(), self.inventory.get_addr(daemon_id), str(self.endpoint_port),
+                           root_cert, str(self.get_module_option('device_enhanced_scan'))])
         else:
             need = {
                 'prometheus': ['mgr', 'alertmanager', 'node-exporter', 'ingress'],

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -508,26 +508,17 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         self.config_checker = CephadmConfigChecks(self)
 
-        self.cherrypy_thread = None
+        self.cherrypy_thread = CherryPyThread(self)
+        self.cherrypy_thread.start()
         self.agent_helpers = CephadmAgentHelpers(self)
-
         if self.use_agent:
-            try:
-                if not self.cherrypy_thread:
-                    self.cherrypy_thread = CherryPyThread(self)
-                    self.cherrypy_thread.start()
-                if 'agent' not in self.spec_store:
-                    self.agent_helpers._apply_agent()
-            except Exception as e:
-                self.log.error(f'Failed to initialize agent spec and cherrypy server: {e}')
+            self.agent_helpers._apply_agent()
 
     def shutdown(self) -> None:
         self.log.debug('shutdown')
         self._worker_pool.close()
         self._worker_pool.join()
-        if self.cherrypy_thread:
-            self.cherrypy_thread.shutdown()
-            self.cherrypy_thread = None
+        self.cherrypy_thread.shutdown()
         self.run = False
         self.event.set()
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2275,7 +2275,8 @@ Then run the following:
             root_cert = ''
             if self.cherrypy_thread and self.cherrypy_thread.ssl_certs.root_cert:
                 root_cert = self.cherrypy_thread.ssl_certs.get_root_cert()
-            deps = [self.get_mgr_ip(), str(self.endpoint_port), root_cert]
+            deps = sorted([self.get_mgr_ip(), str(self.endpoint_port), root_cert,
+                          str(self.get_module_option('device_enhanced_scan'))])
         else:
             need = {
                 'prometheus': ['mgr', 'alertmanager', 'node-exporter', 'ingress'],

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2264,8 +2264,10 @@ Then run the following:
             deps = [d.name() for d in daemons if d.daemon_type == 'haproxy']
         elif daemon_type == 'agent':
             root_cert = ''
-            if self.cherrypy_thread and self.cherrypy_thread.ssl_certs.root_cert:
+            try:
                 root_cert = self.cherrypy_thread.ssl_certs.get_root_cert()
+            except Exception:
+                pass
             deps = sorted([self.get_mgr_ip(), str(self.endpoint_port), root_cert,
                           str(self.get_module_option('device_enhanced_scan'))])
         else:

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -322,9 +322,7 @@ class HostAssignment(object):
         existing = existing_active + existing_standby
 
         # build to_add
-        if self.service_name == 'agent':
-            to_add = [dd for dd in others]
-        elif not count:
+        if not count:
             to_add = [dd for dd in others if dd.hostname not in [
                 h.hostname for h in self.unreachable_hosts]]
         else:

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -322,7 +322,9 @@ class HostAssignment(object):
         existing = existing_active + existing_standby
 
         # build to_add
-        if not count:
+        if self.service_name == 'agent':
+            to_add = [dd for dd in others]
+        elif not count:
             to_add = [dd for dd in others if dd.hostname not in [
                 h.hostname for h in self.unreachable_hosts]]
         else:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -276,7 +276,7 @@ class CephadmServe:
                 self.mgr.cache.metadata_up_to_date[host] = False
                 if host in self.mgr.offline_hosts:
                     return
-                self.mgr.offline_hosts.add(host)
+
                 # In case host is actually offline, it's best to reset the connection to avoid
                 # a long timeout trying to use an existing connection to an offline host
                 # REVISIT AFTER https://github.com/ceph/ceph/pull/42919
@@ -375,11 +375,11 @@ class CephadmServe:
             for agent in agents_down:
                 detail.append((f'Cephadm agent on host {agent} has not reported in '
                               f'{2.5 * self.mgr.agent_refresh_rate} seconds. Agent is assumed '
-                               'down and host has been marked offline.'))
+                               'down and host may be offline.'))
             self.mgr.health_checks['CEPHADM_AGENT_DOWN'] = {
                 'severity': 'warning',
                 'summary': '%d Cephadm Agent(s) are not reporting. '
-                'Hosts marked offline' % (len(agents_down)),
+                'Hosts may be offline' % (len(agents_down)),
                 'count': len(agents_down),
                 'detail': detail,
             }

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -306,6 +306,12 @@ class CephadmServe:
                     r = self._refresh_host_networks(host)
                     if r:
                         failures.append(r)
+
+                if self.mgr.cache.host_needs_device_refresh(host):
+                    self.log.debug('refreshing %s devices' % host)
+                    r = self._refresh_host_devices(host)
+                    if r:
+                        failures.append(r)
                 self.mgr.cache.metadata_up_to_date[host] = True
 
             if self.mgr.cache.host_needs_registry_login(host) and self.mgr.registry_url:
@@ -314,12 +320,6 @@ class CephadmServe:
                                          self.mgr.registry_username, self.mgr.registry_password)
                 if r:
                     bad_hosts.append(r)
-
-            if self.mgr.cache.host_needs_device_refresh(host):
-                self.log.debug('refreshing %s devices' % host)
-                r = self._refresh_host_devices(host)
-                if r:
-                    failures.append(r)
 
             if self.mgr.cache.host_needs_osdspec_preview_refresh(host):
                 self.log.debug(f"refreshing OSDSpec previews for {host}")

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -816,6 +816,7 @@ class CephadmServe:
                         self._remove_daemon(d.name(), d.hostname)
                         daemons_to_remove.remove(d)
                         progress_done += 1
+                        hosts_altered.add(d.hostname)
                         break
 
                 # deploy new daemon
@@ -891,7 +892,7 @@ class CephadmServe:
             if self.mgr.use_agent:
                 # can only send ack to agents if we know for sure port they bound to
                 hosts_altered = set([h for h in hosts_altered if h in self.mgr.cache.agent_ports])
-                self.mgr.agent_helpers._request_agent_acks(hosts_altered)
+                self.mgr.agent_helpers._request_agent_acks(hosts_altered, increment=True)
 
         if r is None:
             r = False

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -101,8 +101,6 @@ class CephadmServe:
                                 self.mgr._schedule_daemon_action(agent.name(), 'redeploy')
                         if 'agent' not in self.mgr.spec_store:
                             self.mgr.agent_helpers._apply_agent()
-                        for host in self.mgr.cache.get_hosts():
-                            self.mgr.cache.metadata_up_to_date[host] = False
                     else:
                         if 'agent' in self.mgr.spec_store:
                             self.mgr.spec_store.rm('agent')

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -605,6 +605,7 @@ class CephadmServe:
         # end up stuck between wanting metadata to be up to date to apply specs
         # and needing to apply the agent spec to get up to date metadata
         if self.mgr.use_agent and not self.mgr.cache.all_host_metadata_up_to_date():
+            self.log.info('Metadata not up to date on all hosts. Skipping non agent specs')
             try:
                 specs.append(self.mgr.spec_store['agent'].spec)
             except Exception as e:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -3,18 +3,19 @@ import json
 import logging
 import uuid
 from collections import defaultdict
-from typing import TYPE_CHECKING, Optional, List, cast, Dict, Any, Union, Tuple
+from typing import TYPE_CHECKING, Optional, List, cast, Dict, Any, Union, Tuple, Iterator, Set
 
 from ceph.deployment import inventory
 from ceph.deployment.drive_group import DriveGroupSpec
 from ceph.deployment.service_spec import ServiceSpec, CustomContainerSpec, PlacementSpec
-from ceph.utils import str_to_datetime, datetime_now
+from ceph.utils import datetime_now
 
 import orchestrator
 from orchestrator import OrchestratorError, set_exception_subject, OrchestratorEvent, \
     DaemonDescriptionStatus, daemon_type_to_service
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.schedule import HostAssignment
+from cephadm.agent import CherryPyThread
 from cephadm.autotune import MemoryAutotuner
 from cephadm.utils import forall_hosts, cephadmNoImage, is_repo_digest, \
     CephadmNoImage, CEPH_TYPES, ContainerInspectInfo
@@ -90,6 +91,19 @@ class CephadmServe:
                     self._check_daemons()
 
                     self._purge_deleted_services()
+
+                    if self.mgr.use_agent:
+                        if not self.mgr.cherrypy_thread:
+                            self.mgr.cherrypy_thread = CherryPyThread(self.mgr)
+                            self.mgr.cherrypy_thread.start()
+                        if 'agent' not in self.mgr.spec_store:
+                            self.mgr.agent_helpers._apply_agent()
+                    else:
+                        if self.mgr.cherrypy_thread:
+                            self.mgr.cherrypy_thread.shutdown()
+                            self.mgr.cherrypy_thread = None
+                        if 'agent' in self.mgr.spec_store:
+                            self.mgr.spec_store.rm('agent')
 
                     if self.mgr.upgrade.continue_upgrade():
                         continue
@@ -242,6 +256,8 @@ class CephadmServe:
                 self.log.warning(
                     f'unable to calc client keyring {ks.entity} placement {ks.placement}: {e}')
 
+        agents_down: List[str] = []
+
         @forall_hosts
         def refresh(host: str) -> None:
 
@@ -249,15 +265,48 @@ class CephadmServe:
             if self.mgr.inventory._inventory[host].get("status", "").lower() == "maintenance":
                 return
 
+            if self.mgr.use_agent and self.mgr.agent_helpers._agent_down(host):
+                if host in self.mgr.offline_hosts:
+                    return
+                self.mgr.offline_hosts.add(host)
+                self.mgr._reset_con(host)
+                agents_down.append(host)
+                # try to schedule redeploy of agent in case it is individually down
+                try:
+                    agent = [a for a in self.mgr.cache.get_daemons_by_host(
+                        host) if a.hostname == host][0]
+                    self.mgr._schedule_daemon_action(agent.name(), 'redeploy')
+                except Exception as e:
+                    self.log.debug(
+                        f'Failed to find entry for agent deployed on host {host}. Agent possibly never deployed: {e}')
+                return
+            else:
+                self.mgr.offline_hosts_remove(host)
+
             if self.mgr.cache.host_needs_check(host):
                 r = self._check_host(host)
                 if r is not None:
                     bad_hosts.append(r)
-            if self.mgr.cache.host_needs_daemon_refresh(host):
-                self.log.debug('refreshing %s daemons' % host)
-                r = self._refresh_host_daemons(host)
-                if r:
-                    failures.append(r)
+
+            if not self.mgr.use_agent:
+                if self.mgr.cache.host_needs_daemon_refresh(host):
+                    self.log.debug('refreshing %s daemons' % host)
+                    r = self._refresh_host_daemons(host)
+                    if r:
+                        failures.append(r)
+
+                if self.mgr.cache.host_needs_facts_refresh(host):
+                    self.log.debug(('Refreshing %s facts' % host))
+                    r = self._refresh_facts(host)
+                    if r:
+                        failures.append(r)
+
+                if self.mgr.cache.host_needs_network_refresh(host):
+                    self.log.debug(('Refreshing %s networks' % host))
+                    r = self._refresh_host_networks(host)
+                    if r:
+                        failures.append(r)
+                self.mgr.cache.metadata_up_to_date[host] = True
 
             if self.mgr.cache.host_needs_registry_login(host) and self.mgr.registry_url:
                 self.log.debug(f"Logging `{host}` into custom registry")
@@ -269,12 +318,6 @@ class CephadmServe:
             if self.mgr.cache.host_needs_device_refresh(host):
                 self.log.debug('refreshing %s devices' % host)
                 r = self._refresh_host_devices(host)
-                if r:
-                    failures.append(r)
-
-            if self.mgr.cache.host_needs_facts_refresh(host):
-                self.log.debug(('Refreshing %s facts' % host))
-                r = self._refresh_facts(host)
                 if r:
                     failures.append(r)
 
@@ -315,6 +358,23 @@ class CephadmServe:
                 self.mgr.cache.save_host(host)
 
         refresh(self.mgr.cache.get_hosts())
+
+        if 'CEPHADM_AGENT_DOWN' in self.mgr.health_checks:
+            del self.mgr.health_checks['CEPHADM_AGENT_DOWN']
+        if agents_down:
+            detail: List[str] = []
+            for agent in agents_down:
+                detail.append((f'Cephadm agent on host {agent} has not reported in '
+                              f'{2.5 * self.mgr.agent_refresh_rate} seconds. Agent is assumed '
+                               'down and host has been marked offline.'))
+            self.mgr.health_checks['CEPHADM_AGENT_DOWN'] = {
+                'severity': 'warning',
+                'summary': '%d Cephadm Agent(s) are not reporting. '
+                'Hosts marked offline' % (len(agents_down)),
+                'count': len(agents_down),
+                'detail': detail,
+            }
+            self.mgr.set_health_checks(self.mgr.health_checks)
 
         self.mgr.config_checker.run_checks()
 
@@ -387,62 +447,7 @@ class CephadmServe:
             ls = self._run_cephadm_json(host, 'mon', 'ls', [], no_fsid=True)
         except OrchestratorError as e:
             return str(e)
-        dm = {}
-        for d in ls:
-            if not d['style'].startswith('cephadm'):
-                continue
-            if d['fsid'] != self.mgr._cluster_fsid:
-                continue
-            if '.' not in d['name']:
-                continue
-            sd = orchestrator.DaemonDescription()
-            sd.last_refresh = datetime_now()
-            for k in ['created', 'started', 'last_configured', 'last_deployed']:
-                v = d.get(k, None)
-                if v:
-                    setattr(sd, k, str_to_datetime(d[k]))
-            sd.daemon_type = d['name'].split('.')[0]
-            if sd.daemon_type not in orchestrator.KNOWN_DAEMON_TYPES:
-                logger.warning(f"Found unknown daemon type {sd.daemon_type} on host {host}")
-                continue
-
-            sd.daemon_id = '.'.join(d['name'].split('.')[1:])
-            sd.hostname = host
-            sd.container_id = d.get('container_id')
-            if sd.container_id:
-                # shorten the hash
-                sd.container_id = sd.container_id[0:12]
-            sd.container_image_name = d.get('container_image_name')
-            sd.container_image_id = d.get('container_image_id')
-            sd.container_image_digests = d.get('container_image_digests')
-            sd.memory_usage = d.get('memory_usage')
-            sd.memory_request = d.get('memory_request')
-            sd.memory_limit = d.get('memory_limit')
-            sd._service_name = d.get('service_name')
-            sd.deployed_by = d.get('deployed_by')
-            sd.version = d.get('version')
-            sd.ports = d.get('ports')
-            sd.ip = d.get('ip')
-            sd.rank = int(d['rank']) if d.get('rank') is not None else None
-            sd.rank_generation = int(d['rank_generation']) if d.get(
-                'rank_generation') is not None else None
-            if sd.daemon_type == 'osd':
-                sd.osdspec_affinity = self.mgr.osd_service.get_osdspec_affinity(sd.daemon_id)
-            if 'state' in d:
-                sd.status_desc = d['state']
-                sd.status = {
-                    'running': DaemonDescriptionStatus.running,
-                    'stopped': DaemonDescriptionStatus.stopped,
-                    'error': DaemonDescriptionStatus.error,
-                    'unknown': DaemonDescriptionStatus.error,
-                }[d['state']]
-            else:
-                sd.status_desc = 'unknown'
-                sd.status = None
-            dm[sd.name()] = sd
-        self.log.debug('Refreshed host %s daemons (%d)' % (host, len(dm)))
-        self.mgr.cache.update_host_daemons(host, dm)
-        self.mgr.cache.save_host(host)
+        self.mgr._process_ls_output(host, ls)
         return None
 
     def _refresh_facts(self, host: str) -> Optional[str]:
@@ -456,7 +461,6 @@ class CephadmServe:
         return None
 
     def _refresh_host_devices(self, host: str) -> Optional[str]:
-
         with_lsm = self.mgr.get_module_option('device_enhanced_scan')
         inventory_args = ['--', 'inventory',
                           '--format=json',
@@ -477,15 +481,26 @@ class CephadmServe:
                 else:
                     raise
 
+        except OrchestratorError as e:
+            return str(e)
+
+        self.log.debug('Refreshed host %s devices (%d)' % (
+            host, len(devices)))
+        ret = inventory.Devices.from_json(devices)
+        self.mgr.cache.update_host_devices(host, ret.devices)
+        self.update_osdspec_previews(host)
+        self.mgr.cache.save_host(host)
+        return None
+
+    def _refresh_host_networks(self, host: str) -> Optional[str]:
+        try:
             networks = self._run_cephadm_json(host, 'mon', 'list-networks', [], no_fsid=True)
         except OrchestratorError as e:
             return str(e)
 
-        self.log.debug('Refreshed host %s devices (%d) networks (%s)' % (
-            host, len(devices), len(networks)))
-        ret = inventory.Devices.from_json(devices)
-        self.mgr.cache.update_host_devices_networks(host, ret.devices, networks)
-        self.update_osdspec_previews(host)
+        self.log.debug('Refreshed host %s networks (%s)' % (
+            host, len(networks)))
+        self.mgr.cache.update_host_networks(host, networks)
         self.mgr.cache.save_host(host)
         return None
 
@@ -578,8 +593,20 @@ class CephadmServe:
     def _apply_all_services(self) -> bool:
         r = False
         specs = []  # type: List[ServiceSpec]
-        for sn, spec in self.mgr.spec_store.active_specs.items():
-            specs.append(spec)
+        # if metadata is not up to date, we still need to apply spec for agent
+        # since the agent is the one who gather the metadata. If we don't we
+        # end up stuck between wanting metadata to be up to date to apply specs
+        # and needing to apply the agent spec to get up to date metadata
+        if self.mgr.use_agent and not self.mgr.cache.all_host_metadata_up_to_date():
+            try:
+                specs.append(self.mgr.spec_store['agent'].spec)
+            except Exception as e:
+                self.log.debug(f'Failed to find agent spec: {e}')
+                self.mgr.agent_helpers._apply_agent()
+                return r
+        else:
+            for sn, spec in self.mgr.spec_store.active_specs.items():
+                specs.append(spec)
         for spec in specs:
             try:
                 if self._apply_service(spec):
@@ -673,7 +700,7 @@ class CephadmServe:
             rank_map = self.mgr.spec_store[spec.service_name()].rank_map or {}
         ha = HostAssignment(
             spec=spec,
-            hosts=self.mgr._schedulable_hosts(),
+            hosts=self.mgr.inventory.all_specs() if spec.service_name() == 'agent' else self.mgr._schedulable_hosts(),
             unreachable_hosts=self.mgr._unreachable_hosts(),
             daemons=daemons,
             networks=self.mgr.cache.networks,
@@ -733,6 +760,8 @@ class CephadmServe:
 
         self.log.debug('Hosts that will receive new daemons: %s' % slots_to_add)
         self.log.debug('Daemons that will be removed: %s' % daemons_to_remove)
+
+        hosts_altered: Set[str] = set()
 
         try:
             # assign names
@@ -812,6 +841,7 @@ class CephadmServe:
                     r = True
                     progress_done += 1
                     update_progress()
+                    hosts_altered.add(daemon_spec.host)
                 except (RuntimeError, OrchestratorError) as e:
                     msg = (f"Failed while placing {slot.daemon_type}.{daemon_id} "
                            f"on {slot.hostname}: {e}")
@@ -851,11 +881,17 @@ class CephadmServe:
 
                 progress_done += 1
                 update_progress()
+                hosts_altered.add(d.hostname)
 
             self.mgr.remote('progress', 'complete', progress_id)
         except Exception as e:
             self.mgr.remote('progress', 'fail', progress_id, str(e))
             raise
+        finally:
+            if self.mgr.use_agent:
+                # can only send ack to agents if we know for sure port they bound to
+                hosts_altered = set([h for h in hosts_altered if h in self.mgr.cache.agent_ports])
+                self.mgr.agent_helpers._request_agent_acks(hosts_altered)
 
         if r is None:
             r = False
@@ -871,7 +907,7 @@ class CephadmServe:
             assert dd.hostname is not None
             assert dd.daemon_type is not None
             assert dd.daemon_id is not None
-            if not spec and dd.daemon_type not in ['mon', 'mgr', 'osd']:
+            if not spec and dd.daemon_type not in ['mon', 'mgr', 'osd', 'agent']:
                 # (mon and mgr specs should always exist; osds aren't matched
                 # to a service spec)
                 self.log.info('Removing orphan daemon %s...' % dd.name())
@@ -1055,6 +1091,9 @@ class CephadmServe:
                     stdin=json.dumps(daemon_spec.final_config),
                     image=image)
 
+                if daemon_spec.daemon_type == 'agent':
+                    self.mgr.cache.agent_timestamp[daemon_spec.host] = datetime_now()
+
                 # refresh daemon state?  (ceph daemon reconfig does not need it)
                 if not reconfig or daemon_spec.daemon_type not in CEPH_TYPES:
                     if not code and daemon_spec.host in self.mgr.cache.daemons:
@@ -1165,7 +1204,7 @@ class CephadmServe:
         self.log.debug(f"_run_cephadm : command = {command}")
         self.log.debug(f"_run_cephadm : args = {args}")
 
-        bypass_image = ('cephadm-exporter',)
+        bypass_image = ('cephadm-exporter', 'agent')
 
         assert image or entity
         # Skip the image check for daemons deployed that are not ceph containers
@@ -1198,7 +1237,9 @@ class CephadmServe:
         # exec
         self.log.debug('args: %s' % (' '.join(final_args)))
         if self.mgr.mode == 'root':
-            if stdin:
+            # agent has cephadm binary as an extra file which is
+            # therefore passed over stdin. Even for debug logs it's too much
+            if stdin and 'agent' not in str(entity):
                 self.log.debug('stdin: %s' % stdin)
 
             cmd = ['which', 'python3']

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -441,9 +441,10 @@ class CephService(CephadmService):
         # the CephService class refers to service types, not daemon types
         if self.TYPE in ['rgw', 'rbd-mirror', 'cephfs-mirror', 'nfs', "iscsi", 'ingress']:
             return AuthEntity(f'client.{self.TYPE}.{daemon_id}')
-        elif self.TYPE == 'crash':
+        elif self.TYPE in ['crash', 'agent']:
             if host == "":
-                raise OrchestratorError("Host not provided to generate <crash> auth entity name")
+                raise OrchestratorError(
+                    f'Host not provided to generate <{self.TYPE}> auth entity name')
             return AuthEntity(f'client.{self.TYPE}.{host}')
         elif self.TYPE == 'mon':
             return AuthEntity('mon.')
@@ -997,3 +998,39 @@ class CephfsMirrorService(CephService):
         daemon_spec.keyring = keyring
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
         return daemon_spec
+
+
+class CephadmAgent(CephService):
+    TYPE = 'agent'
+
+    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+        assert self.TYPE == daemon_spec.daemon_type
+        daemon_id, host = daemon_spec.daemon_id, daemon_spec.host
+
+        if not self.mgr.cherrypy_thread:
+            raise OrchestratorError('Cannot deploy agent before creating cephadm endpoint')
+
+        keyring = self.get_keyring_with_caps(self.get_auth_entity(daemon_id, host=host), [])
+        daemon_spec.keyring = keyring
+        self.mgr.cache.agent_keys[host] = keyring
+
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+
+        return daemon_spec
+
+    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+        cfg = {'target_ip': self.mgr.get_mgr_ip(),
+               'target_port': self.mgr.endpoint_port,
+               'refresh_period': self.mgr.agent_refresh_rate,
+               'listener_port': self.mgr.agent_starting_port,
+               'host': daemon_spec.host}
+
+        assert self.mgr.cherrypy_thread
+        config = {
+            'agent.json': json.dumps(cfg),
+            'cephadm': self.mgr._cephadm,
+            'keyring': daemon_spec.keyring,
+            'root_cert.pem': self.mgr.cherrypy_thread.ssl_certs.get_root_cert(),
+        }
+
+        return config, sorted([str(self.mgr.get_mgr_ip()), str(self.mgr.endpoint_port), self.mgr.cherrypy_thread.ssl_certs.get_root_cert()])

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1033,7 +1033,7 @@ class CephadmAgent(CephService):
             raise OrchestratorError(
                 'Cannot deploy agent daemons until cephadm endpoint has finished generating certs')
         listener_cert, listener_key = self.mgr.cherrypy_thread.ssl_certs.generate_cert(
-            daemon_spec.host)
+            self.mgr.inventory.get_addr(daemon_spec.host))
         config = {
             'agent.json': json.dumps(cfg),
             'cephadm': self.mgr._cephadm,

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1026,8 +1026,12 @@ class CephadmAgent(CephService):
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.get_module_option('device_enhanced_scan'))}
 
-        assert self.mgr.cherrypy_thread
-        assert self.mgr.cherrypy_thread.ssl_certs.get_root_cert()
+        try:
+            assert self.mgr.cherrypy_thread
+            assert self.mgr.cherrypy_thread.ssl_certs.get_root_cert()
+        except Exception:
+            raise OrchestratorError(
+                'Cannot deploy agent daemons until cephadm endpoint has finished generating certs')
         listener_cert, listener_key = self.mgr.cherrypy_thread.ssl_certs.generate_cert(
             daemon_spec.host)
         config = {

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1026,11 +1026,16 @@ class CephadmAgent(CephService):
                'host': daemon_spec.host}
 
         assert self.mgr.cherrypy_thread
+        assert self.mgr.cherrypy_thread.ssl_certs.get_root_cert()
+        listener_cert, listener_key = self.mgr.cherrypy_thread.ssl_certs.generate_cert(
+            daemon_spec.host)
         config = {
             'agent.json': json.dumps(cfg),
             'cephadm': self.mgr._cephadm,
             'keyring': daemon_spec.keyring,
             'root_cert.pem': self.mgr.cherrypy_thread.ssl_certs.get_root_cert(),
+            'listener.crt': listener_cert,
+            'listener.key': listener_key,
         }
 
         return config, sorted([str(self.mgr.get_mgr_ip()), str(self.mgr.endpoint_port), self.mgr.cherrypy_thread.ssl_certs.get_root_cert()])

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1043,4 +1043,6 @@ class CephadmAgent(CephService):
             'listener.key': listener_key,
         }
 
-        return config, sorted([str(self.mgr.get_mgr_ip()), str(self.mgr.endpoint_port), self.mgr.cherrypy_thread.ssl_certs.get_root_cert(), str(self.mgr.get_module_option('device_enhanced_scan'))])
+        return config, sorted([str(self.mgr.get_mgr_ip()), self.mgr.inventory.get_addr(daemon_spec.host),
+                               str(self.mgr.endpoint_port), self.mgr.cherrypy_thread.ssl_certs.get_root_cert(),
+                               str(self.mgr.get_module_option('device_enhanced_scan'))])

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1023,7 +1023,8 @@ class CephadmAgent(CephService):
                'target_port': self.mgr.endpoint_port,
                'refresh_period': self.mgr.agent_refresh_rate,
                'listener_port': self.mgr.agent_starting_port,
-               'host': daemon_spec.host}
+               'host': daemon_spec.host,
+               'device_enhanced_scan': str(self.mgr.get_module_option('device_enhanced_scan'))}
 
         assert self.mgr.cherrypy_thread
         assert self.mgr.cherrypy_thread.ssl_certs.get_root_cert()
@@ -1038,4 +1039,4 @@ class CephadmAgent(CephService):
             'listener.key': listener_key,
         }
 
-        return config, sorted([str(self.mgr.get_mgr_ip()), str(self.mgr.endpoint_port), self.mgr.cherrypy_thread.ssl_certs.get_root_cert()])
+        return config, sorted([str(self.mgr.get_mgr_ip()), str(self.mgr.endpoint_port), self.mgr.cherrypy_thread.ssl_certs.get_root_cert(), str(self.mgr.get_module_option('device_enhanced_scan'))])

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -49,6 +49,7 @@ class MockEventLoopThread:
             loop.close()
             asyncio.set_event_loop(None)
 
+
 def receive_agent_metadata(m: CephadmOrchestrator, host: str, ops: List[str] = None) -> None:
     to_update: Dict[str, Callable[[str, Any], None]] = {
         'ls': m._process_ls_output,
@@ -68,6 +69,7 @@ def receive_agent_metadata(m: CephadmOrchestrator, host: str, ops: List[str] = N
 def receive_agent_metadata_all_hosts(m: CephadmOrchestrator) -> None:
     for host in m.cache.get_hosts():
         receive_agent_metadata(m, host)
+
 
 @contextmanager
 def with_cephadm_module(module_options=None, store=None):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -342,9 +342,8 @@ class TestCephadm(object):
                 'value': '127.0.0.0/8'
             })
 
-            cephadm_module.cache.update_host_devices_networks(
+            cephadm_module.cache.update_host_networks(
                 'test',
-                [],
                 {
                     "127.0.0.0/8": [
                         "127.0.0.1"
@@ -615,7 +614,7 @@ spec:
                 ),
             ])
 
-            cephadm_module.cache.update_host_devices_networks('test', inventory.devices, {})
+            cephadm_module.cache.update_host_devices('test', inventory.devices)
 
             _run_cephadm.return_value = (['{}'], '', 0)
 
@@ -653,7 +652,7 @@ spec:
                 Device('/dev/sdd', available=True)
             ])
 
-            cephadm_module.cache.update_host_devices_networks('test', inventory.devices, {})
+            cephadm_module.cache.update_host_devices('test', inventory.devices)
 
             _run_cephadm.return_value = (['{}'], '', 0)
 

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -4,7 +4,7 @@ from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlaceme
 from ceph.utils import datetime_to_str, datetime_now
 from cephadm import CephadmOrchestrator
 from cephadm.inventory import SPEC_STORE_PREFIX
-from cephadm.tests.fixtures import _run_cephadm, wait, with_host
+from cephadm.tests.fixtures import _run_cephadm, wait, with_host, receive_agent_metadata_all_hosts
 from cephadm.serve import CephadmServe
 from tests import mock
 
@@ -29,6 +29,7 @@ def test_migrate_scheduler(cephadm_module: CephadmOrchestrator):
             assert cephadm_module.migration_current == 0
 
             CephadmServe(cephadm_module)._refresh_hosts_and_daemons()
+            receive_agent_metadata_all_hosts(cephadm_module)
             cephadm_module.migration.migrate()
 
             CephadmServe(cephadm_module)._apply_all_services()

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -6,9 +6,9 @@ import pytest
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpec
 from cephadm import CephadmOrchestrator
 from cephadm.upgrade import CephadmUpgrade
-from cephadm.serve import CephadmServe
 from orchestrator import OrchestratorError, DaemonDescription
-from .fixtures import _run_cephadm, wait, with_host, with_service
+from .fixtures import _run_cephadm, wait, with_host, with_service, \
+    receive_agent_metadata
 
 
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
@@ -95,7 +95,8 @@ def test_upgrade_run(use_repo_digest, cephadm_module: CephadmOrchestrator):
                         )
                     ])
                 )):
-                    CephadmServe(cephadm_module)._refresh_hosts_and_daemons()
+                    receive_agent_metadata(cephadm_module, 'host1', ['ls'])
+                    receive_agent_metadata(cephadm_module, 'host2', ['ls'])
 
                 with mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm(json.dumps({
                     'image_id': 'image_id',

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -469,11 +469,17 @@ class CephadmUpgrade:
         target_digests = self.upgrade_state.target_digests
         target_version = self.upgrade_state.target_version
 
+        if self.mgr.use_agent and not self.mgr.cache.all_host_metadata_up_to_date():
+            # need to wait for metadata to come in
+            self.mgr.agent_helpers._request_agent_acks(
+                set([h for h in self.mgr.cache.get_hosts() if not self.mgr.cache.host_metadata_up_to_date(h)]))
+            return
+
         first = False
         if not target_id or not target_version or not target_digests:
             # need to learn the container hash
             logger.info('Upgrade: First pull of %s' % target_image)
-            self.upgrade_info_str = 'Doing first pull of %s image' % (target_image)
+            self.upgrade_info_str: str = 'Doing first pull of %s image' % (target_image)
             try:
                 target_id, target_version, target_digests = CephadmServe(self.mgr)._get_container_image_info(
                     target_image)

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -472,7 +472,8 @@ class CephadmUpgrade:
         if self.mgr.use_agent and not self.mgr.cache.all_host_metadata_up_to_date():
             # need to wait for metadata to come in
             self.mgr.agent_helpers._request_agent_acks(
-                set([h for h in self.mgr.cache.get_hosts() if not self.mgr.cache.host_metadata_up_to_date(h)]))
+                set([h for h in self.mgr.cache.get_hosts() if
+                     (not self.mgr.cache.host_metadata_up_to_date(h) and h in self.mgr.cache.agent_ports and not self.mgr.cache.messaging_agent(h))]))
             return
 
         first = False
@@ -688,6 +689,7 @@ class CephadmUpgrade:
                         'redeploy',
                         image=target_image if not d_entry[1] else None
                     )
+                    self.mgr.cache.metadata_up_to_date[d.hostname] = False
                 except Exception as e:
                     self._fail_upgrade('UPGRADE_REDEPLOY_DAEMON', {
                         'severity': 'warning',

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -709,6 +709,7 @@ def daemon_type_to_service(dtype: str) -> str:
         'crashcollector': 'crash',  # Specific Rook Daemon
         'container': 'container',
         'cephadm-exporter': 'cephadm-exporter',
+        'agent': 'agent'
     }
     return mapping[dtype]
 
@@ -732,6 +733,7 @@ def service_to_daemon_types(stype: str) -> List[str]:
         'crash': ['crash'],
         'container': ['container'],
         'cephadm-exporter': ['cephadm-exporter'],
+        'agent': ['agent']
     }
     return mapping[stype]
 

--- a/src/pybind/mgr/requirements-required.txt
+++ b/src/pybind/mgr/requirements-required.txt
@@ -1,6 +1,7 @@
 -e../../python-common
 asyncmock
 cherrypy
+cryptography
 jsonpatch
 Jinja2
 pecan

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -414,7 +414,7 @@ class ServiceSpec(object):
 
     """
     KNOWN_SERVICE_TYPES = 'alertmanager crash grafana iscsi mds mgr mon nfs ' \
-                          'node-exporter osd prometheus rbd-mirror rgw ' \
+                          'node-exporter osd prometheus rbd-mirror rgw agent ' \
                           'container cephadm-exporter ingress cephfs-mirror'.split()
     REQUIRES_SERVICE_ID = 'iscsi mds nfs osd rgw container ingress '.split()
     MANAGED_CONFIG_OPTIONS = [


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/51004

Signed-off-by: Adam King <adking@redhat.com>

Still needs cleanup and removal of the old exporter but functionality was there during local testing.

Hasn't really accomplished the goal of simplifying the serve loop code-wise because I left in the old
methods of fetching metadata as a fall back when agent is either not running or hasn't sent anything in a long time.

Maybe a more minor issue but because I'm deploying the binary as a required file for the agent the whole binary is
printed to the debug logs when an agent is deployed. Haven't looked into getting around that yet but it definitely
shouldn't be left that way.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
