### PR TITLE
crimson/osd: use app.alien() to initialize AlienStore::alien

### DIFF
--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -64,9 +64,11 @@ namespace crimson::os {
 
 using crimson::common::get_conf;
 
-AlienStore::AlienStore(const std::string& path, const ConfigValues& values)
+AlienStore::AlienStore(const std::string& path,
+                       const ConfigValues& values,
+                       seastar::alien::instance& alien)
   : path{path},
-    alien{std::make_unique<seastar::alien::instance>()}
+    alien{alien}
 {
   cct = std::make_unique<CephContext>(CEPH_ENTITY_TYPE_OSD);
   g_ceph_context = cct.get();
@@ -420,7 +422,7 @@ seastar::future<> AlienStore::do_transaction(CollectionRef ch,
 	  assert(tp);
 	  return tp->submit(ch->get_cid().hash_to_shard(tp->size()),
 	    [this, ch, id, crimson_wrapper, &txn, &done] {
-	    txn.register_on_commit(new OnCommit(*alien,
+	    txn.register_on_commit(new OnCommit(alien,
 						id, done, crimson_wrapper,
 						txn));
 	    auto c = static_cast<AlienCollection*>(ch.get());

--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -43,7 +43,9 @@ public:
     AlienStore* store;
     CollectionRef ch;
   };
-  AlienStore(const std::string& path, const ConfigValues& values);
+  AlienStore(const std::string& path,
+             const ConfigValues& values,
+             seastar::alien::instance& alien);
   ~AlienStore() final;
 
   seastar::future<> start() final;
@@ -127,7 +129,7 @@ private:
   constexpr static unsigned MAX_KEYS_PER_OMAP_GET_CALL = 32;
   mutable std::unique_ptr<crimson::os::ThreadPool> tp;
   const std::string path;
-  std::unique_ptr<seastar::alien::instance> alien;
+  seastar::alien::instance& alien;
   uint64_t used_bytes = 0;
   std::unique_ptr<ObjectStore> store;
   std::unique_ptr<CephContext> cct;

--- a/src/crimson/os/futurized_store.cc
+++ b/src/crimson/os/futurized_store.cc
@@ -8,12 +8,13 @@ namespace crimson::os {
 std::unique_ptr<FuturizedStore>
 FuturizedStore::create(const std::string& type,
                        const std::string& data,
-                       const ConfigValues& values)
+                       const ConfigValues& values,
+                       seastar::alien::instance& alien)
 {
   if (type == "memstore") {
     return std::make_unique<crimson::os::CyanStore>(data);
   } else if (type == "bluestore") {
-    return std::make_unique<crimson::os::AlienStore>(data, values);
+    return std::make_unique<crimson::os::AlienStore>(data, values, alien);
   } else if (type == "seastore") {
     return crimson::os::seastore::make_seastore(data, values);
   } else {

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -15,6 +15,10 @@
 #include "include/uuid.h"
 #include "osd/osd_types.h"
 
+namespace seastar::alien {
+class instance;
+}
+
 namespace ceph::os {
 class Transaction;
 }
@@ -53,7 +57,8 @@ public:
 
   static std::unique_ptr<FuturizedStore> create(const std::string& type,
                                                 const std::string& data,
-                                                const ConfigValues& values);
+                                                const ConfigValues& values,
+                                                seastar::alien::instance& alien);
   FuturizedStore() = default;
   virtual ~FuturizedStore() = default;
 

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -285,6 +285,7 @@ int main(int argc, char* argv[])
             configure_crc_handling(*msgr);
           }
           osd.start_single(whoami, nonce,
+                           std::ref(app.alien()),
                            cluster_msgr, client_msgr,
                            hb_front_msgr, hb_back_msgr).get();
           auto stop_osd = seastar::defer([&] {

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -284,8 +284,14 @@ int main(int argc, char* argv[])
                                                    nonce);
             configure_crc_handling(*msgr);
           }
+          auto store = crimson::os::FuturizedStore::create(
+            local_conf().get_val<std::string>("osd_objectstore"),
+            local_conf().get_val<std::string>("osd_data"),
+            local_conf().get_config_values(),
+            app.alien());
+
           osd.start_single(whoami, nonce,
-                           std::ref(app.alien()),
+                           std::ref(*store),
                            cluster_msgr, client_msgr,
                            hb_front_msgr, hb_back_msgr).get();
           auto stop_osd = seastar::defer([&] {

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -70,6 +70,7 @@ using crimson::os::FuturizedStore;
 namespace crimson::osd {
 
 OSD::OSD(int id, uint32_t nonce,
+         seastar::alien::instance& alien,
          crimson::net::MessengerRef cluster_msgr,
          crimson::net::MessengerRef public_msgr,
          crimson::net::MessengerRef hb_front_msgr,
@@ -85,7 +86,8 @@ OSD::OSD(int id, uint32_t nonce,
     store{crimson::os::FuturizedStore::create(
       local_conf().get_val<std::string>("osd_objectstore"),
       local_conf().get_val<std::string>("osd_data"),
-      local_conf().get_config_values())},
+      local_conf().get_config_values(),
+      alien)},
     shard_services{*this, whoami, *cluster_msgr, *public_msgr, *monc, *mgrc, *store},
     heartbeat{new Heartbeat{whoami, shard_services, *monc, hb_front_msgr, hb_back_msgr}},
     // do this in background

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -40,10 +40,6 @@ class OSDMap;
 class OSDMeta;
 class Heartbeat;
 
-namespace seastar::alien {
-  class instance;
-}
-
 namespace ceph::os {
   class Transaction;
 }
@@ -81,7 +77,7 @@ class OSD final : public crimson::net::Dispatcher,
   SimpleLRU<epoch_t, bufferlist, false> map_bl_cache;
   cached_map_t osdmap;
   // TODO: use a wrapper for ObjectStore
-  std::unique_ptr<crimson::os::FuturizedStore> store;
+  crimson::os::FuturizedStore& store;
   std::unique_ptr<OSDMeta> meta_coll;
 
   OSDState state;
@@ -125,7 +121,7 @@ class OSD final : public crimson::net::Dispatcher,
 
 public:
   OSD(int id, uint32_t nonce,
-      seastar::alien::instance& alien,
+      crimson::os::FuturizedStore& store,
       crimson::net::MessengerRef cluster_msgr,
       crimson::net::MessengerRef client_msgr,
       crimson::net::MessengerRef hb_front_msgr,

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -40,6 +40,10 @@ class OSDMap;
 class OSDMeta;
 class Heartbeat;
 
+namespace seastar::alien {
+  class instance;
+}
+
 namespace ceph::os {
   class Transaction;
 }
@@ -121,6 +125,7 @@ class OSD final : public crimson::net::Dispatcher,
 
 public:
   OSD(int id, uint32_t nonce,
+      seastar::alien::instance& alien,
       crimson::net::MessengerRef cluster_msgr,
       crimson::net::MessengerRef client_msgr,
       crimson::net::MessengerRef hb_front_msgr,

--- a/src/crimson/osd/osd_meta.cc
+++ b/src/crimson/osd/osd_meta.cc
@@ -25,9 +25,9 @@ void OSDMeta::store_map(ceph::os::Transaction& t,
 
 seastar::future<bufferlist> OSDMeta::load_map(epoch_t e)
 {
-  return store->read(coll,
-                     osdmap_oid(e), 0, 0,
-                     CEPH_OSD_OP_FLAG_FADVISE_WILLNEED).handle_error(
+  return store.read(coll,
+                    osdmap_oid(e), 0, 0,
+                    CEPH_OSD_OP_FLAG_FADVISE_WILLNEED).handle_error(
     read_errorator::all_same_way([e] {
       throw std::runtime_error(fmt::format("read gave enoent on {}",
                                            osdmap_oid(e)));
@@ -44,7 +44,7 @@ void OSDMeta::store_superblock(ceph::os::Transaction& t,
 
 seastar::future<OSDSuperblock> OSDMeta::load_superblock()
 {
-  return store->read(coll, superblock_oid(), 0, 0).safe_then(
+  return store.read(coll, superblock_oid(), 0, 0).safe_then(
     [] (bufferlist&& bl) {
       auto p = bl.cbegin();
       OSDSuperblock superblock;
@@ -60,7 +60,7 @@ seastar::future<std::tuple<pg_pool_t,
 			   std::string,
 			   OSDMeta::ec_profile_t>>
 OSDMeta::load_final_pool_info(int64_t pool) {
-  return store->read(coll, final_pool_info_oid(pool),
+  return store.read(coll, final_pool_info_oid(pool),
                      0, 0).safe_then([] (bufferlist&& bl) {
     auto p = bl.cbegin();
     pg_pool_t pi;

--- a/src/crimson/osd/osd_meta.h
+++ b/src/crimson/osd/osd_meta.h
@@ -23,12 +23,12 @@ namespace crimson::os {
 class OSDMeta {
   template<typename T> using Ref = boost::intrusive_ptr<T>;
 
-  crimson::os::FuturizedStore* store;
+  crimson::os::FuturizedStore& store;
   Ref<crimson::os::FuturizedCollection> coll;
 
 public:
   OSDMeta(Ref<crimson::os::FuturizedCollection> coll,
-          crimson::os::FuturizedStore* store)
+          crimson::os::FuturizedStore& store)
     : store{store}, coll{coll}
   {}
 

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -419,7 +419,7 @@ seastar::future<> PG::read_state(crimson::os::FuturizedStore* store)
 	crimson::common::system_shutdown_exception());
   }
 
-  return seastar::do_with(PGMeta(store, pgid), [] (auto& pg_meta) {
+  return seastar::do_with(PGMeta(*store, pgid), [] (auto& pg_meta) {
     return pg_meta.load();
   }).then([this, store](auto&& ret) {
     auto [pg_info, past_intervals] = std::move(ret);

--- a/src/crimson/osd/pg_meta.cc
+++ b/src/crimson/osd/pg_meta.cc
@@ -12,7 +12,7 @@
 // easily skip them
 using crimson::os::FuturizedStore;
 
-PGMeta::PGMeta(FuturizedStore* store, spg_t pgid)
+PGMeta::PGMeta(FuturizedStore& store, spg_t pgid)
   : store{store},
     pgid{pgid}
 {}
@@ -35,11 +35,11 @@ namespace {
 
 seastar::future<epoch_t> PGMeta::get_epoch()
 {
-  return store->open_collection(coll_t{pgid}).then([this](auto ch) {
-    return store->omap_get_values(ch,
-                                pgid.make_pgmeta_oid(),
-                                {string{infover_key},
-                                 string{epoch_key}}).safe_then(
+  return store.open_collection(coll_t{pgid}).then([this](auto ch) {
+    return store.omap_get_values(ch,
+                                 pgid.make_pgmeta_oid(),
+                                 {string{infover_key},
+                                  string{epoch_key}}).safe_then(
     [](auto&& values) {
       {
         // sanity check
@@ -63,13 +63,13 @@ seastar::future<epoch_t> PGMeta::get_epoch()
 
 seastar::future<std::tuple<pg_info_t, PastIntervals>> PGMeta::load()
 {
-  return store->open_collection(coll_t{pgid}).then([this](auto ch) {
-    return store->omap_get_values(ch,
-                                pgid.make_pgmeta_oid(),
-                                {string{infover_key},
-                                 string{info_key},
-                                 string{biginfo_key},
-                                 string{fastinfo_key}});
+  return store.open_collection(coll_t{pgid}).then([this](auto ch) {
+    return store.omap_get_values(ch,
+                                 pgid.make_pgmeta_oid(),
+                                 {string{infover_key},
+                                  string{info_key},
+                                  string{biginfo_key},
+                                  string{fastinfo_key}});
   }).safe_then([](auto&& values) {
     {
       // sanity check

--- a/src/crimson/osd/pg_meta.h
+++ b/src/crimson/osd/pg_meta.h
@@ -14,10 +14,10 @@ namespace crimson::os {
 /// PG related metadata
 class PGMeta
 {
-  crimson::os::FuturizedStore* store;
+  crimson::os::FuturizedStore& store;
   const spg_t pgid;
 public:
-  PGMeta(crimson::os::FuturizedStore *store, spg_t pgid);
+  PGMeta(crimson::os::FuturizedStore& store, spg_t pgid);
   seastar::future<epoch_t> get_epoch();
   seastar::future<std::tuple<pg_info_t, PastIntervals>> load();
 };


### PR DESCRIPTION
in e53ea0886fba9073904f59ea85fb73d854565921, the new alien::submit_to() API
is used in the place of the old one. but `seastar::alien::instance::_qs`
should be initialized before we are able to use the alien instance, just
creating an instance of alien::instance is not enough.

in this change, instead of creating an instance of alien::instance using
make_unique<>, the return value of app.alien() is used to initialize the
alien member variable of AlienStore. app.alien() is always properly
initialized by reactor.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
