### PR TITLE
doc/cephadm: positions of words are interchanged

### DIFF
--- a/doc/cephadm/osd.rst
+++ b/doc/cephadm/osd.rst
@@ -7,7 +7,7 @@ OSD Service
 List Devices
 ============
 
-``ceph-volume`` scans each cluster in the host from time to time in order
+``ceph-volume`` scans each host in the cluster from time to time in order
 to determine which devices are present and whether they are eligible to be
 used as OSDs.
 


### PR DESCRIPTION
The positions of two words are interchanged:
scans each cluster in the host ----> scans each host in the cluster

Signed-off-by: WangFei wf.ab@126.com