### PR TITLE
Finisher: give up the CPU automatically

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -301,6 +301,28 @@ options:
   - startup
   # default changed by common_preinit()
   with_legacy: true
+- name: finisher_batch_events
+  type: uint
+  level: advanced
+  desc: how many events can finisher process continuously before giving up CPU to allow other threads to run
+  default: 5
+  services:
+  - common
+  see_also:
+  - finisher_sleep_interval
+  flags:
+  - runtime
+- name: finisher_sleep_interval
+  type: uint
+  level: advanced
+  desc: how long will the finisher thread sleep when giving up CPU, in nanoseconds
+  default: 5
+  services:
+  - common
+  see_also:
+  - finisher_batch_events
+  flags:
+  - runtime
 - name: setuser
   type: str
   level: advanced


### PR DESCRIPTION
Give up the CPU to give other threads those are waiting the
locks, such as the mds_lock, a change to run. Because if the
in_process_queue will require the same lock frequently it will
always succeed, and other lock waiters maybe stuck for several
seconds or longer.

Fixes: https://tracker.ceph.com/issues/51722
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
