### PR TITLE
cephadm: Clarify no container engine message

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -167,8 +167,9 @@ class ContainerEngine:
     def __init__(self):
         self.path = find_program(self.EXE)
 
+    @classmethod
     @property
-    def EXE(self) -> str:
+    def EXE(cls) -> str:
         raise NotImplementedError()
 
 
@@ -1981,7 +1982,9 @@ def check_container_engine(ctx):
     # type: (CephadmContext) -> None
     engine = ctx.container_engine
     if not isinstance(engine, CONTAINER_PREFERENCE):
-        raise Error('Unable to locate any of %s' % [i.EXE for i in CONTAINER_PREFERENCE])
+        # See https://github.com/python/mypy/issues/8993
+        exes: List[str] = [i.EXE for i in CONTAINER_PREFERENCE]  # type: ignore
+        raise Error('No container engine binary found ({}). Try run `apt/dnf/yum/zypper install <container engine>`'.format(' or '.join(exes)))
     elif isinstance(engine, Podman):
         engine.get_version(ctx)
         if engine.version < MIN_PODMAN_VERSION:


### PR DESCRIPTION
Multiple people didn't understand the message. Let's try to impove it.

Signed-off-by: Sebastian Wagner <sewagner@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
