### PR TITLE
script: fix a bug in naming the source branch in ceph-debug-docker.sh

### DIFF
--- a/src/script/ceph-debug-docker.sh
+++ b/src/script/ceph-debug-docker.sh
@@ -46,9 +46,9 @@ function main {
 
     if [ -z "$1" ]; then
         printf "specify the branch [default \"master:latest\"]: "
-        read source
-        if [ -z "$source" ]; then
-            source=master:latest
+        read branch
+        if [ -z "$branch" ]; then
+            branch=master:latest
         fi
     else
         branch="$1"


### PR DESCRIPTION
'source' mixed with 'branch'

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

