### PR TITLE
pacific: osd/scrub: separate between PG state flags and internal scrubber operation

### DIFF
--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -337,7 +337,7 @@ function initiate_and_fetch_state() {
     env CEPH_ARGS= ceph --format json daemon $(get_asok_path $the_osd) scrub "$pgid"
 
     # wait for 'scrubbing' to appear
-    for ((i=0; i < 40; i++)); do
+    for ((i=0; i < 80; i++)); do
 
         st=`ceph pg $pgid query --format json | jq '.state' `
         echo $i ") state now: " $st
@@ -346,15 +346,14 @@ function initiate_and_fetch_state() {
             *scrubbing*repair* ) echo "found scrub+repair"; return 1;; # PR #41258 should have prevented this
             *scrubbing* ) echo "found scrub"; return 0;;
             *inconsistent* ) echo "Got here too late. Scrub has already finished"; return 1;;
+            *recovery* ) echo "Got here too late. Scrub has already finished."; return 1;;
             * ) echo $st;;
         esac
 
-        if [ $((i % 5)) == 4 ] ; then
+        if [ $((i % 10)) == 4 ]; then
             echo "loop --------> " $i
-            flush_pg_stats
-	else
-            sleep 0.3
         fi
+    sleep 0.3
     done
 
     echo "Timeout waiting for deep-scrub of " $pgid " on " $the_osd " to start"
@@ -371,7 +370,7 @@ function wait_end_of_scrub() { # osd# pg
         [[ $st =~ (.*scrubbing.*) ]] || break
         if [ $((i % 5)) == 4 ] ; then
             flush_pg_stats
-	fi
+        fi
         sleep 0.3
     done
 
@@ -493,7 +492,8 @@ function TEST_auto_repair_bluestore_scrub() {
     run_mgr $dir x || return 1
     local ceph_osd_args="--osd-scrub-auto-repair=true \
             --osd_deep_scrub_randomize_ratio=0 \
-            --osd-scrub-interval-randomize-ratio=0"
+            --osd-scrub-interval-randomize-ratio=0 \
+            --osd-scrub-backoff-ratio=0"
     for id in $(seq 0 2) ; do
         run_osd $dir $id $ceph_osd_args || return 1
     done

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -277,11 +277,11 @@ function auto_repair_erasure_coded() {
             --osd-scrub-min-interval=5 \
             --osd-scrub-interval-randomize-ratio=0"
     for id in $(seq 0 2) ; do
-	if [ "$allow_overwrites" = "true" ]; then
+        if [ "$allow_overwrites" = "true" ]; then
             run_osd $dir $id $ceph_osd_args || return 1
-	else
+        else
             run_osd_filestore $dir $id $ceph_osd_args || return 1
-	fi
+        fi
     done
     create_rbd_pool || return 1
     wait_for_clean || return 1
@@ -318,6 +318,127 @@ function TEST_auto_repair_erasure_coded_overwrites() {
     fi
 }
 
+# initiate a scrub, then check for the (expected) 'scrubbing' and the
+# (not expected until an error was identified) 'repair'
+# Arguments: osd#, pg, sleep time
+function initiate_and_fetch_state() {
+    local the_osd="osd.$1"
+    local pgid=$2
+    local last_scrub=$(get_last_scrub_stamp $pgid)
+
+    set_config "osd" "$1" "osd_scrub_sleep"  "$3"
+    set_config "osd" "$1" "osd_scrub_auto_repair" "true"
+
+    flush_pg_stats
+    date  --rfc-3339=ns
+
+    # note: must initiate a "regular" (periodic) deep scrub - not an operator-initiated one
+    env CEPH_ARGS= ceph --format json daemon $(get_asok_path $the_osd) deep_scrub "$pgid"
+    env CEPH_ARGS= ceph --format json daemon $(get_asok_path $the_osd) scrub "$pgid"
+
+    # wait for 'scrubbing' to appear
+    for ((i=0; i < 40; i++)); do
+
+        st=`ceph pg $pgid query --format json | jq '.state' `
+        echo $i ") state now: " $st
+
+        case "$st" in
+            *scrubbing*repair* ) echo "found scrub+repair"; return 1;; # PR #41258 should have prevented this
+            *scrubbing* ) echo "found scrub"; return 0;;
+            *inconsistent* ) echo "Got here too late. Scrub has already finished"; return 1;;
+            * ) echo $st;;
+        esac
+
+        if [ $((i % 5)) == 4 ] ; then
+            echo "loop --------> " $i
+            flush_pg_stats
+	else
+            sleep 0.3
+        fi
+    done
+
+    echo "Timeout waiting for deep-scrub of " $pgid " on " $the_osd " to start"
+    return 1
+}
+
+function wait_end_of_scrub() { # osd# pg
+    local the_osd="osd.$1"
+    local pgid=$2
+
+    for ((i=0; i < 40; i++)); do
+        st=`ceph pg $pgid query --format json | jq '.state' `
+        echo "wait-scrub-end state now: " $st
+        [[ $st =~ (.*scrubbing.*) ]] || break
+        if [ $((i % 5)) == 4 ] ; then
+            flush_pg_stats
+	fi
+        sleep 0.3
+    done
+
+    if [[ $st =~ (.*scrubbing.*) ]]
+    then
+        # a timeout
+        return 1
+    fi
+    return 0
+}
+
+
+function TEST_auto_repair_bluestore_tag() {
+    local dir=$1
+    local poolname=testpool
+
+    # Launch a cluster with 3 seconds scrub interval
+    setup $dir || return 1
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    local ceph_osd_args="--osd-scrub-auto-repair=true \
+            --osd_deep_scrub_randomize_ratio=0 \
+            --osd-scrub-interval-randomize-ratio=0"
+    for id in $(seq 0 2) ; do
+        run_osd $dir $id $ceph_osd_args || return 1
+    done
+
+    create_pool $poolname 1 1 || return 1
+    ceph osd pool set $poolname size 2
+    wait_for_clean || return 1
+
+    # Put an object
+    local payload=ABCDEF
+    echo $payload > $dir/ORIGINAL
+    rados --pool $poolname put SOMETHING $dir/ORIGINAL || return 1
+
+    # Remove the object from one shard physically
+    # Restarted osd get $ceph_osd_args passed
+    objectstore_tool $dir $(get_not_primary $poolname SOMETHING) SOMETHING remove || return 1
+
+    local pgid=$(get_pg $poolname SOMETHING)
+    local primary=$(get_primary $poolname SOMETHING)
+    echo "Affected PG " $pgid " w/ primary " $primary
+    local last_scrub_stamp="$(get_last_scrub_stamp $pgid)"
+    initiate_and_fetch_state $primary $pgid "3.0"
+    r=$?
+    echo "initiate_and_fetch_state ret: " $r
+    set_config "osd"  "$1"  "osd_scrub_sleep"  "0"
+    if [ $r -ne 0 ]; then
+        return 1
+    fi
+
+    wait_end_of_scrub "$primary" "$pgid" || return 1
+    ceph pg dump pgs
+
+    # Verify - the file should be back
+    # Restarted osd get $ceph_osd_args passed
+    objectstore_tool $dir $(get_not_primary $poolname SOMETHING) SOMETHING list-attrs || return 1
+    objectstore_tool $dir $(get_not_primary $poolname SOMETHING) SOMETHING get-bytes $dir/COPY || return 1
+    diff $dir/ORIGINAL $dir/COPY || return 1
+    grep scrub_finish $dir/osd.${primary}.log
+
+    # Tear down
+    teardown $dir || return 1
+}
+
+
 function TEST_auto_repair_bluestore_basic() {
     local dir=$1
     local poolname=testpool
@@ -326,7 +447,7 @@ function TEST_auto_repair_bluestore_basic() {
     run_mon $dir a || return 1
     run_mgr $dir x || return 1
     local ceph_osd_args="--osd-scrub-auto-repair=true \
-	    --osd_deep_scrub_randomize_ratio=0 \
+            --osd_deep_scrub_randomize_ratio=0 \
             --osd-scrub-interval-randomize-ratio=0"
     for id in $(seq 0 2) ; do
         run_osd $dir $id $ceph_osd_args || return 1
@@ -371,7 +492,7 @@ function TEST_auto_repair_bluestore_scrub() {
     run_mon $dir a || return 1
     run_mgr $dir x || return 1
     local ceph_osd_args="--osd-scrub-auto-repair=true \
-	    --osd_deep_scrub_randomize_ratio=0 \
+            --osd_deep_scrub_randomize_ratio=0 \
             --osd-scrub-interval-randomize-ratio=0"
     for id in $(seq 0 2) ; do
         run_osd $dir $id $ceph_osd_args || return 1
@@ -422,7 +543,7 @@ function TEST_auto_repair_bluestore_failed() {
     run_mon $dir a || return 1
     run_mgr $dir x || return 1
     local ceph_osd_args="--osd-scrub-auto-repair=true \
-	    --osd_deep_scrub_randomize_ratio=0 \
+            --osd_deep_scrub_randomize_ratio=0 \
             --osd-scrub-interval-randomize-ratio=0"
     for id in $(seq 0 2) ; do
         run_osd $dir $id $ceph_osd_args || return 1
@@ -488,7 +609,7 @@ function TEST_auto_repair_bluestore_failed_norecov() {
     run_mon $dir a || return 1
     run_mgr $dir x || return 1
     local ceph_osd_args="--osd-scrub-auto-repair=true \
-	    --osd_deep_scrub_randomize_ratio=0 \
+            --osd_deep_scrub_randomize_ratio=0 \
             --osd-scrub-interval-randomize-ratio=0"
     for id in $(seq 0 2) ; do
         run_osd $dir $id $ceph_osd_args || return 1

--- a/src/osd/PrimaryLogScrub.cc
+++ b/src/osd/PrimaryLogScrub.cc
@@ -47,10 +47,6 @@ void PrimaryLogScrub::_scrub_finish()
 	   << " info stats: " << (info.stats.stats_invalid ? "invalid" : "valid")
 	   << dendl;
 
-  bool repair = state_test(PG_STATE_REPAIR);
-  bool deep_scrub = state_test(PG_STATE_DEEP_SCRUB);
-  const char* mode = (repair ? "repair" : (deep_scrub ? "deep-scrub" : "scrub"));
-
   if (info.stats.stats_invalid) {
     m_pl_pg->recovery_state.update_stats([=](auto& history, auto& stats) {
       stats.stats = m_scrub_cstat;
@@ -62,7 +58,7 @@ void PrimaryLogScrub::_scrub_finish()
       m_pl_pg->agent_choose_mode();
   }
 
-  dout(10) << mode << " got " << m_scrub_cstat.sum.num_objects << "/"
+  dout(10) << m_mode_desc << " got " << m_scrub_cstat.sum.num_objects << "/"
 	   << info.stats.stats.sum.num_objects << " objects, "
 	   << m_scrub_cstat.sum.num_object_clones << "/"
 	   << info.stats.stats.sum.num_object_clones << " clones, "
@@ -100,7 +96,7 @@ void PrimaryLogScrub::_scrub_finish()
        !info.stats.manifest_stats_invalid) ||
       m_scrub_cstat.sum.num_whiteouts != info.stats.stats.sum.num_whiteouts ||
       m_scrub_cstat.sum.num_bytes != info.stats.stats.sum.num_bytes) {
-    m_osds->clog->error() << info.pgid << " " << mode << " : stat mismatch, got "
+    m_osds->clog->error() << info.pgid << " " << m_mode_desc << " : stat mismatch, got "
 			  << m_scrub_cstat.sum.num_objects << "/"
 			  << info.stats.stats.sum.num_objects << " objects, "
 			  << m_scrub_cstat.sum.num_object_clones << "/"
@@ -125,7 +121,7 @@ void PrimaryLogScrub::_scrub_finish()
 			  << " hit_set_archive bytes.";
     ++m_shallow_errors;
 
-    if (repair) {
+    if (m_is_repair) {
       ++m_fixed_count;
       m_pl_pg->recovery_state.update_stats([this](auto& history, auto& stats) {
 	stats.stats = m_scrub_cstat;
@@ -142,7 +138,7 @@ void PrimaryLogScrub::_scrub_finish()
     }
   }
   // Clear object context cache to get repair information
-  if (repair)
+  if (m_is_repair)
     m_pl_pg->object_contexts.clear();
 }
 
@@ -157,15 +153,14 @@ void PrimaryLogScrub::log_missing(int missing,
 				  LogChannelRef clog,
 				  const spg_t& pgid,
 				  const char* func,
-				  const char* mode,
 				  bool allow_incomplete_clones)
 {
   ceph_assert(head);
   if (allow_incomplete_clones) {
-    dout(20) << func << " " << mode << " " << pgid << " " << *head << " skipped "
+    dout(20) << func << " " << m_mode_desc << " " << pgid << " " << *head << " skipped "
 	     << missing << " clone(s) in cache tier" << dendl;
   } else {
-    clog->info() << mode << " " << pgid << " " << *head << " : " << missing
+    clog->info() << m_mode_desc << " " << pgid << " " << *head << " : " << missing
 		 << " missing clone(s)";
   }
 }
@@ -174,7 +169,6 @@ int PrimaryLogScrub::process_clones_to(const std::optional<hobject_t>& head,
 				       const std::optional<SnapSet>& snapset,
 				       LogChannelRef clog,
 				       const spg_t& pgid,
-				       const char* mode,
 				       bool allow_incomplete_clones,
 				       std::optional<snapid_t> target,
 				       vector<snapid_t>::reverse_iterator* curclone,
@@ -193,7 +187,7 @@ int PrimaryLogScrub::process_clones_to(const std::optional<hobject_t>& head,
     // skip higher-numbered clones in the list.
     if (!allow_incomplete_clones) {
       next_clone.snap = **curclone;
-      clog->error() << mode << " " << pgid << " " << *head << " : expected clone "
+      clog->error() << m_mode_desc << " " << pgid << " " << *head << " : expected clone "
 		    << next_clone << " " << m_missing << " missing";
       ++m_shallow_errors;
       e.set_clone_missing(next_clone.snap);
@@ -239,10 +233,6 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
   const PGPool& pool = m_pl_pg->pool;
   bool allow_incomplete_clones = pool.info.allow_incomplete_clones();
 
-  bool repair = state_test(PG_STATE_REPAIR);
-  bool deep_scrub = state_test(PG_STATE_DEEP_SCRUB);
-  const char* mode = (repair ? "repair" : (deep_scrub ? "deep-scrub" : "scrub"));
-
   std::optional<snapid_t> all_clones;  // Unspecified snapid_t or std::nullopt
 
   // traverse in reverse order.
@@ -274,7 +264,7 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
     // basic checks.
     if (p->second.attrs.count(OI_ATTR) == 0) {
       oi = std::nullopt;
-      m_osds->clog->error() << mode << " " << info.pgid << " " << soid << " : no '"
+      m_osds->clog->error() << m_mode_desc << " " << info.pgid << " " << soid << " : no '"
 			    << OI_ATTR << "' attr";
       ++m_shallow_errors;
       soid_error.set_info_missing();
@@ -286,7 +276,7 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
 	oi->decode(bv);
       } catch (ceph::buffer::error& e) {
 	oi = std::nullopt;
-	m_osds->clog->error() << mode << " " << info.pgid << " " << soid
+	m_osds->clog->error() << m_mode_desc << " " << info.pgid << " " << soid
 			      << " : can't decode '" << OI_ATTR << "' attr " << e.what();
 	++m_shallow_errors;
 	soid_error.set_info_corrupted();
@@ -296,7 +286,7 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
 
     if (oi) {
       if (m_pl_pg->pgbackend->be_get_ondisk_size(oi->size) != p->second.size) {
-	m_osds->clog->error() << mode << " " << info.pgid << " " << soid
+	m_osds->clog->error() << m_mode_desc << " " << info.pgid << " " << soid
 			      << " : on disk size (" << p->second.size
 			      << ") does not match object info size (" << oi->size
 			      << ") adjusted for ondisk to ("
@@ -305,7 +295,7 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
 	++m_shallow_errors;
       }
 
-      dout(20) << mode << "  " << soid << " " << *oi << dendl;
+      dout(20) << m_mode_desc << "  " << soid << " " << *oi << dendl;
 
       // A clone num_bytes will be added later when we have snapset
       if (!soid.is_snap()) {
@@ -332,7 +322,7 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
       // Expecting an object with snap for current head
       if (soid.has_snapset() || soid.get_head() != head->get_head()) {
 
-	dout(10) << __func__ << " " << mode << " " << info.pgid << " new object " << soid
+	dout(10) << __func__ << " " << m_mode_desc << " " << info.pgid << " new object " << soid
 		 << " while processing " << *head << dendl;
 
 	target = all_clones;
@@ -344,7 +334,7 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
       // Log any clones we were expecting to be there up to target
       // This will set missing, but will be a no-op if snap.soid == *curclone.
       missing +=
-	process_clones_to(head, snapset, m_osds->clog, info.pgid, mode,
+	process_clones_to(head, snapset, m_osds->clog, info.pgid,
 			  allow_incomplete_clones, target, &curclone, head_error);
     }
 
@@ -364,10 +354,10 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
     if (!expected) {
       // If we couldn't read the head's snapset, just ignore clones
       if (head && !snapset) {
-	m_osds->clog->error() << mode << " " << info.pgid << " " << soid
+	m_osds->clog->error() << m_mode_desc << " " << info.pgid << " " << soid
 			      << " : clone ignored due to missing snapset";
       } else {
-	m_osds->clog->error() << mode << " " << info.pgid << " " << soid
+	m_osds->clog->error() << m_mode_desc << " " << info.pgid << " " << soid
 			      << " : is an unexpected clone";
       }
       ++m_shallow_errors;
@@ -383,7 +373,7 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
     if (soid.has_snapset()) {
 
       if (missing) {
-	log_missing(missing, head, m_osds->clog, info.pgid, __func__, mode,
+	log_missing(missing, head, m_osds->clog, info.pgid, __func__,
 		    pool.info.allow_incomplete_clones());
       }
 
@@ -396,10 +386,10 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
       head_error = soid_error;
       soid_error_count = 0;
 
-      dout(20) << __func__ << " " << mode << " new head " << head << dendl;
+      dout(20) << __func__ << " " << m_mode_desc << " new head " << head << dendl;
 
       if (p->second.attrs.count(SS_ATTR) == 0) {
-	m_osds->clog->error() << mode << " " << info.pgid << " " << soid << " : no '"
+	m_osds->clog->error() << m_mode_desc << " " << info.pgid << " " << soid << " : no '"
 			      << SS_ATTR << "' attr";
 	++m_shallow_errors;
 	snapset = std::nullopt;
@@ -415,7 +405,7 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
 	} catch (ceph::buffer::error& e) {
 	  snapset = std::nullopt;
 	  m_osds->clog->error()
-	    << mode << " " << info.pgid << " " << soid << " : can't decode '" << SS_ATTR
+	    << m_mode_desc << " " << info.pgid << " " << soid << " : can't decode '" << SS_ATTR
 	    << "' attr " << e.what();
 	  ++m_shallow_errors;
 	  head_error.set_snapset_corrupted();
@@ -430,7 +420,7 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
 	  dout(20) << "  snapset " << *snapset << dendl;
 	  if (snapset->seq == 0) {
 	    m_osds->clog->error()
-	      << mode << " " << info.pgid << " " << soid << " : snaps.seq not set";
+	      << m_mode_desc << " " << info.pgid << " " << soid << " : snaps.seq not set";
 	    ++m_shallow_errors;
 	    head_error.set_snapset_error();
 	  }
@@ -442,24 +432,24 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
       ceph_assert(snapset);
       ceph_assert(soid.snap == *curclone);
 
-      dout(20) << __func__ << " " << mode << " matched clone " << soid << dendl;
+      dout(20) << __func__ << " " << m_mode_desc << " matched clone " << soid << dendl;
 
       if (snapset->clone_size.count(soid.snap) == 0) {
-	m_osds->clog->error() << mode << " " << info.pgid << " " << soid
+	m_osds->clog->error() << m_mode_desc << " " << info.pgid << " " << soid
 			      << " : is missing in clone_size";
 	++m_shallow_errors;
 	soid_error.set_size_mismatch();
       } else {
 	if (oi && oi->size != snapset->clone_size[soid.snap]) {
 	  m_osds->clog->error()
-	    << mode << " " << info.pgid << " " << soid << " : size " << oi->size
+	    << m_mode_desc << " " << info.pgid << " " << soid << " : size " << oi->size
 	    << " != clone_size " << snapset->clone_size[*curclone];
 	  ++m_shallow_errors;
 	  soid_error.set_size_mismatch();
 	}
 
 	if (snapset->clone_overlap.count(soid.snap) == 0) {
-	  m_osds->clog->error() << mode << " " << info.pgid << " " << soid
+	  m_osds->clog->error() << m_mode_desc << " " << info.pgid << " " << soid
 				<< " : is missing in clone_overlap";
 	  ++m_shallow_errors;
 	  soid_error.set_size_mismatch();
@@ -482,7 +472,7 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
 	  }
 
 	  if (bad_interval_set) {
-	    m_osds->clog->error() << mode << " " << info.pgid << " " << soid
+	    m_osds->clog->error() << m_mode_desc << " " << info.pgid << " " << soid
 				  << " : bad interval_set in clone_overlap";
 	    ++m_shallow_errors;
 	    soid_error.set_size_mismatch();
@@ -503,18 +493,18 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
   }
 
   if (doing_clones(snapset, curclone)) {
-    dout(10) << __func__ << " " << mode << " " << info.pgid
+    dout(10) << __func__ << " " << m_mode_desc << " " << info.pgid
 	     << " No more objects while processing " << *head << dendl;
 
     missing +=
-      process_clones_to(head, snapset, m_osds->clog, info.pgid, mode,
+      process_clones_to(head, snapset, m_osds->clog, info.pgid,
 			allow_incomplete_clones, all_clones, &curclone, head_error);
   }
 
   // There could be missing found by the test above or even
   // before dropping out of the loop for the last head.
   if (missing) {
-    log_missing(missing, head, m_osds->clog, info.pgid, __func__, mode,
+    log_missing(missing, head, m_osds->clog, info.pgid, __func__,
 		allow_incomplete_clones);
   }
   if (head && (head_error.errors || soid_error_count))
@@ -529,12 +519,12 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
 
     ObjectContextRef obc = m_pl_pg->get_object_context(p->first, false);
     if (!obc) {
-      m_osds->clog->error() << info.pgid << " " << mode
+      m_osds->clog->error() << info.pgid << " " << m_mode_desc
 			    << " cannot get object context for object " << p->first;
       continue;
     }
     if (obc->obs.oi.soid != p->first) {
-      m_osds->clog->error() << info.pgid << " " << mode << " " << p->first
+      m_osds->clog->error() << info.pgid << " " << m_mode_desc << " " << p->first
 			    << " : object has a valid oi attr with a mismatched name, "
 			    << " obc->obs.oi.soid: " << obc->obs.oi.soid;
       continue;
@@ -565,7 +555,7 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
     m_pl_pg->simple_opc_submit(std::move(ctx));
   }
 
-  dout(10) << __func__ << " (" << mode << ") finish" << dendl;
+  dout(10) << __func__ << " (" << m_mode_desc << ") finish" << dendl;
 }
 
 PrimaryLogScrub::PrimaryLogScrub(PrimaryLogPG* pg) : PgScrubber{pg}, m_pl_pg{pg} {}

--- a/src/osd/PrimaryLogScrub.h
+++ b/src/osd/PrimaryLogScrub.h
@@ -62,14 +62,12 @@ class PrimaryLogScrub : public PgScrubber {
 		   LogChannelRef clog,
 		   const spg_t& pgid,
 		   const char* func,
-		   const char* mode,
 		   bool allow_incomplete_clones);
 
   int process_clones_to(const std::optional<hobject_t>& head,
 			const std::optional<SnapSet>& snapset,
 			LogChannelRef clog,
 			const spg_t& pgid,
-			const char* mode,
 			bool allow_incomplete_clones,
 			std::optional<snapid_t> target,
 			std::vector<snapid_t>::reverse_iterator* curclone,

--- a/src/osd/pg_scrubber.h
+++ b/src/osd/pg_scrubber.h
@@ -559,7 +559,7 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
   /// Maps from objects with errors to missing peers
   HobjToShardSetMapping m_missing;
 
- private:
+ protected:
   /**
    * 'm_is_deep' - is the running scrub a deep one?
    *
@@ -569,6 +569,33 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
    * building the scrub maps.
    */
   bool m_is_deep{false};
+
+  /**
+   * If set: affects the backend & scrubber-backend functions called after all
+   * scrub maps are available.
+   *
+   * Replaces code that directly checks PG_STATE_REPAIR (which was meant to be
+   * a "user facing" status display only).
+   */
+  bool m_is_repair{false};
+
+  /**
+   * User-readable summary of the scrubber's current mode of operation. Used for
+   * both osd.*.log and the cluster log.
+   * One of:
+   *    "repair"
+   *    "deep-scrub",
+   *    "scrub
+   *
+   * Note: based on PG_STATE_REPAIR, and not on m_is_repair. I.e. for
+   * auto_repair will show as "deep-scrub" and not as "repair" (until the first error
+   * is detected).
+   */
+  std::string_view m_mode_desc;
+
+  void update_op_mode_text();
+
+private:
 
   /**
    * initiate a deep-scrub after the current scrub ended with errors.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50900
backport of https://github.com/ceph/ceph/pull/41258
parent tracker: https://tracker.ceph.com/issues/50446

backport tracker: https://tracker.ceph.com/issues/51766
backport of https://github.com/ceph/ceph/pull/42410
parent tracker: https://tracker.ceph.com/issues/51581