### PR TITLE
nautilus: rgw: allow to set ssl options and ciphers for beast frontend

### DIFF
--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -60,6 +60,38 @@ Options
 :Type: String
 :Default: None
 
+``ssl_options``
+
+:Description: Optional colon separated list of ssl context options:
+
+              ``default_workarounds`` Implement various bug workarounds.
+
+              ``no_compression`` Disable compression.
+
+              ``no_sslv2`` Disable SSL v2.
+
+              ``no_sslv3`` Disable SSL v3.
+
+              ``no_tlsv1`` Disable TLS v1.
+
+              ``no_tlsv1_1`` Disable TLS v1.1.
+
+              ``no_tlsv1_2`` Disable TLS v1.2.
+
+              ``single_dh_use`` Always create a new key when using tmp_dh parameters.
+
+:Type: String
+:Default: None
+
+``ssl_ciphers``
+
+:Description: Optional list of one or more cipher strings separated by colons.
+              The format of the string is described in openssl's ciphers(1)
+              manual.
+
+:Type: String
+:Default: None
+
 ``tcp_nodelay``
 
 :Description: If set the socket option will disable Nagle's algorithm on 

--- a/src/common/split.h
+++ b/src/common/split.h
@@ -1,0 +1,107 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <string_view>
+
+namespace ceph {
+
+// a forward iterator over the parts of a split string
+class spliterator {
+  std::string_view str; // full string
+  std::string_view delims; // delimiters
+
+  using size_type = std::string_view::size_type;
+  size_type pos = 0; // start position of current part
+  std::string_view part; // view of current part
+
+  // return the next part after the given position
+  std::string_view next(size_type end) {
+    pos = str.find_first_not_of(delims, end);
+    if (pos == str.npos) {
+      return {};
+    }
+    return str.substr(pos, str.find_first_of(delims, pos) - pos);
+  }
+ public:
+  // types required by std::iterator_traits
+  using difference_type = int;
+  using value_type = std::string_view;
+  using pointer = const value_type*;
+  using reference = const value_type&;
+  using iterator_category = std::forward_iterator_tag;
+
+  spliterator() = default;
+
+  spliterator(std::string_view str, std::string_view delims)
+    : str(str), delims(delims), pos(0), part(next(0))
+  {}
+
+  spliterator& operator++() {
+    part = next(pos + part.size());
+    return *this;
+  }
+  spliterator operator++(int) {
+    spliterator tmp = *this;
+    part = next(pos + part.size());
+    return tmp;
+  }
+
+  reference operator*() const { return part; }
+  pointer operator->() const { return &part; }
+
+  friend bool operator==(const spliterator& lhs, const spliterator& rhs) {
+    return lhs.part.data() == rhs.part.data()
+        && lhs.part.size() == rhs.part.size();
+  }
+  friend bool operator!=(const spliterator& lhs, const spliterator& rhs) {
+    return lhs.part.data() != rhs.part.data()
+        || lhs.part.size() != rhs.part.size();
+  }
+};
+
+// represents an immutable range of split string parts
+//
+// ranged-for loop example:
+//
+//   for (std::string_view s : split(input)) {
+//     ...
+//
+// container initialization example:
+//
+//   auto parts = split(input);
+//
+//   std::vector<std::string> strings;
+//   strings.assign(parts.begin(), parts.end());
+//
+class split {
+  std::string_view str; // full string
+  std::string_view delims; // delimiters
+ public:
+  split(std::string_view str, std::string_view delims = ";,= \t\n")
+    : str(str), delims(delims) {}
+
+  using iterator = spliterator;
+  using const_iterator = spliterator;
+
+  iterator begin() const { return {str, delims}; }
+  const_iterator cbegin() const { return {str, delims}; }
+
+  iterator end() const { return {}; }
+  const_iterator cend() const { return {}; }
+};
+
+} // namespace ceph

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -20,6 +20,9 @@
 
 #ifdef WITH_RADOSGW_BEAST_OPENSSL
 #include <boost/asio/ssl.hpp>
+
+#include "common/split.h"
+
 #endif
 
 #include "rgw_dmclock_async_scheduler.h"
@@ -574,6 +577,56 @@ int AsioFrontend::init_ssl()
       return -ec.value();
     }
   }
+
+  auto options = config.find("ssl_options");
+  const bool have_options = options != config.end();
+  std::string options_str;
+  if (have_options) {
+    if (!have_cert) {
+      lderr(ctx()) << "no ssl_certificate configured for ssl_options" << dendl;
+      return -EINVAL;
+    }
+    options_str = options->second;
+
+    for (auto &option : ceph::split(options_str, ":")) {
+      if (option == "default_workarounds") {
+        ssl_context->set_options(ssl::context::default_workarounds);
+      } else if (option == "no_compression") {
+        ssl_context->set_options(ssl::context::no_compression);
+      } else if (option == "no_sslv2") {
+        ssl_context->set_options(ssl::context::no_sslv2);
+      } else if (option == "no_sslv3") {
+        ssl_context->set_options(ssl::context::no_sslv3);
+      } else if (option == "no_tlsv1") {
+        ssl_context->set_options(ssl::context::no_tlsv1);
+      } else if (option == "no_tlsv1_1") {
+        ssl_context->set_options(ssl::context::no_tlsv1_1);
+      } else if (option == "no_tlsv1_2") {
+        ssl_context->set_options(ssl::context::no_tlsv1_2);
+      } else if (option == "single_dh_use") {
+        ssl_context->set_options(ssl::context::single_dh_use);
+      } else {
+        lderr(ctx()) << "ignoring unknown ssl option '" << option << "'" << dendl;
+      }
+    }
+  }
+
+  auto ciphers = config.find("ssl_ciphers");
+  if (ciphers != config.end()) {
+    if (!have_cert) {
+      lderr(ctx()) << "no ssl_certificate configured for ssl_ciphers" << dendl;
+      return -EINVAL;
+    }
+
+    int r = SSL_CTX_set_cipher_list(ssl_context->native_handle(),
+                                    ciphers->second.c_str());
+    if (r == 0) {
+      lderr(ctx()) << "no cipher could be selected from ssl_ciphers: "
+                   << ciphers->second << dendl;
+      return -EINVAL;
+    }
+  }
+
   if (have_cert) {
     ssl_context->use_certificate_chain_file(cert->second, ec);
     if (ec) {

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -305,6 +305,9 @@ add_executable(unittest_bounded_key_counter
 target_link_libraries(unittest_bounded_key_counter global)
 add_ceph_unittest(unittest_bounded_key_counter)
 
+add_executable(unittest_split test_split.cc)
+add_ceph_unittest(unittest_split)
+
 add_executable(unittest_static_ptr test_static_ptr.cc)
 add_ceph_unittest(unittest_static_ptr)
 

--- a/src/test/common/test_split.cc
+++ b/src/test/common/test_split.cc
@@ -1,0 +1,119 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "common/split.h"
+#include <algorithm>
+#include <gtest/gtest.h>
+
+namespace ceph {
+
+using string_list = std::initializer_list<std::string_view>;
+
+bool operator==(const split& lhs, const string_list& rhs) {
+  return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+bool operator==(const string_list& lhs, const split& rhs) {
+  return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
+TEST(split, split)
+{
+  EXPECT_EQ(string_list({}), split(""));
+  EXPECT_EQ(string_list({}), split(","));
+  EXPECT_EQ(string_list({}), split(",;"));
+
+  EXPECT_EQ(string_list({"a"}), split("a,;"));
+  EXPECT_EQ(string_list({"a"}), split(",a;"));
+  EXPECT_EQ(string_list({"a"}), split(",;a"));
+
+  EXPECT_EQ(string_list({"a", "b"}), split("a,b;"));
+  EXPECT_EQ(string_list({"a", "b"}), split("a,;b"));
+  EXPECT_EQ(string_list({"a", "b"}), split(",a;b"));
+}
+
+TEST(split, iterator_indirection)
+{
+  const auto parts = split("a,b");
+  auto i = parts.begin();
+  ASSERT_NE(i, parts.end());
+  EXPECT_EQ("a", *i); // test operator*
+}
+
+TEST(split, iterator_dereference)
+{
+  const auto parts = split("a,b");
+  auto i = parts.begin();
+  ASSERT_NE(i, parts.end());
+  EXPECT_EQ(1, i->size()); // test operator->
+}
+
+TEST(split, iterator_pre_increment)
+{
+  const auto parts = split("a,b");
+  auto i = parts.begin();
+  ASSERT_NE(i, parts.end());
+
+  ASSERT_EQ("a", *i);
+  EXPECT_EQ("b", *++i); // test operator++()
+  EXPECT_EQ("b", *i);
+}
+
+TEST(split, iterator_post_increment)
+{
+  const auto parts = split("a,b");
+  auto i = parts.begin();
+  ASSERT_NE(i, parts.end());
+
+  ASSERT_EQ("a", *i);
+  EXPECT_EQ("a", *i++); // test operator++(int)
+  ASSERT_NE(parts.end(), i);
+  EXPECT_EQ("b", *i);
+}
+
+TEST(split, iterator_singular)
+{
+  const auto parts = split("a,b");
+  auto i = parts.begin();
+
+  // test comparions against default-constructed 'singular' iterators
+  split::iterator j;
+  split::iterator k;
+  EXPECT_EQ(j, parts.end()); // singular == end
+  EXPECT_EQ(j, k);           // singular == singular
+  EXPECT_NE(j, i);           // singular != valid
+}
+
+TEST(split, iterator_multipass)
+{
+  const auto parts = split("a,b");
+  auto i = parts.begin();
+  ASSERT_NE(i, parts.end());
+
+  // copy the iterator to test LegacyForwardIterator's multipass guarantee
+  auto j = i;
+  ASSERT_EQ(i, j);
+
+  ASSERT_EQ("a", *i);
+  ASSERT_NE(parts.end(), ++i);
+  EXPECT_EQ("b", *i);
+
+  ASSERT_EQ("a", *j); // test that ++i left j unmodified
+  ASSERT_NE(parts.end(), ++j);
+  EXPECT_EQ("b", *j);
+
+  EXPECT_EQ(i, j);
+}
+
+} // namespace ceph


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51726

---

backport of https://github.com/ceph/ceph/pull/41579
parent tracker: https://tracker.ceph.com/issues/50932

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh