### PR TITLE
mgr/cephadm: don't remove daemons from offline hosts

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1390,6 +1390,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             if (
                 self.cache.host_had_daemon_refresh(h.hostname)
                 and h.status.lower() not in ['maintenance', 'offline']
+                and h.hostname not in self.offline_hosts
                 and '_no_schedule' not in h.labels
             )
         ]

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -692,7 +692,7 @@ class CephadmServe:
         try:
             all_slots, slots_to_add, daemons_to_remove = ha.place()
             daemons_to_remove = [d for d in daemons_to_remove if (d.hostname and self.mgr.inventory._inventory[d.hostname].get(
-                'status', '').lower() not in ['maintenance', 'offline'])]
+                'status', '').lower() not in ['maintenance', 'offline'] and d.hostname not in self.mgr.offline_hosts)]
             self.log.debug('Add %s, remove %s' % (slots_to_add, daemons_to_remove))
         except OrchestratorError as e:
             self.log.error('Failed to apply %s spec %s: %s' % (

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1108,7 +1108,7 @@ spec:
                         assert len(cephadm_module.cache.get_daemons_by_type('mgr')) == 3
 
                         # put one host in offline state and one host in maintenance state
-                        cephadm_module.inventory._inventory['test2']['status'] = 'offline'
+                        cephadm_module.offline_hosts = {'test2'}
                         cephadm_module.inventory._inventory['test3']['status'] = 'maintenance'
                         cephadm_module.inventory.save()
 


### PR DESCRIPTION
There was a check for this beforehand but it only looked at the host status 
and not the offline_hosts set we add the host to when we get a HostNotFound 
exception from execnet. Therefore, offline hosts were still having their daemons
scheduled for removal (which would fail since we can't connect to the host).

Signed-off-by: Adam King <adking@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
