### PR TITLE
common/bl, tests: optimize carriage handling in bufferlist::c_str().

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1527,10 +1527,13 @@ static ceph::spinlock debug_lock;
       return nullptr;                         // no non-empty buffers
     }
 
-    auto iter = std::cbegin(_buffers);
-    ++iter;
-
-    if (iter != std::cend(_buffers)) {
+    const auto second = std::next(std::cbegin(_buffers));
+    // splice() tries to not waste our appendable space; to carry
+    // it an empty bptr is added at the end. we account for that.
+    const auto end = _carriage->length() == 0 && \
+      _carriage == &_buffers.back() ? buffers_t::const_iterator(_carriage)
+                                    : std::cend(_buffers);
+    if (second != end) {
       rebuild();
     }
     return _buffers.front().c_str();

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1523,16 +1523,15 @@ static ceph::spinlock debug_lock;
    */
   char *buffer::list::c_str()
   {
-    switch (get_num_buffers()) {
-    case 0:
-      // no buffers
-      return nullptr;
-    case 1:
-      // good, we're already contiguous.
-      break;
-    default:
+    if (length() == 0) {
+      return nullptr;                         // no non-empty buffers
+    }
+
+    auto iter = std::cbegin(_buffers);
+    ++iter;
+
+    if (iter != std::cend(_buffers)) {
       rebuild();
-      break;
     }
     return _buffers.front().c_str();
   }

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -2320,6 +2320,25 @@ TEST(BufferList, c_str) {
   EXPECT_EQ(0, ::memcmp("AB", bl.c_str(), 2));
 }
 
+TEST(BufferList, c_str_carriage) {
+  // verify the c_str() optimization for carriage handling
+  buffer::ptr bp("A", 1);
+  bufferlist bl;
+  bl.append(bp);
+  bl.append('B');
+  EXPECT_EQ(2U, bl.get_num_buffers());
+  EXPECT_EQ(2U, bl.length());
+
+  // this should leave an empty bptr for carriage at the end of the bl
+  bl.splice(1, 1);
+  EXPECT_EQ(2U, bl.get_num_buffers());
+  EXPECT_EQ(1U, bl.length());
+
+  std::ignore = bl.c_str();
+  // if we have an empty bptr at the end, we don't need to rebuild
+  EXPECT_EQ(2U, bl.get_num_buffers());
+}
+
 TEST(BufferList, substr_of) {
   bufferlist bl;
   EXPECT_THROW(bl.substr_of(bl, 1, 1), buffer::end_of_buffer);


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
