### PR TITLE
crimson/os/seastore: trade a map with a plain array

### DIFF
--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -51,7 +51,7 @@ void SeaStore::register_metrics()
   namespace sm = seastar::metrics;
   using op_type_t = SeaStore::op_type_t;
   auto lat_label = sm::label("latency");
-  std::map<op_type_t, sm::label_instance> labels_by_op_type = {
+  std::pair<op_type_t, sm::label_instance> labels_by_op_type[] = {
     {op_type_t::TRANSACTION,     lat_label("TRANSACTION")},
     {op_type_t::READ,            lat_label("READ")},
     {op_type_t::WRITE,           lat_label("WRITE")},
@@ -70,7 +70,7 @@ void SeaStore::register_metrics()
       {
         sm::make_histogram(
           "op_lat", [this, op_type] {
-          return get_latency(op_type);
+            return get_latency(op_type);
           },
           sm::description(desc),
           {label}


### PR DESCRIPTION
simpler this way, as we don't need a std::map<> at all.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
