### PR TITLE
mgr/cephadm: Fix haproxy not being recognized as a proper daemon

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -405,8 +405,8 @@ class CephadmServe:
                 if v:
                     setattr(sd, k, str_to_datetime(d[k]))
             sd.daemon_type = d['name'].split('.')[0]
-            if sd.daemon_type not in ServiceSpec.KNOWN_SERVICE_TYPES:
-                logger.warning(f"Found unknown service type {sd.daemon_type} on host {host}")
+            if sd.daemon_type not in orchestrator.KNOWN_DAEMON_TYPES:
+                logger.warning(f"Found unknown daemon type {sd.daemon_type} on host {host}")
                 continue
 
             sd.daemon_id = '.'.join(d['name'].split('.')[1:])

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -65,7 +65,8 @@ class IngressService(CephService):
         spec = cast(IngressSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
         assert spec.backend_service
         if spec.backend_service not in self.mgr.spec_store:
-            raise RuntimeError(f'{spec.service_name()} backend service {spec.backend_service} does not exist')
+            raise RuntimeError(
+                f'{spec.service_name()} backend service {spec.backend_service} does not exist')
         backend_spec = self.mgr.spec_store[spec.backend_service].spec
         daemons = self.mgr.cache.get_daemons_by_service(spec.backend_service)
         deps = [d.name() for d in daemons]
@@ -183,6 +184,11 @@ class IngressService(CephService):
             password = spec.keepalived_password
 
         daemons = self.mgr.cache.get_daemons_by_service(spec.service_name())
+
+        if not daemons:
+            raise OrchestratorError(
+                f'Failed to generate keepalived.conf: No daemons deployed for {spec.service_name()}')
+
         deps = sorted([d.name() for d in daemons if d.daemon_type == 'haproxy'])
 
         host = daemon_spec.host

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -240,6 +240,11 @@ class TestCephadm(object):
                 style='cephadm',
                 fsid='fsid',
             ),
+            dict(
+                name='haproxy.test.bar',
+                style='cephadm',
+                fsid='fsid',
+            ),
 
         ])
     ))
@@ -248,8 +253,7 @@ class TestCephadm(object):
         with with_host(cephadm_module, 'test'):
             CephadmServe(cephadm_module)._refresh_host_daemons('test')
             dds = wait(cephadm_module, cephadm_module.list_daemons())
-            assert len(dds) == 1
-            assert dds[0].name() == 'rgw.myrgw.foobar'
+            assert {d.name() for d in dds} == {'rgw.myrgw.foobar', 'haproxy.test.bar'}
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
     def test_daemon_action(self, cephadm_module: CephadmOrchestrator):
@@ -887,7 +891,8 @@ spec:
                 placement=ps)
             unmanaged_spec = ServiceSpec.from_json(spec.to_json())
             unmanaged_spec.unmanaged = True
-            cephadm_module._mon_command_mock_mgr_module_ls = lambda *args: json.dumps({'enabled_modules': []})
+            cephadm_module._mon_command_mock_mgr_module_ls = lambda *args: json.dumps({
+                                                                                      'enabled_modules': []})
             with with_service(cephadm_module, unmanaged_spec):
 
                 c = cephadm_module.add_daemon(spec)
@@ -1021,7 +1026,8 @@ spec:
     @mock.patch("subprocess.run", mock.MagicMock())
     def test_apply_save(self, spec: ServiceSpec, meth, cephadm_module: CephadmOrchestrator):
         with with_host(cephadm_module, 'test'):
-            cephadm_module._mon_command_mock_mgr_module_ls = lambda *args: json.dumps({'enabled_modules': []})
+            cephadm_module._mon_command_mock_mgr_module_ls = lambda *args: json.dumps({
+                                                                                      'enabled_modules': []})
             with with_service(cephadm_module, spec, meth, 'test'):
                 pass
 

--- a/src/pybind/mgr/orchestrator/__init__.py
+++ b/src/pybind/mgr/orchestrator/__init__.py
@@ -12,7 +12,7 @@ from ._interface import \
     DaemonDescription, DaemonDescriptionStatus, \
     OrchestratorEvent, set_exception_subject, \
     InventoryHost, DeviceLightLoc, \
-    UpgradeStatusSpec, daemon_type_to_service, service_to_daemon_types
+    UpgradeStatusSpec, daemon_type_to_service, service_to_daemon_types, KNOWN_DAEMON_TYPES
 
 
 import os

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -736,6 +736,10 @@ def service_to_daemon_types(stype: str) -> List[str]:
     return mapping[stype]
 
 
+KNOWN_DAEMON_TYPES: List[str] = list(
+    sum((service_to_daemon_types(t) for t in ServiceSpec.KNOWN_SERVICE_TYPES), []))
+
+
 class UpgradeStatusSpec(object):
     # Orchestrator's report on what's going on with any ongoing upgrade
     def __init__(self) -> None:


### PR DESCRIPTION
Turns out daemon types != service types: 

    cephadm [WRN] Found unknown service type haproxy on host smithi019
    cephadm [WRN] Found unknown service type keepalived on host smithi019

leading to `self.mgr.cache.get_daemons_by_service(spec.service_name())` 
not returning any daemons. 

Fixes: https://tracker.ceph.com/issues/51311

Signed-off-by: Sebastian Wagner <sewagner@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
