### PR TITLE
[WIP] -  RGW tracing implementation

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -796,6 +796,14 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_jaeger_enable
+  type: bool
+  level: advanced
+  desc: should RGW use jaeger tracing system
+  default: false
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_s3_auth_use_keystone
   type: bool
   level: advanced

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -156,7 +156,8 @@ set(librgw_common_srcs
   rgw_lua_utils.cc
   rgw_lua.cc
   rgw_lua_request.cc
-  rgw_bucket_encryption.cc)
+  rgw_bucket_encryption.cc
+  rgw_tracer.cc)
 
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   list(APPEND librgw_common_srcs rgw_amqp.cc)
@@ -229,7 +230,7 @@ if(WITH_LTTNG)
 endif()
 
 if(WITH_JAEGER)
-  add_dependencies(rgw_common jaegertracing::libjaegertracing)
+  add_dependencies(rgw_common jaeger-base)
 endif()
 
 if(WITH_RADOSGW_DBSTORE)

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -38,6 +38,7 @@
 #include "cls/rgw/cls_rgw_types.h"
 #include "include/rados/librados.hpp"
 #include "rgw_public_access.h"
+#include "rgw_tracer.h"
 
 namespace ceph {
   class Formatter;
@@ -1646,6 +1647,8 @@ struct req_state : DoutPrefixProvider {
   std::vector<std::string> token_claims;
 
   std::vector<rgw::IAM::Policy> session_policies;
+
+  jspan trace;
 
   req_state(CephContext* _cct, RGWEnv* e, uint64_t id);
   ~req_state();

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -51,6 +51,7 @@
 #include "rgw_notify_event_type.h"
 #include "rgw_sal.h"
 #include "rgw_sal_rados.h"
+#include "rgw_tracer.h"
 
 #include "services/svc_zone.h"
 #include "services/svc_quota.h"
@@ -3739,6 +3740,7 @@ void RGWPutObj::execute(optional_yield y)
   rgw_placement_rule *pdest_placement = &s->dest_placement;
 
   if (multipart) {
+    s->trace->SetTag(tracing::UPLOAD_ID, multipart_upload_id);
     std::unique_ptr<rgw::sal::MultipartUpload> upload;
     upload = store->get_multipart_upload(s->bucket.get(), s->object->get_name(),
 					 multipart_upload_id);
@@ -5919,6 +5921,7 @@ void RGWInitMultipart::execute(optional_yield y)
   if (op_ret == 0) {
     upload_id = upload->get_upload_id();
   }
+  s->trace->SetTag(tracing::UPLOAD_ID, upload_id);
 
 }
 
@@ -6038,6 +6041,7 @@ void RGWCompleteMultipart::execute(optional_yield y)
 
   upload = store->get_multipart_upload(s->bucket.get(), s->object->get_name(), upload_id);
 
+  s->trace->SetTag(tracing::UPLOAD_ID, upload_id);
 
   RGWCompressionInfo cs_info;
   bool compressed = false;

--- a/src/rgw/rgw_tracer.cc
+++ b/src/rgw/rgw_tracer.cc
@@ -1,0 +1,55 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+#include "common/ceph_context.h"
+#include "global/global_context.h"
+#include "rgw_tracer.h"
+
+#ifdef HAVE_JAEGER
+
+thread_local tracing::Tracer rgw_tracer(jaeger_configuration::jaeger_default_config);
+
+namespace tracing {
+
+const std::shared_ptr<opentracing::Tracer> Tracer::noop_tracer = opentracing::MakeNoopTracer();
+
+Tracer::Tracer(jaegertracing::Config& conf):open_tracer(jaegertracing::Tracer::make(conf)) {}
+
+std::unique_ptr<opentracing::Span> Tracer::start_trace(opentracing::string_view trace_name) {
+  if(is_enabled()) {
+    return open_tracer->StartSpan(trace_name);
+  }
+  return noop_tracer->StartSpan(trace_name);
+}
+
+std::unique_ptr<opentracing::Span> Tracer::start_span(opentracing::string_view span_name, std::unique_ptr<opentracing::Span>& parent_span) {
+  if(is_enabled()) {
+    return open_tracer->StartSpan(span_name, { opentracing::ChildOf(&parent_span->context()) });
+  }
+  return noop_tracer->StartSpan(span_name);
+}
+
+bool Tracer::is_enabled() const {
+  return g_ceph_context->_conf->rgw_jaeger_enable;
+}
+} // namespace tracing
+
+namespace jaeger_configuration {
+
+jaegertracing::samplers::Config const_sampler("const", 1, "", 0, jaegertracing::samplers::Config::defaultSamplingRefreshInterval());
+
+jaegertracing::reporters::Config reporter_default_config(jaegertracing::reporters::Config::kDefaultQueueSize, jaegertracing::reporters::Config::defaultBufferFlushInterval(), true, jaegertracing::reporters::Config::kDefaultLocalAgentHostPort, "");
+
+jaegertracing::propagation::HeadersConfig headers_config("","","","");
+
+jaegertracing::baggage::RestrictionsConfig baggage_config(false, "", std::chrono::steady_clock::duration());
+
+jaegertracing::Config jaeger_default_config(false, const_sampler, reporter_default_config, headers_config, baggage_config, "rgw", std::vector<jaegertracing::Tag>());
+
+}
+
+#else // !HAVE_JAEGER
+
+tracing::Tracer rgw_tracer;
+
+#endif
+ 

--- a/src/rgw/rgw_tracer.h
+++ b/src/rgw/rgw_tracer.h
@@ -1,0 +1,93 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#ifndef RGW_TRACER_H
+#define RGW_TRACER_H
+
+#ifdef HAVE_JAEGER
+
+#define SIGNED_RIGHT_SHIFT_IS 1
+#define ARITHMETIC_RIGHT_SHIFT 1
+#include <jaegertracing/Tracer.h>
+
+typedef std::unique_ptr<opentracing::Span> jspan;
+
+#else  // !HAVE_JAEGER
+
+struct span_stub {
+  template <typename T>
+  void SetTag(std::string_view key, const T& value) const noexcept {}
+  void Log(std::initializer_list<std::pair<std::string_view, std::string_view>> fields) {}
+};
+
+class jspan {
+  span_stub span;
+ public:
+  span_stub& operator*() { return span; }
+  const span_stub& operator*() const { return span; }
+
+  span_stub* operator->() { return &span; }
+  const span_stub* operator->() const { return &span; }
+};
+
+#endif // !HAVE_JAEGER
+
+namespace tracing {
+
+const auto OP = "op";
+const auto BUCKET_NAME = "bucket_name";
+const auto USER_ID = "user_id";
+const auto OBJECT_NAME = "object_name";
+const auto RETURN = "return";
+const auto UPLOAD_ID = "upload_id";
+const auto TYPE = "type";
+const auto REQUEST = "request";
+
+#ifdef HAVE_JAEGER
+
+class Tracer {
+private:
+  const static std::shared_ptr<opentracing::Tracer> noop_tracer;
+  std::shared_ptr<opentracing::Tracer> open_tracer;
+
+public:
+  Tracer(jaegertracing::Config& conf);
+  bool is_enabled() const;
+  // creates and returns a new span with `trace_name`
+  // this span represents a trace, since it has no parent.
+  jspan start_trace(opentracing::string_view trace_name);
+  // creates and returns a new span with `trace_name` which parent span is `parent_span'
+  jspan start_span(opentracing::string_view span_name, jspan& parent_span);
+};
+
+#else // !HAVE_JAEGER
+
+struct Tracer {
+  bool is_enabled() const { return false; }
+  jspan start_trace(std::string_view) { return {}; }
+  jspan start_span(std::string_view, const jspan&) { return {}; }
+};
+
+#endif
+
+} // namespace tracing
+
+
+#ifdef HAVE_JAEGER
+
+extern thread_local tracing::Tracer rgw_tracer;
+
+namespace jaeger_configuration {
+
+extern jaegertracing::Config jaeger_default_config;
+
+}
+
+#else // !HAVE_JAEGER
+
+extern tracing::Tracer rgw_tracer;
+
+#endif
+
+#endif // RGW_TRACER_H
+ 


### PR DESCRIPTION
This is the initial implementation of jaeger tracing in the RGW.

The `rgw_tracer` is a thread_local variable which initialized with some default configuration for now.  the plan is to add args to init a tracer with custom configurations.
the `rgw_tracer` supports runtime toggling using the `rgw_jaeger_enable` option

There are traces for all RGWop's. which contain the basic tags: `object_name`, `bucket_name`, `user_id`, `return`
and `upload_id` tag for Multipart upload ops. 
each trace contains 3 spans: the first span represents span with generic tags and data, and 2 more spans for `verify_permission` and `execute` methods.


Signed-off-by: Omri Zeneva <ozeneva@redhat.com>




