### PR TITLE
rgw/rgw_op.cc: support async md5 calculation

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1689,6 +1689,14 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_async_md5_ops
+  type: int
+  level: advanced
+  desc: max number of ongoing async md5 ops
+  default: 4
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_obj_stripe_size
   type: size
   level: advanced


### PR DESCRIPTION
The current putobject procedure is:

* LOOP
  - read data from client
  - calculate md5
  - async write
* drain write ops
* update index and write header

If we change 'md5 calculation' from sync op to async op, the 'async write' can start earlier, which will reduce put latency.

In my test environment, put latency is decreased from 91ms to 82ms(4M s3 object, test tool is hsbench). Of cause, the rados cluster performence and the rgw node's CPU should not be a bottleneck.

In order to change 'md5 calculation' to async op, one copy of user data chunk is kept until the calculation is finished. I don't know if there is a smart way to handle this.

Any suggestions would be greatly appreciated.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
