### PR TITLE
nautilus: rpm: three spec file cleanups

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1445,14 +1445,6 @@ fi
 %postun base
 /sbin/ldconfig
 %systemd_postun ceph.target
-if [ $1 -ge 1 ] ; then
-  # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
-  # "yes". In any case: if units are not running, do not touch them.
-  SYSCONF_CEPH=%{_sysconfdir}/sysconfig/ceph
-  if [ -f $SYSCONF_CEPH -a -r $SYSCONF_CEPH ] ; then
-    source $SYSCONF_CEPH
-  fi
-fi
 
 %files common
 %dir %{_docdir}/ceph

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1445,8 +1445,7 @@ fi
 %postun base
 /sbin/ldconfig
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph.target
+%service_del_postun_without_restart ceph.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph.target
@@ -1587,8 +1586,7 @@ fi
 
 %postun mds
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-mds@\*.service ceph-mds.target
+%service_del_postun_without_restart ceph-mds@\*.service ceph-mds.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mds@\*.service ceph-mds.target
@@ -1662,8 +1660,7 @@ fi
 
 %postun mgr
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-mgr@\*.service ceph-mgr.target
+%service_del_postun_without_restart ceph-mgr@\*.service ceph-mgr.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mgr@\*.service ceph-mgr.target
@@ -1789,8 +1786,7 @@ fi
 
 %postun mon
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-mon@\*.service ceph-mon.target
+%service_del_postun_without_restart ceph-mon@\*.service ceph-mon.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mon@\*.service ceph-mon.target
@@ -1847,8 +1843,7 @@ fi
 
 %postun -n rbd-mirror
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
+%service_del_postun_without_restart ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
@@ -1906,8 +1901,7 @@ fi
 
 %postun radosgw
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-radosgw@\*.service ceph-radosgw.target
+%service_del_postun_without_restart ceph-radosgw@\*.service ceph-radosgw.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-radosgw@\*.service ceph-radosgw.target
@@ -1973,8 +1967,7 @@ fi
 
 %postun osd
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-osd@\*.service ceph-volume@\*.service ceph-osd.target
+%service_del_postun_without_restart ceph-osd@\*.service ceph-volume@\*.service ceph-osd.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-osd@\*.service ceph-volume@\*.service ceph-osd.target

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1444,12 +1444,7 @@ fi
 
 %postun base
 /sbin/ldconfig
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
@@ -1585,12 +1580,7 @@ fi
 %endif
 
 %postun mds
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph-mds@\*.service ceph-mds.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mds@\*.service ceph-mds.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
@@ -1659,12 +1649,7 @@ fi
 %endif
 
 %postun mgr
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph-mgr@\*.service ceph-mgr.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mgr@\*.service ceph-mgr.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
@@ -1785,12 +1770,7 @@ fi
 %endif
 
 %postun mon
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph-mon@\*.service ceph-mon.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mon@\*.service ceph-mon.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
@@ -1842,12 +1822,7 @@ fi
 %endif
 
 %postun -n rbd-mirror
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
@@ -1900,12 +1875,7 @@ fi
 %endif
 
 %postun radosgw
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph-radosgw@\*.service ceph-radosgw.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-radosgw@\*.service ceph-radosgw.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
@@ -1966,12 +1936,7 @@ fi
 %endif
 
 %postun osd
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph-osd@\*.service ceph-volume@\*.service ceph-osd.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-osd@\*.service ceph-volume@\*.service ceph-osd.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51770

---

backport of https://github.com/ceph/ceph/pull/37455
parent tracker: https://tracker.ceph.com/issues/51768

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh