### PR TITLE
doc/cephfs/journaler: document options using confval directive

### DIFF
--- a/doc/cephfs/journaler.rst
+++ b/doc/cephfs/journaler.rst
@@ -2,40 +2,6 @@
  Journaler
 ===========
 
-``journaler write head interval``
-
-:Description: How frequently to update the journal head object
-:Type: Integer
-:Required: No
-:Default: ``15``
-
-
-``journaler prefetch periods``
-
-:Description: How many stripe periods to read-ahead on journal replay
-:Type: Integer
-:Required: No
-:Default: ``10``
-
-
-``journal prezero periods``
-
-:Description: How many stripe periods to zero ahead of write position
-:Type: Integer
-:Required: No
-:Default: ``10``
-
-``journaler batch interval``
-
-:Description: Maximum additional latency in seconds we incur artificially. 
-:Type: Double
-:Required: No
-:Default: ``.001``
-
-
-``journaler batch max``
-
-:Description: Maximum bytes we will delay flushing. 
-:Type: 64-bit Unsigned Integer 
-:Required: No
-:Default: ``0``
+.. confval:: journaler_write_head_interval
+.. confval:: journaler_prefetch_periods
+.. confval:: journaler_prezero_periods


### PR DESCRIPTION
better maintainablity this way. and drop unsupported options of

- journaler batch interval
- journaler batch max

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
