### PR TITLE
doc/cephadm: troubleshooting - gathering logs

### DIFF
--- a/doc/cephadm/troubleshooting.rst
+++ b/doc/cephadm/troubleshooting.rst
@@ -118,23 +118,47 @@ cephadm log file called ``ceph.cephadm.log`` on all monitor hosts (see
 Gathering log files
 -------------------
 
-Use journalctl to gather the log files of all daemons:
+General Procedure for Gathering Log Files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note:: By default cephadm now stores logs in journald. This means
-   that you will no longer find daemon logs in ``/var/log/ceph/``.
+Use ``journalctl`` to gather the log files of all daemons.
 
-To read the log file of one specific daemon, run::
+.. note:: Since Octopus, cephadm stores logs in journald by default. 
+          Since Octopus, daemon logs are not stored in 
+          ``/var/log/ceph/``.
+
+Reading the log file of a specific daemon
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To read the log file of one specific daemon, run a command of the following
+form:
+
+.. prompt:: bash #
 
     cephadm logs --name <name-of-daemon>
 
-Note: this only works when run on the same host where the daemon is running. To
-get logs of a daemon running on a different host, give the ``--fsid`` option::
+.. note:: This works only when run on the host where the daemon is running.
+          To get the logs of a daemon running on a different host, use the 
+          ``--fsid`` option.
 
-    cephadm logs --fsid <fsid> --name <name-of-daemon>
+To read the log file of a specific daemon that is running on a different 
+host than the one whose command line you are currently using, run a
+command of the following form:
 
-where the ``<fsid>`` corresponds to the cluster ID printed by ``ceph status``.
+.. prompt:: bash #
 
-To fetch all log files of all daemons on a given host, run::
+  cephadm logs --fsid <fsid> --name <name-of-daemon>
+
+where ``<fsid>`` corresponds to the cluster ID returned by 
+the command ``ceph status``.
+
+Fetching all log files of all daemons on a host
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To fetch all log files of all daemons on a particular host, run a command
+of the following form:
+
+.. prompt:: bash #
 
     for name in $(cephadm ls | jq -r '.[].name') ; do
       cephadm logs --fsid <fsid> --name "$name" > $name;

--- a/doc/cephadm/troubleshooting.rst
+++ b/doc/cephadm/troubleshooting.rst
@@ -123,9 +123,8 @@ General Procedure for Gathering Log Files
 
 Use ``journalctl`` to gather the log files of all daemons.
 
-.. note:: Since Octopus, cephadm stores logs in journald by default. 
-          Since Octopus, daemon logs are not stored in 
-          ``/var/log/ceph/``.
+.. note:: Cephadm stores logs in journald by default. 
+          Daemon logs are not stored in ``/var/log/ceph/``.
 
 Reading the log file of a specific daemon
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR rewrites the "Gathering Log Files" section
of the Troubleshooting chapter of the Cephadm guide.

I added some sub-subsection breaks as signposting
to reduce the cognitive load on the reader, and I
made an attempt to simplify the language where possible.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
