### PR TITLE
qa/run-tox-mgr-dashboard: Do not write to /tmp/test_sanitize_password…

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -3,6 +3,7 @@
 
 import errno
 import json
+import tempfile
 import time
 import unittest
 from datetime import datetime, timedelta
@@ -586,7 +587,7 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
     def test_sanitize_password(self):
         self.test_create_user()
         password = 'myPass\\n\\r\\n'
-        with open('/tmp/test_sanitize_password.txt', 'w+') as pwd_file:
+        with tempfile.TemporaryFile(mode='w+') as pwd_file:
             # Add new line separators (like some text editors when a file is saved).
             pwd_file.write('{}{}'.format(password, '\n\r\n\n'))
             pwd_file.seek(0)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/51792

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
