### PR TITLE
cmake: fix failure due missing thrift build scripts if building with jaeger

### DIFF
--- a/cmake/modules/BuildJaeger.cmake
+++ b/cmake/modules/BuildJaeger.cmake
@@ -58,8 +58,6 @@ function(build_jaeger)
   endif()
   include(BuildOpenTracing)
   build_opentracing()
-  include(Buildthrift)
-  build_thrift()
 
   if(CMAKE_MAKE_PROGRAM MATCHES "make")
     # try to inherit command line arguments passed by parent "make" job

--- a/cmake/modules/Findthrift.cmake
+++ b/cmake/modules/Findthrift.cmake
@@ -17,16 +17,15 @@ find_library(
   HINTS ${thrift_HOME} ENV thrift_HOME /usr/local /opt/local
   PATH_SUFFIXES lib lib64)
 
-if(thrift_FOUND AND NOT (TARGET thrift::libthrift))
-  add_library(thrift::libthrift UNKNOWN IMPORTED)
-
-  set_target_properties(
-    thrift::libthrift
-    PROPERTIES IMPORTED_LOCATION ${thrift_LIBRARIES}
-               INTERFACE_INCLUDE_DIRECTORIES ${thrift_INCLUDE_DIR})
-endif()
-
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(thrift DEFAULT_MSG thrift_LIBRARIES
                                   thrift_INCLUDE_DIR)
 mark_as_advanced(thrift_LIBRARIES thrift_INCLUDE_DIR)
+
+if(thrift_FOUND AND NOT (TARGET thrift::libthrift))
+  add_library(thrift::libthrift UNKNOWN IMPORTED)
+  set_target_properties(
+    thrift::libthrift
+    PROPERTIES IMPORTED_LOCATION ${thrift_LIBRARIES}
+	       INTERFACE_INCLUDE_DIRECTORIES ${thrift_INCLUDE_DIR})
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -427,7 +427,7 @@ add_library(common-objs OBJECT ${libcommon_files})
 add_dependencies(common-objs legacy-option-headers)
 
 if(WITH_JAEGER)
-  find_package(thrift 0.13.0)
+  find_package(thrift 0.13.0 REQUIRED)
   find_package(yaml-cpp 0.6.0 REQUIRED)
   include(BuildJaeger)
   list(APPEND jaeger_base

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -450,6 +450,7 @@ if(WITH_JAEGER)
   list(APPEND jaeger_libs
     ${CMAKE_BINARY_DIR}/external/lib/libjaegertracing.so.0
     ${CMAKE_BINARY_DIR}/external/lib/libjaegertracing.so.0.6.1
+    ${CMAKE_BINARY_DIR}/external/lib/libopentracing.so.1
     ${CMAKE_BINARY_DIR}/external/lib/libopentracing.so.1.6.0)
   install(FILES ${jaeger_libs}
     DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
this shall address the missing failure,

CMake Error at cmake/modules/BuildJaeger.cmake:61 (include):
  include could not find load file:

    Buildthrift

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
