### PR TITLE
rpm: drop use of $FIRST_ARG in ceph-immutable-object-cache

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2007,9 +2007,8 @@ fi
 %endif
 
 %postun immutable-object-cache
-test -n "$FIRST_ARG" || FIRST_ARG=$1
 %systemd_postun ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target
-if [ $FIRST_ARG -ge 1 ] ; then
+if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
   SYSCONF_CEPH=%{_sysconfdir}/sysconfig/ceph


### PR DESCRIPTION
The use of $FIRST_ARG was probably required because the SUSE-specific
%service_* rpm macros were playing tricks on the shell positional parameters.
This is bad practice and error-prone, so let's assume that no macros should do
that anymore and hence it's safe to assume that positional parameters remain
unchanged after any rpm macro call.

Thanks to Franck Bui for providing the original patch
926433f5d45e557c42f050b43798ba29dc495e02 that this patch is modeled after.

NOTE: the use of FIRST_ARG had already been eliminated by
926433f5d45e557c42f050b43798ba29dc495e02 but was re-introduced later by
9466d7098573dafcfede5e9c852374fbbd99f9e7

Fixes: 9466d7098573dafcfede5e9c852374fbbd99f9e7

Fixes: https://tracker.ceph.com/issues/51797

Signed-off-by: Nathan Cutler <ncutler@suse.com>
