### PR TITLE
pybind/rbd: fix mirror_image_get_status

### DIFF
--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -4642,7 +4642,7 @@ written." % (self.name, ret, length))
                 if mirror_uuid == '':
                     local_status = site_status
                 else:
-                    site_statuses['mirror_uuid'] = mirror_uuid
+                    site_status['mirror_uuid'] = mirror_uuid
                     site_statuses += site_status
             status = {
                 'name': decode_cstr(c_status.name),

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -2278,6 +2278,8 @@ cdef class MirrorImageStatusIterator(object):
                     'info'        : {
                         'global_id' : decode_cstr(self.images[i].info.global_id),
                         'state'     : self.images[i].info.state,
+                        # primary isn't added here because it is unknown (always
+                        # false, see XXX in Mirror::image_global_status_list())
                         },
                     'remote_statuses': site_statuses,
                     }

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -2270,7 +2270,7 @@ cdef class MirrorImageStatusIterator(object):
                         local_status = site_status
                     else:
                         site_status['mirror_uuid'] = mirror_uuid
-                        site_statuses += site_status
+                        site_statuses.append(site_status)
 
                 status = {
                     'name'        : decode_cstr(self.images[i].name),
@@ -4643,7 +4643,7 @@ written." % (self.name, ret, length))
                     local_status = site_status
                 else:
                     site_status['mirror_uuid'] = mirror_uuid
-                    site_statuses += site_status
+                    site_statuses.append(site_status)
             status = {
                 'name': decode_cstr(c_status.name),
                 'id'  : self.id(),


### PR DESCRIPTION
When retrieving the status of a mirrored image from the Python rbd
library, a TypeError is raised.

### To Reproduce:

Set up two Ceph clusters for block storage, and configure image
mirroring between their pools.  Create a least one image with mirroring
enabled, then run the following script on either cluster (once the image
exists everywhere):

```python
import rados, rbd

CONF_PATH = "YOUR-CONF-PATH"
POOL_NAME = "YOUR-POOL-NAME"
IMAGE_LABEL = "YOUR-IMAGE-LABEL"

with rados.Rados(conffile=CONF_PATH) as cluster:
  with cluster.open_ioctx(POOL_NAME) as ioctx:
    with rbd.Image(ioctx, IMAGE_LABEL) as image:
      image.mirror_image_get_status()
```

This will result in the following stack trace:

```
Traceback (most recent call last):
  File "repo-bug.py", line 10, in <module>
    image.mirror_image_get_status()
  File "rbd.pyx", line 3363, in rbd.requires_not_closed.wrapper
  File "rbd.pyx", line 5209, in rbd.Image.mirror_image_get_status
TypeError: list indices must be integers or slices, not str
```

Fixes: https://tracker.ceph.com/issues/51867

Signed-off-by: Will Smith <wsmith@linode.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
