### PR TITLE
octopus: bind on loopback address if no other addresses are available

### DIFF
--- a/doc/rados/configuration/msgr2.rst
+++ b/doc/rados/configuration/msgr2.rst
@@ -88,7 +88,7 @@ Similarly, two options control whether IPv4 and IPv6 addresses are used:
   * ``ms_bind_ipv6`` [default: false] controls whether a daemon binds
     to an IPv6 address
 
-.. note: The ability to bind to multiple ports has paved the way for
+.. note:: The ability to bind to multiple ports has paved the way for
    dual-stack IPv4 and IPv6 support.  That said, dual-stack support is
    not yet tested as of Nautilus v14.2.0 and likely needs some
    additional code changes to work correctly.

--- a/doc/rados/configuration/network-config-ref.rst
+++ b/doc/rados/configuration/network-config-ref.rst
@@ -201,6 +201,27 @@ following option to the ``[global]`` section of your Ceph configuration file.
 We prefer that the cluster network is **NOT** reachable from the public network
 or the Internet for added security.
 
+IPv4/IPv6 Dual Stack Mode
+-------------------------
+
+If you want to run in an IPv4/IPv6 dual stack mode and want to define your public and/or
+cluster networks, then you need to specify both your IPv4 and IPv6 networks for each:
+
+.. code-block:: ini
+
+	[global]
+		# ... elided configuration
+		public network = {IPv4 public-network/netmask}, {IPv6 public-network/netmask}
+
+This is so ceph can find a valid IP address for both address families.
+
+If you want just an IPv4 or an IPv6 stack environment, then make sure you set the `ms bind`
+options correctly.
+
+.. note::
+   Binding to IPv4 is enabled by default, so if you just add the option to bind to IPv6
+   you'll actually put yourself into dual stack mode. If you want just IPv6, then disable IPv4 and
+   enable IPv6. See `Bind`_ below.
 
 Ceph Daemons
 ============
@@ -336,11 +357,16 @@ addresses.
 :Default: ``7300``
 :Required: No. 
 
+``ms bind ipv4``
+
+:Description: Enables Ceph daemons to bind to IPv4 addresses.
+:Type: Boolean
+:Default: ``true``
+:Required: No
 
 ``ms bind ipv6``
 
-:Description: Enables Ceph daemons to bind to IPv6 addresses. Currently the
-              messenger *either* uses IPv4 or IPv6, but it cannot do both.
+:Description: Enables Ceph daemons to bind to IPv6 addresses.
 :Type: Boolean
 :Default: ``false``
 :Required: No

--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -3,7 +3,6 @@
 #include <ifaddrs.h>
 #include <stdlib.h>
 #include <string.h>
-#include <boost/algorithm/string/predicate.hpp>
 #if defined(__FreeBSD__)
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -29,53 +28,22 @@ void netmask_ipv4(const struct in_addr *addr,
   out->s_addr = addr->s_addr & mask;
 }
 
-
-static bool match_numa_node(const string& if_name, int numa_node)
+bool matches_ipv4_in_subnet(const struct ifaddrs& addrs,
+			  const struct sockaddr_in* net,
+			  unsigned int prefix_len)
 {
-#ifdef WITH_SEASTAR
-  return true;
-#else
-  int if_node = -1;
-  int r = get_iface_numa_node(if_name, &if_node);
-  if (r < 0) {
+  if (addrs.ifa_addr == nullptr)
     return false;
-  }
-  return if_node == numa_node;
-#endif
-}
 
-const struct ifaddrs *find_ipv4_in_subnet(const struct ifaddrs *addrs,
-					  const struct sockaddr_in *net,
-					  unsigned int prefix_len,
-					  int numa_node) {
-  struct in_addr want, temp;
-
+  if (addrs.ifa_addr->sa_family != net->sin_family)
+      return false;
+  struct in_addr want;
   netmask_ipv4(&net->sin_addr, prefix_len, &want);
-  for (; addrs != NULL; addrs = addrs->ifa_next) {
-
-    if (addrs->ifa_addr == NULL)
-      continue;
-
-    if (strcmp(addrs->ifa_name, "lo") == 0 || boost::starts_with(addrs->ifa_name, "lo:"))
-      continue;
-
-    if (numa_node >= 0 && !match_numa_node(addrs->ifa_name, numa_node))
-      continue;
-
-    if (addrs->ifa_addr->sa_family != net->sin_family)
-      continue;
-
-    struct in_addr *cur = &((struct sockaddr_in*)addrs->ifa_addr)->sin_addr;
-    netmask_ipv4(cur, prefix_len, &temp);
-
-    if (temp.s_addr == want.s_addr) {
-      return addrs;
-    }
-  }
-
-  return NULL;
+  struct in_addr *cur = &((struct sockaddr_in*)addrs.ifa_addr)->sin_addr;
+  struct in_addr temp;
+  netmask_ipv4(cur, prefix_len, &temp);
+  return temp.s_addr == want.s_addr;
 }
-
 
 void netmask_ipv6(const struct in6_addr *addr,
 		  unsigned int prefix_len,
@@ -90,58 +58,24 @@ void netmask_ipv6(const struct in6_addr *addr,
     memset(out->s6_addr+prefix_len/8+1, 0, 16-prefix_len/8-1);
 }
 
+bool matches_ipv6_in_subnet(const struct ifaddrs& addrs,
+			    const struct sockaddr_in6* net,
+			    unsigned int prefix_len)
+{
+  if (addrs.ifa_addr == nullptr)
+    return false;
 
-const struct ifaddrs *find_ipv6_in_subnet(const struct ifaddrs *addrs,
-					  const struct sockaddr_in6 *net,
-					  unsigned int prefix_len,
-					  int numa_node) {
-  struct in6_addr want, temp;
-
+  if (addrs.ifa_addr->sa_family != net->sin6_family)
+    return false;
+  struct in6_addr want;
   netmask_ipv6(&net->sin6_addr, prefix_len, &want);
-  for (; addrs != NULL; addrs = addrs->ifa_next) {
-
-    if (addrs->ifa_addr == NULL)
-      continue;
-
-    if (strcmp(addrs->ifa_name, "lo") == 0 || boost::starts_with(addrs->ifa_name, "lo:"))
-      continue;
-
-    if (numa_node >= 0 && !match_numa_node(addrs->ifa_name, numa_node))
-      continue;
-
-    if (addrs->ifa_addr->sa_family != net->sin6_family)
-      continue;
-
-    struct in6_addr *cur = &((struct sockaddr_in6*)addrs->ifa_addr)->sin6_addr;
-    if (IN6_IS_ADDR_LINKLOCAL(cur))
-      continue;
-    netmask_ipv6(cur, prefix_len, &temp);
-
-    if (IN6_ARE_ADDR_EQUAL(&temp, &want))
-      return addrs;
-  }
-
-  return NULL;
+  struct in6_addr temp;
+  struct in6_addr *cur = &((struct sockaddr_in6*)addrs.ifa_addr)->sin6_addr;
+  if (IN6_IS_ADDR_LINKLOCAL(cur))
+    return false;
+  netmask_ipv6(cur, prefix_len, &temp);
+  return IN6_ARE_ADDR_EQUAL(&temp, &want);
 }
-
-
-const struct ifaddrs *find_ip_in_subnet(const struct ifaddrs *addrs,
-					const struct sockaddr *net,
-					unsigned int prefix_len,
-					int numa_node) {
-  switch (net->sa_family) {
-    case AF_INET:
-      return find_ipv4_in_subnet(addrs, (struct sockaddr_in*)net, prefix_len,
-				 numa_node);
-
-    case AF_INET6:
-      return find_ipv6_in_subnet(addrs, (struct sockaddr_in6*)net, prefix_len,
-				 numa_node);
-    }
-
-  return NULL;
-}
-
 
 bool parse_network(const char *s, struct sockaddr_storage *network, unsigned int *prefix_len) {
   char *slash = strchr((char*)s, '/');

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -997,6 +997,11 @@ std::vector<Option> get_global_options() {
     .set_default(100_M)
     .set_description("Limit messages that are read off the network but still being processed"),
 
+    Option("ms_bind_exclude_lo_iface", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_flag(Option::FLAG_STARTUP)
+    .set_description("Allow servers to bind loopback network interfaces (lo)"),
+
     Option("ms_bind_ipv4", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description("Bind servers to IPv4 address(es)")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -997,11 +997,6 @@ std::vector<Option> get_global_options() {
     .set_default(100_M)
     .set_description("Limit messages that are read off the network but still being processed"),
 
-    Option("ms_bind_exclude_lo_iface", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
-    .set_flag(Option::FLAG_STARTUP)
-    .set_description("Allow servers to bind loopback network interfaces (lo)"),
-
     Option("ms_bind_ipv4", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description("Bind servers to IPv4 address(es)")

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -33,6 +33,9 @@
 #include "common/errno.h"
 #include "common/numa.h"
 
+#include <net/if.h>
+#include <netinet/in.h>
+
 #define dout_subsys ceph_subsys_
 
 namespace {
@@ -42,15 +45,42 @@ bool matches_with_name(const ifaddrs& ifa, const std::string& if_name)
   return if_name.compare(ifa.ifa_name) == 0;
 }
 
-bool is_addr_allowed(const ifaddrs& ifa, bool exclude_lo_iface)
+static int is_loopback_addr(sockaddr* addr)
 {
-  if (exclude_lo_iface && strcmp(ifa.ifa_name, "lo") == 0) {
-    return false;
+  if (addr->sa_family == AF_INET) {
+    const sockaddr_in* sin = (struct sockaddr_in *)(addr);
+    const in_addr_t net = ntohl(sin->sin_addr.s_addr) >> IN_CLASSA_NSHIFT;
+    return net == IN_LOOPBACKNET ? 1 : 0;
+  } else if (addr->sa_family == AF_INET6) {
+    sockaddr_in6* sin6 = (struct sockaddr_in6 *)(addr);
+    return IN6_IS_ADDR_LOOPBACK(&sin6->sin6_addr) ? 1 : 0;
+  } else {
+    return -1;
   }
-  if (boost::starts_with(ifa.ifa_name, "lo:")) {
-    return false;
+}
+
+static int grade_addr(const ifaddrs& ifa)
+{
+  if (ifa.ifa_addr == nullptr) {
+    return -1;
   }
-  return true;
+  int score = 0;
+  if (ifa.ifa_flags & IFF_UP) {
+    score += 4;
+  }
+  switch (is_loopback_addr(ifa.ifa_addr)) {
+  case 0:
+    // prefer non-loopback addresses
+    score += 2;
+    break;
+  case 1:
+    score += 0;
+    break;
+  default:
+    score = -1;
+    break;
+  }
+  return score;
 }
 
 bool matches_with_net(const ifaddrs& ifa,
@@ -104,13 +134,13 @@ bool matches_with_numa_node(const ifaddrs& ifa, int numa_node)
 #endif
 }
 }
+
 const struct sockaddr *find_ip_in_subnet_list(
   CephContext *cct,
   const struct ifaddrs *ifa,
   unsigned ipv,
   const std::string &networks,
   const std::string &interfaces,
-  bool exclude_lo_iface,
   int numa_node)
 {
   const auto ifs = get_str_list(interfaces);
@@ -120,25 +150,32 @@ const struct sockaddr *find_ip_in_subnet_list(
       exit(1);
   }
 
+  int best_score = -1;
+  const sockaddr* best_addr = nullptr;
   for (const auto* addr = ifa; addr != nullptr; addr = addr->ifa_next) {
-    if (!is_addr_allowed(*addr, exclude_lo_iface)) {
-      continue;
-    }
-    if ((ifs.empty() ||
-         std::any_of(std::begin(ifs), std::end(ifs),
+    if (!ifs.empty() &&
+	std::none_of(std::begin(ifs), std::end(ifs),
                      [&](const auto& if_name) {
                        return matches_with_name(*addr, if_name);
-                     })) &&
-        (nets.empty() ||
-         std::any_of(std::begin(nets), std::end(nets),
+                     })) {
+      continue;
+    }
+    if (!nets.empty() &&
+	std::none_of(std::begin(nets), std::end(nets),
                      [&](const auto& net) {
                        return matches_with_net(cct, *addr, net, ipv);
-                     })) &&
-        matches_with_numa_node(*addr, numa_node)) {
-      return addr->ifa_addr;
+                     })) {
+      continue;
+    }
+    if (!matches_with_numa_node(*addr, numa_node)) {
+      continue;
+    }
+    if (int score = grade_addr(*addr); score > best_score) {
+      best_score = score;
+      best_addr = addr->ifa_addr;
     }
   }
-  return nullptr;
+  return best_addr;
 }
 
 #ifndef WITH_SEASTAR
@@ -163,7 +200,6 @@ static void fill_in_one_address(CephContext *cct,
 				const struct ifaddrs *ifa,
 				const string &networks,
 				const string &interfaces,
-				bool exclude_lo_iface,
 				const char *conf_var,
 				int numa_node = -1)
 {
@@ -173,7 +209,6 @@ static void fill_in_one_address(CephContext *cct,
     CEPH_PICK_ADDRESS_IPV4|CEPH_PICK_ADDRESS_IPV6,
     networks,
     interfaces,
-    exclude_lo_iface,
     numa_node);
   if (!found) {
     lderr(cct) << "unable to find any IP address in networks '" << networks
@@ -226,27 +261,21 @@ void pick_addresses(CephContext *cct, int needs)
     exit(1);
   }
   auto free_ifa = make_scope_guard([ifa] { freeifaddrs(ifa); });
-
-  const bool exclude_lo_iface =
-    cct->_conf.get_val<bool>("ms_bind_exclude_lo_iface");
   if ((needs & CEPH_PICK_ADDRESS_PUBLIC) &&
     public_addr.is_blank_ip() && !public_network.empty()) {
     fill_in_one_address(cct, ifa, public_network, public_network_interface,
-			exclude_lo_iface,
 			"public_addr");
   }
 
   if ((needs & CEPH_PICK_ADDRESS_CLUSTER) && cluster_addr.is_blank_ip()) {
     if (!cluster_network.empty()) {
       fill_in_one_address(cct, ifa, cluster_network, cluster_network_interface,
-			  exclude_lo_iface,
 			  "cluster_addr");
     } else {
       if (!public_network.empty()) {
         lderr(cct) << "Public network was set, but cluster network was not set " << dendl;
         lderr(cct) << "    Using public network also for cluster network" << dendl;
         fill_in_one_address(cct, ifa, public_network, public_network_interface,
-			    exclude_lo_iface,
 			    "cluster_addr");
       }
     }
@@ -260,14 +289,12 @@ static int fill_in_one_address(
   unsigned ipv,
   const string &networks,
   const string &interfaces,
-  bool exclude_lo_iface,
   entity_addrvec_t *addrs,
   int numa_node = -1)
 {
   const struct sockaddr *found = find_ip_in_subnet_list(cct, ifa, ipv,
 							networks,
 							interfaces,
-							exclude_lo_iface,
 							numa_node);
   if (!found) {
     std::string ip_type = "";
@@ -382,8 +409,6 @@ int pick_addresses(
       !networks.empty()) {
     int ipv4_r = !(ipv & CEPH_PICK_ADDRESS_IPV4) ? 0 : -1;
     int ipv6_r = !(ipv & CEPH_PICK_ADDRESS_IPV6) ? 0 : -1;
-    const bool exclude_lo_iface =
-      cct->_conf.get_val<bool>("ms_bind_exclude_lo_iface");
     // first try on preferred numa node (if >= 0), then anywhere.
     while (true) {
       // note: pass in ipv to filter the matching addresses
@@ -391,14 +416,12 @@ int pick_addresses(
 	  (flags & CEPH_PICK_ADDRESS_PREFER_IPV4)) {
 	ipv4_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV4,
                                      networks, interfaces,
-				     exclude_lo_iface,
 				     addrs,
                                      preferred_numa_node);
       }
       if (ipv & CEPH_PICK_ADDRESS_IPV6) {
 	ipv6_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV6,
                                      networks, interfaces,
-				     exclude_lo_iface,
 				     addrs,
                                      preferred_numa_node);
       }
@@ -406,7 +429,6 @@ int pick_addresses(
 	  !(flags & CEPH_PICK_ADDRESS_PREFER_IPV4)) {
 	ipv4_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV4,
                                      networks, interfaces,
-				     exclude_lo_iface,
 				     addrs,
                                      preferred_numa_node);
       }

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -282,6 +282,32 @@ static int fill_in_one_address(
   return 0;
 }
 
+unsigned networks_address_family_coverage(CephContext *cct, const std::string &networks) {
+  std::list<string> nets;
+  get_str_list(networks, nets);
+  unsigned found_ipv = 0;
+
+  for (auto& s : nets) {
+    struct sockaddr_storage net;
+    unsigned prefix_len;
+    if (!parse_network(s.c_str(), &net, &prefix_len)) {
+      lderr(cct) << "unable to parse network: " << s << dendl;
+      exit(1);
+    }
+
+    switch (net.ss_family) {
+    case AF_INET:
+      found_ipv |= CEPH_PICK_ADDRESS_IPV4;
+      break;
+    case AF_INET6:
+      found_ipv |= CEPH_PICK_ADDRESS_IPV6;
+      break;
+    }
+  }
+
+  return found_ipv;
+}
+
 int pick_addresses(
   CephContext *cct,
   unsigned flags,
@@ -355,6 +381,7 @@ int pick_addresses(
       !networks.empty()) {
     int ipv4_r = !(ipv & CEPH_PICK_ADDRESS_IPV4) ? 0 : -1;
     int ipv6_r = !(ipv & CEPH_PICK_ADDRESS_IPV6) ? 0 : -1;
+    unsigned found_ipv = networks_address_family_coverage(cct, networks);
     // first try on preferred numa node (if >= 0), then anywhere.
     while (true) {
       // note: pass in ipv to filter the matching addresses
@@ -374,6 +401,11 @@ int pick_addresses(
 	ipv4_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV4,
                                      networks, interfaces, addrs,
                                      preferred_numa_node);
+      }
+      if (found_ipv != 0 && (found_ipv & ipv != ipv)) {
+        lderr(cct) << "An IP address was found, but not enough networks to cover both address families. "
+                   << "An IPv4 and IPv6 network is required for dual stack. Continuing with one stack" << dendl;
+        break;
       }
       if (ipv4_r >= 0 && ipv6_r >= 0) {
 	break;

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -160,8 +160,8 @@ struct Observer : public md_config_obs_t {
 
 static void fill_in_one_address(CephContext *cct,
 				const struct ifaddrs *ifa,
-				const string networks,
-				const string interfaces,
+				const string &networks,
+				const string &interfaces,
 				const char *conf_var,
 				int numa_node = -1)
 {
@@ -250,8 +250,8 @@ static int fill_in_one_address(
   CephContext *cct,
   const struct ifaddrs *ifa,
   unsigned ipv,
-  const string networks,
-  const string interfaces,
+  const string &networks,
+  const string &interfaces,
   entity_addrvec_t *addrs,
   int numa_node = -1)
 {

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -282,32 +282,6 @@ static int fill_in_one_address(
   return 0;
 }
 
-unsigned networks_address_family_coverage(CephContext *cct, const std::string &networks) {
-  std::list<string> nets;
-  get_str_list(networks, nets);
-  unsigned found_ipv = 0;
-
-  for (auto& s : nets) {
-    struct sockaddr_storage net;
-    unsigned prefix_len;
-    if (!parse_network(s.c_str(), &net, &prefix_len)) {
-      lderr(cct) << "unable to parse network: " << s << dendl;
-      exit(1);
-    }
-
-    switch (net.ss_family) {
-    case AF_INET:
-      found_ipv |= CEPH_PICK_ADDRESS_IPV4;
-      break;
-    case AF_INET6:
-      found_ipv |= CEPH_PICK_ADDRESS_IPV6;
-      break;
-    }
-  }
-
-  return found_ipv;
-}
-
 int pick_addresses(
   CephContext *cct,
   unsigned flags,
@@ -381,7 +355,6 @@ int pick_addresses(
       !networks.empty()) {
     int ipv4_r = !(ipv & CEPH_PICK_ADDRESS_IPV4) ? 0 : -1;
     int ipv6_r = !(ipv & CEPH_PICK_ADDRESS_IPV6) ? 0 : -1;
-    unsigned found_ipv = networks_address_family_coverage(cct, networks);
     // first try on preferred numa node (if >= 0), then anywhere.
     while (true) {
       // note: pass in ipv to filter the matching addresses
@@ -401,11 +374,6 @@ int pick_addresses(
 	ipv4_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV4,
                                      networks, interfaces, addrs,
                                      preferred_numa_node);
-      }
-      if (found_ipv != 0 && (found_ipv & ipv != ipv)) {
-        lderr(cct) << "An IP address was found, but not enough networks to cover both address families. "
-                   << "An IPv4 and IPv6 network is required for dual stack. Continuing with one stack" << dendl;
-        break;
       }
       if (ipv4_r >= 0 && ipv6_r >= 0) {
 	break;

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -42,9 +42,9 @@ bool matches_with_name(const ifaddrs& ifa, const std::string& if_name)
   return if_name.compare(ifa.ifa_name) == 0;
 }
 
-bool is_addr_allowed(const ifaddrs& ifa)
+bool is_addr_allowed(const ifaddrs& ifa, bool exclude_lo_iface)
 {
-  if (strcmp(ifa.ifa_name, "lo") == 0) {
+  if (exclude_lo_iface && strcmp(ifa.ifa_name, "lo") == 0) {
     return false;
   }
   if (boost::starts_with(ifa.ifa_name, "lo:")) {
@@ -110,6 +110,7 @@ const struct sockaddr *find_ip_in_subnet_list(
   unsigned ipv,
   const std::string &networks,
   const std::string &interfaces,
+  bool exclude_lo_iface,
   int numa_node)
 {
   const auto ifs = get_str_list(interfaces);
@@ -120,7 +121,7 @@ const struct sockaddr *find_ip_in_subnet_list(
   }
 
   for (const auto* addr = ifa; addr != nullptr; addr = addr->ifa_next) {
-    if (!is_addr_allowed(*addr)) {
+    if (!is_addr_allowed(*addr, exclude_lo_iface)) {
       continue;
     }
     if ((ifs.empty() ||
@@ -162,6 +163,7 @@ static void fill_in_one_address(CephContext *cct,
 				const struct ifaddrs *ifa,
 				const string &networks,
 				const string &interfaces,
+				bool exclude_lo_iface,
 				const char *conf_var,
 				int numa_node = -1)
 {
@@ -171,6 +173,7 @@ static void fill_in_one_address(CephContext *cct,
     CEPH_PICK_ADDRESS_IPV4|CEPH_PICK_ADDRESS_IPV6,
     networks,
     interfaces,
+    exclude_lo_iface,
     numa_node);
   if (!found) {
     lderr(cct) << "unable to find any IP address in networks '" << networks
@@ -224,22 +227,27 @@ void pick_addresses(CephContext *cct, int needs)
   }
   auto free_ifa = make_scope_guard([ifa] { freeifaddrs(ifa); });
 
+  const bool exclude_lo_iface =
+    cct->_conf.get_val<bool>("ms_bind_exclude_lo_iface");
   if ((needs & CEPH_PICK_ADDRESS_PUBLIC) &&
     public_addr.is_blank_ip() && !public_network.empty()) {
     fill_in_one_address(cct, ifa, public_network, public_network_interface,
-      "public_addr");
+			exclude_lo_iface,
+			"public_addr");
   }
 
   if ((needs & CEPH_PICK_ADDRESS_CLUSTER) && cluster_addr.is_blank_ip()) {
     if (!cluster_network.empty()) {
       fill_in_one_address(cct, ifa, cluster_network, cluster_network_interface,
-	"cluster_addr");
+			  exclude_lo_iface,
+			  "cluster_addr");
     } else {
       if (!public_network.empty()) {
         lderr(cct) << "Public network was set, but cluster network was not set " << dendl;
         lderr(cct) << "    Using public network also for cluster network" << dendl;
         fill_in_one_address(cct, ifa, public_network, public_network_interface,
-          "cluster_addr");
+			    exclude_lo_iface,
+			    "cluster_addr");
       }
     }
   }
@@ -252,11 +260,15 @@ static int fill_in_one_address(
   unsigned ipv,
   const string &networks,
   const string &interfaces,
+  bool exclude_lo_iface,
   entity_addrvec_t *addrs,
   int numa_node = -1)
 {
-  const struct sockaddr *found = find_ip_in_subnet_list(cct, ifa, ipv, networks,
-							interfaces, numa_node);
+  const struct sockaddr *found = find_ip_in_subnet_list(cct, ifa, ipv,
+							networks,
+							interfaces,
+							exclude_lo_iface,
+							numa_node);
   if (!found) {
     std::string ip_type = "";
     if ((ipv & CEPH_PICK_ADDRESS_IPV4) && (ipv & CEPH_PICK_ADDRESS_IPV6)) {
@@ -370,24 +382,32 @@ int pick_addresses(
       !networks.empty()) {
     int ipv4_r = !(ipv & CEPH_PICK_ADDRESS_IPV4) ? 0 : -1;
     int ipv6_r = !(ipv & CEPH_PICK_ADDRESS_IPV6) ? 0 : -1;
+    const bool exclude_lo_iface =
+      cct->_conf.get_val<bool>("ms_bind_exclude_lo_iface");
     // first try on preferred numa node (if >= 0), then anywhere.
     while (true) {
       // note: pass in ipv to filter the matching addresses
       if ((ipv & CEPH_PICK_ADDRESS_IPV4) &&
 	  (flags & CEPH_PICK_ADDRESS_PREFER_IPV4)) {
 	ipv4_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV4,
-                                     networks, interfaces, addrs,
+                                     networks, interfaces,
+				     exclude_lo_iface,
+				     addrs,
                                      preferred_numa_node);
       }
       if (ipv & CEPH_PICK_ADDRESS_IPV6) {
 	ipv6_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV6,
-                                     networks, interfaces, addrs,
+                                     networks, interfaces,
+				     exclude_lo_iface,
+				     addrs,
                                      preferred_numa_node);
       }
       if ((ipv & CEPH_PICK_ADDRESS_IPV4) &&
 	  !(flags & CEPH_PICK_ADDRESS_PREFER_IPV4)) {
 	ipv4_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV4,
-                                     networks, interfaces, addrs,
+                                     networks, interfaces,
+				     exclude_lo_iface,
+				     addrs,
                                      preferred_numa_node);
       }
       if (ipv4_r >= 0 && ipv6_r >= 0) {

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -35,6 +35,75 @@
 
 #define dout_subsys ceph_subsys_
 
+namespace {
+
+bool matches_with_name(const ifaddrs& ifa, const std::string& if_name)
+{
+  return if_name.compare(ifa.ifa_name) == 0;
+}
+
+bool is_addr_allowed(const ifaddrs& ifa)
+{
+  if (strcmp(ifa.ifa_name, "lo") == 0) {
+    return false;
+  }
+  if (boost::starts_with(ifa.ifa_name, "lo:")) {
+    return false;
+  }
+  return true;
+}
+
+bool matches_with_net(const ifaddrs& ifa,
+                      const sockaddr* net,
+                      unsigned int prefix_len,
+                      unsigned ipv)
+{
+  switch (net->sa_family) {
+  case AF_INET:
+    if (ipv & CEPH_PICK_ADDRESS_IPV4) {
+      return matches_ipv4_in_subnet(ifa, (struct sockaddr_in*)net, prefix_len);
+    }
+    break;
+  case AF_INET6:
+    if (ipv & CEPH_PICK_ADDRESS_IPV6) {
+      return matches_ipv6_in_subnet(ifa, (struct sockaddr_in6*)net, prefix_len);
+    }
+    break;
+  }
+  return false;
+}
+
+bool matches_with_net(CephContext *cct,
+                      const ifaddrs& ifa,
+                      const std::string& s,
+                      unsigned ipv)
+{
+  struct sockaddr_storage net;
+  unsigned int prefix_len;
+  if (!parse_network(s.c_str(), &net, &prefix_len)) {
+    lderr(cct) << "unable to parse network: " << s << dendl;
+    exit(1);
+  }
+  return matches_with_net(ifa, (sockaddr*)&net, prefix_len, ipv);
+}
+
+bool matches_with_numa_node(const ifaddrs& ifa, int numa_node)
+{
+#if defined(WITH_SEASTAR) || defined(_WIN32)
+  return true;
+#else
+  if (numa_node < 0) {
+    return true;
+  }
+  int if_node = -1;
+  int r = get_iface_numa_node(ifa.ifa_name, &if_node);
+  if (r < 0) {
+    return false;
+  }
+  return if_node == numa_node;
+#endif
+}
+}
 const struct sockaddr *find_ip_in_subnet_list(
   CephContext *cct,
   const struct ifaddrs *ifa,
@@ -43,86 +112,32 @@ const struct sockaddr *find_ip_in_subnet_list(
   const std::string &interfaces,
   int numa_node)
 {
-  std::list<string> nets;
-  get_str_list(networks, nets);
-  std::list<string> ifs;
-  get_str_list(interfaces, ifs);
-
-  // filter interfaces by name
-  const struct ifaddrs *filtered = nullptr;
-  if (ifs.empty()) {
-    filtered = ifa;
-  } else {
-    if (nets.empty()) {
+  const auto ifs = get_str_list(interfaces);
+  const auto nets = get_str_list(networks);
+  if (!ifs.empty() && nets.empty()) {
       lderr(cct) << "interface names specified but not network names" << dendl;
       exit(1);
-    }
-    const struct ifaddrs *t = ifa;
-    struct ifaddrs *head = 0;
-    while (t) {
-      bool match = false;
-      for (auto& i : ifs) {
-	if (strcmp(i.c_str(), t->ifa_name) == 0) {
-	  match = true;
-	  break;
-	}
-      }
-      if (match) {
-	struct ifaddrs *n = new ifaddrs;
-	memcpy(n, t, sizeof(*t));
-	n->ifa_next = head;
-	head = n;
-      }
-      t = t->ifa_next;
-    }
-    if (!head) {
-      lderr(cct) << "no interfaces matching " << ifs << dendl;
-      exit(1);
-    }
-    filtered = head;
   }
 
-  struct sockaddr *r = nullptr;
-  for (auto& s : nets) {
-    struct sockaddr_storage net;
-    unsigned int prefix_len;
-
-    if (!parse_network(s.c_str(), &net, &prefix_len)) {
-      lderr(cct) << "unable to parse network: " << s << dendl;
-      exit(1);
+  for (const auto* addr = ifa; addr != nullptr; addr = addr->ifa_next) {
+    if (!is_addr_allowed(*addr)) {
+      continue;
     }
-
-    switch (net.ss_family) {
-    case AF_INET:
-      if (!(ipv & CEPH_PICK_ADDRESS_IPV4)) {
-	continue;
-      }
-      break;
-    case AF_INET6:
-      if (!(ipv & CEPH_PICK_ADDRESS_IPV6)) {
-	continue;
-      }
-      break;
-    }
-
-    const struct ifaddrs *found = find_ip_in_subnet(
-      filtered,
-      (struct sockaddr *) &net, prefix_len, numa_node);
-    if (found) {
-      r = found->ifa_addr;
-      break;
+    if ((ifs.empty() ||
+         std::any_of(std::begin(ifs), std::end(ifs),
+                     [&](const auto& if_name) {
+                       return matches_with_name(*addr, if_name);
+                     })) &&
+        (nets.empty() ||
+         std::any_of(std::begin(nets), std::end(nets),
+                     [&](const auto& net) {
+                       return matches_with_net(cct, *addr, net, ipv);
+                     })) &&
+        matches_with_numa_node(*addr, numa_node)) {
+      return addr->ifa_addr;
     }
   }
-
-  if (filtered != ifa) {
-    while (filtered) {
-      struct ifaddrs *t = filtered->ifa_next;
-      delete filtered;
-      filtered = t;
-    }
-  }
-
-  return r;
+  return nullptr;
 }
 
 #ifndef WITH_SEASTAR
@@ -464,20 +479,15 @@ std::string pick_iface(CephContext *cct, const struct sockaddr_storage &network)
     lderr(cct) << "unable to fetch interfaces and addresses: " << err << dendl;
     return {};
   }
-
-  const unsigned int prefix_len = max(sizeof(in_addr::s_addr), sizeof(in6_addr::s6_addr)) * CHAR_BIT;
-  const struct ifaddrs *found = find_ip_in_subnet(
-    ifa,
-    (const struct sockaddr *) &network, prefix_len);
-
-  std::string result;
-  if (found) {
-    result = found->ifa_name;
+  auto free_ifa = make_scope_guard([ifa] { freeifaddrs(ifa); });
+  const unsigned int prefix_len = std::max(sizeof(in_addr::s_addr), sizeof(in6_addr::s6_addr)) * CHAR_BIT;
+  for (auto addr = ifa; addr != nullptr; addr = addr->ifa_next) {
+    if (matches_with_net(*ifa, (const struct sockaddr *) &network, prefix_len,
+			 CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6)) {
+      return addr->ifa_name;
+    }
   }
-
-  freeifaddrs(ifa);
-
-  return result;
+  return {};
 }
 
 

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -117,20 +117,20 @@ bool matches_with_net(CephContext *cct,
   return matches_with_net(ifa, (sockaddr*)&net, prefix_len, ipv);
 }
 
-bool matches_with_numa_node(const ifaddrs& ifa, int numa_node)
+int grade_with_numa_node(const ifaddrs& ifa, int numa_node)
 {
 #if defined(WITH_SEASTAR) || defined(_WIN32)
-  return true;
+  return 0;
 #else
   if (numa_node < 0) {
-    return true;
+    return 0;
   }
   int if_node = -1;
   int r = get_iface_numa_node(ifa.ifa_name, &if_node);
   if (r < 0) {
-    return false;
+    return 0;
   }
-  return if_node == numa_node;
+  return if_node == numa_node ? 1 : 0;
 #endif
 }
 }
@@ -150,7 +150,7 @@ const struct sockaddr *find_ip_in_subnet_list(
       exit(1);
   }
 
-  int best_score = -1;
+  int best_score = 0;
   const sockaddr* best_addr = nullptr;
   for (const auto* addr = ifa; addr != nullptr; addr = addr->ifa_next) {
     if (!ifs.empty() &&
@@ -167,10 +167,12 @@ const struct sockaddr *find_ip_in_subnet_list(
                      })) {
       continue;
     }
-    if (!matches_with_numa_node(*addr, numa_node)) {
+    int score = grade_addr(*addr);
+    if (score < 0) {
       continue;
     }
-    if (int score = grade_addr(*addr); score > best_score) {
+    score += grade_with_numa_node(*addr, numa_node);
+    if (score > best_score) {
       best_score = score;
       best_addr = addr->ifa_addr;
     }
@@ -409,36 +411,29 @@ int pick_addresses(
       !networks.empty()) {
     int ipv4_r = !(ipv & CEPH_PICK_ADDRESS_IPV4) ? 0 : -1;
     int ipv6_r = !(ipv & CEPH_PICK_ADDRESS_IPV6) ? 0 : -1;
-    // first try on preferred numa node (if >= 0), then anywhere.
-    while (true) {
-      // note: pass in ipv to filter the matching addresses
-      if ((ipv & CEPH_PICK_ADDRESS_IPV4) &&
-	  (flags & CEPH_PICK_ADDRESS_PREFER_IPV4)) {
-	ipv4_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV4,
-                                     networks, interfaces,
-				     addrs,
-                                     preferred_numa_node);
-      }
-      if (ipv & CEPH_PICK_ADDRESS_IPV6) {
-	ipv6_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV6,
-                                     networks, interfaces,
-				     addrs,
-                                     preferred_numa_node);
-      }
-      if ((ipv & CEPH_PICK_ADDRESS_IPV4) &&
-	  !(flags & CEPH_PICK_ADDRESS_PREFER_IPV4)) {
-	ipv4_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV4,
-                                     networks, interfaces,
-				     addrs,
-                                     preferred_numa_node);
-      }
-      if (ipv4_r >= 0 && ipv6_r >= 0) {
-	break;
-      }
-      if (preferred_numa_node < 0) {
-	return ipv4_r >= 0 && ipv6_r >= 0 ? 0 : -1;
-      }
-      preferred_numa_node = -1;      // try any numa node
+    // note: pass in ipv to filter the matching addresses
+    if ((ipv & CEPH_PICK_ADDRESS_IPV4) &&
+	(flags & CEPH_PICK_ADDRESS_PREFER_IPV4)) {
+      ipv4_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV4,
+				   networks, interfaces,
+				   addrs,
+				   preferred_numa_node);
+    }
+    if (ipv & CEPH_PICK_ADDRESS_IPV6) {
+      ipv6_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV6,
+				   networks, interfaces,
+				   addrs,
+				   preferred_numa_node);
+    }
+    if ((ipv & CEPH_PICK_ADDRESS_IPV4) &&
+	!(flags & CEPH_PICK_ADDRESS_PREFER_IPV4)) {
+      ipv4_r = fill_in_one_address(cct, ifa, CEPH_PICK_ADDRESS_IPV4,
+				   networks, interfaces,
+				   addrs,
+				   preferred_numa_node);
+    }
+    if (ipv4_r < 0 || ipv6_r < 0) {
+      return -1;
     }
   }
 

--- a/src/common/pick_address.h
+++ b/src/common/pick_address.h
@@ -80,4 +80,11 @@ int get_iface_numa_node(
   const std::string& iface,
   int *node);
 
+/**
+ * Return a bitmap of address families that are covered by networks
+ *
+ * @param cct context (used for logging)
+ * @param string of networks
+ */
+unsigned networks_address_family_coverage(CephContext *cct, const std::string &networks);
 #endif

--- a/src/common/pick_address.h
+++ b/src/common/pick_address.h
@@ -80,11 +80,4 @@ int get_iface_numa_node(
   const std::string& iface,
   int *node);
 
-/**
- * Return a bitmap of address families that are covered by networks
- *
- * @param cct context (used for logging)
- * @param string of networks
- */
-unsigned networks_address_family_coverage(CephContext *cct, const std::string &networks);
 #endif

--- a/src/common/pick_address.h
+++ b/src/common/pick_address.h
@@ -88,7 +88,6 @@ const struct sockaddr *find_ip_in_subnet_list(
   unsigned ipv,
   const std::string &networks,
   const std::string &interfaces,
-  bool exclude_lo_iface,
   int numa_node=-1);
 
 int get_iface_numa_node(

--- a/src/common/pick_address.h
+++ b/src/common/pick_address.h
@@ -80,6 +80,7 @@ bool have_local_addr(CephContext *cct, const std::list<entity_addr_t>& ls, entit
  *        are accepted if it is empty.
  * @param interfaces a comma separated list of interfaces for the allow list.
  *        all addresses are accepted if it is empty
+ * @param exclude_lo_iface filter out network interface named "lo"
  */
 const struct sockaddr *find_ip_in_subnet_list(
   CephContext *cct,
@@ -87,6 +88,7 @@ const struct sockaddr *find_ip_in_subnet_list(
   unsigned ipv,
   const std::string &networks,
   const std::string &interfaces,
+  bool exclude_lo_iface,
   int numa_node=-1);
 
 int get_iface_numa_node(

--- a/src/common/pick_address.h
+++ b/src/common/pick_address.h
@@ -68,6 +68,19 @@ std::string pick_iface(CephContext *cct, const struct sockaddr_storage &network)
  */
 bool have_local_addr(CephContext *cct, const std::list<entity_addr_t>& ls, entity_addr_t *match);
 
+/**
+ * filter the addresses in @c ifa with specified interfaces, networks and IPv
+ *
+ * @param cct
+ * @param ifa a list of network interface addresses to be filtered
+ * @param ipv bitmask of CEPH_PICK_ADDRESS_IPV4 and CEPH_PICK_ADDRESS_IPV6.
+ *        it is used to filter the @c networks
+ * @param networks a comma separated list of networks as the allow list. only
+ *        the addresses in the specified networks are allowed. all addresses
+ *        are accepted if it is empty.
+ * @param interfaces a comma separated list of interfaces for the allow list.
+ *        all addresses are accepted if it is empty
+ */
 const struct sockaddr *find_ip_in_subnet_list(
   CephContext *cct,
   const struct ifaddrs *ifa,

--- a/src/include/ipaddr.h
+++ b/src/include/ipaddr.h
@@ -4,15 +4,14 @@
 class entity_addr_t;
 
 /*
- * Find an IP address that is in the wanted subnet.
- *
- * If there are multiple matches, the first one is returned; this order
- * is system-dependent and should not be relied on.
+ * Check if an IP address that is in the wanted subnet.
  */
-const struct ifaddrs *find_ip_in_subnet(const struct ifaddrs *addrs,
-					const struct sockaddr *net,
-					unsigned int prefix_len,
-					int numa_node = -1);
+bool matches_ipv4_in_subnet(const struct ifaddrs& addrs,
+                            const struct sockaddr_in* net,
+                            unsigned int prefix_len);
+bool matches_ipv6_in_subnet(const struct ifaddrs& addrs,
+                            const struct sockaddr_in6* net,
+                            unsigned int prefix_len);
 
 /*
  * Validate and parse IPv4 or IPv6 network

--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -200,11 +200,22 @@ TEST(CommonIPAddr, TestV4_SkipLoopback)
   ipv4(&a_two, "127.0.0.1");
   ipv4(&a_three, "10.1.2.3");
 
-  const struct sockaddr *result =
+  const struct sockaddr *result = nullptr;
+  result =
     find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
                            CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "10.0.0.0/8", "");
+                           "10.0.0.0/8", "", true);
   ASSERT_EQ((struct sockaddr*)&a_three, result);
+  result =
+    find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
+                           CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
+                           "127.0.0.0/8", "", true);
+  ASSERT_EQ(nullptr, result);
+  result =
+    find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
+                           CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
+                           "127.0.0.0/8", "", false);
+  ASSERT_EQ((struct sockaddr*)&a_one, result);
 }
 
 TEST(CommonIPAddr, TestV6_Simple)
@@ -325,11 +336,22 @@ TEST(CommonIPAddr, TestV6_SkipLoopback)
   ipv6(&a_three, "2001:1234:5678:90ab::beef");
   ipv6(&net, "ff00::1");
 
-  const struct sockaddr *result =
+  const struct sockaddr *result = nullptr;
+  result =
     find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
                            CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "2001:1234:5678:90ab::0/64", "");
+                           "2001:1234:5678:90ab::0/64", "", true);
   ASSERT_EQ((struct sockaddr*)&a_three, result);
+  result =
+    find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
+                           CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
+                           "::1/128", "", true);
+  ASSERT_EQ(nullptr, result);
+  result =
+    find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
+                           CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
+                           "::1/128", "", false);
+  ASSERT_EQ((struct sockaddr*)&a_one, result);
 }
 
 TEST(CommonIPAddr, ParseNetwork_Empty)
@@ -684,7 +706,8 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV4,
     "10.1.0.0/16",
-    "eth0");
+    "eth0",
+    true);
   ASSERT_EQ((struct sockaddr*)&a_one, result);
 
   result = find_ip_in_subnet_list(
@@ -692,7 +715,8 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV4,
     "10.2.0.0/16",
-    "eth1");
+    "eth1",
+    true);
   ASSERT_EQ((struct sockaddr*)&a_two, result);
 
   // match by eth name
@@ -701,7 +725,8 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV4,
     "10.0.0.0/8",
-    "eth0");
+    "eth0",
+    true);
   ASSERT_EQ((struct sockaddr*)&a_one, result);
 
   result = find_ip_in_subnet_list(
@@ -709,7 +734,8 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV4,
     "10.0.0.0/8",
-    "eth1");
+    "eth1",
+    true);
   ASSERT_EQ((struct sockaddr*)&a_two, result);
 
   result = find_ip_in_subnet_list(
@@ -717,7 +743,8 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV6,
     "2001::/16",
-    "eth1");
+    "eth1",
+    true);
   ASSERT_EQ((struct sockaddr*)&a_three, result);
 }
 

--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -12,6 +12,7 @@
 #endif
 #include <arpa/inet.h>
 #include <ifaddrs.h>
+#include <net/if.h>
 
 static void ipv4(struct sockaddr_in *addr, const char *s) {
   int err;
@@ -189,10 +190,12 @@ TEST(CommonIPAddr, TestV4_SkipLoopback)
   one.ifa_name = lo;
 
   two.ifa_next = &three;
+  two.ifa_flags = IFF_UP;
   two.ifa_addr = (struct sockaddr*)&a_two;
   two.ifa_name = lo0;
 
   three.ifa_next = NULL;
+  three.ifa_flags = IFF_UP;
   three.ifa_addr = (struct sockaddr*)&a_three;
   three.ifa_name = eth0;
 
@@ -201,21 +204,18 @@ TEST(CommonIPAddr, TestV4_SkipLoopback)
   ipv4(&a_three, "10.1.2.3");
 
   const struct sockaddr *result = nullptr;
+  // we prefer the non-loopback address despite the loopback addresses
   result =
     find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
                            CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "10.0.0.0/8", "", true);
+                           "", "");
   ASSERT_EQ((struct sockaddr*)&a_three, result);
+  // the subnet criteria leaves us no choice but the UP loopback address
   result =
     find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
                            CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "127.0.0.0/8", "", true);
-  ASSERT_EQ(nullptr, result);
-  result =
-    find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
-                           CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "127.0.0.0/8", "", false);
-  ASSERT_EQ((struct sockaddr*)&a_one, result);
+                           "127.0.0.0/8", "");
+  ASSERT_EQ((struct sockaddr*)&a_two, result);
 }
 
 TEST(CommonIPAddr, TestV6_Simple)
@@ -315,43 +315,37 @@ TEST(CommonIPAddr, TestV6_SkipLoopback)
   struct sockaddr_in6 a_one;
   struct sockaddr_in6 a_two;
   struct sockaddr_in6 a_three;
-  struct sockaddr_in6 net;
-
-  memset(&net, 0, sizeof(net));
 
   one.ifa_next = &two;
+  ipv6(&a_one, "::1");
   one.ifa_addr = (struct sockaddr*)&a_one;
   one.ifa_name = lo;
 
   two.ifa_next = &three;
+  two.ifa_flags = IFF_UP;
+  ipv6(&a_two, "::1");
   two.ifa_addr = (struct sockaddr*)&a_two;
   two.ifa_name = lo0;
 
   three.ifa_next = NULL;
+  three.ifa_flags = IFF_UP;
+  ipv6(&a_three, "2001:1234:5678:90ab::beef");
   three.ifa_addr = (struct sockaddr*)&a_three;
   three.ifa_name = eth0;
 
-  ipv6(&a_one, "::1");
-  ipv6(&a_two, "::1");
-  ipv6(&a_three, "2001:1234:5678:90ab::beef");
-  ipv6(&net, "ff00::1");
-
   const struct sockaddr *result = nullptr;
+  // we prefer the non-loopback address despite the loopback addresses
   result =
     find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
                            CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "2001:1234:5678:90ab::0/64", "", true);
+                           "", "");
   ASSERT_EQ((struct sockaddr*)&a_three, result);
+  // the subnet criteria leaves us no choice but the UP loopback address
   result =
     find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
                            CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "::1/128", "", true);
-  ASSERT_EQ(nullptr, result);
-  result =
-    find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
-                           CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "::1/128", "", false);
-  ASSERT_EQ((struct sockaddr*)&a_one, result);
+                           "::1/128", "");
+  ASSERT_EQ((struct sockaddr*)&a_two, result);
 }
 
 TEST(CommonIPAddr, ParseNetwork_Empty)
@@ -706,8 +700,7 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV4,
     "10.1.0.0/16",
-    "eth0",
-    true);
+    "eth0");
   ASSERT_EQ((struct sockaddr*)&a_one, result);
 
   result = find_ip_in_subnet_list(
@@ -715,8 +708,7 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV4,
     "10.2.0.0/16",
-    "eth1",
-    true);
+    "eth1");
   ASSERT_EQ((struct sockaddr*)&a_two, result);
 
   // match by eth name
@@ -725,8 +717,7 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV4,
     "10.0.0.0/8",
-    "eth0",
-    true);
+    "eth0");
   ASSERT_EQ((struct sockaddr*)&a_one, result);
 
   result = find_ip_in_subnet_list(
@@ -734,8 +725,7 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV4,
     "10.0.0.0/8",
-    "eth1",
-    true);
+    "eth1");
   ASSERT_EQ((struct sockaddr*)&a_two, result);
 
   result = find_ip_in_subnet_list(
@@ -743,8 +733,7 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV6,
     "2001::/16",
-    "eth1",
-    true);
+    "eth1");
   ASSERT_EQ((struct sockaddr*)&a_three, result);
 }
 

--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -931,119 +931,6 @@ TEST(pick_address, filtering)
 
 TEST(pick_address, ipv4_ipv6_enabled)
 {
-  struct ifaddrs one, two;
-  struct sockaddr_in a_one;
-  struct sockaddr_in6 a_two;
-
-  one.ifa_next = &two;
-  one.ifa_addr = (struct sockaddr*)&a_one;
-  one.ifa_name = eth0;
-
-  two.ifa_next = NULL;
-  two.ifa_addr = (struct sockaddr*)&a_two;
-  two.ifa_name = eth0;
-
-  ipv4(&a_one, "10.1.1.2");
-  ipv6(&a_two, "2001:1234:5678:90ab::cdef");
-
-  CephContext *cct = new CephContext(CEPH_ENTITY_TYPE_OSD);
-  cct->_conf._clear_safe_to_start_threads();  // so we can set configs
-
-  cct->_conf.set_val("public_addr", "");
-  cct->_conf.set_val("public_network", "10.1.1.0/24, 2001::/16");
-  cct->_conf.set_val("public_network_interface", "");
-  cct->_conf.set_val("cluster_addr", "");
-  cct->_conf.set_val("cluster_network", "");
-  cct->_conf.set_val("cluster_network_interface", "");
-  cct->_conf.set_val("ms_bind_ipv6", "true");
-
-  entity_addrvec_t av;
-  {
-    int r = pick_addresses(cct,
-			   CEPH_PICK_ADDRESS_PUBLIC |
-			   CEPH_PICK_ADDRESS_MSGR1,
-			   &one, &av);
-    cout << av << std::endl;
-    ASSERT_EQ(0, r);
-    // Got 2 address
-    ASSERT_EQ(2u, av.v.size());
-    ASSERT_EQ(string("v1:[2001:1234:5678:90ab::cdef]:0/0"), stringify(av.v[0]));
-    ASSERT_EQ(string("v1:10.1.1.2:0/0"), stringify(av.v[1]));
-  }
-}
-
-TEST(pick_address, only_ipv6_enabled)
-{
-  struct ifaddrs one;
-  struct sockaddr_in6 a_one;
-
-  one.ifa_next = NULL;
-  one.ifa_addr = (struct sockaddr*)&a_one;
-  one.ifa_name = eth0;
-
-  ipv6(&a_one, "2001:1234:5678:90ab::cdef");
-
-  CephContext *cct = new CephContext(CEPH_ENTITY_TYPE_OSD);
-  cct->_conf._clear_safe_to_start_threads();  // so we can set configs
-
-  cct->_conf.set_val("public_addr", "");
-  cct->_conf.set_val("public_network", "2001::/16");
-  cct->_conf.set_val("public_network_interface", "");
-  cct->_conf.set_val("cluster_addr", "");
-  cct->_conf.set_val("cluster_network", "");
-  cct->_conf.set_val("cluster_network_interface", "");
-  cct->_conf.set_val("ms_bind_ipv6", "true");
-  cct->_conf.set_val("ms_bind_ipv4", "false");
-
-  entity_addrvec_t av;
-  {
-    int r = pick_addresses(cct,
-			   CEPH_PICK_ADDRESS_PUBLIC |
-			   CEPH_PICK_ADDRESS_MSGR1,
-			   &one, &av);
-    cout << av << std::endl;
-    ASSERT_EQ(0, r);
-    ASSERT_EQ(1u, av.v.size());
-    ASSERT_EQ(string("v1:[2001:1234:5678:90ab::cdef]:0/0"), stringify(av.v[0]));
-  }
-}
-
-TEST(pick_address, only_ipv4_enabled)
-{
-  struct ifaddrs one;
-  struct sockaddr_in a_one;
-
-  one.ifa_next = NULL;
-  one.ifa_addr = (struct sockaddr*)&a_one;
-  one.ifa_name = eth0;
-
-  ipv4(&a_one, "10.1.1.2");
-
-  CephContext *cct = new CephContext(CEPH_ENTITY_TYPE_OSD);
-  cct->_conf._clear_safe_to_start_threads();  // so we can set configs
-
-  cct->_conf.set_val("public_addr", "");
-  cct->_conf.set_val("public_network", "10.1.1.0/24");
-  cct->_conf.set_val("public_network_interface", "");
-  cct->_conf.set_val("cluster_addr", "");
-  cct->_conf.set_val("cluster_network", "");
-  cct->_conf.set_val("cluster_network_interface", "");
-  
-  entity_addrvec_t av;
-  {
-    int r = pick_addresses(cct,
-			   CEPH_PICK_ADDRESS_PUBLIC |
-			   CEPH_PICK_ADDRESS_MSGR1,
-			   &one, &av);
-    cout << av << std::endl;
-    ASSERT_EQ(0, r);
-    ASSERT_EQ(1u, av.v.size());
-    ASSERT_EQ(string("v1:10.1.1.2:0/0"), stringify(av.v[0]));
-  }
-}
-
-TEST(pick_address, ipv4_ipv6_enabled_not_enough_networks)
-{
   struct ifaddrs one;
   struct sockaddr_in a_one;
 
@@ -1072,31 +959,39 @@ TEST(pick_address, ipv4_ipv6_enabled_not_enough_networks)
 			   &one, &av);
     cout << av << std::endl;
     ASSERT_EQ(-1, r);
-    ASSERT_EQ(1u, av.v.size());
-    ASSERT_EQ(string("v2:10.1.1.2:0/0"), stringify(av.v[0]));
   }
 }
 
-TEST(networks_address_family_coverage, just_ipv4)
+TEST(pick_address, ipv4_ipv6_enabled2)
 {
+  struct ifaddrs one;
+  struct sockaddr_in6 a_one;
+
+  one.ifa_next = NULL;
+  one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = eth0;
+
+  ipv6(&a_one, "2001:1234:5678:90ab::cdef");
+
   CephContext *cct = new CephContext(CEPH_ENTITY_TYPE_OSD);
-  std::string networks = "10.0.0.0/24";
-  unsigned r = networks_address_family_coverage(cct, networks);
-  ASSERT_EQ(CEPH_PICK_ADDRESS_IPV4, r);
+  cct->_conf._clear_safe_to_start_threads();  // so we can set configs
+
+  cct->_conf.set_val("public_addr", "");
+  cct->_conf.set_val("public_network", "2001::/16");
+  cct->_conf.set_val("public_network_interface", "");
+  cct->_conf.set_val("cluster_addr", "");
+  cct->_conf.set_val("cluster_network", "");
+  cct->_conf.set_val("cluster_network_interface", "");
+  cct->_conf.set_val("ms_bind_ipv6", "true");
+
+  entity_addrvec_t av;
+  {
+    int r = pick_addresses(cct,
+			   CEPH_PICK_ADDRESS_PUBLIC |
+			   CEPH_PICK_ADDRESS_MSGR1,
+			   &one, &av);
+    cout << av << std::endl;
+    ASSERT_EQ(-1, r);
+  }
 }
 
-TEST(networks_address_family_coverage, just_ipv6)
-{
-  CephContext *cct = new CephContext(CEPH_ENTITY_TYPE_OSD);
-  std::string networks = "2001::/16";
-  unsigned r = networks_address_family_coverage(cct, networks);
-  ASSERT_EQ(CEPH_PICK_ADDRESS_IPV6, r);
-}
-
-TEST(networks_address_family_coverage, ipv6_and_ipv4)
-{
-  CephContext *cct = new CephContext(CEPH_ENTITY_TYPE_OSD);
-  std::string networks = "2001::/16, 10.0.0.0/16";
-  unsigned r = networks_address_family_coverage(cct, networks);
-  ASSERT_EQ(CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6, r);
-}

--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -931,6 +931,119 @@ TEST(pick_address, filtering)
 
 TEST(pick_address, ipv4_ipv6_enabled)
 {
+  struct ifaddrs one, two;
+  struct sockaddr_in a_one;
+  struct sockaddr_in6 a_two;
+
+  one.ifa_next = &two;
+  one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = eth0;
+
+  two.ifa_next = NULL;
+  two.ifa_addr = (struct sockaddr*)&a_two;
+  two.ifa_name = eth0;
+
+  ipv4(&a_one, "10.1.1.2");
+  ipv6(&a_two, "2001:1234:5678:90ab::cdef");
+
+  CephContext *cct = new CephContext(CEPH_ENTITY_TYPE_OSD);
+  cct->_conf._clear_safe_to_start_threads();  // so we can set configs
+
+  cct->_conf.set_val("public_addr", "");
+  cct->_conf.set_val("public_network", "10.1.1.0/24, 2001::/16");
+  cct->_conf.set_val("public_network_interface", "");
+  cct->_conf.set_val("cluster_addr", "");
+  cct->_conf.set_val("cluster_network", "");
+  cct->_conf.set_val("cluster_network_interface", "");
+  cct->_conf.set_val("ms_bind_ipv6", "true");
+
+  entity_addrvec_t av;
+  {
+    int r = pick_addresses(cct,
+			   CEPH_PICK_ADDRESS_PUBLIC |
+			   CEPH_PICK_ADDRESS_MSGR1,
+			   &one, &av);
+    cout << av << std::endl;
+    ASSERT_EQ(0, r);
+    // Got 2 address
+    ASSERT_EQ(2u, av.v.size());
+    ASSERT_EQ(string("v1:[2001:1234:5678:90ab::cdef]:0/0"), stringify(av.v[0]));
+    ASSERT_EQ(string("v1:10.1.1.2:0/0"), stringify(av.v[1]));
+  }
+}
+
+TEST(pick_address, only_ipv6_enabled)
+{
+  struct ifaddrs one;
+  struct sockaddr_in6 a_one;
+
+  one.ifa_next = NULL;
+  one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = eth0;
+
+  ipv6(&a_one, "2001:1234:5678:90ab::cdef");
+
+  CephContext *cct = new CephContext(CEPH_ENTITY_TYPE_OSD);
+  cct->_conf._clear_safe_to_start_threads();  // so we can set configs
+
+  cct->_conf.set_val("public_addr", "");
+  cct->_conf.set_val("public_network", "2001::/16");
+  cct->_conf.set_val("public_network_interface", "");
+  cct->_conf.set_val("cluster_addr", "");
+  cct->_conf.set_val("cluster_network", "");
+  cct->_conf.set_val("cluster_network_interface", "");
+  cct->_conf.set_val("ms_bind_ipv6", "true");
+  cct->_conf.set_val("ms_bind_ipv4", "false");
+
+  entity_addrvec_t av;
+  {
+    int r = pick_addresses(cct,
+			   CEPH_PICK_ADDRESS_PUBLIC |
+			   CEPH_PICK_ADDRESS_MSGR1,
+			   &one, &av);
+    cout << av << std::endl;
+    ASSERT_EQ(0, r);
+    ASSERT_EQ(1u, av.v.size());
+    ASSERT_EQ(string("v1:[2001:1234:5678:90ab::cdef]:0/0"), stringify(av.v[0]));
+  }
+}
+
+TEST(pick_address, only_ipv4_enabled)
+{
+  struct ifaddrs one;
+  struct sockaddr_in a_one;
+
+  one.ifa_next = NULL;
+  one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = eth0;
+
+  ipv4(&a_one, "10.1.1.2");
+
+  CephContext *cct = new CephContext(CEPH_ENTITY_TYPE_OSD);
+  cct->_conf._clear_safe_to_start_threads();  // so we can set configs
+
+  cct->_conf.set_val("public_addr", "");
+  cct->_conf.set_val("public_network", "10.1.1.0/24");
+  cct->_conf.set_val("public_network_interface", "");
+  cct->_conf.set_val("cluster_addr", "");
+  cct->_conf.set_val("cluster_network", "");
+  cct->_conf.set_val("cluster_network_interface", "");
+  
+  entity_addrvec_t av;
+  {
+    int r = pick_addresses(cct,
+			   CEPH_PICK_ADDRESS_PUBLIC |
+			   CEPH_PICK_ADDRESS_MSGR1,
+			   &one, &av);
+    cout << av << std::endl;
+    ASSERT_EQ(0, r);
+    ASSERT_EQ(1u, av.v.size());
+    ASSERT_EQ(string("v1:10.1.1.2:0/0"), stringify(av.v[0]));
+  }
+}
+
+TEST(pick_address, ipv4_ipv6_enabled_not_enough_networks)
+{
   struct ifaddrs one;
   struct sockaddr_in a_one;
 
@@ -959,39 +1072,31 @@ TEST(pick_address, ipv4_ipv6_enabled)
 			   &one, &av);
     cout << av << std::endl;
     ASSERT_EQ(-1, r);
+    ASSERT_EQ(1u, av.v.size());
+    ASSERT_EQ(string("v2:10.1.1.2:0/0"), stringify(av.v[0]));
   }
 }
 
-TEST(pick_address, ipv4_ipv6_enabled2)
+TEST(networks_address_family_coverage, just_ipv4)
 {
-  struct ifaddrs one;
-  struct sockaddr_in6 a_one;
-
-  one.ifa_next = NULL;
-  one.ifa_addr = (struct sockaddr*)&a_one;
-  one.ifa_name = eth0;
-
-  ipv6(&a_one, "2001:1234:5678:90ab::cdef");
-
   CephContext *cct = new CephContext(CEPH_ENTITY_TYPE_OSD);
-  cct->_conf._clear_safe_to_start_threads();  // so we can set configs
-
-  cct->_conf.set_val("public_addr", "");
-  cct->_conf.set_val("public_network", "2001::/16");
-  cct->_conf.set_val("public_network_interface", "");
-  cct->_conf.set_val("cluster_addr", "");
-  cct->_conf.set_val("cluster_network", "");
-  cct->_conf.set_val("cluster_network_interface", "");
-  cct->_conf.set_val("ms_bind_ipv6", "true");
-
-  entity_addrvec_t av;
-  {
-    int r = pick_addresses(cct,
-			   CEPH_PICK_ADDRESS_PUBLIC |
-			   CEPH_PICK_ADDRESS_MSGR1,
-			   &one, &av);
-    cout << av << std::endl;
-    ASSERT_EQ(-1, r);
-  }
+  std::string networks = "10.0.0.0/24";
+  unsigned r = networks_address_family_coverage(cct, networks);
+  ASSERT_EQ(CEPH_PICK_ADDRESS_IPV4, r);
 }
 
+TEST(networks_address_family_coverage, just_ipv6)
+{
+  CephContext *cct = new CephContext(CEPH_ENTITY_TYPE_OSD);
+  std::string networks = "2001::/16";
+  unsigned r = networks_address_family_coverage(cct, networks);
+  ASSERT_EQ(CEPH_PICK_ADDRESS_IPV6, r);
+}
+
+TEST(networks_address_family_coverage, ipv6_and_ipv4)
+{
+  CephContext *cct = new CephContext(CEPH_ENTITY_TYPE_OSD);
+  std::string networks = "2001::/16, 10.0.0.0/16";
+  unsigned r = networks_address_family_coverage(cct, networks);
+  ASSERT_EQ(CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6, r);
+}


### PR DESCRIPTION
backport tracker ticket: https://tracker.ceph.com/issues/50598
backport PR: #40961

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
