### PR TITLE
osd/scrub: remove Scrubber sub-objects reliance on PG::gen_prefix()

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -176,8 +176,6 @@ class PG : public DoutPrefixProvider, public PeeringState::PeeringListener {
   friend struct NamedState;
   friend class PeeringState;
   friend class PgScrubber;
-  friend class Scrub::LocalReservation;  // dout()-only friendship
-  friend class Scrub::ReservedByRemotePrimary;  //  dout()-only friendship
 
 public:
   const pg_shard_t pg_whoami;

--- a/src/osd/scrubber/PrimaryLogScrub.cc
+++ b/src/osd/scrubber/PrimaryLogScrub.cc
@@ -10,16 +10,17 @@
 #include "osd/PrimaryLogPG.h"
 #include "scrub_machine.h"
 
-#define dout_context (m_pg->get_cct())
+#define dout_context (m_osds->cct)
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
-#define dout_prefix _prefix(_dout, this->m_pg)
+#define dout_prefix _prefix(_dout, this)
 
 using std::vector;
 
-template <class T> static ostream& _prefix(std::ostream* _dout, T* t)
+template <class T>
+static ostream& _prefix(std::ostream* _dout, T* t)
 {
-  return t->gen_prefix(*_dout) << " PrimaryLog scrubber pg(" << t->pg_id << ") ";
+  return t->gen_prefix(*_dout);
 }
 
 using namespace Scrub;

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -57,6 +57,8 @@ class ReplicaReservations {
   void send_reject();
 
  public:
+  std::string m_log_msg_prefix;
+
   /**
    *  quietly discard all knowledge about existing reservations. No messages
    *  are sent to peers.
@@ -72,18 +74,19 @@ class ReplicaReservations {
   void handle_reserve_grant(OpRequestRef op, pg_shard_t from);
 
   void handle_reserve_reject(OpRequestRef op, pg_shard_t from);
+
+  std::ostream& gen_prefix(std::ostream& out) const;
 };
 
 /**
  *  wraps the local OSD scrub resource reservation in an RAII wrapper
  */
 class LocalReservation {
-  PG* m_pg;
   OSDService* m_osds;
   bool m_holding_local_reservation{false};
 
  public:
-  LocalReservation(PG* pg, OSDService* osds);
+  LocalReservation(OSDService* osds);
   ~LocalReservation();
   bool is_reserved() const { return m_holding_local_reservation; }
 };
@@ -92,18 +95,21 @@ class LocalReservation {
  *  wraps the OSD resource we are using when reserved as a replica by a scrubbing master.
  */
 class ReservedByRemotePrimary {
+  const PgScrubber* m_scrubber; ///< we will be using its gen_prefix()
   PG* m_pg;
   OSDService* m_osds;
   bool m_reserved_by_remote_primary{false};
   const epoch_t m_reserved_at;
 
  public:
-  ReservedByRemotePrimary(PG* pg, OSDService* osds, epoch_t epoch);
+  ReservedByRemotePrimary(const PgScrubber* scrubber, PG* pg, OSDService* osds, epoch_t epoch);
   ~ReservedByRemotePrimary();
   [[nodiscard]] bool is_reserved() const { return m_reserved_by_remote_primary; }
 
   /// compare the remembered reserved-at epoch to the current interval
   [[nodiscard]] bool is_stale() const;
+
+  std::ostream& gen_prefix(std::ostream& out) const;
 };
 
 /**
@@ -426,6 +432,7 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
   void set_scrub_duration() final;
 
   utime_t scrub_begin_stamp;
+  std::ostream& gen_prefix(std::ostream& out) const final;
 
  protected:
   bool state_test(uint64_t m) const { return m_pg->state_test(m); }

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -41,12 +41,15 @@ void on_event_discard(std::string_view nm)
   dout(20) << " event: --^^^^---- " << nm << dendl;
 }
 
-void ScrubMachine::my_states() const
+std::string ScrubMachine::current_states_desc() const
 {
+  std::string sts{"<"};
   for (auto si = state_begin(); si != state_end(); ++si) {
-    const auto& siw{*si};  // prevents a warning re side-effects
-    dout(20) << " state: " << boost::core::demangle(typeid(siw).name()) << dendl;
+    const auto& siw{ *si };  // prevents a warning re side-effects
+    // the '7' is the size of the 'scrub::'
+    sts += boost::core::demangle(typeid(siw).name()).substr(7, std::string::npos) + "/";
   }
+  return sts + ">";
 }
 
 void ScrubMachine::assert_not_active() const
@@ -69,10 +72,17 @@ bool ScrubMachine::is_accepting_updates() const
 
 // for the rest of the code in this file - we know what PG we are dealing with:
 #undef dout_prefix
-#define dout_prefix _prefix(_dout, this->context<ScrubMachine>().m_pg)
-template <class T> static ostream& _prefix(std::ostream* _dout, T* t)
+#define dout_prefix _prefix(_dout, this->context<ScrubMachine>())
+
+template <class T>
+static ostream& _prefix(std::ostream* _dout, T& t)
 {
-  return t->gen_prefix(*_dout) << " scrubberFSM pg(" << t->pg_id << ") ";
+  return t.gen_prefix(*_dout);
+}
+
+std::ostream& ScrubMachine::gen_prefix(std::ostream& out) const
+{
+  return m_scrbr->gen_prefix(out) << "FSM: ";
 }
 
 // ////////////// the actual actions
@@ -457,9 +467,8 @@ sc::result WaitDigestUpdate::react(const ScrubFinished&)
 }
 
 ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub)
-    : m_pg{pg}, m_pg_id{pg->pg_id}, m_scrbr{pg_scrub}
+    : m_pg_id{pg->pg_id}, m_scrbr{pg_scrub}
 {
-  dout(15) << "ScrubMachine created " << m_pg_id << dendl;
 }
 
 ScrubMachine::~ScrubMachine() = default;

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -124,11 +124,11 @@ class ScrubMachine : public sc::state_machine<ScrubMachine, NotActive> {
   explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub);
   ~ScrubMachine();
 
-  PG* m_pg;  // only used for dout messages
   spg_t m_pg_id;
   ScrubMachineListener* m_scrbr;
+  std::ostream& gen_prefix(std::ostream& out) const;
 
-  void my_states() const;
+  std::string current_states_desc() const;
   void assert_not_active() const;
   [[nodiscard]] bool is_reserving() const;
   [[nodiscard]] bool is_accepting_updates() const;

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -174,4 +174,7 @@ struct ScrubMachineListener {
 
   /// a log/debug interface
   virtual std::string dump_awaited_maps() const = 0;
+
+  /// exposed to be used by the scrub_machine logger
+  virtual std::ostream& gen_prefix(std::ostream& out) const = 0;
 };


### PR DESCRIPTION
Modify the Scrubber's sub-objects to use their own gen_prefix()
functions, instead of using PG::gen_prefix().

Fixes: https://tracker.ceph.com/issues/51843
Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
