### PR TITLE
pacific: osd: log snaptrim message to dout

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4673,7 +4673,7 @@ int PrimaryLogPG::trim_object(
 	ctx->mtime,
 	0)
       );
-    derr << "removing snap head" << dendl;
+    dout(10) << "removing snap head" << dendl;
     object_info_t& oi = head_obc->obs.oi;
     ctx->delta_stats.num_objects--;
     if (oi.is_dirty()) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51840

---

backport of https://github.com/ceph/ceph/pull/42460
parent tracker: https://tracker.ceph.com/issues/51799

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh