### PR TITLE
mgr/volumes/fs/operations/group.py: add extra blank line

### DIFF
--- a/src/pybind/mgr/volumes/fs/operations/group.py
+++ b/src/pybind/mgr/volumes/fs/operations/group.py
@@ -13,6 +13,7 @@ from ..exception import VolumeException
 
 log = logging.getLogger(__name__)
 
+
 class Group(GroupTemplate):
     # Reserved subvolume group name which we use in paths for subvolumes
     # that are not assigned to a group (i.e. created with group=None)
@@ -87,6 +88,7 @@ class Group(GroupTemplate):
                 return []
             raise
 
+
 def create_group(fs, vol_spec, groupname, pool, mode, uid, gid):
     """
     create a subvolume group.
@@ -141,6 +143,7 @@ def create_group(fs, vol_spec, groupname, pool, mode, uid, gid):
             e = VolumeException(-e.args[0], e.args[1])
         raise e
 
+
 def remove_group(fs, vol_spec, groupname):
     """
     remove a subvolume group.
@@ -157,6 +160,7 @@ def remove_group(fs, vol_spec, groupname):
         if e.args[0] == errno.ENOENT:
             raise VolumeException(-errno.ENOENT, "subvolume group '{0}' does not exist".format(groupname))
         raise VolumeException(-e.args[0], e.args[1])
+
 
 @contextmanager
 def open_group(fs, vol_spec, groupname):
@@ -180,6 +184,7 @@ def open_group(fs, vol_spec, groupname):
         else:
             raise VolumeException(-e.args[0], e.args[1])
     yield group
+
 
 @contextmanager
 def open_group_unique(fs, vol_spec, groupname, c_group, c_groupname):


### PR DESCRIPTION
Fixes:https://tracker.ceph.com/issues/51393
Signed-off-by: Akanksha Chaudhari <astroakanksha24@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
