### PR TITLE
common/strtol: replace `const char*` with `std::string_view`

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -150,13 +150,13 @@ int Option::parse_value(
   }
 
   if (type == Option::TYPE_INT) {
-    int64_t f = strict_si_cast<int64_t>(val.c_str(), error_message);
+    int64_t f = strict_si_cast<int64_t>(val, error_message);
     if (!error_message->empty()) {
       return -EINVAL;
     }
     *out = f;
   } else if (type == Option::TYPE_UINT) {
-    uint64_t f = strict_si_cast<uint64_t>(val.c_str(), error_message);
+    uint64_t f = strict_si_cast<uint64_t>(val, error_message);
     if (!error_message->empty()) {
       return -EINVAL;
     }

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -196,7 +196,7 @@ int Option::parse_value(
     }
     *out = uuid;
   } else if (type == Option::TYPE_SIZE) {
-    Option::size_t sz{strict_iecstrtoll(val.c_str(), error_message)};
+    Option::size_t sz{strict_iecstrtoll(val, error_message)};
     if (!error_message->empty()) {
       return -EINVAL;
     }

--- a/src/common/options/rbd.yaml.in
+++ b/src/common/options/rbd.yaml.in
@@ -310,7 +310,7 @@ options:
   max: 32_M
   validator: |
     [](std::string *value, std::string *error_message) {
-      uint64_t f = strict_si_cast<uint64_t>(value->c_str(), error_message);
+      uint64_t f = strict_si_cast<uint64_t>(*value, error_message);
       if (!error_message->empty()) {
         return -EINVAL;
       } else if (!isp2(f)) {

--- a/src/common/strtol.cc
+++ b/src/common/strtol.cc
@@ -307,15 +307,3 @@ uint64_t strict_sistrtoll(const char *str, std::string *err)
 {
   return strict_si_cast<uint64_t>(str, err);
 }
-
-template<typename T>
-T strict_si_cast(const char *str, std::string *err)
-{
-  return strict_si_cast<T>(std::string_view(str), err);
-}
-
-template int strict_si_cast<int>(const char *str, std::string *err);
-template long strict_si_cast<long>(const char *str, std::string *err);
-template long long strict_si_cast<long long>(const char *str, std::string *err);
-template uint64_t strict_si_cast<uint64_t>(const char *str, std::string *err);
-template uint32_t strict_si_cast<uint32_t>(const char *str, std::string *err);

--- a/src/common/strtol.cc
+++ b/src/common/strtol.cc
@@ -282,13 +282,3 @@ template long strict_si_cast<long>(std::string_view str, std::string *err);
 template long long strict_si_cast<long long>(std::string_view str, std::string *err);
 template uint64_t strict_si_cast<uint64_t>(std::string_view str, std::string *err);
 template uint32_t strict_si_cast<uint32_t>(std::string_view str, std::string *err);
-
-uint64_t strict_sistrtoll(std::string_view str, std::string *err)
-{
-  return strict_si_cast<uint64_t>(str, err);
-}
-
-uint64_t strict_sistrtoll(const char *str, std::string *err)
-{
-  return strict_si_cast<uint64_t>(str, err);
-}

--- a/src/common/strtol.cc
+++ b/src/common/strtol.cc
@@ -220,11 +220,6 @@ uint64_t strict_iecstrtoll(std::string_view str, std::string *err)
   return strict_iec_cast<uint64_t>(str, err);
 }
 
-uint64_t strict_iecstrtoll(const char *str, std::string *err)
-{
-  return strict_iec_cast<uint64_t>(str, err);
-}
-
 template<typename T>
 T strict_si_cast(std::string_view str, std::string *err)
 {

--- a/src/common/strtol.cc
+++ b/src/common/strtol.cc
@@ -55,11 +55,6 @@ long long strict_strtoll(std::string_view str, int base, std::string *err)
   return ret;
 }
 
-long long strict_strtoll(const char *str, int base, std::string *err)
-{
-  return strict_strtoll(std::string_view(str), base, err);
-}
-
 int strict_strtol(std::string_view str, int base, std::string *err)
 {
   long long ret = strict_strtoll(str, base, err);
@@ -107,11 +102,6 @@ double strict_strtod(std::string_view str, std::string *err)
   return ret;
 }
 
-double strict_strtod(const char *str, std::string *err)
-{
-  return strict_strtod(std::string_view(str), err);
-}
-
 float strict_strtof(std::string_view str, std::string *err)
 {
   char *endptr;
@@ -138,11 +128,6 @@ float strict_strtof(std::string_view str, std::string *err)
   }
   *err = "";
   return ret;
-}
-
-float strict_strtof(const char *str, std::string *err)
-{
-  return strict_strtof(std::string_view(str), err);
 }
 
 template<typename T>

--- a/src/common/strtol.cc
+++ b/src/common/strtol.cc
@@ -237,20 +237,8 @@ uint64_t strict_iecstrtoll(std::string_view str, std::string *err)
 
 uint64_t strict_iecstrtoll(const char *str, std::string *err)
 {
-  return strict_iec_cast<uint64_t>(std::string_view(str), err);
+  return strict_iec_cast<uint64_t>(str, err);
 }
-
-template<typename T>
-T strict_iec_cast(const char *str, std::string *err)
-{
-  return strict_iec_cast<T>(std::string_view(str), err);
-}
-
-template int strict_iec_cast<int>(const char *str, std::string *err);
-template long strict_iec_cast<long>(const char *str, std::string *err);
-template long long strict_iec_cast<long long>(const char *str, std::string *err);
-template uint64_t strict_iec_cast<uint64_t>(const char *str, std::string *err);
-template uint32_t strict_iec_cast<uint32_t>(const char *str, std::string *err);
 
 template<typename T>
 T strict_si_cast(std::string_view str, std::string *err)

--- a/src/common/strtol.h
+++ b/src/common/strtol.h
@@ -84,8 +84,6 @@ uint64_t strict_iecstrtoll(const char *str, std::string *err);
 template<typename T>
 T strict_iec_cast(std::string_view str, std::string *err);
 
-uint64_t strict_sistrtoll(const char *str, std::string *err);
-
 template<typename T>
 T strict_si_cast(std::string_view str, std::string *err);
 

--- a/src/common/strtol.h
+++ b/src/common/strtol.h
@@ -79,7 +79,7 @@ double strict_strtod(std::string_view str, std::string *err);
 
 float strict_strtof(std::string_view str, std::string *err);
 
-uint64_t strict_iecstrtoll(const char *str, std::string *err);
+uint64_t strict_iecstrtoll(std::string_view str, std::string *err);
 
 template<typename T>
 T strict_iec_cast(std::string_view str, std::string *err);

--- a/src/common/strtol.h
+++ b/src/common/strtol.h
@@ -72,14 +72,12 @@ auto consume(std::string_view& s, int base = 10)
 bool strict_strtob(const char* str, std::string *err);
 
 long long strict_strtoll(std::string_view str, int base, std::string *err);
-long long strict_strtoll(const char *str, int base, std::string *err);
 
 int strict_strtol(std::string_view str, int base, std::string *err);
-int strict_strtol(const char *str, int base, std::string *err);
 
-double strict_strtod(const char *str, std::string *err);
+double strict_strtod(std::string_view str, std::string *err);
 
-float strict_strtof(const char *str, std::string *err);
+float strict_strtof(std::string_view str, std::string *err);
 
 uint64_t strict_iecstrtoll(const char *str, std::string *err);
 

--- a/src/common/strtol.h
+++ b/src/common/strtol.h
@@ -89,7 +89,7 @@ T strict_iec_cast(std::string_view str, std::string *err);
 uint64_t strict_sistrtoll(const char *str, std::string *err);
 
 template<typename T>
-T strict_si_cast(const char *str, std::string *err);
+T strict_si_cast(std::string_view str, std::string *err);
 
 /* On enter buf points to the end of the buffer, e.g. where the least
  * significant digit of the input number will be printed. Returns pointer to

--- a/src/common/strtol.h
+++ b/src/common/strtol.h
@@ -84,7 +84,7 @@ float strict_strtof(const char *str, std::string *err);
 uint64_t strict_iecstrtoll(const char *str, std::string *err);
 
 template<typename T>
-T strict_iec_cast(const char *str, std::string *err);
+T strict_iec_cast(std::string_view str, std::string *err);
 
 uint64_t strict_sistrtoll(const char *str, std::string *err);
 

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -319,14 +319,14 @@ int RocksDBStore::tryInterpret(const string &key, const string &val, rocksdb::Op
 {
   if (key == "compaction_threads") {
     std::string err;
-    int f = strict_iecstrtoll(val.c_str(), &err);
+    int f = strict_iecstrtoll(val, &err);
     if (!err.empty())
       return -EINVAL;
     //Low priority threadpool is used for compaction
     opt.env->SetBackgroundThreads(f, rocksdb::Env::Priority::LOW);
   } else if (key == "flusher_threads") {
     std::string err;
-    int f = strict_iecstrtoll(val.c_str(), &err);
+    int f = strict_iecstrtoll(val, &err);
     if (!err.empty())
       return -EINVAL;
     //High priority threadpool is used for flusher
@@ -960,7 +960,7 @@ int RocksDBStore::verify_sharding(const rocksdb::Options& opt,
       size_t cache_size = cct->_conf->rocksdb_cache_size;
       if (auto it = cache_options_map.find("size"); it !=cache_options_map.end()) {
 	std::string error;
-	cache_size = strict_iecstrtoll(it->second.c_str(), &error);
+	cache_size = strict_iecstrtoll(it->second, &error);
 	if (!error.empty()) {
 	  derr << __func__ << " invalid size: '" << it->second << "'" << dendl;
 	}

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7346,7 +7346,7 @@ int OSDMonitor::normalize_profile(const string& profilename,
   auto it = profile.find("stripe_unit");
   if (it != profile.end()) {
     string err_str;
-    uint32_t stripe_unit = strict_iecstrtoll(it->second.c_str(), &err_str);
+    uint32_t stripe_unit = strict_iecstrtoll(it->second, &err_str);
     if (!err_str.empty()) {
       *ss << "could not parse stripe_unit '" << it->second
 	  << "': " << err_str << std::endl;
@@ -7644,7 +7644,7 @@ int OSDMonitor::prepare_pool_stripe_width(const unsigned pool_type,
       auto it = profile.find("stripe_unit");
       if (it != profile.end()) {
 	string err_str;
-	stripe_unit = strict_iecstrtoll(it->second.c_str(), &err_str);
+	stripe_unit = strict_iecstrtoll(it->second, &err_str);
 	ceph_assert(err_str.empty());
       }
       *stripe_width = data_chunks *
@@ -13435,7 +13435,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     if (field == "max_objects") {
       value = strict_si_cast<uint64_t>(val, &tss);
     } else if (field == "max_bytes") {
-      value = strict_iecstrtoll(val.c_str(), &tss);
+      value = strict_iecstrtoll(val, &tss);
     } else {
       ceph_abort_msg("unrecognized option");
     }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8128,7 +8128,7 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
     "csum_min_block",
   };
   if (count(begin(si_options), end(si_options), var)) {
-    n = strict_si_cast<int64_t>(val.c_str(), &interr);
+    n = strict_si_cast<int64_t>(val, &interr);
   } else if (count(begin(iec_options), end(iec_options), var)) {
     n = strict_iec_cast<int64_t>(val, &interr);
   } else {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8130,7 +8130,7 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
   if (count(begin(si_options), end(si_options), var)) {
     n = strict_si_cast<int64_t>(val.c_str(), &interr);
   } else if (count(begin(iec_options), end(iec_options), var)) {
-    n = strict_iec_cast<int64_t>(val.c_str(), &interr);
+    n = strict_iec_cast<int64_t>(val, &interr);
   } else {
     // parse string as both int and float; different fields use different types.
     n = strict_strtoll(val.c_str(), 10, &interr);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -13433,7 +13433,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     string tss;
     int64_t value;
     if (field == "max_objects") {
-      value = strict_sistrtoll(val.c_str(), &tss);
+      value = strict_si_cast<uint64_t>(val, &tss);
     } else if (field == "max_bytes") {
       value = strict_iecstrtoll(val.c_str(), &tss);
     } else {

--- a/src/os/bluestore/BitmapFreelistManager.cc
+++ b/src/os/bluestore/BitmapFreelistManager.cc
@@ -260,7 +260,7 @@ int BitmapFreelistManager::_read_cfg(
     string val;
     int r = cfg_reader(keys[i], &val);
     if (r == 0) {
-      *(vals[i]) = strict_iecstrtoll(val.c_str(), &err);
+      *(vals[i]) = strict_iecstrtoll(val, &err);
       if (!err.empty()) {
         derr << __func__ << " Failed to parse - "
           << keys[i] << ":" << val

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3322,7 +3322,7 @@ int main(int argc, const char **argv)
         return EINVAL;
       }
     } else if (ceph_argparse_witharg(args, i, &val, "--max-size", (char*)NULL)) {
-      max_size = strict_iec_cast<long long>(val.c_str(), &err);
+      max_size = strict_iec_cast<long long>(val, &err);
       if (!err.empty()) {
         cerr << "ERROR: failed to parse max size: " << err << std::endl;
         return EINVAL;

--- a/src/test/objectstore_bench.cc
+++ b/src/test/objectstore_bench.cc
@@ -47,7 +47,7 @@ struct byte_units {
 
 bool byte_units::parse(const std::string &val, std::string *err)
 {
-  v = strict_iecstrtoll(val.c_str(), err);
+  v = strict_iecstrtoll(val, err);
   return err->empty();
 }
 

--- a/src/test/strtol.cc
+++ b/src/test/strtol.cc
@@ -278,7 +278,7 @@ TEST(StrictIECCast, Error) {
 static void test_strict_sistrtoll(const char *str)
 {
   std::string err;
-  strict_sistrtoll(str, &err);
+  strict_si_cast<uint64_t>(str, &err);
   ASSERT_EQ(err, "");
 }
 
@@ -289,7 +289,7 @@ static void test_strict_sistrtoll_units(const std::string& foo,
   s.append(u);
   const char *str = s.c_str();
   std::string err;
-  uint64_t r = strict_sistrtoll(str, &err);
+  uint64_t r = strict_si_cast<uint64_t>(str, &err);
   ASSERT_EQ(err, "");
 
   str = foo.c_str();
@@ -327,7 +327,7 @@ TEST(SIStrToLL, WithoutUnits) {
 static void test_strict_sistrtoll_err(const char *str)
 {
   std::string err;
-  strict_sistrtoll(str, &err);
+  strict_si_cast<uint64_t>(str, &err);
   ASSERT_NE(err, "");
 }
 

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -147,7 +147,7 @@ void usage()
 template <typename I, typename T>
 static int rados_sistrtoll(I &i, T *val) {
   std::string err;
-  *val = strict_iecstrtoll(i->second.c_str(), &err);
+  *val = strict_iecstrtoll(i->second, &err);
   if (err != "") {
     cerr << "Invalid value for " << i->first << ": " << err << std::endl;
     return -EINVAL;

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -382,7 +382,7 @@ void validate(boost::any& v, const std::vector<std::string>& values,
   const std::string &s = po::validators::get_single_string(values);
 
   std::string parse_error;
-  uint64_t size = strict_iecstrtoll(s.c_str(), &parse_error);
+  uint64_t size = strict_iecstrtoll(s, &parse_error);
   if (!parse_error.empty()) {
     throw po::validation_error(po::validation_error::invalid_option_value);
   }
@@ -416,7 +416,7 @@ void validate(boost::any& v, const std::vector<std::string>& values,
   const std::string &s = po::validators::get_single_string(values);
 
   std::string parse_error;
-  uint64_t objectsize = strict_iecstrtoll(s.c_str(), &parse_error);
+  uint64_t objectsize = strict_iecstrtoll(s, &parse_error);
   if (!parse_error.empty()) {
     throw po::validation_error(po::validation_error::invalid_option_value);
   }
@@ -500,7 +500,7 @@ void validate(boost::any& v, const std::vector<std::string>& values,
   const std::string &s = po::validators::get_single_string(values);
 
   std::string parse_error;
-  uint64_t size = strict_iecstrtoll(s.c_str(), &parse_error);
+  uint64_t size = strict_iecstrtoll(s, &parse_error);
   if (parse_error.empty() && (size >= (1 << 12)) && (size <= (1 << 26))) {
     v = boost::any(size);
     return;
@@ -527,7 +527,7 @@ void validate(boost::any& v, const std::vector<std::string>& values,
   const std::string &s = po::validators::get_single_string(values);
 
   std::string parse_error;
-  uint64_t format = strict_iecstrtoll(s.c_str(), &parse_error);
+  uint64_t format = strict_iecstrtoll(s, &parse_error);
   if (!parse_error.empty() || (format != 1 && format != 2)) {
     throw po::validation_error(po::validation_error::invalid_option_value);
   }

--- a/src/tools/rbd/action/Bench.cc
+++ b/src/tools/rbd/action/Bench.cc
@@ -59,7 +59,7 @@ void validate(boost::any& v, const std::vector<std::string>& values,
   const std::string &s = po::validators::get_single_string(values);
 
   std::string parse_error;
-  uint64_t size = strict_iecstrtoll(s.c_str(), &parse_error);
+  uint64_t size = strict_iecstrtoll(s, &parse_error);
   if (!parse_error.empty()) {
     throw po::validation_error(po::validation_error::invalid_option_value);
   }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
