### PR TITLE
doc: set glance rbd_store_chunk_size same as cinder

### DIFF
--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -209,7 +209,7 @@ Edit ``/etc/glance/glance-api.conf`` and add under the ``[glance_store]`` sectio
     rbd_store_pool = images
     rbd_store_user = glance
     rbd_store_ceph_conf = /etc/ceph/ceph.conf
-    rbd_store_chunk_size = 8
+    rbd_store_chunk_size = 4
 
 For more information about the configuration options available in Glance please refer to the OpenStack Configuration Reference: http://docs.openstack.org/.
 


### PR DESCRIPTION
In case of using copy-on-write cloning of images, `rbd_store_chunk_size` should same in both glance and cinder

Signed-off-by: Seena Fallah <seenafallah@gmail.com>