### PR TITLE
qa/suites/upgrade/pacific-x/stress-split: do not avoid_pacific_features

### DIFF
--- a/qa/suites/upgrade/pacific-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/pacific-x/stress-split/1-start.yaml
@@ -11,9 +11,6 @@ tasks:
         #set config option for which cls modules are allowed to be loaded / used
         osd_class_load_list: "*"
         osd_class_default_list: "*"
-    # deploy additional mons the "old" (pacific) way
-    add_mons_via_daemon_add: true
-    avoid_pacific_features: true
 
 - cephadm.shell:
     mon.a:


### PR DESCRIPTION
We can use pacific features when installing pacific.

Otherwise, we end up with the default keyring rule for client.admin,
which uses mode 0600, which makes teuthology jobs fail.

Signed-off-by: Sage Weil <sage@newdream.net>