### PR TITLE
pacific: ceph-volume/tests: update ansible environment variables in tox

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -51,7 +51,7 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/tests/functional/setup.yml
 
   # test cluster state using testinfra
-  py.test -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
+  py.test --reruns 5 --reruns-delay 10 -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
 
   # reboot all vms - attempt
   bash {toxinidir}/../scripts/vagrant_reload.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
@@ -60,13 +60,13 @@ commands=
   sleep 30
 
   # retest to ensure cluster came back up correctly after rebooting
-  py.test -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
+  py.test --reruns 5 --reruns-delay 10 -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
 
   # destroy an OSD, zap it's device and recreate it using it's ID
   ansible-playbook -vv -i {changedir}/hosts {changedir}/test.yml
 
   # retest to ensure cluster came back up correctly
-  py.test -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
+  py.test --reruns 5 --reruns-delay 10 -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
 
   # test zap OSDs by ID
   ansible-playbook -vv -i {changedir}/hosts {changedir}/test_zap.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -12,11 +12,9 @@ whitelist_externals =
     sleep
 passenv=*
 setenv=
+  ANSIBLE_CONFIG = {envdir}/tmp/ceph-ansible/ansible.cfg
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
-  ANSIBLE_ACTION_PLUGINS = {envdir}/tmp/ceph-ansible/plugins/actions
   ANSIBLE_STDOUT_CALLBACK = debug
-  ANSIBLE_RETRY_FILES_ENABLED = False
-  ANSIBLE_SSH_RETRIES = 5
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
   DEBIAN_FRONTEND=noninteractive

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -12,7 +12,7 @@ whitelist_externals =
     sleep
 passenv=*
 setenv=
-  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
   ANSIBLE_ACTION_PLUGINS = {envdir}/tmp/ceph-ansible/plugins/actions
   ANSIBLE_STDOUT_CALLBACK = debug
   ANSIBLE_RETRY_FILES_ENABLED = False

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -51,7 +51,7 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/tests/functional/setup.yml
 
   # test cluster state using testinfra
-  py.test -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
+  py.test --reruns 5 --reruns-delay 10 -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
 
   # reboot all vms - attempt
   bash {toxinidir}/../scripts/vagrant_reload.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
@@ -60,12 +60,12 @@ commands=
   sleep 30
 
   # retest to ensure cluster came back up correctly after rebooting
-  py.test -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
+  py.test --reruns 5 --reruns-delay 10 -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
 
   # destroy an OSD, zap it's device and recreate it using it's ID
   ansible-playbook -vv -i {changedir}/hosts {changedir}/test.yml
 
   # retest to ensure cluster came back up correctly
-  py.test -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
+  py.test --reruns 5 --reruns-delay 10 -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
 
   vagrant destroy {env:VAGRANT_DESTROY_FLAGS:"--force"}

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -12,11 +12,9 @@ whitelist_externals =
     sleep
 passenv=*
 setenv=
+  ANSIBLE_CONFIG = {envdir}/tmp/ceph-ansible/ansible.cfg
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
-  ANSIBLE_ACTION_PLUGINS = {envdir}/tmp/ceph-ansible/plugins/actions
   ANSIBLE_STDOUT_CALLBACK = debug
-  ANSIBLE_RETRY_FILES_ENABLED = False
-  ANSIBLE_SSH_RETRIES = 5
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
   DEBIAN_FRONTEND=noninteractive

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -12,7 +12,7 @@ whitelist_externals =
     sleep
 passenv=*
 setenv=
-  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
   ANSIBLE_ACTION_PLUGINS = {envdir}/tmp/ceph-ansible/plugins/actions
   ANSIBLE_STDOUT_CALLBACK = debug
   ANSIBLE_RETRY_FILES_ENABLED = False

--- a/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
@@ -75,8 +75,8 @@
     - name: install required packages for fedora > 23
       raw: sudo dnf -y install python2-dnf libselinux-python ntp
       when:
-        - ansible_distribution == 'Fedora'
-        - ansible_distribution_major_version|int >= 23
+        - ansible_facts['distribution'] == 'Fedora'
+        - ansible_facts['distribution_major_version']|int >= 23
 
     - name: check if it is atomic host
       stat:
@@ -120,7 +120,7 @@
         dest: "/usr/lib/python3.6/site-packages"
         use_ssh_args: true
       when:
-        - ansible_os_family == "RedHat"
+        - ansible_facts['os_family'] == "RedHat"
         - inventory_hostname in groups.get(osd_group_name, [])
 
     - name: rsync ceph-volume to test nodes on ubuntu
@@ -129,7 +129,7 @@
         dest: "/usr/lib/python2.7/dist-packages"
         use_ssh_args: true
       when:
-        - ansible_os_family == "Debian"
+        - ansible_facts['os_family'] == "Debian"
         - inventory_hostname in groups.get(osd_group_name, [])
 
     - name: run ceph-config role

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -12,7 +12,7 @@ whitelist_externals =
     cp
 passenv=*
 setenv=
-  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
   ANSIBLE_ACTION_PLUGINS = {envdir}/tmp/ceph-ansible/plugins/actions
   ANSIBLE_STDOUT_CALLBACK = debug
   ANSIBLE_RETRY_FILES_ENABLED = False

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -41,7 +41,7 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/tests/functional/setup.yml
 
   # test cluster state testinfra
-  py.test -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
+  py.test --reruns 5 --reruns-delay 10 -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
 
   # make ceph-volume simple take over all the OSDs that got deployed, disabling ceph-disk
   ansible-playbook -vv -i {changedir}/hosts {changedir}/test.yml
@@ -53,6 +53,6 @@ commands=
   sleep 120
 
   # retest to ensure cluster came back up correctly after rebooting
-  py.test -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
+  py.test --reruns 5 --reruns-delay 10 -n 4 --sudo -v --connection=ansible --ssh-config={changedir}/vagrant_ssh_config --ansible-inventory={changedir}/hosts {toxinidir}/../tests
 
   vagrant destroy {env:VAGRANT_DESTROY_FLAGS:"--force"}

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -12,11 +12,9 @@ whitelist_externals =
     cp
 passenv=*
 setenv=
+  ANSIBLE_CONFIG = {envdir}/tmp/ceph-ansible/ansible.cfg
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
-  ANSIBLE_ACTION_PLUGINS = {envdir}/tmp/ceph-ansible/plugins/actions
   ANSIBLE_STDOUT_CALLBACK = debug
-  ANSIBLE_RETRY_FILES_ENABLED = False
-  ANSIBLE_SSH_RETRIES = 5
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
   DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51851

---

backport of https://github.com/ceph/ceph/pull/42443
parent tracker: https://tracker.ceph.com/issues/51849

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh