### PR TITLE
doc/rados: rewrite index.rst

### DIFF
--- a/doc/rados/index.rst
+++ b/doc/rados/index.rst
@@ -4,11 +4,15 @@
 
 The :term:`Ceph Storage Cluster` is the foundation for all Ceph deployments.
 Based upon :abbr:`RADOS (Reliable Autonomic Distributed Object Store)`, Ceph
-Storage Clusters consist of two types of daemons: a :term:`Ceph OSD Daemon`
-(OSD) stores data as objects on a storage node; and a :term:`Ceph Monitor` (MON)
-maintains a master copy of the cluster map. A Ceph Storage Cluster may contain
-thousands of storage nodes. A minimal system will have at least one 
-Ceph Monitor and two Ceph OSD Daemons for data replication. 
+Storage Clusters consist of several types of daemons: 
+
+  1. a :term:`Ceph OSD Daemon` (OSD) stores data as objects on a storage node
+  2. a :term:`Ceph Monitor` (MON) maintains a master copy of the cluster map. 
+  3. a :term:`Ceph Manager`  manager daemon
+       
+A Ceph Storage Cluster might contain thousands of storage nodes. A
+minimal system has at least one Ceph Monitor and two Ceph OSD
+Daemons for data replication. 
 
 The Ceph File System, Ceph Object Storage and Ceph Block Devices read data from
 and write data to the Ceph Storage Cluster.


### PR DESCRIPTION
This PR makes minor alterations to the
text at the beginning of the RADOS Guide.

Most notably, the monitor daemon has been
added to the list of types of daemons that
constitute a Ceph cluster.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
