### PR TITLE
rgw:If the endpoint of the event notification does not respond, the process will be stuck.

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -632,6 +632,7 @@ int RGWHTTPClient::init_request(rgw_http_req_data *_req_data)
   }
   curl_easy_setopt(easy_handle, CURLOPT_PRIVATE, (void *)req_data);
   curl_easy_setopt(easy_handle, CURLOPT_TIMEOUT, req_timeout);
+  curl_easy_setopt(easy_handle, CURLOPT_CONNECTTIMEOUT, req_connect_timeout);
 
   return 0;
 }
@@ -1047,7 +1048,7 @@ void RGWHTTPManager::manage_pending_requests()
 int RGWHTTPManager::add_request(RGWHTTPClient *client)
 {
   rgw_http_req_data *req_data = new rgw_http_req_data;
-
+  client->set_req_connect_timeout(3);
   int ret = client->init_request(req_data);
   if (ret < 0) {
     req_data->put();

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -65,6 +65,8 @@ protected:
 
   long  req_timeout{0L};
 
+  long  req_connect_timeout{0L};
+
   void init();
 
   RGWHTTPManager *get_manager();
@@ -149,6 +151,12 @@ public:
   // zero (default) mean that request will never timeout
   void set_req_timeout(long timeout) {
     req_timeout = timeout;
+  }
+
+  // set connect timeout in seconds
+  // zero (default) mean that request will never timeout
+  void set_req_connect_timeout(long connect_timeout) {
+    req_connect_timeout = connect_timeout;
   }
 
   int process(optional_yield y);


### PR DESCRIPTION
rgw:If the endpoint of the event notification does not respond, the process will be stuck.

We use the function of uploading objects and set an event notification for the bucket. However, due to the wrong endpoint setting, the file cannot be uploaded and is stuck all the time without reporting an error.
So we added the CURLOPT_CONNECTTIMEOUT parameter to control the connection timeout.

fix: https://tracker.ceph.com/issues/51855

Signed-off-by: wangyingbin <ybwang0211@163.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
