### PR TITLE
octopus: qa/workunits/mon/test_mon_config_key: use subprocess.run() instead of proc.communicate()

### DIFF
--- a/qa/workunits/mon/test_mon_config_key.py
+++ b/qa/workunits/mon/test_mon_config_key.py
@@ -78,38 +78,18 @@ def run_cmd(cmd, expects=0):
     cmdlog = LOG.getChild('run_cmd')
     cmdlog.debug('{fc}'.format(fc=' '.join(full_cmd)))
 
-    proc = subprocess.Popen(full_cmd,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-
-    stdout = []
-    stderr = []
-    while True:
-        try:
-            out, err = proc.communicate()
-            if out is not None:
-                stdout += out.decode().split('\n')
-                cmdlog.debug('stdout: {s}'.format(s=out))
-            if err is not None:
-                stdout += err.decode().split('\n')
-                cmdlog.debug('stderr: {s}'.format(s=err))
-        except ValueError:
-            ret = proc.wait()
-            break
-
-    if ret != expects:
-        cmdlog.error('cmd > {cmd}'.format(cmd=full_cmd))
-        cmdlog.error("expected return '{expected}' got '{got}'".format(
-            expected=expects, got=ret))
+    proc = subprocess.run(full_cmd,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+                          universal_newlines=True)
+    if proc.returncode != expects:
+        cmdlog.error(f'cmd > {proc.args}')
+        cmdlog.error(f'expected return "{expects}" got "{proc.returncode}"')
         cmdlog.error('stdout')
-        for i in stdout:
-            cmdlog.error('{x}'.format(x=i))
+        cmdlog.error(proc.stdout)
         cmdlog.error('stderr')
-        for i in stderr:
-            cmdlog.error('{x}'.format(x=i))
+        cmdlog.error(proc.stderr)
 
-
-# end run_cmd
 
 def gen_data(size, rnd):
     chars = string.ascii_letters + string.digits


### PR DESCRIPTION
… proc.communicate()

the loop of proc.communicate() on python3.6, where we always are able to
get something out of stdout and/or stderr PIPEs. and the `stdout` and
`stderr` keep growing until out of memory. and teuthology considers
the command crashed after a while.

Fixes: https://tracker.ceph.com/issues/50393
Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit f2e0770c276e6fffa01a0bcb2d969f02ee1aafef)

ceph-backport.sh: Parent issue: https://tracker.ceph.com/issues/50393
ceph-backport.sh: Parent issue ostensibly fixed by: https://github.com/ceph/ceph/pull/40881

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
