### PR TITLE
rgw/notification: assigning the value of zonegroup to awsRegion

### DIFF
--- a/src/rgw/rgw_notify.cc
+++ b/src/rgw/rgw_notify.cc
@@ -689,6 +689,7 @@ void populate_event_from_request(const reservation_t& res,
   event.object_size = size;
   event.object_etag = etag;
   event.object_versionId = version;
+  event.awsRegion = res.store->get_zone()->get_zonegroup().api_name;
   // use timestamp as per key sequence id (hex encoded)
   const utime_t ts(real_clock::now());
   boost::algorithm::hex((const char*)&ts, (const char*)&ts + sizeof(utime_t), 

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -827,6 +827,7 @@ def test_ps_s3_notification_filter_on_master():
     for event in receiver.get_and_reset_events():
         notif_id = event['Records'][0]['s3']['configurationId']
         key_name = event['Records'][0]['s3']['object']['key']
+        awsRegion = event['Records'][0]['awsRegion']
         if notif_id == notification_name+'_1':
             found_in1.append(key_name)
         elif notif_id == notification_name+'_2':
@@ -841,6 +842,7 @@ def test_ps_s3_notification_filter_on_master():
     assert_equal(set(found_in1), set(expected_in1))
     assert_equal(set(found_in2), set(expected_in2))
     assert_equal(set(found_in3), set(expected_in3))
+    assert_equal(awsRegion, zonegroup)
     if not skip_notif4:
         assert_equal(set(found_in4), set(expected_in4))
 


### PR DESCRIPTION
rgw/notification: assigning the value of zonegroup to awsRegion

Fixes: https://tracker.ceph.com/issues/46169

Signed-off-by: Arjun Sharma <arjsharm@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
