### PR TITLE
compression/snappy: use uint32_t to be compatible with 1.1.9

### DIFF
--- a/src/compressor/snappy/SnappyCompressor.h
+++ b/src/compressor/snappy/SnappyCompressor.h
@@ -97,7 +97,11 @@ class SnappyCompressor : public Compressor {
     if (qat_enabled)
       return qat_accel.decompress(p, compressed_len, dst, compressor_message);
 #endif
+#if SNAPPY_VERSION <= 0x10108
     snappy::uint32 res_len = 0;
+#else
+    uint32_t res_len = 0;
+#endif
     BufferlistSource source_1(p, compressed_len);
     if (!snappy::GetUncompressedLength(&source_1, &res_len)) {
       return -1;


### PR DESCRIPTION
The snappy project made the following change in snappy.h between version 1.1.8
and 1.1.9:

```
<   bool GetUncompressedLength(Source* source, uint32_t* result);
---
>   bool GetUncompressedLength(Source* source, uint32* result);
```

This causes Ceph to FTBFS with snappy 1.1.9.

Thanks to Chris Denice for bringing this to our attention via Redmine.

Fixes: https://tracker.ceph.com/issues/50934
Signed-off-by: Nathan Cutler <ncutler@suse.com>