### PR TITLE
octopus: rpm: drop use of $FIRST_ARG in ceph-immutable-object-cache

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1885,9 +1885,8 @@ fi
 %endif
 
 %postun immutable-object-cache
-test -n "$FIRST_ARG" || FIRST_ARG=$1
 %systemd_postun ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target
-if [ $FIRST_ARG -ge 1 ] ; then
+if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
   SYSCONF_CEPH=%{_sysconfdir}/sysconfig/ceph


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51837

---

backport of https://github.com/ceph/ceph/pull/42452
parent tracker: https://tracker.ceph.com/issues/51797

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh