### PR TITLE
 crimson/osd: fix misdirecting msgs when an OSD flips at Sepia. 

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -114,13 +114,13 @@ seastar::future<> make_keyring()
 
 uint64_t get_nonce()
 {
-  if (auto pid = getpid(); pid != 1) {
-    return pid;
-  } else {
+  if (auto pid = getpid(); pid == 1 || std::getenv("CEPH_USE_RANDOM_NONCE")) {
     // we're running in a container; use a random number instead!
     std::random_device rd;
     std::default_random_engine rng{rd()};
     return std::uniform_int_distribution<uint64_t>{}(rng);
+  } else {
+    return pid;
   }
 }
 

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -112,7 +112,7 @@ seastar::future<> make_keyring()
   });
 }
 
-uint64_t get_nonce()
+static uint64_t get_nonce()
 {
   if (auto pid = getpid(); pid == 1 || std::getenv("CEPH_USE_RANDOM_NONCE")) {
     // we're running in a container; use a random number instead!

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -110,6 +110,7 @@ OSD::OSD(int id, uint32_t nonce,
                     __func__, cpp_strerror(r));
     }
   }
+  logger().info("{}: nonce is {}", __func__, nonce);
 }
 
 OSD::~OSD() = default;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
