### PR TITLE
mgr/dashboard: backend unit tests: decouple from build dir

### DIFF
--- a/src/pybind/mgr/dashboard/__init__.py
+++ b/src/pybind/mgr/dashboard/__init__.py
@@ -37,9 +37,6 @@ else:
     import logging
     logging.basicConfig(level=logging.DEBUG)
     logging.root.handlers[0].setLevel(logging.DEBUG)
-    build_dir = os.path.abspath('../../../../build')
-    os.environ['PATH'] = '{}:{}'.format(os.path.join(build_dir, 'bin'),
-                                        os.environ['PATH'])
     import sys
 
     # Used to allow the running of a tox-based yml doc generator from the dashboard directory
@@ -49,10 +46,9 @@ else:
     from tests import mock  # type: ignore
 
     mgr = mock.Mock()
-    mgr.get_frontend_path.side_effect = \
-        lambda: os.path.join(build_dir,
-                             'src/pybind/mgr/dashboard',
-                             'frontend/dist')
+    mgr.get_frontend_path.return_value = os.path.abspath(os.path.join(
+        os.path.dirname(__file__),
+        'frontend/dist'))
 
 # DO NOT REMOVE: required for ceph-mgr to load a module
 from .module import Module, StandbyModule  # noqa: F401


### PR DESCRIPTION
After https://github.com/ceph/ceph/pull/42255 some unit tests got coupled
to the frontend folder of the build dir.
Backend unit tests do not need a build folder: they only test our business logic.

Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
