### PR TITLE
win32_deps_build.sh: bump snappy version to 1.1.9

### DIFF
--- a/src/compressor/snappy/SnappyCompressor.h
+++ b/src/compressor/snappy/SnappyCompressor.h
@@ -97,8 +97,8 @@ class SnappyCompressor : public Compressor {
     if (qat_enabled)
       return qat_accel.decompress(p, compressed_len, dst, compressor_message);
 #endif
-    snappy::uint32 res_len = 0;
     BufferlistSource source_1(p, compressed_len);
+    uint32_t res_len = 0;
     if (!snappy::GetUncompressedLength(&source_1, &res_len)) {
       return -1;
     }

--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -105,8 +105,8 @@ _make BINARY_PATH=$zlibDir \
 echo "Building lz4."
 cd $depsToolsetDir
 if [[ ! -d $lz4Dir ]]; then
-    git clone https://github.com/lz4/lz4
-    cd $lz4Dir; git checkout $lz4Tag
+    git clone --branch $lz4Tag --depth 1 https://github.com/lz4/lz4
+    cd $lz4Dir
 fi
 cd $lz4Dir
 _make BUILD_STATIC=no CC=${MINGW_CC%-posix*} \
@@ -117,8 +117,8 @@ _make BUILD_STATIC=no CC=${MINGW_CC%-posix*} \
 echo "Building OpenSSL."
 cd $depsSrcDir
 if [[ ! -d $sslSrcDir ]]; then
-    git clone https://github.com/openssl/openssl
-    cd $sslSrcDir; git checkout $sslTag
+    git clone --branch $sslTag --depth 1 https://github.com/openssl/openssl
+    cd $sslSrcDir
 fi
 cd $sslSrcDir
 mkdir -p $sslDir
@@ -131,8 +131,8 @@ _make install
 echo "Building libcurl."
 cd $depsSrcDir
 if [[ ! -d $curlSrcDir ]]; then
-    git clone https://github.com/curl/curl
-    cd $curlSrcDir && git checkout $curlTag
+    git clone --branch $curlTag --depth 1 https://github.com/curl/curl
+    cd $curlSrcDir
 fi
 cd $curlSrcDir
 ./buildconf
@@ -223,8 +223,8 @@ _make install
 echo "Building snappy."
 cd $depsSrcDir
 if [[ ! -d $snappySrcDir ]]; then
-    git clone https://github.com/google/snappy
-    cd $snappySrcDir && git checkout $snappyTag
+    git clone --branch $snappyTag --depth 1 https://github.com/google/snappy
+    cd $snappySrcDir
 fi
 mkdir -p $snappySrcDir/build
 cd $snappySrcDir/build

--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -33,7 +33,7 @@ backtraceDir="${depsToolsetDir}/libbacktrace"
 backtraceSrcDir="${depsSrcDir}/libbacktrace"
 snappySrcDir="${depsSrcDir}/snappy"
 snappyDir="${depsToolsetDir}/snappy"
-snappyTag="1.1.7"
+snappyTag="1.1.9"
 # Additional Windows libraries, which aren't provided by Mingw
 winLibDir="${depsToolsetDir}/windows/lib"
 
@@ -233,6 +233,7 @@ cmake -DCMAKE_INSTALL_PREFIX=$snappyDir \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=ON \
       -DSNAPPY_BUILD_TESTS=OFF \
+      -DSNAPPY_BUILD_BENCHMARKS=OFF \
       -DCMAKE_TOOLCHAIN_FILE=$MINGW_CMAKE_FILE \
       ../
 _make


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50934