### PR TITLE
cephfs: implement snapdiff via fake .snap subfolder [RFC]

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9980,14 +9980,19 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl)
     len = in->size - off;    
   }
 
+  auto snapid = in->snapid;
+  if (snapid < CEPH_MAXSNAP && CEPH_IS_SNAPDIFF(snapid)) {
+    snapid = snapid & CEPH_SNAPDIFF_ID_MASK;
+  }
   ldout(cct, 10) << " min_bytes=" << f->readahead.get_min_readahead_size()
                  << " max_bytes=" << f->readahead.get_max_readahead_size()
-                 << " max_periods=" << conf->client_readahead_max_periods << dendl;
+                 << " max_periods=" << conf->client_readahead_max_periods
+                 << " snapid=" << snapid << dendl;
 
   // read (and possibly block)
   int r = 0;
   C_SaferCond onfinish("Client::_read_async flock");
-  r = objectcacher->file_read(&in->oset, &in->layout, in->snapid,
+  r = objectcacher->file_read(&in->oset, &in->layout, snapid,
 			      off, len, bl, 0, &onfinish);
   if (r == 0) {
     get_cap_ref(in, CEPH_CAP_FILE_CACHE);
@@ -10003,7 +10008,7 @@ int Client::_read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl)
       ldout(cct, 20) << "readahead " << readahead_extent.first << "~" << readahead_extent.second
 		     << " (caller wants " << off << "~" << len << ")" << dendl;
       Context *onfinish2 = new C_Readahead(this, f);
-      int r2 = objectcacher->file_read(&in->oset, &in->layout, in->snapid,
+      int r2 = objectcacher->file_read(&in->oset, &in->layout, snapid,
 				       readahead_extent.first, readahead_extent.second,
 				       NULL, 0, onfinish2);
       if (r2 == 0) {

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -474,6 +474,7 @@ int ceph_flags_sys2wire(int flags);
 #define CEPH_READDIR_FRAG_COMPLETE	(1<<8)
 #define CEPH_READDIR_HASH_ORDER		(1<<9)
 #define CEPH_READDIR_OFFSET_HASH       (1<<10)
+#define CEPH_READDIR_SNAPDIFF          (1<<11)
 
 /* Note that this is embedded wthin ceph_mds_request_head_legacy. */
 union ceph_mds_request_args_legacy {

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -38,6 +38,10 @@ typedef __le64 ceph_snapid_t;
 #define CEPH_SNAPDIR ((__u64)(-1))  /* reserved for hidden .snap dir */
 #define CEPH_NOSNAP  ((__u64)(-2))  /* "head", "live" revision */
 #define CEPH_MAXSNAP ((__u64)(-3))  /* largest valid snapid */
+#define CEPH_SNAPDIFF_ID_BITS 32    /*single snapdiff snapid significant bits*/
+#define CEPH_SNAPDIFF_ID_MASK ((1ull << CEPH_SNAPDIFF_ID_BITS) - 1)
+
+#define CEPH_IS_SNAPDIFF(snapid) (!!(snapid & CEPH_SNAPDIFF_ID_MASK))
 
 struct ceph_timespec {
 	__le32 tv_sec;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8226,20 +8226,49 @@ int MDCache::path_traverse(MDRequestRef& mdr, MDSContextFactory& cf,
       if (!mdr)
 	return -CEPHFS_EINVAL;
       SnapRealm *realm = cur->find_snaprealm();
-      snapid = realm->resolve_snapname(path[depth], cur->ino());
-      dout(10) << "traverse: snap " << path[depth] << " -> " << snapid << dendl;
-      if (!snapid) {
+      auto [snapid_new, is_diff, snapid_diff_other] =
+	realm->resolve_snapname(path[depth], cur->ino());
+      dout(10) << "traverse: snap " << path[depth] << " -> "
+	       << snapid_new << ", " << is_diff << ", " << snapid_diff_other
+	       << dendl;
+      if (snapid_new == CEPH_NOSNAP || (is_diff && snapid_diff_other == CEPH_NOSNAP)) {
 	if (pdnvec)
 	  pdnvec->clear();   // do not confuse likes of rdlock_path_pin_ref();
 	return -CEPHFS_ENOENT;
       }
-      mdr->snapid = snapid;
+
+      if (snapid_new) {
+	mdr->snapid = snapid_new;
+	if (is_diff) {
+	  mdr->snapid_diff_other = snapid_diff_other;
+	  if (mdr->snapid < mdr->snapid_diff_other) {
+	    std::swap(mdr->snapid, mdr->snapid_diff_other);
+	  }
+	  mdr->is_snapid_diff = is_diff;
+	  mdr->removed_snapid_diff_level = 0;
+	}
+      }
+      snapid = mdr->snapid;
       depth++;
       continue;
     }
+    string_view p = path[depth];
+    if (mdr->is_snapid_diff) {
+      dout(15) << "traverse diff: " << p << " " << mdr->removed_snapid_diff_level
+               << " " << std::hex << mdr->snapid
+               << " " << mdr->snapid_diff_other
+               << std::dec << dendl;
+      if (path[depth][0] == SNAPDIFF_RM_INDICATOR) {
+	p.remove_prefix(1);
+	if (!mdr->removed_snapid_diff_level) {
+	  snapid = mdr->snapid_diff_other;
+	}
+	++mdr->removed_snapid_diff_level;
+      }
+    }
 
     // open dir
-    frag_t fg = cur->pick_dirfrag(path[depth]);
+    frag_t fg = cur->pick_dirfrag(p);
     CDir *curdir = cur->get_dirfrag(fg);
     if (!curdir) {
       if (cur->is_auth()) {
@@ -8293,14 +8322,14 @@ int MDCache::path_traverse(MDRequestRef& mdr, MDSContextFactory& cf,
 
     // Before doing dirfrag->dn lookup, compare with DamageTable's
     // record of which dentries were unreadable
-    if (mds->damage_table.is_dentry_damaged(curdir, path[depth], snapid)) {
+    if (mds->damage_table.is_dentry_damaged(curdir, p, snapid)) {
       dout(4) << "traverse: stopped lookup at damaged dentry "
-              << *curdir << "/" << path[depth] << " snap=" << snapid << dendl;
+              << *curdir << "/" << p << " snap=" << snapid << dendl;
       return -CEPHFS_EIO;
     }
 
     // dentry
-    CDentry *dn = curdir->lookup(path[depth], snapid);
+    CDentry *dn = curdir->lookup(p, snapid);
     if (dn) {
       if (dn->state_test(CDentry::STATE_PURGING))
 	return -CEPHFS_ENOENT;
@@ -8400,14 +8429,14 @@ int MDCache::path_traverse(MDRequestRef& mdr, MDSContextFactory& cf,
     ceph_assert(!dn);
 
     // MISS.  dentry doesn't exist.
-    dout(12) << "traverse: miss on dentry " << path[depth] << " in " << *curdir << dendl;
+    dout(12) << "traverse: miss on dentry " << p << " in " << *curdir << dendl;
 
     if (curdir->is_auth()) {
       // dentry is mine.
       if (curdir->is_complete() ||
 	  (snapid == CEPH_NOSNAP &&
 	   curdir->has_bloom() &&
-	   !curdir->is_in_bloom(path[depth]))) {
+	   !curdir->is_in_bloom(p))) {
         // file not found
 	if (pdnvec) {
 	  // instantiate a null dn?
@@ -8421,7 +8450,7 @@ int MDCache::path_traverse(MDRequestRef& mdr, MDSContextFactory& cf,
 	    return 1;
 	  } else {
 	    // create a null dentry
-	    dn = curdir->add_null_dentry(path[depth]);
+	    dn = curdir->add_null_dentry(p);
 	    dout(20) << " added null " << *dn << dendl;
 
 	    if (rdlock_path) {
@@ -8468,7 +8497,7 @@ int MDCache::path_traverse(MDRequestRef& mdr, MDSContextFactory& cf,
 	// directory isn't complete; reload
         dout(7) << "traverse: incomplete dir contents for " << *cur << ", fetching" << dendl;
         touch_inode(cur);
-        curdir->fetch(cf.build(), path[depth]);
+        curdir->fetch(cf.build(), p);
 	if (mds->logger) mds->logger->inc(l_mds_traverse_dir_fetch);
         return 1;
       }
@@ -8486,7 +8515,7 @@ int MDCache::path_traverse(MDRequestRef& mdr, MDSContextFactory& cf,
       }
 
       if ((discover)) {
-	dout(7) << "traverse: discover from " << path[depth] << " from " << *curdir << dendl;
+	dout(7) << "traverse: discover from " << p << " from " << *curdir << dendl;
 	discover_path(curdir, snapid, path.postfixpath(depth), cf.build(),
 		      path_locked);
 	if (mds->logger) mds->logger->inc(l_mds_traverse_discover);
@@ -8530,9 +8559,7 @@ int MDCache::path_traverse(MDRequestRef& mdr, MDSContextFactory& cf,
   
   // success.
   if (mds->logger) mds->logger->inc(l_mds_traverse_hit);
-  dout(10) << "path_traverse finish on snapid " << snapid << dendl;
-  if (mdr) 
-    ceph_assert(mdr->snapid == snapid);
+  dout(10) << "path_traverse finish on " << *cur << " snapid " << snapid << dendl;
 
   if (flags & MDS_TRAVERSE_RDLOCK_SNAP)
     mdr->locking_state |= MutationImpl::SNAP_LOCKED;

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -442,6 +442,29 @@ int MDRequestImpl::compare_paths()
   return 0;
 }
 
+snapid_t MDRequestImpl::get_effective_snapid_diff(snapid_t s1,
+                                                  snapid_t s2,
+                                                  bool is_removed)
+{
+  if (((s1 > s2) && !is_removed) ||
+      ((s1 < s2) && is_removed)) {
+    std::swap(s1, s2);
+  }
+  snapid_t res = (s1 & CEPH_SNAPDIFF_ID_MASK) << CEPH_SNAPDIFF_ID_BITS;
+  res = res | (s2 & CEPH_SNAPDIFF_ID_MASK);
+  return res;
+}
+
+snapid_t MDRequestImpl::get_effective_snapid_diff(size_t remove_lvl) const
+{
+  snapid_t res = is_snapid_diff ?
+    get_effective_snapid_diff(snapid_diff_other,
+                              snapid,
+                              removed_snapid_diff_level >= remove_lvl) :
+    snapid;
+  return res;
+}
+
 cref_t<MClientRequest> MDRequestImpl::release_client_request()
 {
   msg_lock.lock();

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -2252,10 +2252,17 @@ void Server::set_trace_dist(const ref_t<MClientReply> &reply,
   bufferlist bl;
   mds_rank_t whoami = mds->get_nodeid();
   Session *session = mdr->session;
-  snapid_t snapid = mdr->snapid;
+  // Build an effective snapid (union of first and last snap ids) depending on
+  // whether the parent is a removed subdir (tilda-prefixed) or not.
+  // For a removed subdir the snapdiff's removed level would be 2+. Hence we
+  // use first snapid as a primary for the "removed" parrent as well.
+  snapid_t parent_snapid = mdr->get_effective_snapid_diff(2);
+  snapid_t snapid = mdr->get_effective_snapid_diff();
+
   utime_t now = ceph_clock_now();
 
-  dout(20) << "set_trace_dist snapid " << snapid << dendl;
+  dout(20) << "set_trace_dist snapid " << snapid
+	   << " parent_snapid " << parent_snapid << dendl;
 
   // realm
   if (snapid == CEPH_NOSNAP) {
@@ -2274,7 +2281,7 @@ void Server::set_trace_dist(const ref_t<MClientReply> &reply,
     CDir *dir = dn->get_dir();
     CInode *diri = dir->get_inode();
 
-    diri->encode_inodestat(bl, session, NULL, snapid);
+    diri->encode_inodestat(bl, session, NULL, parent_snapid);
     dout(20) << "set_trace_dist added diri " << *diri << dendl;
 
 #ifdef MDS_VERIFY_FRAGSTAT
@@ -2290,6 +2297,9 @@ void Server::set_trace_dist(const ref_t<MClientReply> &reply,
     dir->encode_dirstat(bl, session->info, ds);
     dout(20) << "set_trace_dist added dir  " << *dir << dendl;
 
+    if (mdr->removed_snapid_diff_level) {
+      encode(SNAPDIFF_RM_INDICATOR, bl);
+    }
     encode(dn->get_name(), bl);
 
     int lease_mask = 0;
@@ -2304,14 +2314,16 @@ void Server::set_trace_dist(const ref_t<MClientReply> &reply,
 	ceph_assert(!in);
     }
     mds->locker->issue_client_lease(dn, mdr, lease_mask, now, bl);
-    dout(20) << "set_trace_dist added dn   " << snapid << " " << *dn << dendl;
+    dout(20) << "set_trace_dist added snap " << parent_snapid << "    dn " << *dn
+             << dendl;
   } else
     reply->head.is_dentry = 0;
 
   // inode
   if (in) {
     in->encode_inodestat(bl, session, NULL, snapid, 0, mdr->getattr_caps);
-    dout(20) << "set_trace_dist added in   " << *in << dendl;
+    dout(20) << "set_trace_dist added snap " << snapid << " in " << *in
+             << dendl;
     reply->head.is_target = 1;
   } else
     reply->head.is_target = 0;
@@ -4550,9 +4562,12 @@ void Server::handle_client_readdir(MDRequestRef& mdr)
   string offset_str = req->get_path2();
 
   __u32 offset_hash = 0;
-  if (!offset_str.empty())
+  if (!offset_str.empty()) {
+    if (mdr->is_snapid_diff && offset_str[0] == SNAPDIFF_RM_INDICATOR) {
+      offset_str = offset_str.substr(1);
+    }
     offset_hash = ceph_frag_value(diri->hash_dentry_name(offset_str));
-  else
+  } else
     offset_hash = (__u32)req->head.args.readdir.offset_hash;
 
   dout(10) << " frag " << fg << " offset '" << offset_str << "'"
@@ -4604,11 +4619,32 @@ void Server::handle_client_readdir(MDRequestRef& mdr)
   utime_t now = ceph_clock_now();
   mdr->set_mds_stamp(now);
 
+  dout(10) << "snapid " << mdr->snapid
+           << " is_diff " << mdr->is_snapid_diff
+	   << " snapid_diff_other " << mdr->snapid_diff_other
+	   << dendl;
+
+
+  SnapRealm* realm = diri->find_snaprealm();
+  if (mdr->is_snapid_diff) {
+    if (!mdr->session->info.has_feature(CEPHFS_FEATURE_SNAP_DIFF)) {
+      dout(0) << "old client shouldn't cannot issue snap diff requests " << dendl;
+      respond_to_request(mdr, -CEPHFS_EOPNOTSUPP);
+      return;
+    }
+    _readdir_diff(
+      now,
+      mdr,
+      diri,
+      dir,
+      realm,
+      req_flags,
+      offset_str,
+      offset_hash);
+    return;
+  }
+
   snapid_t snapid = mdr->snapid;
-  dout(10) << "snapid " << snapid << dendl;
-
-  SnapRealm *realm = diri->find_snaprealm();
-
   unsigned max = req->head.args.readdir.max_entries;
   if (!max)
     max = dir->get_num_any();  // whatever, something big.
@@ -4716,7 +4752,7 @@ void Server::handle_client_readdir(MDRequestRef& mdr)
     mds->locker->issue_client_lease(dn, mdr, lease_mask, now, dnbl);
 
     // inode
-    dout(12) << "including inode " << *in << dendl;
+    dout(12) << "including inode in " << *in << " snap " << snapid << dendl;
     int r = in->encode_inodestat(dnbl, mdr->session, realm, snapid, bytes_left - (int)dnbl.length());
     if (r < 0) {
       // chop off dn->name, lease
@@ -10174,8 +10210,10 @@ void Server::handle_client_lssnap(MDRequestRef& mdr)
 
   __u64 last_snapid = 0;
   string offset_str = req->get_path2();
-  if (!offset_str.empty())
-    last_snapid = realm->resolve_snapname(offset_str, diri->ino());
+  if (!offset_str.empty()) {
+    auto [snapid, is_diff_dummy, snapid_other_dummy] = realm->resolve_snapname(offset_str, diri->ino());
+    last_snapid = snapid;
+  }
 
   //Empty DirStat
   bufferlist dirbl;
@@ -10204,6 +10242,7 @@ void Server::handle_client_lssnap(MDRequestRef& mdr)
     encode(snap_name, dnbl);
     //infinite lease
     LeaseStat e(CEPH_LEASE_VALID, -1, 0);
+
     mds->locker->encode_lease(dnbl, mdr->session->info, e);
     dout(20) << "encode_infinite_lease" << dendl;
 
@@ -10469,7 +10508,11 @@ void Server::handle_client_rmsnap(MDRequestRef& mdr)
     respond_to_request(mdr, -CEPHFS_ENOENT);
     return;
   }
-  snapid_t snapid = diri->snaprealm->resolve_snapname(snapname, diri->ino());
+  auto [snapid, is_diff, snapid_other_dummy] = diri->snaprealm->resolve_snapname(snapname, diri->ino());
+  if (is_diff) {
+    respond_to_request(mdr, -CEPHFS_EROFS);
+    return;
+  }
   dout(10) << " snapname " << snapname << " is " << snapid << dendl;
 
   if (!(mdr->locking_state & MutationImpl::ALL_LOCKED)) {
@@ -10612,7 +10655,12 @@ void Server::handle_client_renamesnap(MDRequestRef& mdr)
     return;
   }
 
-  snapid_t snapid = diri->snaprealm->resolve_snapname(srcname, diri->ino());
+  auto [snapid, is_diff, snapid_other_dummy] = diri->snaprealm->resolve_snapname(srcname, diri->ino());
+  if (is_diff) {
+    respond_to_request(mdr, -CEPHFS_EROFS);
+    return;
+  }
+
   dout(10) << " snapname " << srcname << " is " << snapid << dendl;
 
   // lock snap
@@ -10709,4 +10757,311 @@ void Server::dump_reconnect_status(Formatter *f) const
   f->open_object_section("reconnect_status");
   f->dump_stream("client_reconnect_gather") << client_reconnect_gather;
   f->close_section();
+}
+
+void Server::_readdir_diff(
+  utime_t now,
+  MDRequestRef& mdr,
+  CInode* diri,
+  CDir* dir,
+  SnapRealm* realm,
+  unsigned req_flags,
+  const string& offset_str,
+  uint32_t offset_hash)
+{
+  const cref_t<MClientRequest>& req = mdr->client_request;
+  Session* session = mds->get_session(req);
+  client_t client = req->get_source().num();
+
+  snapid_t snapid = mdr->snapid;
+  snapid_t snapid_before = mdr->snapid_diff_other;
+  if (snapid < snapid_before) {
+    std::swap(snapid, snapid_before);
+  }
+
+  unsigned max = req->head.args.readdir.max_entries;
+  if (!max)
+    max = dir->get_num_any();  // whatever, something big.
+  unsigned max_bytes = req->head.args.readdir.max_bytes;
+  if (!max_bytes)
+    // make sure at least one item can be encoded
+    max_bytes = (512 << 10) + g_conf()->mds_max_xattr_pairs_size;
+
+  // start final blob
+  bufferlist dirbl;
+  DirStat ds;
+  ds.frag = dir->get_frag();
+  ds.auth = dir->get_dir_auth().first;
+  if (dir->is_auth() && !forward_all_requests_to_auth)
+    dir->get_dist_spec(ds.dist, mds->get_nodeid());
+
+  dir->encode_dirstat(dirbl, mdr->session->info, ds);
+
+  // count bytes available.
+  //  this isn't perfect, but we should capture the main variable/unbounded size items!
+  int front_bytes = dirbl.length() + sizeof(__u32) + sizeof(__u8) * 2;
+  int bytes_left = max_bytes - front_bytes;
+  bytes_left -= realm->get_snap_trace().length();
+
+  // build dir contents
+  bufferlist dnbl;
+  __u32 numfiles = 0;
+  bool start = !offset_hash && offset_str.empty();
+  // skip all dns < dentry_key_t(snapid, offset_str, offset_hash)
+  dentry_key_t skip_key(snapid_before, offset_str.c_str(), offset_hash);
+  auto it = start ? dir->begin() : dir->lower_bound(skip_key);
+  bool end = (it == dir->end());
+
+
+  CDentry* dn_before = nullptr;
+  CInode* in_before = nullptr;
+  int lease_mask_before = 0;
+
+  utime_t mtime_before;
+
+  for (; !end && numfiles < max; end = (it == dir->end())) {
+    CDentry* dn = it->second;
+    dout(20) << __func__ << " " << it->first << "->" << dn->get_name() << dendl;
+    ++it;
+    if (dn->state_test(CDentry::STATE_PURGING))
+      continue;
+
+    bool dnp = dn->use_projected(client, mdr);
+    CDentry::linkage_t* dnl = dnp ? dn->get_projected_linkage() : dn->get_linkage();
+
+    if (dnl->is_null())
+      continue;
+
+    if (dn->last < snapid_before || dn->first > snapid) {
+      continue;
+    }
+
+    if (!start) {
+      dentry_key_t offset_key(dn->last, offset_str.c_str(), offset_hash);
+      //FIXME: is greater or equal valid condition, shouldn't it be just greater?
+      if (!(offset_key < dn->key()))
+	continue;
+    }
+
+    CInode* in = dnl->get_inode();
+
+    if (in && in->ino() == CEPH_INO_CEPH)
+      continue;
+
+    // remote link?
+    // better for the MDS to do the work, if we think the client will stat any of these files.
+    if (dnl->is_remote() && !in) {
+      in = mdcache->get_inode(dnl->get_remote_ino());
+      dout(20) << __func__ << " remote in: " << in << " ino " << std::hex << dnl->get_remote_ino() << std::dec << dendl;
+      if (in) {
+	dn->link_remote(dnl, in);
+      } else if (dn->state_test(CDentry::STATE_BADREMOTEINO)) {
+	dout(10) << "skipping bad remote ino on " << *dn << dendl;
+	continue;
+      } else {
+	// touch everything i _do_ have
+	for (auto& p : *dir) {
+	  if (!p.second->get_linkage()->is_null())
+	    mdcache->lru.lru_touch(p.second);
+	}
+
+	// already issued caps and leases, reply immediately.
+	if (dnbl.length() > 0) {
+	  mdcache->open_remote_dentry(dn, dnp, new C_MDSInternalNoop);
+	  dout(10) << " open remote dentry after caps were issued, stopping at "
+	    << dnbl.length() << " < " << bytes_left << dendl;
+	  break;
+	}
+
+	mds->locker->drop_locks(mdr.get());
+	mdr->drop_local_auth_pins();
+
+	mdcache->open_remote_dentry(dn, dnp, new C_MDS_RetryRequest(mdcache, mdr));
+	return;
+      }
+    }
+    ceph_assert(in);
+    int lease_mask = dnl->is_primary() ? CEPH_LEASE_PRIMARY_LINK : 0;
+
+    auto effective_snapid = mdr->get_effective_snapid_diff();
+    std::string name;
+    utime_t mtime = in->get_inode()->mtime;
+
+    if (in->is_dir()) {
+      if (snapid_before < dn->first && dn->last < snapid ) {
+	  dout(20) << __func__ << " skipping inner " << dn->get_name() << " "
+	           << dn->first << "/" << dn->last << dendl;
+	  continue;
+      } else if (dn->first <= snapid_before && dn->last < snapid) {
+	// dir deleted
+	name.append(1, SNAPDIFF_RM_INDICATOR);
+	dout(20) << __func__ << " deleted dir " << dn->get_name() << " "
+	         << dn->first << "/" << dn->last << dendl;
+	effective_snapid = mdr->get_effective_snapid_diff(0); //use first snapid as a primary unconditionally
+	name.append(dn->get_name());
+      }	else {
+	//FIXME: escape starting tildas(~) if any
+	name.append(dn->get_name());
+      }
+    } else {
+      name = dn->get_name();
+      if (snapid_before >= dn->first && snapid <= dn->last) {
+	dout(20) << __func__ << " skipping unchanged " << name << " "
+	         << dn->first << "/" << dn->last << dendl;
+	continue;
+      } else if (snapid_before < dn->first && snapid > dn->last) {
+	dout(20) << __func__ << " skipping inner modification " << name << " "
+	         << dn->first << "/" << dn->last << dendl;
+	continue;
+      }
+      string_view name_before =
+        dn_before ? string_view(dn_before->get_name()) : string_view();
+      if (snapid_before >= dn->first && snapid_before <= dn->last) {
+	if (dn_before && name != name_before) {
+	  string name(1, SNAPDIFF_RM_INDICATOR);
+	  name.append(name_before);
+	  dout(20) << __func__ << " deleted file " << name_before << " "
+	           << dn_before->first << "/" << dn_before->last << dendl;
+	  effective_snapid = mdr->get_effective_snapid_diff(0); //use first snapid as a primary unconditionally
+
+	  int r = _include_into_readdir_diff(now, mdr, realm, lease_mask_before,
+	    effective_snapid, name, dn_before, in_before, bytes_left, dnbl);
+	  dn_before = nullptr;
+	  in_before = nullptr;
+	  lease_mask_before = 0;
+	  if (r < 0) {
+	    //FIXME
+	    break;
+	  }
+	  numfiles++;
+	}
+	dout(30) << __func__ << " dn_before " << name << " "
+	         << dn->first << "/" << dn->last << dendl;
+	dn_before = dn;
+	in_before = in;
+	lease_mask_before = lease_mask;
+	mtime_before = mtime;
+	continue;
+      } else {
+	if (dn_before && name == name_before) {
+	  if (mtime == mtime_before) {
+	    dout(30) << __func__ << " timestamp not changed " << name << " "
+	             << dn->first << "/" << dn->last
+	             << " " << mtime
+		     << dendl;
+	    in_before = nullptr;
+	    dn_before = nullptr;
+	    lease_mask_before = 0;
+	    continue;
+	  } else {
+	    dn_before = nullptr;
+	    in_before = nullptr;
+	    lease_mask_before = 0;
+	    dout(30) << __func__ << " timestamp changed " << name << " "
+	             << dn->first << "/" << dn->last
+	             << " " << mtime_before << " vs. " << mtime
+	             << dendl;
+	  }
+	}
+	dout(20) << __func__ << " new file " << name << " "
+	  << dn->first << "/" << dn->last
+	  << dendl;
+	ceph_assert(snapid >= dn->first && snapid <= dn->last);
+      }
+    }
+    int r = _include_into_readdir_diff(now, mdr, realm, lease_mask,
+      effective_snapid, name, dn, in, bytes_left, dnbl);
+    if (r < 0) {
+      //FIXME
+      break;
+    }
+    numfiles++;
+  }
+  if (dn_before) {
+    string name(1, SNAPDIFF_RM_INDICATOR);
+    name.append(dn_before->get_name());
+    dout(20) << __func__ << " deleted file " << dn_before->get_name() << " "
+            << dn_before->first << "/" << dn_before->last << dendl;
+    auto effective_snapid = mdr->get_effective_snapid_diff(0); //use first snapid as a primary unconditionally
+
+    int r = _include_into_readdir_diff(now, mdr, realm, lease_mask_before,
+      effective_snapid, name, dn_before, in_before, bytes_left, dnbl);
+    dn_before = nullptr;
+    in_before = nullptr;
+    lease_mask_before = 0;
+    if (r < 0) {
+      //FIXME
+    }
+    numfiles++;
+  }
+
+  session->touch_readdir_cap(numfiles);
+
+  __u16 flags = CEPH_READDIR_SNAPDIFF;
+  if (end) {
+    flags |= CEPH_READDIR_FRAG_END;
+    if (start)
+      flags |= CEPH_READDIR_FRAG_COMPLETE; // FIXME: what purpose does this serve
+  }
+
+  // finish final blob
+  encode(numfiles, dirbl);
+  encode(flags, dirbl);
+  dirbl.claim_append(dnbl);
+
+  // yay, reply
+  dout(10) << "reply to " << *req << " readdir num=" << numfiles
+    << " bytes=" << dirbl.length()
+    << " start=" << (int)start
+    << " end=" << (int)end
+    << dendl;
+  mdr->reply_extra_bl = dirbl;
+
+  // bump popularity.  NOTE: this doesn't quite capture it.
+  mds->balancer->hit_dir(dir, META_POP_IRD, -1, numfiles);
+
+  // reply
+  mdr->tracei = diri;
+  respond_to_request(mdr, 0);
+}
+
+int Server::_include_into_readdir_diff(
+  utime_t now,
+  MDRequestRef& mdr,
+  SnapRealm* realm,
+  int lease_mask,
+  snapid_t snapid,
+  const std::string& name,
+  CDentry* dn,
+  CInode* in,
+  int bytes_left,
+  bufferlist& dnbl)
+{
+  if ((int)(dnbl.length() + dn->get_name().length() + sizeof(__u32) + sizeof(LeaseStat)) > bytes_left) {
+    dout(10) << " ran out of room, stopping at " << dnbl.length() << " < " << bytes_left << dendl;
+    return -ENOSPC;
+  }
+
+  unsigned start_len = dnbl.length();
+
+  dout(10) << "including    dn " << *dn << " as " << name << dendl;
+  encode(name, dnbl);
+  mds->locker->issue_client_lease(dn, mdr, lease_mask, now, dnbl);
+
+  // inode
+  dout(10) << "including inode " << *in << " snap "
+	   << snapid << dendl;
+  int r = in->encode_inodestat(dnbl, mdr->session, realm, snapid, bytes_left - (int)dnbl.length());
+  if (r < 0) {
+    // chop off dn->name, lease
+    dout(10) << " ran out of room, stopping at " << start_len << " < " << bytes_left << dendl;
+    bufferlist keep;
+    keep.substr_of(dnbl, 0, start_len);
+    dnbl.swap(keep);
+    return r;
+  }
+
+  // touch dn
+  mdcache->lru.lru_touch(dn);
+  return 0;
 }

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -433,6 +433,27 @@ private:
   void reply_client_request(MDRequestRef& mdr, const ref_t<MClientReply> &reply);
   void flush_session(Session *session, MDSGatherBuilder& gather);
 
+  void _readdir_diff(
+    utime_t now,
+    MDRequestRef& mdr,
+    CInode* diri,
+    CDir* dir,
+    SnapRealm* realm,
+    unsigned req_flags,
+    const std::string& offset_str,
+    uint32_t offset_hash);
+  int _include_into_readdir_diff(
+    utime_t now,
+    MDRequestRef& mdr,
+    SnapRealm* realm,
+    int lease_mask,
+    snapid_t snapid,
+    const std::string& name,
+    CDentry* dn,
+    CInode* in,
+    int bytes_left,
+    bufferlist& dnbl);
+
   MDSRank *mds;
   MDCache *mdcache;
   MDLog *mdlog;

--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -20,6 +20,8 @@
 #include <string_view>
 
 
+char SNAP_DIFF_KEYWORD[] = ".~diff=";
+
 /*
  * SnapRealm
  */
@@ -221,12 +223,65 @@ std::string_view SnapRealm::get_snapname(snapid_t snapid, inodeno_t atino)
   return parent->get_snapname(snapid, atino);
 }
 
-snapid_t SnapRealm::resolve_snapname(std::string_view n, inodeno_t atino, snapid_t first, snapid_t last)
+SnapNameResolved SnapRealm::maybe_resolve_snapdiff(
+  std::string_view n,
+  snapid_t first,
+  snapid_t last)
+{
+  string_view snap1;
+  string_view snap2;
+  const size_t diff_keyword_len = sizeof(SNAP_DIFF_KEYWORD) - 1;
+  string_view v = n.substr(0, diff_keyword_len);
+  bool is_diff = false;
+  if (v.compare(SNAP_DIFF_KEYWORD) == 0) {
+    auto snap2_pos = n.find(SNAP_DIFF_KEYWORD, diff_keyword_len);
+    if (snap2_pos != string_view::npos) {
+      snap1 = n.substr(diff_keyword_len, snap2_pos - diff_keyword_len);
+
+      v = n.substr(snap2_pos, diff_keyword_len);
+      if (v.compare(SNAP_DIFF_KEYWORD) == 0) {
+	snap2 = n.substr(snap2_pos + diff_keyword_len); // the rest part
+	is_diff = true;
+      }
+    }
+  }
+  if (!is_diff) {
+    return SnapNameResolved {CEPH_NOSNAP, false, CEPH_NOSNAP};
+  }
+  snapid_t snaps[2] = {CEPH_NOSNAP, CEPH_NOSNAP};
+  size_t snap_pos = 0;
+  dout(10) << __func__ << " snap1: " << snap1 << " vs. snap2:" << snap2
+	   << dendl;
+  for (auto p = srnode.snaps.lower_bound(first); // first element >= first
+       p != srnode.snaps.end() && p->first <= last && snap_pos < 2;
+       ++p) {
+    dout(15) << " ? " << p->second << dendl;
+    if (p->second.name == snap1 || p->second.name == snap2) {
+      snaps[snap_pos++] = p->first;
+    }
+  }
+  return snap_pos == 2 ?
+    SnapNameResolved {snaps[0], true, snaps[1]} :
+    SnapNameResolved {CEPH_NOSNAP, true, CEPH_NOSNAP};
+}
+
+SnapNameResolved SnapRealm::resolve_snapname(
+  std::string_view n,
+  inodeno_t atino,
+  snapid_t first,
+  snapid_t last)
 {
   // first try me
   dout(10) << "resolve_snapname '" << n << "' in [" << first << "," << last << "]" << dendl;
 
   bool actual = (atino == inode->ino());
+  if (actual) {
+    SnapNameResolved snr = maybe_resolve_snapdiff(n, first, last);
+    if (snr.is_snapdiff) {
+      return snr;
+    }
+  }
+
   string pname;
   inodeno_t pino;
   if (n.length() && n[0] == '_') {
@@ -245,9 +300,9 @@ snapid_t SnapRealm::resolve_snapname(std::string_view n, inodeno_t atino, snapid
     //if (num && p->second.snapid == num)
     //return p->first;
     if (actual && p->second.name == n)
-	return p->first;
+      return SnapNameResolved {p->first, false, CEPH_NOSNAP};
     if (!actual && p->second.name == pname && p->second.ino == pino)
-      return p->first;
+      return SnapNameResolved {p->first, false, CEPH_NOSNAP};
   }
 
   if (!srnode.past_parent_snaps.empty()) {
@@ -264,17 +319,16 @@ snapid_t SnapRealm::resolve_snapname(std::string_view n, inodeno_t atino, snapid
       dout(15) << " ? " << *it.second << dendl;
       actual = (it.second->ino == atino);
       if (actual && it.second->name == n)
-	return it.first;
+	return SnapNameResolved {it.first, false, CEPH_NOSNAP};
       if (!actual && it.second->name == pname && it.second->ino == pino)
-	return it.first;
+	return SnapNameResolved {it.first, false, CEPH_NOSNAP};
     }
   }
 
   if (parent && srnode.current_parent_since <= last)
     return parent->resolve_snapname(n, atino, std::max(first, srnode.current_parent_since), last);
-  return 0;
+  return SnapNameResolved {CEPH_NOSNAP, false, CEPH_NOSNAP};
 }
-
 
 void SnapRealm::adjust_parent()
 {

--- a/src/mds/SnapRealm.h
+++ b/src/mds/SnapRealm.h
@@ -24,6 +24,12 @@
 #include "common/snap_types.h"
 #include "MDSContext.h"
 
+struct SnapNameResolved {
+  snapid_t snapid_primary;
+  bool is_snapdiff = false;
+  snapid_t snapid_other;
+};
+
 struct SnapRealm {
 public:
   SnapRealm(MDCache *c, CInode *in);
@@ -48,7 +54,11 @@ public:
   void build_snap_trace() const;
 
   std::string_view get_snapname(snapid_t snapid, inodeno_t atino);
-  snapid_t resolve_snapname(std::string_view name, inodeno_t atino, snapid_t first=0, snapid_t last=CEPH_NOSNAP);
+  SnapNameResolved resolve_snapname(
+    std::string_view name,
+    inodeno_t atino,
+    snapid_t first=0,
+    snapid_t last=CEPH_NOSNAP);
 
   const std::set<snapid_t>& get_snaps() const;
   const SnapContext& get_snap_context() const;
@@ -132,7 +142,10 @@ public:
 
 protected:
   void check_cache() const;
-
+  SnapNameResolved maybe_resolve_snapdiff(
+    std::string_view n,
+    snapid_t first,
+    snapid_t last);
 private:
   bool global;
 

--- a/src/mds/cephfs_features.cc
+++ b/src/mds/cephfs_features.cc
@@ -23,6 +23,7 @@ static const std::array feature_names
   "deleg_ino",
   "metric_collect",
   "alternate_name",
+  "snap_diff",
 };
 static_assert(feature_names.size() == CEPHFS_FEATURE_MAX + 1);
 

--- a/src/mds/cephfs_features.h
+++ b/src/mds/cephfs_features.h
@@ -43,7 +43,8 @@ namespace ceph {
 #define CEPHFS_FEATURE_OCTOPUS          13
 #define CEPHFS_FEATURE_METRIC_COLLECT   14
 #define CEPHFS_FEATURE_ALTERNATE_NAME   15
-#define CEPHFS_FEATURE_MAX              15
+#define CEPHFS_FEATURE_SNAP_DIFF        16
+#define CEPHFS_FEATURE_MAX              16
 
 #define CEPHFS_FEATURES_ALL {		\
   0, 1, 2, 3, 4,			\
@@ -60,6 +61,7 @@ namespace ceph {
   CEPHFS_FEATURE_OCTOPUS,               \
   CEPHFS_FEATURE_METRIC_COLLECT,        \
   CEPHFS_FEATURE_ALTERNATE_NAME,        \
+  CEPHFS_FEATURE_SNAP_DIFF,             \
 }
 
 #define CEPHFS_METRIC_FEATURES_ALL {		\

--- a/src/mds/snap.h
+++ b/src/mds/snap.h
@@ -103,4 +103,5 @@ struct sr_t {
 WRITE_CLASS_ENCODER(sr_t)
 
 class MDCache;
+#define SNAPDIFF_RM_INDICATOR '~'
 #endif

--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -10,6 +10,7 @@ if(${WITH_CEPHFS})
     main.cc
     deleg.cc
     monconfig.cc
+    snapdiff.cc
   )
   target_link_libraries(ceph_test_libcephfs
     ceph-common

--- a/src/test/libcephfs/snapdiff.cc
+++ b/src/test/libcephfs/snapdiff.cc
@@ -1,0 +1,918 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "gtest/gtest.h"
+#include "include/cephfs/libcephfs.h"
+#include "include/stat.h"
+#include "include/ceph_assert.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <limits.h>
+#include <dirent.h>
+
+using namespace std;
+class TestMount {
+  ceph_mount_info* cmount = nullptr;
+  char dir_path[64];
+
+public:
+  TestMount( const char* root_dir_name = "dir0") {
+    ceph_create(&cmount, NULL);
+    ceph_conf_read_file(cmount, NULL);
+    ceph_conf_parse_env(cmount, NULL);
+    ceph_assert(0 == ceph_mount(cmount, NULL));
+
+    sprintf(dir_path, "/%s_%d", root_dir_name, getpid());
+    ceph_assert(0 == ceph_mkdir(cmount, dir_path, 0777));
+  }
+  ~TestMount()
+  {
+    ceph_assert(0 == ceph_rmdir(cmount, dir_path));
+    ceph_shutdown(cmount);
+  }
+
+  string make_file_path(const char* relpath) {
+    char path[PATH_MAX];
+    sprintf(path, "%s/%s", dir_path, relpath);
+    return path;
+  }
+
+  string make_snap_name(const char* name) {
+    char snap_name[64];
+    sprintf(snap_name, "%s_%d", name, getpid());
+    return snap_name;
+  }
+  string make_snap_path(const char* name) {
+    char snap_path[PATH_MAX];
+    string snap_name = make_snap_name(name);
+    sprintf(snap_path, "%s/.snap/%s", dir_path, snap_name.c_str());
+    return snap_path;
+  }
+  string make_snapdiff_relpath(const char* name1, const char* name2,
+    const char* relpath = nullptr) {
+    char diff_path[PATH_MAX];
+    string snap_name1 = make_snap_name(name1);
+    string snap_name2 = make_snap_name(name2);
+    if (relpath) {
+      sprintf(diff_path, ".snap/.~diff=%s.~diff=%s/%s",
+        snap_name1.c_str(), snap_name2.c_str(), relpath);
+    } else {
+      sprintf(diff_path, ".snap/.~diff=%s.~diff=%s",
+        snap_name1.c_str(), snap_name2.c_str());
+    }
+    return diff_path;
+  }
+
+  int mksnap(const char* name) {
+    string snap_name = make_snap_name(name);
+    return ceph_mksnap(cmount, dir_path, snap_name.c_str(),
+      0755, nullptr, 0);
+  }
+  int rmsnap(const char* name) {
+    string snap_name = make_snap_name(name);
+    return ceph_rmsnap(cmount, dir_path, snap_name.c_str());
+  }
+
+  int write_full(const char* relpath, const string& data)
+  {
+    auto file_path = make_file_path(relpath);
+    int fd = ceph_open(cmount, file_path.c_str(), O_WRONLY | O_CREAT, 0666);
+    if (fd < 0) {
+      return -EACCES;
+    }
+    int r = ceph_write(cmount, fd, data.c_str(), data.size(), 0);
+    if (r >= 0) {
+      ceph_fsync(cmount, fd, 0);
+    }
+    ceph_close(cmount, fd);
+    return r;
+  }
+  string concat_path(string_view path, string_view name) {
+    string s(path);
+    if (s.back() != '/') {
+      s += '/';
+    }
+    s += name;
+    return s;
+  }
+  int readfull_and_compare(string_view path,
+                           string_view name,
+    const string_view expected)
+  {
+    string s = concat_path(path, name);
+    return readfull_and_compare(s.c_str(), expected);
+  }
+  int readfull_and_compare(const char* relpath,
+    const string_view expected)
+  {
+    auto file_path = make_file_path(relpath);
+    int fd = ceph_open(cmount, file_path.c_str(), O_RDONLY, 0);
+    if (fd < 0) {
+      return -EACCES;
+    }
+    std::string s;
+    s.resize(expected.length() + 1);
+
+    int ret = ceph_read(cmount, fd, s.data(), s.length(), 0);
+    ceph_close(cmount, fd);
+
+    if (ret < 0) {
+      return -EIO;
+    }
+    if (ret != int(expected.length())) {
+      return -ERANGE;
+    }
+    s.resize(ret);
+    if (s != expected) {
+      return -EINVAL;
+    }
+    return 0;
+  }
+  int unlink(const char* relpath)
+  {
+    auto file_path = make_file_path(relpath);
+    return ceph_unlink(cmount, file_path.c_str());
+  }
+
+  int for_each_readdir(const char* relpath,
+    std::function<bool(const dirent* dire)> fn)
+  {
+    auto subdir_path = make_file_path(relpath);
+    struct ceph_dir_result* ls_dir;
+    int r = ceph_opendir(cmount, subdir_path.c_str(), &ls_dir);
+    if (r != 0) {
+      return r;
+    }
+    struct dirent* result;
+    while( nullptr != (result = ceph_readdir(cmount, ls_dir))) {
+      if (strcmp(result->d_name, ".") == 0 ||
+          strcmp(result->d_name, "..") == 0) {
+        continue;
+      }
+      if (!fn(result)) {
+        r = -EINTR;
+        break;
+      }
+    }
+    ceph_assert(0 == ceph_closedir(cmount, ls_dir));
+    return r;
+  }
+  int readdir_and_compare(const char* relpath,
+    const vector<string>& expected0)
+  {
+    vector<string> expected(expected0);
+    auto end = expected.end();
+    int r = for_each_readdir(relpath,
+      [&](const dirent* dire) {
+
+        std::string name(dire->d_name);
+        auto it = std::find(expected.begin(), end, name);
+        if (it == end) {
+          return false;
+        }
+        expected.erase(it);
+        return true;
+      });
+    if (r == 0 && !expected.empty()) {
+      r = -ENOTEMPTY;
+    }
+    return r;
+  }
+
+  int mkdir(const char* relpath)
+  {
+    auto path = make_file_path(relpath);
+    return ceph_mkdir(cmount, path.c_str(), 0777);
+  }
+  int rmdir(const char* relpath)
+  {
+    auto path = make_file_path(relpath);
+    return ceph_rmdir(cmount, path.c_str());
+  }
+  int purge_dir(const char* relpath0, bool inclusive = true)
+  {
+    int r =
+      for_each_readdir(relpath0,
+        [&] (const dirent* dire) {
+          string relpath = concat_path(relpath0, dire->d_name);
+          if (dire->d_type == DT_REG) {
+            unlink(relpath.c_str());
+          } else if (dire->d_type == DT_DIR) {
+            purge_dir(relpath.c_str());
+            rmdir(relpath.c_str());
+          }
+          return true;
+        });
+    if (r != 0) {
+      return r;
+    }
+    r = rmdir(relpath0);
+    return r;
+  }
+
+  void remove_all() {
+    purge_dir("/", false);
+  }
+
+  ceph_mount_info* get_cmount() {
+    return cmount;
+  }
+};
+
+TEST(LibCephFS, SnapDiffSimple)
+{
+  TestMount test_mount;
+
+  ASSERT_LT(0, test_mount.write_full("fileA", "hello world"));
+  ASSERT_LT(0, test_mount.write_full("fileC", "hello world in another file"));
+  ASSERT_LT(0, test_mount.write_full("fileD", "hello world unmodified"));
+
+  ASSERT_EQ(0, test_mount.mksnap("snap1"));
+
+  std::cout << "---------snap1 listing---------" << std::endl;
+  ASSERT_EQ(0, test_mount.for_each_readdir("/",
+    [&](const dirent* dire) {
+      std::cout << dire->d_name<< std::endl;
+      return true;
+    }));
+  {
+    vector<string> expected;
+    expected.push_back("fileA");
+    expected.push_back("fileC");
+    expected.push_back("fileD");
+    ASSERT_EQ(0, test_mount.readdir_and_compare("/", expected));
+  }
+  ASSERT_EQ(0, test_mount.readfull_and_compare("fileA", "hello world"));
+  ASSERT_EQ(-ERANGE, test_mount.readfull_and_compare("fileC", "hello world"));
+
+  ASSERT_LT(0, test_mount.write_full("fileA", "hello world again"));
+  ASSERT_LT(0, test_mount.write_full("fileB", "hello world again in B"));
+  ASSERT_EQ(0, test_mount.unlink("fileC"));
+
+  ASSERT_EQ(0, test_mount.mksnap("snap2"));
+  std::cout << "---------snap2 listing---------" << std::endl;
+  ASSERT_EQ(0, test_mount.for_each_readdir("/",
+    [&](const dirent* dire) {
+      std::cout << dire->d_name << std::endl;
+      return true;
+    }));
+
+  std::cout << "---------invalid snapdiff path, the same snaps---------" << std::endl;
+  {
+    auto snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap1");
+    ASSERT_EQ(-ENOENT, test_mount.for_each_readdir(snapdiff_path.c_str(),
+      [&](const dirent* dire) {
+        return true;
+      }));
+  }
+  std::cout << "---------snap1 vs. snap2 diff listing---------" << std::endl;
+  auto snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap2");
+  ASSERT_EQ(0, test_mount.for_each_readdir(snapdiff_path.c_str(),
+    [&](const dirent* dire) {
+      std::cout << dire->d_name << std::endl;
+      return true;
+    }));
+  std::cout << "---------reading from snapdiff results---------" << std::endl;
+  {
+    vector<string> expected;
+    expected.push_back("fileA");
+    expected.push_back("~fileC");
+    expected.push_back("fileB");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(),expected));
+  }
+
+  ASSERT_EQ(0, test_mount.readfull_and_compare("fileA", "hello world again"));
+  ASSERT_EQ(-EACCES, test_mount.readfull_and_compare("fileC", "hello world"));
+
+  ASSERT_EQ(0, test_mount.readfull_and_compare(snapdiff_path, "fileA", "hello world again"));
+  ASSERT_EQ(-EINVAL, test_mount.readfull_and_compare(snapdiff_path, "fileA", "hello world AGAIN"));
+  ASSERT_EQ(0, test_mount.readfull_and_compare(snapdiff_path, "fileB", "hello world again in B"));
+  ASSERT_EQ(0, test_mount.readfull_and_compare(snapdiff_path, "~fileC", "hello world in another file"));
+  std::cout << "---------invalid snapdiff path, no snap2 ---------" << std::endl;
+  {
+    // invalid file path - no slash between snapdiff and file names
+    string s = snapdiff_path;
+    s += "fileA";
+    ASSERT_EQ(-EACCES, test_mount.readfull_and_compare(s.c_str(), "hello world again"));
+  }
+  std::cout << "------------- closing -------------" << std::endl;
+
+  ASSERT_EQ(0, test_mount.unlink("fileA"));
+  ASSERT_EQ(0, test_mount.unlink("fileB"));
+  ASSERT_EQ(0, test_mount.unlink("fileD"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
+}
+
+/* The following method creates the following layout of files/folders/snapshots,
+* where:
+  - xN denotes file 'x' version N.
+  - X denotes folder name
+  - * denotes no/removed file/folder
+
+#     snap1        snap2      snap3      head
+# a1     |     a1     |    a3    |    a4
+# b1     |     b2     |    b3    |    b3
+# c1     |     *      |    *     |    *
+# *      |     d2     |    d3    |    d3
+# f1     |     f2     |    *     |    *
+# ff1    |     ff1    |    *     |    *
+# g1     |     *      |    g3    |    g3
+# *      |     *      |    *     |    h4
+# i1     |     i1     |    i1    |    i1
+# S      |     S      |    S     |    S
+# S/sa1  |     S/sa2  |    S/sa3 |    S/sa3
+# *      |     *      |    *     |    S/sh4
+# *      |     T      |    T     |    T
+# *      |     T/td2  |    T/td3 |    T/td3
+# C      |     *      |    *     |    *
+# C/cc1  |     *      |    *     |    *
+# C/C1   |     *      |    *     |    *
+# C/C1/c1|     *      |    *     |    *
+# G      |     *      |    G     |    G
+# G/gg1  |     *      |    G/gg3 |    G/gg3
+# *      |     k2     |    *     |    *
+# *      |     l2     |    l2    |    *
+# *      |     K      |    *     |    *
+# *      |     K/kk2  |    *     |    *
+# *      |     *      |    H     |    H
+# *      |     *      |    H/hh3 |    H/hh3
+# I      |     I      |    I     |    *
+# I/ii1  |     I/ii2  |    I/ii3 |    *
+# I/iii1 |     I/iii1 |    I/iii3|    *
+# *      |     *      |   I/iiii3|    *
+# *      |    I/J     |  I/J     |    *
+# *      |   I/J/i2   |  I/J/i3  |    *
+# *      |   I/J/j2   |  I/J/j2  |    *
+# *      |   I/J/k2   |    *     |    *
+# *      |     *      |  I/J/l3  |    *
+# L      |     L      |    L     |    L
+# L/ll1  |    L/ll1   |   L/ll3  |    L/ll3
+# L/LL   |    L/LL    |  L/LL    |    L/LL
+# *      |    L/LL/ll2|  L/LL/ll3|    L/LL/ll4
+# *      |    L/LM    |    *     |    *
+# *      |    L/LM/lm2|    *     |    *
+# *      |    L/LN    |    L/LN  |    *
+*/
+void prepareSnapDiffCases(TestMount& test_mount)
+{
+  //************ snap1 *************
+  ceph_assert(0 < test_mount.write_full("a", "file 'a' v1"));
+  ceph_assert(0 < test_mount.write_full("b", "file 'b' v1"));
+  ceph_assert(0 < test_mount.write_full("c", "file 'c' v1"));
+  ceph_assert(0 < test_mount.write_full("f", "file 'f' v1"));
+  ceph_assert(0 < test_mount.write_full("ff", "file 'ff' v1"));
+  ceph_assert(0 < test_mount.write_full("g", "file 'g' v1"));
+  ceph_assert(0 < test_mount.write_full("i", "file 'i' v1"));
+
+  ceph_assert(0 == test_mount.mkdir("S"));
+  ceph_assert(0 < test_mount.write_full("S/sa", "file 'S/sa' v1"));
+
+  ceph_assert(0 == test_mount.mkdir("C"));
+  ceph_assert(0 < test_mount.write_full("C/cc", "file 'C/cc' v1"));
+
+  ceph_assert(0 == test_mount.mkdir("C/C1"));
+  ceph_assert(0 < test_mount.write_full("C/C1/c", "file 'C/C1/c' v1"));
+
+  ceph_assert(0 == test_mount.mkdir("G"));
+  ceph_assert(0 < test_mount.write_full("G/gg", "file 'G/gg' v1"));
+
+  ceph_assert(0 == test_mount.mkdir("I"));
+  ceph_assert(0 < test_mount.write_full("I/ii", "file 'I/ii' v1"));
+  ceph_assert(0 < test_mount.write_full("I/iii", "file 'I/iii' v1"));
+
+  ceph_assert(0 == test_mount.mkdir("L"));
+  ceph_assert(0 < test_mount.write_full("L/ll", "file 'L/ll' v1"));
+  ceph_assert(0 == test_mount.mkdir("L/LL"));
+
+  ceph_assert(0 == test_mount.mksnap("snap1"));
+  //************ snap2 *************
+
+  ceph_assert(0 < test_mount.write_full("b", "file 'b' v2"));
+  ceph_assert(0 == test_mount.unlink("c"));
+  ceph_assert(0 < test_mount.write_full("d", "file 'd' v2"));
+  ceph_assert(0 < test_mount.write_full("f", "file 'f' v2"));
+  ceph_assert(0 == test_mount.unlink("g"));
+
+  ceph_assert(0 < test_mount.write_full("S/sa", "file 'S/sa' v2"));
+
+  ceph_assert(0 == test_mount.mkdir("T"));
+  ceph_assert(0 < test_mount.write_full("T/td", "file 'T/td' v2"));
+
+  ceph_assert(0 == test_mount.purge_dir("C"));
+  ceph_assert(0 == test_mount.purge_dir("G"));
+
+  ceph_assert(0 < test_mount.write_full("k", "file 'k' v2"));
+  ceph_assert(0 < test_mount.write_full("l", "file 'l' v2"));
+
+  ceph_assert(0 == test_mount.mkdir("K"));
+  ceph_assert(0 < test_mount.write_full("K/kk", "file 'K/kk' v2"));
+
+  ceph_assert(0 < test_mount.write_full("I/ii", "file 'I/ii' v2"));
+
+  ceph_assert(0 == test_mount.mkdir("I/J"));
+  ceph_assert(0 < test_mount.write_full("I/J/i", "file 'I/J/i' v2"));
+  ceph_assert(0 < test_mount.write_full("I/J/j", "file 'I/J/j' v2"));
+  ceph_assert(0 < test_mount.write_full("I/J/k", "file 'I/J/k' v2"));
+
+  ceph_assert(0 < test_mount.write_full("L/LL/ll", "file 'L/LL/ll' v2"));
+
+  ceph_assert(0 == test_mount.mkdir("L/LM"));
+  ceph_assert(0 < test_mount.write_full("L/LM/lm", "file 'L/LM/lm' v2"));
+
+  ceph_assert(0 == test_mount.mkdir("L/LN"));
+
+  ceph_assert(0 == test_mount.mksnap("snap2"));
+    //************ snap3 *************
+
+  ceph_assert(0 < test_mount.write_full("a", "file 'a' v3"));
+  ceph_assert(0 < test_mount.write_full("b", "file 'b' v3"));
+  ceph_assert(0 < test_mount.write_full("d", "file 'd' v3"));
+  ceph_assert(0 == test_mount.unlink("f"));
+  ceph_assert(0 == test_mount.unlink("ff"));
+  ceph_assert(0 < test_mount.write_full("g", "file 'g' v3"));
+
+  ceph_assert(0 < test_mount.write_full("S/sa", "file 'S/sa' v3"));
+
+  ceph_assert(0 < test_mount.write_full("T/td", "file 'T/td' v3"));
+
+  ceph_assert(0 == test_mount.mkdir("G"));
+  ceph_assert(0 < test_mount.write_full("G/gg", "file 'G/gg' v3"));
+
+  ceph_assert(0 == test_mount.unlink("k"));
+
+  ceph_assert(0 == test_mount.purge_dir("K"));
+
+  ceph_assert(0 == test_mount.mkdir("H"));
+  ceph_assert(0 < test_mount.write_full("H/hh", "file 'H/hh' v3"));
+
+  ceph_assert(0 < test_mount.write_full("I/ii", "file 'I/ii' v3"));
+  ceph_assert(0 < test_mount.write_full("I/iii", "file 'I/iii' v3"));
+  ceph_assert(0 < test_mount.write_full("I/iiii", "file 'I/iiii' v3"));
+
+  ceph_assert(0 < test_mount.write_full("I/J/i", "file 'I/J/i' v3"));
+  ceph_assert(0 == test_mount.unlink("I/J/k"));
+  ceph_assert(0 < test_mount.write_full("I/J/l", "file 'I/J/l' v3"));
+
+  ceph_assert(0 < test_mount.write_full("L/ll", "file 'L/ll' v3"));
+
+  ceph_assert(0 < test_mount.write_full("L/LL/ll", "file 'L/LL/ll' v3"));
+
+  ceph_assert(0 == test_mount.purge_dir("L/LM"));
+
+  ceph_assert(0 == test_mount.mksnap("snap3"));
+  //************ head *************
+  ceph_assert(0 < test_mount.write_full("a", "file 'a' head"));
+
+  ceph_assert(0 < test_mount.write_full("h", "file 'h' head"));
+
+  ceph_assert(0 < test_mount.write_full("S/sh", "file 'S/sh' head"));
+
+  ceph_assert(0 == test_mount.unlink("l"));
+
+  ceph_assert(0 == test_mount.purge_dir("I"));
+
+  ceph_assert(0 < test_mount.write_full("L/LL/ll", "file 'L/LL/ll' head"));
+
+  ceph_assert(0 == test_mount.purge_dir("L/LN"));
+}
+
+TEST(LibCephFS, SnapDiffVariousCases)
+{
+  TestMount test_mount;
+
+  prepareSnapDiffCases(test_mount);
+
+  string snapdiff_path;
+
+  {
+    std::cout << "---------snap1 vs. snap2 diff listing---------" << std::endl;
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap2");
+    ASSERT_EQ(0, test_mount.for_each_readdir(snapdiff_path.c_str(),
+      [&](const dirent* dire) {
+        std::cout << dire->d_name << " ";
+        return true;
+      }));
+    std::cout << std::endl;
+
+    vector<string> expected;
+    expected.push_back("b");
+    expected.push_back("~c");
+    expected.push_back("d");
+    expected.push_back("f");
+    expected.push_back("~g");
+    expected.push_back("S");
+    expected.push_back("T");
+    expected.push_back("~C");
+    expected.push_back("~G");
+    expected.push_back("k");
+    expected.push_back("l");
+    expected.push_back("K");
+    expected.push_back("I");
+    expected.push_back("L");
+
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "b", "file 'b' v2"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~c", "file 'c' v1"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "d", "file 'd' v2"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~g", "file 'g' v1"));
+
+    expected.clear();
+    expected.push_back("sa");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap2", "S");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "sa", "file 'S/sa' v2"));
+
+    expected.clear();
+    expected.push_back("td");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap2", "T");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "td", "file 'T/td' v2"));
+
+    expected.clear();
+    expected.push_back("~cc");
+    expected.push_back("~C1");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap2", "~C");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~cc", "file 'C/cc' v1"));
+
+    expected.clear();
+    expected.push_back("~c");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap2", "~C/~C1");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~c", "file 'C/C1/c' v1"));
+
+    expected.clear();
+    expected.push_back("ii");
+    expected.push_back("J");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap2", "I");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "ii", "file 'I/ii' v2"));
+
+    expected.clear();
+    expected.push_back("i");
+    expected.push_back("j");
+    expected.push_back("k");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap2", "I/J");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "k", "file 'I/J/k' v2"));
+
+    expected.clear();
+    expected.push_back("LL");
+    expected.push_back("LM");
+    expected.push_back("LN");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap2", "L");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+
+    expected.clear();
+    expected.push_back("ll");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap2", "L/LL");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "ll", "file 'L/LL/ll' v2"));
+
+    expected.clear();
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap2", "L/LN");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+  }
+
+  {
+    std::cout << "---------snap2 vs. snap3 diff listing---------" << std::endl;
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap2", "snap3");
+    ASSERT_EQ(0, test_mount.for_each_readdir(snapdiff_path.c_str(),
+      [&](const dirent* dire) {
+        std::cout << dire->d_name << " ";
+        return true;
+      }));
+    std::cout << std::endl;
+
+    vector<string> expected;
+    expected.push_back("a");
+    expected.push_back("b");
+    expected.push_back("d");
+    expected.push_back("~f");
+    expected.push_back("~ff");
+    expected.push_back("g");
+    expected.push_back("S");
+    expected.push_back("T");
+    expected.push_back("G");
+    expected.push_back("~k");
+    expected.push_back("~K");
+    expected.push_back("H");
+    expected.push_back("I");
+    expected.push_back("L");
+
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "a", "file 'a' v3"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "b", "file 'b' v3"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "d", "file 'd' v3"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~f", "file 'f' v2"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~ff", "file 'ff' v1"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "g", "file 'g' v3"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~k", "file 'k' v2"));
+
+    expected.clear();
+    expected.push_back("sa");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap2", "snap3", "S");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "sa", "file 'S/sa' v3"));
+
+    expected.clear();
+    expected.push_back("td");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap2", "snap3", "T");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "td", "file 'T/td' v3"));
+
+    expected.clear();
+    expected.push_back("gg");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap2", "snap3", "G");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "gg", "file 'G/gg' v3"));
+
+    expected.clear();
+    expected.push_back("~kk");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap2", "snap3", "~K");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~kk", "file 'K/kk' v2"));
+
+    expected.clear();
+    expected.push_back("hh");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap2", "snap3", "H");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "hh", "file 'H/hh' v3"));
+
+    expected.clear();
+    expected.push_back("ii");
+    expected.push_back("iii");
+    expected.push_back("iiii");
+    expected.push_back("J");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap2", "snap3", "I");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "ii", "file 'I/ii' v3"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "iii", "file 'I/iii' v3"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "iiii", "file 'I/iiii' v3"));
+
+    expected.clear();
+    expected.push_back("i");
+    expected.push_back("~k");
+    expected.push_back("l");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap2", "snap3", "I/J");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "i", "file 'I/J/i' v3"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~k", "file 'I/J/k' v2"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "l", "file 'I/J/l' v3"));
+
+    expected.clear();
+    expected.push_back("ll");
+    expected.push_back("LL");
+    expected.push_back("~LM");
+    expected.push_back("LN");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap2", "snap3", "L");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "ll", "file 'L/ll' v3"));
+
+    expected.clear();
+    expected.push_back("ll");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap2", "snap3", "L/LL");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "ll", "file 'L/LL/ll' v3"));
+
+    expected.clear();
+    expected.push_back("~lm");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap2", "snap3", "L/~LM");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~lm", "file 'L/LM/lm' v2"));
+
+    expected.clear();
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap2", "snap3", "L/LN");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+  }
+  {
+    std::cout << "---------snap1 vs. snap3 diff listing---------" << std::endl;
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap3", "snap1");
+    ASSERT_EQ(0, test_mount.for_each_readdir(snapdiff_path.c_str(),
+      [&](const dirent* dire) {
+        std::cout << dire->d_name << " ";
+        return true;
+      }));
+    std::cout << std::endl;
+    vector<string> expected;
+    expected.push_back("a");
+    expected.push_back("b");
+    expected.push_back("~c");
+    expected.push_back("d");
+    expected.push_back("~f");
+    expected.push_back("~ff");
+    expected.push_back("g");
+    expected.push_back("S");
+    expected.push_back("T");
+    expected.push_back("~C");
+    expected.push_back("G");
+    expected.push_back("l");
+    expected.push_back("~G");
+    expected.push_back("H");
+    expected.push_back("I");
+    expected.push_back("L");
+
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "a", "file 'a' v3"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "b", "file 'b' v3"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~c", "file 'c' v1"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "d", "file 'd' v3"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~f", "file 'f' v1"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~ff", "file 'ff' v1"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "g", "file 'g' v3"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "l", "file 'l' v2"));
+
+    expected.clear();
+    expected.push_back("sa");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap3", "S");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "sa", "file 'S/sa' v3"));
+
+    expected.clear();
+    expected.push_back("td");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap3", "T");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "td", "file 'T/td' v3"));
+
+    expected.clear();
+    expected.push_back("~cc");
+    expected.push_back("~C1");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap3", "~C");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~cc", "file 'C/cc' v1"));
+
+    expected.clear();
+    expected.push_back("~c");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap3", "~C/~C1");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~c", "file 'C/C1/c' v1"));
+
+    expected.clear();
+    expected.push_back("~gg");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap3", "~G");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "~gg", "file 'G/gg' v1"));
+
+    expected.clear();
+    expected.push_back("gg");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap3", "G");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "gg", "file 'G/gg' v3"));
+
+    expected.clear();
+    expected.push_back("hh");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap3", "H");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "hh", "file 'H/hh' v3"));
+
+    expected.clear();
+    expected.push_back("ii");
+    expected.push_back("iii");
+    expected.push_back("iiii");
+    expected.push_back("J");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap3", "I");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "iii", "file 'I/iii' v3"));
+
+    expected.clear();
+    expected.push_back("i");
+    expected.push_back("j");
+    expected.push_back("l");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap3", "I/J");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "i", "file 'I/J/i' v3"));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "l", "file 'I/J/l' v3"));
+
+    expected.clear();
+    expected.push_back("ll");
+    expected.push_back("LL");
+    expected.push_back("LN");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap3", "L");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "ll", "file 'L/ll' v3"));
+
+    expected.clear();
+    expected.push_back("ll");
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap3", "L/LL");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+    ASSERT_EQ(0,
+      test_mount.readfull_and_compare(snapdiff_path.c_str(), "ll", "file 'L/LL/ll' v3"));
+
+    expected.clear();
+    snapdiff_path = test_mount.make_snapdiff_relpath("snap1", "snap3", "L/LN");
+    ASSERT_EQ(0,
+      test_mount.readdir_and_compare(snapdiff_path.c_str(), expected));
+  }
+  std::cout << "-------------" << std::endl;
+
+  test_mount.remove_all();
+  test_mount.rmsnap("snap1");
+  test_mount.rmsnap("snap2");
+  test_mount.rmsnap("snap3");
+}


### PR DESCRIPTION
This patch allows to obtain snapshots' file delta (aka Snap Diff) by
reading fake 'snapdiff-query-formatted' subfolders under .snap directory.
Snapdiff subfolders are not visible when reading from .snap folder, one
has to build and issue such a "query" manually.

Resulting output (directory listing) contains just entries which have
been altered (created/updated/removed) in the final shapshot since the
initial one. New/updated entries are presented as regular files, names
of the removed ones are prefixed with tilda '~'.
E.g. to compare snapshots named snap1 and snap2 one can issue:

>ls -l /mnt/mycephfs/dir0/.snap/.~diff=snap1.~diff=snap2

which would return something like that:
total 8
-rw-r--r-- 1 root root  3 Jul 19 16:40 b
-rw-r--r-- 1 root root  3 Jul 19 16:40 ~c
drwxr-xr-x 0 root root  0 Jul 19 16:40 ~C
-rw-r--r-- 1 root root  3 Jul 19 16:40 d
-rw-r--r-- 1 root root  3 Jul 19 16:40 f
-rw-r--r-- 1 root root  3 Jul 19 16:40 ~g
drwxr-xr-x 0 root root  0 Jul 19 16:40 ~G
drwxr-xr-x 0 root root  0 Jul 19 16:40 I
-rw-r--r-- 1 root root  3 Jul 19 16:40 k
drwxr-xr-x 0 root root  0 Jul 19 16:40 K
-rw-r--r-- 1 root root  3 Jul 19 16:40 l
drwxr-xr-x 4 root root 12 Jul 19 16:41 L
drwxr-xr-x 2 root root  6 Jul 19 16:40 S
drwxr-xr-x 2 root root  3 Jul 19 16:40 T

or

> ls -l /mnt/mycephfs/dir0/.snap/.~diff=snap1.~diff=snap3
total 7.5K
-rw-r--r-- 1 root root  3 Jul 19 16:40 a
-rw-r--r-- 1 root root  3 Jul 19 16:40 b
-rw-r--r-- 1 root root  3 Jul 19 16:40 ~c
drwxr-xr-x 0 root root  0 Jul 19 16:40 ~C
-rw-r--r-- 1 root root  3 Jul 19 16:40 d
-rw-r--r-- 1 root root  3 Jul 19 16:40 ~f
-rw-r--r-- 1 root root  3 Jul 19 16:40 g
drwxr-xr-x 0 root root  0 Jul 19 16:40 ~G
drwxr-xr-x 0 root root  0 Jul 19 16:41 G
drwxr-xr-x 2 root root  3 Jul 19 16:40 H
drwxr-xr-x 0 root root  0 Jul 19 16:40 I
-rw-r--r-- 1 root root  3 Jul 19 16:40 l
drwxr-xr-x 4 root root 12 Jul 19 16:41 L
drwxr-xr-x 2 root root  6 Jul 19 16:40 S
drwxr-xr-x 2 root root  3 Jul 19 16:40 T

then diving deeper in the subfolder might show:
> ls -l /mnt/mycephfs/dir0/.snap/.~diff=snap1.~diff=snap2/~C
total 1
drwxr-xr-x 0 root root 0 Jul 19 16:40 ~C1
-rw-r--r-- 1 root root 3 Jul 19 16:40 ~cc1

and so on and so forth:
> ls -l /mnt/mycephfs/dir0/.snap/.~diff=snap1.~diff=snap2/~C/~C1
total 1
-rw-r--r-- 1 root root 6 Jul 19 16:40 ~c2

File content reading is also available. It returns the full(!) file
content in the target snapshot for new/updated files and one in the
initial snapshot for removed files.
E.g.
> less /mnt/mycephfs/dir0/.snap/.~diff=snap1.~diff=snap2/~C/~C1/~c2
snap1

Order of snapshot names in a snapdiff ""query" isn't important - they're
properly sorted properly according to their ids when processed.
Comparing snapshot and live data isn't supported. Byte-level "deltas"
are not supported.

Signed-off-by: Denis Barahtanov <denis.barahtanov@croit.io>