### PR TITLE
doc/cephadm: remove repeated section on disabling logging to stderr

### DIFF
--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -41,17 +41,17 @@ monitor hosts as well as to the monitor daemons' stderr.
 Ceph daemon logs
 ================
 
-Logging to stdout
------------------
+Logging to journald
+-------------------
 
-Ceph daemons traditionally write logs to ``/var/log/ceph``. Ceph
-daemons log to stderr by default and Ceph logs are captured by the
-container runtime environment. By default, most systems send these
-logs to journald, which means that they are accessible via
-``journalctl``.
+Ceph daemons traditionally write logs to ``/var/log/ceph``. Ceph daemons log to
+journald by default and Ceph logs are captured by the container runtime
+environment. They are accessible via ``journalctl``.
 
-Example of logging to stdout 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. note:: Prior to Quincy, ceph daemons logged to stderr.
+
+Example of logging to journald
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For example, to view the logs for the daemon ``mon.foo`` for a cluster
 with ID ``5c5a50ae-272a-455d-99e9-32c6a013e694``, the command would be
@@ -67,11 +67,11 @@ Logging to files
 ----------------
 
 You can also configure Ceph daemons to log to files instead of to
-stderr if you prefer logs to appear in files (as they did in earlier,
+journald if you prefer logs to appear in files (as they did in earlier,
 pre-cephadm, pre-Octopus versions of Ceph).  When Ceph logs to files,
 the logs appear in ``/var/log/ceph/<cluster-fsid>``. If you choose to
-configure Ceph to log to files instead of to stderr, remember to
-configure Ceph so that it will not log to stderr (the commands for
+configure Ceph to log to files instead of to journald, remember to
+configure Ceph so that it will not log to journald (the commands for
 this are covered below).
 
 Enabling logging to files
@@ -84,10 +84,10 @@ To enable logging to files, run the following commands:
   ceph config set global log_to_file true
   ceph config set global mon_cluster_log_to_file true
 
-Disabling logging to stderr
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Disabling logging to journald
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you choose to log to files, we recommend disabling logging to stderr or else
+If you choose to log to files, we recommend disabling logging to journald or else
 everything will be logged twice. Run the following commands to disable logging
 to stderr:
 
@@ -95,6 +95,11 @@ to stderr:
 
   ceph config set global log_to_stderr false
   ceph config set global mon_cluster_log_to_stderr false
+  ceph config set global log_to_journald false
+  ceph config set global mon_cluster_log_to_journald false
+
+.. note:: You can change the default by passing --log-to-file during
+   bootstrapping a new cluster.
 
 Modifying the log retention schedule
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -63,16 +63,6 @@ something like:
 
 This works well for normal operations when logging levels are low.
 
-Disabling logging to stderr
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To disable logging to stderr:
-
-.. prompt:: bash #
-
-  ceph config set global log_to_stderr false
-  ceph config set global mon_cluster_log_to_stderr false
-
 Logging to files
 ----------------
 
@@ -97,9 +87,9 @@ To enable logging to files, run the following commands:
 Disabling logging to stderr
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you choose to log to files, we recommend disabling logging to
-stderr (see above) or else everything will be logged twice. Run the
-following commands to disable logging to stderr:
+If you choose to log to files, we recommend disabling logging to stderr or else
+everything will be logged twice. Run the following commands to disable logging
+to stderr:
 
 .. prompt:: bash #
 


### PR DESCRIPTION
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
