### PR TITLE
doc/rados: rewrite storage device front matter

### DIFF
--- a/doc/rados/configuration/storage-devices.rst
+++ b/doc/rados/configuration/storage-devices.rst
@@ -2,22 +2,26 @@
  Storage Devices
 =================
 
-There are two Ceph daemons that store data on devices:
+There are several Ceph daemons in a storage cluster:
 
-* **Ceph OSDs** (or Object Storage Daemons) are where most of the
-  data is stored in Ceph.  Generally speaking, each OSD is backed by
-  a single storage device, like a traditional hard disk (HDD) or
-  solid state disk (SSD).  OSDs can also be backed by a combination
-  of devices, like a HDD for most data and an SSD (or partition of an
-  SSD) for some metadata.  The number of OSDs in a cluster is
-  generally a function of how much data will be stored, how big each
-  storage device will be, and the level and type of redundancy
-  (replication or erasure coding).
-* **Ceph Monitor** daemons manage critical cluster state like cluster
-  membership and authentication information.  For smaller clusters a
-  few gigabytes is all that is needed, although for larger clusters
-  the monitor database can reach tens or possibly hundreds of
-  gigabytes.
+* **Ceph OSDs** (Object Storage Daemons) store most of the data
+  in Ceph. Usually each OSD is backed by a single storage device.
+  This can be a traditional hard disk (HDD) or a solid state disk
+  (SSD). OSDs can also be backed by a combination of devices: for
+  example, a HDD for most data and an SSD (or partition of an
+  SSD) for some metadata. The number of OSDs in a cluster is
+  usually a function of the amount of data to be stored, the size
+  of each storage device, and the level and type of redundancy
+  specified (replication or erasure coding).
+* **Ceph Monitor** daemons manage critical cluster state. This
+  includes cluster membership and authentication information.
+  Small clusters require only a few gigabytes of storage to hold
+  the monitor database. In large clusters, however, the monitor
+  database can reach sizes of tens of gigabytes to hundreds of
+  gigabytes.  
+* **Ceph Manager** daemons run alongside monitor daemons, providing
+  additional monitoring and providing interfaces to external
+  monitoring and management systems.
 
 
 OSD Backends


### PR DESCRIPTION
This PR updates the text in the RADOS Guide
(the Ceph Storage Cluster Guide) that appears
at the beginning of the "Storage Devices"
chapter. I did the following:

- rewrote some of the sentences so that
  they read more like written text than like
  spoken language
- added "Ceph Manager" to the list of daemons
  that a Ceph cluster comprises
- that's about it.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
