### PR TITLE
doc/mgr/telemetry: fix formatting problem

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -47,6 +47,7 @@ the per-channel setting has no effect.)
     - contact email address
 
 * **perf** (default: off): Aggregated performance counter metrics of a cluster, which can be used to
+
     - reveal overall cluster health
     - identify workload patterns
     - troubleshoot issues with latency, throttling, memory management, etc.


### PR DESCRIPTION
There was a formatting issue in the perf description that was causing strange bolding and bullet point misplacement.

Signed-off-by: Laura Flores <lflores@redhat.com>