### PR TITLE
mon/LogMonitor: fix crash when cluster log file is not writeable

### DIFF
--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -400,9 +400,10 @@ void LogMonitor::log_external(const LogEntry& le)
 	if (fd < 0) {
 	  int err = -errno;
 	  dout(1) << "unable to write to '" << log_file << "' for channel '"
-		  << p->first << "': " << cpp_strerror(err) << dendl;
+		  << channel << "': " << cpp_strerror(err) << dendl;
+	} else {
+	  channel_fds[channel] = fd;
 	}
-	channel_fds[channel] = fd;
       }
     } else {
       fd = p->second;


### PR DESCRIPTION
If we are in this block, then p == channel_fds.end() and p->first is not
valid.

Also, no need to populate channel_fds with an fd of -1.

Fixes: https://tracker.ceph.com/issues/51816



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>