### PR TITLE
cephadm: don't use ctx.fsid for clean_cgroup

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2716,20 +2716,16 @@ def _write_container_cmd_to_bash(ctx, file_obj, container, comment=None, backgro
         + (' &' if background else '') + '\n')
 
 
-def clean_cgroup(ctx: CephadmContext, unit_name: str):
+def clean_cgroup(ctx: CephadmContext, fsid: str, unit_name: str):
     # systemd may fail to cleanup cgroups from previous stopped unit, which will cause next "systemctl start" to fail.
     # see https://tracker.ceph.com/issues/50998
-
-    # In bootstrap we set the context fsid at the end.
-    if not ctx.fsid:
-        return
 
     CGROUPV2_PATH = Path('/sys/fs/cgroup')
     if not (CGROUPV2_PATH / 'system.slice').exists():
         # Only unified cgroup is affected, skip if not the case
         return
 
-    slice_name = 'system-ceph\\x2d{}.slice'.format(ctx.fsid.replace('-', '\\x2d'))
+    slice_name = 'system-ceph\\x2d{}.slice'.format(fsid.replace('-', '\\x2d'))
     cg_path = CGROUPV2_PATH / 'system.slice' / slice_name / f'{unit_name}.service'
     if not cg_path.exists():
         return
@@ -2881,7 +2877,7 @@ def deploy_daemon_units(
     if enable:
         call_throws(ctx, ['systemctl', 'enable', unit_name])
     if start:
-        clean_cgroup(ctx, unit_name)
+        clean_cgroup(ctx, fsid, unit_name)
         call_throws(ctx, ['systemctl', 'start', unit_name])
 
 


### PR DESCRIPTION
The clean_cgroup method assumes that the ctx.fsid is set while this is
true for the bootstrap command, it isn't set for adopt or deploy commands
(and maybe others).

This ends up to the adopt command to fails:

```console
Traceback (most recent call last):
  File "/sbin/cephadm", line 8301, in <module>
    main()
  File "/sbin/cephadm", line 8289, in main
    r = ctx.func(ctx)
  File "/sbin/cephadm", line 1764, in _default_image
    return func(ctx)
  File "/sbin/cephadm", line 5091, in command_adopt
    command_adopt_ceph(ctx, daemon_type, daemon_id, fsid)
  File "/sbin/cephadm", line 5299, in command_adopt_ceph
    osd_fsid=osd_fsid)
  File "/sbin/cephadm", line 2884, in deploy_daemon_units
    clean_cgroup(ctx, unit_name)
  File "/sbin/cephadm", line 2724, in clean_cgroup
    if not ctx.fsid:
  File "/sbin/cephadm", line 155, in __getattr__
    return super().__getattribute__(name)
AttributeError: 'CephadmContext' object has no attribute 'fsid'
```

Since we already have the fsid value in deploy_daemon_units (which calls
clean_cgroup) then we can pass the fsid value directly.

This fixes a regression introduced by 1fee255

Fixes: https://tracker.ceph.com/issues/51902

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
