### PR TITLE
mds/client: switch to use ceph_assert() instead of assert()

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -281,12 +281,12 @@ void Client::_assign_faked_root(Inode *in)
     last_used_faked_root = 0;
     it = free_faked_inos.lower_bound(last_used_faked_root + 1);
   }
-  assert(it != free_faked_inos.end());
+  ceph_assert(it != free_faked_inos.end());
   vinodeno_t inode_info = in->vino();
   uint64_t inode_num = (uint64_t)inode_info.ino;
   ldout(cct, 10) << "inode_num " << inode_num << "inode_num & 0x3ff=" << (inode_num & 0x3ff)<< dendl;
   last_used_faked_root = it.get_start()  + (inode_num & 0x3ff); // 0x3ff mask and get_start will not exceed 2048
-  assert(it.get_start() + it.get_len() > last_used_faked_root);
+  ceph_assert(it.get_start() + it.get_len() > last_used_faked_root);
 
   in->faked_ino = last_used_faked_root;
   free_faked_inos.erase(in->faked_ino);
@@ -3100,7 +3100,7 @@ void Client::kick_requests_closed(MetaSession *session)
 	req->unsafe_item.remove_myself();
 	if (is_dir_operation(req)) {
 	  Inode *dir = req->inode();
-	  assert(dir);
+	  ceph_assert(dir);
 	  dir->set_async_err(-CEPHFS_EIO);
 	  lderr(cct) << "kick_requests_closed drop req of inode(dir) : "
 		     <<  dir->ino  << " " << req->get_tid() << dendl;
@@ -10804,7 +10804,7 @@ int Client::statfs(const char *path, struct statvfs *stbuf,
   int rval = cond.wait();
   lock.lock();
 
-  assert(root);
+  ceph_assert(root);
   total_files_on_fs = root->rstat.rfiles + root->rstat.rsubdirs;
 
   if (rval < 0) {
@@ -12369,7 +12369,7 @@ int Client::_do_setxattr(Inode *in, const char *name, const void *value,
   req->head.args.setxattr.flags = xattr_flags;
 
   bufferlist bl;
-  assert (value || size == 0);
+  ceph_assert(value || size == 0);
   bl.append((const char*)value, size);
   req->set_data(bl);
 
@@ -14999,7 +14999,7 @@ void Client::ms_handle_remote_reset(Connection *con)
 	}
       }
       if (mds >= 0) {
-	assert (s != NULL);
+	ceph_assert(s != NULL);
 	switch (s->state) {
 	case MetaSession::STATE_CLOSING:
 	  ldout(cct, 1) << "reset from mds we were closing; we'll call that closed" << dendl;
@@ -15355,7 +15355,7 @@ void Client::set_uuid(const std::string& uuid)
   ceph_assert(iref_reader.is_state_satisfied());
 
   std::scoped_lock l(client_lock);
-  assert(!uuid.empty());
+  ceph_assert(!uuid.empty());
 
   metadata["uuid"] = uuid;
   _close_sessions();

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2444,7 +2444,7 @@ void CDir::_omap_commit(int op_prio)
   };
 
   if (state_test(CDir::STATE_FRAGMENTING) && is_new()) {
-    assert(committed_version == 0);
+    ceph_assert(committed_version == 0);
     for (auto p = items.begin(); p != items.end(); ) {
       CDentry *dn = p->second;
       ++p;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6588,10 +6588,10 @@ public:
 			       LogSegment *_ls, version_t iv)
     : MDCacheLogContext(m), inos(_inos), ls(_ls), inotablev(iv) {}
   void finish(int r) override {
-    assert(r == 0);
+    ceph_assert(r == 0);
     if (inotablev) {
       get_mds()->inotable->apply_release_ids(inos);
-      assert(get_mds()->inotable->get_version() == inotablev);
+      ceph_assert(get_mds()->inotable->get_version() == inotablev);
     }
     ls->purge_inodes_finish(inos);
   }
@@ -6613,10 +6613,10 @@ void MDCache::purge_inodes(const interval_set<inodeno_t>& inos, LogSegment *ls)
   // FIXME: handle non-default data pool and namespace
 
   auto cb = new LambdaContext([this, inos, ls](int r){
-      assert(r == 0 || r == -2);
+      ceph_assert(r == 0 || r == -2);
       mds->inotable->project_release_ids(inos);
       version_t piv = mds->inotable->get_projected_version();
-      assert(piv != 0);
+      ceph_assert(piv != 0);
       mds->mdlog->start_submit_entry(new EPurged(inos, ls->seq, piv),
 				     new C_MDS_purge_completed_finish(this, inos, ls, piv));
       mds->mdlog->flush();

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -626,7 +626,7 @@ void MDLog::trim(int m)
   unsigned max_expiring_segments = 0;
   if (pre_segments_size > 0){
     max_expiring_segments = max_segments/2;
-    assert(segments.size() >= pre_segments_size);
+    ceph_assert(segments.size() >= pre_segments_size);
     max_expiring_segments = std::max<unsigned>(max_expiring_segments,segments.size() - pre_segments_size);
   }
   

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -374,23 +374,23 @@ void MDSDaemon::set_up_admin_socket()
 				     "name=value,type=CephString,req=false ",
 				     asok_hook,
 				     "Config a CephFS client session");
-  assert(r == 0);
+  ceph_assert(r == 0);
   r = admin_socket->register_command("client config "
 				     "name=client_id,type=CephInt,req=true "
 				     "name=option,type=CephString,req=true "
 				     "name=value,type=CephString,req=false ",
 				     asok_hook,
 				     "Config a CephFS client session");
-  assert(r == 0);
+  ceph_assert(r == 0);
   r = admin_socket->register_command("damage ls",
 				     asok_hook,
 				     "List detected metadata damage");
-  assert(r == 0);
+  ceph_assert(r == 0);
   r = admin_socket->register_command("damage rm "
 				     "name=damage_id,type=CephInt",
 				     asok_hook,
 				     "Remove a damage table entry");
-  assert(r == 0);
+  ceph_assert(r == 0);
   r = admin_socket->register_command("osdmap barrier name=target_epoch,type=CephInt",
 				     asok_hook,
 				     "Wait until the MDS has this OSD map epoch");

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -56,7 +56,7 @@ public:
   }
 
   void send() {
-    assert(ceph_mutex_is_locked(mds->mds_lock));
+    ceph_assert(ceph_mutex_is_locked(mds->mds_lock));
 
     dout(20) << __func__ << dendl;
 
@@ -257,7 +257,7 @@ public:
   void send() {
     // not really a hard requirement here, but lets ensure this in
     // case we change the logic here.
-    assert(ceph_mutex_is_locked(mds->mds_lock));
+    ceph_assert(ceph_mutex_is_locked(mds->mds_lock));
 
     dout(20) << __func__ << dendl;
     f->open_object_section("result");
@@ -2318,7 +2318,7 @@ void MDSRankDispatcher::handle_mds_map(
 
     if (oldstate == MDSMap::STATE_STANDBY_REPLAY) {
         dout(10) << "Monitor activated us! Deactivating replay loop" << dendl;
-        assert (state == MDSMap::STATE_REPLAY);
+        ceph_assert (state == MDSMap::STATE_REPLAY);
     } else {
       // did i just recover?
       if ((is_active() || is_clientreplay()) &&

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -1407,7 +1407,7 @@ void Migrator::export_frozen(CDir *dir, uint64_t tid)
   // send.
   it->second.state = EXPORT_PREPPING;
   mds->send_message_mds(prep, it->second.peer);
-  assert (g_conf()->mds_kill_export_at != 4);
+  ceph_assert(g_conf()->mds_kill_export_at != 4);
 
   // make sure any new instantiations of caps are flushed out
   ceph_assert(it->second.warning_ack_waiting.empty());
@@ -1487,7 +1487,7 @@ void Migrator::handle_export_prep_ack(const cref_t<MExportDirPrepAck> &m)
     return;
   }
 
-  assert (g_conf()->mds_kill_export_at != 5);
+  ceph_assert(g_conf()->mds_kill_export_at != 5);
   // send warnings
   set<CDir*> bounds;
   mdcache->get_subtree_bounds(dir, bounds);
@@ -1912,7 +1912,7 @@ void Migrator::handle_export_ack(const cref_t<MExportDirAck> &m)
   decode(it->second.peer_imported, bp);
 
   it->second.state = EXPORT_LOGGINGFINISH;
-  assert (g_conf()->mds_kill_export_at != 9);
+  ceph_assert(g_conf()->mds_kill_export_at != 9);
   set<CDir*> bounds;
   mdcache->get_subtree_bounds(dir, bounds);
 
@@ -1939,7 +1939,7 @@ void Migrator::handle_export_ack(const cref_t<MExportDirAck> &m)
   // log export completion, then finish (unfreeze, trigger finish context, etc.)
   mds->mdlog->submit_entry(le, new C_MDS_ExportFinishLogged(this, dir));
   mds->mdlog->flush();
-  assert (g_conf()->mds_kill_export_at != 10);
+  ceph_assert(g_conf()->mds_kill_export_at != 10);
 }
 
 void Migrator::export_notify_abort(CDir *dir, export_state_t& stat, set<CDir*>& bounds)
@@ -2075,7 +2075,7 @@ void Migrator::export_logged_finish(CDir *dir)
 
   // wait for notifyacks
   stat.state = EXPORT_NOTIFYING;
-  assert (g_conf()->mds_kill_export_at != 11);
+  ceph_assert(g_conf()->mds_kill_export_at != 11);
   
   // no notifies to wait for?
   if (stat.notify_ack_waiting.empty()) {
@@ -2156,7 +2156,7 @@ void Migrator::export_finish(CDir *dir)
 {
   dout(3) << *dir << dendl;
 
-  assert (g_conf()->mds_kill_export_at != 12);
+  ceph_assert(g_conf()->mds_kill_export_at != 12);
   map<CDir*,export_state_t>::iterator it = export_state.find(dir);
   if (it == export_state.end()) {
     dout(7) << "target must have failed, not sending final commit message.  export succeeded anyway." << dendl;
@@ -2315,7 +2315,7 @@ void Migrator::handle_export_discover(const cref_t<MExportDirDiscover> &m, bool 
     return;
   }
 
-  assert (g_conf()->mds_kill_import_at != 1);
+  ceph_assert(g_conf()->mds_kill_import_at != 1);
 
   // do we have it?
   CInode *in = mdcache->get_inode(m->get_dirfrag().ino);
@@ -2348,7 +2348,7 @@ void Migrator::handle_export_discover(const cref_t<MExportDirDiscover> &m, bool 
   // reply
   dout(7) << " sending export_discover_ack on " << *in << dendl;
   mds->send_message_mds(make_message<MExportDirDiscoverAck>(df, m->get_tid()), p_state->peer);
-  assert (g_conf()->mds_kill_import_at != 2);
+  ceph_assert(g_conf()->mds_kill_import_at != 2);
 }
 
 void Migrator::import_reverse_discovering(dirfrag_t df)
@@ -2659,7 +2659,7 @@ public:
 
 void Migrator::handle_export_dir(const cref_t<MExportDir> &m)
 {
-  assert (g_conf()->mds_kill_import_at != 5);
+  ceph_assert(g_conf()->mds_kill_import_at != 5);
   CDir *dir = mdcache->get_dirfrag(m->dirfrag);
   ceph_assert(dir);
 
@@ -2735,7 +2735,7 @@ void Migrator::handle_export_dir(const cref_t<MExportDir> &m)
 
   // note state
   it->second.state = IMPORT_LOGGINGSTART;
-  assert (g_conf()->mds_kill_import_at != 6);
+  ceph_assert(g_conf()->mds_kill_import_at != 6);
 
   // log it
   mds->mdlog->submit_entry(le, onlogged);
@@ -2974,7 +2974,7 @@ void Migrator::import_notify_abort(CDir *dir, set<CDir*>& bounds)
     dout(7) << "no bystanders, finishing reverse now" << dendl;
     import_reverse_unfreeze(dir);
   } else {
-    assert (g_conf()->mds_kill_import_at != 10);
+    ceph_assert(g_conf()->mds_kill_import_at != 10);
   }
 }
 
@@ -3031,7 +3031,7 @@ void Migrator::import_logged_start(dirfrag_t df, CDir *dir, mds_rank_t from,
   // note state
   it->second.state = IMPORT_ACKING;
 
-  assert (g_conf()->mds_kill_import_at != 7);
+  ceph_assert(g_conf()->mds_kill_import_at != 7);
 
   // force open client sessions and finish cap import
   mds->server->finish_force_open_sessions(imported_session_map, false);
@@ -3057,7 +3057,7 @@ void Migrator::import_logged_start(dirfrag_t df, CDir *dir, mds_rank_t from,
   encode(imported_caps, ack->imported_caps);
 
   mds->send_message_mds(ack, from);
-  assert (g_conf()->mds_kill_import_at != 8);
+  ceph_assert(g_conf()->mds_kill_import_at != 8);
 
   mdcache->show_subtrees();
 }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -404,10 +404,10 @@ Session* Server::find_session_by_uuid(std::string_view uuid)
     if (!session) {
       session = it.second;
     } else if (!session->reclaiming_from) {
-      assert(it.second->reclaiming_from == session);
+      ceph_assert(it.second->reclaiming_from == session);
       session = it.second;
     } else {
-      assert(session->reclaiming_from == it.second);
+      ceph_assert(session->reclaiming_from == it.second);
     }
   }
   return session;
@@ -445,8 +445,8 @@ void Server::reclaim_session(Session *session, const cref_t<MClientReclaim> &m)
       mds->send_message_client(reply, session);
     }
 
-    assert(!target->reclaiming_from);
-    assert(!session->reclaiming_from);
+    ceph_assert(!target->reclaiming_from);
+    ceph_assert(!session->reclaiming_from);
     session->reclaiming_from = target;
     reply->set_addrs(entity_addrvec_t(target->info.inst.addr));
   }
@@ -469,7 +469,7 @@ void Server::finish_reclaim_session(Session *session, const ref_t<MClientReclaim
     if (reply) {
       int64_t session_id = session->get_client().v;
       send_reply = new LambdaContext([this, session_id, reply](int r) {
-	    assert(ceph_mutex_is_locked_by_me(mds->mds_lock));
+	    ceph_assert(ceph_mutex_is_locked_by_me(mds->mds_lock));
 	    Session *session = mds->sessionmap.get_session(entity_name_t::CLIENT(session_id));
 	    if (!session) {
 	      return;
@@ -501,7 +501,7 @@ void Server::handle_client_reclaim(const cref_t<MClientReclaim> &m)
 {
   Session *session = mds->get_session(m);
   dout(3) << __func__ <<  " " << *m << " from " << m->get_source() << dendl;
-  assert(m->get_source().is_client()); // should _not_ come from an mds!
+  ceph_assert(m->get_source().is_client()); // should _not_ come from an mds!
 
   if (!session) {
     dout(0) << " ignoring sessionless msg " << *m << dendl;
@@ -1162,7 +1162,7 @@ void Server::find_idle_sessions()
   const auto sessions_p2 = mds->sessionmap.by_state.find(Session::STATE_STALE);
   if (sessions_p2 != mds->sessionmap.by_state.end() && !sessions_p2->second->empty()) {
     for (auto session : *(sessions_p2->second)) {
-      assert(session->is_stale());
+      ceph_assert(session->is_stale());
       auto last_cap_renew_span = std::chrono::duration<double>(now - session->last_cap_renew).count();
       if (last_cap_renew_span < cutoff) {
 	dout(20) << "oldest stale session is " << session->info.inst

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -1731,7 +1731,7 @@ void EPurged::replay(MDSRank *mds)
       dout(10) << "EPurged.replay inotable " << mds->inotable->get_version()
 	       << " < " << inotablev << " " << dendl;
       mds->inotable->replay_release_ids(inos);
-      assert(mds->inotable->get_version() == inotablev);
+      ceph_assert(mds->inotable->get_version() == inotablev);
     }
   }
   update_segment();


### PR DESCRIPTION
If the -DNDEBUG was specified when build the code, the assert()
will do nothing.

Fixes: https://tracker.ceph.com/issues/51956
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
