### PR TITLE
rgw: missing CommonPrefixes with some shard count

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2066,6 +2066,7 @@ done:
  * is_truncated: if number of objects in the bucket is bigger than max, then
  *               truncated.
  */
+#warning "temporary change to allow a pr to be created"
 int RGWRados::Bucket::List::list_objects_unordered(const DoutPrefixProvider *dpp,
                                                    int64_t max_p,
 						   vector<rgw_bucket_dir_entry> *result,


### PR DESCRIPTION
rgw: common prefixes missing depending on shard-count

When both a prefix and a delimiter are provided in a bucket listing operation, some items may not be listed and that seems to be dependent on the shard count.

ADD MORE HERE LATER

Fixes: https://tracker.ceph.com/issues/51767
Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>