### PR TITLE
pacific: rpm/luarocks: simplify conditional and support Leap 15.3

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -49,6 +49,8 @@
 %bcond_without lttng
 %bcond_without libradosstriper
 %bcond_without ocf
+%global luarocks_package_name luarocks
+%bcond_without lua_packages
 %global _remote_tarball_prefix https://download.ceph.com/tarballs/
 %endif
 %if 0%{?suse_version}
@@ -73,6 +75,21 @@
 %if ! %{defined _fillupdir}
 %global _fillupdir /var/adm/fillup-templates
 %endif
+#luarocks
+%if 0%{?is_opensuse}
+# openSUSE
+%bcond_without lua_packages
+%if 0%{?sle_version}
+# openSUSE Leap
+%global luarocks_package_name lua53-luarocks
+%else
+# openSUSE Tumbleweed
+%global luarocks_package_name lua54-luarocks
+%endif
+%else
+# SLE
+%bcond_with lua_packages
+%endif
 %endif
 %bcond_with seastar
 %bcond_with jaeger
@@ -94,19 +111,6 @@
 %else
 %{!?_selinux_policy_version: %global _selinux_policy_version 0.0.0}
 %endif
-%endif
-
-%if 0%{?suse_version}
-%if !0%{?is_opensuse}
-# SLE does not support luarocks
-%bcond_with lua_packages
-%else
-%global luarocks_package_name lua53-luarocks
-%bcond_without lua_packages
-%endif
-%else
-%global luarocks_package_name luarocks
-%bcond_without lua_packages
 %endif
 
 %{!?_udevrulesdir: %global _udevrulesdir /lib/udev/rules.d}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51969

---

backport of https://github.com/ceph/ceph/pull/39762
parent tracker: https://tracker.ceph.com/issues/51968

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh