### PR TITLE
nautilus: rbd-mirror: rename per-image replication perf counters

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7790,6 +7790,15 @@ static std::vector<Option> get_rbd_mirror_options() {
                           "mgr_stats_threshold.")
     .set_min_max((int64_t)PerfCountersBuilder::PRIO_DEBUGONLY,
                  (int64_t)PerfCountersBuilder::PRIO_CRITICAL + 1),
+
+    Option("rbd_mirror_image_perf_stats_prio", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default((int64_t)PerfCountersBuilder::PRIO_USEFUL)
+    .set_description("Priority level for mirror daemon per-image replication perf counters")
+    .set_long_description("The daemon will send per-image perf counter data to the "
+                          "manager daemon if the priority is not lower than "
+                          "mgr_stats_threshold.")
+    .set_min_max((int64_t)PerfCountersBuilder::PRIO_DEBUGONLY,
+                 (int64_t)PerfCountersBuilder::PRIO_CRITICAL + 1),
   });
 }
 

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -762,11 +762,11 @@ class MgrModule(ceph_module.BaseMgrModule):
 
         if daemon.startswith('rbd-mirror.'):
             match = re.match(
-                r'^rbd_mirror_([^/]+)/(?:(?:([^/]+)/)?)(.*)\.(replay(?:_bytes|_latency)?)$',
+                r'^rbd_mirror_image_([^/]+)/(?:(?:([^/]+)/)?)(.*)\.(replay(?:_bytes|_latency)?)$',
                 path
             )
             if match:
-                path = 'rbd_mirror_' + match.group(4)
+                path = 'rbd_mirror_image_' + match.group(4)
                 pool = match.group(1)
                 namespace = match.group(2) or ''
                 image = match.group(3)

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -1846,7 +1846,7 @@ void ImageReplayer<I>::register_admin_socket_hook() {
       m_asok_hook = asok_hook;
 
       CephContext *cct = static_cast<CephContext *>(m_local->cct());
-      auto prio = cct->_conf.get_val<int64_t>("rbd_mirror_perf_stats_prio");
+      auto prio = cct->_conf.get_val<int64_t>("rbd_mirror_image_perf_stats_prio");
       PerfCountersBuilder plb(g_ceph_context, "rbd_mirror_image_" + m_name,
                               l_rbd_mirror_first, l_rbd_mirror_last);
       plb.add_u64_counter(l_rbd_mirror_replay, "replay", "Replays", "r", prio);

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -1847,7 +1847,7 @@ void ImageReplayer<I>::register_admin_socket_hook() {
 
       CephContext *cct = static_cast<CephContext *>(m_local->cct());
       auto prio = cct->_conf.get_val<int64_t>("rbd_mirror_perf_stats_prio");
-      PerfCountersBuilder plb(g_ceph_context, "rbd_mirror_" + m_name,
+      PerfCountersBuilder plb(g_ceph_context, "rbd_mirror_image_" + m_name,
                               l_rbd_mirror_first, l_rbd_mirror_last);
       plb.add_u64_counter(l_rbd_mirror_replay, "replay", "Replays", "r", prio);
       plb.add_u64_counter(l_rbd_mirror_replay_bytes, "replay_bytes",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51970

---

backport of https://github.com/ceph/ceph/pull/32184
parent tracker: https://tracker.ceph.com/issues/43004

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh