### PR TITLE
pybind/mgr/pg_autoscaler: Added PROFILE to autoscale-status

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -189,7 +189,8 @@ class PgAutoscaler(MgrModule):
                                  'BIAS',
                                  'PG_NUM',
 #                                 'IDEAL',
-                                 'NEW PG_NUM', 'AUTOSCALE'],
+                                 'NEW PG_NUM', 'AUTOSCALE',
+                                 'PROFILE'],
                                 border=False)
             table.left_padding_width = 0
             table.right_padding_width = 2
@@ -206,6 +207,7 @@ class PgAutoscaler(MgrModule):
 #            table.align['IDEAL'] = 'r'
             table.align['NEW PG_NUM'] = 'r'
             table.align['AUTOSCALE'] = 'l'
+            table.align['PROFILE'] =  'l'
             for p in ps:
                 if p['would_adjust']:
                     final = str(p['pg_num_final'])
@@ -237,6 +239,7 @@ class PgAutoscaler(MgrModule):
 #                    p['pg_num_ideal'],
                     final,
                     p['pg_autoscale_mode'],
+                    profile
                 ])
             return 0, table.get_string(), ''
 


### PR DESCRIPTION
Autoscaler now shows the PROFILE status of each pool
in `ceph osd pool autoscale-status`

Signed-off-by: Kamoltat <ksirivad@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
