### PR TITLE
mgr, mgr/telemetry: add access to osd commands in mgr and workload metrics to telemetry

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1500,7 +1500,18 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         return r
 
     def osd_command(self, cmd_dict: dict, inbuf: Optional[str] = None) -> Tuple[int, str, str]:
+        """
+        Helper for osd command execution.
 
+        See send_command for general case. Also, see osd/OSD.cc for available commands.
+
+        :param dict cmd_dict: expects a prefix and an osd id, i.e.:
+            cmd_dict = {
+                'prefix': 'perf histogram dump',
+                'id': '0'
+            }
+        :return: status int, out std, err str
+        """
         t1 = time.time()
         result = CommandResult()
         self.send_command(result, "osd", cmd_dict['id'], json.dumps(cmd_dict), "", inbuf)

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1499,6 +1499,20 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
 
         return r
 
+    def osd_command(self, cmd_dict: dict, inbuf: Optional[str] = None) -> Tuple[int, str, str]:
+
+        t1 = time.time()
+        result = CommandResult()
+        self.send_command(result, "osd", cmd_dict['id'], json.dumps(cmd_dict), "", inbuf)
+        r = result.wait()
+        t2 = time.time()
+
+        self.log.debug("osd_command: '{0}' -> {1} in {2:.3f}s".format(
+            cmd_dict['prefix'], r[0], t2 - t1
+        ))
+
+        return r
+
     def send_command(
             self,
             result: CommandResult,

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -356,9 +356,13 @@ class Module(MgrModule):
 
     def get_osd_histograms(self) -> Dict[str, dict]:
         # Initialize result dict
-        result: Dict[str, dict] = defaultdict()
+        result: Dict[str, dict] = defaultdict(lambda: defaultdict(
+                                              lambda: defaultdict(
+                                              lambda: defaultdict(
+                                              lambda: defaultdict(
+                                              lambda: defaultdict(int))))))
 
-        # You can get a list of osd ids from the metadata
+        # Get list of osd ids from the metadata
         osd_metadata = self.get('osd_metadata')
         
         # Grab output from the "osd.x perf histogram dump" command
@@ -374,12 +378,73 @@ class Module(MgrModule):
                 continue
             else:
                 try:
-                    # This is where the histograms will land
-                    # if there are any
+                    # This is where the histograms will land if there are any
                     dump = json.loads(outb)
-                    result['osd.'+osd_id] = dump
-                # Sometimes, json errors occur if
-                # you give it an empty string
+                    #------- Testing -------------
+                    # result[osd_id] = dump //// Add this line back if you need to
+                    for histogram in dump['osd']:
+                        # Log axis information. There are two axes, represented each
+                        # as a dictionary. Both dictionary are contained inside a
+                        # list called 'axes'.
+                        axes = []
+                        for axis in dump['osd'][histogram]['axes']:
+
+                            # This is the dict that contains information for an individual
+                            # axis. It will be appended to the 'axes' list at the end.
+                            axis_dict: Dict[str, dict] = defaultdict(int)
+
+                            # These are all single values.
+                            axis_dict['buckets'] = axis['buckets']
+                            axis_dict['min'] = axis['min']
+                            axis_dict['name'] = axis['name']
+                            axis_dict['quant_size'] = axis['quant_size']
+                            axis_dict['scale_type'] = axis['scale_type']
+
+                            # Ranges were originally kept in dictionaries, but
+                            # I am placing them inside lists so that they will
+                            # be more human-readable later on.
+                            ranges = []
+                            for _range in axis['ranges']:
+                                _max, _min = None, None
+                                if 'max' in _range:
+                                    _max = _range['max']
+                                if 'min' in _range:
+                                    _min = _range['min']
+
+                                # Use json.dumps() to help the final output be
+                                # readable to users. The original data can be
+                                # retrieved later (perhaps on the server side) with json.loads().
+                                ranges.append(json.dumps([_min, _max]))
+                            axis_dict['ranges'] = ranges
+
+                            # Now that the axis dict contains all the appropriate
+                            # information, append it to the 'axes' list. This loop
+                            # will happen twice, once for each axis.
+                            axes.append(axis_dict)
+
+                        # Add the 'axes' list, containing both axes, to result.
+                        result['osd'][histogram]['axes'] = axes
+
+                        # Collect current values
+                        values = []
+                        for value_list in dump['osd'][histogram]['values']:
+                            # values.append(json.dumps(value_list))
+                            values.append(value_list)
+
+                        # Aggregate values. If 'values' have already been initialized,
+                        # you can safely add.
+                        if 'values' in result:
+                            for i in range (0, len(values)):
+                                for j in range (0, len(values[i])):
+                                    values[i][j] += result['osd'][histogram]['values'][i][j]
+
+                        # Add the values to result, using json.dumps() to improve readability.
+                        # These values can be retrieved later with json.loads().
+                        for i in range(0, len(values)):
+                            values[i] = json.dumps(values[i])
+                        result['osd'][histogram]['values'] = values
+
+                # Sometimes, json errors occur if you give it an empty string.
                 except json.decoder.JSONDecodeError:
                     continue
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -375,16 +375,16 @@ class Module(MgrModule):
             r, outb, outs = self.osd_command(cmd_dict)
             # Check for invalid calls
             if r != 0:
+                self.log.debug("Invalid command dictionary.")
                 continue
             else:
                 try:
-                    # This is where the histograms will land if there are any
+                    # This is where the histograms will land if there are any.
                     dump = json.loads(outb)
-                    #------- Testing -------------
-                    # result[osd_id] = dump //// Add this line back if you need to
+
                     for histogram in dump['osd']:
-                        # Log axis information. There are two axes, represented each
-                        # as a dictionary. Both dictionary are contained inside a
+                        # Log axis information. There are two axes, each represented
+                        # as a dictionary. Both dictionaries are contained inside a
                         # list called 'axes'.
                         axes = []
                         for axis in dump['osd'][histogram]['axes']:
@@ -393,16 +393,18 @@ class Module(MgrModule):
                             # axis. It will be appended to the 'axes' list at the end.
                             axis_dict: Dict[str, dict] = defaultdict(int)
 
-                            # These are all single values.
+                            # Collecting information for buckets, min, name, etc.
+                            # TODO: In some cases, the user might change the size of
+                            # their buckets. A check needs to be written that separates
+                            # out histograms with unique bucket sizes.
                             axis_dict['buckets'] = axis['buckets']
                             axis_dict['min'] = axis['min']
                             axis_dict['name'] = axis['name']
                             axis_dict['quant_size'] = axis['quant_size']
                             axis_dict['scale_type'] = axis['scale_type']
 
-                            # Ranges were originally kept in dictionaries, but
-                            # I am placing them inside lists so that they will
-                            # be more human-readable later on.
+                            # Collecting ranges; placing them in lists to
+                            # improve readability later on.
                             ranges = []
                             for _range in axis['ranges']:
                                 _max, _min = None, None
@@ -410,44 +412,48 @@ class Module(MgrModule):
                                     _max = _range['max']
                                 if 'min' in _range:
                                     _min = _range['min']
-
-                                # Use json.dumps() to help the final output be
-                                # readable to users. The original data can be
-                                # retrieved later (perhaps on the server side) with json.loads().
-                                ranges.append(json.dumps([_min, _max]))
+                                ranges.append([_min, _max])
                             axis_dict['ranges'] = ranges
 
-                            # Now that the axis dict contains all the appropriate
-                            # information, append it to the 'axes' list. This loop
-                            # will happen twice, once for each axis.
+                            # Now that 'axis_dict' contains all the appropriate
+                            # information for the current axis, append it to the 'axes' list.
+                            # There will end up being two axes in the 'axes' list, since the
+                            # histograms are 2D.
                             axes.append(axis_dict)
 
                         # Add the 'axes' list, containing both axes, to result.
                         result['osd'][histogram]['axes'] = axes
 
-                        # Collect current values
+                        # Collect current values and make sure they are in
+                        # integer form.
                         values = []
                         for value_list in dump['osd'][histogram]['values']:
-                            # values.append(json.dumps(value_list))
-                            values.append(value_list)
+                            values.append([int(v) for v in value_list])
 
                         # Aggregate values. If 'values' have already been initialized,
-                        # you can safely add.
-                        if 'values' in result:
+                        # we can safely add.
+                        if 'values' in result['osd'][histogram]:
                             for i in range (0, len(values)):
                                 for j in range (0, len(values[i])):
                                     values[i][j] += result['osd'][histogram]['values'][i][j]
 
-                        # Add the values to result, using json.dumps() to improve readability.
-                        # These values can be retrieved later with json.loads().
-                        for i in range(0, len(values)):
-                            values[i] = json.dumps(values[i])
+                        # Add the values to result.
                         result['osd'][histogram]['values'] = values
 
                 # Sometimes, json errors occur if you give it an empty string.
-                except json.decoder.JSONDecodeError:
-                    continue
+                # I am also putting in a catch for a KeyError since it could
+                # happen where the code is assuming that a key exists in the
+                # schema when it doesn't. In either case, we'll handle that
+                # bt returning an empty dict.
+                except (json.decoder.JSONDecodeError, KeyError) as e:
+                    self.log.debug("Error caught: {}".format(e))
+                    return {}
 
+        # TODO: Improve the JSON formatting of the histograms to make them
+        # more human-readable. This can be done directly in this function with json.dumps(),
+        # but it will be better to locate the exact area where the whole report
+        # is getting formatted, and make some formatting edits there. We want to ensure
+        # that the data is easily retrievable on the server side.
         return result
 
     def get_io_rate(self) -> dict:

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -302,6 +302,92 @@ class Module(MgrModule):
             'active_changed': sorted(list(active)),
         }
 
+    def get_stat_sum_per_pool(self) -> List[dict]:
+        # Initialize 'result' list
+        result: List[dict] = []
+
+        # Create a list of tuples containing pool ids and their associated names
+        # that will later act as a queue, i.e.:
+        #   pool_queue = [('1', '.mgr'), ('2', 'cephfs.a.meta'), ('3', 'cephfs.a.data')]
+        osd_map = self.get('osd_map')
+        pool_queue: List[tuple] = []
+        for pool in osd_map['pools']:
+            pool_queue.append((str(pool['pool']), pool['pool_name']))
+
+        # Populate 'result', i.e.:
+        #   {
+        #       'pool_id': '1'
+        #       'pool_name': '.mgr'
+        #       'stats_sum': {
+        #           'num_bytes': 36,
+        #           'num_bytes_hit_set_archive': 0,
+        #           ...
+        #           'num_write_kb': 0
+        #           }
+        #       }
+        #   }
+        while pool_queue:
+            # Pop a pool out of pool_queue
+            curr_pool = pool_queue.pop(0)
+
+            # Get the current pool's id and name
+            curr_pool_id, curr_pool_name = curr_pool[0], curr_pool[1]
+
+            # Initialize a dict that will hold aggregated stats for the current pool
+            compiled_stats_dict: Dict[str, dict] = defaultdict(lambda: defaultdict(int))
+
+            # Find out which pgs belong to the current pool and add up
+            # their stats
+            pg_dump = self.get('pg_dump')
+            for pg in pg_dump['pg_stats']:
+                pool_id = pg['pgid'][0:1]
+                if pool_id == curr_pool_id:
+                    for metric in pg['stat_sum']:
+                        compiled_stats_dict['pool_id'] = int(pool_id)
+                        compiled_stats_dict['pool_name'] = curr_pool_name
+                        compiled_stats_dict['stats_sum'][metric] += pg['stat_sum'][metric]
+                else:
+                    continue
+            # 'compiled_stats_dict' now holds all stats pertaining to
+            # the current pool. Adding it to the list of results.
+            result.append(compiled_stats_dict)
+
+        return result
+
+    def get_osd_histograms(self) -> Dict[str, dict]:
+        # Initialize result dict
+        result: Dict[str, dict] = defaultdict()
+
+        # You can get a list of osd ids from the metadata
+        osd_metadata = self.get('osd_metadata')
+        
+        # Grab output from the "osd.x perf histogram dump" command
+        for osd_id in osd_metadata:
+            cmd_dict = {
+                'prefix': 'perf histogram dump',
+                'id': str(osd_id),
+                'format': 'json'
+            }
+            r, outb, outs = self.osd_command(cmd_dict)
+            # Check for invalid calls
+            if r != 0:
+                continue
+            else:
+                try:
+                    # This is where the histograms will land
+                    # if there are any
+                    dump = json.loads(outb)
+                    result['osd.'+osd_id] = dump
+                # Sometimes, json errors occur if
+                # you give it an empty string
+                except json.decoder.JSONDecodeError:
+                    continue
+
+        return result
+
+    def get_io_rate(self) -> dict:
+        return self.get('io_rate')
+
     def gather_crashinfo(self) -> List[Dict[str, str]]:
         crashlist: List[Dict[str, str]] = list()
         errno, crashids, err = self.remote('crash', 'ls')
@@ -731,6 +817,9 @@ class Module(MgrModule):
 
         if 'perf' in channels:
             report['perf_counters'] = self.gather_perf_counters()
+            report['stat_sum_per_pool'] = self.get_stat_sum_per_pool()
+            report['io_rate'] = self.get_io_rate()
+            report['osd_perf_histograms'] = self.get_osd_histograms()
 
         # NOTE: We do not include the 'device' channel in this report; it is
         # sent to a different endpoint.


### PR DESCRIPTION
In the manager module (src/pybind/mgr/mgr_module.py), there was a command that allowed access to monitor commands, but there was nothing available to access osd commands. I added a new method called osd_command that allows access to the output of commands like "perf dump" and "perf histogram dump".
    
In the telemetry module (src/pybind/mgr/telemetry/module.py), I added information under the perf channel that can help to better characterize a workload. These additions include:

1. **io rate**: delta in pg stats since last report, including a pg stats summary and some store stats
2. **stats sum per pool**: summed up stats from every pg in a pool
3. **perf histograms**: histogram dump of latency and request size for each osd, aggregated

There are two TODO's for this PR before it is officially merged:
1. In some cases, the user might change the bucket size for a histogram. A check needs to be written that separates histograms with unique bucket sizes so there are no conflicts with schema.
2. Improve the JSON formatting of the histograms to make them more human-readable. This can be done directly in the get_osd_histograms() function with json.dumps(), but it will be better to locate the exact area where the whole report is getting formatted and make some formatting edits there. This is to ensure that the data is human-readable, but also easily retrievable on the server side.

I should be able to handle both of the TODO's on this PR soon.

An example of a human-readable histogram would look like this:
```
"op_r_latency_out_bytes_histogram": {
                "axes": [
                    {
                        "buckets": 32,
                        "min": 0,
                        "name": "Latency (usec)",
                        "quant_size": 100000,
                        "ranges": [
                            "[null, -1]",
                            "[0, 99999]",
                            "[100000, 199999]",
                            "[200000, 399999]",
                            "[400000, 799999]",
                            "[800000, 1599999]",
                            "[1600000, 3199999]",
                            "[3200000, 6399999]",
                            "[6400000, 12799999]",
                            "[12800000, 25599999]",
                            "[25600000, 51199999]",
                            "[51200000, 102399999]",
                            "[102400000, 204799999]",
                            "[204800000, 409599999]",
                            "[409600000, 819199999]",
                            "[819200000, 1638399999]",
                            "[1638400000, 3276799999]",
                            "[3276800000, 6553599999]",
                            "[6553600000, 13107199999]",
                            "[13107200000, 26214399999]",
                            "[26214400000, 52428799999]",
                            "[52428800000, 104857599999]",
                            "[104857600000, 209715199999]",
                            "[209715200000, 419430399999]",
                            "[419430400000, 838860799999]",
                            "[838860800000, 1677721599999]",
                            "[1677721600000, 3355443199999]",
                            "[3355443200000, 6710886399999]",
                            "[6710886400000, 13421772799999]",
                            "[13421772800000, 26843545599999]",
                            "[26843545600000, 53687091199999]",
                            "[53687091200000, null]"
                        ],
                        "scale_type": "log2"
                    },
                    {
                        "buckets": 32,
                        "min": 0,
                        "name": "Request size (bytes)",
                        "quant_size": 512,
                        "ranges": [
                            "[null, -1]",
                            "[0, 511]",
                            "[512, 1023]",
                            "[1024, 2047]",
                            "[2048, 4095]",
                            "[4096, 8191]",
                            "[8192, 16383]",
                            "[16384, 32767]",
                            "[32768, 65535]",
                            "[65536, 131071]",
                            "[131072, 262143]",
                            "[262144, 524287]",
                            "[524288, 1048575]",
                            "[1048576, 2097151]",
                            "[2097152, 4194303]",
                            "[4194304, 8388607]",
                            "[8388608, 16777215]",
                            "[16777216, 33554431]",
                            "[33554432, 67108863]",
                            "[67108864, 134217727]",
                            "[134217728, 268435455]",
                            "[268435456, 536870911]",
                            "[536870912, 1073741823]",
                            "[1073741824, 2147483647]",
                            "[2147483648, 4294967295]",
                            "[4294967296, 8589934591]",
                            "[8589934592, 17179869183]",
                            "[17179869184, 34359738367]",
                            "[34359738368, 68719476735]",
                            "[68719476736, 137438953471]",
                            "[137438953472, 274877906943]",
                            "[274877906944, null]"
                        ],
                        "scale_type": "log2"
                    }
                ],
                "values": [
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 215, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 166, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 155, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]",
                    "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
                ]
            },
```
Signed-off-by: Laura Flores <lflores@redhat.com>