### PR TITLE
librbd/crypto/luks: require libcryptsetup v2.0.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,11 +206,8 @@ endif()
 
 # libcryptsetup is only available on linux
 if(WITH_RBD AND LINUX)
-  find_package(libcryptsetup REQUIRED)
+  find_package(libcryptsetup 2.0.5 REQUIRED)
   set(HAVE_LIBCRYPTSETUP ${LIBCRYPTSETUP_FOUND})
-  if(${LIBCRYPTSETUP_VERSION} VERSION_LESS 2.0.5)
-    set(LIBCRYPTSETUP_LEGACY_DATA_ALIGNMENT TRUE)
-  endif()
 endif()
 
 include(CMakeDependentOption)

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -375,9 +375,6 @@
 /* Define if PWL-SSD is enabled */
 #cmakedefine WITH_RBD_SSD_CACHE
 
-/* Define if libcryptsetup version < 2.0.5 */
-#cmakedefine LIBCRYPTSETUP_LEGACY_DATA_ALIGNMENT
-
 /* Define if libcryptsetup can be used (linux only) */
 #cmakedefine HAVE_LIBCRYPTSETUP
 

--- a/src/librbd/crypto/luks/Header.cc
+++ b/src/librbd/crypto/luks/Header.cc
@@ -133,11 +133,7 @@ int Header::format(const char* type, const char* alg, const char* key,
   struct crypt_params_luks1 luks1params;
   struct crypt_params_luks2 luks2params;
 
-#ifdef LIBCRYPTSETUP_LEGACY_DATA_ALIGNMENT
-  size_t converted_data_alignment = data_alignment / sector_size;
-#else
-  size_t converted_data_alignment = data_alignment / 512;
-#endif
+  const size_t converted_data_alignment = data_alignment / 512;
 
   void* params = nullptr;
   if (strcmp(type, CRYPT_LUKS1) == 0) {


### PR DESCRIPTION
- ubuntu focal ships libcryptsetup-dev (2:2.2.2),
- centos 8 app stream comes with cryptsetup-devel-2.3.3.
- openSUSE Leap 15.3 packages libcryptsetup-devel-2.3.4
- openSUSE Leap 15.2 packages libcryptsetup-devel-2.0.5

so we can drop the support for libcryptsetup < 2.0.5

see also ea3c1bfb9ef2edcdf572df0cb143c463b7551905

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
