### PR TITLE
cmake: initialize dpdk_LIBRARIES with empty list

### DIFF
--- a/cmake/modules/Finddpdk.cmake
+++ b/cmake/modules/Finddpdk.cmake
@@ -72,8 +72,7 @@ set(components
 # for collecting dpdk library targets, it will be used when defining dpdk::dpdk
 set(_dpdk_libs)
 # for list of dpdk library archive paths
-set(dpdk_LIBRARIES)
-
+set(dpdk_LIBRARIES "")
 foreach(c ${components})
   set(dpdk_lib dpdk::${c})
   if(TARGET ${dpdk_lib})

--- a/cmake/modules/Finddpdk.cmake
+++ b/cmake/modules/Finddpdk.cmake
@@ -79,7 +79,11 @@ foreach(c ${components})
     get_target_property(DPDK_rte_${c}_LIBRARY
       ${dpdk_lib} IMPORTED_LOCATION)
   else()
-    find_library(DPDK_rte_${c}_LIBRARY rte_${c}
+    find_library(DPDK_rte_${c}_LIBRARY
+      NAMES
+        # use static library
+        ${CMAKE_STATIC_LIBRARY_PREFIX}rte_${c}${CMAKE_STATIC_LIBRARY_SUFFIX}
+        rte_${c}
       HINTS
         ENV DPDK_DIR
         ${dpdk_LIBRARY_DIRS}

--- a/src/mgr/ServiceMap.cc
+++ b/src/mgr/ServiceMap.cc
@@ -3,9 +3,7 @@
 
 #include "mgr/ServiceMap.h"
 
-#include <experimental/iterator>
 #include <fmt/format.h>
-#include <regex>
 
 #include "common/Formatter.h"
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
