### PR TITLE
crimson/osd: Port rgw object classes to run in crimson

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -616,6 +616,11 @@ OpsExecuter::execute_op(OSDOp& osd_op)
   }
 }
 
+// Defined here because there is a circular dependency between OpsExecuter and PG
+uint32_t OpsExecuter::get_pool_stripe_width() const {
+  return pg->get_pool().info.get_stripe_width();
+}
+
 static inline std::unique_ptr<const PGLSFilter> get_pgls_filter(
   const std::string& type,
   bufferlist::const_iterator& iter)

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -639,6 +639,12 @@ uint32_t OpsExecuter::get_pool_stripe_width() const {
   return pg->get_pool().info.get_stripe_width();
 }
 
+// Defined here because there is a circular dependency between OpsExecuter and PG
+version_t OpsExecuter::get_last_user_version() const
+{
+  return pg->get_last_user_version();
+}
+
 static inline std::unique_ptr<const PGLSFilter> get_pgls_filter(
   const std::string& type,
   bufferlist::const_iterator& iter)

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -604,6 +604,14 @@ OpsExecuter::execute_op(OSDOp& osd_op)
     return do_write_op([this, &osd_op] (auto& backend, auto& os, auto& txn) {
       return backend.omap_remove_range(os, osd_op, txn, delta_stats);
     }, true);
+  case CEPH_OSD_OP_OMAPRMKEYS:
+    /** TODO: Implement supports_omap()
+    if (!pg.get_pool().info.supports_omap()) {
+      return crimson::ct_error::operation_not_supported::make();
+    }*/
+    return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
+      return backend.omap_remove_key(os, osd_op, txn);
+    }, true);
   case CEPH_OSD_OP_OMAPCLEAR:
     return do_write_op([this, &osd_op] (auto& backend, auto& os, auto& txn) {
       return backend.omap_clear(os, osd_op, txn, *osd_op_params, delta_stats);

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -272,6 +272,8 @@ public:
   object_stat_sum_t& get_stats(){
     return delta_stats;
   }
+
+  version_t get_last_user_version() const;
 };
 
 template <class Context, class MainFunc, class EffectFunc>

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -154,7 +154,6 @@ private:
   Ref<PG> pg; // for the sake of object class
   ObjectContextRef obc;
   const OpInfo& op_info;
-  const pg_pool_t& pool_info;  // for the sake of the ObjClass API
   PGBackend& backend;
   ceph::static_ptr<ExecutableMessage,
                    sizeof(ExecutableMessagePimpl<void>)> msg;
@@ -240,13 +239,11 @@ public:
   OpsExecuter(Ref<PG> pg,
               ObjectContextRef obc,
               const OpInfo& op_info,
-              const pg_pool_t& pool_info,
               PGBackend& backend,
               const MsgT& msg)
     : pg(std::move(pg)),
       obc(std::move(obc)),
       op_info(op_info),
-      pool_info(pool_info),
       backend(backend),
       msg(std::in_place_type_t<ExecutableMessagePimpl<MsgT>>{}, &msg) {
   }
@@ -279,9 +276,7 @@ public:
     return num_read + num_write;
   }
 
-  uint32_t get_pool_stripe_width() const {
-    return pool_info.get_stripe_width();
-  }
+  uint32_t get_pool_stripe_width() const;
 
   bool has_seen_write() const {
     return num_write > 0;

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -683,7 +683,6 @@ PG::do_osd_ops_execute(
       ox->get_target());
     peering_state.apply_op_stats(ox->get_target(), ox->get_stats());
     return std::move(*ox).flush_changes_n_do_ops_effects(
-      Ref<PG>{this},
       [this, &op_info, &ops] (auto&& txn,
                               auto&& obc,
                               auto&& osd_op_p,
@@ -751,7 +750,7 @@ PG::do_osd_ops(
   }
   return do_osd_ops_execute<MURef<MOSDOpReply>>(
     seastar::make_lw_shared<OpsExecuter>(
-      std::move(obc), op_info, get_pool().info, get_backend(), *m),
+      Ref<PG>{this}, std::move(obc), op_info, *m),
     m->ops,
     op_info,
     [this, m, rvec = op_info.allows_returnvec()] {
@@ -795,7 +794,7 @@ PG::do_osd_ops(
 {
   return do_osd_ops_execute<void>(
     seastar::make_lw_shared<OpsExecuter>(
-      std::move(obc), op_info, get_pool().info, get_backend(), msg_params),
+      Ref<PG>{this}, std::move(obc), op_info, msg_params),
     ops,
     std::as_const(op_info),
     std::move(success_func),

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -750,7 +750,7 @@ PG::do_osd_ops(
   }
   return do_osd_ops_execute<MURef<MOSDOpReply>>(
     seastar::make_lw_shared<OpsExecuter>(
-      Ref<PG>{this}, std::move(obc), op_info, *m),
+      Ref<PG>{this}, std::move(obc), op_info, get_backend(), *m),
     m->ops,
     op_info,
     [this, m, rvec = op_info.allows_returnvec()] {
@@ -794,7 +794,7 @@ PG::do_osd_ops(
 {
   return do_osd_ops_execute<void>(
     seastar::make_lw_shared<OpsExecuter>(
-      Ref<PG>{this}, std::move(obc), op_info, msg_params),
+      Ref<PG>{this}, std::move(obc), op_info, get_backend(), msg_params),
     ops,
     std::as_const(op_info),
     std::move(success_func),

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -750,7 +750,7 @@ PG::do_osd_ops(
   }
   return do_osd_ops_execute<MURef<MOSDOpReply>>(
     seastar::make_lw_shared<OpsExecuter>(
-      Ref<PG>{this}, std::move(obc), op_info, get_backend(), *m),
+      Ref<PG>{this}, std::move(obc), op_info, *m),
     m->ops,
     op_info,
     [this, m, rvec = op_info.allows_returnvec()] {
@@ -794,7 +794,7 @@ PG::do_osd_ops(
 {
   return do_osd_ops_execute<void>(
     seastar::make_lw_shared<OpsExecuter>(
-      Ref<PG>{this}, std::move(obc), op_info, get_backend(), msg_params),
+      Ref<PG>{this}, std::move(obc), op_info, msg_params),
     ops,
     std::as_const(op_info),
     std::move(success_func),

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -450,6 +450,9 @@ public:
   bool is_backfilling() const final {
     return peering_state.is_backfilling();
   }
+  uint64_t get_last_user_version() const {
+    return get_info().last_user_version;
+  }
   bool get_need_up_thru() const {
     return peering_state.get_need_up_thru();
   }

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -273,6 +273,10 @@ public:
     const OSDOp& osd_op,
     ceph::os::Transaction& trans,
     object_stat_sum_t& delta_stats);
+  interruptible_future<> omap_remove_key(
+    ObjectState& os,
+    const OSDOp& osd_op,
+    ceph::os::Transaction& trans);
   using omap_clear_ertr = crimson::errorator<crimson::ct_error::enoent>;
   using omap_clear_iertr =
     ::crimson::interruptible::interruptible_errorator<


### PR DESCRIPTION
Implemented the remaining methods in the objclass api that are used by rgw object classes

Signed-off-by: Amnon Hanuhov <ahanukov@redhat.com>
