### PR TITLE
rgw: default ms_mon_client_mode = secure

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -190,7 +190,8 @@ int radosgw_Main(int argc, const char **argv)
   map<string,string> defaults = {
     { "debug_rgw", "1/5" },
     { "keyring", "$rgw_data/keyring" },
-    { "objecter_inflight_ops", "24576" }
+    { "objecter_inflight_ops", "24576" },
+    { "ms_mon_client_mode", "secure" }
   };
 
   vector<const char*> args;


### PR DESCRIPTION
Require a secure connection to the monitor.  This is important because
we may store SSL certs on the mon.

Note that secure mode was introduce before Nautilus, so this can be
backported at least to Pacific.

Signed-off-by: Sage Weil <sage@newdream.net>