### PR TITLE
cephadm: Fix bootstrap error with IPv6 mon-ip

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3843,7 +3843,7 @@ def prepare_ssh(
     try:
         args = ['orch', 'host', 'add', host]
         if ctx.mon_ip:
-            args.append(ctx.mon_ip)
+            args.append(unwrap_ipv6(ctx.mon_ip))
         cli(args)
     except RuntimeError as e:
         raise Error('Failed to add host <%s>: %s' % (host, e))


### PR DESCRIPTION
Fix the following error by removing the enclosing square brackets in `ctx.mon_ip`.

This issue also occurs on pacific.

```sh
$ sudo cephadm --verbose bootstrap --mon-ip fd49:277:42:2020:c4ba:e6ff:fedf:604

/usr/bin/ceph: stderr > ssh -F ssh_config -i ~/cephadm_private_key root@[fd49:277:42:2020:c4ba:e6ff:fedf:604]
Traceback (most recent call last):
  File "/usr/sbin/cephadm", line 3776, in prepare_ssh
    cli(args)
  File "/usr/sbin/cephadm", line 4076, in cli
    return CephContainer(
  File "/usr/sbin/cephadm", line 3263, in run
    out, _, _ = call_throws(self.ctx, self.run_cmd(),
  File "/usr/sbin/cephadm", line 1453, in call_throws
    raise RuntimeError('Failed command: %s' % ' '.join(command))
RuntimeError: Failed command: /usr/bin/podman run --rm --ipc=host --stop-signal=SIGTERM --net=host --entrypoint /usr/bin/ceph --init -e CONTAINER_IMAGE=docker.io/ceph/ceph:v16 -e NODE_NAME=ceph-node2 -e CEPH_USE_RANDOM_NONCE=1 -v /var/log/ceph/fee89f24-f3af-11eb-87b1-c6bae6df0604:/var/log/ceph:z -v /tmp/ceph-tmpnjeaui27:/etc/ceph/ceph.client.admin.keyring:z -v /tmp/ceph-tmpjfm82r9d:/etc/ceph/ceph.conf:z docker.io/ceph/ceph:v16 orch host add ceph-node2 [fd49:277:42:2020:c4ba:e6ff:fedf:604]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/sbin/cephadm", line 8230, in <module>
    main()
  File "/usr/sbin/cephadm", line 8218, in main
    r = ctx.func(ctx)
  File "/usr/sbin/cephadm", line 1759, in _default_image
    return func(ctx)
  File "/usr/sbin/cephadm", line 4142, in command_bootstrap
    prepare_ssh(ctx, cli, wait_for_mgr_restart)
  File "/usr/sbin/cephadm", line 3778, in prepare_ssh
    raise Error('Failed to add host <%s>: %s' % (host, e))
__main__.Error: Failed to add host <ceph-node2>: Failed command: /usr/bin/podman run --rm --ipc=host --stop-signal=SIGTERM --net=host --entrypoint /usr/bin/ceph --init -e CONTAINER_IMAGE=docker.io/ceph/ceph:v16 -e NODE_NAME=ceph-node2 -e CEPH_USE_RANDOM_NONCE=1 -v /var/log/ceph/fee89f24-f3af-11eb-87b1-c6bae6df0604:/var/log/ceph:z -v /tmp/ceph-tmpnjeaui27:/etc/ceph/ceph.client.admin.keyring:z -v /tmp/ceph-tmpjfm82r9d:/etc/ceph/ceph.conf:z docker.io/ceph/ceph:v16 orch host add ceph-node2 [fd49:277:42:2020:c4ba:e6ff:fedf:604]
Releasing lock 140115256165328 on /run/cephadm/fee89f24-f3af-11eb-87b1-c6bae6df0604.lock
Lock 140115256165328 released on /run/cephadm/fee89f24-f3af-11eb-87b1-c6bae6df0604.lock
```


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
