### PR TITLE
doc/dev/osd_internals: improve stale read wording

### DIFF
--- a/cmake/modules/FindSQLite3.cmake
+++ b/cmake/modules/FindSQLite3.cmake
@@ -1,12 +1,38 @@
-find_path(SQLite3_INCLUDE_DIR NAMES sqlite3.h)
-find_library(SQLite3_LIBRARY NAMES sqlite3 sqlite)
+# Copyright (C) 2007-2009 LuaDist.
+# Created by Peter Kapec <kapecp@gmail.com>
+# Redistribution and use of this file is allowed according to the terms of the MIT license.
+# For details see the COPYRIGHT file distributed with LuaDist.
+#	Note:
+#		Searching headers and libraries is very simple and is NOT as powerful as scripts
+#		distributed with CMake, because LuaDist defines directories to search for.
+#		Everyone is encouraged to contact the author with improvements. Maybe this file
+#		becomes part of CMake distribution sometimes.
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(SQLite3 DEFAULT_MSG SQLite3_LIBRARY SQLite3_INCLUDE_DIR)
+# - Find sqlite3
+# Find the native SQLITE3 headers and libraries.
+#
+# SQLITE3_INCLUDE_DIRS	- where to find sqlite3.h, etc.
+# SQLITE3_LIBRARIES	- List of libraries when using sqlite.
+# SQLITE3_FOUND	- True if sqlite found.
 
-if(NOT TARGET SQLite3::SQLite3)
-  add_library(SQLite3::SQLite3 UNKNOWN IMPORTED)
-  set_target_properties(SQLite3::SQLite3 PROPERTIES
-      IMPORTED_LOCATION "${SQLite3_LIBRARY}"
-      INTERFACE_INCLUDE_DIRECTORIES "${SQLite3_INCLUDE_DIR}")
-endif()
+# Look for the header file.
+FIND_PATH(SQLITE3_INCLUDE_DIR NAMES sqlite3.h)
+
+# Look for the library.
+FIND_LIBRARY(SQLITE3_LIBRARY NAMES sqlite sqlite3)
+
+# Handle the QUIETLY and REQUIRED arguments and set SQLITE3_FOUND to TRUE if all listed variables are TRUE.
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SQLITE3
+                                  REQUIRED_VARS SQLITE3_LIBRARY SQLITE3_INCLUDE_DIR
+                                  FAIL_MESSAGE "Could not find sqlite3.h and/or libsqlite3.so")
+# Copy the results to the output variables.
+IF(SQLITE3_FOUND)
+	SET(SQLITE3_LIBRARIES ${SQLITE3_LIBRARY})
+	SET(SQLITE3_INCLUDE_DIRS ${SQLITE3_INCLUDE_DIR})
+ELSE(SQLITE3_FOUND)
+	SET(SQLITE3_LIBRARIES)
+	SET(SQLITE3_INCLUDE_DIRS)
+ENDIF(SQLITE3_FOUND)
+
+MARK_AS_ADVANCED(SQLITE3_INCLUDE_DIRS SQLITE3_LIBRARIES)

--- a/doc/dev/osd_internals/stale_read.rst
+++ b/doc/dev/osd_internals/stale_read.rst
@@ -2,9 +2,10 @@ Preventing Stale Reads
 ======================
 
 We write synchronously to all replicas before sending an ack to the
-client, which ensures that we do not introduce potential inconsistency
-in the write path.  However, we only read from one replica, and the
-client will use whatever OSDMap is has to identify which OSD to read
+client, which limits the potential for inconsistency
+in the write path.  However, by default we read from just one replica
+(the lead/primary OSD for each PG), and the
+client will use whatever OSDMap it has to identify which OSD to read
 from.  In most cases, this is fine: either the client map is correct,
 or the OSD that we think is the primary for the object knows that it
 is not the primary anymore, and can feed the client an updated map


### PR DESCRIPTION
Signed-off-by: Anthony D'Atri <anthony.datri@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
