### PR TITLE
qa/workunits/rbd: use xenial version of qemu-iotests for centos stream 8

### DIFF
--- a/qa/workunits/rbd/qemu-iotests.sh
+++ b/qa/workunits/rbd/qemu-iotests.sh
@@ -12,7 +12,7 @@ cd qemu
 if lsb_release -da 2>&1 | grep -iqE '(bionic|focal)'; then
     # Bionic requires a matching test harness
     git checkout v2.11.0
-elif lsb_release -da 2>&1 | grep -iqE '(xenial|linux release 8)'; then
+elif lsb_release -da 2>&1 | grep -iqE '(xenial|linux release 8|stream release 8)'; then
     # Xenial requires a recent test harness
     git checkout v2.3.0
 else


### PR DESCRIPTION
It is already used for centos 8(.3) and rhel 8(.4).

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>