### PR TITLE
rados+rpm: Update symver defs and re-enable LTO

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1235,9 +1235,11 @@ This package provides Ceph default alerts for Prometheus.
 %autosetup -p1 -n @TARBALL_BASENAME@
 
 %build
-# LTO can be enabled as soon as the following GCC bug is fixed:
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48200
+# Disable lto on systems that do not support symver attribute
+# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48200 for details
+%if ( 0%{?rhel} && 0%{?rhel} < 9 ) || ( 0%{?suse_version} && 0%{?suse_version} <= 1500 )
 %define _lto_cflags %{nil}
+%endif
 
 %if 0%{with seastar} && 0%{?rhel}
 . /opt/rh/gcc-toolset-9/enable

--- a/cmake/modules/CephChecks.cmake
+++ b/cmake/modules/CephChecks.cmake
@@ -155,6 +155,12 @@ __attribute__((__symver__ (\"func@v2\"))) void func_v2() {};
 
 int main() {}"
   HAVE_ATTR_SYMVER)
+  if(NOT HAVE_ATTR_SYMVER)
+    if(CMAKE_CXX_FLAGS MATCHES "-flto" AND NOT CMAKE_CXX_FLAGS MATCHES "-flto-partition=none")
+      # https://tracker.ceph.com/issues/40060
+      message(FATAL_ERROR "please pass -flto-partition=none as part of CXXFLAGS")
+    endif()
+  endif()
 set(CMAKE_REQUIRED_FLAGS -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/version_script.txt)
 check_c_source_compiles("
 void func_v1() {}

--- a/cmake/modules/CephChecks.cmake
+++ b/cmake/modules/CephChecks.cmake
@@ -148,6 +148,13 @@ endif(NOT CMAKE_CROSSCOMPILING)
 set(version_script_source "v1 { }; v2 { } v1;")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/version_script.txt "${version_script_source}")
 cmake_push_check_state(RESET)
+set(CMAKE_REQUIRED_FLAGS "-Werror=attribute -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/version_script.txt")
+check_c_source_compiles("
+__attribute__((__symver__ (\"func@v1\"))) void func_v1() {};
+__attribute__((__symver__ (\"func@v2\"))) void func_v2() {};
+
+int main() {}"
+  HAVE_ATTR_SYMVER)
 set(CMAKE_REQUIRED_FLAGS -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/version_script.txt)
 check_c_source_compiles("
 void func_v1() {}

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -271,6 +271,9 @@
 /* Define if the C compiler supports __PRETTY_FUNCTION__ */
 #cmakedefine HAVE_PRETTY_FUNC
 
+/* Define if the C compiler supports __attribute__((__symver__ (".."))) */
+#cmakedefine HAVE_ATTR_SYMVER
+
 /* Define if the C compiler supports __asm__(".symver ..") */
 #cmakedefine HAVE_ASM_SYMVER
 

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -44,15 +44,25 @@
 #endif
 
 #ifdef HAVE_ASM_SYMVER
+#ifdef HAVE_ATTR_SYMVER
 #define LIBRADOS_C_API_BASE(fn)               \
   extern __typeof (_##fn##_base) _##fn##_base __attribute__((__symver__ (#fn "@")))
 #define LIBRADOS_C_API_BASE_DEFAULT(fn)       \
   extern __typeof (_##fn) _##fn __attribute__((__symver__ (#fn "@@")))
 #define LIBRADOS_C_API_DEFAULT(fn, ver)       \
   extern __typeof (_##fn) _##fn __attribute__((__symver__ (#fn "@@LIBRADOS_" #ver)))
+#else
+#define LIBRADOS_C_API_BASE(fn)               \
+  asm(".symver _" #fn "_base, " #fn "@")
+#define LIBRADOS_C_API_BASE_DEFAULT(fn)       \
+  asm(".symver _" #fn ", " #fn "@@")
+#define LIBRADOS_C_API_DEFAULT(fn, ver)       \
+  asm(".symver _" #fn ", " #fn "@@LIBRADOS_" #ver)
+#endif
 
 #define LIBRADOS_C_API_BASE_F(fn) _ ## fn ## _base
 #define LIBRADOS_C_API_DEFAULT_F(fn) _ ## fn
+
 #else
 #define LIBRADOS_C_API_BASE(fn)
 #define LIBRADOS_C_API_BASE_DEFAULT(fn)

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -43,7 +43,13 @@
 #define tracepoint(...)
 #endif
 
-#ifdef HAVE_ASM_SYMVER
+#if defined(HAVE_ASM_SYMVER) || defined(HAVE_ATTR_SYMVER)
+// prefer __attribute__() over global asm(".symver"). because the latter
+// is not parsed by the compiler and is partitioned away by GCC if
+// lto-partitions is enabled, in other words, these asm() statements
+// are dropped by the -flto option by default. the way to address it is
+// to use __attribute__. so this information can be processed by the
+// C compiler, and be preserved after LTO partitions the code
 #ifdef HAVE_ATTR_SYMVER
 #define LIBRADOS_C_API_BASE(fn)               \
   extern __typeof (_##fn##_base) _##fn##_base __attribute__((__symver__ (#fn "@")))

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -45,11 +45,11 @@
 
 #ifdef HAVE_ASM_SYMVER
 #define LIBRADOS_C_API_BASE(fn)               \
-  asm(".symver _" #fn "_base, " #fn "@")
+  extern __typeof (_##fn##_base) _##fn##_base __attribute__((__symver__ (#fn "@")))
 #define LIBRADOS_C_API_BASE_DEFAULT(fn)       \
-  asm(".symver _" #fn ", " #fn "@@")
+  extern __typeof (_##fn) _##fn __attribute__((__symver__ (#fn "@@")))
 #define LIBRADOS_C_API_DEFAULT(fn, ver)       \
-  asm(".symver _" #fn ", " #fn "@@LIBRADOS_" #ver)
+  extern __typeof (_##fn) _##fn __attribute__((__symver__ (#fn "@@LIBRADOS_" #ver)))
 
 #define LIBRADOS_C_API_BASE_F(fn) _ ## fn ## _base
 #define LIBRADOS_C_API_DEFAULT_F(fn) _ ## fn

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -530,21 +530,23 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_unset_osdmap_full_try)(
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   ctx->extra_op_flags &= ~CEPH_OSD_FLAG_FULL_TRY;
 }
-LIBRADOS_C_API_BASE_DEFAULT(rados_unset_pool_full_try);
+LIBRADOS_C_API_BASE_DEFAULT(rados_unset_osdmap_full_try);
 
-extern "C" void _rados_set_pool_full_try(rados_ioctx_t io)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_set_pool_full_try)(
+  rados_ioctx_t io)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   ctx->extra_op_flags |= CEPH_OSD_FLAG_FULL_TRY;
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_set_pool_full_try);
 
-extern "C" void _rados_unset_pool_full_try(rados_ioctx_t io)
+extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_unset_pool_full_try)(
+  rados_ioctx_t io)
 {
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
   ctx->extra_op_flags &= ~CEPH_OSD_FLAG_FULL_TRY;
 }
-LIBRADOS_C_API_BASE_DEFAULT(rados_unset_osdmap_full_try);
+LIBRADOS_C_API_BASE_DEFAULT(rados_unset_pool_full_try);
 
 extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_application_enable)(
   rados_ioctx_t io,


### PR DESCRIPTION
The gcc compiler now supports symver attribute. We should update the symvers to be able to support LTO on the platforms that support the symver attribute.

Fixes: https://tracker.ceph.com/issues/40060
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
