### PR TITLE
osd: Add config option to skip running the osd benchmark during init and update documentation.

### DIFF
--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -151,14 +151,14 @@ command:
 
   .. prompt:: bash #
 
-    ceph config set [global,osd] osd_mclock_profile <value>
+    ceph config set osd.N osd_mclock_profile <value>
 
-For example, to change the profile to allow faster recoveries, the following
-command can be used to switch to the *high_recovery_ops* profile:
+For example, to change the profile to allow faster recoveries on "osd.0", the
+following command can be used to switch to the *high_recovery_ops* profile:
 
   .. prompt:: bash #
 
-    ceph config set osd osd_mclock_profile high_recovery_ops
+    ceph config set osd.0 osd_mclock_profile high_recovery_ops
 
 .. note:: The *custom* profile is not recommended unless you are an advanced
           user.
@@ -179,9 +179,9 @@ cluster is brought up by using the following command:
 
   .. prompt:: bash #
 
-    ceph config show osd.x osd_mclock_max_capacity_iops_[hdd, ssd]
+    ceph config show osd.N osd_mclock_max_capacity_iops_[hdd, ssd]
 
-For example, the following command shows the max capacity for osd.0 on a Ceph
+For example, the following command shows the max capacity for "osd.0" on a Ceph
 node whose underlying device type is SSD:
 
   .. prompt:: bash #
@@ -195,6 +195,11 @@ Steps to Manually Benchmark an OSD (Optional)
 .. note:: These steps are only necessary if you want to override the OSD
           capacity already determined automatically during OSD initialization.
           Otherwise, you may skip this section entirely.
+
+.. tip:: If you have already determined the benchmark data and wish to manually
+         override the max osd capacity for an OSD, you may skip to section
+         `Specifying  Max OSD Capacity`_.
+
 
 Any existing benchmarking tool can be used for this purpose. In this case, the
 steps use the *Ceph OSD Bench* command described in the next section. Regardless
@@ -285,27 +290,24 @@ Specifying  Max OSD Capacity
 ````````````````````````````
 
 The steps in this section may be performed only if you want to override the
-max osd capacity automatically determined during OSD initialization. The option
-``osd_mclock_max_capacity_iops_[hdd, ssd]`` can be set by running the
+max osd capacity automatically set during OSD initialization. The option
+``osd_mclock_max_capacity_iops_[hdd, ssd]`` for an OSD can be set by running the
 following command:
 
   .. prompt:: bash #
 
-     ceph config set [global,osd] osd_mclock_max_capacity_iops_[hdd,ssd] <value>
+     ceph config set osd.N osd_mclock_max_capacity_iops_[hdd,ssd] <value>
 
-For example, the following command sets the max capacity for all the OSDs in a
-Ceph node whose underlying device type is SSDs:
-
-  .. prompt:: bash #
-
-    ceph config set osd osd_mclock_max_capacity_iops_ssd 25000
-
-To set the capacity for a specific OSD (for example "osd.0") whose underlying
-device type is HDD, use a command like this:
+For example, the following command sets the max capacity for a specific OSD
+(say "osd.0") whose underlying device type is HDD to 350 IOPS:
 
   .. prompt:: bash #
 
     ceph config set osd.0 osd_mclock_max_capacity_iops_hdd 350
+
+Alternatively, you may specify the max capacity for OSDs within the Ceph
+configuration file under the respective [osd.N] section. See
+:ref:`ceph-conf-settings` for more details.
 
 
 .. index:: mclock; config settings

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -942,6 +942,41 @@ function test_activate_osd_after_mark_down() {
 
     teardown $dir || return 1
 }
+
+function test_activate_osd_skip_benchmark() {
+    local dir=$1
+
+    setup $dir || return 1
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+
+    # Skip the osd benchmark during first osd bring-up.
+    run_osd $dir 0 --osd-op-queue=mclock_scheduler \
+        --osd-mclock-skip-benchmark=true || return 1
+    local max_iops_hdd_def=$(CEPH_ARGS='' ceph --format=json daemon \
+        $(get_asok_path osd.0) config get osd_mclock_max_capacity_iops_hdd)
+    local max_iops_ssd_def=$(CEPH_ARGS='' ceph --format=json daemon \
+        $(get_asok_path osd.0) config get osd_mclock_max_capacity_iops_ssd)
+
+    kill_daemons $dir TERM osd || return 1
+    ceph osd down 0 || return 1
+    wait_for_osd down 0 || return 1
+
+    # Skip the osd benchmark during activation as well. Validate that
+    # the max osd capacities are left unchanged.
+    activate_osd $dir 0 --osd-op-queue=mclock_scheduler \
+        --osd-mclock-skip-benchmark=true || return 1
+    local max_iops_hdd_after_boot=$(CEPH_ARGS='' ceph --format=json daemon \
+        $(get_asok_path osd.0) config get osd_mclock_max_capacity_iops_hdd)
+    local max_iops_ssd_after_boot=$(CEPH_ARGS='' ceph --format=json daemon \
+        $(get_asok_path osd.0) config get osd_mclock_max_capacity_iops_ssd)
+
+    test "$max_iops_hdd_def" = "$max_iops_hdd_after_boot" || return 1
+    test "$max_iops_ssd_def" = "$max_iops_ssd_after_boot" || return 1
+
+    teardown $dir || return 1
+}
 #######################################################################
 
 ##

--- a/qa/suites/rados/objectstore/backends/alloc-hint.yaml
+++ b/qa/suites/rados/objectstore/backends/alloc-hint.yaml
@@ -12,6 +12,7 @@ overrides:
       osd:
         filestore xfs extsize: true
         osd objectstore: filestore
+        osd op queue: wpq
 
 tasks:
 - install:

--- a/qa/suites/rados/objectstore/backends/ceph_objectstore_tool.yaml
+++ b/qa/suites/rados/objectstore/backends/ceph_objectstore_tool.yaml
@@ -14,6 +14,7 @@ tasks:
         osd max object namespace len: 64
       osd:
         osd objectstore: filestore
+        osd op queue: wpq
     log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -1061,6 +1061,19 @@ options:
   - osd_mclock_max_capacity_iops_ssd
   flags:
   - startup
+- name: osd_mclock_skip_benchmark
+  type: bool
+  level: dev
+  desc: Skip the OSD benchmark on OSD initialization/boot-up
+  long_desc: This option specifies whether the OSD benchmark must be skipped during
+    the OSD boot-up sequence. Only considered for osd_op_queue = mclock_scheduler.
+  fmt_desc: Skip the OSD benchmark on OSD initialization/boot-up
+  default: false
+  see_also:
+  - osd_mclock_max_capacity_iops_hdd
+  - osd_mclock_max_capacity_iops_ssd
+  flags:
+  - runtime
 - name: osd_mclock_profile
   type: str
   level: advanced

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10205,7 +10205,8 @@ void OSD::maybe_override_max_osd_capacity_for_qos()
   // If the scheduler enabled is mclock, override the default
   // osd capacity with the value obtained from running the
   // osd bench test. This is later used to setup mclock.
-  if (cct->_conf.get_val<std::string>("osd_op_queue") == "mclock_scheduler") {
+  if ((cct->_conf.get_val<std::string>("osd_op_queue") == "mclock_scheduler") &&
+      (cct->_conf.get_val<bool>("osd_mclock_skip_benchmark") == false)) {
     std::string max_capacity_iops_config;
     bool force_run_benchmark =
       cct->_conf.get_val<bool>("osd_mclock_force_run_benchmark_on_init");


### PR DESCRIPTION
1. Introduce a new dev config option "osd_mclock_skip_benchmark" that when
set skips running the OSD benchmark on start-up. By default this option is
disabled. This is useful in the following scenarios:
   - Dev/CI testing,
   - Configurations that don't need QoS.

2. Update mclock-config-ref doc steps to override osd max iops capacity.

Fixes: https://tracker.ceph.com/issues/52025
Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
