### PR TITLE
rbd-nbd: add ability to quiesce on signal

### DIFF
--- a/doc/man/8/rbd-nbd.rst
+++ b/doc/man/8/rbd-nbd.rst
@@ -9,7 +9,7 @@
 Synopsis
 ========
 
-| **rbd-nbd** [-c conf] [--read-only] [--device *nbd device*] [--nbds_max *limit*] [--max_part *limit*] [--exclusive] [--notrim] [--encryption-format *format*] [--encryption-passphrase-file *passphrase-file*] [--io-timeout *seconds*] [--reattach-timeout *seconds*] map *image-spec* | *snap-spec*
+| **rbd-nbd** [-c conf] [--read-only] [--device *nbd device*] [--quiesce] [--quiesce-hook *path*] [--quiesce-onsignal] [--nbds_max *limit*] [--max_part *limit*] [--exclusive] [--notrim] [--encryption-format *format*] [--encryption-passphrase-file *passphrase-file*] [--io-timeout *seconds*] [--reattach-timeout *seconds*] map *image-spec* | *snap-spec*
 | **rbd-nbd** unmap *nbd device* | *image-spec* | *snap-spec*
 | **rbd-nbd** list-mapped
 | **rbd-nbd** attach --device *nbd device* *image-spec* | *snap-spec*
@@ -29,6 +29,18 @@ Options
 
    Use *ceph.conf* configuration file instead of the default
    ``/etc/ceph/ceph.conf`` to determine monitor addresses during startup.
+
+.. option:: --quiesce
+
+   Enable quiesce callbacks.
+
+.. option:: --quiesce-hook *path*
+
+   Specify quiesce hook path (defaults to package provided rbd-nbd_quiesce script).
+
+.. option:: --quiesce-onsignal
+
+   Run quiesce hook on signal/detach.
 
 .. option:: --read-only
 

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -255,13 +255,13 @@ private:
 
   void io_start(IOContext *ctx)
   {
-    std::lock_guard l{lock};
+    std::scoped_lock l{lock};
     io_pending.push_back(&ctx->item);
   }
 
   void io_finish(IOContext *ctx)
   {
-    std::lock_guard l{lock};
+    std::scoped_lock l{lock};
     ceph_assert(ctx->item.is_on_list());
     ctx->item.remove_myself();
     io_finished.push_back(&ctx->item);
@@ -449,11 +449,11 @@ error:
       }
     }
 signal:
-    std::lock_guard l{lock};
+    std::scoped_lock l{lock};
     terminated = true;
     cond.notify_all();
 
-    std::lock_guard disconnect_l{disconnect_lock};
+    std::scoped_lock disconnect_l{disconnect_lock};
     disconnect_cond.notify_all();
 
     dout(20) << __func__ << ": terminated" << dendl;


### PR DESCRIPTION
Problem:
-------
Scenario possible most commonly with the new attach command.

Say we had mapped the image and mounted it, and now the application is performing IO to the device, while the IO is ongoing it might be possible that the rbd-nbd process received a detach request or a SIGTERM (this is very common if the rbd-nbd is running inside a container, if there is a container restart then it will result in SIGTERM). It is very much possible that we hit a filesystem corruption because it might be possible that some of the writes are still waiting at the filesystem or the block layers, which have not reached rbd-nbd layer yet.

This can be easily handled:
1. If the application can send sync before killing the rbd-nbd process, but that cannot be guaranteed all the time, because we should be ready for ungraceful shutdown nature.
2. Also we might not want to afford synchronous I/O (mount -osync)

Also what about the IO which might be still continuing on the mount while process is down? We cannot simply assume that the applications are always aware of rbd-nbd process state.

One thing we all agree with is that we should always give highest priority to the data consistency.

Solution:
--------
Freeze the filesystem as part of the detach (SIGTERM handling) so that:
1. All the data is flushed from filesystem till backend, so that data is guaranteed to be consistent across.
2. IO on the mount, while rbd-nbd process is down is blocked waiting for the filesystem.
3. Snapshots on the image, while rbd-nbd process is down can also be consistent.
4. Just in case if the rbd-nbd process cannot be reattached, no problem! we have a safe copy.

By the way, this is provided just as an option `--quiesce-onsignal` (read as quiesce on signal) so that default is still the same as old.

Fixes: https://tracker.ceph.com/issues/51820
Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>

## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
