### PR TITLE
mgr/dashboard: show perf. counters for rgw svc. on Cluster > Hosts

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -97,6 +97,7 @@ class RgwDaemon(RESTController):
                 # extract per-daemon service data and health
                 daemon = {
                     'id': metadata['id'],
+                    'service_map_id': service['id'],
                     'version': metadata['ceph_version'],
                     'server_hostname': hostname,
                     'zonegroup_name': metadata['zonegroup_name'],

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-daemon.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-daemon.ts
@@ -1,5 +1,6 @@
 export class RgwDaemon {
   id: string;
+  service_map_id: string;
   version: string;
   server_hostname: string;
   zonegroup_name: string;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html
@@ -17,7 +17,7 @@
          i18n>Performance Counters</a>
       <ng-template ngbNavContent>
         <cd-table-performance-counter serviceType="rgw"
-                                      [serviceId]="serviceId">
+                                      [serviceId]="serviceMapId">
         </cd-table-performance-counter>
       </ng-template>
     </li>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { PerformanceCounterModule } from '~/app/ceph/performance-counter/performance-counter.module';
+import { RgwDaemon } from '~/app/ceph/rgw/models/rgw-daemon';
 import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { RgwDaemonDetailsComponent } from './rgw-daemon-details.component';
@@ -26,5 +27,16 @@ describe('RgwDaemonDetailsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should set service id and service map id on changes', () => {
+    const daemon = new RgwDaemon();
+    daemon.id = 'daemon1';
+    daemon.service_map_id = '4832';
+    component.selection = daemon;
+    component.ngOnChanges();
+
+    expect(component.serviceId).toBe(daemon.id);
+    expect(component.serviceMapId).toBe(daemon.service_map_id);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnChanges } from '@angular/core';
 
 import _ from 'lodash';
 
+import { RgwDaemon } from '~/app/ceph/rgw/models/rgw-daemon';
 import { RgwDaemonService } from '~/app/shared/api/rgw-daemon.service';
 import { Permission } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
@@ -14,10 +15,11 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 export class RgwDaemonDetailsComponent implements OnChanges {
   metadata: any;
   serviceId = '';
+  serviceMapId = '';
   grafanaPermission: Permission;
 
   @Input()
-  selection: any;
+  selection: RgwDaemon;
 
   constructor(
     private rgwDaemonService: RgwDaemonService,
@@ -27,9 +29,9 @@ export class RgwDaemonDetailsComponent implements OnChanges {
   }
 
   ngOnChanges() {
-    // Get the service id of the first selected row.
     if (this.selection) {
       this.serviceId = this.selection.id;
+      this.serviceMapId = this.selection.service_map_id;
     }
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/context/context.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/context/context.component.ts
@@ -42,7 +42,7 @@ export class ContextComponent implements OnInit, OnDestroy {
     this.subs.add(
       this.router.events
         .pipe(filter((event: Event) => event instanceof NavigationEnd))
-        .subscribe(() => (this.isRgwRoute = this.router.url.includes(this.rgwUrlPrefix)))
+        .subscribe(() => (this.isRgwRoute = this.router.url.startsWith(this.rgwUrlPrefix)))
     );
     // Set daemon list polling only when in RGW route:
     this.subs.add(

--- a/src/pybind/mgr/dashboard/tests/test_rgw.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw.py
@@ -71,7 +71,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
         RgwStub.get_settings()
         mgr.list_servers.return_value = [{
             'hostname': 'host1',
-            'services': [{'id': 'daemon1', 'type': 'rgw'}, {'id': 'daemon2', 'type': 'rgw'}]
+            'services': [{'id': '4832', 'type': 'rgw'}, {'id': '5356', 'type': 'rgw'}]
         }]
         mgr.get_metadata.side_effect = [
             {
@@ -90,6 +90,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
         self.assertStatus(200)
         self.assertJsonBody([{
             'id': 'daemon1',
+            'service_map_id': '4832',
             'version': 'ceph version master (dev)',
             'server_hostname': 'host1',
             'zonegroup_name': 'zg1',
@@ -97,6 +98,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
         },
             {
             'id': 'daemon2',
+            'service_map_id': '5356',
             'version': 'ceph version master (dev)',
             'server_hostname': 'host1',
             'zonegroup_name': 'zg2',


### PR DESCRIPTION
- Use service_map_id to retrieve perf. counters for rgw services.
- Move logic from controller to CephService.
- Cluster > Hosts > Performance Counters: do not show the context bar (Object Gateway selection).

Fixes: https://tracker.ceph.com/issues/52022


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
