### PR TITLE
[DNM][RFC] os/bluestore: refactor bluefs log mechanics

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3894,6 +3894,21 @@ options:
   long_desc: The number of times to retry on getting the block device lock. Programs
     such as systemd-udevd may compete with Ceph for this lock. 0 means 'unlimited'.
   default: 3
+- name: bluefs_mode
+  type: str
+  level: dev
+  default: static_log
+  enum_values:
+  - original
+  - static_log
+  - static_log
+  with_legacy: true
+- name: bluefs_static_log_size
+  type: size
+  level: advanced
+  desc: Bluefs static log preallocated size
+  default: 16_M
+  with_legacy: true
 - name: bluefs_alloc_size
   type: size
   level: advanced

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -399,6 +399,7 @@ private:
 #endif
 
   int _flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
+			  bool allow_delta,
 			  uint64_t want_seq = 0,
 			  uint64_t jump_to = 0);
   uint64_t _estimate_log_size();


### PR DESCRIPTION
This rework attempts to make BlueFS log implementation less complicated and less error prone.

The major design idea is to get rid off dynamic log allocations and use two statically allocated ones, 16MB is the proposed single log size atm.
At every given time single log is in use, when it becomes full switching to another one (coupled with compaction) occurs. To perform such a switching in a safe manner each log is coupled with a stamp (a small disk block-aligned structure) which keeps monotonically incremented log compaction/switching number, first owned operation seq number and a checksum. 
Related stamp is written as a last step during log switching/compaction. On OSD restart this allows to learn which of the two logs is the effective one - attached log compaction number is used for that, the one with a higher value is chosen. Checksum permits to handle stamp write failure and the first owned operation seq number allows to filter out legacy records during log replay.

Additionally the patch introduces an ability to log op_update operation in an incremental manner, i.e. instead of logging the whole allocation map from fnode it writes out just a new portion of it (if any). The full allocation map is recovered during log replay on startup or from a full op_update record produced during log compaction. 
This works fine given that we do not perform partial trimming on bluefs files. The feature is pretty independent from the log refactoring though.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
