### PR TITLE
qa/tasks/rook: set storage_class to scratch

### DIFF
--- a/qa/suites/orch/rook/smoke/rook/1.6.2.yaml
+++ b/qa/suites/orch/rook/smoke/rook/1.6.2.yaml
@@ -1,4 +1,0 @@
-overrides:
-  rook:
-    rook_image: rook/ceph:v1.6.2
-    rook_branch: v1.6.2

--- a/qa/suites/orch/rook/smoke/rook/1.7.0.yaml
+++ b/qa/suites/orch/rook/smoke/rook/1.7.0.yaml
@@ -1,0 +1,4 @@
+overrides:
+  rook:
+    rook_image: rook/ceph:v1.7.0
+    rook_branch: v1.7.0

--- a/qa/tasks/rook.py
+++ b/qa/tasks/rook.py
@@ -465,6 +465,21 @@ def rook_toolbox(ctx, config):
 
 
 @contextlib.contextmanager
+def rook_post_config(ctx, config):
+    try:
+        _shell(ctx, config, ['ceph', 'config', 'set', 'mgr', 'mgr/rook/storage_class',
+                             'scratch'])
+        yield
+
+    except Exception as e:
+        log.exception(e)
+        raise
+
+    finally:
+        pass
+
+
+@contextlib.contextmanager
 def wait_for_osds(ctx, config):
     cluster_name = config.get('cluster', 'ceph')
 
@@ -616,6 +631,7 @@ def task(ctx, config):
             lambda: rook_cluster(ctx, config),
             lambda: rook_toolbox(ctx, config),
             lambda: wait_for_osds(ctx, config),
+            lambda: rook_post_config(ctx, config),
             lambda: ceph_config_keyring(ctx, config),
             lambda: ceph_clients(ctx, config),
     ):


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>