### PR TITLE
pacific: common/options: Set osd_client_message_cap to 256.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2678,7 +2678,7 @@ std::vector<Option> get_global_options() {
     .set_long_description("If this value is exceeded, the OSD will not read any new client data off of the network until memory is freed."),
 
     Option("osd_client_message_cap", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(0)
+    .set_default(256)
     .set_description("maximum number of in-flight client requests"),
 
     Option("osd_crush_update_weight_set", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51830

---

backport of https://github.com/ceph/ceph/pull/42157
parent tracker: https://tracker.ceph.com/issues/49894

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh