### PR TITLE
octopus: qa/*/test_envlibrados_for_rocksdb.sh: fix libarchive dependency

### DIFF
--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -33,7 +33,7 @@ case $(distro_id) in
                 sudo subscription-manager repos --enable "codeready-builder-for-rhel-8-x86_64-rpms"
                 ;;
         esac
-        install git gcc-c++.x86_64 snappy-devel zlib zlib-devel bzip2 bzip2-devel libradospp-devel.x86_64 cmake libarchive-3.3.3
+        install git gcc-c++.x86_64 snappy-devel zlib zlib-devel bzip2 bzip2-devel libradospp-devel.x86_64 cmake libarchive
         ;;
 	opensuse*|suse|sles)
 		install git gcc-c++ snappy-devel zlib-devel libbz2-devel libradospp-devel


### PR DESCRIPTION
Fixes failures like the following with rhel 8.3 in octopus

```
2021-08-03T17:32:19.328 INFO:tasks.workunit.client.0.smithi148.stdout:No match for argument: libarchive-3.3.3
2021-08-03T17:32:19.338 INFO:tasks.workunit.client.0.smithi148.stderr:Error: Unable to find a match: libarchive-3.3.3
2021-08-03T17:32:19.376 DEBUG:teuthology.orchestra.run:got remote process result: 1
2021-08-03T17:32:19.377 INFO:tasks.workunit:Stopping ['rados/test_envlibrados_for_rocksdb.sh'] on client.0...
```

Follow-up to https://github.com/ceph/ceph/pull/42421

Signed-off-by: Neha Ojha <nojha@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
