### PR TITLE
script/ceph-release-notes: improve output for markdown and limit verbosity

### DIFF
--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -137,6 +137,10 @@ def _title_message(commit, pr, strict):
         # assume that a single line means the intention is to
         # re-write the PR title
         return (lines[0], None)
+    elif len(lines) < 3 and 'refs/pull' in lines[0]:
+        # assume the intent was rewriting the title and something like
+        # ptl-tool was used to generate the merge message
+        return (lines[1], None)
     message = "    " + "\n    ".join(lines)
     return (title, message)
 

--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -285,8 +285,9 @@ def make_release_notes(gh, repo, ref, plaintext, html, markdown, verbose, strict
                 )
             )
         elif markdown:
+            markdown_title = title.replace('_', '\_').replace('.', '<!-- breaklink >.')
             print ("- {title} ({issues}[pr#{pr}](https://github.com/ceph/ceph/pull/{pr}), {author})\n".format(
-                    title=title,
+                    title=markdown_title,
                     issues=issues,
                     author=author, pr=pr
                 )

--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -242,7 +242,7 @@ def make_release_notes(gh, repo, ref, plaintext, html, markdown, verbose, strict
                        issue + " " + str(prs))
 
     for (pr, (author, title, message)) in sorted(
-        pr2info.items(), key=lambda title: title[1][1]
+        pr2info.items(), key=lambda title: title[1][1].lower()
     ):
         if pr in pr2issues:
             if plaintext:

--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -144,7 +144,7 @@ def _title_message(commit, pr, strict):
     message = "    " + "\n    ".join(lines)
     return (title, message)
 
-def make_release_notes(gh, repo, ref, plaintext, html, markdown, verbose, strict, use_tags):
+def make_release_notes(gh, repo, ref, plaintext, html, markdown, verbose, strict, use_tags, include_pr_messages):
 
     issue2prs = {}
     pr2issues = {}
@@ -308,7 +308,7 @@ def make_release_notes(gh, repo, ref, plaintext, html, markdown, verbose, strict
                     author=author, pr=pr
                 )
             )
-        if message:
+        if include_pr_messages and message:
             print (message)
 
 
@@ -354,6 +354,8 @@ if __name__ == "__main__":
     )
     parser.add_argument("--use-tags", default=False,
                         help="Use github tags to guess the component")
+    parser.add_argument("--include-pr-messages", default=False, action='store_true',
+                        help="Include full PR message in addition to PR title, if available")
 
     args = parser.parse_args()
     gh = github.GitHub(
@@ -368,5 +370,6 @@ if __name__ == "__main__":
         args.markdown,
         args.verbose,
         args.strict,
-        args.use_tags
+        args.use_tags,
+        args.include_pr_messages
     )


### PR DESCRIPTION
These were requested by @djgalloway - sample markdown output for v14.2.22 looks like this:

```
- qa/tasks/mgr/test\_progress: fix wait\_until\_equal ([pr#39397](https://github.com/ceph/ceph/pull/39397), Kamoltat, Ricardo Dias)
                                                                                                                          
- qa/tasks/qemu: precise repos have been archived ([pr#41641](https://github.com/ceph/ceph/pull/41641), Ilya Dryomov)
                                                                                                                                                                                            
- qa/tasks/vstart\_runner<!-- breaklink >.py: start max required mgrs ([pr#40751](https://github.com/ceph/ceph/pull/40751), Alfonso Martínez)

- qa/tests: added client-upgrade-nautilus-pacific tests ([pr#39818](https://github.com/ceph/ceph/pull/39818), Yuri Weinstein)         

- qa/tests: advanced nautilus initial version to 14<!-- breaklink >.2<!-- breaklink >.20 ([pr#41227](https://github.com/ceph/ceph/pull/41227), Yuri Weinstein)

- qa/upgrade: disable update\_features test\_notify with older client as lockowner ([pr#41513](https://github.com/ceph/ceph/pull/41513), Deepika Upadhyay)

- qa: add sleep for blocklisting to take effect ([pr#40714](https://github.com/ceph/ceph/pull/40714), Patrick Donnelly)            

- qa: avoid TypeError in cleanup ([pr#41485](https://github.com/ceph/ceph/pull/41485), Patrick Donnelly)                                               

- qa: bump osd heartbeat grace for ffsb workload ([pr#40713](https://github.com/ceph/ceph/pull/40713), Nathan Cutler)

- qa: delete all fs during tearDown ([pr#40709](https://github.com/ceph/ceph/pull/40709), Patrick Donnelly)                    

- qa: krbd\_blkroset<!-- breaklink >.t: update for separate hw and user read-only flags ([pr#40212](https://github.com/ceph/ceph/pull/40212), Ilya Dryomov)

- rbd-mirror: image replayer stop might race with instance replayer shut down ([pr#41792](https://github.com/ceph/ceph/pull/41792), Mykola Golub, Jason Dillaman)

- rgw : catch non int exception ([pr#40356](https://github.com/ceph/ceph/pull/40356), caolei)                                          

- rgw/http: add timeout to http client ([pr#40667](https://github.com/ceph/ceph/pull/40667), Yuval Lifshitz)                                      

- rgw: Added caching for S3 credentials retrieved from keystone ([pr#41158](https://github.com/ceph/ceph/pull/41158), James Weaver)

- rgw: allow rgw-orphan-list to handle intermediate files w/ binary data ([pr#39767](https://github.com/ceph/ceph/pull/39767), J. Eric Ivancich)

- rgw: beast frontend uses 512k mprotected coroutine stacks ([pr#39947](https://github.com/ceph/ceph/pull/39947), Yaakov Selkowitz, Mauricio Faria de Oliveira, Daniel Gryniewicz, Casey Bodley)

- rgw: check object locks in multi-object delete ([issue#47586](http://tracker.ceph.com/issues/47586), [pr#41164](https://github.com/ceph/ceph/pull/41164), Mark Houghton, Matt Benjamin)

- rgw: during reshard lock contention, adjust logging ([pr#41156](https://github.com/ceph/ceph/pull/41156), J. Eric Ivancich)

- rgw: limit rgw\_gc\_max\_objs to RGW\_SHARDS\_PRIME\_1 ([pr#40670](https://github.com/ceph/ceph/pull/40670), Rafał Wądołowski)

- rgw: radoslist incomplete multipart parts marker ([pr#40827](https://github.com/ceph/ceph/pull/40827), J. Eric Ivancich)

- rgw: return ERR\_NO\_SUCH\_BUCKET early while evaluating bucket policy ([issue#38420](http://tracker.ceph.com/issues/38420), [pr#40668](https://github.com/ceph/ceph/pull/40668), Abhishek Lekshmanan)

- rgw: return error when trying to copy encrypted object without key ([pr#40671](https://github.com/ceph/ceph/pull/40671), Ilsoo Byun)

- rgw: tooling to locate rgw objects with missing rados components ([pr#39771](https://github.com/ceph/ceph/pull/39771), Michael Kidd, J. Eric Ivancich)

- rgw: Use correct bucket info when put or get large object with swift ([pr#40106](https://github.com/ceph/ceph/pull/40106), zhiming zhang, yupeng chen)

- run-make-check<!-- breaklink >.sh: let ctest generate XML output ([pr#40407](https://github.com/ceph/ceph/pull/40407), Kefu Chai)

- src/global/signal\_handler<!-- breaklink >.h: fix preprocessor logic for alpine ([pr#39942](https://github.com/ceph/ceph/pull/39942), Duncan Bellamy)

- test/pybind: s/nosetests/python3/ ([pr#40536](https://github.com/ceph/ceph/pull/40536), Kefu Chai)

- test/rgw: test\_datalog\_autotrim filters out new entries ([pr#40674](https://github.com/ceph/ceph/pull/40674), Casey Bodley)

- test/TestOSDScrub: fix mktime() error ([pr#40621](https://github.com/ceph/ceph/pull/40621), luo rixin)

- test: use std::atomic<bool> instead of volatile for cb\_done var ([pr#40701](https://github.com/ceph/ceph/pull/40701), Jeff Layton)

- tests: ceph\_test\_rados\_api\_watch\_notify: Allow for reconnect ([pr#40697](https://github.com/ceph/ceph/pull/40697), Brad Hubbard)

- vstart<!-- breaklink >.sh: disable "auth\_allow\_insecure\_global\_id\_reclaim" ([pr#40959](https://github.com/ceph/ceph/pull/40959), Kefu Chai)


```