### PR TITLE
mds: switch mds_lock to fair mutex to fix the slow performance issue

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -61,7 +61,6 @@ set(common_srcs
   code_environment.cc
   common_init.cc
   compat.cc
-  condition_variable_debug.cc
   config.cc
   config_values.cc
   dout.cc
@@ -112,6 +111,7 @@ if(WITH_CEPH_DEBUG_MUTEX)
   list(APPEND common_srcs
     lockdep.cc
     mutex_debug.cc
+    condition_variable_debug.cc
     shared_mutex_debug.cc)
 endif()
 

--- a/src/common/fair_mutex.h
+++ b/src/common/fair_mutex.h
@@ -1,7 +1,10 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 
+#pragma once
+
 #include "common/ceph_mutex.h"
 
+#include <thread>
 #include <string>
 
 namespace ceph {
@@ -22,6 +25,7 @@ public:
     cond.wait(lock, [&] {
       return my_id == unblock_id;
     });
+    _set_locked_by();
   }
 
   bool try_lock()
@@ -31,6 +35,7 @@ public:
       return false;
     }
     ++next_id;
+    _set_locked_by();
     return true;
   }
 
@@ -38,6 +43,7 @@ public:
   {
     std::lock_guard lock(mutex);
     ++unblock_id;
+    _reset_locked_by();
     cond.notify_all();
   }
 
@@ -45,10 +51,30 @@ public:
   {
     return next_id != unblock_id;
   }
+
+#ifdef CEPH_DEBUG_MUTEX
+  bool is_locked_by_me() const {
+    return is_locked() && locked_by == std::this_thread::get_id();
+  }
+private:
+  void _set_locked_by() {
+    locked_by = std::this_thread::get_id();
+  }
+  void _reset_locked_by() {
+    locked_by = {};
+  }
+#else
+  void _set_locked_by() {}
+  void _reset_locked_by() {}
+#endif
+
 private:
   unsigned next_id = 0;
   unsigned unblock_id = 0;
   ceph::condition_variable cond;
   ceph::mutex mutex;
+#ifdef CEPH_DEBUG_MUTEX
+  std::thread::id locked_by = {};
+#endif
 };
 } // namespace ceph

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -10,7 +10,6 @@ set(crimson_alien_common_srcs
   ${PROJECT_SOURCE_DIR}/src/common/blkdev.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_context.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_crypto.cc
-  ${PROJECT_SOURCE_DIR}/src/common/condition_variable_debug.cc
   ${PROJECT_SOURCE_DIR}/src/common/cmdparse.cc
   ${PROJECT_SOURCE_DIR}/src/common/Finisher.cc
   ${PROJECT_SOURCE_DIR}/src/common/HeartbeatMap.cc
@@ -32,6 +31,7 @@ if(WITH_CEPH_DEBUG_MUTEX)
   list(APPEND crimson_alien_common_srcs
     ${PROJECT_SOURCE_DIR}/src/common/lockdep.cc
     ${PROJECT_SOURCE_DIR}/src/common/mutex_debug.cc
+    ${PROJECT_SOURCE_DIR}/src/common/condition_variable_debug.cc
     ${PROJECT_SOURCE_DIR}/src/common/shared_mutex_debug.cc)
 endif()
 add_library(crimson-alien-common STATIC

--- a/src/journal/JournalMetadata.h
+++ b/src/journal/JournalMetadata.h
@@ -9,6 +9,7 @@
 #include "include/rados/librados.hpp"
 #include "common/AsyncOpTracker.h"
 #include "common/Cond.h"
+#include "common/Timer.h"
 #include "common/ceph_mutex.h"
 #include "common/RefCountedObj.h"
 #include "common/WorkQueue.h"
@@ -22,8 +23,6 @@
 #include <map>
 #include <string>
 #include "include/ceph_assert.h"
-
-class SafeTimer;
 
 namespace journal {
 

--- a/src/journal/JournalPlayer.h
+++ b/src/journal/JournalPlayer.h
@@ -8,6 +8,7 @@
 #include "include/Context.h"
 #include "include/rados/librados.hpp"
 #include "common/AsyncOpTracker.h"
+#include "common/Timer.h"
 #include "journal/JournalMetadata.h"
 #include "journal/ObjectPlayer.h"
 #include "journal/Types.h"
@@ -15,8 +16,6 @@
 #include <boost/none.hpp>
 #include <boost/optional.hpp>
 #include <map>
-
-class SafeTimer;
 
 namespace journal {
 

--- a/src/journal/JournalRecorder.h
+++ b/src/journal/JournalRecorder.h
@@ -9,14 +9,13 @@
 #include "include/rados/librados.hpp"
 #include "common/ceph_mutex.h"
 #include "common/containers.h"
+#include "common/Timer.h"
 #include "journal/Future.h"
 #include "journal/FutureImpl.h"
 #include "journal/JournalMetadata.h"
 #include "journal/ObjectRecorder.h"
 #include <map>
 #include <string>
-
-class SafeTimer;
 
 namespace journal {
 

--- a/src/journal/Journaler.h
+++ b/src/journal/Journaler.h
@@ -11,13 +11,13 @@
 #include "journal/Future.h"
 #include "journal/JournalMetadataListener.h"
 #include "cls/journal/cls_journal_types.h"
+#include "common/Timer.h"
 #include <list>
 #include <map>
 #include <string>
 #include "include/ceph_assert.h"
 
 class ContextWQ;
-class SafeTimer;
 class ThreadPool;
 
 namespace journal {

--- a/src/journal/ObjectPlayer.h
+++ b/src/journal/ObjectPlayer.h
@@ -8,6 +8,7 @@
 #include "include/interval_set.h"
 #include "include/rados/librados.hpp"
 #include "common/ceph_mutex.h"
+#include "common/Timer.h"
 #include "common/RefCountedObj.h"
 #include "journal/Entry.h"
 #include <list>
@@ -15,8 +16,6 @@
 #include <boost/noncopyable.hpp>
 #include <boost/unordered_map.hpp>
 #include "include/ceph_assert.h"
-
-class SafeTimer;
 
 namespace journal {
 

--- a/src/journal/ObjectRecorder.h
+++ b/src/journal/ObjectRecorder.h
@@ -10,14 +10,13 @@
 #include "common/ceph_mutex.h"
 #include "common/RefCountedObj.h"
 #include "common/WorkQueue.h"
+#include "common/Timer.h"
 #include "journal/FutureImpl.h"
 #include <list>
 #include <map>
 #include <set>
 #include <boost/noncopyable.hpp>
 #include "include/ceph_assert.h"
-
-class SafeTimer;
 
 namespace journal {
 

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -59,7 +59,7 @@ namespace librbd {
 
 namespace {
 
-class SafeTimerSingleton : public SafeTimer {
+class SafeTimerSingleton : public CommonSafeTimer<ceph::mutex> {
 public:
   ceph::mutex lock = ceph::make_mutex("librbd::SafeTimerSingleton::lock");
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "common/Timer.h"
 #include "common/ceph_mutex.h"
 #include "common/config_proxy.h"
 #include "common/event_socket.h"
@@ -34,8 +35,6 @@
 
 #include <boost/lockfree/policies.hpp>
 #include <boost/lockfree/queue.hpp>
-
-class SafeTimer;
 
 namespace neorados {
 class IOContext;

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -10,6 +10,7 @@
 #include "include/rados/librados_fwd.hpp"
 #include "common/AsyncOpTracker.h"
 #include "common/Cond.h"
+#include "common/Timer.h"
 #include "common/RefCountedObj.h"
 #include "journal/Future.h"
 #include "journal/JournalMetadataListener.h"
@@ -27,7 +28,6 @@
 #include <unordered_map>
 
 class ContextWQ;
-class SafeTimer;
 namespace journal { class Journaler; }
 
 namespace librbd {

--- a/src/librbd/cache/pwl/AbstractWriteLog.h
+++ b/src/librbd/cache/pwl/AbstractWriteLog.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_LIBRBD_CACHE_PARENT_WRITE_LOG
 #define CEPH_LIBRBD_CACHE_PARENT_WRITE_LOG
 
+#include "common/Timer.h"
 #include "common/RWLock.h"
 #include "common/WorkQueue.h"
 #include "common/AsyncOpTracker.h"
@@ -20,7 +21,6 @@
 #include <list>
 
 class Context;
-class SafeTimer;
 
 namespace librbd {
 

--- a/src/librbd/cache/pwl/rwl/WriteLog.h
+++ b/src/librbd/cache/pwl/rwl/WriteLog.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <libpmemobj.h>
 #include <list>
+#include "common/Timer.h"
 #include "common/RWLock.h"
 #include "common/WorkQueue.h"
 #include "common/AsyncOpTracker.h"
@@ -21,7 +22,6 @@
 #include "librbd/cache/pwl/rwl/Builder.h"
 
 class Context;
-class SafeTimer;
 
 namespace librbd {
 

--- a/src/librbd/image/RemoveRequest.h
+++ b/src/librbd/image/RemoveRequest.h
@@ -7,11 +7,11 @@
 #include "include/rados/librados.hpp"
 #include "librbd/ImageCtx.h"
 #include "librbd/image/TypeTraits.h"
+#include "common/Timer.h"
 
 #include <list>
 
 class Context;
-class SafeTimer;
 
 namespace librbd {
 

--- a/src/librbd/io/TypeTraits.h
+++ b/src/librbd/io/TypeTraits.h
@@ -4,7 +4,7 @@
 #ifndef CEPH_LIBRBD_IO_TYPE_TRAITS_H
 #define CEPH_LIBRBD_IO_TYPE_TRAITS_H
 
-class SafeTimer;
+#include "common/Timer.h"
 
 namespace librbd {
 namespace io {

--- a/src/librbd/journal/CreateRequest.h
+++ b/src/librbd/journal/CreateRequest.h
@@ -9,6 +9,7 @@
 #include "include/rados/librados.hpp"
 #include "include/rbd/librbd.hpp"
 #include "common/ceph_mutex.h"
+#include "common/Timer.h"
 #include "librbd/ImageCtx.h"
 #include "journal/Journaler.h"
 #include "librbd/journal/Types.h"
@@ -20,7 +21,6 @@ using journal::Journaler;
 
 class Context;
 class ContextWQ;
-class SafeTimer;
 
 namespace journal {
   class Journaler;

--- a/src/librbd/journal/RemoveRequest.h
+++ b/src/librbd/journal/RemoveRequest.h
@@ -11,13 +11,13 @@
 #include "librbd/ImageCtx.h"
 #include "journal/Journaler.h"
 #include "librbd/journal/TypeTraits.h"
+#include "common/Timer.h"
 
 using librados::IoCtx;
 using journal::Journaler;
 
 class Context;
 class ContextWQ;
-class SafeTimer;
 
 namespace journal {
   class Journaler;

--- a/src/librbd/journal/ResetRequest.h
+++ b/src/librbd/journal/ResetRequest.h
@@ -9,11 +9,11 @@
 #include "include/rados/librados.hpp"
 #include "include/rbd/librbd.hpp"
 #include "librbd/journal/TypeTraits.h"
+#include "common/Timer.h"
 #include <string>
 
 class Context;
 class ContextWQ;
-class SafeTimer;
 
 namespace journal { class Journaler; }
 

--- a/src/librbd/mirror/snapshot/PromoteRequest.h
+++ b/src/librbd/mirror/snapshot/PromoteRequest.h
@@ -7,12 +7,12 @@
 #include "include/buffer.h"
 #include "include/rbd/librbd.hpp"
 #include "common/ceph_mutex.h"
+#include "common/Timer.h"
 #include "librbd/internal.h"
 
 #include <string>
 #include <set>
 
-class SafeTimer;
 struct Context;
 
 namespace librbd {

--- a/src/librbd/plugin/Api.h
+++ b/src/librbd/plugin/Api.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_LIBRBD_PLUGIN_API_H
 #define CEPH_LIBRBD_PLUGIN_API_H
 
+#include "common/Timer.h"
 #include "common/ceph_mutex.h"
 #include "include/common_fwd.h"
 #include "include/int_types.h"
@@ -12,8 +13,6 @@
 #include "librbd/io/ReadResult.h"
 
 namespace ZTracer { struct Trace; }
-
-class SafeTimer;
 
 namespace librbd {
 

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -25,6 +25,7 @@
 
 #include "common/LogClient.h"
 #include "common/ceph_mutex.h"
+#include "common/fair_mutex.h"
 #include "common/Timer.h"
 #include "include/Context.h"
 #include "include/types.h"
@@ -72,10 +73,10 @@ class MDSDaemon : public Dispatcher {
    * also check the `stopping` flag.  If stopping is true, you
    * must either do nothing and immediately drop the lock, or
    * never drop the lock again (i.e. call respawn()) */
-  ceph::mutex mds_lock = ceph::make_mutex("MDSDaemon::mds_lock");
+  ceph::fair_mutex mds_lock{"MDSDaemon::mds_lock"};
   bool stopping = false;
 
-  SafeTimer    timer;
+  class CommonSafeTimer<ceph::fair_mutex> timer;
   std::string gss_ktfile_client{};
 
   int orig_argc;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -482,9 +482,9 @@ private:
 
 MDSRank::MDSRank(
     mds_rank_t whoami_,
-    ceph::mutex &mds_lock_,
+    ceph::fair_mutex &mds_lock_,
     LogChannelRef &clog_,
-    SafeTimer &timer_,
+    CommonSafeTimer<ceph::fair_mutex> &timer_,
     Beacon &beacon_,
     std::unique_ptr<MDSMap>& mdsmap_,
     Messenger *msgr,
@@ -3622,9 +3622,9 @@ bool MDSRank::evict_client(int64_t session_id,
 
 MDSRankDispatcher::MDSRankDispatcher(
     mds_rank_t whoami_,
-    ceph::mutex &mds_lock_,
+    ceph::fair_mutex &mds_lock_,
     LogChannelRef &clog_,
-    SafeTimer &timer_,
+    CommonSafeTimer<ceph::fair_mutex> &timer_,
     Beacon &beacon_,
     std::unique_ptr<MDSMap> &mdsmap_,
     Messenger *msgr,

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -22,7 +22,9 @@
 #include "common/DecayCounter.h"
 #include "common/LogClient.h"
 #include "common/Timer.h"
+#include "common/fair_mutex.h"
 #include "common/TrackedOp.h"
+#include "common/ceph_mutex.h"
 
 #include "include/common_fwd.h"
 
@@ -164,9 +166,9 @@ class MDSRank {
 
     MDSRank(
         mds_rank_t whoami_,
-        ceph::mutex &mds_lock_,
+        ceph::fair_mutex &mds_lock_,
         LogChannelRef &clog_,
-        SafeTimer &timer_,
+        CommonSafeTimer<ceph::fair_mutex> &timer_,
         Beacon &beacon_,
         std::unique_ptr<MDSMap> & mdsmap_,
         Messenger *msgr,
@@ -367,7 +369,7 @@ class MDSRank {
     // Reference to global MDS::mds_lock, so that users of MDSRank don't
     // carry around references to the outer MDS, and we can substitute
     // a separate lock here in future potentially.
-    ceph::mutex &mds_lock;
+    ceph::fair_mutex &mds_lock;
 
     // Reference to global cluster log client, just to avoid initialising
     // a separate one here.
@@ -376,7 +378,7 @@ class MDSRank {
     // Reference to global timer utility, because MDSRank and MDSDaemon
     // currently both use the same mds_lock, so it makes sense for them
     // to share a timer.
-    SafeTimer &timer;
+    CommonSafeTimer<ceph::fair_mutex> &timer;
 
     std::unique_ptr<MDSMap> &mdsmap; /* MDSDaemon::mdsmap */
 
@@ -429,7 +431,7 @@ class MDSRank {
       void signal() {cond.notify_all();}
       private:
       MDSRank *mds;
-      ceph::condition_variable cond;
+      std::condition_variable_any cond;
     } progress_thread;
 
     class C_MDS_StandbyReplayRestart;
@@ -657,9 +659,9 @@ class MDSRankDispatcher : public MDSRank, public md_config_obs_t
 public:
   MDSRankDispatcher(
       mds_rank_t whoami_,
-      ceph::mutex &mds_lock_,
+      ceph::fair_mutex &mds_lock_,
       LogChannelRef &clog_,
-      SafeTimer &timer_,
+      CommonSafeTimer<ceph::fair_mutex> &timer_,
       Beacon &beacon_,
       std::unique_ptr<MDSMap> &mdsmap_,
       Messenger *msgr,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -11,6 +11,7 @@
 #include "include/Context.h"
 #include "common/RefCountedObj.h"
 #include "common/ceph_time.h"
+#include "common/Timer.h"
 #include "rgw_common.h"
 #include "cls/rgw/cls_rgw_types.h"
 #include "cls/version/cls_version_types.h"
@@ -38,7 +39,6 @@
 struct D3nDataCache;
 
 class RGWWatcher;
-class SafeTimer;
 class ACLOwner;
 class RGWGC;
 class RGWMetaNotifier;

--- a/src/tools/cephfs_mirror/Mirror.cc
+++ b/src/tools/cephfs_mirror/Mirror.cc
@@ -27,7 +27,7 @@ namespace {
 
 const std::string SERVICE_DAEMON_MIRROR_ENABLE_FAILED_KEY("mirroring_failed");
 
-class SafeTimerSingleton : public SafeTimer {
+class SafeTimerSingleton : public CommonSafeTimer<ceph::mutex> {
 public:
   ceph::mutex timer_lock = ceph::make_mutex("cephfs::mirror::timer_lock");
 

--- a/src/tools/cephfs_mirror/ServiceDaemon.h
+++ b/src/tools/cephfs_mirror/ServiceDaemon.h
@@ -5,10 +5,9 @@
 #define CEPHFS_MIRROR_SERVICE_DAEMON_H
 
 #include "common/ceph_mutex.h"
+#include "common/Timer.h"
 #include "mds/FSMap.h"
 #include "Types.h"
-
-class SafeTimer;
 
 namespace cephfs {
 namespace mirror {

--- a/src/tools/immutable_object_cache/ObjectCacheStore.cc
+++ b/src/tools/immutable_object_cache/ObjectCacheStore.cc
@@ -18,13 +18,13 @@ namespace immutable_obj_cache {
 
 namespace {
 
-class SafeTimerSingleton : public SafeTimer {
+class SafeTimerSingleton : public CommonSafeTimer<ceph::mutex> {
 public:
   ceph::mutex lock = ceph::make_mutex
     ("ceph::immutable_object_cache::SafeTimerSingleton::lock");
 
   explicit SafeTimerSingleton(CephContext *cct)
-      : SafeTimer(cct, lock, true) {
+      : CommonSafeTimer(cct, lock, true) {
     init();
   }
   ~SafeTimerSingleton() {

--- a/src/tools/immutable_object_cache/ObjectCacheStore.h
+++ b/src/tools/immutable_object_cache/ObjectCacheStore.h
@@ -6,6 +6,7 @@
 
 #include "common/ceph_context.h"
 #include "common/ceph_mutex.h"
+#include "common/Timer.h"
 #include "common/Throttle.h"
 #include "common/Cond.h"
 #include "include/rados/librados.hpp"

--- a/src/tools/rbd_mirror/ImageDeleter.h
+++ b/src/tools/rbd_mirror/ImageDeleter.h
@@ -18,6 +18,7 @@
 #include "include/utime.h"
 #include "common/AsyncOpTracker.h"
 #include "common/ceph_mutex.h"
+#include "common/Timer.h"
 #include "tools/rbd_mirror/Types.h"
 #include "tools/rbd_mirror/image_deleter/Types.h"
 #include <atomic>
@@ -29,7 +30,6 @@
 
 class AdminSocketHook;
 class Context;
-class SafeTimer;
 namespace librbd {
 struct ImageCtx;
 namespace asio { struct ContextWQ; }

--- a/src/tools/rbd_mirror/Threads.h
+++ b/src/tools/rbd_mirror/Threads.h
@@ -7,9 +7,9 @@
 #include "include/common_fwd.h"
 #include "include/rados/librados_fwd.hpp"
 #include "common/ceph_mutex.h"
+#include "common/Timer.h"
 #include <memory>
 
-class SafeTimer;
 class ThreadPool;
 
 namespace librbd {

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
@@ -7,6 +7,7 @@
 #include "include/int_types.h"
 #include "include/rados/librados.hpp"
 #include "common/ceph_mutex.h"
+#include "common/Timer.h"
 #include "cls/rbd/cls_rbd_types.h"
 #include "librbd/mirror/Types.h"
 #include "tools/rbd_mirror/CancelableRequest.h"
@@ -14,7 +15,6 @@
 #include <string>
 
 class Context;
-class SafeTimer;
 
 namespace journal { class CacheManagerHandler; }
 namespace librbd { class ImageCtx; }


### PR DESCRIPTION
The std::mutex is not fair for all the mutex lock waiters, that means the waiters
come earlier won't be guaranteed to be woke up first.

For the `mds_lock` because if the callbacks in finisher thread will require it 
frequently it will always succeed, and for other lock waiters, such as for the
rmdir request, they maybe stuck for several seconds or longer. This will cause
a long delay in client.

Fixes: https://tracker.ceph.com/issues/51722
Signed-off-by: Xiubo Li xiubli@redhat.com


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
