### PR TITLE
pacific: RGW Zipper - Make sure bucket list progresses

### DIFF
--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -374,6 +374,7 @@ int RGWRadosBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int 
   int ret = list_op.list_objects(dpp, max, &results.objs, &results.common_prefixes, &results.is_truncated, y);
   if (ret >= 0) {
     results.next_marker = list_op.get_next_marker();
+    params.marker = results.next_marker;
   }
 
   return ret;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51751

---

backport of https://github.com/ceph/ceph/pull/40553
parent tracker: https://tracker.ceph.com/issues/49892

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh