### PR TITLE
pacific: rgw: avoid occuring radosgw daemon crash when access a conditionally …

### DIFF
--- a/src/rgw/rgw_website.cc
+++ b/src/rgw/rgw_website.cc
@@ -45,7 +45,9 @@ void RGWBWRoutingRule::apply_rule(const string& default_protocol, const string& 
 
   if (!redirect_info.replace_key_prefix_with.empty()) {
     *new_url += redirect_info.replace_key_prefix_with;
-    *new_url += key.substr(condition.key_prefix_equals.size());
+    if (key.size() > condition.key_prefix_equals.size()) {
+      *new_url += key.substr(condition.key_prefix_equals.size());
+    }
   } else if (!redirect_info.replace_key_with.empty()) {
     *new_url += redirect_info.replace_key_with;
   } else {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52007

---

backport of https://github.com/ceph/ceph/pull/42382
parent tracker: https://tracker.ceph.com/issues/51715

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh