### PR TITLE
pacific: mgr/dashboard: show perf. counters for rgw svc. on Cluster > Hosts

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/perf_counters.py
+++ b/src/pybind/mgr/dashboard/controllers/perf_counters.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from typing import Any, Dict
-
 import cherrypy
 
 from .. import mgr
@@ -28,35 +26,10 @@ class PerfCounter(RESTController):
     service_type = None  # type: str
 
     def get(self, service_id):
-        schema_dict = mgr.get_perf_schema(self.service_type, str(service_id))
         try:
-            schema = schema_dict["{}.{}".format(self.service_type, service_id)]
-        except KeyError as e:
-            raise cherrypy.HTTPError(404, "{0} not found".format(e))
-        counters = []
-
-        for key, value in sorted(schema.items()):
-            counter = dict()
-            counter['name'] = str(key)
-            counter['description'] = value['description']
-            # pylint: disable=W0212
-            if mgr._stattype_to_str(value['type']) == 'counter':
-                counter['value'] = CephService.get_rate(
-                    self.service_type, service_id, key)
-                counter['unit'] = mgr._unit_to_str(value['units'])
-            else:
-                counter['value'] = mgr.get_latest(
-                    self.service_type, service_id, key)
-                counter['unit'] = ''
-            counters.append(counter)
-
-        return {
-            'service': {
-                'type': self.service_type,
-                'id': str(service_id)
-            },
-            'counters': counters
-        }
+            return CephService.get_service_perf_counters(self.service_type, str(service_id))
+        except KeyError as error:
+            raise cherrypy.HTTPError(404, "{0} not found".format(error))
 
 
 @ApiController('perf_counters/mds', Scope.CEPHFS)
@@ -81,39 +54,6 @@ class OsdPerfCounter(PerfCounter):
 @ControllerDoc("Rgw Perf Counters Management API", "RgwPerfCounter")
 class RgwPerfCounter(PerfCounter):
     service_type = 'rgw'
-
-    def get(self, service_id: str) -> Dict[str, Any]:
-        svc_data = CephService.get_service_data_by_metadata_id(self.service_type, service_id)
-        service_map_id = svc_data['service_map_id']
-        schema_dict = mgr.get_perf_schema(self.service_type, service_map_id)
-        try:
-            schema = schema_dict["{}.{}".format(self.service_type, service_map_id)]
-        except KeyError as e:
-            raise cherrypy.HTTPError(404, "{0} not found".format(e))
-        counters = []
-
-        for key, value in sorted(schema.items()):
-            counter = dict()
-            counter['name'] = str(key)
-            counter['description'] = value['description']
-            # pylint: disable=W0212
-            if mgr._stattype_to_str(value['type']) == 'counter':
-                counter['value'] = CephService.get_rate(
-                    self.service_type, service_map_id, key)
-                counter['unit'] = mgr._unit_to_str(value['units'])
-            else:
-                counter['value'] = mgr.get_latest(
-                    self.service_type, service_map_id, key)
-                counter['unit'] = ''
-            counters.append(counter)
-
-        return {
-            'service': {
-                'type': self.service_type,
-                'id': svc_data['id']
-            },
-            'counters': counters
-        }
 
 
 @ApiController('perf_counters/rbd-mirror', Scope.RBD_MIRRORING)

--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -98,6 +98,7 @@ class RgwDaemon(RESTController):
                 # extract per-daemon service data and health
                 daemon = {
                     'id': metadata['id'],
+                    'service_map_id': service['id'],
                     'version': metadata['ceph_version'],
                     'server_hostname': hostname,
                     'zonegroup_name': metadata['zonegroup_name'],

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-daemon.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-daemon.ts
@@ -1,5 +1,6 @@
 export class RgwDaemon {
   id: string;
+  service_map_id: string;
   version: string;
   server_hostname: string;
   zonegroup_name: string;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html
@@ -17,7 +17,7 @@
          i18n>Performance Counters</a>
       <ng-template ngbNavContent>
         <cd-table-performance-counter serviceType="rgw"
-                                      [serviceId]="serviceId">
+                                      [serviceId]="serviceMapId">
         </cd-table-performance-counter>
       </ng-template>
     </li>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { PerformanceCounterModule } from '~/app/ceph/performance-counter/performance-counter.module';
+import { RgwDaemon } from '~/app/ceph/rgw/models/rgw-daemon';
 import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { RgwDaemonDetailsComponent } from './rgw-daemon-details.component';
@@ -26,5 +27,16 @@ describe('RgwDaemonDetailsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should set service id and service map id on changes', () => {
+    const daemon = new RgwDaemon();
+    daemon.id = 'daemon1';
+    daemon.service_map_id = '4832';
+    component.selection = daemon;
+    component.ngOnChanges();
+
+    expect(component.serviceId).toBe(daemon.id);
+    expect(component.serviceMapId).toBe(daemon.service_map_id);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnChanges } from '@angular/core';
 
 import _ from 'lodash';
 
+import { RgwDaemon } from '~/app/ceph/rgw/models/rgw-daemon';
 import { RgwDaemonService } from '~/app/shared/api/rgw-daemon.service';
 import { Permission } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
@@ -14,10 +15,11 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 export class RgwDaemonDetailsComponent implements OnChanges {
   metadata: any;
   serviceId = '';
+  serviceMapId = '';
   grafanaPermission: Permission;
 
   @Input()
-  selection: any;
+  selection: RgwDaemon;
 
   constructor(
     private rgwDaemonService: RgwDaemonService,
@@ -27,9 +29,9 @@ export class RgwDaemonDetailsComponent implements OnChanges {
   }
 
   ngOnChanges() {
-    // Get the service id of the first selected row.
     if (this.selection) {
       this.serviceId = this.selection.id;
+      this.serviceMapId = this.selection.service_map_id;
     }
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/context/context.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/context/context.component.ts
@@ -42,7 +42,7 @@ export class ContextComponent implements OnInit, OnDestroy {
     this.subs.add(
       this.router.events
         .pipe(filter((event: Event) => event instanceof NavigationEnd))
-        .subscribe(() => (this.isRgwRoute = this.router.url.includes(this.rgwUrlPrefix)))
+        .subscribe(() => (this.isRgwRoute = this.router.url.startsWith(this.rgwUrlPrefix)))
     );
     // Set daemon list polling only when in RGW route:
     this.subs.add(

--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -26,6 +26,7 @@ class SendCommandError(rados.Error):
         super(SendCommandError, self).__init__(err, errno)
 
 
+# pylint: disable=too-many-public-methods
 class CephService(object):
 
     OSD_FLAG_NO_SCRUB = 'noscrub'
@@ -90,6 +91,32 @@ class CephService(object):
         if svc_data:
             svc_data['status'] = mgr.get_daemon_status(svc_data['type'], svc_data['service_map_id'])
         return svc_data
+
+    @classmethod
+    def get_service_perf_counters(cls, service_type: str, service_id: str) -> Dict[str, Any]:
+        schema_dict = mgr.get_perf_schema(service_type, service_id)
+        schema = schema_dict["{}.{}".format(service_type, service_id)]
+        counters = []
+        for key, value in sorted(schema.items()):
+            counter = {'name': str(key), 'description': value['description']}
+            # pylint: disable=W0212
+            if mgr._stattype_to_str(value['type']) == 'counter':
+                counter['value'] = cls.get_rate(
+                    service_type, service_id, key)
+                counter['unit'] = mgr._unit_to_str(value['units'])
+            else:
+                counter['value'] = mgr.get_latest(
+                    service_type, service_id, key)
+                counter['unit'] = ''
+            counters.append(counter)
+
+        return {
+            'service': {
+                'type': service_type,
+                'id': str(service_id)
+            },
+            'counters': counters
+        }
 
     @classmethod
     def get_pool_list(cls, application=None):

--- a/src/pybind/mgr/dashboard/tests/test_rgw.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw.py
@@ -71,7 +71,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
         RgwStub.get_settings()
         mgr.list_servers.return_value = [{
             'hostname': 'host1',
-            'services': [{'id': 'daemon1', 'type': 'rgw'}, {'id': 'daemon2', 'type': 'rgw'}]
+            'services': [{'id': '4832', 'type': 'rgw'}, {'id': '5356', 'type': 'rgw'}]
         }]
         mgr.get_metadata.side_effect = [
             {
@@ -90,6 +90,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
         self.assertStatus(200)
         self.assertJsonBody([{
             'id': 'daemon1',
+            'service_map_id': '4832',
             'version': 'ceph version master (dev)',
             'server_hostname': 'host1',
             'zonegroup_name': 'zg1',
@@ -97,6 +98,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
         },
             {
             'id': 'daemon2',
+            'service_map_id': '5356',
             'version': 'ceph version master (dev)',
             'server_hostname': 'host1',
             'zonegroup_name': 'zg2',


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52049

---

backport of https://github.com/ceph/ceph/pull/42610
parent tracker: https://tracker.ceph.com/issues/52022

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh