### PR TITLE
libcephsqlite: fix unconditional success bug in CheckReservedLock

### DIFF
--- a/src/libcephsqlite.cc
+++ b/src/libcephsqlite.cc
@@ -255,6 +255,7 @@ static int CheckReservedLock(sqlite3_file *file, int *result)
   auto f = (cephsqlite_file*)file;
   auto start = ceph::coarse_mono_clock::now();
   df(5) << dendl;
+  *result = 0;
 
   auto& lock = f->lock;
   if (lock > SQLITE_LOCK_SHARED) {
@@ -265,7 +266,6 @@ static int CheckReservedLock(sqlite3_file *file, int *result)
   f->io.rs->print_lockers(*_dout);
   *_dout << dendl;
 
-  *result = 0;
   auto end = ceph::coarse_mono_clock::now();
   getdata(f->vfs).logger->tinc(P_OPF_CHECKRESERVEDLOCK, end-start);
   return SQLITE_OK;


### PR DESCRIPTION
we don't want to set result to zero at the end. Otherwise, the if above would be useless and the function cannot be used to check the reserved lock.

Fixes: https://tracker.ceph.com/issues/52001
Signed-off-by: Shuai Wang <shuaiw2@andrew.cmu.edu>