### PR TITLE
pacific: rgw: fix segfault related to explicit object manifest handling

### DIFF
--- a/src/rgw/rgw_obj_manifest.cc
+++ b/src/rgw/rgw_obj_manifest.cc
@@ -205,6 +205,12 @@ void RGWObjManifest::obj_iterator::operator++()
   if (manifest->explicit_objs) {
     ++explicit_iter;
 
+    if (explicit_iter == manifest->objs.end()) {
+      ofs = manifest->obj_size;
+      stripe_size = 0;
+      return;
+    }
+
     update_explicit_pos();
 
     update_location();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50679

---

backport of https://github.com/ceph/ceph/pull/41028
parent tracker: https://tracker.ceph.com/issues/50467

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh