### PR TITLE
pacific: rgw: remove quota soft threshold

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1445,7 +1445,6 @@ OPTION(rgw_data_log_num_shards, OPT_INT) // number of objects to keep data chang
 OPTION(rgw_data_log_obj_prefix, OPT_STR) //
 
 OPTION(rgw_bucket_quota_ttl, OPT_INT) // time for cached bucket stats to be cached within rgw instance
-OPTION(rgw_bucket_quota_soft_threshold, OPT_DOUBLE) // threshold from which we don't rely on cached info for quota decisions
 OPTION(rgw_bucket_quota_cache_size, OPT_INT) // number of entries in bucket quota cache
 OPTION(rgw_bucket_default_quota_max_objects, OPT_INT) // number of objects allowed
 OPTION(rgw_bucket_default_quota_max_size, OPT_LONGLONG) // Max size of object in bytes

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6777,16 +6777,6 @@ std::vector<Option> get_rgw_options() {
     .set_long_description(
         "Length of time for bucket stats to be cached within RGW instance."),
 
-    Option("rgw_bucket_quota_soft_threshold", Option::TYPE_FLOAT, Option::LEVEL_BASIC)
-    .set_default(0.95)
-    .set_description("RGW quota soft threshold")
-    .set_long_description(
-        "Threshold from which RGW doesn't rely on cached info for quota "
-        "decisions. This is done for higher accuracy of the quota mechanism at "
-        "cost of performance, when getting close to the quota limit. The value "
-        "configured here is the ratio between the data usage to the max usage "
-        "as specified by the quota."),
-
     Option("rgw_bucket_quota_cache_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(10000)
     .set_description("RGW quota stats cache size")

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -37,14 +37,6 @@ namespace rgw { namespace sal {
 
 struct RGWQuotaInfo {
   template<class T> friend class RGWQuotaCache;
-protected:
-  /* The quota thresholds after which comparing against cached storage stats
-   * is disallowed. Those fields may be accessed only by the RGWQuotaCache.
-   * They are not intended as tunables but rather as a mean to store results
-   * of repeating calculations in the quota cache subsystem. */
-  int64_t max_size_soft_threshold;
-  int64_t max_objs_soft_threshold;
-
 public:
   int64_t max_size;
   int64_t max_objects;
@@ -54,9 +46,7 @@ public:
   bool check_on_raw;
 
   RGWQuotaInfo()
-    : max_size_soft_threshold(-1),
-      max_objs_soft_threshold(-1),
-      max_size(-1),
+    : max_size(-1),
       max_objects(-1),
       enabled(false),
       check_on_raw(false) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51014

---

backport of https://github.com/ceph/ceph/pull/41495
parent tracker: https://tracker.ceph.com/issues/50975

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh