### PR TITLE
pacific: rgw: radosgw-admin errors if marker not specified on data/mdlog trim

### DIFF
--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -704,10 +704,11 @@ int RGWDataChangesLog::add_entry(const DoutPrefixProvider *dpp, const RGWBucketI
 
 int DataLogBackends::list(const DoutPrefixProvider *dpp, int shard, int max_entries,
 			  std::vector<rgw_data_change_log_entry>& entries,
-			  std::optional<std::string_view> marker,
-			  std::string* out_marker, bool* truncated)
+			  std::string_view marker,
+			  std::string* out_marker,
+			  bool* truncated)
 {
-  const auto [start_id, start_cursor] = cursorgeno(marker);
+  const auto [start_id, start_cursor] = cursorgen(marker);
   auto gen_id = start_id;
   std::string out_cursor;
   while (max_entries > 0) {
@@ -744,7 +745,7 @@ int DataLogBackends::list(const DoutPrefixProvider *dpp, int shard, int max_entr
 
 int RGWDataChangesLog::list_entries(const DoutPrefixProvider *dpp, int shard, int max_entries,
 				    std::vector<rgw_data_change_log_entry>& entries,
-				    std::optional<std::string_view> marker,
+				    std::string_view marker,
 				    std::string* out_marker, bool* truncated)
 {
   assert(shard < num_shards);
@@ -758,7 +759,7 @@ int RGWDataChangesLog::list_entries(const DoutPrefixProvider *dpp, int max_entri
   bool truncated;
   entries.clear();
   for (; marker.shard < num_shards && int(entries.size()) < max_entries;
-       marker.shard++, marker.marker.reset()) {
+       marker.shard++, marker.marker.clear()) {
     int ret = list_entries(dpp, marker.shard, max_entries - entries.size(),
 			   entries, marker.marker, NULL, &truncated);
     if (ret == -ENOENT) {

--- a/src/rgw/rgw_datalog.h
+++ b/src/rgw/rgw_datalog.h
@@ -113,7 +113,7 @@ struct RGWDataChangesLogInfo {
 
 struct RGWDataChangesLogMarker {
   int shard = 0;
-  std::optional<std::string> marker;
+  std::string marker;
 
   RGWDataChangesLogMarker() = default;
 };
@@ -148,7 +148,7 @@ public:
   }
   int list(const DoutPrefixProvider *dpp, int shard, int max_entries,
 	   std::vector<rgw_data_change_log_entry>& entries,
-	   std::optional<std::string_view> marker,
+	   std::string_view marker,
 	   std::string* out_marker, bool* truncated);
   int trim_entries(const DoutPrefixProvider *dpp, int shard_id, std::string_view marker);
   void trim_entries(const DoutPrefixProvider *dpp, int shard_id, std::string_view marker,
@@ -232,7 +232,7 @@ public:
   int get_log_shard_id(rgw_bucket& bucket, int shard_id);
   int list_entries(const DoutPrefixProvider *dpp, int shard, int max_entries,
 		   std::vector<rgw_data_change_log_entry>& entries,
-		   std::optional<std::string_view> marker,
+		   std::string_view marker,
 		   std::string* out_marker, bool* truncated);
   int trim_entries(const DoutPrefixProvider *dpp, int shard_id, std::string_view marker);
   int trim_entries(const DoutPrefixProvider *dpp, int shard_id, std::string_view marker,

--- a/src/rgw/rgw_log_backing.h
+++ b/src/rgw/rgw_log_backing.h
@@ -241,6 +241,9 @@ inline std::string gencursor(uint64_t gen_id, std::string_view cursor) {
 
 inline std::pair<uint64_t, std::string_view>
 cursorgen(std::string_view cursor_) {
+  if (cursor_.empty()) {
+    return { 0, ""sv };
+  }
   std::string_view cursor = cursor_;
   if (cursor[0] != 'G') {
     return { 0, cursor };
@@ -252,15 +255,6 @@ cursorgen(std::string_view cursor_) {
   }
   cursor.remove_prefix(1);
   return { *gen_id, cursor };
-}
-
-inline std::pair<uint64_t, std::string_view>
-cursorgeno(std::optional<std::string_view> cursor) {
-  if (cursor && !cursor->empty()) {
-    return cursorgen(*cursor);
-  } else {
-    return { 0, ""s };
-  }
 }
 
 class LazyFIFO {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51801

---

backport of https://github.com/ceph/ceph/pull/42380
parent tracker: https://tracker.ceph.com/issues/51712

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh