### PR TITLE
pacific: rgw/http/notifications: support content type in HTTP POST messages

### DIFF
--- a/src/rgw/rgw_pubsub_push.cc
+++ b/src/rgw/rgw_pubsub_push.cc
@@ -141,6 +141,7 @@ public:
     const auto post_data = json_format_pubsub_event(event);
     request.set_post_data(post_data);
     request.set_send_length(post_data.length());
+    request.append_header("Content-Type", "application/json");
     if (perfcounter) perfcounter->inc(l_rgw_pubsub_push_pending);
     const auto rc = RGWHTTP::process(&request, y);
     if (perfcounter) perfcounter->dec(l_rgw_pubsub_push_pending);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51804

---

backport of https://github.com/ceph/ceph/pull/42189
parent tracker: https://tracker.ceph.com/issues/51530

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh