### PR TITLE
pacific: rgw/multisite: return correct error code when op fails

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1024,7 +1024,7 @@ int RGWBucket::sync(RGWBucketAdminOpState& op_state, map<string, bufferlist> *at
 {
   if (!store->svc()->zone->is_meta_master()) {
     set_err_msg(err_msg, "ERROR: failed to update bucket sync: only allowed on meta master zone");
-    return EINVAL;
+    return -EINVAL;
   }
   bool sync = op_state.will_sync_bucket();
   if (sync) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50463

---

backport of https://github.com/ceph/ceph/pull/40639
parent tracker: https://tracker.ceph.com/issues/50201

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh