### PR TITLE
tools/setup-virtualenv: do not use wheel if wheelhouse does not exist

### DIFF
--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -77,10 +77,11 @@ else
 fi
 
 if test -d wheelhouse ; then
-    export NO_INDEX=--no-index
+    NO_INDEX=--no-index
+    FIND_LINKS_OPT=--find-links=file://$(pwd)/wheelhouse
 fi
 
-pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --find-links=file://$(pwd)/wheelhouse 'tox >=2.9.1'
+pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX $FIND_LINKS_OPT 'tox >=2.9.1'
 
 require_files=$(ls *requirements*.txt 2>/dev/null) || true
 constraint_files=$(ls *constraints*.txt 2>/dev/null) || true
@@ -90,7 +91,8 @@ md5=wheelhouse/md5
 if test "$require"; then
     if ! test -f $md5 || ! md5sum -c wheelhouse/md5 > /dev/null; then
         NO_INDEX=''
+        FIND_LINKS_OPT=''
     fi
-    pip --exists-action i $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX \
-      --find-links=file://$(pwd)/wheelhouse $require $constraint 
+    pip --exists-action i $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install \
+        $NO_INDEX $FIND_LINKS_OPT $require $constraint
 fi


### PR DESCRIPTION
some times, developer does not use install-deps.sh to prepare the wheel
at all. in that case, just do not pass the wheelhouse options to pip.

this helps to silence the pip warnings complaining that the wheelhouse does
not exist.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
