### PR TITLE
admin/build-doc: rebuild venv if md5 does not match

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -50,8 +50,12 @@ set -e
 
 [ -z "$vdir" ] && vdir="$TOPDIR/build-doc/virtualenv"
 
-if [ ! -e $vdir ]; then
-    python3 -m venv $vdir
+md5=$vdir/md5
+if test -f $md5 && md5sum --check $md5 > /dev/null; then
+    # reusing existing venv
+    :
+else
+    virtualenv --python=python3 $vdir
 
     $vdir/bin/pip install --quiet wheel
     $vdir/bin/pip install --quiet \
@@ -59,6 +63,11 @@ if [ ! -e $vdir ]; then
               -r $TOPDIR/admin/doc-python-common-requirements.txt
     BUILD_DOC=1 $vdir/bin/pip install --quiet \
          -r $TOPDIR/admin/doc-pybind.txt
+    md5sum \
+        $TOPDIR/admin/doc-requirements.txt \
+        $TOPDIR/admin/doc-python-common-requirements.txt \
+        $TOPDIR/admin/doc-pybind.txt \
+        > $md5
 fi
 
 install -d -m0755 \


### PR DESCRIPTION
we should rebuild the venv if any of the requirements change.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
