### PR TITLE
pacific: SimpleRADOSStriper: use debug_cephsqlite

### DIFF
--- a/src/SimpleRADOSStriper.cc
+++ b/src/SimpleRADOSStriper.cc
@@ -46,7 +46,7 @@
 
 using ceph::bufferlist;
 
-#define dout_subsys ceph_subsys_client
+#define dout_subsys ceph_subsys_cephsqlite
 #undef dout_prefix
 #define dout_prefix *_dout << "client." << ioctx.get_instance_id() << ": SimpleRADOSStriper: " << __func__ << ": " << oid << ": "
 #define d(lvl) ldout((CephContext*)ioctx.cct(), (lvl))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50386

---

backport of https://github.com/ceph/ceph/pull/40829
parent tracker: https://tracker.ceph.com/issues/50307

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh