### PR TITLE
doc/rados: rewrite "FileStore" section

### DIFF
--- a/doc/rados/configuration/storage-devices.rst
+++ b/doc/rados/configuration/storage-devices.rst
@@ -66,19 +66,19 @@ For more information, see :doc:`bluestore-config-ref` and :doc:`/rados/operation
 FileStore
 ---------
 
-FileStore is the legacy approach to storing objects in Ceph.  It
+FileStore is the legacy approach to storing objects in Ceph. It
 relies on a standard file system (normally XFS) in combination with a
 key/value database (traditionally LevelDB, now RocksDB) for some
 metadata.
 
-FileStore is well-tested and widely used in production but suffers
-from many performance deficiencies due to its overall design and
-reliance on a traditional file system for storing object data.
+FileStore is well-tested and widely used in production. However, it
+suffers from many performance deficiencies due to its overall design
+and its reliance on a traditional file system for storing object data.
 
-Although FileStore is generally capable of functioning on most
-POSIX-compatible file systems (including btrfs and ext4), we only
-recommend that XFS be used.  Both btrfs and ext4 have known bugs and
-deficiencies and their use may lead to data loss.  By default all Ceph
-provisioning tools will use XFS.
+Although FileStore is capable of functioning on most POSIX-compatible
+file systems (including btrfs and ext4), we recommend that only the
+XFS file system be used with Ceph. Both btrfs and ext4 have known bugs and
+deficiencies and their use may lead to data loss. By default, all Ceph
+provisioning tools use XFS.
 
 For more information, see :doc:`filestore-config-ref`.


### PR DESCRIPTION
This PR makes minor improvements to the
syntax of the sentences in the "FileStore"
material in the Configuration chapter of
the RADOS manual.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
