### PR TITLE
crimson/osd: OpSequencer allows for out-of-order ClientRequests

### DIFF
--- a/src/crimson/osd/osd_connection_priv.h
+++ b/src/crimson/osd/osd_connection_priv.h
@@ -5,6 +5,7 @@
 
 #include "crimson/net/Connection.h"
 #include "crimson/osd/osd_operation.h"
+#include "crimson/osd/osd_operation_sequencer.h"
 #include "crimson/osd/osd_operations/client_request.h"
 #include "crimson/osd/osd_operations/peering_event.h"
 #include "crimson/osd/osd_operations/replicated_request.h"

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -3,9 +3,10 @@
 
 #pragma once
 
-#include "crimson/osd/osd_operation_sequencer.h"
+#include "crimson/common/operation.h"
 #include "crimson/osd/pg_interval_interrupt_condition.h"
 #include "crimson/osd/scheduler/scheduler.h"
+#include "osd/osd_types.h"
 
 namespace crimson::osd {
 

--- a/src/crimson/osd/osd_operation_sequencer.h
+++ b/src/crimson/osd/osd_operation_sequencer.h
@@ -54,9 +54,9 @@ public:
       ::crimson::get_logger(ceph_subsys_osd).debug(
         "OpSequencer::start_op: {} waiting ({} > {})",
         op, prev_op->get_id(), last_unblocked->get_id());
-      have_green_light = unblocked.wait([prev_op, this] {
+      have_green_light = unblocked.wait([&op, this] {
         // wait until the previous op is unblocked
-        return last_unblocked == prev_op;
+        return last_unblocked == &op.get_prev_op();
       });
     }
     return have_green_light.then([&op, do_op=std::move(do_op), this]() mutable {

--- a/src/crimson/osd/osd_operation_sequencer.h
+++ b/src/crimson/osd/osd_operation_sequencer.h
@@ -7,7 +7,6 @@
 #include <fmt/format.h>
 #include <seastar/core/condition-variable.hh>
 #include "crimson/common/operation.h"
-#include "osd/osd_types.h"
 
 namespace crimson::osd {
 

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -36,7 +36,7 @@ ClientRequest::~ClientRequest()
 
 void ClientRequest::print(std::ostream &lhs) const
 {
-  lhs << "m=[" << *m << "], prev_op_id=" << prev_op_id;
+  lhs << "m=[" << *m << "], prev_op_id=" << prev_op->get_id();
 }
 
 void ClientRequest::dump_detail(Formatter *f) const
@@ -62,9 +62,9 @@ bool ClientRequest::is_pg_op() const
 
 void ClientRequest::may_set_prev_op()
 {
-  // set prev_op_id if it's not set yet
-  if (__builtin_expect(!prev_op_id.has_value(), true)) {
-    prev_op_id.emplace(sequencer.get_last_issued());
+  // set prev_op if it's not set yet
+  if (__builtin_expect(!prev_op, true)) {
+    prev_op = sequencer.get_last_issued();
   }
 }
 

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -57,9 +57,9 @@ public:
 
 public:
   seastar::future<> start();
-  uint64_t get_prev_id() const {
-    assert(prev_op_id.has_value());
-    return *prev_op_id;
+  const Operation& get_prev_op() const {
+    assert(prev_op);
+    return *prev_op;
   }
 
 private:
@@ -86,7 +86,7 @@ private:
   PGPipeline &pp(PG &pg);
 
   OpSequencer& sequencer;
-  std::optional<uint64_t> prev_op_id;
+  const Operation* prev_op = nullptr;
 
   template <typename Errorator>
   using interruptible_errorator =

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -64,13 +64,7 @@ public:
 
 private:
   template <typename FuncT>
-  interruptible_future<> with_sequencer(FuncT&& func) {
-    may_set_prev_op();
-    return sequencer.start_op(*this, handle, std::forward<FuncT>(func))
-    .then_interruptible([this] {
-      sequencer.finish_op(*this);
-    });
-  }
+  interruptible_future<> with_sequencer(FuncT&& func);
   interruptible_future<> do_process(
     Ref<PG>& pg,
     crimson::osd::ObjectContextRef obc);
@@ -85,7 +79,7 @@ private:
   ConnectionPipeline &cp();
   PGPipeline &pp(PG &pg);
 
-  OpSequencer& sequencer;
+  class OpSequencer& sequencer;
   const Operation* prev_op = nullptr;
 
   template <typename Errorator>

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -57,7 +57,7 @@ public:
 
 public:
   seastar::future<> start();
-  const Operation& get_prev_op() const {
+  const ClientRequest& get_prev_op() const {
     assert(prev_op);
     return *prev_op;
   }
@@ -80,7 +80,7 @@ private:
   PGPipeline &pp(PG &pg);
 
   class OpSequencer& sequencer;
-  const Operation* prev_op = nullptr;
+  const ClientRequest* prev_op = nullptr;
 
   template <typename Errorator>
   using interruptible_errorator =

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -61,6 +61,7 @@ public:
     assert(prev_op);
     return *prev_op;
   }
+  bool same_session_and_pg(const ClientRequest& other_op) const;
 
 private:
   template <typename FuncT>
@@ -81,6 +82,7 @@ private:
 
   class OpSequencer& sequencer;
   const ClientRequest* prev_op = nullptr;
+  friend class OpSequencer;
 
   template <typename Errorator>
   using interruptible_errorator =


### PR DESCRIPTION
This is basically a RFC. Tested locally just with `rados bench`; thrashing tests at Sepia are TBD.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
