### PR TITLE
crimson/os/seastore/lba_manager: remove assert non-empty delta

### DIFF
--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.h
@@ -230,7 +230,6 @@ struct LBAInternalNode
   std::ostream &print_detail(std::ostream &out) const final;
 
   ceph::bufferlist get_delta() final {
-    assert(!delta_buffer.empty());
     ceph::buffer::ptr bptr(delta_buffer.get_bytes());
     delta_buffer.copy_out(bptr.c_str(), bptr.length());
     ceph::bufferlist bl;
@@ -500,7 +499,6 @@ struct LBALeafNode
   }
 
   ceph::bufferlist get_delta() final {
-    assert(!delta_buffer.empty());
     ceph::buffer::ptr bptr(delta_buffer.get_bytes());
     delta_buffer.copy_out(bptr.c_str(), bptr.length());
     ceph::bufferlist bl;


### PR DESCRIPTION
Delta can be empty when measure the effort of invalidated transactions.

Signed-off-by: Yingxin Cheng <yingxin.cheng@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
