### PR TITLE
octopus: Don't persist report data

### DIFF
--- a/qa/tasks/mgr/test_insights.py
+++ b/qa/tasks/mgr/test_insights.py
@@ -148,17 +148,6 @@ class TestInsights(MgrTestCase):
         active_id = self.mgr_cluster.get_active_id()
         self.mgr_cluster.mgr_restart(active_id)
 
-        # ensure that at least one of the checks is present after the restart.
-        # we don't for them all to be present because "earlier" checks may not
-        # have sat in memory long enough to be flushed.
-        all_missing = True
-        report = self._insights()
-        for check in check_names:
-            if check in report["health"]["history"]["checks"]:
-                all_missing = False
-                break
-        self.assertFalse(all_missing)
-
         # pruning really removes history
         self.mgr_cluster.mon_manager.raw_cluster_cmd_result(
             "insights", "prune-health", "0")

--- a/src/pybind/mgr/insights/module.py
+++ b/src/pybind/mgr/insights/module.py
@@ -42,6 +42,26 @@ class Module(MgrModule):
         # health history tracking
         self._pending_health = []
         self._health_slot = None
+        self._store = {}
+
+    # The following three functions, get_store, set_store, and get_store_prefix
+    # mask the functions defined in the parent to avoid storing large keys
+    # persistently to disk as that was proving problematic. Long term we may
+    # implement a different mechanism to make these persistent. When that day
+    # comes it should just be a matter of deleting these three functions.
+    def get_store(self, key):
+        return self._store.get(key)
+
+    def set_store(self, key, value):
+        if value is None:
+            if key in self._store:
+                del self._store[key]
+        else:
+            self._store[key] = value
+
+    def get_store_prefix(self, prefix):
+        return { k: v for k, v in self._store.items() if k.startswith(prefix) }
+
 
     def notify(self, ttype, ident):
         """Queue updates for processing"""

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -44,7 +44,7 @@ if 'UNITTEST' in os.environ:
             else:
                 self._store[k] = value
 
-        def mock_store_preifx(self, kind, prefix):
+        def mock_store_prefix(self, kind, prefix):
             if not hasattr(self, '_store'):
                 self._store = {}
             full_prefix = f'mock_store/{kind}/{prefix}'
@@ -61,7 +61,7 @@ if 'UNITTEST' in os.environ:
             self.mock_store_set('store', k, v)
 
         def _ceph_get_store_prefix(self, prefix):
-            return self.mock_store_preifx('store', prefix)
+            return self.mock_store_prefix('store', prefix)
 
         def _ceph_get_module_option(self, module, key, localized_prefix= None):
             try:
@@ -117,7 +117,7 @@ if 'UNITTEST' in os.environ:
 
             def config_dump():
                 r = []
-                for prefix, value in self.mock_store_preifx('config', '').items():
+                for prefix, value in self.mock_store_prefix('config', '').items():
                     section, name = prefix.split('/', 1)
                     r.append({
                         'name': name,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51949

---

backport of https://github.com/ceph/ceph/pull/42442
parent tracker: https://tracker.ceph.com/issues/48269

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh