### PR TITLE
cephadm: add --container-cli-args parameter

### DIFF
--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -84,7 +84,7 @@ Synopsis
 | **cephadm** **deploy** [-h] --name NAME --fsid FSID [--config CONFIG]
 |                        [--config-json CONFIG_JSON] [--keyring KEYRING]
 |                        [--key KEY] [--osd-fsid OSD_FSID] [--skip-firewalld]
-|                        [--tcp-ports TCP_PORTS] [--reconfig] [--allow-ptrace]
+|                        [--tcp-ports TCP_PORTS] [--reconfig]
 
 | **cephadm** **check-host** [-h] [--expect-hostname EXPECT_HOSTNAME]
 
@@ -300,7 +300,6 @@ Arguments:
 * [--skip-firewalld]          Do not configure firewalld
 * [--tcp-ports                List of tcp ports to open in the host firewall
 * [--reconfig]                Reconfigure a previously deployed daemon
-* [--allow-ptrace]            Allow SYS_PTRACE on daemon container
 
 
 enter

--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -12,7 +12,7 @@ Synopsis
 | **cephadm**** [-h] [--image IMAGE] [--docker] [--data-dir DATA_DIR]
 |               [--log-dir LOG_DIR] [--logrotate-dir LOGROTATE_DIR]
 |               [--unit-dir UNIT_DIR] [--verbose] [--timeout TIMEOUT]
-|               [--retry RETRY] [--no-container-init]
+|               [--retry RETRY] [--no-container-init] [--container-cli-args]
 |               {version,pull,inspect-image,ls,list-networks,adopt,rm-daemon,rm-cluster,run,shell,enter,ceph-volume,unit,logs,bootstrap,deploy,check-host,prepare-host,add-repo,rm-repo,install}
 |               ...
 
@@ -159,6 +159,14 @@ Options
 .. option:: --no-container-init
 
    do not run podman/docker with `--init` (default: False)
+
+.. option:: --container-cli-args
+
+   pass any additional flags to podman/docker cli (default: None)
+
+   For example, to debug Ceph daemons at runtime with gdb or strace, you must
+   enable the SYS_PTRACE capability on ceph's containers, and you can do this
+   with `--container-cli-args="--cap-add=PTRACE"`
 
 
 Commands

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -504,7 +504,7 @@ def ceph_bootstrap(ctx, config):
         # set options
         if config.get('allow_ptrace', True):
             _shell(ctx, cluster_name, bootstrap_remote,
-                   ['ceph', 'config', 'set', 'mgr', 'mgr/cephadm/allow_ptrace', 'true'])
+                   ['ceph', 'config', 'set', 'mgr', 'mgr/cephadm/container_cli_args', '--value="--cap-add=PTRACE"'])
 
         if not config.get('avoid_pacific_features', False):
             log.info('Distributing conf and client.admin keyring to all hosts + 0755')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -108,6 +108,7 @@ class BaseConfig:
 
     def __init__(self) -> None:
         self.image: str = ''
+        self.container_cli_args: Optional[str] = None
         self.docker: bool = False
         self.data_dir: str = DATA_DIR
         self.log_dir: str = LOG_DIR
@@ -2777,6 +2778,9 @@ def get_container(ctx: CephadmContext,
         if ctx.container_engine.version >= CGROUPS_SPLIT_PODMAN_VERSION:
             container_args.append('--cgroups=split')
 
+        if ctx.container_cli_args is not None:
+            container_args.extend(shlex.split(ctx.container_cli_args))
+
     return CephContainer.for_daemon(
         ctx,
         fsid=fsid,
@@ -3440,6 +3444,7 @@ class CephContainer:
                  host_network: bool = True,
                  memory_request: Optional[str] = None,
                  memory_limit: Optional[str] = None,
+                 container_cli_args: Optional[List[str]] = None,
                  ) -> None:
         self.ctx = ctx
         self.image = image
@@ -3456,6 +3461,7 @@ class CephContainer:
         self.host_network = host_network
         self.memory_request = memory_request
         self.memory_limit = memory_limit
+        self.container_cli_args = container_cli_args if container_cli_args else ctx.container_cli_args
 
     @classmethod
     def for_daemon(cls,
@@ -3535,6 +3541,9 @@ class CephContainer:
             # fall back to SIGKILL).
             '--stop-signal=SIGTERM',
         ]
+
+        if self.container_cli_args is not None:
+            cmd_args.extend(shlex.split(self.container_cli_args))
 
         if isinstance(self.ctx.container_engine, Podman):
             if os.path.exists('/etc/ceph/podman-auth.json'):
@@ -5119,6 +5128,9 @@ def command_bootstrap(ctx):
         is_available(ctx, 'mgr epoch %d' % epoch, mgr_has_latest_epoch)
 
     enable_cephadm_mgr_module(cli, wait_for_mgr_restart)
+
+    if ctx.container_cli_args is not None:
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/container_cli_args', '--value={}'.format(ctx.container_cli_args), '--force'])
 
     # ssh
     if not ctx.skip_ssh:
@@ -7928,6 +7940,9 @@ def _get_parser():
         '--image',
         help='container image. Can also be set via the "CEPHADM_IMAGE" '
         'env var')
+    parser.add_argument(
+        '--container-cli-args',
+        help='Run the container cli with extra args')
     parser.add_argument(
         '--docker',
         action='store_true',

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2689,7 +2689,6 @@ def get_ceph_volume_container(ctx: CephadmContext,
 def get_container(ctx: CephadmContext,
                   fsid: str, daemon_type: str, daemon_id: Union[int, str],
                   privileged: bool = False,
-                  ptrace: bool = False,
                   container_args: Optional[List[str]] = None) -> 'CephContainer':
     entrypoint: str = ''
     name: str = ''
@@ -2793,7 +2792,6 @@ def get_container(ctx: CephadmContext,
         bind_mounts=get_container_binds(ctx, fsid, daemon_type, daemon_id),
         envs=envs,
         privileged=privileged,
-        ptrace=ptrace,
         host_network=host_network,
     )
 
@@ -3438,7 +3436,6 @@ class CephContainer:
                  container_args: List[str] = [],
                  envs: Optional[List[str]] = None,
                  privileged: bool = False,
-                 ptrace: bool = False,
                  bind_mounts: Optional[List[List[str]]] = None,
                  init: Optional[bool] = None,
                  host_network: bool = True,
@@ -3455,7 +3452,6 @@ class CephContainer:
         self.container_args = container_args
         self.envs = envs
         self.privileged = privileged
-        self.ptrace = ptrace
         self.bind_mounts = bind_mounts if bind_mounts else []
         self.init = init if init else ctx.container_init
         self.host_network = host_network
@@ -3475,7 +3471,6 @@ class CephContainer:
                    container_args: List[str] = [],
                    envs: Optional[List[str]] = None,
                    privileged: bool = False,
-                   ptrace: bool = False,
                    bind_mounts: Optional[List[List[str]]] = None,
                    init: Optional[bool] = None,
                    host_network: bool = True,
@@ -3492,7 +3487,6 @@ class CephContainer:
             container_args=container_args,
             envs=envs,
             privileged=privileged,
-            ptrace=ptrace,
             bind_mounts=bind_mounts,
             init=init,
             host_network=host_network,
@@ -3571,11 +3565,11 @@ class CephContainer:
                 '--privileged',
                 # let OSD etc read block devs that haven't been chowned
                 '--group-add=disk'])
-        if self.ptrace and not self.privileged:
-            # if privileged, the SYS_PTRACE cap is already added
-            # in addition, --cap-add and --privileged are mutually
-            # exclusive since podman >= 2.0
-            cmd_args.append('--cap-add=SYS_PTRACE')
+            if '--cap-add=PTRACE' in self.container_cli_args:
+                # if privileged, the SYS_PTRACE cap is already added
+                # in addition, --cap-add and --privileged are mutually
+                # exclusive since podman >= 2.0
+                self.container_cli_args.remove('--cap-add=PTRACE')
         if self.init:
             cmd_args.append('--init')
             envs += ['-e', 'CEPH_USE_RANDOM_NONCE=1']
@@ -5306,8 +5300,7 @@ def command_deploy(ctx):
         uid, gid = extract_uid_gid(ctx)
         make_var_run(ctx, ctx.fsid, uid, gid)
 
-        c = get_container_with_extra_args(ctx, ctx.fsid, daemon_type, daemon_id,
-                                          ptrace=ctx.allow_ptrace)
+        c = get_container_with_extra_args(ctx, ctx.fsid, daemon_type, daemon_id)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
                       osd_fsid=ctx.osd_fsid,
@@ -5379,8 +5372,7 @@ def command_deploy(ctx):
         if not ctx.reconfig and not redeploy:
             daemon_ports.extend(cc.ports)
         c = get_container_with_extra_args(ctx, ctx.fsid, daemon_type, daemon_id,
-                                          privileged=cc.privileged,
-                                          ptrace=ctx.allow_ptrace)
+                                          privileged=cc.privileged)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c,
                       uid=cc.uid, gid=cc.gid, config=None,
                       keyring=None, reconfig=ctx.reconfig,
@@ -8452,7 +8444,7 @@ def _get_parser():
     parser_deploy.add_argument(
         '--allow-ptrace',
         action='store_true',
-        help='Allow SYS_PTRACE on daemon container')
+        help=argparse.SUPPRESS)
     parser_deploy.add_argument(
         '--container-init',
         action='store_true',

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -245,16 +245,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='log to the "cephadm" cluster log channel"',
         ),
         Option(
-            'allow_ptrace',
-            type='bool',
-            default=False,
-            desc='allow SYS_PTRACE capability on ceph containers',
-            long_desc='The SYS_PTRACE capability is needed to attach to a '
-            'process with gdb or strace.  Enabling this options '
-            'can allow debugging daemons that encounter problems '
-            'at runtime.',
-        ),
-        Option(
             'container_init',
             type='bool',
             default=True,
@@ -423,7 +413,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.warn_on_stray_hosts = True
             self.warn_on_stray_daemons = True
             self.warn_on_failed_host_check = True
-            self.allow_ptrace = False
             self.container_init = True
             self.prometheus_alerts_path = ''
             self.migration_current: Optional[int] = None

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -172,6 +172,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='mode for remote execution of cephadm',
         ),
         Option(
+            'container_cli_args',
+            type='str',
+            default=None,
+            desc='Run the container cli with extra args',
+        ),
+        Option(
             'container_image_base',
             default=DEFAULT_IMAGE,
             desc='Container image name, without the tag',
@@ -405,6 +411,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.host_check_interval = 0
             self.max_count_per_host = 0
             self.mode = ''
+            self.container_cli_args = None
             self.container_image_base = ''
             self.container_image_prometheus = ''
             self.container_image_grafana = ''

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1282,6 +1282,8 @@ class CephadmServe:
 
         # subcommand
         final_args.append(command)
+        if self.mgr.container_cli_args is not None:
+            final_args.append('--container-cli-args="{}"'.format(self.mgr.container_cli_args))
 
         # subcommand args
         if not no_fsid:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1102,8 +1102,6 @@ class CephadmServe:
 
                 if reconfig:
                     daemon_spec.extra_args.append('--reconfig')
-                if self.mgr.allow_ptrace:
-                    daemon_spec.extra_args.append('--allow-ptrace')
 
                 try:
                     eca = daemon_spec.extra_container_args


### PR DESCRIPTION
So we can add any extra parameters to any calls to `podman run` executed
by cephadm.

Fixes: https://tracker.ceph.com/issues/52065

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
