### PR TITLE
tools/ceph-bluestore-tool: Enable configuration options from monitor/ceph.conf

### DIFF
--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -11,6 +11,7 @@ Synopsis
 
 | **ceph-bluestore-tool** *command*
   [ --dev *device* ... ]
+  [ -i *osd_id* ]
   [ --path *osd path* ]
   [ --out-dir *dir* ]
   [ --log-file | -l *filename* ]
@@ -121,6 +122,11 @@ Options
 
    Add *device* to the list of devices to consider
 
+.. option:: -i *osd_id*
+
+   Operate as OSD *osd_id*. Connect to monitor for OSD specific options.
+   If monitor is unavailable, add --no-mon-config to read from ceph.conf instead.
+
 .. option:: --devs-source *device*
 
    Add *device* to the list of devices to consider as sources for migrate operation
@@ -131,7 +137,7 @@ Options
 
 .. option:: --path *osd path*
 
-   Specify an osd path.  In most cases, the device list is inferred from the symlinks present in *osd path*.  This is usually simpler than explicitly specifying the device(s) with --dev.
+   Specify an osd path.  In most cases, the device list is inferred from the symlinks present in *osd path*.  This is usually simpler than explicitly specifying the device(s) with --dev. Not necessary if -i *osd_id* is provided.
 
 .. option:: --out-dir *dir*
 
@@ -160,6 +166,12 @@ Options
    and how large should commit batch be before committing to RocksDB. Option format is:
    <iterator_refresh_bytes>/<iterator_refresh_keys>/<batch_commit_bytes>/<batch_commit_keys>
    Default: 10000000/10000/1000000/1000
+
+Additional ceph.conf options
+============================
+
+Any configuration option that is accepted by OSD can be also passed to **ceph-bluestore-tool**.
+Useful to provide necessary configuration options when access to monitor/ceph.conf is impossible and -i option cannot be used.
 
 Device labels
 =============

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -274,6 +274,7 @@ static void bluefs_import(
 int main(int argc, char **argv)
 {
   string out_dir;
+  string osd_instance;
   vector<string> devs;
   vector<string> devs_source;
   string dev_target;
@@ -292,6 +293,7 @@ int main(int argc, char **argv)
   po::options_description po_options("Options");
   po_options.add_options()
     ("help,h", "produce help message")
+    (",i", po::value<string>(&osd_instance), "OSD instance. Requires access to monitor/ceph.conf")
     ("path", po::value<string>(&path), "bluestore path")
     ("out-dir", po::value<string>(&out_dir), "output directory")
     ("input-file", po::value<string>(&input_file), "import file")
@@ -335,14 +337,12 @@ int main(int argc, char **argv)
     ;
   po::options_description po_all("All options");
   po_all.add(po_options).add(po_positional);
-  po::positional_options_description pd;
-  pd.add("command", 1);
 
   vector<string> ceph_option_strings;
   po::variables_map vm;
   try {
     po::parsed_options parsed =
-      po::command_line_parser(argc, argv).options(po_all).allow_unregistered().positional(pd).run();
+      po::command_line_parser(argc, argv).options(po_all).allow_unregistered().run();
     po::store( parsed, vm);
     po::notify(vm);
     ceph_option_strings = po::collect_unrecognized(parsed.options,
@@ -359,9 +359,69 @@ int main(int argc, char **argv)
     usage(po_all);
     exit(EXIT_SUCCESS);
   }
+
+  vector<const char*> args;
+  if (log_file.size()) {
+    args.push_back("--log-file");
+    args.push_back(log_file.c_str());
+    static char ll[10];
+    snprintf(ll, sizeof(ll), "%d", log_level);
+    args.push_back("--debug-bluestore");
+    args.push_back(ll);
+    args.push_back("--debug-bluefs");
+    args.push_back(ll);
+    args.push_back("--debug-rocksdb");
+    args.push_back(ll);
+  } else {
+    // do not write to default-named log "osd.x.log" if --log-file is not provided
+    if (!osd_instance.empty()) {
+      args.push_back("--no-log-to-file");
+    }
+  }
+
+  if (!osd_instance.empty()) {
+    args.push_back("-i");
+    args.push_back(osd_instance.c_str());
+  }
+  args.push_back("--no-log-to-stderr");
+  args.push_back("--err-to-stderr");
+
+  for (auto& i : ceph_option_strings) {
+    args.push_back(i.c_str());
+  }
+  auto cct = global_init(NULL, args, osd_instance.empty() ? CEPH_ENTITY_TYPE_CLIENT : CEPH_ENTITY_TYPE_OSD,
+			 CODE_ENVIRONMENT_UTILITY,
+			 osd_instance.empty() ? CINIT_FLAG_NO_DEFAULT_CONFIG_FILE : 0);
+
+  common_init_finish(cct.get());
+  if (action.empty()) {
+    // if action ("command") is not yet defined try to use first param as action
+    if (args.size() > 0) {
+      if (args.size() == 1) {
+	// treat first unparsed value as action
+	action = args[0];
+      } else {
+	std::cerr << "Unknown options: " << args << std::endl;
+	exit(EXIT_FAILURE);
+      }
+    }
+  } else {
+    if (args.size() != 0) {
+      std::cerr << "Unknown options: " << args << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  }
+
   if (action.empty()) {
     cerr << "must specify an action; --help for help" << std::endl;
     exit(EXIT_FAILURE);
+  }
+
+  if (!osd_instance.empty()) {
+    // when "-i" is provided "osd data" can be used as path
+    if (path.size() == 0) {
+      path = cct->_conf.get_val<std::string>("osd_data");
+    }
   }
 
   if (action == "fsck" || action == "repair" || action == "quick-fix") {
@@ -483,30 +543,6 @@ int main(int argc, char **argv)
       exit(EXIT_FAILURE);
     }
   }
-  vector<const char*> args;
-  if (log_file.size()) {
-    args.push_back("--log-file");
-    args.push_back(log_file.c_str());
-    static char ll[10];
-    snprintf(ll, sizeof(ll), "%d", log_level);
-    args.push_back("--debug-bluestore");
-    args.push_back(ll);
-    args.push_back("--debug-bluefs");
-    args.push_back(ll);
-    args.push_back("--debug-rocksdb");
-    args.push_back(ll);
-  }
-  args.push_back("--no-log-to-stderr");
-  args.push_back("--err-to-stderr");
-
-  for (auto& i : ceph_option_strings) {
-    args.push_back(i.c_str());
-  }
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
-			 CODE_ENVIRONMENT_UTILITY,
-			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
-
-  common_init_finish(cct.get());
 
   if (action == "fsck" ||
       action == "repair" ||


### PR DESCRIPTION
Added option -i that allows to operate as specific osd.
It reads configuration options from monitor or ceph.conf.
In addition providing configuration option not accepted by OSD or ceph-bluestore-tool is now an error.

This significantly reduces problems on importing actual configuration options to ceph-bluestore-tool.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
