### PR TITLE
pacific: monitoring/grafana/cluster: use per-unit max and limit values

### DIFF
--- a/monitoring/grafana/dashboards/ceph-cluster.json
+++ b/monitoring/grafana/dashboards/ceph-cluster.json
@@ -264,7 +264,7 @@
       "decimals": 2,
       "format": "percentunit",
       "gauge": {
-        "maxValue": 100,
+        "maxValue": 1,
         "minValue": 0,
         "show": true,
         "thresholdLabels": false,
@@ -320,7 +320,7 @@
           "refId": "A"
         }
       ],
-      "thresholds": "70,80",
+      "thresholds": "0.7,0.8",
       "title": "Capacity used",
       "type": "singlestat",
       "valueFontSize": "80%",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51992

---

backport of https://github.com/ceph/ceph/pull/41880
parent tracker: https://tracker.ceph.com/issues/51990

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh