### PR TITLE
rgw: Use 100-continue in OPA requests to reduce latency

### DIFF
--- a/src/rgw/rgw_opa.cc
+++ b/src/rgw/rgw_opa.cc
@@ -31,6 +31,7 @@ int rgw_opa_authorize(RGWOp *& op,
   /* set required headers for OPA request */
   req.append_header("X-Auth-Token", opa_token);
   req.append_header("Content-Type", "application/json");
+  req.append_header("Expect", "100-continue");
 
   /* check if we want to verify OPA server SSL certificate */
   req.set_verify_ssl(s->cct->_conf->rgw_opa_verify_ssl);


### PR DESCRIPTION
When we send a POST request to Open Policy Agent, we send the headers first,
wait for TCP ACK from the server, and then send the body. But due to [delayed
ACK], the TCP ACK can be delayed by up to 500 ms (but typically 40 ms on
Linux), which in this case is huge as OPA typically takes only 1 ms to process
a request.

This commit adds the

```
Expect: 100-continue
```

header to the `POST` requests sent to OPA, which makes the server reply with

```
HTTP/1.1 100 Continue
```

immediately after receiving the headers, thereby avoiding the 40 ms delay.

[delayed ACK]: https://en.wikipedia.org/wiki/TCP_delayed_acknowledgment

Fixes: https://tracker.ceph.com/issues/52067
Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
