### PR TITLE
qa: test the "ms_mode" option in kclient workflows

### DIFF
--- a/qa/suites/fs/workload/ms_mode/crc.yaml
+++ b/qa/suites/fs/workload/ms_mode/crc.yaml
@@ -1,0 +1,3 @@
+overrides:
+  kclient:
+    mntopts: ["ms_mode=crc"]

--- a/qa/suites/fs/workload/ms_mode/legacy.yaml
+++ b/qa/suites/fs/workload/ms_mode/legacy.yaml
@@ -1,0 +1,3 @@
+overrides:
+  kclient:
+    mntopts: ["ms_mode=legacy"]

--- a/qa/suites/fs/workload/ms_mode/secure.yaml
+++ b/qa/suites/fs/workload/ms_mode/secure.yaml
@@ -1,0 +1,3 @@
+overrides:
+  kclient:
+    mntopts: ["ms_mode=secure"]


### PR DESCRIPTION
Note that I didn't bother adding the prefer-* options for ms_mode, as I
figure it's better to be definite. We could add them though.

Fixes: https://tracker.ceph.com/issues/52068
Signed-off-by: Jeff Layton <jlayton@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
