### PR TITLE
crimson/os/seastore: do not capture unused variable

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -314,7 +314,7 @@ class TreeBuilder {
 #ifndef NDEBUG
       validate_cursor_from_item(p_kv->key, p_kv->value, cursor);
       return tree->find(t, p_kv->key
-      ).si_then([this, cursor, p_kv](auto cursor_) mutable {
+      ).si_then([cursor, p_kv](auto cursor_) mutable {
         assert(!cursor_.is_end());
         ceph_assert(cursor_.get_ghobj() == p_kv->key);
         ceph_assert(cursor_.value() == cursor.value());
@@ -374,7 +374,7 @@ class TreeBuilder {
             assert(c_iter != cursors->end());
             auto p_kv = **ref_kv_iter;
             // validate values in tree keep intact
-            return tree->find(t, p_kv->key).si_then([this, &c_iter, ref_kv_iter](auto cursor) {
+            return tree->find(t, p_kv->key).si_then([&c_iter, ref_kv_iter](auto cursor) {
               auto p_kv = **ref_kv_iter;
               validate_cursor_from_item(p_kv->key, p_kv->value, cursor);
               // validate values in cursors keep intact
@@ -494,7 +494,7 @@ class TreeBuilder {
 
   eagain_ifuture<> get_stats(Transaction& t) {
     return tree->get_stats_slow(t
-    ).si_then([this](auto stats) {
+    ).si_then([](auto stats) {
       logger().warn("{}", stats);
     });
   }
@@ -537,7 +537,7 @@ class TreeBuilder {
           return seastar::make_ready_future<seastar::stop_iteration>(
             seastar::stop_iteration::yes);
         }
-        return validate_one(t, iter).si_then([this, &iter] {
+        return validate_one(t, iter).si_then([&iter] {
           ++iter;
           return seastar::make_ready_future<seastar::stop_iteration>(
             seastar::stop_iteration::no);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -172,7 +172,7 @@ SeaStore::list_objects(CollectionRef ch,
         [this, start, end, limit, &ret] (auto& t) {
 	return with_trans_intr(
 	  *t,
-	  [this, start, end, limit, &ret](auto &t) {
+	  [this, start, end, limit](auto &t) {
             return onode_manager->list_onodes(t, start, end, limit);
 	}).safe_then([&ret] (auto&& _ret) {
             ret = std::move(_ret);

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -154,7 +154,7 @@ struct fltree_onode_manager_test_t
       items.emplace_back(&p_kv->value);
       ++it;
     }
-    with_transaction([this, &oids, &items, f=std::move(f)] (auto& t) mutable {
+    with_transaction([&oids, &items, f=std::move(f)] (auto& t) mutable {
       std::invoke(f, t, oids, items);
     });
   }

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -163,7 +163,7 @@ TEST_F(a_basic_test_t, 1_basic_sizes)
 
 TEST_F(a_basic_test_t, 2_node_sizes)
 {
-  run_async([this] {
+  run_async([] {
     auto nm = NodeExtentManager::create_dummy(IS_DUMMY_SYNC);
     auto t = make_test_transaction();
     ValueBuilderImpl<UnboundedValue> vb;
@@ -616,7 +616,7 @@ struct c_dummy_test_t : public seastar_test_suite_t {};
 
 TEST_F(c_dummy_test_t, 4_split_merge_leaf_node)
 {
-  run_async([this] {
+  run_async([] {
     {
       TestTree test;
       test.build_tree({2, 5}, {2, 5}, {2, 5}, 120).get0();
@@ -1050,7 +1050,7 @@ class DummyChildPool {
       ).handle_error_interruptible(
         eagain_iertr::pass_further{},
         crimson::ct_error::assert_all{"Invalid error during create_initial()"}
-      ).si_then([c, &pool, initial](auto super) {
+      ).si_then([c, initial](auto super) {
         initial->make_root_new(c, std::move(super));
         return initial->upgrade_root(c).si_then([initial] {
           return initial;
@@ -1301,7 +1301,7 @@ class DummyChildPool {
 
 TEST_F(c_dummy_test_t, 5_split_merge_internal_node)
 {
-  run_async([this] {
+  run_async([] {
     DummyChildPool pool;
     {
       logger().info("\n---------------------------------------------"

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -17,7 +17,7 @@ namespace {
   }
 }
 
-class TestOnode : public Onode {
+class TestOnode final : public Onode {
   onode_layout_t layout;
   bool dirty = false;
 


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
