### PR TITLE
tools/ceph-dencoder: fix FreeBSD loading of dllib

### DIFF
--- a/src/tools/ceph-dencoder/denc_plugin.h
+++ b/src/tools/ceph-dencoder/denc_plugin.h
@@ -10,7 +10,11 @@ class DencoderPlugin {
   using dencoders_t = std::vector<std::pair<std::string, Dencoder*>>;
 public:
   DencoderPlugin(const fs::path& path) {
+#if defined(__FreeBSD__)
+    mod = dlopen(path.c_str(), RTLD_NOW | RTLD_NODELETE);
+#else
     mod = dlopen(path.c_str(), RTLD_NOW);
+#endif
     if (mod == nullptr) {
       std::cerr << "failed to dlopen(" << path << "): " << dlerror() << std::endl;
     }


### PR DESCRIPTION
In contrast to Linux, FreeDSB does not maintain a counter with the
number of dlopen()'s. So the first dlclose() unloads the lib.
In Linux only the counter is decremented until it is the last
dlclose()

fixes: #42607



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>