### PR TITLE
common: drop noexcept on thread entry points

### DIFF
--- a/src/common/Thread.cc
+++ b/src/common/Thread.cc
@@ -70,7 +70,7 @@ Thread::~Thread()
 {
 }
 
-void *Thread::_entry_func(void *arg) noexcept {
+void *Thread::_entry_func(void *arg) {
   void *r = ((Thread*)arg)->entry_wrapper();
   return r;
 }

--- a/src/common/Thread.h
+++ b/src/common/Thread.h
@@ -48,7 +48,7 @@ class Thread {
   virtual void *entry() = 0;
 
  private:
-  static void *_entry_func(void *arg) noexcept;
+  static void *_entry_func(void *arg);
 
  public:
   const pthread_t &get_thread_id() const;

--- a/src/common/async/context_pool.h
+++ b/src/common/async/context_pool.h
@@ -58,13 +58,8 @@ public:
       guard.emplace(boost::asio::make_work_guard(ioctx));
       ioctx.restart();
       for (std::int16_t i = 0; i < threadcnt; ++i) {
-	// Mark this function as noexcept so any uncaught exceptions
-	// call terminate at point of throw. Otherwise, under
-	// libstdc++, they get caught by the thread cancellation
-	// infrastructure, unwinding the stack and making debugging
-	// much more difficult.
 	threadvec.emplace_back(make_named_thread("io_context_pool",
-						 [this]() noexcept {
+						 [this]() {
 						   ioctx.run();
 						 }));
       }


### PR DESCRIPTION
noexcept was added in https://github.com/ceph/ceph/pull/32601 and https://github.com/ceph/ceph/pull/38852:

```
// Mark this function as noexcept so any uncaught exceptions
// call terminate at point of throw. Otherwise, under
// libstdc++, they get caught by the thread cancellation
// infrastructure, unwinding the stack and making debugging
// much more difficult.
```
This issue has been addressed in g++ 8: there is no try/catch in
execute_native_thread_routine() anymore [1][2] and noexcept ends up
having the opposite effect.  Whereas without noexcept g++ guarantees
that the stack would not be unwound [3], it doesn't make such guarantee
for the noexcept case.  According to the standard, these cases are
distinct and even though both are implementation defined, g++ only
defines the former.  With noexcept, it unwinds up to the noexcept frame
which is not useful at all.  (clang unwinds up to and including the
noexcept frame and only msvc does the right thing and immediately
terminates.)

[1] https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=754d67d5ba4a1f9994210d402893a4cf49ce6a71
[2] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55917
[3] https://gcc.gnu.org/onlinedocs/gcc/Exception-handling.html

ubuntu focal: g++ 9.3
centos 8: g++ 8.4

Before:

```
(gdb) bt
#0  raise (sig=<optimized out>) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00005565cc58100a in reraise_fatal (signum=6) at ../src/global/signal_handler.cc:88
#2  handle_oneshot_fatal_signal (signum=6) at ../src/global/signal_handler.cc:363
#3  <signal handler called>
#4  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#5  0x00007f7c94589859 in __GI_abort () at abort.c:79
#6  0x00007f7c94960951 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007f7c9496c47c in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#8  0x00007f7c9496b459 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x00007f7c9496be11 in __gxx_personality_v0 () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#10 0x00007f7c94766bdf in ?? () from /lib/x86_64-linux-gnu/libgcc_s.so.1
#11 0x00007f7c9476759a in _Unwind_Resume () from /lib/x86_64-linux-gnu/libgcc_s.so.1
#12 0x00007f7c957b3b22 in boost::asio::detail::thread_info_base::~thread_info_base (this=<optimized out>, __in_chrg=<optimized out>) at boost/include/boost/asio/detail/thread_info_base.hpp:68
#13 boost::asio::detail::scheduler_thread_info::~scheduler_thread_info (this=<optimized out>, __in_chrg=<optimized out>) at boost/include/boost/asio/detail/scheduler_thread_info.hpp:30
#14 boost::asio::detail::scheduler::run (this=<optimized out>, ec=...) at boost/include/boost/asio/detail/impl/scheduler.ipp:197
#15 0x00007f7c957b9308 in boost::asio::io_context::run (this=<optimized out>) at boost/include/boost/asio/impl/io_context.ipp:63
< ... more asio/thread frames ... >
```
After:
```
(gdb) bt
#0  raise (sig=<optimized out>) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00005568558eb01a in reraise_fatal (signum=6) at ../src/global/signal_handler.cc:88
#2  handle_oneshot_fatal_signal (signum=6) at ../src/global/signal_handler.cc:363
#3  <signal handler called>
#4  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#5  0x00007f58597cd859 in __GI_abort () at abort.c:79
#6  0x00007f5859ba4951 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007f5859bb047c in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#8  0x00007f5859bb04e7 in std::terminate() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x00007f5859bb0799 in __cxa_throw () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#10 0x00007f585a9865e1 in ceph::buffer::v15_2_0::ptr::iterator_impl<true>::operator+= (this=this@entry=0x7f5855cac8f0, len=<optimized out>) at ../src/common/buffer.cc:640
#11 0x00007f585429f642 in librbd::cache::pwl::WriteLogCacheEntry::_denc_finish (struct_v=<synthetic pointer>, struct_compat=<synthetic pointer>, start_pos=<synthetic pointer>,
    struct_len=<synthetic pointer>, p=...) at ../src/librbd/cache/pwl/Types.h:262
#12 librbd::cache::pwl::_denc_friend<librbd::cache::pwl::WriteLogCacheEntry, ceph::buffer::v15_2_0::ptr::iterator_impl<true> > (p=..., v=...) at ../src/librbd/cache/pwl/Types.h:272
#13 librbd::cache::pwl::WriteLogCacheEntry::decode (p=..., this=0x7f5855cac980) at ../src/librbd/cache/pwl/Types.h:262
#14 denc_traits<librbd::cache::pwl::WriteLogCacheEntry, void>::decode (f=0, p=..., v=...) at ../src/librbd/cache/pwl/Types.h:389
#15 denc<librbd::cache::pwl::WriteLogCacheEntry, ceph::buffer::v15_2_0::ptr::iterator_impl<true>, denc_traits<librbd::cache::pwl::WriteLogCacheEntry, void> > (features=0, p=..., o=...)
    at ../src/include/denc.h:682
#16 _denc::container_base<std::vector, _denc::pushback_details<std::vector<librbd::cache::pwl::WriteLogCacheEntry, std::allocator<librbd::cache::pwl::WriteLogCacheEntry> > >, librbd::cache::pwl::WriteLogCacheEntry, std::allocator<librbd::cache::pwl::WriteLogCacheEntry> >::decode_nohead (f=0, p=..., s=std::vector of length 0, capacity 0, num=1734829926) at ../src/include/denc.h:1018
#17 _denc::container_base<std::vector, _denc::pushback_details<std::vector<librbd::cache::pwl::WriteLogCacheEntry, std::allocator<librbd::cache::pwl::WriteLogCacheEntry> > >, librbd::cache::pwl::WriteLogCacheEntry, std::allocator<librbd::cache::pwl::WriteLogCacheEntry> >::decode (f=0, p=..., s=std::vector of length 0, capacity 0) at ../src/include/denc.h:990
#18 ceph::decode<std::vector<librbd::cache::pwl::WriteLogCacheEntry, std::allocator<librbd::cache::pwl::WriteLogCacheEntry> >, denc_traits<std::vector<librbd::cache::pwl::WriteLogCacheEntry, std::allocator<librbd::cache::pwl::WriteLogCacheEntry> >, void> > (p=..., o=std::vector of length 0, capacity 0) at ../src/include/denc.h:1737
#19 librbd::cache::pwl::ssd::WriteLog<librbd::ImageCtx>::load_existing_entries (this=this@entry=0x7f583400cd40, later=...) at ../src/librbd/cache/pwl/ssd/WriteLog.cc:238
#20 0x00007f58542a0179 in librbd::cache::pwl::ssd::WriteLog<librbd::ImageCtx>::initialize_pool (this=0x7f583400cd40, on_finish=0x7f5834023640, later=...)
    at /usr/include/c++/9/ext/atomicity.h:96
#21 0x00007f5854261fc3 in librbd::cache::pwl::AbstractWriteLog<librbd::ImageCtx>::pwl_init (this=this@entry=0x7f583400cd40, on_finish=0x7f5834023640, later=...)
    at ../src/common/StackStringStream.h:145
#22 0x00007f5854263786 in librbd::cache::pwl::AbstractWriteLog<librbd::ImageCtx>::init (this=0x7f583400cd40, on_finish=0x7f5834013050) at /usr/include/c++/9/atomic:88
#23 0x00007f5854274c19 in librbd::cache::pwl::InitRequest<librbd::ImageCtx>::init_image_cache (this=this@entry=0x7f585002e000) at ../src/common/config_proxy.h:120
#24 0x00007f5854276460 in librbd::cache::pwl::InitRequest<librbd::ImageCtx>::get_image_cache_state (this=0x7f585002e000) at ../src/common/config_proxy.h:120
#25 0x00007f585ac52a9e in librbd::PluginRegistry<librbd::ImageCtx>::acquired_exclusive_lock (this=0x5568567b86c0, on_finish=<optimized out>)
    at /usr/include/x86_64-linux-gnu/c++/9/bits/gthr-default.h:779
#26 0x00007f585aec2b7c in librbd::exclusive_lock::PostAcquireRequest<librbd::ImageCtx>::send_process_plugin_acquire_lock (this=this@entry=0x7f5850028000) at ../src/common/config_proxy.h:120
#27 0x00007f585aec58c6 in librbd::exclusive_lock::PostAcquireRequest<librbd::ImageCtx>::send_open_journal (this=this@entry=0x7f5850028000) at /usr/include/c++/9/shared_mutex:75
#28 0x00007f585aec6243 in librbd::exclusive_lock::PostAcquireRequest<librbd::ImageCtx>::handle_open_object_map (this=0x7f5850028000, r=0) at ../src/common/config_proxy.h:120
#29 0x00007f585abba299 in Context::complete (this=0x7f58500012a0, r=<optimized out>) at ../src/include/Context.h:99
#30 0x00007f585abba299 in Context::complete (this=0x7f5834013810, r=<optimized out>) at ../src/include/Context.h:99
#31 0x00007f585ae200c9 in librbd::util::detail::rados_state_callback<librbd::object_map::RefreshRequest<librbd::ImageCtx>, &librbd::object_map::RefreshRequest<librbd::ImageCtx>::handle_load, true> (c=<optimized out>, arg=0x7f58340161b0) at ../src/librbd/Utils.h:42
#32 0x00007f585a9d79ee in librados::CB_AioComplete::operator() (this=<synthetic pointer>) at ../src/librados/AioCompletionImpl.h:140
#33 boost::asio::asio_handler_invoke<librados::CB_AioComplete> (function=<synthetic pointer>...) at boost/include/boost/asio/handler_invoke_hook.hpp:88
#34 boost_asio_handler_invoke_helpers::invoke<librados::CB_AioComplete, librados::CB_AioComplete> (context=<synthetic pointer>..., function=<synthetic pointer>...)
    at boost/include/boost/asio/detail/handler_invoke_helpers.hpp:54
#35 boost::asio::detail::handler_work<librados::CB_AioComplete, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0u>, void>::complete<librados::CB_AioComplete> (
    this=<synthetic pointer>, handler=<synthetic pointer>..., function=<synthetic pointer>...) at boost/include/boost/asio/detail/handler_work.hpp:425
#36 boost::asio::detail::completion_handler<librados::CB_AioComplete, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0u> >::do_complete (owner=0x5568565f3fa0,
    base=0x7f585002e000) at boost/include/boost/asio/detail/completion_handler.hpp:74
#37 0x00007f585a9f5f05 in boost::asio::detail::scheduler_operation::complete (bytes_transferred=0, ec=..., owner=0x5568565f3fa0, this=<optimized out>)
    at boost/include/boost/asio/detail/scheduler_operation.hpp:40
#38 boost::asio::detail::strand_service::do_complete (owner=0x5568565f3fa0, base=0x5568566b44b0, ec=...) at boost/include/boost/asio/detail/impl/strand_service.ipp:169
#39 0x00007f585a9f75bd in boost::asio::detail::scheduler_operation::complete (bytes_transferred=<optimized out>, ec=..., owner=0x5568565f3fa0, this=<optimized out>)
    at boost/include/boost/asio/detail/scheduler_operation.hpp:40
#40 boost::asio::detail::scheduler::do_run_one (ec=..., this_thread=..., lock=..., this=<optimized out>) at boost/include/boost/asio/detail/impl/scheduler.ipp:481
#41 boost::asio::detail::scheduler::run (this=0x5568565f3fa0, ec=...) at boost/include/boost/asio/detail/impl/scheduler.ipp:204
#42 0x00007f585a9fd306 in boost::asio::io_context::run (this=<optimized out>) at boost/include/boost/asio/impl/io_context.ipp:63
< ... more asio/thread frames ... >
```