### PR TITLE
common: removing the explicit attribute from a public copy constructor

### DIFF
--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -109,7 +109,7 @@ public:
   explicit ConfigProxy(bool is_daemon)
     : config{values, obs_mgr, is_daemon}
   {}
-  explicit ConfigProxy(const ConfigProxy &config_proxy)
+  ConfigProxy(const ConfigProxy &config_proxy)
     : values(config_proxy.get_config_values()),
       config{values, obs_mgr, config_proxy.config.is_daemon}
   {}


### PR DESCRIPTION
A copy constructor marked 'explicit' is almost useless (and
triggers a static-analyzer warning).

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
