### PR TITLE
osd/scrub: only telling the scrubber of 'updates' events if these eve…

### DIFF
--- a/src/messages/MOSDRepScrub.h
+++ b/src/messages/MOSDRepScrub.h
@@ -29,7 +29,7 @@ public:
 
   spg_t pgid;             // PG to scrub
   eversion_t scrub_from; // only scrub log entries after scrub_from
-  eversion_t scrub_to;   // last_update_applied when message sent
+  eversion_t scrub_to;   // last_update_applied when message sent (not used)
   epoch_t map_epoch = 0, min_epoch = 0;
   bool chunky;           // true for chunky scrubs
   hobject_t start;       // lower bound of scrub, inclusive

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -11278,8 +11278,10 @@ void PrimaryLogPG::op_applied(const eversion_t &applied_version)
   ceph_assert(applied_version <= info.last_update);
   recovery_state.local_write_applied(applied_version);
 
-  if (is_primary() && m_scrubber->should_requeue_blocked_ops(recovery_state.get_last_update_applied())) {
-    osd->queue_scrub_applied_update(this, is_scrub_blocking_ops());
+  if (is_primary() && m_scrubber) {
+    // if there's a scrub operation waiting for the selected chunk to be fully updated -
+    // allow it to continue
+    m_scrubber->on_applied_when_primary(recovery_state.get_last_update_applied());
   }
 }
 

--- a/src/osd/PrimaryLogScrub.cc
+++ b/src/osd/PrimaryLogScrub.cc
@@ -585,14 +585,3 @@ void PrimaryLogScrub::stats_of_handled_objects(const object_stat_sum_t& delta_st
     }
   }
 }
-
-bool PrimaryLogScrub::should_requeue_blocked_ops(eversion_t last_recovery_applied) const
-{
-  if (!is_scrub_active()) {
-    // just verify that things indeed are quiet
-    ceph_assert(m_start == m_end);
-    return false;
-  }
-
-  return last_recovery_applied >= m_subset_last_update;
-}

--- a/src/osd/PrimaryLogScrub.h
+++ b/src/osd/PrimaryLogScrub.h
@@ -36,15 +36,6 @@ class PrimaryLogScrub : public PgScrubber {
   bool get_store_errors(const scrub_ls_arg_t& arg,
 			scrub_ls_result_t& res_inout) const final;
 
-  /**
-   *  should we requeue blocked ops?
-   *  Yes - if our 'subset_last_applied' is less up-to-date than the
-   *  new recovery_state.get_last_update_applied().
-   *  (used by PrimaryLogPG::op_applied())
-   */
-  [[nodiscard]] bool should_requeue_blocked_ops(
-    eversion_t last_recovery_applied) const final;
-
   void stats_of_handled_objects(const object_stat_sum_t& delta_stats,
 				const hobject_t& soid) final;
 

--- a/src/osd/pg_scrubber.cc
+++ b/src/osd/pg_scrubber.cc
@@ -558,6 +558,17 @@ void PgScrubber::set_subset_last_update(eversion_t e)
   dout(15) << __func__ << " last-update: " << e << dendl;
 }
 
+void PgScrubber::on_applied_when_primary(const eversion_t& applied_version)
+{
+  // we are only interested in updates if we are the Primary, and in state
+  // WaitLastUpdate
+  if (m_fsm->is_accepting_updates() && (applied_version >= m_subset_last_update)) {
+    m_osds->queue_scrub_applied_update(m_pg, m_pg->is_scrub_blocking_ops());
+    dout(15) << __func__ << " update: " << applied_version
+	     << " vs. required: " << m_subset_last_update << dendl;
+  }
+}
+
 /*
  * The selected range is set directly into 'm_start' and 'm_end'
  * setting:
@@ -1111,6 +1122,7 @@ int PgScrubber::build_scrub_map_chunk(
   while (!pos.done()) {
 
     int r = m_pg->get_pgbackend()->be_scan_list(map, pos);
+    dout(30) << __func__ << " BE returned " << r << dendl;
     if (r == -EINPROGRESS) {
       dout(20) << __func__ << " in progress" << dendl;
       return r;
@@ -1200,7 +1212,6 @@ void PgScrubber::replica_scrub_op(OpRequestRef op)
 
   // are we still processing a previous scrub-map request without noticing that the
   // interval changed? won't see it here, but rather at the reservation stage.
-
 
   if (msg->map_epoch < m_pg->info.history.same_interval_since) {
     dout(10) << "replica_scrub_op discarding old replica_scrub from " << msg->map_epoch
@@ -1465,12 +1476,13 @@ void PgScrubber::handle_scrub_reserve_request(OpRequestRef op)
    *  otherwise the interval would have changed.
    *  Ostensibly we can discard & redo the reservation. But then we
    *  will be temporarily releasing the OSD resource - and might not be able to grab it
-   *  again. Thus we simple treat this as a successful new request.
+   *  again. Thus, we simply treat this as a successful new request.
    */
 
   if (m_remote_osd_resource.has_value() && m_remote_osd_resource->is_stale()) {
     // we are holding a stale reservation from a past epoch
     m_remote_osd_resource.reset();
+    dout(10) << __func__ << " stale reservation request" << dendl;
   }
 
   if (request_ep < m_pg->get_same_interval_since()) {

--- a/src/osd/pg_scrubber.h
+++ b/src/osd/pg_scrubber.h
@@ -306,16 +306,6 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
   /// handle a message carrying a replica map
   void map_from_replica(OpRequestRef op) final;
 
-  /**
-   *  should we requeue blocked ops?
-   *  Applicable to the PrimaryLogScrub derived class.
-   */
-  [[nodiscard]] virtual bool should_requeue_blocked_ops(
-    eversion_t last_recovery_applied) const override
-  {
-    return false;
-  }
-
   void scrub_clear_state() final;
 
   /**

--- a/src/osd/scrub_machine.h
+++ b/src/osd/scrub_machine.h
@@ -74,7 +74,7 @@ MEV(ChunkIsBusy)
 MEV(ActivePushesUpd)  ///< Update to active_pushes. 'active_pushes' represents recovery
 		      ///< that is in-flight to the local ObjectStore
 
-MEV(UpdatesApplied)  // external
+MEV(UpdatesApplied)  ///< (Primary only) all updates are committed
 
 MEV(InternalAllUpdates)	 ///< the internal counterpart of UpdatesApplied
 
@@ -89,8 +89,6 @@ MEV(IntLocalMapDone)
 
 MEV(DigestUpdate)  ///< external. called upon success of a MODIFY op. See
 		   ///< scrub_snapshot_metadata()
-
-MEV(AllChunksDone)
 
 MEV(MapsCompared)  ///< (Crimson) maps_compare_n_cleanup() transactions are done
 
@@ -133,6 +131,7 @@ class ScrubMachine : public sc::state_machine<ScrubMachine, NotActive> {
   void my_states() const;
   void assert_not_active() const;
   [[nodiscard]] bool is_reserving() const;
+  [[nodiscard]] bool is_accepting_updates() const;
 };
 
 /**
@@ -192,13 +191,9 @@ struct ActiveScrubbing : sc::state<ActiveScrubbing, ScrubMachine, PendingTimer> 
   ~ActiveScrubbing();
 
   using reactions = mpl::list<
-    // done scrubbing
-    sc::transition<AllChunksDone, NotActive>,
-
     sc::custom_reaction<InternalError>,
     sc::custom_reaction<FullReset>>;
 
-  sc::result react(const AllChunksDone&);
   sc::result react(const FullReset&);
   sc::result react(const InternalError&);
 };

--- a/src/osd/scrub_machine_lstnr.h
+++ b/src/osd/scrub_machine_lstnr.h
@@ -63,6 +63,8 @@ struct ScrubMachineListener {
 
   virtual ~ScrubMachineListener() = default;
 
+  [[nodiscard]] virtual bool is_primary() const = 0;
+
   virtual void select_range_n_notify() = 0;
 
   virtual Scrub::BlockedRangeWarning acquire_blocked_alarm() = 0;

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -206,10 +206,6 @@ struct ScrubPgIF {
 
   virtual void add_callback(Context* context) = 0;
 
-  /// should we requeue blocked ops?
-  [[nodiscard]] virtual bool should_requeue_blocked_ops(
-    eversion_t last_recovery_applied) const = 0;
-
   /// add to scrub statistics, but only if the soid is below the scrub start
   virtual void stats_of_handled_objects(const object_stat_sum_t& delta_stats,
 					const hobject_t& soid) = 0;

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -152,6 +152,8 @@ struct ScrubPgIF {
 
   virtual void send_maps_compared(epoch_t epoch_queued) = 0;
 
+  virtual void on_applied_when_primary(const eversion_t &applied_version) = 0;
+
   // --------------------------------------------------
 
   [[nodiscard]] virtual bool are_callbacks_pending()


### PR DESCRIPTION
Only telling the scrubber of 'update' events if these events are awaited.

Only the Primary, and only when there is an active scrubbing going on and the
scrubber's state machine is in WaitUpdates states, should be notified of 'updates'.
The extra messages currently queued and processed are, apart from creating redundant
log lines and wasting CPU time, complicating the task of preventing a race in the handling
of stale scrubs.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

