### PR TITLE
qa: test copy_file_range syscall in kclient workflows

### DIFF
--- a/qa/suites/fs/functional/tasks/copy_range.yaml
+++ b/qa/suites/fs/functional/tasks/copy_range.yaml
@@ -1,0 +1,7 @@
+overrides:
+  kclient:
+    mntopts: ["copyfrom"]
+tasks:
+  - cephfs_test_runner:
+      modules:
+        - tasks.cephfs.test_copy_range

--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -23,9 +23,9 @@ class FuseMount(CephFSMount):
         super(FuseMount, self).__init__(ctx=ctx, test_dir=test_dir,
             client_id=client_id, client_remote=client_remote,
             client_keyring_path=client_keyring_path, hostfs_mntpt=hostfs_mntpt,
-            cephfs_name=cephfs_name, cephfs_mntpt=cephfs_mntpt, brxnet=brxnet)
+            cephfs_name=cephfs_name, cephfs_mntpt=cephfs_mntpt, brxnet=brxnet,
+            client_config=client_config)
 
-        self.client_config = client_config
         self.fuse_daemon = None
         self._fuse_conn = None
         self.id = None

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -27,7 +27,8 @@ class KernelMount(CephFSMount):
         super(KernelMount, self).__init__(ctx=ctx, test_dir=test_dir,
             client_id=client_id, client_remote=client_remote,
             client_keyring_path=client_keyring_path, hostfs_mntpt=hostfs_mntpt,
-            cephfs_name=cephfs_name, cephfs_mntpt=cephfs_mntpt, brxnet=brxnet)
+            cephfs_name=cephfs_name, cephfs_mntpt=cephfs_mntpt, brxnet=brxnet,
+            client_config=config)
 
         self.client_config = client_config
         self.dynamic_debug = client_config.get('dynamic_debug', False)

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -28,7 +28,8 @@ UMOUNT_TIMEOUT = 300
 class CephFSMount(object):
     def __init__(self, ctx, test_dir, client_id, client_remote,
                  client_keyring_path=None, hostfs_mntpt=None,
-                 cephfs_name=None, cephfs_mntpt=None, brxnet=None):
+                 cephfs_name=None, cephfs_mntpt=None, brxnet=None,
+                 client_config={}):
         """
         :param test_dir: Global teuthology test dir
         :param client_id: Client ID, the 'foo' in client.foo
@@ -70,6 +71,7 @@ class CephFSMount(object):
             self.ceph_brx_net = '192.168.0.0/16'
         else:
             self.ceph_brx_net = brxnet
+        self.client_config = client_config if client_config else {}
 
         self.test_files = ['a', 'b', 'c']
 

--- a/qa/tasks/cephfs/test_copy_range.py
+++ b/qa/tasks/cephfs/test_copy_range.py
@@ -1,0 +1,13 @@
+import logging
+
+from tasks.cephfs.xfstests_dev import XFSTestsDev
+
+log = logging.getLogger(__name__)
+
+class TestCopyRange(XFSTestsDev):
+    def test_copy_range_001(self):
+        self.runFstest('ceph/001', (30*60)) # 30mins timeout
+    def test_copy_range_002(self):
+        self.runFstest('ceph/002', 60)
+    def test_copy_range_003(self):
+        self.runFstest('ceph/003', 60)


### PR DESCRIPTION
Similar to 'ms_mode', the 'copyfrom' mount option also requires some testing in teuthology.  Unfortunately, it will also require fstests to be executed, which isn't happening right now.

This pull request is an initial attempt to enable the 'copyfrom' mount option *and* add the 3 ceph-specific fstests that exercise this syscall.

Fixes: https://tracker.ceph.com/issues/52104
Signed-off-by: Luis Henriques <lhenriques@suse.de>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
