### PR TITLE
mgr/dashboard: disable create snapshot with subvolumes

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
@@ -1073,5 +1073,39 @@ describe('CephfsDirectoriesComponent', () => {
         expect(component.loadingIndicator).toBe(true);
       });
     });
+    describe('disable create snapshot', () => {
+      let actions: CdTableAction[];
+      beforeEach(() => {
+        actions = component.snapshot.tableActions;
+        mockLib.mkDir('/', 'volumes', 2, 2);
+        mockLib.mkDir('/volumes', 'group1', 2, 2);
+        mockLib.mkDir('/volumes/group1', 'subvol', 2, 2);
+        mockLib.mkDir('/volumes/group1/subvol', 'subfile', 2, 2);
+      });
+
+      const empty = (): CdTableSelection => new CdTableSelection();
+
+      it('should return a descriptive message to explain why it is disabled', () => {
+        const path = '/volumes/group1/subvol/subfile';
+        const res = 'Cannot create snapshots for files/folders in the subvolume subvol';
+        mockLib.selectNode(path);
+        expect(actions[0].disable(empty())).toContain(res);
+      });
+
+      it('should return false if it is not a subvolume node', () => {
+        const testCases = [
+          '/volumes/group1/subvol',
+          '/volumes/group1',
+          '/volumes',
+          '/',
+          '/a',
+          '/a/b'
+        ];
+        testCases.forEach((testCase) => {
+          mockLib.selectNode(testCase);
+          expect(actions[0].disable(empty())).toBeFalsy();
+        });
+      });
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.ts
@@ -219,7 +219,8 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
           icon: Icons.add,
           permission: 'create',
           canBePrimary: (selection) => !selection.hasSelection,
-          click: () => this.createSnapshot()
+          click: () => this.createSnapshot(),
+          disable: () => this.disableCreateSnapshot()
         },
         {
           name: this.actionLabels.DELETE,
@@ -231,6 +232,16 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
         }
       ]
     };
+  }
+
+  private disableCreateSnapshot(): string | boolean {
+    const folders = this.selectedDir.path.split('/').slice(1);
+    // With deph of 4 or more we have the subvolume files/folders for which we cannot create
+    // a snapshot. Somehow, you can create a snapshot of the subvolume but not its files.
+    if (folders.length >= 4 && folders[0] === 'volumes') {
+      return $localize`Cannot create snapshots for files/folders in the subvolume ${folders[2]}`;
+    }
+    return false;
   }
 
   ngOnChanges() {


### PR DESCRIPTION
It was suggested to disable or show an error when trying to create a snapshot. I decided to go with disabling the button so we can prevent this error without calling the api and even though you can't see, it shows a message as of why you cannot create a snapshot when hovering the button(I don't know how to screenshot hovering the button lmao).

I also found this weird behaviour. Every folder/file in the volume and subvolumes have the same uid and mode but you cannot create directories files on the .snap folder inside a subovolume folder but you can in another place. For example:
```
[mgr self-test eval] >>> cfs.statx('/volumes/_nogroup/subvol', 0xFFFF, 0)
{'mode': 16877, 'nlink': 3, 'uid': 0, 'gid': 0, 'rdev': 0, 'atime': datetime.datetime(2021, 8, 9, 9, 44, 20), 'mtime': datetime.datetime(2021, 8, 9, 9, 44, 20), 'ctime': datetime.datetime(2021, 8, 9, 9, 44, 20), '
ino': 1099511628783, 'size': 125, 'blocks': 1, 'btime': datetime.datetime(2021, 8, 9, 9, 44, 20), 'version': 2}
[mgr self-test eval] >>> cfs.statx('/volumes/_nogroup/subvol/.snap', 0xFFFF, 0)
{'mode': 16877, 'nlink': 2, 'uid': 0, 'gid': 0, 'rdev': 0, 'atime': datetime.datetime(2021, 8, 9, 9, 44, 20), 'mtime': datetime.datetime(2021, 8, 9, 9, 44, 20), 'ctime': datetime.datetime(2021, 8, 9, 9, 44, 20), '
ino': 1099511628783, 'size': 0, 'blocks': 1, 'btime': datetime.datetime(2021, 8, 9, 9, 44, 20), 'version': 2}
[mgr self-test eval] >>> cfs.mkdir('/volumes/_nogroup/subvol/.snap/snapshot', 0o755)
[mgr self-test eval] >>> cfs.mkdir('/volumes/_nogroup/subvol/subfolder', 0o755)

# If you try to create a snapshot of 'subfolder' in the dashboard it fails, and if you can reproduce this error with:

[mgr self-test eval] >>> cfs.mkdir('/volumes/_nogroup/subvol/subfolder/.snap', 0o755)
[mgr self-test eval] >>> cfs.mkdir('/volumes/_nogroup/subvol/subfolder/.snap/snapshot', 0o755) # should this work?
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "cephfs.pyx", line 1022, in cephfs.LibCephFS.mkdir
cephfs.PermissionError: error in mkdir /volumes/_nogroup/subvol/subfolder/.snap/snapshot: Operation not permitted [Errno 1]
[mgr self-test eval] >>> cfs.mkdir('/volumes/_nogroup/subvol/subfolder/nothidden', 0o755)
[mgr self-test eval] >>> cfs.mkdir('/volumes/_nogroup/subvol/subfolder/nothidden/works', 0o755)

[mgr self-test eval] >>> clear
Traceback (most recent call last):
  File "<input>", line 1, in <module>
NameError: name 'clear' is not defined
[mgr self-test eval] >>> ls
Traceback (most recent call last):
  File "<input>", line 1, in <module>
NameError: name 'ls' is not defined
[mgr self-test eval] >>> cfs.mkdir('/subfolder', 0o755)
[mgr self-test eval] >>> cfs.mkdir('/subfolder/.snap/e', 0o755) # this works


```

![image](https://user-images.githubusercontent.com/30913090/128832799-fdb4d87f-3059-420b-9ebe-3e6cf9aa9ef2.png)

Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>
Fixes: https://tracker.ceph.com/issues/52131

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
