### PR TITLE
osd/scrub: Add stats to PG dump for number of objects scrubbed

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -87,10 +87,11 @@
 
   https://docs.ceph.com/en/latest/rados/operations/placement-groups/
 
-* The ``ceph pg dump`` command now prints two additional columns:
+* The ``ceph pg dump`` command now prints three additional columns:
   `LAST_SCRUB_DURATION` shows the duration (in seconds) of the last completed scrub;
   `SCRUB_SCHEDULING` conveys whether a PG is scheduled to be scrubbed at a specified
-  time, queued for scrubbing, or being scrubbed.
+  time, queued for scrubbing, or being scrubbed;
+  `OBJECTS_SCRUBBED` shows the number of objects scrubbed in a PG after scrub begins.
 
 * A health warning will now be reported if the ``require-osd-release`` flag is not
   set to the appropriate release after a cluster upgrade.

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1675,6 +1675,7 @@ void PGMap::dump_pg_stats_plain(
     tab.define_column("SNAPTRIMQ_LEN", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("LAST_SCRUB_DURATION", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("SCRUB_SCHEDULING", TextTable::LEFT, TextTable::LEFT);
+    tab.define_column("OBJECTS_SCRUBBED", TextTable::LEFT, TextTable::RIGHT);
   }
 
   for (const auto& [pg, st] : pg_stats) {
@@ -1716,6 +1717,7 @@ void PGMap::dump_pg_stats_plain(
           << st.snaptrimq_len
           << st.last_scrub_duration
           << st.dump_scrub_schedule()
+          << st.objects_scrubbed
           << TextTable::endrow;
     }
   }

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -295,6 +295,18 @@ public:
       });
   }
 
+  static void reset_objects_scrubbed(pg_stat_t &stats) {
+    stats.objects_scrubbed = 0;
+  }
+
+  void reset_objects_scrubbed() {
+    recovery_state.update_stats(
+      [=](auto &history, auto &stats) {
+  reset_objects_scrubbed(stats);
+  return true;
+      });
+  }
+
   bool is_deleting() const {
     return recovery_state.is_deleting();
   }

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -282,6 +282,19 @@ public:
       });
   }
 
+  static void add_objects_scrubbed_count(
+    int64_t count, pg_stat_t &stats) {
+    stats.objects_scrubbed += count;
+  }
+
+  void add_objects_scrubbed_count(int64_t count) {
+    recovery_state.update_stats(
+      [=](auto &history, auto &stats) {
+	add_objects_scrubbed_count(count, stats);
+	return true;
+      });
+  }
+
   bool is_deleting() const {
     return recovery_state.is_deleting();
   }

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2246,6 +2246,7 @@ struct pg_stat_t {
 
   int64_t log_size;
   int64_t ondisk_log_size;    // >= active_log_size
+  int64_t objects_scrubbed;
 
   std::vector<int32_t> up, acting;
   std::vector<pg_shard_t> avail_no_missing;
@@ -2286,6 +2287,7 @@ struct pg_stat_t {
       created(0), last_epoch_clean(0),
       parent_split_bits(0),
       log_size(0), ondisk_log_size(0),
+      objects_scrubbed(0),
       mapping_epoch(0),
       up_primary(-1),
       acting_primary(-1),

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1370,6 +1370,8 @@ void PgScrubber::scrub_compare_maps()
 {
   dout(10) << __func__ << " has maps, analyzing" << dendl;
 
+  int64_t primary_objects = 0;
+
   // construct authoritative scrub map for type-specific scrubbing
   m_cleaned_meta_map.insert(m_primary_scrubmap);
   map<hobject_t, pair<std::optional<uint32_t>, std::optional<uint32_t>>> missing_digest;
@@ -1410,6 +1412,8 @@ void PgScrubber::scrub_compare_maps()
 
     dout(2) << __func__ << ": primary (" << m_pg->get_primary() << ") has "
 	    << m_primary_scrubmap.objects.size() << " items" << dendl;
+    primary_objects = m_primary_scrubmap.objects.size();
+    m_pg->add_objects_scrubbed_count(primary_objects);
 
     ss.str("");
     ss.clear();

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -950,7 +950,7 @@ void PgScrubber::on_init()
 {
   // going upwards from 'inactive'
   ceph_assert(!is_scrub_active());
-
+  m_pg->reset_objects_scrubbed();
   preemption_data.reset();
   m_pg->publish_stats_to_osd();
   m_interval_start = m_pg->get_history().same_interval_since;
@@ -1370,8 +1370,6 @@ void PgScrubber::scrub_compare_maps()
 {
   dout(10) << __func__ << " has maps, analyzing" << dendl;
 
-  int64_t primary_objects = 0;
-
   // construct authoritative scrub map for type-specific scrubbing
   m_cleaned_meta_map.insert(m_primary_scrubmap);
   map<hobject_t, pair<std::optional<uint32_t>, std::optional<uint32_t>>> missing_digest;
@@ -1412,8 +1410,7 @@ void PgScrubber::scrub_compare_maps()
 
     dout(2) << __func__ << ": primary (" << m_pg->get_primary() << ") has "
 	    << m_primary_scrubmap.objects.size() << " items" << dendl;
-    primary_objects = m_primary_scrubmap.objects.size();
-    m_pg->add_objects_scrubbed_count(primary_objects);
+    m_pg->add_objects_scrubbed_count(m_primary_scrubmap.objects.size());
 
     ss.str("");
     ss.clear();


### PR DESCRIPTION
Addition of a new column in PG dump, OBJECTS_SCRUBBED, which keeps track of the number of objects scrubbed.

Signed-off-by: Aishwarya Mathuria <amathuri@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
