### PR TITLE
rgw: fix install packages function

### DIFF
--- a/src/rgw/rgw_lua.cc
+++ b/src/rgw/rgw_lua.cc
@@ -198,7 +198,8 @@ int install_packages(const DoutPrefixProvider *dpp, rgw::sal::Store* store, opti
   // luarocks directory cleanup
   std::error_code ec;
   const auto& luarocks_path = store->get_luarocks_path();
-  if (!std::filesystem::remove_all(luarocks_path, ec) &&
+  if (std::filesystem::remove_all(luarocks_path, ec)
+      == static_cast<std::uintmax_t>(-1) &&
       ec != std::errc::no_such_file_or_directory) {
     output.append("failed to clear luarock directory: ");
     output.append(ec.message());


### PR DESCRIPTION
remove_all() doesn't return bool,
instead it returns static_cast<std::uintmax_t>(-1) on error.

Signed-off-by: Matan Breizman <Matan.Brz@gmail.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
