### PR TITLE
doc: document that NEARFULL conditions can result in slow writes

### DIFF
--- a/doc/cephfs/troubleshooting.rst
+++ b/doc/cephfs/troubleshooting.rst
@@ -124,8 +124,8 @@ slow requests are probably the ``mdsc`` and ``osdc`` files.
 * osdc: Dumps the current ops in-flight to OSDs (ie, file data IO)
 * osdmap: Dumps the current OSDMap epoch, pools, and OSDs
 
-If there are no stuck requests but you have file IO which is not progressing,
-you might have a...
+If the data pool is in a NEARFULL condition, then the kernel cephfs client
+will switch to doing writes synchronously, which is quite slow.
 
 Disconnected+Remounted FS
 =========================


### PR DESCRIPTION
The change to doing sync I/Os when we're in NEARFULL conditions
apparently caught some folks by surprise. Add something to clarify that
to the kclient debugging docs.

Fixes: https://tracker.ceph.com/issues/49406
Signed-off-by: Jeff Layton <jlayton@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
