### PR TITLE
pacific: ceph-volume: work around phantom atari partitions 

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/devices/raw/test_list.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/raw/test_list.py
@@ -1,0 +1,234 @@
+import pytest
+from mock.mock import patch
+from ceph_volume.devices import raw
+
+# Sample lsblk output is below that overviews the test scenario. (--json output for reader clarity)
+#  - sda and all its children are used for the OS
+#  - sdb is a bluestore OSD with phantom Atari partitions
+#  - sdc is an empty disk
+#  - sdd has 2 LVM device children
+# > lsblk --paths --json
+#   {
+#      "blockdevices": [
+#         {"name": "/dev/sda", "maj:min": "8:0", "rm": "0", "size": "128G", "ro": "0", "type": "disk", "mountpoint": null,
+#            "children": [
+#               {"name": "/dev/sda1", "maj:min": "8:1", "rm": "0", "size": "487M", "ro": "0", "type": "part", "mountpoint": null},
+#               {"name": "/dev/sda2", "maj:min": "8:2", "rm": "0", "size": "1.9G", "ro": "0", "type": "part", "mountpoint": null},
+#               {"name": "/dev/sda3", "maj:min": "8:3", "rm": "0", "size": "125.6G", "ro": "0", "type": "part", "mountpoint": "/etc/hosts"}
+#            ]
+#         },
+#         {"name": "/dev/sdb", "maj:min": "8:16", "rm": "0", "size": "1T", "ro": "0", "type": "disk", "mountpoint": null,
+#            "children": [
+#               {"name": "/dev/sdb2", "maj:min": "8:18", "rm": "0", "size": "48G", "ro": "0", "type": "part", "mountpoint": null},
+#               {"name": "/dev/sdb3", "maj:min": "8:19", "rm": "0", "size": "6M", "ro": "0", "type": "part", "mountpoint": null}
+#            ]
+#         },
+#         {"name": "/dev/sdc", "maj:min": "8:32", "rm": "0", "size": "1T", "ro": "0", "type": "disk", "mountpoint": null},
+#         {"name": "/dev/sdd", "maj:min": "8:48", "rm": "0", "size": "1T", "ro": "0", "type": "disk", "mountpoint": null,
+#            "children": [
+#               {"name": "/dev/mapper/ceph--osd--block--1", "maj:min": "253:0", "rm": "0", "size": "512G", "ro": "0", "type": "lvm", "mountpoint": null},
+#               {"name": "/dev/mapper/ceph--osd--block--2", "maj:min": "253:1", "rm": "0", "size": "512G", "ro": "0", "type": "lvm", "mountpoint": null}
+#            ]
+#         }
+#      ]
+#   }
+
+def _devices_side_effect():
+    return {
+        "/dev/sda": {},
+        "/dev/sda1": {},
+        "/dev/sda2": {},
+        "/dev/sda3": {},
+        "/dev/sdb": {},
+        "/dev/sdb2": {},
+        "/dev/sdb3": {},
+        "/dev/sdc": {},
+        "/dev/sdd": {},
+        "/dev/mapper/ceph--osd--block--1": {},
+        "/dev/mapper/ceph--osd--block--2": {},
+    }
+
+def _lsblk_list_output():
+    return [
+        '/dev/sda',
+        '/dev/sda1',
+        '/dev/sda2',
+        '/dev/sda3',
+        '/dev/sdb',
+        '/dev/sdb2',
+        '/dev/sdb3',
+        '/dev/sdc',
+        '/dev/sdd',
+        '/dev/mapper/ceph--osd--block--1',
+        '/dev/mapper/ceph--osd--block--2',
+    ]
+
+# dummy lsblk output for device with optional parent output
+def _lsblk_output(dev, parent=None):
+    if parent is None:
+        parent = ""
+    ret = 'NAME="{}" KNAME="{}" PKNAME="{}"'.format(dev, dev, parent)
+    return [ret] # needs to be in a list form
+
+def _bluestore_tool_label_output_sdb():
+    return '''{
+    "/dev/sdb": {
+        "osd_uuid": "sdb-uuid",
+        "size": 1099511627776,
+        "btime": "2021-07-23T16:02:22.809186+0000",
+        "description": "main",
+        "bfm_blocks": "268435456",
+        "bfm_blocks_per_key": "128",
+        "bfm_bytes_per_block": "4096",
+        "bfm_size": "1099511627776",
+        "bluefs": "1",
+        "ceph_fsid": "sdb-fsid",
+        "kv_backend": "rocksdb",
+        "magic": "ceph osd volume v026",
+        "mkfs_done": "yes",
+        "osd_key": "AQAO6PpgK+y4CBAAixq/X7OVimbaezvwD/cDmg==",
+        "ready": "ready",
+        "require_osd_release": "16",
+        "whoami": "0"
+    }
+}'''
+
+def _bluestore_tool_label_output_sdb2():
+    return '''{
+    "/dev/sdb2": {
+        "osd_uuid": "sdb2-uuid",
+        "size": 1099511627776,
+        "btime": "2021-07-23T16:02:22.809186+0000",
+        "description": "main",
+        "bfm_blocks": "268435456",
+        "bfm_blocks_per_key": "128",
+        "bfm_bytes_per_block": "4096",
+        "bfm_size": "1099511627776",
+        "bluefs": "1",
+        "ceph_fsid": "sdb2-fsid",
+        "kv_backend": "rocksdb",
+        "magic": "ceph osd volume v026",
+        "mkfs_done": "yes",
+        "osd_key": "AQAO6PpgK+y4CBAAixq/X7OVimbaezvwD/cDmg==",
+        "ready": "ready",
+        "require_osd_release": "16",
+        "whoami": "2"
+    }
+}'''
+
+def _bluestore_tool_label_output_dm_okay():
+    return '''{
+    "/dev/mapper/ceph--osd--block--1": {
+        "osd_uuid": "lvm-1-uuid",
+        "size": 549751619584,
+        "btime": "2021-07-23T16:04:37.881060+0000",
+        "description": "main",
+        "bfm_blocks": "134216704",
+        "bfm_blocks_per_key": "128",
+        "bfm_bytes_per_block": "4096",
+        "bfm_size": "549751619584",
+        "bluefs": "1",
+        "ceph_fsid": "lvm-1-fsid",
+        "kv_backend": "rocksdb",
+        "magic": "ceph osd volume v026",
+        "mkfs_done": "yes",
+        "osd_key": "AQCU6Ppgz+UcIRAAh6IUjtPjiXBlEXfwO8ixzw==",
+        "ready": "ready",
+        "require_osd_release": "16",
+        "whoami": "2"
+    }
+}'''
+
+def _process_call_side_effect(command, **kw):
+    if "lsblk" in command:
+        if "/dev/" in command[-1]:
+            dev = command[-1]
+            if dev == "/dev/sda1" or dev == "/dev/sda2" or dev == "/dev/sda3":
+                return _lsblk_output(dev, parent="/dev/sda"), '', 0
+            if dev == "/dev/sdb2" or dev == "/dev/sdb3":
+                return _lsblk_output(dev, parent="/dev/sdb"), '', 0
+            if dev == "/dev/sda" or dev == "/dev/sdb" or dev == "/dev/sdc" or dev == "/dev/sdd":
+                return _lsblk_output(dev), '', 0
+            if "mapper" in dev:
+                return _lsblk_output(dev, parent="/dev/sdd"), '', 0
+            pytest.fail('dev {} needs behavior specified for it'.format(dev))
+        if "/dev/" not in command:
+            return _lsblk_list_output(), '', 0
+        pytest.fail('command {} needs behavior specified for it'.format(command))
+
+    if "ceph-bluestore-tool" in command:
+        if "/dev/sdb" in command:
+            # sdb is a bluestore OSD
+            return _bluestore_tool_label_output_sdb(), '', 0
+        if "/dev/sdb2" in command:
+            # sdb2 is a phantom atari partition that appears to have some valid bluestore info
+            return _bluestore_tool_label_output_sdb2(), '', 0
+        if "/dev/mapper/ceph--osd--block--1" in command:
+            # dm device 1 is a valid bluestore OSD (the other is corrupted/invalid)
+            return _bluestore_tool_label_output_dm_okay(), '', 0
+        # sda and children, sdb's children, sdc, sdd, dm device 2 all do NOT have bluestore OSD data
+        return [], 'fake No such file or directory error', 1
+    pytest.fail('command {} needs behavior specified for it'.format(command))
+
+def _has_bluestore_label_side_effect(disk_path):
+    if "/dev/sda" in disk_path:
+        return False # disk and all children are for the OS
+    if disk_path == "/dev/sdb":
+        return True # sdb is a valid bluestore OSD
+    if disk_path == "/dev/sdb2":
+        return True # sdb2 appears to be a valid bluestore OSD even though it should not be
+    if disk_path == "/dev/sdc":
+        return False # empty disk
+    if disk_path == "/dev/sdd":
+        return False # has LVM subdevices
+    if disk_path == "/dev/mapper/ceph--osd--block--1":
+        return True # good OSD
+    if disk_path == "/dev/mapper/ceph--osd--block--2":
+        return False # corrupted
+    pytest.fail('device {} needs behavior specified for it'.format(disk_path))
+
+class TestList(object):
+
+    @patch('ceph_volume.util.device.disk.get_devices')
+    @patch('ceph_volume.util.disk.has_bluestore_label')
+    @patch('ceph_volume.process.call')
+    def test_raw_list(self, patched_call, patched_bluestore_label, patched_get_devices):
+        raw.list.logger.setLevel("DEBUG")
+        patched_call.side_effect = _process_call_side_effect
+        patched_bluestore_label.side_effect = _has_bluestore_label_side_effect
+        patched_get_devices.side_effect = _devices_side_effect
+
+        result = raw.list.List([]).generate()
+        assert len(result) == 2
+
+        sdb = result['sdb-uuid']
+        assert sdb['osd_uuid'] == 'sdb-uuid'
+        assert sdb['osd_id'] == 0
+        assert sdb['device'] == '/dev/sdb'
+        assert sdb['ceph_fsid'] == 'sdb-fsid'
+        assert sdb['type'] == 'bluestore'
+
+        lvm1 = result['lvm-1-uuid']
+        assert lvm1['osd_uuid'] == 'lvm-1-uuid'
+        assert lvm1['osd_id'] == 2
+        assert lvm1['device'] == '/dev/mapper/ceph--osd--block--1'
+        assert lvm1['ceph_fsid'] == 'lvm-1-fsid'
+        assert lvm1['type'] == 'bluestore'
+
+    @patch('ceph_volume.util.device.disk.get_devices')
+    @patch('ceph_volume.util.disk.has_bluestore_label')
+    @patch('ceph_volume.process.call')
+    def test_raw_list_with_OSError(self, patched_call, patched_bluestore_label, patched_get_devices):
+        def _has_bluestore_label_side_effect_with_OSError(device_path):
+            if device_path == "/dev/sdd":
+                raise OSError('fake OSError')
+            return _has_bluestore_label_side_effect(device_path)
+
+        raw.list.logger.setLevel("DEBUG")
+        patched_call.side_effect = _process_call_side_effect
+        patched_bluestore_label.side_effect = _has_bluestore_label_side_effect_with_OSError
+        patched_get_devices.side_effect = _devices_side_effect
+
+        result = raw.list.List([]).generate()
+        assert len(result) == 1
+        assert 'sdb-uuid' in result

--- a/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
@@ -80,10 +80,10 @@ class TestValidDevice(object):
     def setup(self):
         self.validator = arg_validators.ValidDevice()
 
-    def test_path_is_valid(self, fake_call):
+    def test_path_is_valid(self, fake_call, patch_bluestore_label):
         result = self.validator('/')
         assert result.abspath == '/'
 
-    def test_path_is_invalid(self, fake_call):
+    def test_path_is_invalid(self, fake_call, patch_bluestore_label):
         with pytest.raises(argparse.ArgumentError):
             self.validator('/device/does/not/exist')

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -125,7 +125,7 @@ class TestDevice(object):
 
     def test_is_partition(self, device_info):
         data = {"/dev/sda1": {"foo": "bar"}}
-        lsblk = {"TYPE": "part"}
+        lsblk = {"TYPE": "part", "PKNAME": "sda"}
         device_info(devices=data, lsblk=lsblk)
         disk = device.Device("/dev/sda1")
         assert disk.is_partition
@@ -139,14 +139,14 @@ class TestDevice(object):
 
     def test_is_not_lvm_memeber(self, device_info):
         data = {"/dev/sda1": {"foo": "bar"}}
-        lsblk = {"TYPE": "part"}
+        lsblk = {"TYPE": "part", "PKNAME": "sda"}
         device_info(devices=data, lsblk=lsblk)
         disk = device.Device("/dev/sda1")
         assert not disk.is_lvm_member
 
     def test_is_lvm_memeber(self, device_info):
         data = {"/dev/sda1": {"foo": "bar"}}
-        lsblk = {"TYPE": "part"}
+        lsblk = {"TYPE": "part", "PKNAME": "sda"}
         device_info(devices=data, lsblk=lsblk)
         disk = device.Device("/dev/sda1")
         assert not disk.is_lvm_member
@@ -315,7 +315,7 @@ class TestDevice(object):
     def test_used_by_ceph(self, device_info,
                           monkeypatch, ceph_type):
         data = {"/dev/sda": {"foo": "bar"}}
-        lsblk = {"TYPE": "part"}
+        lsblk = {"TYPE": "part", "PKNAME": "sda"}
         FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000",
                                  lv_uuid="0000", pv_tags={}, vg_name="vg")
         pvolumes = []
@@ -342,7 +342,7 @@ class TestDevice(object):
         pvolumes = []
         pvolumes.append(FooPVolume)
         data = {"/dev/sda": {"foo": "bar"}}
-        lsblk = {"TYPE": "part"}
+        lsblk = {"TYPE": "part", "PKNAME": "sda"}
         lv_data = {"lv_path": "vg/lv", "vg_name": "vg", "lv_uuid": "0000", "tags": {"ceph.osd_id": 0, "ceph.type": "journal"}}
         monkeypatch.setattr(api, 'get_pvs', lambda **kwargs: pvolumes)
 
@@ -372,26 +372,26 @@ class TestDevice(object):
 class TestDeviceEncryption(object):
 
     def test_partition_is_not_encrypted_lsblk(self, device_info):
-        lsblk = {'TYPE': 'part', 'FSTYPE': 'xfs'}
+        lsblk = {'TYPE': 'part', 'FSTYPE': 'xfs', 'PKNAME': 'sda'}
         device_info(lsblk=lsblk)
         disk = device.Device("/dev/sda")
         assert disk.is_encrypted is False
 
     def test_partition_is_encrypted_lsblk(self, device_info):
-        lsblk = {'TYPE': 'part', 'FSTYPE': 'crypto_LUKS'}
+        lsblk = {'TYPE': 'part', 'FSTYPE': 'crypto_LUKS', 'PKNAME': 'sda'}
         device_info(lsblk=lsblk)
         disk = device.Device("/dev/sda")
         assert disk.is_encrypted is True
 
     def test_partition_is_not_encrypted_blkid(self, device_info):
-        lsblk = {'TYPE': 'part'}
+        lsblk = {'TYPE': 'part', 'PKNAME': 'sda'}
         blkid = {'TYPE': 'ceph data'}
         device_info(lsblk=lsblk, blkid=blkid)
         disk = device.Device("/dev/sda")
         assert disk.is_encrypted is False
 
     def test_partition_is_encrypted_blkid(self, device_info):
-        lsblk = {'TYPE': 'part'}
+        lsblk = {'TYPE': 'part', 'PKNAME': 'sda'}
         blkid = {'TYPE': 'crypto_LUKS'}
         device_info(lsblk=lsblk, blkid=blkid)
         disk = device.Device("/dev/sda")

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 from functools import total_ordering
-from ceph_volume import sys_info, process
+from ceph_volume import sys_info
 from ceph_volume.api import lvm
 from ceph_volume.util import disk, system
 from ceph_volume.util.lsmdisk import LSMDisk
 from ceph_volume.util.constants import ceph_disk_guids
+
+
+logger = logging.getLogger(__name__)
+
 
 report_template = """
 {dev:<25} {size:<12} {rot!s:<7} {available!s:<9} {model}"""
@@ -348,12 +353,17 @@ class Device(object):
 
     @property
     def has_bluestore_label(self):
-        out, err, ret = process.call([
-            'ceph-bluestore-tool', 'show-label',
-            '--dev', self.abspath], verbose_on_failure=False)
-        if ret:
-            return False
-        return True
+        isBluestore = False
+        bluestoreDiskSignature = 'bluestore block device' # 22 bytes long
+
+        # throws OSError on failure
+        with open(self.abspath, "rb") as fd:
+            # read first 22 bytes looking for bluestore disk signature
+            signature = fd.read(22)
+            if signature.decode('ascii', 'replace') == bluestoreDiskSignature:
+                isBluestore = True
+
+        return isBluestore
 
     @property
     def is_mapper(self):
@@ -476,8 +486,16 @@ class Device(object):
             rejected.append("Device type is not acceptable. It should be raw device or partition")
         if self.is_ceph_disk_member:
             rejected.append("Used by ceph-disk")
-        if self.has_bluestore_label:
-            rejected.append('Has BlueStore device label')
+
+        try:
+            if self.has_bluestore_label:
+                rejected.append('Has BlueStore device label')
+        except OSError as e:
+            # likely failed to open the device. assuming it is BlueStore is the safest option
+            # so that a possibly-already-existing OSD doesn't get overwritten
+            logger.error('failed to determine if device {} is Bluestore. device should not be used to avoid false negatives. err: {}'.format(self.abspath, e))
+            rejected.append('Failed to determine if device is BlueStore')
+
         if self.has_gpt_headers:
             rejected.append('Has GPT headers')
         return rejected

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -325,6 +325,12 @@ class Device(object):
         return self.sys_api['size']
 
     @property
+    def parent_device(self):
+        if 'PKNAME' in self.disk_api:
+            return '/dev/%s' % self.disk_api['PKNAME']
+        return None
+
+    @property
     def lvm_size(self):
         """
         If this device was made into a PV it would lose 1GB in total size
@@ -353,17 +359,7 @@ class Device(object):
 
     @property
     def has_bluestore_label(self):
-        isBluestore = False
-        bluestoreDiskSignature = 'bluestore block device' # 22 bytes long
-
-        # throws OSError on failure
-        with open(self.abspath, "rb") as fd:
-            # read first 22 bytes looking for bluestore disk signature
-            signature = fd.read(22)
-            if signature.decode('ascii', 'replace') == bluestoreDiskSignature:
-                isBluestore = True
-
-        return isBluestore
+        return disk.has_bluestore_label(self.abspath)
 
     @property
     def is_mapper(self):
@@ -493,8 +489,18 @@ class Device(object):
         except OSError as e:
             # likely failed to open the device. assuming it is BlueStore is the safest option
             # so that a possibly-already-existing OSD doesn't get overwritten
-            logger.error('failed to determine if device {} is Bluestore. device should not be used to avoid false negatives. err: {}'.format(self.abspath, e))
+            logger.error('failed to determine if device {} is BlueStore. device should not be used to avoid false negatives. err: {}'.format(self.abspath, e))
             rejected.append('Failed to determine if device is BlueStore')
+
+        if self.is_partition:
+            try:
+                if disk.has_bluestore_label(self.parent_device):
+                    rejected.append('Parent has BlueStore device label')
+            except OSError as e:
+                # likely failed to open the device. assuming the parent is BlueStore is the safest
+                # option so that a possibly-already-existing OSD doesn't get overwritten
+                logger.error('failed to determine if partition {} (parent: {}) has a BlueStore parent. partition should not be used to avoid false negatives. err: {}'.format(self.abspath, self.parent_device, e))
+                rejected.append('Failed to determine if parent device is BlueStore')
 
         if self.has_gpt_headers:
             rejected.append('Has GPT headers')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52133

---

backport of https://github.com/ceph/ceph/pull/42469
parent tracker: https://tracker.ceph.com/issues/52060

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh