### PR TITLE
pacific: ceph-volume: Consider /dev/root as mounted

### DIFF
--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -260,6 +260,7 @@ def get_mounts(devices=False, paths=False, realpath=False):
 
     - tmpfs
     - devtmpfs
+    - /dev/root
 
     If ``devices`` is set to ``True`` the mapping will be a device-to-path(s),
     if ``paths`` is set to ``True`` then the mapping will be
@@ -270,7 +271,7 @@ def get_mounts(devices=False, paths=False, realpath=False):
     """
     devices_mounted = {}
     paths_mounted = {}
-    do_not_skip = ['tmpfs', 'devtmpfs']
+    do_not_skip = ['tmpfs', 'devtmpfs', '/dev/root']
     default_to_devices = devices is False and paths is False
 
     with open(PROCDIR + '/mounts', 'rb') as mounts:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50896

---

backport of https://github.com/ceph/ceph/pull/41277
parent tracker: https://tracker.ceph.com/issues/50604

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh