### PR TITLE
mgr/rook: Rook orchestrator OSD creation using `ceph orch apply osd`

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -457,6 +457,22 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
     @handle_orch_error
     def remove_daemons(self, names: List[str]) -> List[str]:
         return self.rook_cluster.remove_pods(names)
+
+    def apply_drivegroups(self, specs: List[DriveGroupSpec]) -> OrchResult[List[str]]:
+        all_hosts = raise_if_exception(self.get_hosts())
+        for drive_group in specs:
+            matching_hosts = drive_group.placement.filter_matching_hosts(lambda label=None, as_hostspec=None: all_hosts)
+
+            if not self.rook_cluster.node_exists(matching_hosts[0]):
+                raise RuntimeError("Node '{0}' is not in the Kubernetes "
+                               "cluster".format(matching_hosts))
+
+            # Validate whether cluster CRD can accept individual OSD
+            # creations (i.e. not useAllDevices)
+            if not self.rook_cluster.can_create_osd():
+                raise RuntimeError("Rook cluster configuration does not "
+                                "support OSD creation.")
+        return OrchResult([self.rook_cluster.add_osds(drive_group, matching_hosts)])
     """
     @handle_orch_error
     def create_osds(self, drive_group):

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -459,6 +459,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         return self.rook_cluster.remove_pods(names)
 
     def apply_drivegroups(self, specs: List[DriveGroupSpec]) -> OrchResult[List[str]]:
+        result_list = []
         all_hosts = raise_if_exception(self.get_hosts())
         for drive_group in specs:
             matching_hosts = drive_group.placement.filter_matching_hosts(lambda label=None, as_hostspec=None: all_hosts)
@@ -472,7 +473,8 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             if not self.rook_cluster.can_create_osd():
                 raise RuntimeError("Rook cluster configuration does not "
                                 "support OSD creation.")
-        return OrchResult([self.rook_cluster.add_osds(drive_group, matching_hosts)])
+            result_list.append(self.rook_cluster.add_osds(drive_group, matching_hosts))
+        return OrchResult(result_list)
     """
     @handle_orch_error
     def create_osds(self, drive_group):

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -185,11 +185,18 @@ class LSOFetcher(DefaultFetcher):
     def device(self, i: Any) -> Tuple[str, Device]:
         node = i.metadata.labels['kubernetes.io/hostname']
         device_discovery = self.lso_devices[i.metadata.annotations['storage.openshift.com/device-id']]
+        pv_name = i.metadata.name
+        vendor: str = device_discovery['model'].split()[0] if len(device_discovery['model'].split()) >= 1 else ''
+        model: str = ' '.join(device_discovery['model'].split()[1:]) if len(device_discovery['model'].split()) > 1 else ''
         device = Device(
             path = device_discovery['path'],
             sys_api = dict(
                     size = device_discovery['size'],
-                    rotational = '1' if device_discovery['property']=='Rotational' else '0'
+                    rotational = '1' if device_discovery['property']=='Rotational' else '0',
+                    node = node,
+                    pv_name = pv_name,
+                    model = model,
+                    vendor = vendor
                 ),
             available = device_discovery['status']['state']=='Available',
             device_id = device_discovery['deviceID'].split('/')[-1],

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -99,14 +99,16 @@ class DefaultFetcher():
         self.pvs_in_sc = [i for i in self.inventory.items if i.spec.storage_class_name == self.storage_class]
 
     def convert_size(self, size_str: str) -> int:
-        units = ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei")
-        unit = size_str[-2:]
-        try:
-            factor = units.index(unit)
+        units = ("", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "", "K", "M", "G", "T", "P", "E")
+        coeff_and_unit = re.search('(\d+)(\D+)', size_str)
+        assert coeff_and_unit is not None
+        coeff = int(coeff_and_unit[1])
+        unit = coeff_and_unit[2]
+        try: 
+            factor = units.index(unit) % 7
         except ValueError:
             log.error("PV size format invalid")
             raise
-        coeff = int(size_str[:-2])
         size = coeff * (2 ** (10 * factor))
         return size
 

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -404,13 +404,18 @@ class DefaultCreator():
         device_list = []
         assert drive_group.data_devices is not None
         low, high = self.parse_drive_group_size(drive_group.data_devices.size)
-        limit = drive_group.data_devices.limit if hasattr(drive_group.data_devices, 'limit') else None
+        limit = getattr(drive_group.data_devices, 'limit', None)
         count = 0
-        all = drive_group.data_devices.all if hasattr(drive_group.data_devices, 'all') else None
+        all = getattr(drive_group.data_devices, 'all', None)
         paths = [device.path for device in drive_group.data_devices.paths]
         osd_list = []
         for pod in rook_pods.items:
-            if hasattr(pod, 'metadata') and hasattr(pod.metadata, 'labels') and 'osd' in pod.metadata.labels and 'ceph.rook.io/DeviceSet' in pod.metadata.labels:
+            if (
+                hasattr(pod, 'metadata') 
+                and hasattr(pod.metadata, 'labels') 
+                and 'osd' in pod.metadata.labels 
+                and 'ceph.rook.io/DeviceSet' in pod.metadata.labels
+            ):
                 osd_list.append(pod.metadata.labels['ceph.rook.io/DeviceSet'])
         for _, node in self.inventory.items():
             for device in node:
@@ -420,7 +425,17 @@ class DefaultCreator():
             for device in node:
                 if not limit or (count < limit):
                     if device.available:
-                        if all or ((device.sys_api['node'] in matching_hosts) and (self.check_bounds(low, high, int(device.sys_api['size']))) and ((not drive_group.data_devices.paths) or (device.path in paths))):
+                        if (
+                            all 
+                            or (
+                                device.sys_api['node'] in matching_hosts 
+                                and self.check_bounds(low, high, int(device.sys_api['size']))
+                                and (
+                                    not drive_group.data_devices.paths
+                                    or (device.path in paths)
+                                )
+                            )
+                        ):
                             device_list.append(device)
                             count += 1
         return device_list
@@ -447,15 +462,20 @@ class LSOCreator(DefaultCreator):
         device_list = []
         assert drive_group.data_devices is not None
         low, high = self.parse_drive_group_size(drive_group.data_devices.size)
-        limit = drive_group.data_devices.limit if hasattr(drive_group.data_devices, 'limit') else None
+        limit = getattr(drive_group.data_devices, 'limit', None)
         count = 0
-        all = drive_group.data_devices.all if hasattr(drive_group.data_devices, 'all') else None
+        all = getattr(drive_group.data_devices, 'all', None)
         paths = [device.path for device in drive_group.data_devices.paths]
-        vendor = drive_group.data_devices.model if hasattr(drive_group.data_devices, 'vendor') else None
-        model = drive_group.data_devices.model if hasattr(drive_group.data_devices, 'model') else None
+        vendor = getattr(drive_group.data_devices, 'vendor', None)
+        model = getattr(drive_group.data_devices, 'model', None)
         osd_list = []
         for pod in rook_pods.items:
-            if hasattr(pod, 'metadata') and hasattr(pod.metadata, 'labels') and 'osd' in pod.metadata.labels and 'ceph.rook.io/DeviceSet' in pod.metadata.labels:
+            if (
+                hasattr(pod, 'metadata') 
+                and hasattr(pod.metadata, 'labels') 
+                and 'osd' in pod.metadata.labels 
+                and 'ceph.rook.io/DeviceSet' in pod.metadata.labels
+            ):
                 osd_list.append(pod.metadata.labels['ceph.rook.io/DeviceSet'])
         for _, node in self.inventory.items():
             for device in node:
@@ -465,7 +485,25 @@ class LSOCreator(DefaultCreator):
             for device in node:
                 if not limit or (count < limit):
                     if device.available:
-                        if all or ((device.sys_api['node'] in matching_hosts) and (self.check_bounds(low, high, int(device.sys_api['size']))) and ((not drive_group.data_devices.paths) or (device.path in paths)) and (not vendor or (device.sys_api['vendor'] == vendor)) and (not model or (device.sys_api['model'].startsWith(model)))):
+                        if (
+                            all 
+                            or (
+                                device.sys_api['node'] in matching_hosts
+                                and self.check_bounds(low, high, int(device.sys_api['size']))
+                                and (
+                                    not drive_group.data_devices.paths
+                                    or device.path in paths
+                                ) 
+                                and (
+                                    not vendor 
+                                    or device.sys_api['vendor'] == vendor
+                                )
+                                and (
+                                    not model 
+                                    or device.sys_api['model'].startsWith(model)
+                                )
+                            )
+                        ):
                             device_list.append(device)
                             count += 1
         return device_list


### PR DESCRIPTION
Implement `ceph orch apply osd` for the rook manager module.

Implement `apply_drivegroups` method on the RookOrchestrator class.

Add vendor and model information to `Device` objects in `device` method in `LSOFetcher`.

Create `DefaultCreator` and `LSOCreator` classes that handle parsing drivegroups, filtering devices by those drivegroups and creating a StorageClassDeviceSet for each of those devices. Class used is based on storage class provided by user in ceph config.

Implement `drive_group_loop` method to update OSDs based on added PVs or devices that match applied drivegroups.

Create `get_storage_class` method to check if the storage class provided in the config exists.

Fix `convert_size` method to support all formats of expressing storage size.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
