### PR TITLE
rgw/dbstore: Resolve library link issues on FreeBSD

### DIFF
--- a/src/rgw/store/dbstore/sqlite/CMakeLists.txt
+++ b/src/rgw/store/dbstore/sqlite/CMakeLists.txt
@@ -13,4 +13,4 @@ set(SQLITE_COMPILE_FLAGS "-DSQLITE_THREADSAFE=1")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SQLITE_COMPILE_FLAGS}")
 
 add_library(sqlite_db ${sqlite_db_srcs})
-target_link_libraries(sqlite_db sqlite3 dbstore_lib)
+target_link_libraries(sqlite_db sqlite3 dbstore_lib rgw_common)


### PR DESCRIPTION
Add "rgw_common" to the target_link_libraries list to resolve issues with sqlite_db target build on FreeBSD

Reported-by: Willem Jan Withagen wjw@digiware.nl
Signed-off-by: Soumya Koduri <skoduri@redhat.com>

