### PR TITLE
.githubmap: fix format

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -65,6 +65,7 @@ jdurgin Josh Durgin <jdurgin@redhat.com>
 jecluis João Eduardo Luís <joao@suse.de>
 jmolmo Juan Miguel Olmo <jolmomar@redhat.com>
 joscollin Jos Collin <jcollin@redhat.com>
+josephsawaya Joseph Sawaya <jsawaya@redhat.com>
 jschmid1 Joshua Schmid <jschmid@suse.de>
 jtlayton Jeff Layton <jlayton@redhat.com>
 kotreshhr Kotresh Hiremath Ravishankar <khiremat@redhat.com>
@@ -139,4 +140,3 @@ yuvalif Yuval Lifshitz <ylifshit@redhat.com>
 yuyuyu101 Haomai Wang <haomai@xsky.com>
 zdover23 Zac Dover <zac.dover@gmail.com>
 Thingee Mike Perez <miperez@redhat.com>
-josephsawaya merge 42318


### PR DESCRIPTION
Issue introduced by merge commit 4b9a3b217127d003d4ae6addb1f0e1d8ce21b816.

I use a [Chrome extension](https://chrome.google.com/webstore/detail/ceph-github-helper/ikpfebikkeabmdnccbimlomheocpgkmn), source [here](https://github.com/tspmelo/ceph-github-helper) (by @tspmelo, thanks forever Tiago), to auto-fill the PR reviewers, and that change broke the parsing of the githubmap. 

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
