### PR TITLE
Revert "librbd/cache/pwl: fix bug of flush request blocked by deferd IO"

### DIFF
--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -825,9 +825,10 @@ void AbstractWriteLog<I>::write(Extents &&image_extents,
 
   ceph_assert(m_initialized);
 
-  /* Split images because PMDK doesn't support allocating too big extent
-   * TODO: If the bluestore allocator is implemented as a library,
-   * the split operation is not necessary
+  /*
+   * Split image extents larger than 1M. This isn't strictly necessary but
+   * makes libpmemobj allocator's job easier and reduces pmemobj_defrag() cost.
+   * We plan to manage pmem space and allocation by ourselves in the future.
    */
   Extents split_image_extents;
   uint64_t max_extent_size = get_max_extent();

--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -1677,7 +1677,7 @@ Context* AbstractWriteLog<I>::construct_flush_entry(std::shared_ptr<GenericLogEn
 }
 
 template <typename I>
-void AbstractWriteLog<I>::process_writeback_dirty_entries() {
+void AbstractWriteLog<I>::process_writeback_dirty_entries(bool force) {
   CephContext *cct = m_image_ctx.cct;
   bool all_clean = false;
   int flushed = 0;
@@ -1701,8 +1701,9 @@ void AbstractWriteLog<I>::process_writeback_dirty_entries() {
         break;
       }
       auto candidate = m_dirty_log_entries.front();
+      ceph_assert(candidate->completed);
       bool flushable = can_flush_entry(candidate);
-      if (flushable) {
+      if (flushable || force) {
         post_unlock.add(construct_flush_entry_ctx(candidate));
         flushed++;
         m_dirty_log_entries.pop_front();

--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -825,11 +825,9 @@ void AbstractWriteLog<I>::write(Extents &&image_extents,
 
   ceph_assert(m_initialized);
 
-  /* Split images because PMDK's space management is not perfect, there are
-   * fragment problems. The larger the block size difference of the block,
-   * the easier the fragmentation problem will occur, resulting in the
-   * remaining space can not be allocated in large size. We plan to manage
-   * pmem space and allocation by ourselves in the future.
+  /* Split images because PMDK doesn't support allocating too big extent
+   * TODO: If the bluestore allocator is implemented as a library,
+   * the split operation is not necessary
    */
   Extents split_image_extents;
   uint64_t max_extent_size = get_max_extent();
@@ -1439,11 +1437,6 @@ void AbstractWriteLog<I>::alloc_and_dispatch_io_req(C_BlockIORequestT *req)
     {
       std::lock_guard locker(m_lock);
       dispatch_here = m_deferred_ios.empty();
-      // Only flush req's total_bytes is the max uint64
-      if ((req->image_extents_summary.total_bytes ==
-          std::numeric_limits<uint64_t>::max())) {
-        dispatch_here = true;
-      }
     }
     if (dispatch_here) {
       dispatch_here = req->alloc_resources();

--- a/src/librbd/cache/pwl/AbstractWriteLog.h
+++ b/src/librbd/cache/pwl/AbstractWriteLog.h
@@ -346,7 +346,7 @@ protected:
       std::shared_ptr<pwl::GenericLogEntry> log_entry) = 0;
   Context *construct_flush_entry(
       const std::shared_ptr<pwl::GenericLogEntry> log_entry, bool invalidating);
-  void process_writeback_dirty_entries();
+  void process_writeback_dirty_entries(bool force);
   bool can_retire_entry(const std::shared_ptr<pwl::GenericLogEntry> log_entry);
 
   void dispatch_deferred_writes(void);

--- a/src/librbd/cache/pwl/LogEntry.cc
+++ b/src/librbd/cache/pwl/LogEntry.cc
@@ -46,10 +46,8 @@ std::ostream &operator<<(std::ostream &os,
 }
 
 bool GenericWriteLogEntry::can_writeback() const {
-  return (this->completed &&
-          (ram_entry.sequenced ||
-           (sync_point_entry &&
-            sync_point_entry->completed)));
+  return ram_entry.sequenced ||
+         (sync_point_entry && sync_point_entry->completed);
 }
 
 std::ostream& GenericWriteLogEntry::format(std::ostream &os) const {

--- a/src/librbd/cache/pwl/rwl/WriteLog.cc
+++ b/src/librbd/cache/pwl/rwl/WriteLog.cc
@@ -799,16 +799,19 @@ void WriteLog<I>::process_work() {
            this->m_alloc_failed_since_retire)
             ? MAX_ALLOC_PER_TRANSACTION
             : MAX_FREE_PER_TRANSACTION)) {
+          if (this->m_alloc_failed_since_retire) {
+            this->process_writeback_dirty_entries(true);
+          }
           break;
         }
         retired++;
         this->dispatch_deferred_writes();
-        this->process_writeback_dirty_entries();
+        this->process_writeback_dirty_entries(false);
       }
       ldout(m_image_ctx.cct, 10) << "Retired " << retired << " times" << dendl;
     }
     this->dispatch_deferred_writes();
-    this->process_writeback_dirty_entries();
+    this->process_writeback_dirty_entries(false);
 
     {
       std::lock_guard locker(m_lock);


### PR DESCRIPTION
This reverts commit 6583182.
It cause that flush requests are dispatched in advance, which
may lead to semantic changes of user requests and data loss.

Fixes: https://tracker.ceph.com/issues/52599

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
