### PR TITLE
rgw: Lua scripting global map feature

### DIFF
--- a/doc/radosgw/lua-scripting.rst
+++ b/doc/radosgw/lua-scripting.rst
@@ -6,9 +6,10 @@ Lua Scripting
 
 .. contents::
 
-This feature allows users to upload Lua scripts to different context in the radosgw. The two supported context are "preRequest" that will execute a script before the
-operation was taken, and "postRequest" that will execute after each operation is taken. Script may be uploaded to address requests for users of a specific tenant.
-The script can access fields in the request and modify some fields. All Lua language features can be used in the script.
+This feature allows users to upload Lua scripts to different context in the radosgw. The three supported contexts are "preRequest" that will execute a script before the
+operation was taken, "postRequest" that will execute after each operation is taken and "background" that will execute a script in a given time interval.
+Request context script may be uploaded to address requests for users of a specific tenant.
+The request context script can also access fields in the request and modify some fields. All Lua language features can be used in the script.
 
 By default, all lua standard libraries are available in the script, however, in order to allow for other lua modules to be used in the script, we support adding packages to an allowlist:
 
@@ -28,23 +29,27 @@ Script Management via CLI
 
 To upload a script:
    
+
 ::
    
-   # radosgw-admin script put --infile={lua-file} --context={preRequest|postRequest} [--tenant={tenant-name}]
+   # radosgw-admin script put --infile={lua-file} --context={preRequest|postRequest|background} [--tenant={tenant-name}]
+
+
+* When uploading a script in background context, tenant name could not be specified.
 
 
 To print the content of the script to standard output:
 
 ::
    
-   # radosgw-admin script get --context={preRequest|postRequest} [--tenant={tenant-name}]
+   # radosgw-admin script get --context={preRequest|postRequest|background} [--tenant={tenant-name}]
 
 
 To remove the script:
 
 ::
    
-   # radosgw-admin script rm --context={preRequest|postRequest} [--tenant={tenant-name}]
+   # radosgw-admin script rm --context={preRequest|postRequest|background} [--tenant={tenant-name}]
 
 
 Package Management via CLI
@@ -296,6 +301,23 @@ Request Functions
 Operations Log
 ~~~~~~~~~~~~~~
 The ``Request.Log()`` function prints the requests into the operations log. This function has no parameters. It returns 0 for success and an error code if it fails.
+
+Background Context
+--------------------
+The background context may be used for various need such as analytics, monitoring and
+caching data from other context executions.
+
+The ``RGW`` Lua table which is accesible from any context saves the data written into it
+while execution and this data could be read and used later in any other execution.
+
+- Background script execution default interval is 5 seconds.
+
+- Each RGW instance has its own ``RGW`` Lua table, while the Background Context script
+  will run on every instance.
+
+- The maximum number of entries in the table is 100,000. Each entry has a key and string value
+  of no more than 1KB (together). Lua script will abort with an error if the
+  number of entries or entry size exceeds their limits.
 
 Lua Code Samples
 ----------------

--- a/doc/radosgw/lua-scripting.rst
+++ b/doc/radosgw/lua-scripting.rst
@@ -6,10 +6,10 @@ Lua Scripting
 
 .. contents::
 
-This feature allows users to upload Lua scripts to different context in the radosgw. The three supported contexts are "preRequest" that will execute a script before the
-operation was taken, "postRequest" that will execute after each operation is taken and "background" that will execute a script in a given time interval.
-Request context script may be uploaded to address requests for users of a specific tenant.
-The request context script can also access fields in the request and modify some fields. All Lua language features can be used in the script.
+This feature allows users to assign execution context to Lua scripts. The three supported contexts are ``preRequest``" which will execute a script before each
+operation is performed, ``postRequest`` which will execute after each operation is performed, and ``background`` which will execute within a specified time interval.
+A request context script may be constrained to operations belonging to a specific tenant's users.
+The request context script can also access fields in the request and modify some fields. All Lua language features can be used.
 
 By default, all lua standard libraries are available in the script, however, in order to allow for other lua modules to be used in the script, we support adding packages to an allowlist:
 
@@ -35,7 +35,7 @@ To upload a script:
    # radosgw-admin script put --infile={lua-file} --context={preRequest|postRequest|background} [--tenant={tenant-name}]
 
 
-* When uploading a script in background context, tenant name could not be specified.
+* When uploading a script with the ``background`` context, a tenant name may not be specified.
 
 
 To print the content of the script to standard output:
@@ -304,20 +304,17 @@ The ``Request.Log()`` function prints the requests into the operations log. This
 
 Background Context
 --------------------
-The background context may be used for various need such as analytics, monitoring and
-caching data from other context executions.
+The ``background`` context may be used for purposes that include analytics, monitoring, caching data for other context executions.
 
-The ``RGW`` Lua table which is accesible from any context saves the data written into it
-while execution and this data could be read and used later in any other execution.
+The ``RGW`` Lua table is accessible from all contexts and saves data written to it
+during execution so that it may be read and used later during other executions, from the same context of a different one.
 
 - Background script execution default interval is 5 seconds.
 
-- Each RGW instance has its own ``RGW`` Lua table, while the Background Context script
-  will run on every instance.
+- Each RGW instance has its own private and ephemeral ``RGW`` Lua table that is lost when the daemon restarts. Note that ``background`` context scripts will run on every instance.
 
-- The maximum number of entries in the table is 100,000. Each entry has a key and string value
-  of no more than 1KB (together). Lua script will abort with an error if the
-  number of entries or entry size exceeds their limits.
+- The maximum number of entries in the table is 100,000. Each entry has a key and string value with a combined length of no more than 1KB. 
+  A Lua script will abort with an error if the number of entries or entry size exceeds these limits.
 
 Lua Code Samples
 ----------------

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -162,7 +162,8 @@ set(librgw_common_srcs
   rgw_lua_utils.cc
   rgw_lua.cc
   rgw_bucket_encryption.cc
-  rgw_tracer.cc)
+  rgw_tracer.cc
+  rgw_lua_background.cc)
 
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   list(APPEND librgw_common_srcs rgw_amqp.cc)
@@ -357,7 +358,10 @@ add_library(radosgw SHARED
 target_compile_definitions(radosgw PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 target_include_directories(radosgw
   PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src"
-  PRIVATE "${CMAKE_SOURCE_DIR}/src/libkmip")
+  PRIVATE "${CMAKE_SOURCE_DIR}/src/libkmip"
+  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
+  PRIVATE "${LUA_INCLUDE_DIR}")
+
 target_include_directories(radosgw SYSTEM PUBLIC "../rapidjson/include")
 
 target_link_libraries(radosgw

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -454,7 +454,7 @@ void usage()
   cout << "   --subscription            pubsub subscription name\n";
   cout << "   --event-id                event id in a pubsub subscription\n";
   cout << "\nScript options:\n";
-  cout << "   --context                 context in which the script runs. one of: preRequest, postRequest\n";
+  cout << "   --context                 context in which the script runs. one of: preRequest, postRequest, background\n";
   cout << "   --package                 name of the lua package that should be added/removed to/from the allowlist\n";
   cout << "   --allow-compilation       package is allowed to compile C code as part of its installation\n";
   cout << "\nradoslist options:\n";
@@ -10037,7 +10037,11 @@ next:
     }
     const rgw::lua::context script_ctx = rgw::lua::to_context(*str_script_ctx);
     if (script_ctx == rgw::lua::context::none) {
-      cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: preRequest, postRequest" <<  std::endl;
+      cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: preRequest, postRequest, background" << std::endl;
+      return EINVAL;
+    }
+    if (script_ctx == rgw::lua::context::background && !tenant.empty()) {
+      cerr << "ERROR: cannot specify tenant in background context" << std::endl;
       return EINVAL;
     }
     rc = rgw::lua::write_script(dpp(), store, tenant, null_yield, script_ctx, script);
@@ -10054,7 +10058,7 @@ next:
     }
     const rgw::lua::context script_ctx = rgw::lua::to_context(*str_script_ctx);
     if (script_ctx == rgw::lua::context::none) {
-      cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: preRequest, postRequest" <<  std::endl;
+      cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: preRequest, postRequest, background" << std::endl;
       return EINVAL;
     }
     std::string script;
@@ -10077,7 +10081,7 @@ next:
     }
     const rgw::lua::context script_ctx = rgw::lua::to_context(*str_script_ctx);
     if (script_ctx == rgw::lua::context::none) {
-      cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: preRequest, postRequest" <<  std::endl;
+      cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: preRequest, postRequest, background" << std::endl;
       return EINVAL;
     }
     const auto rc = rgw::lua::delete_script(dpp(), store, tenant, null_yield, script_ctx);

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -269,7 +269,7 @@ void handle_connection(boost::asio::io_context& context,
                       *env.auth_registry, &client, env.olog, y,
                       scheduler, &user, &latency,
                       env.ratelimiting->get_active(),
-                      &http_ret);
+                      &http_ret, env.lua_background);
 
       if (cct->_conf->subsys.should_gather(dout_subsys, 1)) {
         // access log line elements begin per Apache Combined Log Format with additions following

--- a/src/rgw/rgw_loadgen_process.cc
+++ b/src/rgw/rgw_loadgen_process.cc
@@ -137,7 +137,7 @@ void RGWLoadGenProcess::handle_request(const DoutPrefixProvider *dpp, RGWRequest
   int ret = process_request(store, rest, req, uri_prefix,
                             *auth_registry, &client_io, olog,
                             null_yield, nullptr, nullptr, nullptr,
-                            ratelimit.get_active());
+                            ratelimit.get_active(), nullptr);
   if (ret < 0) {
     /* we don't really care about return code */
     dout(20) << "process_request() returned " << ret << dendl;

--- a/src/rgw/rgw_lua.cc
+++ b/src/rgw/rgw_lua.cc
@@ -23,6 +23,9 @@ context to_context(const std::string& s)
   if (strcasecmp(s.c_str(), "postrequest") == 0) {
     return context::postRequest;
   }
+  if (strcasecmp(s.c_str(), "background") == 0) {
+    return context::background;
+  }
   return context::none;
 }
 
@@ -33,6 +36,8 @@ std::string to_string(context ctx)
       return "prerequest";
     case context::postRequest:
       return "postrequest";
+    case context::background:
+      return "background";
     case context::none:
       break;
   }

--- a/src/rgw/rgw_lua.h
+++ b/src/rgw/rgw_lua.h
@@ -15,6 +15,7 @@ namespace rgw::lua {
 enum class context {
   preRequest,
   postRequest,
+  background,
   none
 };
 

--- a/src/rgw/rgw_lua_background.cc
+++ b/src/rgw/rgw_lua_background.cc
@@ -1,0 +1,56 @@
+#include "rgw_lua_background.h"
+#include "rgw_lua.h"
+#include "rgw_lua_utils.h"
+#include "include/ceph_assert.h"
+#include <lua.hpp>
+
+namespace rgw::lua {
+
+void Background::shutdown(){
+  this->stop();
+  runner.join();
+}
+void Background::stop(){
+  stopped = true;
+}
+
+//(1) Loads the script from the object
+//(2) Executes the script
+//(3) Sleep (configurable)
+void Background::run() {
+  lua_State* const L = luaL_newstate();
+  rgw::lua::lua_state_guard lguard(L);
+  open_standard_libs(L);
+  set_package_path(L, luarocks_path);
+  create_debug_action(L, cct->get());
+  create_background_metatable(L);
+
+  while (!stopped) {
+
+    std::string tenant;
+    auto rc = rgw::lua::read_script(dpp, store, tenant, null_yield, rgw::lua::context::background, rgw_script);
+    if (rc == -ENOENT) {
+      // no script, nothing to do
+    } else if (rc < 0) {
+      ldpp_dout(dpp, 1) << "WARNING: failed to read background script. error " << rc << dendl;
+    } else {
+      try {
+        //execute the background lua script
+        if (luaL_dostring(L, rgw_script.c_str()) != LUA_OK) {
+          const std::string err(lua_tostring(L, -1));
+          ldpp_dout(dpp, 1) << "Lua ERROR: " << err << dendl;
+        }
+      } catch (const std::exception& e) {
+         ldpp_dout(dpp, 1) << "Lua ERROR: " << e.what() << dendl;
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(execute_interval));
+  }
+}
+
+void Background::create_background_metatable(lua_State* L) {
+  create_metatable<rgw::lua::RGWTable>(L, true, &rgw_map, &m_mutex);
+}
+
+} //namespace lua
+

--- a/src/rgw/rgw_lua_background.cc
+++ b/src/rgw/rgw_lua_background.cc
@@ -5,16 +5,28 @@
 #include "include/ceph_assert.h"
 #include <lua.hpp>
 
+#define dout_subsys ceph_subsys_rgw
+
 namespace rgw::lua {
 
+Background::Background(rgw::sal::Store* store,
+    CephContext* cct,
+      const std::string& luarocks_path,
+      int execute_interval) :
+    execute_interval(execute_interval),
+    dp(cct, dout_subsys, "lua background: "),
+    store(store),
+    cct(cct),
+    luarocks_path(luarocks_path) {}
+
 void Background::shutdown(){
-  this->stop();
+  stopped = true;
+  cond.notify_all();
   if (runner.joinable()) {
     runner.join();
   }
-}
-void Background::stop(){
-  stopped = true;
+  started = false;
+  stopped = false;
 }
 
 void Background::start() {
@@ -29,12 +41,46 @@ void Background::start() {
   ceph_assert(rc == 0);
 }
 
-int Background::read_script() {
-  std::string tenant;
-  return rgw::lua::read_script(dpp, store, tenant, null_yield, rgw::lua::context::background, rgw_script);
+void Background::pause() {
+  {
+    std::unique_lock cond_lock(pause_mutex);
+    paused = true;
+  }
+  cond.notify_all();
 }
 
-//(1) Loads the script from the object
+void Background::resume(rgw::sal::Store* _store) {
+  store = _store;
+  paused = false;
+  cond.notify_all();
+}
+
+int Background::read_script() {
+  std::unique_lock cond_lock(pause_mutex);
+  if (paused) {
+    return -EAGAIN;
+  }
+  std::string tenant;
+  return rgw::lua::read_script(&dp, store, tenant, null_yield, rgw::lua::context::background, rgw_script);
+}
+
+const std::string Background::empty_table_value;
+
+const std::string& Background::get_table_value(const std::string& key) const {
+  std::unique_lock cond_lock(table_mutex);
+  const auto it = rgw_map.find(key);
+  if (it == rgw_map.end()) {
+    return empty_table_value;
+  }
+  return it->second;
+}
+
+void Background::put_table_value(const std::string& key, const std::string& value) {
+  std::unique_lock cond_lock(table_mutex);
+  rgw_map[key] = value;
+}
+
+//(1) Loads the script from the object if not paused
 //(2) Executes the script
 //(3) Sleep (configurable)
 void Background::run() {
@@ -44,11 +90,22 @@ void Background::run() {
   set_package_path(L, luarocks_path);
   create_debug_action(L, cct);
   create_background_metatable(L);
+  const DoutPrefixProvider* const dpp = &dp;
 
   while (!stopped) {
+    if (paused) {
+      ldpp_dout(dpp, 10) << "Lua background thread paused" << dendl;
+      std::unique_lock cond_lock(cond_mutex);
+      cond.wait(cond_lock, [this]{return !paused || stopped;}); 
+      if (stopped) {
+        ldpp_dout(dpp, 10) << "Lua background thread stopped" << dendl;
+        return;
+      }
+      ldpp_dout(dpp, 10) << "Lua background thread resumed" << dendl;
+    }
     const auto rc = read_script();
-    if (rc == -ENOENT) {
-      // no script, nothing to do
+    if (rc == -ENOENT || rc == -EAGAIN) {
+      // either no script or paused, nothing to do
     } else if (rc < 0) {
       ldpp_dout(dpp, 1) << "WARNING: failed to read background script. error " << rc << dendl;
     } else {
@@ -68,12 +125,14 @@ void Background::run() {
         perfcounter->inc((failed ? l_rgw_lua_script_fail : l_rgw_lua_script_ok), 1);
       }
     }
-    std::this_thread::sleep_for(std::chrono::seconds(execute_interval));
+    std::unique_lock cond_lock(cond_mutex);
+    cond.wait_for(cond_lock, std::chrono::seconds(execute_interval), [this]{return stopped;}); 
   }
+  ldpp_dout(dpp, 10) << "Lua background thread stopped" << dendl;
 }
 
 void Background::create_background_metatable(lua_State* L) {
-  create_metatable<rgw::lua::RGWTable>(L, true, &rgw_map, &m_mutex);
+  create_metatable<rgw::lua::RGWTable>(L, true, &rgw_map, &table_mutex);
 }
 
 } //namespace lua

--- a/src/rgw/rgw_lua_background.h
+++ b/src/rgw/rgw_lua_background.h
@@ -1,0 +1,73 @@
+#pragma once
+#include "common/dout.h"
+#include "rgw_common.h"
+#include <string>
+#include "rgw_lua_utils.h"
+
+namespace rgw::lua {
+
+//Interval between each execution of the script is set to 5 seconds
+constexpr const int INIT_EXECUTE_INTERVAL = 5;
+
+//Writeable meta table named RGW with mutex protection
+using BackgroundMap = std::unordered_map<std::string, std::string>;
+struct RGWTable : StringMapMetaTable<BackgroundMap,
+  StringMapWriteableNewIndex<BackgroundMap>> {
+    static std::string TableName() {return "RGW";}
+    static std::string Name() {return TableName() + "Meta";}
+    static int IndexClosure(lua_State* L) {
+      auto& mtx = *reinterpret_cast<std::mutex*>(lua_touserdata(L, lua_upvalueindex(2)));
+      std::lock_guard l(mtx);
+      return StringMapMetaTable::IndexClosure(L);
+    }
+    static int LenClosure(lua_State* L) {
+      auto& mtx = *reinterpret_cast<std::mutex*>(lua_touserdata(L, lua_upvalueindex(2)));
+      std::lock_guard l(mtx);
+      return StringMapMetaTable::LenClosure(L);
+    }
+    static int NewIndexClosure(lua_State* L) {
+      auto& mtx = *reinterpret_cast<std::mutex*>(lua_touserdata(L, lua_upvalueindex(2)));
+      std::lock_guard l(mtx);
+      return StringMapMetaTable::NewIndexClosure(L);
+    }
+};
+
+class Background {
+
+private:
+  BackgroundMap rgw_map;
+  std::string rgw_script;
+  bool stopped = false;
+  int execute_interval = INIT_EXECUTE_INTERVAL;
+  const DoutPrefixProvider* const dpp;
+  rgw::sal::Store* const store;
+  CephContext* const cct;
+  std::string luarocks_path;
+  std::thread runner;
+  std::mutex m_mutex;
+
+  void run();
+
+public:
+  Background(const DoutPrefixProvider* dpp,
+      rgw::sal::Store* store,
+      CephContext* cct,
+      const std::string& luarocks_path) :
+    dpp(dpp),
+    store(store),
+    cct(cct),
+    luarocks_path(luarocks_path),
+    runner(std::thread(&Background::run, this)) {
+      const auto rc = ceph_pthread_setname(runner.native_handle(),
+                                           "lua_background");
+      ceph_assert(rc == 0);
+    }
+
+    ~Background() = default;
+    void stop();
+    void shutdown();
+    void create_background_metatable(lua_State* L);
+};
+
+} //namepsace lua
+

--- a/src/rgw/rgw_lua_background.h
+++ b/src/rgw/rgw_lua_background.h
@@ -36,17 +36,21 @@ class Background {
 
 private:
   BackgroundMap rgw_map;
-  std::string rgw_script;
   bool stopped = false;
+  bool started = false;
   int execute_interval = INIT_EXECUTE_INTERVAL;
   const DoutPrefixProvider* const dpp;
   rgw::sal::Store* const store;
   CephContext* const cct;
-  std::string luarocks_path;
+  const std::string luarocks_path;
   std::thread runner;
   std::mutex m_mutex;
 
   void run();
+
+protected:
+  std::string rgw_script;
+  virtual int read_script();
 
 public:
   Background(const DoutPrefixProvider* dpp,
@@ -56,14 +60,10 @@ public:
     dpp(dpp),
     store(store),
     cct(cct),
-    luarocks_path(luarocks_path),
-    runner(std::thread(&Background::run, this)) {
-      const auto rc = ceph_pthread_setname(runner.native_handle(),
-                                           "lua_background");
-      ceph_assert(rc == 0);
-    }
+    luarocks_path(luarocks_path) {}
 
-    ~Background() = default;
+    virtual ~Background() = default;
+    void start();
     void stop();
     void shutdown();
     void create_background_metatable(lua_State* L);

--- a/src/rgw/rgw_lua_request.cc
+++ b/src/rgw/rgw_lua_request.cc
@@ -11,6 +11,7 @@
 #include "rgw_zone.h"
 #include "rgw_acl.h"
 #include "rgw_sal_rados.h"
+#include "rgw_lua_background.h"
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -237,90 +238,6 @@ struct ObjectMetaTable : public EmptyMetaTable {
     } else {
       return error_unknown_field(L, index, TableName());
     }
-    return ONE_RETURNVAL;
-  }
-};
-
-typedef int MetaTableClosure(lua_State* L);
-
-template<typename MapType>
-int StringMapWriteableNewIndex(lua_State* L) {
-  const auto map = reinterpret_cast<MapType*>(lua_touserdata(L, lua_upvalueindex(1)));
-
-  const char* index = luaL_checkstring(L, 2);
-  const char* value = luaL_checkstring(L, 3);
-  map->insert_or_assign(index, value);
-  return NO_RETURNVAL;
-}
-
-template<typename MapType=std::map<std::string, std::string>,
-  MetaTableClosure NewIndex=EmptyMetaTable::NewIndexClosure>
-struct StringMapMetaTable : public EmptyMetaTable {
-
-  static std::string TableName() {return "StringMap";}
-  static std::string Name() {return TableName() + "Meta";}
-
-  static int IndexClosure(lua_State* L) {
-    const auto map = reinterpret_cast<MapType*>(lua_touserdata(L, lua_upvalueindex(1)));
-
-    const char* index = luaL_checkstring(L, 2);
-
-    const auto it = map->find(std::string(index));
-    if (it == map->end()) {
-      lua_pushnil(L);
-    } else {
-      pushstring(L, it->second);
-    }
-    return ONE_RETURNVAL;
-  }
-
-  static int NewIndexClosure(lua_State* L) {
-    return NewIndex(L);
-  }
-
-  static int PairsClosure(lua_State* L) {
-    auto map = reinterpret_cast<MapType*>(lua_touserdata(L, lua_upvalueindex(1)));
-    ceph_assert(map);
-    lua_pushlightuserdata(L, map);
-    lua_pushcclosure(L, stateless_iter, ONE_UPVAL); // push the stateless iterator function
-    lua_pushnil(L);                                 // indicate this is the first call
-    // return stateless_iter, nil
-
-    return TWO_RETURNVALS;
-  }
-  
-  static int stateless_iter(lua_State* L) {
-    // based on: http://lua-users.org/wiki/GeneralizedPairsAndIpairs
-    auto map = reinterpret_cast<MapType*>(lua_touserdata(L, lua_upvalueindex(1)));
-    typename MapType::const_iterator next_it;
-    if (lua_isnil(L, -1)) {
-      next_it = map->begin();
-    } else {
-      const char* index = luaL_checkstring(L, 2);
-      const auto it = map->find(std::string(index));
-      ceph_assert(it != map->end());
-      next_it = std::next(it);
-    }
-
-    if (next_it == map->end()) {
-      // index of the last element was provided
-      lua_pushnil(L);
-      lua_pushnil(L);
-      // return nil, nil
-    } else {
-      pushstring(L, next_it->first);
-      pushstring(L, next_it->second);
-      // return key, value
-    }
-
-    return TWO_RETURNVALS;
-  }
-
-  static int LenClosure(lua_State* L) {
-    const auto map = reinterpret_cast<MapType*>(lua_touserdata(L, lua_upvalueindex(1)));
-
-    lua_pushinteger(L, map->size());
-
     return ONE_RETURNVAL;
   }
 };
@@ -799,7 +716,8 @@ int execute(
     OpsLogSink* olog,
     req_state* s, 
     const char* op_name,
-    const std::string& script)
+    const std::string& script,
+    rgw::lua::Background* background)
 
 {
   auto L = luaL_newstate();
@@ -811,12 +729,13 @@ int execute(
       "");
 
   create_debug_action(L, s->cct);  
-
-  create_metatable<RequestMetaTable>(L, true, s, const_cast<char*>(op_name));
   
-  // add the ops log action
+  create_metatable<RequestMetaTable>(L, true, s, const_cast<char*>(op_name));
+
   lua_getglobal(L, RequestMetaTable::TableName().c_str());
   ceph_assert(lua_istable(L, -1));
+
+  // add the ops log action
   pushstring(L, RequestLogAction);
   lua_pushlightuserdata(L, rest);
   lua_pushlightuserdata(L, olog);
@@ -824,6 +743,12 @@ int execute(
   lua_pushlightuserdata(L, const_cast<char*>(op_name));
   lua_pushcclosure(L, RequestLog, FOUR_UPVALS);
   lua_rawset(L, -3);
+  
+  if (background) {
+    background->create_background_metatable(L);
+    lua_getglobal(L, rgw::lua::RGWTable::TableName().c_str());
+    ceph_assert(lua_istable(L, -1));
+  }
 
   try {
     // execute the lua script

--- a/src/rgw/rgw_lua_request.h
+++ b/src/rgw/rgw_lua_request.h
@@ -9,6 +9,9 @@ class OpsLogSink;
 namespace rgw::sal {
   class Store;
 }
+namespace rgw::lua {
+  class Background;
+}
 
 namespace rgw::lua::request {
 
@@ -19,7 +22,8 @@ int execute(
     OpsLogSink* olog,
     req_state *s, 
     const char* op_name,
-    const std::string& script);
+    const std::string& script,
+    rgw::lua::Background* background = nullptr);
 
 }
 

--- a/src/rgw/rgw_lua_utils.h
+++ b/src/rgw/rgw_lua_utils.h
@@ -43,6 +43,9 @@ public:
   void reset(lua_State* _l=nullptr) {l = _l;}
 };
 
+constexpr const int MAX_LUA_VALUE_SIZE = 1000;
+constexpr const int MAX_LUA_KEY_ENTRIES = 100000;
+
 constexpr auto ONE_UPVAL    = 1;
 constexpr auto TWO_UPVALS   = 2;
 constexpr auto THREE_UPVALS = 3;
@@ -193,5 +196,101 @@ void set_package_path(lua_State* L, const std::string& install_dir);
 // and the "debug" library
 void open_standard_libs(lua_State* L);
 
+typedef int MetaTableClosure(lua_State* L);
+
+template<typename MapType>
+int StringMapWriteableNewIndex(lua_State* L) {
+  const auto map = reinterpret_cast<MapType*>(lua_touserdata(L, lua_upvalueindex(1)));
+
+  const char* index = luaL_checkstring(L, 2);
+
+  if (lua_isnil(L, 3) == 0) {
+    const char* value = luaL_checkstring(L, 3);
+    if (strnlen(value, MAX_LUA_VALUE_SIZE) + strnlen(index, MAX_LUA_VALUE_SIZE)
+        > MAX_LUA_VALUE_SIZE) {
+      return luaL_error(L, "Lua maximum size of entry limit exceeded");
+    } else if (map->size() > MAX_LUA_KEY_ENTRIES) {
+      return luaL_error(L, "Lua max number of entries limit exceeded");
+    } else {
+      map->insert_or_assign(index, value);
+    }
+  } else {
+    map->erase(std::string(index));
+  }
+
+  return NO_RETURNVAL;
+}
+
+template<typename MapType=std::map<std::string, std::string>,
+  MetaTableClosure NewIndex=EmptyMetaTable::NewIndexClosure>
+struct StringMapMetaTable : public EmptyMetaTable {
+
+  static std::string TableName() {return "StringMap";}
+  static std::string Name() {return TableName() + "Meta";}
+
+  static int IndexClosure(lua_State* L) {
+    const auto map = reinterpret_cast<MapType*>(lua_touserdata(L, lua_upvalueindex(1)));
+
+    const char* index = luaL_checkstring(L, 2);
+
+    const auto it = map->find(std::string(index));
+    if (it == map->end()) {
+      lua_pushnil(L);
+    } else {
+        pushstring(L, it->second);
+    }
+    return ONE_RETURNVAL;
+  }
+
+  static int NewIndexClosure(lua_State* L) {
+    return NewIndex(L);
+  }
+
+  static int PairsClosure(lua_State* L) {
+    auto map = reinterpret_cast<MapType*>(lua_touserdata(L, lua_upvalueindex(1)));
+    ceph_assert(map);
+    lua_pushlightuserdata(L, map);
+    lua_pushcclosure(L, stateless_iter, ONE_UPVAL); // push the stateless iterator function
+    lua_pushnil(L);                                 // indicate this is the first call
+    // return stateless_iter, nil
+
+    return TWO_RETURNVALS;
+  }
+  
+  static int stateless_iter(lua_State* L) {
+    // based on: http://lua-users.org/wiki/GeneralizedPairsAndIpairs
+    auto map = reinterpret_cast<MapType*>(lua_touserdata(L, lua_upvalueindex(1)));
+    typename MapType::const_iterator next_it;
+    if (lua_isnil(L, -1)) {
+      next_it = map->begin();
+    } else {
+      const char* index = luaL_checkstring(L, 2);
+      const auto it = map->find(std::string(index));
+      ceph_assert(it != map->end());
+      next_it = std::next(it);
+    }
+
+    if (next_it == map->end()) {
+      // index of the last element was provided
+      lua_pushnil(L);
+      lua_pushnil(L);
+      // return nil, nil
+    } else {
+      pushstring(L, next_it->first);
+      pushstring(L, next_it->second);
+      // return key, value
+    }
+
+    return TWO_RETURNVALS;
+  }
+
+  static int LenClosure(lua_State* L) {
+    const auto map = reinterpret_cast<MapType*>(lua_touserdata(L, lua_upvalueindex(1)));
+
+    lua_pushinteger(L, map->size());
+
+    return ONE_RETURNVAL;
+  }
+};
 }
 

--- a/src/rgw/rgw_lua_utils.h
+++ b/src/rgw/rgw_lua_utils.h
@@ -7,6 +7,7 @@
 #include <lua.hpp>
 
 #include "include/common_fwd.h"
+#include "rgw_perf_counters.h"
 
 namespace rgw::lua {
 
@@ -38,8 +39,17 @@ void stack_dump(lua_State* L);
 class lua_state_guard {
   lua_State* l;
 public:
-  lua_state_guard(lua_State* _l) : l(_l) {}
-  ~lua_state_guard() {lua_close(l);}
+  lua_state_guard(lua_State* _l) : l(_l) {
+    if (perfcounter) {
+      perfcounter->inc(l_rgw_lua_current_vms, 1);
+    }
+  }
+  ~lua_state_guard() {
+    lua_close(l);
+    if (perfcounter) {
+      perfcounter->dec(l_rgw_lua_current_vms, 1);
+    }
+  }
   void reset(lua_State* _l=nullptr) {l = _l;}
 };
 

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -607,6 +607,7 @@ int radosgw_Main(int argc, const char **argv)
   int fe_count = 0;
 
   rgw::lua::Background lua_background(&dp, store, cct.get(), store->get_luarocks_path());
+  lua_background.start();
 
   for (multimap<string, RGWFrontendConfig *>::iterator fiter = fe_map.begin();
        fiter != fe_map.end(); ++fiter, ++fe_count) {

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -188,6 +188,25 @@ static RGWRESTMgr *rest_filter(rgw::sal::Store* store, int dialect, RGWRESTMgr *
   }
 }
 
+class RGWPauser : public RGWRealmReloader::Pauser {
+  std::vector<Pauser*> pausers;
+
+public:
+  ~RGWPauser() override = default;
+  
+  void add_pauser(Pauser* pauser) {
+    pausers.push_back(pauser);
+  }
+
+  void pause() override {
+    std::for_each(pausers.begin(), pausers.end(), [](Pauser* p){p->pause();});
+  }
+  void resume(rgw::sal::Store* store) override {
+    std::for_each(pausers.begin(), pausers.end(), [store](Pauser* p){p->resume(store);});
+  }
+
+};
+
 /*
  * start up the RADOS connection and then handle HTTP messages as they come in
  */
@@ -606,8 +625,11 @@ int radosgw_Main(int argc, const char **argv)
 
   int fe_count = 0;
 
-  rgw::lua::Background lua_background(&dp, store, cct.get(), store->get_luarocks_path());
-  lua_background.start();
+  std::unique_ptr<rgw::lua::Background> lua_background;
+  if (rados) { /* Supported for only RadosStore */
+    lua_background = std::make_unique<rgw::lua::Background>(store, cct.get(), store->get_luarocks_path());
+    lua_background->start();
+  }
 
   for (multimap<string, RGWFrontendConfig *>::iterator fiter = fe_map.begin();
        fiter != fe_map.end(); ++fiter, ++fe_count) {
@@ -628,7 +650,7 @@ int radosgw_Main(int argc, const char **argv)
       config->get_val("prefix", "", &uri_prefix);
 
       RGWProcessEnv env = { store, &rest, olog, port, uri_prefix, 
-                            auth_registry, &ratelimiting, &lua_background};
+                            auth_registry, &ratelimiting, lua_background.get()};
 
       fe = new RGWLoadGenFrontend(env, config);
     }
@@ -638,7 +660,7 @@ int radosgw_Main(int argc, const char **argv)
       std::string uri_prefix;
       config->get_val("prefix", "", &uri_prefix);
       RGWProcessEnv env{ store, &rest, olog, port, uri_prefix, 
-                         auth_registry, &ratelimiting, &lua_background};
+                         auth_registry, &ratelimiting, lua_background.get()};
       fe = new RGWAsioFrontend(env, config, sched_ctx);
     }
 
@@ -675,13 +697,19 @@ int radosgw_Main(int argc, const char **argv)
 
   std::unique_ptr<RGWRealmReloader> reloader;
   std::unique_ptr<RGWPeriodPusher> pusher;
-  std::unique_ptr<RGWFrontendPauser> pauser;
+  std::unique_ptr<RGWFrontendPauser> fe_pauser;
   std::unique_ptr<RGWRealmWatcher> realm_watcher;
+  std::unique_ptr<RGWPauser> rgw_pauser;
   if (store->get_name() == "rados") {
     // add a watcher to respond to realm configuration changes
     pusher = std::make_unique<RGWPeriodPusher>(&dp, store, null_yield);
-    pauser = std::make_unique<RGWFrontendPauser>(fes, implicit_tenant_context, pusher.get());
-    reloader = std::make_unique<RGWRealmReloader>(store, service_map_meta, pauser.get());
+    fe_pauser = std::make_unique<RGWFrontendPauser>(fes, implicit_tenant_context, pusher.get());
+    rgw_pauser = std::make_unique<RGWPauser>();
+    rgw_pauser->add_pauser(fe_pauser.get());
+    if (lua_background) {
+      rgw_pauser->add_pauser(lua_background.get());
+    }
+    reloader = std::make_unique<RGWRealmReloader>(store, service_map_meta, rgw_pauser.get());
 
     realm_watcher = std::make_unique<RGWRealmWatcher>(&dp, g_ceph_context,
 				  static_cast<rgw::sal::RadosStore*>(store)->svc()->zone->get_realm());
@@ -731,6 +759,10 @@ int radosgw_Main(int argc, const char **argv)
   rgw_log_usage_finalize();
   delete olog;
 
+  if (lua_background) {
+    lua_background->shutdown();
+  }
+
   StoreManager::close_storage(store);
   rgw::auth::s3::LDAPEngine::shutdown();
   rgw_tools_cleanup();
@@ -746,7 +778,6 @@ int radosgw_Main(int argc, const char **argv)
   rgw::kafka::shutdown();
 #endif
 
-  lua_background.shutdown();
 
   rgw_perf_stop(g_ceph_context);
 

--- a/src/rgw/rgw_perf_counters.cc
+++ b/src/rgw/rgw_perf_counters.cc
@@ -60,6 +60,10 @@ int rgw_perf_start(CephContext *cct)
   plb.add_u64(l_rgw_pubsub_push_pending, "pubsub_push_pending", "Pubsub events pending reply from endpoint");
   plb.add_u64_counter(l_rgw_pubsub_missing_conf, "pubsub_missing_conf", "Pubsub events could not be handled because of missing configuration");
   
+  plb.add_u64_counter(l_rgw_lua_script_ok, "lua_script_ok", "Successfull executions of lua scripts");
+  plb.add_u64_counter(l_rgw_lua_script_fail, "lua_script_fail", "Failed executions of lua scripts");
+  plb.add_u64(l_rgw_lua_current_vms, "lua_current_vms", "Number of Lua VMs currently being executed");
+  
   perfcounter = plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(perfcounter);
   return 0;

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -50,6 +50,10 @@ enum {
   l_rgw_pubsub_push_pending,
   l_rgw_pubsub_missing_conf,
 
+  l_rgw_lua_current_vms,
+  l_rgw_lua_script_ok,
+  l_rgw_lua_script_fail,
+
   l_rgw_last,
 };
 

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -273,10 +273,10 @@ int process_request(rgw::sal::Store* const store,
                     string* user,
                     ceph::coarse_real_clock::duration* latency,
                     std::shared_ptr<RateLimiter> ratelimit,
-                    int* http_ret)
+                    int* http_ret,
+                    rgw::lua::Background* lua_background)
 {
   int ret = client_io->init(g_ceph_context);
-
   dout(1) << "====== starting new request req=" << hex << req << dec
 	  << " =====" << dendl;
   perfcounter->inc(l_rgw_req);
@@ -335,7 +335,7 @@ int process_request(rgw::sal::Store* const store,
     } else if (rc < 0) {
       ldpp_dout(op, 5) << "WARNING: failed to read pre request script. error: " << rc << dendl;
     } else {
-      rc = rgw::lua::request::execute(store, rest, olog, s, op->name(), script);
+      rc = rgw::lua::request::execute(store, rest, olog, s, op->name(), script, lua_background);
       if (rc < 0) {
         ldpp_dout(op, 5) << "WARNING: failed to execute pre request script. error: " << rc << dendl;
       }
@@ -417,7 +417,7 @@ done:
     } else if (rc < 0) {
       ldpp_dout(op, 5) << "WARNING: failed to read post request script. error: " << rc << dendl;
     } else {
-      rc = rgw::lua::request::execute(store, rest, olog, s, op->name(), script);
+      rc = rgw::lua::request::execute(store, rest, olog, s, op->name(), script, lua_background);
       if (rc < 0) {
         ldpp_dout(op, 5) << "WARNING: failed to execute post request script. error: " << rc << dendl;
       }

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -356,7 +356,7 @@
      --event-id                event id in a pubsub subscription
   
   Script options:
-     --context                 context in which the script runs. one of: preRequest, postRequest
+     --context                 context in which the script runs. one of: preRequest, postRequest, background
      --package                 name of the lua package that should be added/removed to/from the allowlist
      --allow-compilation       package is allowed to compile C code as part of its installation
   

--- a/src/test/rgw/test_rgw_lua.cc
+++ b/src/test/rgw/test_rgw_lua.cc
@@ -153,23 +153,21 @@ public:
   }
 };
 
-auto cct = new CephContext(CEPH_ENTITY_TYPE_CLIENT);
+auto g_cct = new CephContext(CEPH_ENTITY_TYPE_CLIENT);
 
-CctCleaner cleaner(cct);
+CctCleaner cleaner(g_cct);
+
+#define DEFINE_REQ_STATE RGWEnv e; req_state s(g_cct, &e, 0);
 
 TEST(TestRGWLua, EmptyScript)
 {
   const std::string script;
 
-  RGWEnv e;
-  uint64_t id = 0;
-  req_state s(cct, &e, id); 
+  DEFINE_REQ_STATE;
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", script);
   ASSERT_EQ(rc, 0);
 }
-
-#define DEFINE_REQ_STATE RGWEnv e; req_state s(cct, &e, 0);
 
 TEST(TestRGWLua, SyntaxError)
 {
@@ -268,7 +266,7 @@ TEST(TestRGWLua, SetResponse)
   ASSERT_EQ(rc, 0);
 }
 
-TEST(TestRGWLua, SetRGWId)
+TEST(TestRGWLua, RGWIdNotWriteable)
 {
   const std::string script = R"(
     assert(Request.RGWId == "foo")
@@ -480,7 +478,7 @@ TEST(TestRGWLua, Acl)
   ACLOwner owner;
   owner.set_id(rgw_user("jack", "black"));
   owner.set_name("jack black");
-  s.user_acl.reset(new RGWAccessControlPolicy(cct));
+  s.user_acl.reset(new RGWAccessControlPolicy(g_cct));
   s.user_acl->set_owner(owner);
   ACLGrant grant1, grant2, grant3, grant4, grant5;
   grant1.set_canon(rgw_user("jane", "doe"), "her grant", 1);
@@ -648,15 +646,18 @@ TEST(TestRGWLua, OpsLog)
 }
 
 class TestBackground : public rgw::lua::Background {
+  const unsigned read_time;
 protected:
   int read_script() override {
     // don't read the object from the store
+    std::this_thread::sleep_for(std::chrono::seconds(read_time));
     return 0;
   }
 
 public:
-  TestBackground(const std::string& script) : 
-    rgw::lua::Background(nullptr, nullptr, nullptr, "") {
+  TestBackground(const std::string& script, unsigned read_time = 0) : 
+    rgw::lua::Background(nullptr, g_cct, "", 1 /*run every second*/),
+    read_time(read_time) {
       // the script is passed in the constructor
       rgw_script = script;
     }
@@ -666,7 +667,7 @@ public:
   }
 };
 
-TEST(TestRGWLua, Background)
+TEST(TestRGWLuaBackground, Start)
 {
   {
     // ctr and dtor without running
@@ -676,56 +677,175 @@ TEST(TestRGWLua, Background)
     // ctr and dtor with running
     TestBackground lua_background("");
     lua_background.start();
-    // let the background context run for 5 seconds
-    std::this_thread::sleep_for(std::chrono::seconds(5));
   }
 }
 
-TEST(TestRGWLua, BackgroundScript)
+
+constexpr auto wait_time = std::chrono::seconds(2);
+
+TEST(TestRGWLuaBackground, Script)
 {
   const std::string script = R"(
     local key = "hello"
     local value = "world"
     RGW[key] = value
-    print(RGW[key] == value)
   )";
 
   TestBackground lua_background(script);
   lua_background.start();
-  // let the background context run for 5 seconds
-  std::this_thread::sleep_for(std::chrono::seconds(5));
+  std::this_thread::sleep_for(wait_time);
+  EXPECT_EQ(lua_background.get_table_value("hello"), "world");
 }
 
-TEST(TestRGWLua, BackgroundRequestScript)
+TEST(TestRGWLuaBackground, RequestScript)
 {
   const std::string background_script = R"(
     local key = "hello"
     local value = "from background"
-    -- set the value only if not set
-    if RGW[key] == nil then 
-      RGW[key] = value
-    end
-    print("from background:", RGW[key])
+    RGW[key] = value
   )";
 
   TestBackground lua_background(background_script);
   lua_background.start();
-  // let the background context run for 5 seconds
-  std::this_thread::sleep_for(std::chrono::seconds(5));
+  std::this_thread::sleep_for(wait_time);
 
   const std::string request_script = R"(
     local key = "hello"
+    assert(RGW[key] == "from background") 
     local value = "from request"
-    print("from request (before setting):", RGW[key])
     RGW[key] = value
-    print("from request (after setting):", RGW[key])
   )";
 
   DEFINE_REQ_STATE;
 
+  // to make sure test is consistent we have to puase the background
+  lua_background.pause();
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "", request_script, &lua_background);
   ASSERT_EQ(rc, 0);
-  // let the background context run for 5 seconds
-  std::this_thread::sleep_for(std::chrono::seconds(5));
+  EXPECT_EQ(lua_background.get_table_value("hello"), "from request");
+  // now we resume and let the background set the value
+  lua_background.resume(nullptr);
+  std::this_thread::sleep_for(wait_time);
+  EXPECT_EQ(lua_background.get_table_value("hello"), "from background");
+}
+
+TEST(TestRGWLuaBackground, Pause)
+{
+  const std::string script = R"(
+    local key = "hello"
+    local value = "1"
+    if RGW[key] then
+      RGW[key] = value..RGW[key]
+    else
+      RGW[key] = value
+    end
+  )";
+
+  TestBackground lua_background(script);
+  lua_background.start();
+  std::this_thread::sleep_for(wait_time);
+  const auto value_len = lua_background.get_table_value("hello").size();
+  EXPECT_GT(value_len, 0);
+  lua_background.pause();
+  std::this_thread::sleep_for(wait_time);
+  // no change in len
+  EXPECT_EQ(value_len, lua_background.get_table_value("hello").size());
+}
+
+TEST(TestRGWLuaBackground, PauseWhileReading)
+{
+  const std::string script = R"(
+    local key = "hello"
+    local value = "world"
+    RGW[key] = value
+    if RGW[key] then
+      RGW[key] = value..RGW[key]
+    else
+      RGW[key] = value
+    end
+  )";
+
+  constexpr auto long_wait_time = std::chrono::seconds(6);
+  TestBackground lua_background(script, 2);
+  lua_background.start();
+  std::this_thread::sleep_for(long_wait_time);
+  const auto value_len = lua_background.get_table_value("hello").size();
+  EXPECT_GT(value_len, 0);
+  lua_background.pause();
+  std::this_thread::sleep_for(long_wait_time);
+  // one execution might occur after pause
+  EXPECT_TRUE(value_len + 1 >= lua_background.get_table_value("hello").size());
+}
+
+TEST(TestRGWLuaBackground, ReadWhilePaused)
+{
+  const std::string script = R"(
+    local key = "hello"
+    local value = "world"
+    RGW[key] = value
+  )";
+
+  TestBackground lua_background(script);
+  lua_background.pause();
+  lua_background.start();
+  std::this_thread::sleep_for(wait_time);
+  EXPECT_EQ(lua_background.get_table_value("hello"), "");
+  lua_background.resume(nullptr);
+  std::this_thread::sleep_for(wait_time);
+  EXPECT_EQ(lua_background.get_table_value("hello"), "world");
+}
+
+TEST(TestRGWLuaBackground, PauseResume)
+{
+  const std::string script = R"(
+    local key = "hello"
+    local value = "1"
+    if RGW[key] then
+      RGW[key] = value..RGW[key]
+    else
+      RGW[key] = value
+    end
+  )";
+
+  TestBackground lua_background(script);
+  lua_background.start();
+  std::this_thread::sleep_for(wait_time);
+  const auto value_len = lua_background.get_table_value("hello").size();
+  EXPECT_GT(value_len, 0);
+  lua_background.pause();
+  std::this_thread::sleep_for(wait_time);
+  // no change in len
+  EXPECT_EQ(value_len, lua_background.get_table_value("hello").size());
+  lua_background.resume(nullptr);
+  std::this_thread::sleep_for(wait_time);
+  // should be a change in len
+  EXPECT_GT(lua_background.get_table_value("hello").size(), value_len);
+}
+
+TEST(TestRGWLuaBackground, MultipleStarts)
+{
+  const std::string script = R"(
+    local key = "hello"
+    local value = "1"
+    if RGW[key] then
+      RGW[key] = value..RGW[key]
+    else
+      RGW[key] = value
+    end
+  )";
+
+  TestBackground lua_background(script);
+  lua_background.start();
+  std::this_thread::sleep_for(wait_time);
+  const auto value_len = lua_background.get_table_value("hello").size();
+  EXPECT_GT(value_len, 0);
+  lua_background.start();
+  lua_background.shutdown();
+  lua_background.shutdown();
+  std::this_thread::sleep_for(wait_time);
+  lua_background.start();
+  std::this_thread::sleep_for(wait_time);
+  // should be a change in len
+  EXPECT_GT(lua_background.get_table_value("hello").size(), value_len);
 }
 


### PR DESCRIPTION
Adding a lua background class. This class aims to allow to run a background
Lua script and bind a shared Lua table with a cpp map.

Signed-off-by: Matan Breizman <Matan.Brz@gmail.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug
- [x] Updates documentation if necessary
---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
