### PR TITLE
crimson/tools: silence [[maybe_unused]] warning in store-nbd.cc.

### DIFF
--- a/src/crimson/tools/store_nbd/store-nbd.cc
+++ b/src/crimson/tools/store_nbd/store-nbd.cc
@@ -321,7 +321,7 @@ class nbd_oldstyle_negotiation_t {
   uint64_t magic2 = seastar::cpu_to_be(0x00420281861253);  // "IHAVEOPT"
   uint64_t size = 0;
   uint32_t flags = seastar::cpu_to_be(0);
-  [[maybe_unused]] char reserved[124] = {0};
+  char reserved[124] = {0};
 
 public:
   nbd_oldstyle_negotiation_t(uint64_t size, uint32_t flags)


### PR DESCRIPTION
```
[595/2463] Building CXX object src/crimson/tools/CMakeFiles/crimson-store-nbd.dir/store_nbd/store-nbd.cc.o
../src/crimson/tools/store_nbd/store-nbd.cc:324:43: warning: maybe_unused attribute ignored [-Wattributes]
  324 |   [[maybe_unused]] char reserved[124] = {0};
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
