### PR TITLE
pacific: mgr/dashboard: tox.ini: delete useless env. 'apidocs' 

### DIFF
--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -5,8 +5,7 @@ envlist =
     fix,
     check,
     run,
-    apidocs,
-    openapi-{check,fix, doc}
+    openapi-{check, fix, doc}
 skipsdist = true
 minversion = 2.9.1
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52248

---

backport of https://github.com/ceph/ceph/pull/42745
parent tracker: https://tracker.ceph.com/issues/52130

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh