### PR TITLE
pybind/mgr: Fix IPv6 url generation

### DIFF
--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -5,6 +5,7 @@ import string
 from typing import List, Dict, Any, Tuple, cast, Optional
 
 from ceph.deployment.service_spec import IngressSpec
+from mgr_util import build_url
 from cephadm.utils import resolve_ip
 from orchestrator import OrchestratorError
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephService
@@ -226,7 +227,7 @@ class IngressService(CephService):
                 if d.daemon_type == 'haproxy':
                     assert d.ports
                     port = d.ports[1]   # monitoring port
-                    script = f'/usr/bin/curl http://{d.ip or "localhost"}:{port}/health'
+                    script = f'/usr/bin/curl {build_url(scheme="http", host=d.ip or "localhost", port=port)}/health'
         assert script
 
         # set state. first host in placement is master all others backups

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -9,7 +9,7 @@ from orchestrator import DaemonDescription
 from ceph.deployment.service_spec import AlertManagerSpec, ServiceSpec
 from cephadm.services.cephadmservice import CephadmService, CephadmDaemonDeploySpec
 from cephadm.services.ingress import IngressSpec
-from mgr_util import verify_tls, ServerConfigException, create_self_signed_cert
+from mgr_util import verify_tls, ServerConfigException, create_self_signed_cert, build_url
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,7 @@ class GrafanaService(CephadmService):
         assert dd.hostname is not None
         addr = dd.ip if dd.ip else self._inventory_get_addr(dd.hostname)
         port = dd.ports[0] if dd.ports else self.DEFAULT_SERVICE_PORT
-        service_url = 'https://{}:{}'.format(addr, port)
+        service_url = build_url(scheme='https', host=addr, port=port)
         self._set_service_url_on_dashboard(
             'Grafana',
             'dashboard get-grafana-api-url',

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
 
 from mgr_module import CLIWriteCommand, HandleCommandResult, MgrModule, \
     MgrStandbyModule, Option, _get_localized_key
-from mgr_util import ServerConfigException, create_self_signed_cert, \
-    get_default_addr, verify_tls_files
+from mgr_util import ServerConfigException, build_url, \
+    create_self_signed_cert, get_default_addr, verify_tls_files
 
 from . import mgr
 from .controllers import generate_routes, json_error_page
@@ -191,13 +191,12 @@ class CherryPyConfig(object):
         self._url_prefix = prepare_url_prefix(self.get_module_option(  # type: ignore
             'url_prefix', default=''))
 
-        uri = "{0}://{1}:{2}{3}/".format(
-            'https' if use_ssl else 'http',
-            server_addr,
-            server_port,
-            self.url_prefix
+        base_url = build_url(
+            scheme='https' if use_ssl else 'http',
+            host=server_addr,
+            port=server_port,
         )
-
+        uri = f'{base_url}{self.url_prefix}/'
         return uri
 
     def await_configuration(self):

--- a/src/pybind/mgr/dashboard/rest_client.py
+++ b/src/pybind/mgr/dashboard/rest_client.py
@@ -17,21 +17,19 @@ import logging
 import re
 
 import requests
+from requests.auth import AuthBase
 from requests.exceptions import ConnectionError, InvalidURL, Timeout
 
 from .settings import Settings
-from .tools import build_url
 
 try:
     from requests.packages.urllib3.exceptions import SSLError
 except ImportError:
     from urllib3.exceptions import SSLError  # type: ignore
 
-try:
-    from typing import List
-except ImportError:
-    pass  # Just for type checking
+from typing import List, Optional
 
+from mgr_util import build_url
 
 logger = logging.getLogger('rest_client')
 
@@ -330,7 +328,13 @@ class _Request(object):
 
 
 class RestClient(object):
-    def __init__(self, host, port, client_name=None, ssl=False, auth=None, ssl_verify=True):
+    def __init__(self,
+                 host: str,
+                 port: int,
+                 client_name: Optional[str] = None,
+                 ssl: bool = False,
+                 auth: Optional[AuthBase] = None,
+                 ssl_verify: bool = True) -> None:
         super(RestClient, self).__init__()
         self.client_name = client_name if client_name else ''
         self.host = host

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -8,12 +8,14 @@ import xml.etree.ElementTree as ET  # noqa: N814
 from distutils.util import strtobool
 from subprocess import SubprocessError
 
+from mgr_util import build_url
+
 from .. import mgr
 from ..awsauth import S3Auth
 from ..exceptions import DashboardException
 from ..rest_client import RequestException, RestClient
 from ..settings import Settings
-from ..tools import build_url, dict_contains_path, dict_get, json_str_to_object
+from ..tools import dict_contains_path, dict_get, json_str_to_object
 
 try:
     from typing import Any, Dict, List, Optional, Tuple, Union
@@ -385,10 +387,10 @@ class RgwClient(RestClient):
                            service_url=self.service_url)
 
     def __init__(self,
-                 access_key,
-                 secret_key,
-                 daemon_name,
-                 user_id=None):
+                 access_key: str,
+                 secret_key: str,
+                 daemon_name: str,
+                 user_id: Optional[str] = None) -> None:
         try:
             daemon = RgwClient._daemons[daemon_name]
         except KeyError as error:

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 from distutils.util import strtobool
 
 import cherrypy
-from ceph.deployment.utils import wrap_ipv6
+from mgr_util import build_url
 
 from . import mgr
 from .exceptions import ViewCacheNoDataException
@@ -670,41 +670,6 @@ class Task(object):
     def begin_time(self) -> float:
         assert self._begin_time is not None
         return self._begin_time
-
-
-def build_url(host, scheme=None, port=None):
-    """
-    Build a valid URL. IPv6 addresses specified in host will be enclosed in brackets
-    automatically.
-
-    >>> build_url('example.com', 'https', 443)
-    'https://example.com:443'
-
-    >>> build_url(host='example.com', port=443)
-    '//example.com:443'
-
-    >>> build_url('fce:9af7:a667:7286:4917:b8d3:34df:8373', port=80, scheme='http')
-    'http://[fce:9af7:a667:7286:4917:b8d3:34df:8373]:80'
-
-    :param scheme: The scheme, e.g. http, https or ftp.
-    :type scheme: str
-    :param host: Consisting of either a registered name (including but not limited to
-                 a hostname) or an IP address.
-    :type host: str
-    :type port: int
-    :rtype: str
-    """
-    netloc = wrap_ipv6(host)
-    if port:
-        netloc += ':{}'.format(port)
-    pr = urllib.parse.ParseResult(
-        scheme=scheme if scheme else '',
-        netloc=netloc,
-        path='',
-        params='',
-        query='',
-        fragment='')
-    return pr.geturl()
 
 
 def prepare_url_prefix(url_prefix):

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -13,6 +13,7 @@ import logging
 import sys
 from threading import Lock, Condition, Event
 from typing import no_type_check
+import urllib
 from functools import wraps
 if sys.version_info >= (3, 3):
     from threading import Timer
@@ -20,6 +21,9 @@ else:
     from threading import _Timer as Timer
 
 from typing import Tuple, Any, Callable, Optional, Dict, TYPE_CHECKING, TypeVar, List, Iterable, Generator, Generic, Iterator
+
+from ceph.deployment.utils import wrap_ipv6
+
 T = TypeVar('T')
 
 if TYPE_CHECKING:
@@ -429,6 +433,41 @@ def get_default_addr():
         result = '::' if is_ipv6_enabled() else '0.0.0.0'
         get_default_addr.result = result  # type: ignore
         return result
+
+
+def build_url(host: str, scheme: Optional[str] = None, port: Optional[int] = None) -> str:
+    """
+    Build a valid URL. IPv6 addresses specified in host will be enclosed in brackets
+    automatically.
+
+    >>> build_url('example.com', 'https', 443)
+    'https://example.com:443'
+
+    >>> build_url(host='example.com', port=443)
+    '//example.com:443'
+
+    >>> build_url('fce:9af7:a667:7286:4917:b8d3:34df:8373', port=80, scheme='http')
+    'http://[fce:9af7:a667:7286:4917:b8d3:34df:8373]:80'
+
+    :param scheme: The scheme, e.g. http, https or ftp.
+    :type scheme: str
+    :param host: Consisting of either a registered name (including but not limited to
+                 a hostname) or an IP address.
+    :type host: str
+    :type port: int
+    :rtype: str
+    """
+    netloc = wrap_ipv6(host)
+    if port:
+        netloc += ':{}'.format(port)
+    pr = urllib.parse.ParseResult(
+        scheme=scheme if scheme else '',
+        netloc=netloc,
+        path='',
+        params='',
+        query='',
+        fragment='')
+    return pr.geturl()
 
 
 class ServerConfigException(Exception):

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -8,13 +8,11 @@ import re
 import threading
 import time
 from mgr_module import CLIReadCommand, MgrModule, MgrStandbyModule, PG_STATES, Option, ServiceInfoT
-from mgr_util import get_default_addr, profile_method
+from mgr_util import get_default_addr, profile_method, build_url
 from rbd import RBD
 from collections import namedtuple
-try:
-    from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List
-except ImportError:
-    pass
+
+from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List
 
 # Defaults for the Prometheus HTTP server.  Can also set in config-key
 # see https://github.com/prometheus/prometheus/wiki/Default-port-allocations
@@ -1369,10 +1367,10 @@ class Module(MgrModule):
                                              self.STALE_CACHE_RETURN]:
             self.stale_cache_strategy = self.STALE_CACHE_FAIL
 
-        server_addr = self.get_localized_module_option(
-            'server_addr', get_default_addr())
-        server_port = self.get_localized_module_option(
-            'server_port', DEFAULT_PORT)
+        server_addr = cast(str, self.get_localized_module_option(
+            'server_addr', get_default_addr()))
+        server_port = cast(int, self.get_localized_module_option(
+            'server_port', DEFAULT_PORT))
         self.log.info(
             "server_addr: %s server_port: %s" %
             (server_addr, server_port)
@@ -1384,7 +1382,7 @@ class Module(MgrModule):
         # about to start serving
         if server_addr in ['::', '0.0.0.0']:
             server_addr = self.get_mgr_ip()
-        self.set_uri('http://{0}:{1}/'.format(server_addr, server_port))
+        self.set_uri(build_url(scheme='http', host=server_addr, port=server_port))
 
         cherrypy.config.update({
             'server.socket_host': server_addr,

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -24,6 +24,7 @@ from werkzeug.serving import make_server, make_ssl_devcert
 
 from .hooks import ErrorHook
 from mgr_module import MgrModule, CommandResult
+from mgr_util import build_url
 
 
 class CannotServe(Exception):
@@ -311,10 +312,8 @@ class Module(MgrModule):
 
         # Publish the URI that others may use to access the service we're
         # about to start serving
-        self.set_uri("https://{0}:{1}/".format(
-            self.get_mgr_ip() if server_addr == "::" else server_addr,
-            server_port
-        ))
+        addr = self.get_mgr_ip() if server_addr == "::" else server_addr
+        self.set_uri(build_url(scheme='https', host=addr, port=server_port))
 
         # Create the HTTPS werkzeug server serving pecan app
         self.server = make_server(


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/52117
Signed-off-by: Sebastian Wagner <sewagner@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
