### PR TITLE
octopus: mgr/dashboard: cephadm e2e start script: add --expanded option 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,7 +47,8 @@ https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst
 - `jenkins test make check arm64`
 - `jenkins test submodules`
 - `jenkins test dashboard`
-- `jenkins test dashboard backend`
+- `jenkins test dashboard cephadm`
+- `jenkins test api`
 - `jenkins test docs`
 - `jenkins render docs`
 - `jenkins test ceph-volume all`

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -184,7 +184,7 @@ Note:
   permissions.
 
 run-cephadm-e2e-tests.sh
-........................
+.........................
 
 ``run-cephadm-e2e-tests.sh`` runs a subset of E2E tests to verify that the Dashboard and cephadm as
 Orchestrator backend behave correctly.
@@ -208,14 +208,24 @@ Start E2E tests by running::
   $ cd <your/ceph/repo/dir>
   $ sudo chown -R $(id -un) src/pybind/mgr/dashboard/frontend/{dist,node_modules,src/environments}
   $ ./src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
-  $ kcli delete plan -y ceph  # After tests finish.
 
-You can also start a cluster in development mode and later run E2E tests by running::
+You can also start a cluster in development mode (so the frontend build starts in watch mode and you
+only have to reload the page for the changes to be reflected) by running::
 
   $ ./src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh --dev-mode
-  $ # Work on your feature, bug fix, ...
+
+Note:
+  Add ``--expanded`` if you need a cluster ready to deploy services (one with enough monitor
+  daemons spread across different hosts and enough OSDs).
+
+Test your changes by running:
+
   $ ./src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
-  $ # Remember to kill the npm build watch process i.e.: pkill -f "ng build"
+
+Shutdown the cluster by running:
+
+  $ kcli delete plan -y ceph
+  $ # In development mode, also kill the npm build watch process (e.g., pkill -f "ng build")
 
 Other running options
 .....................

--- a/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
@@ -10,6 +10,15 @@ mon_ip=$(ifconfig eth0  | grep 'inet ' | awk '{ print $2}')
 
 cephadm bootstrap --mon-ip $mon_ip --initial-dashboard-password {{ admin_password }} --allow-fqdn-hostname --dashboard-password-noupdate --shared_ceph_folder /mnt/{{ ceph_dev_folder }}
 
+fsid=$(cat /etc/ceph/ceph.conf | grep fsid | awk '{ print $3}')
+
 {% for number in range(1, nodes) %}
   ssh-copy-id -f -i /etc/ceph/ceph.pub  -o StrictHostKeyChecking=no root@{{ prefix }}-node-0{{ number }}.{{ domain }}
+  {% if expanded_cluster is defined %}
+    cephadm shell --fsid $fsid -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring ceph orch host add {{ prefix }}-node-0{{ number }}.{{ domain }}
+  {% endif %}
 {% endfor %}
+
+{% if expanded_cluster is defined %}
+  cephadm shell --fsid $fsid -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring ceph orch apply osd --all-available-devices
+{% endif %}


### PR DESCRIPTION
(Aldo added commit from: https://github.com/ceph/ceph/pull/42724)

backport tracker: https://tracker.ceph.com/issues/52249

---

backport of https://github.com/ceph/ceph/pull/42697
parent tracker: https://tracker.ceph.com/issues/52082

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh