### PR TITLE
crimson/common: allow the tls interrupt_cond to exist when a continuation starts to run

### DIFF
--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -365,7 +365,7 @@ public:
 		std::invoke_result_t<Func, seastar::future<T>>>>
   [[gnu::always_inline]]
   Result then_wrapped_interruptible(Func&& func) {
-    assert(interrupt_cond<InterruptCond>);
+    ceph_assert(interrupt_cond<InterruptCond>);
     return core_type::then_wrapped(
       [func=std::move(func), interrupt_condition=interrupt_cond<InterruptCond>]
       (auto&& fut) mutable {
@@ -379,7 +379,7 @@ public:
   template <typename Func>
   [[gnu::always_inline]]
   auto then_interruptible(Func&& func) {
-    assert(interrupt_cond<InterruptCond>);
+    ceph_assert(interrupt_cond<InterruptCond>);
     if constexpr (std::is_void_v<T>) {
       auto fut = core_type::then(
 	[func=std::move(func), interrupt_condition=interrupt_cond<InterruptCond>]
@@ -415,7 +415,7 @@ public:
 		std::result_of_t<Func(std::exception_ptr)>>>
   [[gnu::always_inline]]
   Result handle_exception_interruptible(Func&& func) {
-    assert(interrupt_cond<InterruptCond>);
+    ceph_assert(interrupt_cond<InterruptCond>);
     return core_type::then_wrapped(
       [func=std::forward<Func>(func),
       interrupt_condition=interrupt_cond<InterruptCond>](auto&& fut) mutable {
@@ -436,7 +436,7 @@ public:
   [[gnu::always_inline]]
   Result finally_interruptible(Func&& func) {
     if constexpr (may_interrupt) {
-      assert(interrupt_cond<InterruptCond>);
+      ceph_assert(interrupt_cond<InterruptCond>);
       return core_type::then_wrapped(
 	[func=std::forward<Func>(func),
 	interrupt_condition=interrupt_cond<InterruptCond>](auto&& fut) mutable {
@@ -455,7 +455,7 @@ public:
 		  typename seastar::function_traits<Func>::template arg<0>::type)>>>
   [[gnu::always_inline]]
   Result handle_exception_type_interruptible(Func&& func) {
-    assert(interrupt_cond<InterruptCond>);
+    ceph_assert(interrupt_cond<InterruptCond>);
     using trait = seastar::function_traits<Func>;
     static_assert(trait::arity == 1, "func can take only one parameter");
     using ex_type = typename trait::template arg<0>::type;
@@ -683,7 +683,7 @@ public:
 	   typename U = T, std::enable_if_t<!std::is_void_v<U> && interruptible, int> = 0>
   [[gnu::always_inline]]
   auto safe_then_interruptible(ValueInterruptCondT&& valfunc, ErrorVisitorT&& errfunc) {
-    assert(interrupt_cond<InterruptCond>);
+    ceph_assert(interrupt_cond<InterruptCond>);
     auto fut = core_type::safe_then(
       [func=std::move(valfunc), interrupt_condition=interrupt_cond<InterruptCond>]
       (T&& args) mutable {
@@ -719,7 +719,7 @@ public:
 	   typename U = T, std::enable_if_t<std::is_void_v<U> && interruptible, int> = 0>
   [[gnu::always_inline]]
   auto safe_then_interruptible(ValueInterruptCondT&& valfunc, ErrorVisitorT&& errfunc) {
-    assert(interrupt_cond<InterruptCond>);
+    ceph_assert(interrupt_cond<InterruptCond>);
     auto fut = core_type::safe_then(
       [func=std::move(valfunc), interrupt_condition=interrupt_cond<InterruptCond>]
       () mutable {
@@ -754,7 +754,7 @@ public:
 	    typename U = T, std::enable_if_t<std::is_void_v<T> && interruptible, int> = 0>
   [[gnu::always_inline]]
   auto safe_then_interruptible(ValueInterruptCondT&& valfunc) {
-    assert(interrupt_cond<InterruptCond>);
+    ceph_assert(interrupt_cond<InterruptCond>);
     auto fut = core_type::safe_then(
       [func=std::move(valfunc),
        interrupt_condition=interrupt_cond<InterruptCond>]
@@ -786,7 +786,7 @@ public:
 	    typename U = T, std::enable_if_t<!std::is_void_v<T> && interruptible, int> = 0>
   [[gnu::always_inline]]
   auto safe_then_interruptible(ValueInterruptCondT&& valfunc) {
-    assert(interrupt_cond<InterruptCond>);
+    ceph_assert(interrupt_cond<InterruptCond>);
     auto fut = core_type::safe_then(
       [func=std::move(valfunc),
        interrupt_condition=interrupt_cond<InterruptCond>]
@@ -852,7 +852,7 @@ public:
   template <bool interruptible = true, typename ErrorFunc>
   auto handle_error_interruptible(ErrorFunc&& errfunc) {
     if constexpr (interruptible) {
-      assert(interrupt_cond<InterruptCond>);
+      ceph_assert(interrupt_cond<InterruptCond>);
       auto fut = core_type::handle_error(
 	[errfunc=std::move(errfunc),
 	 interrupt_condition=interrupt_cond<InterruptCond>]
@@ -885,7 +885,7 @@ public:
 	    typename... ErrorFuncTail>
   auto handle_error_interruptible(ErrorFuncHead&& error_func_head,
 				  ErrorFuncTail&&... error_func_tail) {
-    assert(interrupt_cond<InterruptCond>);
+    ceph_assert(interrupt_cond<InterruptCond>);
     static_assert(sizeof...(ErrorFuncTail) > 0);
     return this->handle_error_interruptible(
       ::crimson::composer(
@@ -1355,7 +1355,7 @@ public:
   }
 
   static void yield() {
-    assert(interrupt_cond<InterruptCond>);
+    ceph_assert(interrupt_cond<InterruptCond>);
     auto interruption_condition = interrupt_cond<InterruptCond>;
     interrupt_cond<InterruptCond>.release();
     seastar::thread::yield();
@@ -1363,7 +1363,7 @@ public:
   }
 
   static void maybe_yield() {
-    assert(interrupt_cond<InterruptCond>);
+    ceph_assert(interrupt_cond<InterruptCond>);
     if (seastar::thread::should_yield()) {
       auto interruption_condition = interrupt_cond<InterruptCond>;
       interrupt_cond<InterruptCond>.release();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -561,9 +561,7 @@ class NodeExtentAccessorT {
         })
       );
     }).si_then([this, c] {
-      // FIXME: interruptive-future failed to check invalidation
-      // assert(!c.t.is_conflicted());
-      std::ignore = c;
+      assert(!c.t.is_conflicted());
       return *mut;
     });
   }
@@ -587,9 +585,7 @@ class NodeExtentAccessorT {
       })
 #ifndef NDEBUG
     ).si_then([c] {
-      // FIXME: interruptive-future failed to check invalidation
-      // assert(!c.t.is_conflicted());
-      std::ignore = c;
+      assert(!c.t.is_conflicted());
     }
 #endif
     );

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -107,8 +107,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
       if (trigger_eagain()) {
         DEBUGT("reading at {:#x}: trigger eagain", t, addr);
         t.test_set_conflict();
-        // FIXME: interruptive-future failed to check invalidation
-        // return read_iertr::make_ready_future<NodeExtentRef>();
+        return read_iertr::make_ready_future<NodeExtentRef>();
       }
     }
     return tm.read_extent<SeastoreNodeExtent>(t, addr
@@ -128,8 +127,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
       if (trigger_eagain()) {
         DEBUGT("allocating {}B: trigger eagain", t, len);
         t.test_set_conflict();
-        // FIXME: interruptive-future failed to check invalidation
-        // return alloc_iertr::make_ready_future<NodeExtentRef>();
+        return alloc_iertr::make_ready_future<NodeExtentRef>();
       }
     }
     return tm.alloc_extent<SeastoreNodeExtent>(t, hint, len
@@ -159,8 +157,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
         DEBUGT("retiring {}B at {:#x} -- {} : trigger eagain",
                t, len, addr, *extent);
         t.test_set_conflict();
-        // FIXME: interruptive-future failed to check invalidation
-        // return retire_iertr::now();
+        return retire_iertr::now();
       }
     }
     return tm.dec_ref(t, extent).si_then([addr, len, &t] (unsigned cnt) {
@@ -176,8 +173,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
       if (trigger_eagain()) {
         DEBUGT("get root: trigger eagain", t);
         t.test_set_conflict();
-        // FIXME: interruptive-future failed to check invalidation
-        // return getsuper_iertr::make_ready_future<Super::URef>();
+        return getsuper_iertr::make_ready_future<Super::URef>();
       }
     }
     return tm.read_onode_root(t).si_then([this, &t, &tracker](auto root_addr) {

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -90,7 +90,7 @@ struct fltree_onode_manager_test_t
 	    return with_trans_intr(*ref_t, [&](auto &t) {
 	      return manager->mkfs(t
 	      ).si_then([this, &t] {
-	        return submit_transaction_fut(t);
+	        return submit_transaction_fut2(t);
 	      });
 	    });
 	  });

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -157,6 +157,10 @@ protected:
     return tm->create_weak_transaction(Transaction::src_t::READ);
   }
 
+  auto submit_transaction_fut2(Transaction& t) {
+    return tm->submit_transaction(t);
+  }
+
   auto submit_transaction_fut(Transaction &t) {
     return with_trans_intr(
       t,


### PR DESCRIPTION
Release build of seastar invokes continuations synchronously if their predecessor futures
are resolved at the time when those continuations are constructed, so we have to allow
these circumstances to happen
    
Fixes: https://tracker.ceph.com/issues/52275
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
