### PR TITLE
doc: clarify use of `rados rm` command

### DIFF
--- a/doc/man/8/rados.rst
+++ b/doc/man/8/rados.rst
@@ -264,8 +264,8 @@ Pool specific commands
 :command:`append` *name* *infile*
   Append object name to the cluster with contents from infile.
 
-:command:`rm` *name*
-  Remove object name.
+:command:`rm` [--force-full] *name* ...
+  Remove object(s) with name(s). With ``--force-full`` will remove when cluster is marked full.
 
 :command:`listwatchers` *name*
   List the watchers of object name.

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -107,7 +107,7 @@ void usage(ostream& out)
 "   append <obj-name> <infile>       append object\n"
 "   truncate <obj-name> length       truncate object\n"
 "   create <obj-name>                create object\n"
-"   rm <obj-name> ...[--force-full]  [force no matter full or not]remove object(s)\n"
+"   rm <obj-name> ... [--force-full] remove object(s), --force-full forces remove when cluster is full\n"
 "   cp <obj-name> [target-obj]       copy object\n"
 "   listxattr <obj-name>             list attrs of this object\n"
 "   getxattr <obj-name> <attr>       get the <attr> attribute of this object\n"


### PR DESCRIPTION
The man page did not make it clear that multiple objects could be specified, nor did it describe use of "--force-full".

Info displayed about "rm" with `rados --help` was poorly formatted and the wording was adjusted.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>

Fixes: https://tracker.ceph.com/issues/52288