### PR TITLE
doc: improve RBD "Block Devices and Nomad"

### DIFF
--- a/doc/rbd/rbd-nomad.rst
+++ b/doc/rbd/rbd-nomad.rst
@@ -2,15 +2,18 @@
  Block Devices and Nomad
 =========================
 
-Like Kubernetes, Nomad can use Ceph Block Device thanks to `ceph-csi`_, 
-which allow to dynamically provision RBD images or import existing one.
+Like Kubernetes, Nomad can use Ceph Block Device. This is made possible by
+`ceph-csi`_, which allows you to dynamically provision RBD images or import
+existing RBD images.
 
-Every nomad version can use `ceph-csi`_, however we'll here describe the
-latest version available at writing time, Nomad v1.1.2 .
+Every version of Nomad is compatible with `ceph-csi`_, but the reference
+version of Nomad that was used to generate the procedures and guidance in this
+document is Nomad v1.1.2, the latest version available at the time of the
+writing of the document.
 
 To use Ceph Block Devices with Nomad, you must install
 and configure ``ceph-csi`` within your Nomad environment. The following
-diagram depicts the Nomad/Ceph technology stack.
+diagram shows the Nomad/Ceph technology stack.
 
 .. ditaa::
             +-------------------------+-------------------------+
@@ -43,11 +46,11 @@ diagram depicts the Nomad/Ceph technology stack.
             +------------------------+ +------------------------+
 
 .. note::
-    Nomad has many task drivers, but we'll only use a Docker container in this example.
+    Nomad has many possible task drivers, but this example uses only a Docker container.
 
 .. important::
-   ``ceph-csi`` uses the RBD kernel modules by default which may not support all
-   Ceph `CRUSH tunables`_ or `RBD image features`_.
+   ``ceph-csi`` uses the RBD kernel modules by default, which may not support
+   all Ceph `CRUSH tunables`_ or `RBD image features`_.
 
 Create a Pool
 =============


### PR DESCRIPTION
This PR improves the English syntax and
spelling in the "Block Devices and Nomad"
section of the rbd-nomad.rst page.

This PR rewrites the top-level matter.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
