### PR TITLE
doc: improve "Create a Pool" in rbd-nomad.rst

### DIFF
--- a/doc/rbd/rbd-nomad.rst
+++ b/doc/rbd/rbd-nomad.rst
@@ -52,20 +52,23 @@ diagram depicts the Nomad/Ceph technology stack.
 Create a Pool
 =============
 
-By default, Ceph block devices use the ``rbd`` pool. Create a pool for
-Nopmad persistent storage. Ensure your Ceph cluster is running, then create
-the pool. ::
+By default, Ceph block devices use the ``rbd`` pool. Ensure that your Ceph
+cluster is running, then create a pool for Nomad persistent storage:
 
-        $ ceph osd pool create nomad
+.. prompt:: bash $
+
+  ceph osd pool create nomad
 
 See `Create a Pool`_ for details on specifying the number of placement groups
-for your pools, and `Placement Groups`_ for details on the number of placement
+for your pools. See `Placement Groups`_ for details on the number of placement
 groups you should set for your pools.
 
 A newly created pool must be initialized prior to use. Use the ``rbd`` tool
-to initialize the pool::
+to initialize the pool:
 
-        $ rbd pool init nomad
+.. prompt:: bash $
+
+  rbd pool init nomad
 
 Configure ceph-csi
 ==================


### PR DESCRIPTION
This PR improves the English in the "Create
a Pool" section of the "RBD & Nomad Integration"
chapter of the RBD Guide.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
