### PR TITLE
doc: rewrite configure ceph-csi to "conf. nomad"

### DIFF
--- a/doc/rbd/rbd-nomad.rst
+++ b/doc/rbd/rbd-nomad.rst
@@ -73,39 +73,58 @@ Configure ceph-csi
 Setup Ceph Client Authentication
 --------------------------------
 
-Create a new user for nomad and `ceph-csi`. Execute the following and
-record the generated key::
+Create a new user for nomad and `ceph-csi`. Execute the following command and
+record the generated key:
 
-    $ ceph auth get-or-create client.nomad mon 'profile rbd' osd 'profile rbd pool=nomad' mgr 'profile rbd pool=nomad'
-    [client.nomad]
-        key = AQAlh9Rgg2vrDxAARy25T7KHabs6iskSHpAEAQ==
+.. code-block:: console
+
+  $ ceph auth get-or-create client.nomad mon 'profile rbd' osd 'profile rbd pool=nomad' mgr 'profile rbd pool=nomad'
+  [client.nomad]
+          key = AQAlh9Rgg2vrDxAARy25T7KHabs6iskSHpAEAQ==
 
 
-Configure Nomad  
+Configure Nomad
 ---------------
 
-By default Nomad doesn't allow containers to use privileged mode.
-Edit the nomad configuration file by adding this configuration block to `/etc/nomad.d/nomad.hcl`::
+Configuring Nomad to Allow Containers to Use Privileged Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, Nomad doesn't allow containers to use privileged mode. We must
+configure Nomad so that it allows containers to use privileged mode. Edit the
+Nomad configuration file by adding the following configuration block to
+`/etc/nomad.d/nomad.hcl`::
 
     plugin "docker" {
-        config {
+      config {
         allow_privileged = true
-        }
+      }
     }
 
+Loading the rbd module
+~~~~~~~~~~~~~~~~~~~~~~
 
-Nomad must have `rbd` module loaded, check if it's the case.::
+Nomad must have the `rbd` module loaded. Run the following command to confirm that the `rbd` module is loaded:
 
-        $ lsmod |grep rbd
-        rbd                    94208  2
-        libceph               364544  1 rbd
+.. code-block:: console
 
-If it's not the case, load it.::
+  $ lsmod | grep rbd
+  rbd                    94208  2
+  libceph               364544  1 rbd
 
-        $ sudo modprobe rbd
+If the `rbd` module is not loaded, load it:
 
-And restart Nomad.
+.. prompt:: bash $
 
+  sudo modprobe rbd
+
+Restarting Nomad
+~~~~~~~~~~~~~~~~
+
+Restart Nomad:
+
+.. prompt:: bash $
+
+  sudo systemctl restart nomad
 
 
 Create ceph-csi controller and plugin nodes


### PR DESCRIPTION
This PR rewrites the sections
     - Configure Ceph-CSI
     - Configure Nomad

in the rbd-nomad.rst Chapter of the RBD
Guide.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
