### PR TITLE
pacific: mgr/dashboard: fix rename inventory to disks 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/01-hosts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/01-hosts.e2e-spec.ts
@@ -33,7 +33,7 @@ describe('Hosts page', () => {
 
     it('should display inventory', function () {
       for (const host of this.hosts) {
-        hosts.clickHostTab(host.name, 'Inventory');
+        hosts.clickHostTab(host.name, 'Physical Disks');
         cy.get('cd-host-details').within(() => {
           hosts.getTableCount('total').should('be.gte', 0);
         });

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/02-hosts-inventory.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/02-hosts-inventory.e2e-spec.ts
@@ -16,7 +16,7 @@ describe('Hosts page', () => {
 
     it('should display correct inventory', function () {
       for (const host of this.hosts) {
-        hosts.clickHostTab(host.name, 'Inventory');
+        hosts.clickHostTab(host.name, 'Physical Disks');
         cy.get('cd-host-details').within(() => {
           hosts.getTableCount('total').should('be.eq', host.devices.length);
         });

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/03-inventory.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/03-inventory.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { InventoryPageHelper } from '../cluster/inventory.po';
 
-describe('Inventory page', () => {
+describe('Physical Disks page', () => {
   const inventory = new InventoryPageHelper();
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/navigation.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/navigation.po.ts
@@ -20,7 +20,7 @@ export class NavigationPageHelper extends PageHelper {
       menu: 'Cluster',
       submenus: [
         { menu: 'Hosts', component: 'cd-hosts' },
-        { menu: 'Inventory', component: 'cd-error' },
+        { menu: 'Physical Disks', component: 'cd-error' },
         { menu: 'Monitors', component: 'cd-monitor' },
         { menu: 'Services', component: 'cd-error' },
         { menu: 'OSDs', component: 'cd-osd-list' },

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -138,7 +138,7 @@ const routes: Routes = [
             section_info: 'Orchestrator',
             header: 'Orchestrator is not available'
           },
-          breadcrumbs: 'Cluster/Inventory'
+          breadcrumbs: 'Cluster/Physical Disks'
         }
       },
       {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.html
@@ -13,7 +13,7 @@
     <li ngbNavItem="inventory"
         *ngIf="permissions.hosts.read">
       <a ngbNavLink
-         i18n>Inventory</a>
+         i18n>Physical Disks</a>
       <ng-template ngbNavContent>
         <cd-inventory [hostname]="selectedHostname"></cd-inventory>
       </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.spec.ts
@@ -58,7 +58,7 @@ describe('HostDetailsComponent', () => {
     it('should show tabs', () => {
       expect(TabHelper.getTextContents(fixture)).toEqual([
         'Devices',
-        'Inventory',
+        'Physical Disks',
         'Daemons',
         'Performance Details',
         'Device health'

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -110,7 +110,7 @@
             class="tc_submenuitem tc_submenuitem_cluster_inventory"
             *ngIf="permissions.hosts.read">
           <a i18n
-             routerLink="/inventory">Physical disks</a>
+             routerLink="/inventory">Physical Disks</a>
         </li>
         <li routerLinkActive="active"
             class="tc_submenuitem tc_submenuitem_cluster_monitor"

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -110,7 +110,7 @@
             class="tc_submenuitem tc_submenuitem_cluster_inventory"
             *ngIf="permissions.hosts.read">
           <a i18n
-             routerLink="/inventory">Inventory</a>
+             routerLink="/inventory">Physical disks</a>
         </li>
         <li routerLinkActive="active"
             class="tc_submenuitem tc_submenuitem_cluster_monitor"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52291

---

backport of https://github.com/ceph/ceph/pull/41100
parent tracker: https://tracker.ceph.com/issues/50314

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh