### PR TITLE
blk: start 1st line of hexdump() on a new line

### DIFF
--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -915,7 +915,7 @@ int KernelDevice::write(
       bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX)) {
     dout(20) << __func__ << " rebuilding buffer to be aligned" << dendl;
   }
-  dout(40) << "data: ";
+  dout(40) << "data:\n";
   bl.hexdump(*_dout);
   *_dout << dendl;
 
@@ -944,7 +944,7 @@ int KernelDevice::aio_write(
       bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX)) {
     dout(20) << __func__ << " rebuilding buffer to be aligned" << dendl;
   }
-  dout(40) << "data: ";
+  dout(40) << "data:\n";
   bl.hexdump(*_dout);
   *_dout << dendl;
 
@@ -1071,7 +1071,7 @@ int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   ceph_assert((uint64_t)r == len);
   pbl->push_back(std::move(p));
 
-  dout(40) << "data: ";
+  dout(40) << "data:\n"; 
   pbl->hexdump(*_dout);
   *_dout << dendl;
 
@@ -1141,7 +1141,7 @@ int KernelDevice::direct_read_unaligned(uint64_t off, uint64_t len, char *buf)
   ceph_assert((uint64_t)r == aligned_len);
   memcpy(buf, p.c_str() + (off - aligned_off), len);
 
-  dout(40) << __func__ << " data: ";
+  dout(40) << __func__ << " data:\n";
   bufferlist bl;
   bl.append(buf, len);
   bl.hexdump(*_dout);
@@ -1214,7 +1214,7 @@ int KernelDevice::read_random(uint64_t off, uint64_t len, char *buf,
     ceph_assert((uint64_t)r == len);
   }
 
-  dout(40) << __func__ << " data: ";
+  dout(40) << __func__ << " data:\n";
   bufferlist bl;
   bl.append(buf, len);
   bl.hexdump(*_dout);

--- a/src/blk/pmem/PMEMDevice.cc
+++ b/src/blk/pmem/PMEMDevice.cc
@@ -202,7 +202,7 @@ int PMEMDevice::write(uint64_t off, bufferlist& bl, bool buffered, int write_hin
   dout(20) << __func__ << " " << off << "~" << len  << dendl;
   ceph_assert(is_valid_io(off, len));
 
-  dout(40) << "data: ";
+  dout(40) << "data:\n";
   bl.hexdump(*_dout);
   *_dout << dendl;
 
@@ -250,7 +250,7 @@ int PMEMDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   pbl->clear();
   pbl->push_back(std::move(p));
 
-  dout(40) << "data: ";
+  dout(40) << "data:\n";
   pbl->hexdump(*_dout);
   *_dout << dendl;
 

--- a/src/blk/zoned/HMSMRDevice.cc
+++ b/src/blk/zoned/HMSMRDevice.cc
@@ -901,7 +901,7 @@ int HMSMRDevice::write(
       bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX)) {
     dout(20) << __func__ << " rebuilding buffer to be aligned" << dendl;
   }
-  dout(40) << "data: ";
+  dout(40) << "data:\n";
   bl.hexdump(*_dout);
   *_dout << dendl;
 
@@ -930,7 +930,7 @@ int HMSMRDevice::aio_write(
       bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX)) {
     dout(20) << __func__ << " rebuilding buffer to be aligned" << dendl;
   }
-  dout(40) << "data: ";
+  dout(40) << "data:\n";
   bl.hexdump(*_dout);
   *_dout << dendl;
 
@@ -1056,7 +1056,7 @@ int HMSMRDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   ceph_assert((uint64_t)r == len);
   pbl->push_back(std::move(p));
 
-  dout(40) << "data: ";
+  dout(40) << "data:\n";
   pbl->hexdump(*_dout);
   *_dout << dendl;
 
@@ -1126,7 +1126,7 @@ int HMSMRDevice::direct_read_unaligned(uint64_t off, uint64_t len, char *buf)
   ceph_assert((uint64_t)r == aligned_len);
   memcpy(buf, p.c_str() + (off - aligned_off), len);
 
-  dout(40) << __func__ << " data: ";
+  dout(40) << __func__ << " data:\n";
   bufferlist bl;
   bl.append(buf, len);
   bl.hexdump(*_dout);
@@ -1199,7 +1199,7 @@ int HMSMRDevice::read_random(uint64_t off, uint64_t len, char *buf,
     ceph_assert((uint64_t)r == len);
   }
 
-  dout(40) << __func__ << " data: ";
+  dout(40) << __func__ << " data:\n";
   bufferlist bl;
   bl.append(buf, len);
   bl.hexdump(*_dout);


### PR DESCRIPTION
Otherwise the fist line looks rather strange

```
2021-08-19T23:42:33.604+0200 4f60700 40 bdev:kd:965(0x4fab180 /usr/local/src/wip.bluestore-test/build/dev/osd0/block.db) data: 00000000  56 f9 b8
 f8 1c 00 01 01  1a 6c 65 76 65 6c 64 62  |V........leveldb|
00000010  2e 42 79 74 65 77 69 73  65 43 6f 6d 70 61 72 61  |.BytewiseCompara|
00000020  74 6f 72 98 af 58 a6 02  00 01 02 00 d2 c7 3c 95  |tor..X........<.|
00000030  06 00 01 09 00 03 04 04  00 6b 93 6d c5 2b 00 01  |.........k.m.+..|
00000040  01 1a 6c 65 76 65 6c 64  62 2e 42 79 74 65 77 69  |..leveldb.Bytewi|

```

versus new:
```
2021-08-19T23:42:33.604+0200 4f60700 40 bdev:kd:965(0x4fab180 /usr/local/src/wip.bluestore-test/build/dev/osd0/block.db) data:
00000000  56 f9 b8 f8 1c 00 01 01  1a 6c 65 76 65 6c 64 62  |V........leveldb|
00000010  2e 42 79 74 65 77 69 73  65 43 6f 6d 70 61 72 61  |.BytewiseCompara|
00000020  74 6f 72 98 af 58 a6 02  00 01 02 00 d2 c7 3c 95  |tor..X........<.|
00000030  06 00 01 09 00 03 04 04  00 6b 93 6d c5 2b 00 01  |.........k.m.+..|
00000040  01 1a 6c 65 76 65 6c 64  62 2e 42 79 74 65 77 69  |..leveldb.Bytewi|
```
