### PR TITLE
pacific: mgr/dashboard: disable create snapshot with subvolumes 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.spec.ts
@@ -1073,5 +1073,39 @@ describe('CephfsDirectoriesComponent', () => {
         expect(component.loadingIndicator).toBe(true);
       });
     });
+    describe('disable create snapshot', () => {
+      let actions: CdTableAction[];
+      beforeEach(() => {
+        actions = component.snapshot.tableActions;
+        mockLib.mkDir('/', 'volumes', 2, 2);
+        mockLib.mkDir('/volumes', 'group1', 2, 2);
+        mockLib.mkDir('/volumes/group1', 'subvol', 2, 2);
+        mockLib.mkDir('/volumes/group1/subvol', 'subfile', 2, 2);
+      });
+
+      const empty = (): CdTableSelection => new CdTableSelection();
+
+      it('should return a descriptive message to explain why it is disabled', () => {
+        const path = '/volumes/group1/subvol/subfile';
+        const res = 'Cannot create snapshots for files/folders in the subvolume subvol';
+        mockLib.selectNode(path);
+        expect(actions[0].disable(empty())).toContain(res);
+      });
+
+      it('should return false if it is not a subvolume node', () => {
+        const testCases = [
+          '/volumes/group1/subvol',
+          '/volumes/group1',
+          '/volumes',
+          '/',
+          '/a',
+          '/a/b'
+        ];
+        testCases.forEach((testCase) => {
+          mockLib.selectNode(testCase);
+          expect(actions[0].disable(empty())).toBeFalsy();
+        });
+      });
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-directories/cephfs-directories.component.ts
@@ -219,7 +219,8 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
           icon: Icons.add,
           permission: 'create',
           canBePrimary: (selection) => !selection.hasSelection,
-          click: () => this.createSnapshot()
+          click: () => this.createSnapshot(),
+          disable: () => this.disableCreateSnapshot()
         },
         {
           name: this.actionLabels.DELETE,
@@ -231,6 +232,16 @@ export class CephfsDirectoriesComponent implements OnInit, OnChanges {
         }
       ]
     };
+  }
+
+  private disableCreateSnapshot(): string | boolean {
+    const folders = this.selectedDir.path.split('/').slice(1);
+    // With deph of 4 or more we have the subvolume files/folders for which we cannot create
+    // a snapshot. Somehow, you can create a snapshot of the subvolume but not its files.
+    if (folders.length >= 4 && folders[0] === 'volumes') {
+      return $localize`Cannot create snapshots for files/folders in the subvolume ${folders[2]}`;
+    }
+    return false;
   }
 
   ngOnChanges() {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52293

---

backport of https://github.com/ceph/ceph/pull/42732
parent tracker: https://tracker.ceph.com/issues/52131

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh