### PR TITLE
common: create a faster & cleaner alternative to argv_to_vec()

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -118,8 +118,7 @@ static void usage()
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -132,6 +132,12 @@ void argv_to_vec(int argc, const char **argv,
   args.insert(args.end(), argv + 1, argv + argc);
 }
 
+std::vector<const char*> argv_to_vec(int argc, const char** argv)
+{
+  assert(argc > 0);
+  return {argv + 1, argv + argc};
+}
+
 void vec_to_argv(const char *argv0, std::vector<const char*>& args,
                  int *argc, const char ***argv)
 {

--- a/src/common/ceph_argparse.h
+++ b/src/common/ceph_argparse.h
@@ -46,6 +46,7 @@ extern void clear_g_str_vec();
 extern void env_to_vec(std::vector<const char*>& args, const char *name=NULL);
 extern void argv_to_vec(int argc, const char **argv,
                  std::vector<const char*>& args);
+extern std::vector<const char*> argv_to_vec(int argc, const char** argv);
 extern void vec_to_argv(const char *argv0, std::vector<const char*>& args,
 			int *argc, const char ***argv);
 


### PR DESCRIPTION

New function signature follows current C++ guidance regarding
returning values from functions. It is also faster
(1.3X for a sample test of 10 arguments. See
https://quick-bench.com/q/IkMchTCg9I5V5DvUm7W5ya2durE
and the code in https://godbolt.org/z/dYKaxWfjx )

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>


