### PR TITLE
blk/pmem: Add namespace std for map,string

### DIFF
--- a/src/blk/pmem/PMEMDevice.cc
+++ b/src/blk/pmem/PMEMDevice.cc
@@ -54,7 +54,7 @@ int PMEMDevice::_lock()
   return 0;
 }
 
-int PMEMDevice::open(const string& p)
+int PMEMDevice::open(const std::string& p)
 {
   path = p;
   int r = 0;
@@ -128,7 +128,7 @@ void PMEMDevice::close()
   path.clear();
 }
 
-int PMEMDevice::collect_metadata(const string& prefix, map<string,string> *pm) const
+int PMEMDevice::collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const
 {
   (*pm)[prefix + "rotational"] = stringify((int)(bool)rotational);
   (*pm)[prefix + "size"] = stringify(get_size());

--- a/src/blk/pmem/PMEMDevice.h
+++ b/src/blk/pmem/PMEMDevice.h
@@ -18,6 +18,8 @@
 #define CEPH_BLK_PMEMDEVICE_H
 
 #include <atomic>
+#include <map>
+#include <string>
 
 #include "os/fs/FS.h"
 #include "include/interval_set.h"
@@ -41,7 +43,7 @@ public:
 
   void aio_submit(IOContext *ioc) override;
 
-  int collect_metadata(const std::string& prefix, map<std::string,std::string> *pm) const override;
+  int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const override;
 
   static bool support(const std::string& path);
 


### PR DESCRIPTION
Due to not use namespace std for map,string, it leads to
`map,string` not be declared.

Signed-off-by: Feng Hualong <hualong.feng@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
