### PR TITLE
test/common/test_fair_mutex: increase NR_ROUNDS from 256 to 512

### DIFF
--- a/src/test/common/test_fair_mutex.cc
+++ b/src/test/common/test_fair_mutex.cc
@@ -34,7 +34,7 @@ TEST(FairMutex, fair)
   ceph::fair_mutex mutex{"fair::fair"};
   const int NR_TEAMS = 2;
   std::array<unsigned, NR_TEAMS> scoreboard{0, 0};
-  const int NR_ROUNDS = 256;
+  const int NR_ROUNDS = 512;
   auto play = [&](int team) {
     for (int i = 0; i < NR_ROUNDS; i++) {
       std::unique_lock lock{mutex};

--- a/src/test/common/test_fair_mutex.cc
+++ b/src/test/common/test_fair_mutex.cc
@@ -3,7 +3,7 @@
 #include <array>
 #include <mutex>
 #include <numeric>
-#include <thread>
+#include <future>
 #include <gtest/gtest.h>
 #include "common/fair_mutex.h"
 
@@ -61,11 +61,8 @@ TEST(FairMutex, fair)
       };
     }
   };
-  std::array<std::thread, NR_TEAMS> teams;
+  std::array<std::future<void>, NR_TEAMS> completed;
   for (int team = 0; team < NR_TEAMS; team++) {
-    teams[team] = std::thread(play, team);
-  }
-  for (auto& team : teams) {
-    team.join();
+    completed[team] = std::async(std::launch::async, play, team);
   }
 }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
