### PR TITLE
cephadm: check for openntpd.service as time sync service

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -5784,6 +5784,7 @@ def check_time_sync(ctx, enabler=None):
         'ntpd.service',  # el7 (at least)
         'ntp.service',  # 18.04 (at least)
         'ntpsec.service',  # 20.04 (at least) / buster
+        'openntpd.service',  # ubuntu / debian
     ]
     if not check_units(ctx, units, enabler):
         logger.warning('No time sync service is running; checked for %s' % units)


### PR DESCRIPTION
openntpd is an alternative implementation of time synchronization
by the openbsd project and is packaged for debian and ubuntu
since at least jessie / 18.04 with the service named openntpd.service

Signed-off-by: Oleander Reis <oleander.reis@hostserver.de>