### PR TITLE
rgw: fix bucket index list test error

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2599,6 +2599,7 @@ static int list_plain_entries_help(cls_method_context_t hctx,
 	      escape_str(e.key.name).c_str());
       // skip the rest of the entries
       more = false;
+      end_key_reached = true;
       return count;
     }
 
@@ -2623,8 +2624,17 @@ static int list_plain_entries_help(cls_method_context_t hctx,
   } // iter for loop
 
   return count;
-}
+} // list_plain_entries_help
 
+/*
+ * Lists plain entries in either or both regions, the region of those
+ * beginning with an ASCII character or a non-ASCII character, which
+ * surround the "ugly" namespace used by special entries for versioned
+ * buckets.
+ *
+ * The entries parameter is not cleared and additional entries are
+ * appended to it.
+ */
 static int list_plain_entries(cls_method_context_t hctx,
                               const std::string& name_filter,
                               const std::string& marker,
@@ -2633,9 +2643,9 @@ static int list_plain_entries(cls_method_context_t hctx,
                               bool* pmore,
 			      const PlainEntriesRegion region = PlainEntriesRegion::Both)
 {
-  int r;
-  bool end_key_reached;
-  bool more;
+  int r = 0;
+  bool end_key_reached = false;
+  bool more = false;
   const size_t start_size = entries->size();
 
   if (region <= PlainEntriesRegion::Both && marker < BI_PREFIX_BEGIN) {
@@ -2647,10 +2657,11 @@ static int list_plain_entries(cls_method_context_t hctx,
     }
 
     // see if we're done for this call (there may be more for a later call)
-    if (r >= int(max) || !end_key_reached || (!more && region != PlainEntriesRegion::Both)) {
+    if (r >= int(max) || !end_key_reached || (!more && region == PlainEntriesRegion::Low)) {
       if (pmore) {
 	*pmore = more;
       }
+
       return int(entries->size() - start_size);
     }
 
@@ -2661,8 +2672,8 @@ static int list_plain_entries(cls_method_context_t hctx,
     const std::string start_after_key = std::max(marker, BI_PREFIX_END);
 
     // listing non-ascii plain namespace
-    r = list_plain_entries_help(hctx, name_filter, start_after_key, {}, max, entries,
-				end_key_reached, more);
+    r = list_plain_entries_help(hctx, name_filter, start_after_key, {}, max,
+				entries, end_key_reached, more);
     if (r < 0) {
       return r;
     }
@@ -2891,10 +2902,12 @@ static int rgw_bi_list_op(cls_method_context_t hctx,
     return -EINVAL;
   }
 
+  constexpr uint32_t MAX_BI_LIST_ENTRIES = 1000;
+  const uint32_t max = std::min(op.max, MAX_BI_LIST_ENTRIES);
+
+
   int ret;
-  int count = 0;
-  constexpr int MAX_BI_LIST_ENTRIES = 1000;
-  const int32_t max = (op.max < MAX_BI_LIST_ENTRIES ? op.max : MAX_BI_LIST_ENTRIES);
+  uint32_t count = 0;
   bool more = false;
   rgw_cls_bi_list_ret op_ret;
 
@@ -2938,7 +2951,7 @@ static int rgw_bi_list_op(cls_method_context_t hctx,
       return ret;
     }
 
-    count = ret;
+    count += ret;
     CLS_LOG(20, "found %d non-ascii (high) plain entries", count);
   }
 
@@ -2951,7 +2964,7 @@ static int rgw_bi_list_op(cls_method_context_t hctx,
   encode(op_ret, *out);
 
   return 0;
-}
+} // rgw_bi_list_op
 
 
 int bi_log_record_decode(bufferlist& bl, rgw_bi_log_entry& e)

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -562,14 +562,14 @@ TEST_F(cls_rgw, bi_list)
   cls_rgw_bucket_init_index(op);
   ASSERT_EQ(0, ioctx.operate(bucket_oid, &op));
 
-  string name;
-  string marker;
+  const std::string empty_name_filter;
   uint64_t max = 10;
-  list<rgw_cls_bi_entry> entries;
+  std::list<rgw_cls_bi_entry> entries;
   bool is_truncated;
+  std::string marker;
 
-  int ret = cls_rgw_bi_list(ioctx, bucket_oid, name, marker, max, &entries,
-			    &is_truncated);
+  int ret = cls_rgw_bi_list(ioctx, bucket_oid, empty_name_filter, marker, max,
+			    &entries, &is_truncated);
   ASSERT_EQ(ret, 0);
   ASSERT_EQ(entries.size(), 0u) <<
     "The listing of an empty bucket as 0 entries.";
@@ -578,7 +578,7 @@ TEST_F(cls_rgw, bi_list)
 
   uint64_t epoch = 1;
   uint64_t obj_size = 1024;
-  uint64_t num_objs = 35;
+  const uint64_t num_objs = 35;
 
   for (uint64_t i = 0; i < num_objs; i++) {
     string obj = str_int(i % 4 ? "obj" : "об'єкт", i);
@@ -594,8 +594,8 @@ TEST_F(cls_rgw, bi_list)
 		   RGW_BILOG_FLAG_VERSIONED_OP);
   }
 
-  ret = cls_rgw_bi_list(ioctx, bucket_oid, name, marker, num_objs + 10, &entries,
-			    &is_truncated);
+  ret = cls_rgw_bi_list(ioctx, bucket_oid, empty_name_filter, marker, num_objs + 10,
+			&entries, &is_truncated);
   ASSERT_EQ(ret, 0);
   if (is_truncated) {
     ASSERT_LT(entries.size(), num_objs);
@@ -606,9 +606,10 @@ TEST_F(cls_rgw, bi_list)
   uint64_t num_entries = 0;
 
   is_truncated = true;
+  marker.clear();
   while(is_truncated) {
-    ret = cls_rgw_bi_list(ioctx, bucket_oid, name, marker, max, &entries,
-			  &is_truncated);
+    ret = cls_rgw_bi_list(ioctx, bucket_oid, empty_name_filter, marker, max,
+			  &entries, &is_truncated);
     ASSERT_EQ(ret, 0);
     if (is_truncated) {
       ASSERT_LT(entries.size(), num_objs - num_entries);
@@ -619,8 +620,9 @@ TEST_F(cls_rgw, bi_list)
     marker = entries.back().idx;
   }
 
-  ret = cls_rgw_bi_list(ioctx, bucket_oid, name, marker, max, &entries,
-			&is_truncated);
+  // try with marker as final entry
+  ret = cls_rgw_bi_list(ioctx, bucket_oid, empty_name_filter, marker, max,
+			&entries, &is_truncated);
   ASSERT_EQ(ret, 0);
   ASSERT_EQ(entries.size(), 0u);
   ASSERT_EQ(is_truncated, false);
@@ -631,8 +633,8 @@ TEST_F(cls_rgw, bi_list)
     is_truncated = true;
     marker.clear();
     while(is_truncated) {
-      ret = cls_rgw_bi_list(ioctx, bucket_oid, name, marker, max, &entries,
-			    &is_truncated);
+      ret = cls_rgw_bi_list(ioctx, bucket_oid, empty_name_filter, marker, max,
+			    &entries, &is_truncated);
       ASSERT_EQ(ret, 0);
       if (is_truncated) {
 	ASSERT_LT(entries.size(), num_objs - num_entries);
@@ -642,13 +644,57 @@ TEST_F(cls_rgw, bi_list)
       num_entries += entries.size();
       marker = entries.back().idx;
     }
+
+    // try with marker as final entry
+    ret = cls_rgw_bi_list(ioctx, bucket_oid, empty_name_filter, marker, max,
+			  &entries, &is_truncated);
+    ASSERT_EQ(ret, 0);
+    ASSERT_EQ(entries.size(), 0u);
+    ASSERT_EQ(is_truncated, false);
   }
 
-  ret = cls_rgw_bi_list(ioctx, bucket_oid, name, marker, max, &entries,
-			&is_truncated);
-  ASSERT_EQ(ret, 0);
-  ASSERT_EQ(entries.size(), 0u);
-  ASSERT_EQ(is_truncated, false);
+  // test with name filters; pairs contain filter and expected number of elements returned
+  const std::list<std::pair<const std::string,unsigned>> filters_results =
+    { { str_int("obj", 9), 1 },
+      { str_int("об'єкт", 8), 1 },
+      { str_int("obj", 8), 0 } };
+  for (const auto& filter_result : filters_results) {
+    is_truncated = true;
+    entries.clear();
+    marker.clear();
+
+    ret = cls_rgw_bi_list(ioctx, bucket_oid, filter_result.first, marker, max,
+			  &entries, &is_truncated);
+
+    ASSERT_EQ(ret, 0) << "bi list test with name filters should succeed";
+    ASSERT_EQ(entries.size(), filter_result.second) <<
+      "bi list test with filters should return the correct number of results";
+    ASSERT_EQ(is_truncated, false) <<
+      "bi list test with filters should return correct truncation indicator";
+  }
+
+  // test whether combined segment count is correcgt
+  is_truncated = false;
+  entries.clear();
+  marker.clear();
+
+  ret = cls_rgw_bi_list(ioctx, bucket_oid, empty_name_filter, marker, num_objs - 1,
+			&entries, &is_truncated);
+  ASSERT_EQ(ret, 0) << "combined segment count should succeed";
+  ASSERT_EQ(entries.size(), num_objs - 1) <<
+    "combined segment count should return the correct number of results";
+  ASSERT_EQ(is_truncated, true) <<
+    "combined segment count should return correct truncation indicator";
+
+
+  marker = entries.back().idx; // advance marker
+  ret = cls_rgw_bi_list(ioctx, bucket_oid, empty_name_filter, marker, num_objs - 1,
+			&entries, &is_truncated);
+  ASSERT_EQ(ret, 0) << "combined segment count should succeed";
+  ASSERT_EQ(entries.size(), 1) <<
+    "combined segment count should return the correct number of results";
+  ASSERT_EQ(is_truncated, false) <<
+    "combined segment count should return correct truncation indicator";
 }
 
 /* test garbage collection */


### PR DESCRIPTION
Fix bug surrounding calculation of number of entries returned. Add additional level 20 logging. 

In test, make sure marker is cleared. Put end-of-list check inside the conditional with the rest of the test. End use of uninitialized variable.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>

Fixes: https://tracker.ceph.com/issues/52315