### PR TITLE
crimson/common: keep ref count of crimson::interruptible::interrupt_cond

### DIFF
--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -146,8 +146,8 @@ auto call_with_interruption_impl(
   // 		});
   // 	})
   // In this case, as crimson::do_for_each would directly do futurize_invoke
-  // for "call_with_interruption", we have make sure this invocation would
-  // errorly release ::crimson::interruptible::interrupt_cond<InterruptCond>
+  // for "call_with_interruption", we have to make sure this invocation would
+  // not errorly release ::crimson::interruptible::interrupt_cond<InterruptCond>
 
   // If there exists an interrupt condition, which means "Func" may not be
   // permitted to run as a result of the interruption, test it. If it does

--- a/src/crimson/os/seastore/transaction.cc
+++ b/src/crimson/os/seastore/transaction.cc
@@ -3,6 +3,6 @@
 
 namespace crimson::interruptible {
 template
-thread_local InterruptCondRef<::crimson::os::seastore::TransactionConflictCondition>
+thread_local interrupt_cond_t<::crimson::os::seastore::TransactionConflictCondition>
 interrupt_cond<::crimson::os::seastore::TransactionConflictCondition>;
 }

--- a/src/test/crimson/test_interruptible_future.cc
+++ b/src/test/crimson/test_interruptible_future.cc
@@ -52,31 +52,31 @@ TEST_F(seastar_test_suite_t, basic)
   run_async([] {
     interruptor::with_interruption(
       [] {
-	ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+	ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	return interruptor::make_interruptible(seastar::now())
 	.then_interruptible([] {
-	  ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+	  ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	}).then_interruptible([] {
-	  ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+	  ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	  return errorator<ct_error::enoent>::make_ready_future<>();
 	}).safe_then_interruptible([] {
-	  ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+	  ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	  return seastar::now();
 	}, errorator<ct_error::enoent>::all_same_way([] {
-	  ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+	  ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	  })
 	);
       }, [](std::exception_ptr) {}, false).get0();
 
     interruptor::with_interruption(
       [] {
-	ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+	ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	return interruptor::make_interruptible(seastar::now())
 	.then_interruptible([] {
-	  ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+	  ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	});
       }, [](std::exception_ptr) {
-	ceph_assert(!interruptible::interrupt_cond<TestInterruptCondition>);
+	ceph_assert(!interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	return seastar::now();
       }, true).get0();
 
@@ -94,14 +94,14 @@ TEST_F(seastar_test_suite_t, loops)
     interruptor::with_interruption(
       [] {
 	std::cout << "interruptiion enabled" << std::endl;
-	ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+	ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	return interruptor::make_interruptible(seastar::now())
 	.then_interruptible([] {
 	  std::cout << "test seastar future do_for_each" << std::endl;
 	  std::vector<int> vec = {1, 2};
 	  return seastar::do_with(std::move(vec), [](auto& vec) {
 	    return interruptor::do_for_each(std::begin(vec), std::end(vec), [](int) {
-	      ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+	      ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	      return seastar::now();
 	    });
 	  });
@@ -110,14 +110,14 @@ TEST_F(seastar_test_suite_t, loops)
 	  std::vector<int> vec = {1, 2};
 	  return seastar::do_with(std::move(vec), [](auto& vec) {
 	    return interruptor::do_for_each(std::begin(vec), std::end(vec), [](int) {
-	      ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+	      ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	      return interruptor::make_interruptible(seastar::now());
 	    });
 	  });
 	}).then_interruptible([] {
 	  std::cout << "test seastar future repeat" << std::endl;
 	  return interruptor::repeat([] {
-	    ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+	    ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	    return interruptor::make_interruptible(
 		seastar::make_ready_future<
 		  seastar::stop_iteration>(
@@ -126,7 +126,7 @@ TEST_F(seastar_test_suite_t, loops)
 	}).then_interruptible([] {
 	  std::cout << "test interruptible seastar future repeat" << std::endl;
 	  return interruptor::repeat([] {
-	    ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+	    ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	    return seastar::make_ready_future<
 		    seastar::stop_iteration>(
 		      seastar::stop_iteration::yes);
@@ -138,14 +138,14 @@ TEST_F(seastar_test_suite_t, loops)
 	    using namespace std::chrono_literals;
 	    return interruptor::make_interruptible(seastar::now()).then_interruptible([&vec] {
 	      return interruptor::do_for_each(std::begin(vec), std::end(vec), [](int) {
-		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 		return interruptor::make_interruptible(
 		  errorator<ct_error::enoent>::make_ready_future<>());
 	      }).safe_then_interruptible([] {
-		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 		return seastar::now();
 	      }, errorator<ct_error::enoent>::all_same_way([] {
-		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	      }));
 	    });
 	  });
@@ -156,18 +156,18 @@ TEST_F(seastar_test_suite_t, loops)
 	    using namespace std::chrono_literals;
 	    return interruptor::make_interruptible(seastar::now()).then_interruptible([&vec] {
 	      return interruptor::do_for_each(std::begin(vec), std::end(vec), [](int) {
-		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 		return errorator<ct_error::enoent>::make_ready_future<>();
 	      }).safe_then_interruptible([] {
-		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 		return seastar::now();
 	      }, errorator<ct_error::enoent>::all_same_way([] {
-		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	      }));
 	    });
 	  });
 	}).then_interruptible([] {
-	  ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>);
+	  ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
 	  return seastar::now();
 	});
       }, [](std::exception_ptr) {}, false).get0();


### PR DESCRIPTION

Fixes: https://tracker.ceph.com/issues/52305
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
