### PR TITLE
run-make-check.sh: fix run-make-check.sh skipping cmake options 

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -69,6 +69,7 @@ function main() {
         echo "Please fix 'hostname --fqdn', otherwise 'make check' will fail"
         return 1
     fi
+    # uses run-make.sh to install-deps
     FOR_MAKE_CHECK=1 prepare
     local cxx_compiler=g++
     local c_compiler=gcc
@@ -98,7 +99,7 @@ function main() {
     if [ $WITH_PMEM ]; then
         cmake_opts+=" -DWITH_RBD_RWL=ON -DWITH_SYSTEM_PMDK=ON"
     fi
-    configure $cmake_opts $@
+    configure "$cmake_opts" "$@"
     build tests
     echo "make check: successful build on $(git rev-parse HEAD)"
     run


### PR DESCRIPTION
looking into a failed log:

looks like we are also not using ninja[1]:
```+ cmake -DWITH_CCACHE=ON -DBOOST_J=12 -DWITH_SYSTEM_BOOST=ON -DBOOST_ROOT=/opt/ceph -DWITH_PYTHON3=3 -DWITH_GTEST_PARALLEL=ON -DWITH_FIO=ON -DWITH_CEPHFS_SHELL=ON -DWITH_GRAFANA=ON -DWITH_SPDK=ON -DENABLE_GIT_VERSION=OFF -DWITH_SEASTAR=ON -DWITH_ZBD=ON ..```

speaks
```
    cmake_opts+=" -DCMAKE_CXX_COMPILER=$cxx_compiler -DCMAKE_C_COMPILER=$c_compiler"
    cmake_opts+=" -DCMAKE_CXX_FLAGS_DEBUG=\-Werror"
    cmake_opts+=" -DENABLE_GIT_VERSION=OFF"

```
the first 2 options here were skipped
locally args build: `+ echo -GNinja -DWITH_PYTHON3=3 -DWITH_CCACHE=ON`
works fine, needs to investigate jenkins

[1] https://jenkins.ceph.com/job/ceph-pull-requests/81328/consoleText


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
