### PR TITLE
cephadm: modify ceph-volume bindmount propagation

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2420,7 +2420,7 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
         if ctx.shared_ceph_folder:  # make easy manager modules/ceph-volume development
             ceph_folder = pathify(ctx.shared_ceph_folder)
             if os.path.exists(ceph_folder):
-                mounts[ceph_folder + '/src/ceph-volume/ceph_volume'] = '/usr/lib/python3.6/site-packages/ceph_volume'
+                mounts[ceph_folder + '/src/ceph-volume/ceph_volume'] = '/usr/lib/python3.6/site-packages/ceph_volume:rshared'
                 mounts[ceph_folder + '/src/cephadm/cephadm'] = '/usr/sbin/cephadm'
                 mounts[ceph_folder + '/src/pybind/mgr'] = '/usr/share/ceph/mgr'
                 mounts[ceph_folder + '/src/python-common/ceph'] = '/usr/lib/python3.6/site-packages/ceph'


### PR DESCRIPTION
When using `--shared_ceph_folder` which is essentially intended for
development purposes, it can be useful to see the ceph-volume source
code from any containers launched by cephadm.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
