### PR TITLE
common: modify 'main()s' to use new argv_to_vec() signature 

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -92,8 +92,7 @@ void usage()
 int main(int argc, const char **argv, const char *envp[]) {
   int filer_flags = 0;
   //cerr << "ceph-fuse starting " << myrank << "/" << world << std::endl;
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -83,8 +83,7 @@ int main(int argc, const char **argv)
 {
   ceph_pthread_setname(pthread_self(), "ceph-mds");
 
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/ceph_mgr.cc
+++ b/src/ceph_mgr.cc
@@ -43,8 +43,7 @@ int main(int argc, const char **argv)
 {
   ceph_pthread_setname(pthread_self(), "ceph-mgr");
 
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     std::cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -260,8 +260,7 @@ int main(int argc, const char **argv)
   bool yes_really = false;
   std::string osdmapfn, inject_monmap, extract_monmap, crush_loc;
 
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/ceph_syn.cc
+++ b/src/ceph_syn.cc
@@ -41,8 +41,7 @@ extern int syn_filer_flags;
 int main(int argc, const char **argv, char *envp[]) 
 {
   //cerr << "ceph-syn starting" << std::endl;
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY, 0);

--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -126,13 +126,7 @@ void env_to_vec(std::vector<const char*>& args, const char *name)
   args.insert(args.end(), arguments.begin(), arguments.end());
 }
 
-void argv_to_vec(int argc, const char **argv,
-                 std::vector<const char*>& args)
-{
-  args.insert(args.end(), argv + 1, argv + argc);
-}
-
-std::vector<const char*> argv_to_vec(int argc, const char** argv)
+std::vector<const char*> argv_to_vec(int argc, const char* const * argv)
 {
   assert(argc > 0);
   return {argv + 1, argv + argc};

--- a/src/common/ceph_argparse.h
+++ b/src/common/ceph_argparse.h
@@ -43,10 +43,8 @@ public:
 /////////////////////// Functions ///////////////////////
 extern void string_to_vec(std::vector<std::string>& args, std::string argstr);
 extern void clear_g_str_vec();
-extern void env_to_vec(std::vector<const char*>& args, const char *name=NULL);
-extern void argv_to_vec(int argc, const char **argv,
-                 std::vector<const char*>& args);
-extern std::vector<const char*> argv_to_vec(int argc, const char** argv);
+extern void env_to_vec(std::vector<const char*>& args, const char *name=nullptr);
+extern std::vector<const char*> argv_to_vec(int argc, const char* const * argv);
 extern void vec_to_argv(const char *argv0, std::vector<const char*>& args,
 			int *argc, const char ***argv);
 

--- a/src/dokan/ceph_dokan.cc
+++ b/src/dokan/ceph_dokan.cc
@@ -989,8 +989,7 @@ int do_map() {
 boost::intrusive_ptr<CephContext> do_global_init(
   int argc, const char **argv, Command cmd)
 {
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   code_environment_t code_env;
   int flags;
@@ -1032,8 +1031,7 @@ int main(int argc, const char** argv)
   g_cfg = new Config;
 
   Command cmd = Command::None;
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   std::ostringstream err_msg;
   int r = parse_args(args, &err_msg, &cmd, g_cfg);
   if (r) {

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -275,10 +275,8 @@ public:
 
   int conf_parse_argv(int argc, const char **argv)
   {
-    int ret;
-    vector<const char*> args;
-    argv_to_vec(argc, argv, args);
-    ret = cct->_conf.parse_argv(args);
+    auto args = argv_to_vec(argc, argv);
+    int ret = cct->_conf.parse_argv(args);
     if (ret)
 	return ret;
     cct->_conf.apply_changes(nullptr);

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -317,8 +317,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_conf_parse_argv)(
   }
   librados::RadosClient *client = (librados::RadosClient *)cluster;
   auto& conf = client->cct->_conf;
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   int ret = conf.parse_argv(args);
   if (ret) {
     tracepoint(librados, rados_conf_parse_argv_exit, ret);

--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -369,10 +369,9 @@ TEST(Log, GarbleRecovery)
 
 int main(int argc, char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/rbd_replay/rbd-replay.cc
+++ b/src/rbd_replay/rbd-replay.cc
@@ -55,9 +55,7 @@ static void usage(const char* program) {
 }
 
 int main(int argc, const char **argv) {
-  vector<const char*> args;
-
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -752,14 +752,13 @@ int librgw_create(librgw_t* rgw, int argc, char **argv)
   if (! g_ceph_context) {
     std::lock_guard<std::mutex> lg(librgw_mtx);
     if (! g_ceph_context) {
-      vector<const char*> args;
       std::vector<std::string> spl_args;
       // last non-0 argument will be split and consumed
       if (argc > 1) {
 	const std::string spl_arg{argv[(--argc)]};
 	get_str_vec(spl_arg, " \t", spl_args);
       }
-      argv_to_vec(argc, const_cast<const char**>(argv), args);
+      auto args = argv_to_vec(argc, argv);
       // append split args, if any
       for (const auto& elt : spl_args) {
 	args.push_back(elt.c_str());

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3151,8 +3151,7 @@ void init_realm_param(CephContext *cct, string& var, std::optional<string>& opt_
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/rgw/rgw_es_main.cc
+++ b/src/rgw/rgw_es_main.cc
@@ -16,8 +16,7 @@ using namespace std;
 
 int main(int argc, char *argv[])
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY, 0);

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -196,8 +196,7 @@ int radosgw_Main(int argc, const char **argv)
     { "ms_mon_client_mode", "secure" }
   };
 
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/rgw/rgw_object_expirer.cc
+++ b/src/rgw/rgw_object_expirer.cc
@@ -53,8 +53,7 @@ static void usage()
 
 int main(const int argc, const char **argv)
 {
-  vector<const char *> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/rgw/rgw_token.cc
+++ b/src/rgw/rgw_token.cc
@@ -62,9 +62,8 @@ void usage()
 
 int main(int argc, char **argv)
 {
+  auto args = argv_to_vec(argc, argv);
   std::string val;
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);
@@ -74,7 +73,7 @@ int main(int argc, char **argv)
     exit(0);
   }
 
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
 

--- a/src/test/ObjectMap/test_keyvaluedb_iterators.cc
+++ b/src/test/ObjectMap/test_keyvaluedb_iterators.cc
@@ -1739,8 +1739,7 @@ TEST_F(EmptyStore, UpperBoundMockDB)
 
 int main(int argc, char *argv[])
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **) argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/ObjectMap/test_object_map.cc
+++ b/src/test/ObjectMap/test_object_map.cc
@@ -657,8 +657,7 @@ public:
 
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/TestSignalHandlers.cc
+++ b/src/test/TestSignalHandlers.cc
@@ -77,8 +77,7 @@ typedef void (*test_fn_t)(void);
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/test/TestTimers.cc
+++ b/src/test/TestTimers.cc
@@ -246,10 +246,9 @@ static int safe_timer_cancellation_test(SafeTimer &safe_timer,
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
 
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/bench_log.cc
+++ b/src/test/bench_log.cc
@@ -50,8 +50,7 @@ int main(int argc, const char **argv)
 
   cout << threads << " threads, " << num << " lines per thread" << std::endl;
 
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_OSD,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/client/main.cc
+++ b/src/test/client/main.cc
@@ -21,8 +21,7 @@
  
 int main(int argc, char **argv)
 {
-  std::vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
   [[maybe_unused]] auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/test/common/get_command_descriptions.cc
+++ b/src/test/common/get_command_descriptions.cc
@@ -97,8 +97,7 @@ static void pull585()
 }
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/daemon_config.cc
+++ b/src/test/daemon_config.cc
@@ -131,8 +131,7 @@ TEST(DaemonConfig, ArgV) {
   const char *argv[] = { "foo", "--log-graylog-port", "22",
 			 "--key", "my-key", NULL };
   size_t argc = (sizeof(argv) / sizeof(argv[0])) - 1;
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   g_ceph_context->_conf.parse_argv(args);
   g_ceph_context->_conf.apply_changes(nullptr);
 

--- a/src/test/direct_messenger/test_direct_messenger.cc
+++ b/src/test/direct_messenger/test_direct_messenger.cc
@@ -424,8 +424,7 @@ TEST(DirectMessenger, StartWithoutPeer)
 int main(int argc, char **argv)
 {
   // command-line arguments
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_ANY,
                          CODE_ENVIRONMENT_DAEMON,

--- a/src/test/erasure-code/TestErasureCodeShec_all.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_all.cc
@@ -293,8 +293,7 @@ int main(int argc, char **argv)
     }
   }
 
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **) argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/erasure-code/TestErasureCodeShec_arguments.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_arguments.cc
@@ -369,10 +369,7 @@ TEST(ParameterTest, combination_all)
 
 int main(int argc, char **argv)
 {
-  int r;
-
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **) argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
@@ -383,7 +380,7 @@ int main(int argc, char **argv)
 
   create_table_shec432();
 
-  r = RUN_ALL_TESTS();
+  int r = RUN_ALL_TESTS();
 
   std::cout << "minimum_to_decode:total_num = " << count_num
       << std::endl;

--- a/src/test/filestore/TestFileStore.cc
+++ b/src/test/filestore/TestFileStore.cc
@@ -67,10 +67,9 @@ TEST(FileStore, create)
 }
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/journal/test_main.cc
+++ b/src/test/journal/test_main.cc
@@ -13,10 +13,9 @@ int main(int argc, char **argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  std::vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_OSD,
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_OSD,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_MON_CONFIG);
   g_conf().set_val("lockdep", "true");

--- a/src/test/kv_store_bench.cc
+++ b/src/test/kv_store_bench.cc
@@ -55,8 +55,7 @@ KvStoreBench::~KvStoreBench()
 }
 
 int KvStoreBench::setup(int argc, const char** argv) {
-  vector<const char*> args;
-  argv_to_vec(argc,argv,args);
+  auto args = argv_to_vec(argc, argv);
   srand(time(NULL));
 
   stringstream help;

--- a/src/test/libcephsqlite/main.cc
+++ b/src/test/libcephsqlite/main.cc
@@ -1093,8 +1093,7 @@ out:
 
 
 int main(int argc, char **argv) {
-  std::vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   std::string conf_file_list;
   std::string cluster;

--- a/src/test/librados/asio.cc
+++ b/src/test/librados/asio.cc
@@ -358,8 +358,7 @@ TEST_F(AsioRados, AsyncWriteOperationYield)
 
 int main(int argc, char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,

--- a/src/test/librgw_file.cc
+++ b/src/test/librgw_file.cc
@@ -242,14 +242,10 @@ TEST(LibRGW, SHUTDOWN) {
 
 int main(int argc, char *argv[])
 {
-  char *v{nullptr};
-  string val;
-  vector<const char*> args;
-
-  argv_to_vec(argc, const_cast<const char**>(argv), args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
 
-  v = getenv("AWS_ACCESS_KEY_ID");
+  char* v = getenv("AWS_ACCESS_KEY_ID");
   if (v) {
     access_key = v;
   }
@@ -259,6 +255,7 @@ int main(int argc, char *argv[])
     secret_key = v;
   }
 
+  string val;
   for (auto arg_iter = args.begin(); arg_iter != args.end();) {
     if (ceph_argparse_witharg(args, arg_iter, &val, "--access",
 			      (char*) nullptr)) {

--- a/src/test/librgw_file_aw.cc
+++ b/src/test/librgw_file_aw.cc
@@ -367,14 +367,10 @@ TEST(LibRGW, SHUTDOWN) {
 
 int main(int argc, char *argv[])
 {
-  char *v{nullptr};
-  string val;
-  vector<const char*> args;
-
-  argv_to_vec(argc, const_cast<const char**>(argv), args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
 
-  v = getenv("AWS_ACCESS_KEY_ID");
+  char* v = getenv("AWS_ACCESS_KEY_ID");
   if (v) {
     access_key = v;
   }
@@ -383,6 +379,8 @@ int main(int argc, char *argv[])
   if (v) {
     secret_key = v;
   }
+
+  string val;
 
   for (auto arg_iter = args.begin(); arg_iter != args.end();) {
     if (ceph_argparse_witharg(args, arg_iter, &val, "--access",

--- a/src/test/librgw_file_cd.cc
+++ b/src/test/librgw_file_cd.cc
@@ -138,14 +138,10 @@ TEST(LibRGW, SHUTDOWN) {
 
 int main(int argc, char *argv[])
 {
-  char *v{nullptr};
-  string val;
-  vector<const char*> args;
-
-  argv_to_vec(argc, const_cast<const char**>(argv), args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
 
-  v = getenv("AWS_ACCESS_KEY_ID");
+  char* v = getenv("AWS_ACCESS_KEY_ID");
   if (v) {
     access_key = v;
   }
@@ -155,6 +151,7 @@ int main(int argc, char *argv[])
     secret_key = v;
   }
 
+  string val;
   for (auto arg_iter = args.begin(); arg_iter != args.end();) {
     if (ceph_argparse_witharg(args, arg_iter, &val, "--access",
 			      (char*) nullptr)) {

--- a/src/test/librgw_file_gp.cc
+++ b/src/test/librgw_file_gp.cc
@@ -439,14 +439,10 @@ TEST(LibRGW, SHUTDOWN) {
 
 int main(int argc, char *argv[])
 {
-  char *v{nullptr};
-  string val;
-  vector<const char*> args;
-
-  argv_to_vec(argc, const_cast<const char**>(argv), args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
 
-  v = getenv("AWS_ACCESS_KEY_ID");
+  char* v = getenv("AWS_ACCESS_KEY_ID");
   if (v) {
     access_key = v;
   }
@@ -456,6 +452,7 @@ int main(int argc, char *argv[])
     secret_key = v;
   }
 
+  string val;
   for (auto arg_iter = args.begin(); arg_iter != args.end();) {
     if (ceph_argparse_witharg(args, arg_iter, &val, "--access",
 			      (char*) nullptr)) {

--- a/src/test/librgw_file_marker.cc
+++ b/src/test/librgw_file_marker.cc
@@ -427,14 +427,10 @@ TEST(LibRGW, SHUTDOWN) {
 
 int main(int argc, char *argv[])
 {
-  char *v{nullptr};
-  string val;
-  vector<const char*> args;
-
-  argv_to_vec(argc, const_cast<const char**>(argv), args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
 
-  v = getenv("AWS_ACCESS_KEY_ID");
+  char* v = getenv("AWS_ACCESS_KEY_ID");
   if (v) {
     access_key = v;
   }
@@ -444,6 +440,7 @@ int main(int argc, char *argv[])
     secret_key = v;
   }
 
+  string val;
   for (auto arg_iter = args.begin(); arg_iter != args.end();) {
     if (ceph_argparse_witharg(args, arg_iter, &val, "--access",
 			      (char*) nullptr)) {

--- a/src/test/librgw_file_nfsns.cc
+++ b/src/test/librgw_file_nfsns.cc
@@ -1114,14 +1114,10 @@ TEST(LibRGW, SHUTDOWN) {
 
 int main(int argc, char *argv[])
 {
-  char *v{nullptr};
-  string val;
-  vector<const char*> args;
-
-  argv_to_vec(argc, const_cast<const char**>(argv), args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
 
-  v = getenv("AWS_ACCESS_KEY_ID");
+  char* v = getenv("AWS_ACCESS_KEY_ID");
   if (v) {
     access_key = v;
   }
@@ -1131,6 +1127,7 @@ int main(int argc, char *argv[])
     secret_key = v;
   }
 
+  string val;
   for (auto arg_iter = args.begin(); arg_iter != args.end();) {
     if (ceph_argparse_witharg(args, arg_iter, &val, "--access",
 			      (char*) nullptr)) {

--- a/src/test/librgw_file_xattr.cc
+++ b/src/test/librgw_file_xattr.cc
@@ -371,14 +371,10 @@ TEST(LibRGW, SHUTDOWN) {
 
 int main(int argc, char *argv[])
 {
-  char *v{nullptr};
-  string val;
-  vector<const char*> args;
-
-  argv_to_vec(argc, const_cast<const char**>(argv), args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
 
-  v = getenv("AWS_ACCESS_KEY_ID");
+  char* v = getenv("AWS_ACCESS_KEY_ID");
   if (v) {
     access_key = v;
   }
@@ -388,6 +384,7 @@ int main(int argc, char *argv[])
     secret_key = v;
   }
 
+  string val;
   for (auto arg_iter = args.begin(); arg_iter != args.end();) {
     if (ceph_argparse_witharg(args, arg_iter, &val, "--access",
 			      (char*) nullptr)) {

--- a/src/test/mon/test-mon-msg.cc
+++ b/src/test/mon/test-mon-msg.cc
@@ -325,8 +325,7 @@ TEST_F(MonMsgTest, MMonJoin)
 
 int main(int argc, char *argv[])
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(nullptr, args,
 			 CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -990,11 +990,10 @@ int get_id_interval(int &first, int &last, string &str)
 
 int main(int argc, const char *argv[])
 {
-  vector<const char*> args;
   our_name = argv[0];
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
 
-  auto cct = global_init(NULL, args,
+  auto cct = global_init(nullptr, args,
 			 CEPH_ENTITY_TYPE_OSD, CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
 

--- a/src/test/msgr/perf_msgr_client.cc
+++ b/src/test/msgr/perf_msgr_client.cc
@@ -177,8 +177,7 @@ void usage(const string &name) {
 
 int main(int argc, char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/msgr/perf_msgr_server.cc
+++ b/src/test/msgr/perf_msgr_server.cc
@@ -144,8 +144,7 @@ void usage(const string &name) {
 
 int main(int argc, char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/msgr/test_frames_v2.cc
+++ b/src/test/msgr/test_frames_v2.cc
@@ -469,10 +469,9 @@ INSTANTIATE_TEST_SUITE_P(
 }  // namespace ceph::msgr::v2
 
 int main(int argc, char* argv[]) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char**)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY,
                          CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -2340,8 +2340,7 @@ INSTANTIATE_TEST_SUITE_P(
 );
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/neorados/list_pool.cc
+++ b/src/test/neorados/list_pool.cc
@@ -127,8 +127,7 @@ int main(int argc, char** argv)
 {
   using namespace std::literals;
 
-  std::vector<const char*> args;
-  argv_to_vec(argc, const_cast<const char**>(argv), args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,

--- a/src/test/neorados/start_stop.cc
+++ b/src/test/neorados/start_stop.cc
@@ -30,11 +30,10 @@ int main(int argc, char** argv)
 {
   using namespace std::literals;
 
-  std::vector<const char*> args;
-  argv_to_vec(argc, const_cast<const char**>(argv), args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
 
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(cct.get());
 

--- a/src/test/objectstore/ObjectStoreTransactionBenchmark.cc
+++ b/src/test/objectstore/ObjectStoreTransactionBenchmark.cc
@@ -241,8 +241,7 @@ void usage(const string &name) {
 
 int main(int argc, char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/objectstore/chain_xattr.cc
+++ b/src/test/objectstore/chain_xattr.cc
@@ -437,10 +437,9 @@ TEST(chain_xattr, skip_chain_cleanup_and_ensure_single_attr)
 }
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -9387,9 +9387,7 @@ TEST_P(StoreTestSpecificAUSize, Ticket45195Repro) {
 #endif  // WITH_BLUESTORE
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);

--- a/src/test/objectstore/test_bdev.cc
+++ b/src/test/objectstore/test_bdev.cc
@@ -92,9 +92,7 @@ TEST(KernelDevice, Ticket45337) {
 }
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   map<string,string> defaults = {
     { "debug_bdev", "1/20" }
   };

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -829,9 +829,7 @@ TEST(BlueFS, test_tracker_50965) {
 }
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   map<string,string> defaults = {
     { "debug_bluefs", "1/20" },
     { "debug_bdev", "1/20" }

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1691,8 +1691,7 @@ TEST(bluestore_blob_t, unused)
 }
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);

--- a/src/test/objectstore/test_idempotent.cc
+++ b/src/test/objectstore/test_idempotent.cc
@@ -41,9 +41,7 @@ typename T::iterator rand_choose(T &cont) {
 }
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);

--- a/src/test/objectstore/test_idempotent_sequence.cc
+++ b/src/test/objectstore/test_idempotent_sequence.cc
@@ -212,9 +212,8 @@ int run_command(std::string& command, std::vector<std::string>& args)
 
 int main(int argc, const char *argv[])
 {
-  vector<const char*> args;
   our_name = argv[0];
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args,
 			 CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -1289,9 +1289,7 @@ INSTANTIATE_TEST_SUITE_P(
 		    "Betelgeuse(3) D(3)"));
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);

--- a/src/test/objectstore/test_memstore_clone.cc
+++ b/src/test/objectstore/test_memstore_clone.cc
@@ -191,9 +191,7 @@ int main(int argc, char** argv)
     { "memstore_page_size", "4" }
   };
 
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);

--- a/src/test/objectstore_bench.cc
+++ b/src/test/objectstore_bench.cc
@@ -149,11 +149,8 @@ void osbench_worker(ObjectStore *os, const Config &cfg,
 
 int main(int argc, const char *argv[])
 {
-  Config cfg;
-
   // command-line arguments
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
@@ -168,6 +165,7 @@ int main(int argc, const char *argv[])
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
 
+  Config cfg;
   std::string val;
   vector<const char*>::iterator i = args.begin();
   while (i != args.end()) {

--- a/src/test/omap_bench.cc
+++ b/src/test/omap_bench.cc
@@ -31,8 +31,7 @@ using ceph::bufferlist;
 
 int OmapBench::setup(int argc, const char** argv) {
   //parse key_value_store_bench args
-  vector<const char*> args;
-  argv_to_vec(argc,argv,args);
+  auto args = argv_to_vec(argc, argv);
   for (unsigned i = 0; i < args.size(); i++) {
     if(i < args.size() - 1) {
       if (strcmp(args[i], "-t") == 0) {

--- a/src/test/os/TestLFNIndex.cc
+++ b/src/test/os/TestLFNIndex.cc
@@ -472,8 +472,7 @@ int main(int argc, char **argv) {
   if (ret < 0) {
     cerr << "SKIP LFNIndex because unable to test for xattr" << std::endl;
   } else {
-    vector<const char*> args;
-    argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
     auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			   CODE_ENVIRONMENT_UTILITY,

--- a/src/test/osd/ceph_test_osd_stale_read.cc
+++ b/src/test/osd/ceph_test_osd_stale_read.cc
@@ -168,9 +168,8 @@ TEST(OSD, StaleRead) {
 }
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto args = argv_to_vec(argc, argv);
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/test/osdc/object_cacher_stress.cc
+++ b/src/test/osdc/object_cacher_stress.cc
@@ -353,9 +353,8 @@ int correctness_test(uint64_t delay_ns)
 
 int main(int argc, const char **argv)
 {
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto args = argv_to_vec(argc, argv);
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
 

--- a/src/test/perf_local.cc
+++ b/src/test/perf_local.cc
@@ -1033,8 +1033,7 @@ void run_test(TestInfo& info)
 
 int main(int argc, char *argv[])
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/rbd_mirror/random_write.cc
+++ b/src/test/rbd_mirror/random_write.cc
@@ -150,8 +150,7 @@ void write_image(librbd::Image &image) {
 
 int main(int argc, const char **argv)
 {
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     std::cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);
@@ -161,7 +160,7 @@ int main(int argc, const char **argv)
     exit(0);
   }
 
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY,
                          CINIT_FLAG_NO_MON_CONFIG);
 

--- a/src/test/rgw/test_http_manager.cc
+++ b/src/test/rgw/test_http_manager.cc
@@ -105,9 +105,7 @@ TEST(HTTPManager, SignalThread)
 
 int main(int argc, char** argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);

--- a/src/test/rgw/test_rgw_crypto.cc
+++ b/src/test/rgw/test_rgw_crypto.cc
@@ -797,9 +797,7 @@ TEST(TestRGWCrypto, verify_Encrypt_Decrypt)
 
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);

--- a/src/test/rgw/test_rgw_manifest.cc
+++ b/src/test/rgw/test_rgw_manifest.cc
@@ -386,9 +386,7 @@ TEST(TestRGWManifest, old_obj_manifest) {
 
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);

--- a/src/test/rgw/test_rgw_period_history.cc
+++ b/src/test/rgw/test_rgw_period_history.cc
@@ -325,9 +325,7 @@ TEST(PeriodHistory, AttachAfter)
 
 int main(int argc, char** argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);

--- a/src/test/test_c2c.cc
+++ b/src/test/test_c2c.cc
@@ -34,8 +34,7 @@ void sigterm_handler(int signum)
 int main(int argc, const char **argv)
 {
   int ret = 0;
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);

--- a/src/test/test_cors.cc
+++ b/src/test/test_cors.cc
@@ -869,8 +869,7 @@ TEST(TestCORS, deletecors_test){
 }
 
 int main(int argc, char *argv[]){
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY,

--- a/src/test/test_features.cc
+++ b/src/test/test_features.cc
@@ -35,10 +35,9 @@ TEST(features, release_from_features) {
 
 int main(int argc, char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -64,8 +64,7 @@ unsigned size_mb = 200;
 const char GTEST_PRFIX[] = "--gtest_";
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/test_mempool.cc
+++ b/src/test/test_mempool.cc
@@ -436,8 +436,7 @@ TEST(mempool, check_shard_select)
 
 int main(int argc, char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/test_mutate.cc
+++ b/src/test/test_mutate.cc
@@ -40,9 +40,7 @@ static void usage(void)
 
 int main(int argc, const char **argv)
 {
-  int ret = 0;
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
@@ -83,6 +81,7 @@ int main(int argc, const char **argv)
      return 1;
   }
 
+  int ret = 0;
   librados::ObjectWriteOperation o;
   IoCtx ioctx;
   if (rados.pool_lookup(pool_name.c_str()) <= 0) {

--- a/src/test/test_rgw_admin_log.cc
+++ b/src/test/test_rgw_admin_log.cc
@@ -1560,8 +1560,7 @@ TEST(TestRGWAdmin, bilog_trim) {
 }
 
 int main(int argc, char *argv[]){
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/test_rgw_admin_meta.cc
+++ b/src/test/test_rgw_admin_meta.cc
@@ -894,8 +894,7 @@ TEST(TestRGWAdmin, meta_delete){
 }
 
 int main(int argc, char *argv[]){
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/test_rgw_ldap.cc
+++ b/src/test/test_rgw_ldap.cc
@@ -86,12 +86,10 @@ TEST(RGW_LDAP, SHUTDOWN) {
 
 int main(int argc, char *argv[])
 {
-  string val;
-  vector<const char*> args;
-
-  argv_to_vec(argc, const_cast<const char**>(argv), args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
 
+  string val;
   for (auto arg_iter = args.begin(); arg_iter != args.end();) {
     if (ceph_argparse_witharg(args, arg_iter, &val, "--access",
 			      (char*) nullptr)) {

--- a/src/test/test_rgw_token.cc
+++ b/src/test/test_rgw_token.cc
@@ -106,12 +106,10 @@ TEST(TOKEN, SHUTDOWN) {
 
 int main(int argc, char *argv[])
 {
-  string val;
-  vector<const char*> args;
-
-  argv_to_vec(argc, const_cast<const char**>(argv), args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
 
+  string val;
   for (auto arg_iter = args.begin(); arg_iter != args.end();) {
     if (ceph_argparse_flag(args, arg_iter, "--verbose",
 			      (char*) nullptr)) {

--- a/src/test/test_trans.cc
+++ b/src/test/test_trans.cc
@@ -37,8 +37,7 @@ struct Foo : public Thread {
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/testkeys.cc
+++ b/src/test/testkeys.cc
@@ -12,8 +12,7 @@ using namespace std;
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY,

--- a/src/test/testmsgr.cc
+++ b/src/test/testmsgr.cc
@@ -69,8 +69,7 @@ private:
 
 int main(int argc, const char **argv, const char *envp[]) {
 
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/test/xattr_bench.cc
+++ b/src/test/xattr_bench.cc
@@ -144,8 +144,7 @@ uint64_t do_run(ObjectStore *store, int attrsize, int numattrs,
 }
 
 int main(int argc, char **argv) {
-  vector<const char*> args;
-  argv_to_vec(argc, (const char **)argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/tools/ceph-client-debug.cc
+++ b/src/tools/ceph-client-debug.cc
@@ -84,8 +84,7 @@ int lookup_trace(ceph_mount_info *client, inodeno_t const ino)
 int main(int argc, const char **argv)
 {
   // Argument handling
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/tools/ceph-dencoder/ceph_dencoder.cc
+++ b/src/tools/ceph-dencoder/ceph_dencoder.cc
@@ -100,8 +100,7 @@ int main(int argc, const char **argv)
     }
   }
 
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
 
   Dencoder *den = NULL;

--- a/src/tools/ceph_authtool.cc
+++ b/src/tools/ceph_authtool.cc
@@ -58,9 +58,7 @@ void usage()
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   std::string add_key;
   std::string caps_fn;
   std::string import_keyring;

--- a/src/tools/ceph_conf.cc
+++ b/src/tools/ceph_conf.cc
@@ -181,7 +181,6 @@ static void maybe_override_pid(vector<const char*>& args)
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
   deque<std::string> sections;
   bool resolve_search = false;
   std::string action;
@@ -191,7 +190,7 @@ int main(int argc, const char **argv)
   std::map<string,string> filter_key_value;
   std::string dump_format;
 
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   auto orig_args = args;
   auto cct = [&args] {

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -876,8 +876,7 @@ out:
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -56,8 +56,7 @@ void usage(const char *pname)
 
 int main(int argc, const char *argv[])
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/tools/cephfs/cephfs-data-scan.cc
+++ b/src/tools/cephfs/cephfs-data-scan.cc
@@ -11,9 +11,7 @@ using namespace std;
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/tools/cephfs/cephfs-journal-tool.cc
+++ b/src/tools/cephfs/cephfs-journal-tool.cc
@@ -23,8 +23,7 @@
 
 int main(int argc, const char **argv)
 {
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     std::cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/tools/cephfs/cephfs-meta-injection.cc
+++ b/src/tools/cephfs/cephfs-meta-injection.cc
@@ -19,8 +19,7 @@ static string version = "cephfs-meta-injection v1.1";
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY, 0);

--- a/src/tools/cephfs/cephfs-table-tool.cc
+++ b/src/tools/cephfs/cephfs-table-tool.cc
@@ -11,9 +11,7 @@ using namespace std;
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/tools/cephfs_mirror/main.cc
+++ b/src/tools/cephfs_mirror/main.cc
@@ -36,8 +36,7 @@ static void handle_signal(int signum) {
 }
 
 int main(int argc, const char **argv) {
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     ::exit(1);
@@ -83,8 +82,7 @@ int main(int argc, const char **argv) {
   register_async_signal_handler_oneshot(SIGINT, handle_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_signal);
 
-  std::vector<const char*> cmd_args;
-  argv_to_vec(argc, argv, cmd_args);
+  auto cmd_args = argv_to_vec(argc, argv);
 
   Messenger *msgr = Messenger::create_client_messenger(g_ceph_context, "client");
   msgr->set_default_policy(Messenger::Policy::lossy_client(0));

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -376,8 +376,7 @@ int do_move_item(CephContext* cct,
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/tools/erasure-code/ceph-erasure-code-tool.cc
+++ b/src/tools/erasure-code/ceph-erasure-code-tool.cc
@@ -287,8 +287,7 @@ int do_decode(const std::vector<const char*> &args) {
 }
 
 int main(int argc, const char **argv) {
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY,
                          CINIT_FLAG_NO_MON_CONFIG);

--- a/src/tools/immutable_object_cache/main.cc
+++ b/src/tools/immutable_object_cache/main.cc
@@ -31,9 +31,8 @@ static void handle_signal(int signum) {
 }
 
 int main(int argc, const char **argv) {
-  std::vector<const char*> args;
+  auto args = argv_to_vec(argc, argv);
   env_to_vec(args);
-  argv_to_vec(argc, argv, args);
 
   if (ceph_argparse_need_usage(args)) {
     usage();
@@ -56,8 +55,8 @@ int main(int argc, const char **argv) {
   register_async_signal_handler_oneshot(SIGINT, handle_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_signal);
 
-  std::vector<const char*> cmd_args;
-  argv_to_vec(argc, argv, cmd_args);
+  auto cmd_args = argv_to_vec(argc, argv);
+
 
   cachectl = new ceph::immutable_obj_cache::CacheController(g_ceph_context,
                                                             cmd_args);

--- a/src/tools/monmaptool.cc
+++ b/src/tools/monmaptool.cc
@@ -182,8 +182,7 @@ bool handle_features(list<feature_op_t>& lst, MonMap &m)
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -103,8 +103,7 @@ void print_inc_upmaps(const OSDMap::Incremental& pending_inc, int fd)
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -4047,8 +4047,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 
 int main(int argc, const char **argv)
 {
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);

--- a/src/tools/rbd/Shell.cc
+++ b/src/tools/rbd/Shell.cc
@@ -28,8 +28,7 @@ static const std::string BASH_COMPLETION_SPEC("bash-completion");
 boost::intrusive_ptr<CephContext> global_init(
     int argc, const char **argv, std::vector<std::string> *command_args,
     std::vector<std::string> *global_init_args) {
-  std::vector<const char*> cmd_args;
-  argv_to_vec(argc, argv, cmd_args);
+  auto cmd_args = argv_to_vec(argc, argv);
   std::vector<const char*> args(cmd_args);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY,

--- a/src/tools/rbd_ggate/main.cc
+++ b/src/tools/rbd_ggate/main.cc
@@ -87,9 +87,7 @@ static int do_map(int argc, const char *argv[])
 
   Preforker forker;
 
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_DAEMON,
                          CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS);
@@ -402,9 +400,7 @@ int main(int argc, const char *argv[]) {
     List
   } cmd = None;
 
-  vector<const char*> args;
-
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);
@@ -418,9 +414,8 @@ int main(int argc, const char *argv[]) {
 
   std::string format;
   bool pretty_format = false;
-  std::vector<const char*>::iterator i;
 
-  for (i = args.begin(); i != args.end(); ) {
+  for (auto i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
       usage();
       return 0;

--- a/src/tools/rbd_mirror/main.cc
+++ b/src/tools/rbd_mirror/main.cc
@@ -34,8 +34,7 @@ static void handle_signal(int signum)
 
 int main(int argc, const char **argv)
 {
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     std::cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);
@@ -60,8 +59,7 @@ int main(int argc, const char **argv)
   register_async_signal_handler_oneshot(SIGINT, handle_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_signal);
 
-  std::vector<const char*> cmd_args;
-  argv_to_vec(argc, argv, cmd_args);
+  auto cmd_args = argv_to_vec(argc, argv);
 
   // disable unnecessary librbd cache
   g_ceph_context->_conf.set_val_or_die("rbd_cache", "false");

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -1566,8 +1566,7 @@ static int do_map(int argc, const char *argv[], Config *cfg, bool reconnect)
   Preforker forker;
   NBDServer *server;
 
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);
@@ -2152,9 +2151,7 @@ static int rbd_nbd(int argc, const char *argv[])
 {
   int r;
   Config cfg;
-  vector<const char*> args;
-  argv_to_vec(argc, argv, args);
-
+  auto args = argv_to_vec(argc, argv);
   std::ostringstream err_msg;
   r = parse_args(args, &err_msg, &cfg);
   if (r == HELP_INFO) {

--- a/src/tools/rbd_wnbd/rbd_wnbd.cc
+++ b/src/tools/rbd_wnbd/rbd_wnbd.cc
@@ -998,8 +998,7 @@ int construct_devpath_if_missing(Config* cfg)
 boost::intrusive_ptr<CephContext> do_global_init(
   int argc, const char *argv[], Config *cfg)
 {
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   code_environment_t code_env;
   int flags;
@@ -1593,10 +1592,8 @@ static int parse_args(std::vector<const char*>& args,
 
 static int rbd_wnbd(int argc, const char *argv[])
 {
-  int r;
   Config cfg;
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
+  auto args = argv_to_vec(argc, argv);
 
   // Avoid using dout before calling "do_global_init"
   if (args.empty()) {
@@ -1605,7 +1602,7 @@ static int rbd_wnbd(int argc, const char *argv[])
   }
 
   std::ostringstream err_msg;
-  r = parse_args(args, &err_msg, &cmd, &cfg);
+  int r = parse_args(args, &err_msg, &cmd, &cfg);
   if (r == HELP_INFO) {
     usage();
     return 0;


### PR DESCRIPTION

A followup to PR #42820 that modified argv_to_vec() signature
(for style and performance).

Also - a minor change to argv_to_vec() signature, as    
some of Ceph main()'s use the standard 'char** av', while others use
'const char**'. The modified signature of argv_to_vec() handles both,
allowing us to remove the existing const-cast used by some executables.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
