### PR TITLE
mgr/dashboard:Only run Grafana tox tests in run-make-check.sh

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1351,7 +1351,8 @@ cmake .. \
 %if 0%{?rhel}
     -DWITH_FMT_HEADER_ONLY:BOOL=ON \
 %endif
-    -DWITH_GRAFANA:BOOL=ON
+    -DWITH_GRAFANA:BOOL=ON \
+    -DWITH_GRAFANA_TESTS:BOOL=OFF
 
 %if %{with cmake_verbose_logging}
 cat ./CMakeFiles/CMakeOutput.log

--- a/debian/rules
+++ b/debian/rules
@@ -29,6 +29,7 @@ extraopts += -DWITH_CEPHFS_JAVA=ON
 extraopts += -DWITH_CEPHFS_SHELL=ON
 extraopts += -DWITH_SYSTEMD=ON -DCEPH_SYSTEMD_ENV_DIR=/etc/default
 extraopts += -DWITH_GRAFANA=ON
+extraopts += -DWITH_GRAFANA_TESTS=OFF
 ifeq ($(DEB_HOST_ARCH), amd64)
   extraopts += -DWITH_RBD_RWL=ON
 else

--- a/monitoring/grafana/dashboards/CMakeLists.txt
+++ b/monitoring/grafana/dashboards/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT CEPH_BUILD_VIRTUALENV)
   set(CEPH_BUILD_VIRTUALENV ${CMAKE_BINARY_DIR})
 endif()
 
-if(WITH_GRAFANA)
+if(WITH_GRAFANA AND WITH_GRAFANA_TESTS)
   include(AddCephTest)
   add_tox_test(grafana TOX_ENVS grafonnet-check)
   set(ver 0.1.0)

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -88,6 +88,7 @@ function main() {
     cmake_opts+=" -DWITH_GTEST_PARALLEL=ON"
     cmake_opts+=" -DWITH_FIO=ON"
     cmake_opts+=" -DWITH_CEPHFS_SHELL=ON"
+    cmake_opts+=" -DWITH_GRAFANA_TESTS=ON"
     cmake_opts+=" -DWITH_GRAFANA=ON"
     cmake_opts+=" -DWITH_SPDK=ON"
     if [ $WITH_SEASTAR ]; then


### PR DESCRIPTION
This PR intends to fix the error caused by #42194

Signed-off-by: Aashish Sharma <aasharma@redhat.com>




<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
