### PR TITLE
mgr/cephadm: show unhandled exceptions during host add

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -176,6 +176,9 @@ class ContainerEngine:
     def EXE(cls) -> str:
         raise NotImplementedError()
 
+    def __str__(self) -> str:
+        return f'{self.EXE} ({self.path})'
+
 
 class Podman(ContainerEngine):
     EXE = 'podman'
@@ -193,6 +196,10 @@ class Podman(ContainerEngine):
     def get_version(self, ctx: CephadmContext) -> None:
         out, _, _ = call_throws(ctx, [self.path, 'version', '--format', '{{.Client.Version}}'])
         self._version = _parse_podman_version(out)
+
+    def __str__(self) -> str:
+        version = '.'.join(map(str, self.version))
+        return f'{self.EXE} ({self.path}) version {version}'
 
 
 class Docker(ContainerEngine):
@@ -5801,7 +5808,7 @@ def command_check_host(ctx: CephadmContext) -> None:
 
     try:
         engine = check_container_engine(ctx)
-        logger.info('podman|docker (%s) is present' % engine.path)
+        logger.info(f'{engine} is present')
     except Error as e:
         errors.append(str(e))
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2000,8 +2000,7 @@ def find_container_engine(ctx: CephadmContext) -> Optional[ContainerEngine]:
     return None
 
 
-def check_container_engine(ctx):
-    # type: (CephadmContext) -> None
+def check_container_engine(ctx: CephadmContext) -> ContainerEngine:
     engine = ctx.container_engine
     if not isinstance(engine, CONTAINER_PREFERENCE):
         # See https://github.com/python/mypy/issues/8993
@@ -2011,6 +2010,7 @@ def check_container_engine(ctx):
         engine.get_version(ctx)
         if engine.version < MIN_PODMAN_VERSION:
             raise Error('podman version %d.%d.%d or later is required' % MIN_PODMAN_VERSION)
+    return engine
 
 
 def get_unit_name(fsid, daemon_type, daemon_id=None):
@@ -5796,14 +5796,12 @@ def check_time_sync(ctx, enabler=None):
 
 
 def command_check_host(ctx: CephadmContext) -> None:
-    container_path = ctx.container_engine.path
-
     errors = []
     commands = ['systemctl', 'lvcreate']
 
     try:
-        check_container_engine(ctx)
-        logger.info('podman|docker (%s) is present' % container_path)
+        engine = check_container_engine(ctx)
+        logger.info('podman|docker (%s) is present' % engine.path)
     except Error as e:
         errors.append(str(e))
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1480,4 +1480,21 @@ if ! grep -qs /var/lib/ceph/9b9d7609-f4d5-4aba-94c8-effa764d96c9/iscsi.daemon_id
             assert c.old_cname == 'ceph-9b9d7609-f4d5-4aba-94c8-effa764d96c9-iscsi.something'
 
 
+class TestCheckHost:
 
+    @mock.patch('cephadm.find_executable', return_value='foo')
+    def test_container_engine(self, find_executable):
+        cmd = ['check-host']
+
+        ctx = cd.CephadmContext()
+        ctx.container_engine = None
+
+        err = r'No container engine binary found'
+        with pytest.raises(cd.Error, match=err):
+            cd.command_check_host(ctx)
+
+        ctx.container_engine = mock_podman()
+        cd.command_check_host(ctx)
+
+        ctx.container_engine = mock_docker()
+        cd.command_check_host(ctx)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1330,11 +1330,13 @@ Then run the following:
             addr=addr,
             error_ok=True, no_fsid=True)
         if code:
+            msg = 'check-host failed:\n' + '\n'.join(err)
             # err will contain stdout and stderr, so we filter on the message text to
             # only show the errors
             errors = [_i.replace("ERROR: ", "") for _i in err if _i.startswith('ERROR')]
-            raise OrchestratorError('Host %s (%s) failed check(s): %s' % (
-                host, addr, errors))
+            if errors:
+                msg = f'Host {host} ({addr}) failed check(s): {errors}'
+            raise OrchestratorError(msg)
         return ip_addr
 
     def _add_host(self, spec):


### PR DESCRIPTION
138700e assumes stderr will always have a line containing the
prefix 'ERROR', which leads to an empty error reason when `check-host`
fails with an unhandled exception

Fixes: https://tracker.ceph.com/issues/51818
Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
