### PR TITLE
mgr/dashboard: stats=false not working when listing buckets

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rgw.py
+++ b/qa/tasks/mgr/dashboard/test_rgw.py
@@ -202,6 +202,11 @@ class RgwBucketTest(RgwTestCase):
             'tenant': JLeaf(str),
         }, allow_unknown=True))
 
+        # List all buckets names without stats.
+        data = self._get('/api/rgw/bucket?stats=false')
+        self.assertStatus(200)
+        self.assertEqual(data, ['teuth-test-bucket'])
+
         # Get the bucket.
         data = self._get('/api/rgw/bucket/teuth-test-bucket')
         self.assertStatus(200)

--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -233,7 +233,7 @@ class RgwBucket(RgwRESTController):
 
     def list(self, stats=False, daemon_name=None):
         # type: (bool, Optional[str]) -> List[Any]
-        query_params = '?stats' if stats else ''
+        query_params = '?stats' if str_to_bool(stats) else ''
         result = self.proxy(daemon_name, 'GET', 'bucket{}'.format(query_params))
 
         if stats:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/51154
Signed-off-by: Avan Thakkar <athakkar@redhat.com>

Before:
![Screenshot from 2021-08-20 14-47-22](https://user-images.githubusercontent.com/23611106/130211062-541d401e-5b57-40bb-b7bf-eb897f27ba58.png)


After:
![Screenshot from 2021-08-20 14-40-01](https://user-images.githubusercontent.com/23611106/130210716-0cb506f3-9c62-4e94-aa53-d1df248fc7f6.png)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
