### PR TITLE
bluestore: FreeBSD make ceph-osd mkfs use AIO 

### DIFF
--- a/src/blk/BlockDevice.cc
+++ b/src/blk/BlockDevice.cc
@@ -43,7 +43,7 @@
 #define dout_context cct
 #define dout_subsys ceph_subsys_bdev
 #undef dout_prefix
-#define dout_prefix *_dout << "bdev "
+#define dout_prefix *_dout << "bdev:bd: " << __LINE__ << " "
 
 using std::string;
 

--- a/src/blk/aio/aio.cc
+++ b/src/blk/aio/aio.cc
@@ -1,8 +1,23 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include <algorithm>
+
+#include "acconfig.h"
+#include "include/compat.h"
 #include "aio.h"
+
+#include <algorithm>
+
+#if defined(DEBUG_AIO)
+#include "global/global_context.h"
+#include "common/errno.h"
+#include "common/debug.h"
+
+#define dout_context cct
+#define dout_subsys ceph_subsys_bdev
+#undef dout_prefix
+#define dout_prefix *_dout << "bdev:aio:" << __LINE__ << " "
+#endif 
 
 std::ostream& operator<<(std::ostream& os, const aio_t& aio)
 {
@@ -15,6 +30,25 @@ std::ostream& operator<<(std::ostream& os, const aio_t& aio)
   return os;
 }
 
+#if defined(HAVE_POSIXAIO)
+std::ostream& operator<<(std::ostream& os, const struct aiocb *cb)
+{
+  os << "aiocb @ "    << &cb << "(";
+  os << "fildes = "   << cb->aio_fildes;
+  os << ", offset = " << cb->aio_offset;
+  os << ", nbytes = " << cb->aio_nbytes;
+  os << ", buf = 0x"    << std::hex << (size_t)cb->aio_buf << std::dec;
+  os << ", lio_opcode = " << cb->aio_lio_opcode;
+  os << ", priv.status = " << cb->_aiocb_private.status;
+  os << ", priv.error = " << cb->_aiocb_private.error;
+  os << ", priv.sigevent.notify = " << cb->aio_sigevent.sigev_notify;
+  os << ", priv.sigevent.notify_kqueue = " << cb->aio_sigevent.sigev_notify_kqueue;
+  os << ", priv.sigevent.kevent_flags = " << cb->aio_sigevent.sigev_notify_kevent_flags;
+  os << ")";
+  return os;
+}
+#endif
+
 int aio_queue_t::submit_batch(aio_iter begin, aio_iter end, 
 			      uint16_t aios_size, void *priv, 
 			      int *retries)
@@ -23,7 +57,12 @@ int aio_queue_t::submit_batch(aio_iter begin, aio_iter end,
   int attempts = 16;
   int delay = 125;
   int r;
-
+#if defined(DEBUG_AIO)
+  dout(20) << __func__
+           << " aios_size = " << aios_size
+           << " retries = " << (*retries)
+           << dendl;
+#endif
   aio_iter cur = begin;
   struct aio_t *piocb[aios_size];
   int left = 0;
@@ -39,20 +78,63 @@ int aio_queue_t::submit_batch(aio_iter begin, aio_iter end,
 #if defined(HAVE_LIBAIO)
     r = io_submit(ctx, std::min(left, max_iodepth), (struct iocb**)(piocb + done));
 #elif defined(HAVE_POSIXAIO)
+#if defined(DEBUG_AIO)
+    dout(20) << __func__
+        << " left = " << left
+        << " aio " << &(piocb[done]->aio)
+        << dendl;
     if (piocb[done]->n_aiocb == 1) {
+
+      dout(25) << __func__
+          << "  n_aiocb == 1 "
+          << " &piocb[done]->aio.aiocbp[0] = " << &(piocb[done]->aio.aiocbp[0])
+          << " on kqueue = " << ctx
+          << " for (fd, off, len) = ("
+            << piocb[done]->aio.aiocbp[0].aio_fildes << ","
+            << piocb[done]->aio.aiocbp[0].aio_offset << ","
+            << piocb[done]->aio.aiocbp[0].aio_nbytes
+          << ")"
+          << dendl;
+#else
+    if (piocb[done]->n_aiocb == 1) {
+#endif
+      ceph_assert( 0 < piocb[done]->aio.aiocbp[0].aio_fildes
+                   && piocb[done]->aio.aiocbp[0].aio_fildes < 4096 );
       // TODO: consider batching multiple reads together with lio_listio
-      piocb[done]->aio.aiocb.aio_sigevent.sigev_notify = SIGEV_KEVENT;
-      piocb[done]->aio.aiocb.aio_sigevent.sigev_notify_kqueue = ctx;
-      piocb[done]->aio.aiocb.aio_sigevent.sigev_value.sival_ptr = piocb[done];
-      r = aio_read(&piocb[done]->aio.aiocb);
+      piocb[done]->aio.aiocbp[0].aio_sigevent.sigev_notify = SIGEV_KEVENT;
+      piocb[done]->aio.aiocbp[0].aio_sigevent.sigev_notify_kqueue = ctx;
+      piocb[done]->aio.aiocbp[0].aio_sigevent.sigev_notify_kevent_flags = EV_ONESHOT;
+      // make that kevent can read back this piocb
+      piocb[done]->aio.aiocbp[0].aio_sigevent.sigev_value.sival_ptr =
+                                                    (void*)&(piocb[done]->aio);
+      r = 0;
+      switch (piocb[done]->aio.aiocbp[0].aio_lio_opcode) {
+        case LIO_WRITE:
+          r = aio_write(&(piocb[done]->aio.aiocbp[0]));
+          break;
+        case LIO_READ:
+          r = aio_read(&(piocb[done]->aio.aiocbp[0]));
+          break;
+        case LIO_NOP:
+          break;
+        default:
+	  ;;
+      }
+      if (r < 0 )
+        r = -errno;
+      else
+        r = 1;
     } else {
+#if defined(DEBUG_AIO)
+      dout(30) << __func__ << "  using lio_listio" << dendl;
+#endif
       struct sigevent sev;
       sev.sigev_notify = SIGEV_KEVENT;
       sev.sigev_notify_kqueue = ctx;
       sev.sigev_value.sival_ptr = piocb[done];
       r = lio_listio(LIO_NOWAIT, &piocb[done]->aio.aiocbp, piocb[done]->n_aiocb, &sev);
     }
-#endif
+#endif  // HAVE_POSIXAIO
     if (r < 0) {
       if (r == -EAGAIN && attempts-- > 0) {
 	usleep(delay);
@@ -71,13 +153,10 @@ int aio_queue_t::submit_batch(aio_iter begin, aio_iter end,
   return done;
 }
 
+#if defined(HAVE_LIBAIO)
 int aio_queue_t::get_next_completed(int timeout_ms, aio_t **paio, int max)
 {
-#if defined(HAVE_LIBAIO)
   io_event events[max];
-#elif defined(HAVE_POSIXAIO)
-  struct kevent events[max];
-#endif
   struct timespec t = {
     timeout_ms / 1000,
     (timeout_ms % 1000) * 1000 * 1000
@@ -85,40 +164,140 @@ int aio_queue_t::get_next_completed(int timeout_ms, aio_t **paio, int max)
 
   int r = 0;
   do {
-#if defined(HAVE_LIBAIO)
     r = io_getevents(ctx, 1, max, events, &t);
-#elif defined(HAVE_POSIXAIO)
-    r = kevent(ctx, NULL, 0, events, max, &t);
-    if (r < 0)
-      r = -errno;
-#endif
   } while (r == -EINTR);
 
   for (int i=0; i<r; ++i) {
-#if defined(HAVE_LIBAIO)
     paio[i] = (aio_t *)events[i].obj;
     paio[i]->rval = events[i].res;
-#else
-    paio[i] = (aio_t*)events[i].udata;
-    if (paio[i]->n_aiocb == 1) {
-      paio[i]->rval = aio_return(&paio[i]->aio.aiocb);
-    } else {
-      // Emulate the return value of pwritev.  I can't find any documentation
-      // for what the value of io_event.res is supposed to be.  I'm going to
-      // assume that it's just like pwritev/preadv/pwrite/pread.
-      paio[i]->rval = 0;
-      for (int j = 0; j < paio[i]->n_aiocb; j++) {
-	int res = aio_return(&paio[i]->aio.aiocbp[j]);
-	if (res < 0) {
-	  paio[i]->rval = res;
-	  break;
-	} else {
-	  paio[i]->rval += res;
-	}
-      }
-      free(paio[i]->aio.aiocbp);
-    }
-#endif
   }
   return r;
 }
+
+#elif defined(HAVE_POSIXAIO)
+
+// return value: the number of completed AIOs.
+//        paio:  the completed AIOs
+//        paio->rval: the number of bytes read/written
+// or     zero if a timeout has occurred
+// or     any negative return will result in a assert upon return
+
+int aio_queue_t::get_next_completed(int timeout_ms, aio_t **paio, int max, int fd = 0)
+{
+  struct timespec t = {
+    timeout_ms / 1000,
+    (timeout_ms % 1000) * 1000 * 1000
+  };
+  struct kevent events[max];
+  int timeouts = 0;
+  // Setup the eventqueue to monitor events on fd
+  struct kevent ev;
+#if defined(DEBUG_AIO)
+  dout(21) << __func__ << " kqueue registration"
+      << " on fd = " << fd
+      << " , with kqueue handle ctx = " << ctx
+      << dendl;
+#endif
+  EV_SET(&ev, fd, 0, EV_ADD | EV_CLEAR, 0, 0, 0);
+  int rev = kevent(ctx, &ev, 1, NULL, 0, 0 );
+  if (rev < 0) {
+    dout(5) << __func__ << " kqueue registration error "
+            << " kevent return(" << errno << ") "
+            << cpp_strerror(errno)
+            << dendl;
+    return -errno;
+  }
+  
+  // Now wait until an event is reported
+  do {
+    memset(&events, 0, sizeof(events));
+    rev = kevent(ctx, NULL, 0, events, max, &t);
+#if defined(DEBUG_AIO)
+    dout(25) << __func__
+        << " on kqueue handle = " << ctx
+        << " kevent return = " << rev
+        << " max = " << max
+        << dendl;
+    if (rev < 0) {
+        dout(5) << __func__
+                << " error event " << cpp_strerror(errno)
+                << dendl;
+#else
+    if (rev < 0) {
+#endif
+        return -errno;
+    } else if (rev == 0) {
+        // Got a timeout
+        timeouts++;
+        dout(30) << __func__ << " return"
+            << " timeouts " << timeouts
+            << " rev = 0"
+            << dendl;
+        return rev;
+      } else {
+        // Process all the events posted
+        // Emulate the return value of pwritev. I can't find any documentation
+        // for what the value of io_event.res is supposed to be. I'm going to
+        // assume that it's just like pwritev/preadv/pwrite/pread.
+#if defined(DEBUG_AIO)
+        dout(25) << __func__ << " process " << rev << " events"
+            << dendl;
+#endif
+        for(int i = 0; i < rev; i++) {
+            struct aio_t* aio = (struct aio_t*)events[i].udata;
+            struct aiocb* slot = &(aio->aio.aiocbp[i]);
+#if defined(DEBUG_AIO)
+            dout(10) << __func__ << " slot = " << &slot << dendl;
+#endif
+            int ree = aio_error(slot);
+            if (ree != 0) {
+                dout(5) << __func__ << " aio_error" << cpp_strerror(errno)
+                         << dendl;
+                if (ree == EINPROGRESS) {
+                  // Try again after timeout
+                } else {
+                  return -errno;
+                }
+            }
+            int res = aio_return(slot);
+            if (res < 0) {
+                // Most common error to be returned here is 22: Invalid argument
+                // Meaning that there was a problem submitting the aio in
+                // aio_{read/write}. Usually a coding problem in submit_batch
+                dout(5) << __func__
+                        << " error in processing event i = " << i
+                        << " aio_return"
+                        << cpp_strerror(errno)
+                        << dendl;
+                return -errno;
+            } else {
+#if defined(DEBUG_AIO)
+                dout(15) << __func__ << " aio completed: "
+                         << res << " bytes."
+                         << dendl;
+#endif
+                paio[i]         = aio;
+                paio[i]->rval   = res;
+                paio[i]->fd     = slot->aio_fildes;
+                paio[i]->offset = slot->aio_offset;
+                paio[i]->length = slot->aio_nbytes;
+                paio[i]->priv   = aio->priv;
+#if defined(DEBUG_AIO)
+                paio[i]->cct    = cct;
+                dout(25) << __func__
+                         << " processing event i = " << i
+                         << " ident = "  << events[i].ident
+                         << " flags = "  << events[i].flags
+                         << " fflags = " << events[i].fflags
+                         << " udata = "  << aio
+                         << " aiocbp = " << slot
+                         << dendl;
+#endif
+           }
+        }
+    }
+  } while (rev == 0);
+
+  return rev;
+}
+#endif

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -461,7 +461,7 @@ int KernelDevice::flush()
     _exit(1);
   }
   utime_t start = ceph_clock_now();
-  int r = ::fdatasync(fd_directs[WRITE_LIFE_NOT_SET]);
+  int r = ::fdatasync(choose_fd(false, WRITE_LIFE_NOT_SET));
   utime_t end = ceph_clock_now();
   utime_t dur = end - start;
   if (r < 0) {
@@ -1054,7 +1054,7 @@ int KernelDevice::discard(uint64_t offset, uint64_t len)
 	       << " 0x" << std::hex << offset << "~" << len << std::dec
 	       << dendl;
 
-      r = BlkDev{fd_directs[WRITE_LIFE_NOT_SET]}.discard((int64_t)offset, (int64_t)len);
+      r = BlkDev{choose_fd(false, WRITE_LIFE_NOT_SET)}.discard((int64_t)offset, (int64_t)len);
   }
   return r;
 }
@@ -1152,7 +1152,7 @@ int KernelDevice::direct_read_unaligned(uint64_t off, uint64_t len, char *buf)
   int r = 0;
 
   auto start1 = mono_clock::now();
-  r = ::pread(fd_directs[WRITE_LIFE_NOT_SET], p.c_str(), aligned_len, aligned_off);
+  r = ::pread(choose_fd(false, WRITE_LIFE_NOT_SET), p.c_str(), aligned_len, aligned_off);
   auto age = cct->_conf->bdev_debug_aio_log_age;
   if (mono_clock::now() - start1 >= make_timespan(age)) {
     derr << __func__ << " stalled read "
@@ -1226,7 +1226,7 @@ int KernelDevice::read_random(uint64_t off, uint64_t len, char *buf,
     }
   } else {
     //direct and aligned read
-    r = ::pread(fd_directs[WRITE_LIFE_NOT_SET], buf, len, off);
+    r = ::pread(choose_fd(false, WRITE_LIFE_NOT_SET), buf, len, off);
     if (mono_clock::now() - start1 >= make_timespan(age)) {
       derr << __func__ << " stalled read "
 	   << " 0x" << std::hex << off << "~" << len << std::dec

--- a/src/blk/kernel/io_uring.cc
+++ b/src/blk/kernel/io_uring.cc
@@ -251,10 +251,17 @@ int ioring_queue_t::submit_batch(aio_iter beg, aio_iter end,
   ceph_assert(0);
 }
 
+#if defined(HAVE_LIBAIO)
 int ioring_queue_t::get_next_completed(int timeout_ms, aio_t **paio, int max)
 {
   ceph_assert(0);
 }
+#elif defined(HAVE_POSIXAIO)
+int ioring_queue_t::get_next_completed(int timeout_ms, aio_t **paio, int max, int fd)
+{
+  ceph_assert(0);
+}
+#endif
 
 bool ioring_queue_t::supported()
 {

--- a/src/blk/kernel/io_uring.h
+++ b/src/blk/kernel/io_uring.h
@@ -29,5 +29,9 @@ struct ioring_queue_t final : public io_queue_t {
 
   int submit_batch(aio_iter begin, aio_iter end, uint16_t aios_size,
                    void *priv, int *retries) final;
-  int get_next_completed(int timeout_ms, aio_t **paio, int max) final;
+#if defined(HAVE_LIBAIO)
+    int get_next_completed(int timeout_ms, aio_t **paio, int max) final;
+#elif defined(HAVE_POSIXAIO)
+  int get_next_completed(int timeout_ms, aio_t **paio, int max, int fd) final;
+#endif
 };

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2220,7 +2220,7 @@ void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
   log_writer->append(bl);
   r = _flush(log_writer, true);
   ceph_assert(r == 0);
-#ifdef HAVE_LIBAIO
+#if defined(HAVE_LIBAIO) || defined(HAVE_POSIXAIO)
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
     _claim_completed_aios(log_writer, &completed_ios);
@@ -2947,7 +2947,7 @@ void BlueFS::_flush_bdev_safely(FileWriter *h)
 {
   std::array<bool, MAX_BDEV> flush_devs = h->dirty_devs;
   h->dirty_devs.fill(false);
-#ifdef HAVE_LIBAIO
+#if defined(HAVE_LIBAIO) || defined(HAVE_POSIXAIO)
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
     _claim_completed_aios(h, &completed_ios);


### PR DESCRIPTION
A new attempt to get FreeBSD running with AIO

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
