### PR TITLE
cmake: link Threads::Threads instead of CMAKE_THREAD_LIBS_INIT

### DIFF
--- a/cmake/modules/Buildpmem.cmake
+++ b/cmake/modules/Buildpmem.cmake
@@ -44,10 +44,11 @@ function(build_pmem)
   add_library(pmem::pmem STATIC IMPORTED GLOBAL)
   add_dependencies(pmem::pmem pmdk_ext)
   file(MAKE_DIRECTORY ${PMDK_INCLUDE})
+  find_package(Threads)
   set_target_properties(pmem::pmem PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES ${PMDK_INCLUDE}
     IMPORTED_LOCATION "${PMDK_LIB}/libpmem.a"
-    INTERFACE_LINK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+    INTERFACE_LINK_LIBRARIES Threads::Threads)
 
   # libpmemobj
   add_library(pmem::pmemobj STATIC IMPORTED GLOBAL)


### PR DESCRIPTION
`CMAKE_THREAD_LIBS_INIT` can be empty. On CentOS Stream 9, this leads to an error:

```
  CMake Error at cmake/modules/Buildpmem.cmake:47 (set_target_properties):
    set_target_properties called with incorrect number of arguments.
```

~~Quote the variable so that cmake treats this as an empty string. With this change, cmake 3.20.2 succeeds on CentOS 9.~~ EDIT: different resolution (using `Threads::Threads` directly), see below discussion.

Fixes: https://tracker.ceph.com/issues/52353

## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>