### PR TITLE
cmake: exclude "grafonnet-lib" target from "all" 

### DIFF
--- a/monitoring/grafana/dashboards/CMakeLists.txt
+++ b/monitoring/grafana/dashboards/CMakeLists.txt
@@ -24,7 +24,8 @@ if(WITH_GRAFANA)
     INSTALL_COMMAND ""
     LOG_DOWNLOAD ON
     LOG_MERGED_STDOUTERR ON
-    LOG_OUTPUT_ON_FAILURE ON)
+    LOG_OUTPUT_ON_FAILURE ON
+    EXCLUDE_FROM_ALL ON)
   add_dependencies(tests
     ${name})
   ExternalProject_Get_Property(${name} SOURCE_DIR)


### PR DESCRIPTION
so we don't build this target when running "make", and hence avoid
accessing the internet in a building envronment where the internest
access is not allowed.

Fixes:https://tracker.ceph.com/issues/52338
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
