### PR TITLE
rgw multisite: fix 'bucket sync status' shard count and backward compat

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2325,7 +2325,7 @@ static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::Ra
 
   std::vector<rgw_bucket_shard_sync_info> status;
   status.resize(full_status.shards_done_with_gen.size());
-  r = rgw_read_bucket_inc_sync_status(dpp, store, pipe, bucket_info, &source_bucket->get_info(), full_status.incremental_gen,  &status);
+  r = rgw_read_bucket_inc_sync_status(dpp, store, pipe, full_status.incremental_gen, &status);
   if (r < 0) {
     lderr(store->ctx()) << "failed to read bucket incremental sync status: " << cpp_strerror(r) << dendl;
     return r;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2324,6 +2324,7 @@ static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::Ra
   }
 
   std::vector<rgw_bucket_shard_sync_info> status;
+  status.resize(full_status.shards_done_with_gen.size());
   r = rgw_read_bucket_inc_sync_status(dpp, store, pipe, bucket_info, &source_bucket->get_info(), full_status.incremental_gen,  &status);
   if (r < 0) {
     lderr(store->ctx()) << "failed to read bucket incremental sync status: " << cpp_strerror(r) << dendl;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2363,12 +2363,17 @@ static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::Ra
   }
 
   std::set<int> shards_behind;
-  for (auto& r : remote_markers.get()) {
+  for (const auto& r : remote_markers.get()) {
     auto shard_id = r.first;
-    auto& m = shard_status[shard_id];
     if (r.second.empty()) {
       continue; // empty bucket index shard
     }
+    if (shard_id >= total_shards) {
+      // unexpected shard id. we don't have status for it, so we're behind
+      shards_behind.insert(shard_id);
+      continue;
+    }
+    auto& m = shard_status[shard_id];
     const auto pos = BucketIndexShardsManager::get_shard_marker(m.inc_marker.position);
     if (pos < r.second) {
       shards_behind.insert(shard_id);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2303,35 +2303,53 @@ static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::Ra
 
   pipe.dest.bucket = bucket_info.bucket;
 
+  uint64_t gen = 0;
+  std::vector<rgw_bucket_shard_sync_info> shard_status;
+
+  // check for full sync status
   rgw_bucket_sync_status full_status;
   r = rgw_read_bucket_full_sync_status(dpp, store, pipe, &full_status, null_yield);
-  if (r < 0) {
+  if (r >= 0) {
+    if (full_status.state == BucketSyncState::Init) {
+      out << indented{width} << "init: bucket sync has not started\n";
+      return 0;
+    }
+    if (full_status.state == BucketSyncState::Stopped) {
+      out << indented{width} << "stopped: bucket sync is disabled\n";
+      return 0;
+    }
+    if (full_status.state == BucketSyncState::Full) {
+      out << indented{width} << "full sync: " << full_status.full.count << " objects completed\n";
+      return 0;
+    }
+    gen = full_status.incremental_gen;
+    shard_status.resize(full_status.shards_done_with_gen.size());
+  } else if (r == -ENOENT) {
+    // no full status, but there may be per-shard status from before upgrade
+    const auto& log = source_bucket->get_info().layout.logs.front();
+    if (log.gen > 0) {
+      // this isn't the backward-compatible case, so we just haven't started yet
+      out << indented{width} << "init: bucket sync has not started\n";
+      return 0;
+    }
+    if (log.layout.type != rgw::BucketLogType::InIndex) {
+      ldpp_dout(dpp, -1) << "unrecognized log layout type " << log.layout.type << dendl;
+      return -EINVAL;
+    }
+    // use shard count from our log gen=0
+    shard_status.resize(log.layout.in_index.layout.num_shards);
+  } else {
     lderr(store->ctx()) << "failed to read bucket full sync status: " << cpp_strerror(r) << dendl;
     return r;
   }
 
-  if (full_status.state == BucketSyncState::Init) {
-    out << indented{width} << "init: bucket sync has not started\n";
-    return 0;
-  }
-  if (full_status.state == BucketSyncState::Stopped) {
-    out << indented{width} << "stopped: bucket sync is disabled\n";
-    return 0;
-  }
-  if (full_status.state == BucketSyncState::Full) {
-    out << indented{width} << "full sync: " << full_status.full.count << " objects completed\n";
-    return 0;
-  }
-
-  std::vector<rgw_bucket_shard_sync_info> status;
-  status.resize(full_status.shards_done_with_gen.size());
-  r = rgw_read_bucket_inc_sync_status(dpp, store, pipe, full_status.incremental_gen, &status);
+  r = rgw_read_bucket_inc_sync_status(dpp, store, pipe, gen, &shard_status);
   if (r < 0) {
     lderr(store->ctx()) << "failed to read bucket incremental sync status: " << cpp_strerror(r) << dendl;
     return r;
   }
 
-  const size_t total_shards = status.size();
+  const size_t total_shards = shard_status.size();
 
   out << indented{width} << "incremental sync on " << total_shards << " shards\n";
 
@@ -2347,7 +2365,7 @@ static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::Ra
   std::set<int> shards_behind;
   for (auto& r : remote_markers.get()) {
     auto shard_id = r.first;
-    auto& m = status[shard_id];
+    auto& m = shard_status[shard_id];
     if (r.second.empty()) {
       continue; // empty bucket index shard
     }

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2814,8 +2814,11 @@ RGWRemoteBucketManager::RGWRemoteBucketManager(const DoutPrefixProvider *_dpp,
                                                                     source_bucket_info.bucket,
                                                                     dest_bucket))
 {
-  int num_shards = (source_bucket_info.layout.current_index.layout.normal.num_shards <= 0 ? 
-                    1 : source_bucket_info.layout.current_index.layout.normal.num_shards);
+  rgw_bucket_index_marker_info remote_info;
+  BucketIndexShardsManager remote_markers;
+  rgw_read_remote_bilog_info(dpp, conn, source_bucket_info.bucket,
+                             remote_info, remote_markers, null_yield);
+  int num_shards = remote_markers.get().size();
 
   sync_pairs.resize(num_shards);
 
@@ -5168,6 +5171,8 @@ class RGWSyncBucketCR : public RGWCoroutine {
   rgw_bucket_index_marker_info info;
 
   RGWSyncTraceNodeRef tn;
+  rgw_bucket_index_marker_info remote_info;
+  BucketIndexShardsManager remote_markers;
 
 public:
   RGWSyncBucketCR(RGWDataSyncCtx *_sc,
@@ -5350,7 +5355,9 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
         // init sync status
         yield {
           init_check_compat = objv.read_version.ver <= 1; // newly-created
-          const int num_shards = sync_pipe.dest_bucket_info.layout.current_index.layout.normal.num_shards;
+          rgw_read_remote_bilog_info(dpp, sc->conn, sync_pair.source_bs.bucket,
+                                      remote_info, remote_markers, null_yield);
+          const int num_shards = remote_markers.get().size();
           call(new InitBucketFullSyncStatusCR(sc, sync_pair, status_obj,
                                               bucket_status, objv, num_shards,
                                               init_check_compat, info));

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -5744,7 +5744,9 @@ class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
       store(store), sc(sc), env(sc->env), gen(gen),
       i(status->begin()), end(status->end())
   {
-    sync_pair.source_bs = rgw_bucket_shard(source_bucket_info.bucket, source_bucket_info.layout.current_index.layout.normal.num_shards > 0 ? 0 : -1);
+    // This function doesn't need to know the remote shard count, but
+    // callers of read_bucket_inc_sync_status do
+    sync_pair.source_bs = rgw_bucket_shard(source_bucket_info.bucket, 0);
     sync_pair.dest_bucket = dest_bucket_info.bucket;
   }
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -5736,19 +5736,13 @@ class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
   }
  public:
   RGWCollectBucketSyncStatusCR(rgw::sal::RadosStore* store, RGWDataSyncCtx *sc,
-                               const RGWBucketInfo& source_bucket_info,
-                               const RGWBucketInfo& dest_bucket_info,
+                               const rgw_bucket_sync_pair_info& sync_pair,
                                uint64_t gen,
                                Vector *status)
     : RGWShardCollectCR(sc->cct, max_concurrent_shards),
-      store(store), sc(sc), env(sc->env), gen(gen),
+      store(store), sc(sc), env(sc->env), gen(gen), sync_pair(sync_pair),
       i(status->begin()), end(status->end())
-  {
-    // This function doesn't need to know the remote shard count, but
-    // callers of read_bucket_inc_sync_status do
-    sync_pair.source_bs = rgw_bucket_shard(source_bucket_info.bucket, 0);
-    sync_pair.dest_bucket = dest_bucket_info.bucket;
-  }
+  {}
 
   bool spawn_next() override {
     if (i == end) {
@@ -5795,8 +5789,6 @@ int rgw_read_bucket_full_sync_status(const DoutPrefixProvider *dpp,
 int rgw_read_bucket_inc_sync_status(const DoutPrefixProvider *dpp,
                                     rgw::sal::RadosStore *store,
                                     const rgw_sync_bucket_pipe& pipe,
-                                    const RGWBucketInfo& dest_bucket_info,
-                                    const RGWBucketInfo *psource_bucket_info,
                                     uint64_t gen,
                                     std::vector<rgw_bucket_shard_sync_info> *status)
 {
@@ -5807,27 +5799,10 @@ int rgw_read_bucket_inc_sync_status(const DoutPrefixProvider *dpp,
     return -EINVAL;
   }
 
-  if (*pipe.dest.bucket !=
-      dest_bucket_info.bucket) {
-    return -EINVAL;
-  }
-
-  const rgw_bucket& source_bucket = *pipe.source.bucket;
-
-  RGWBucketInfo source_bucket_info;
-
-  if (!psource_bucket_info) {
-    auto& bucket_ctl = store->getRados()->ctl.bucket;
-
-    int ret = bucket_ctl->read_bucket_info(source_bucket, &source_bucket_info, null_yield, dpp);
-    if (ret < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: failed to get bucket instance info: bucket=" << source_bucket << ": " << cpp_strerror(-ret) << dendl;
-      return ret;
-    }
-
-    psource_bucket_info = &source_bucket_info;
-  }
-
+  rgw_bucket_sync_pair_info sync_pair;
+  sync_pair.source_bs.bucket = *pipe.source.bucket;
+  sync_pair.source_bs.shard_id = 0;
+  sync_pair.dest_bucket = *pipe.dest.bucket;
 
   RGWDataSyncEnv env;
   RGWSyncModuleInstanceRef module; // null sync module
@@ -5839,8 +5814,7 @@ int rgw_read_bucket_inc_sync_status(const DoutPrefixProvider *dpp,
 
   RGWCoroutinesManager crs(store->ctx(), store->getRados()->get_cr_registry());
   return crs.run(dpp, new RGWCollectBucketSyncStatusCR(store, &sc,
-                                                  *psource_bucket_info,
-                                                  dest_bucket_info,
+                                                  sync_pair,
                                                   gen,
                                                   status));
 }

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2812,7 +2812,8 @@ RGWRemoteBucketManager::RGWRemoteBucketManager(const DoutPrefixProvider *_dpp,
     full_status_obj(sync_env->svc->zone->get_zone_params().log_pool,
                     RGWBucketPipeSyncStatusManager::full_status_oid(source_zone,
                                                                     source_bucket_info.bucket,
-                                                                    dest_bucket))
+                                                                    dest_bucket)),
+    source_bucket_info(source_bucket_info)
 {
   rgw_bucket_index_marker_info remote_info;
   BucketIndexShardsManager remote_markers;
@@ -3140,24 +3141,27 @@ class InitBucketFullSyncStatusCR : public RGWCoroutine {
   const rgw_raw_obj& status_obj;
   rgw_bucket_sync_status& status;
   RGWObjVersionTracker& objv;
-  const int num_shards;
+  const RGWBucketInfo& source_info;
   const bool check_compat;
 
   const rgw_bucket_index_marker_info& info;
   BucketIndexShardsManager marker_mgr;
 
   bool all_incremental = true;
+
+
 public:
   InitBucketFullSyncStatusCR(RGWDataSyncCtx* sc,
                              const rgw_bucket_sync_pair_info& sync_pair,
                              const rgw_raw_obj& status_obj,
                              rgw_bucket_sync_status& status,
                              RGWObjVersionTracker& objv,
-                             int num_shards, bool check_compat,
+			     const RGWBucketInfo& source_info,
+                             bool check_compat,
                              const rgw_bucket_index_marker_info& info)
     : RGWCoroutine(sc->cct), sc(sc), sync_env(sc->env),
       sync_pair(sync_pair), status_obj(status_obj),
-      status(status), objv(objv), num_shards(num_shards),
+      status(status), objv(objv), source_info(source_info),
       check_compat(check_compat), info(info)
   {}
 
@@ -3174,26 +3178,51 @@ public:
 
       if (info.oldest_gen == 0) {
         if (check_compat) {
-          // try to convert existing per-shard incremental status for backward compatibility
-          yield call(new CheckAllBucketShardStatusIsIncremental(sc, sync_pair, num_shards, &all_incremental));
-          if (retcode < 0) {
-            return set_cr_error(retcode);
-          }
-          if (all_incremental) {
-            // we can use existing status and resume incremental sync
-            status.state = BucketSyncState::Incremental;
-          }
-        }
+	  yield {
+	    // use shard count from our log gen=0
+	    // try to convert existing per-shard incremental status for backward compatibility
+	    const auto& log = source_info.layout.logs.front();
+	    bool no_zero = false;
+	    if (log.gen > 0) {
+	      ldpp_dout(dpp, 20)
+		<< "no generation zero when check compatibility" << dendl;
+	      no_zero = true;
+	    }
+	    if (log.layout.type != rgw::BucketLogType::InIndex) {
+	      ldpp_dout(dpp, 20) <<
+		"unrecognized log layout type when when checking compatibility " << log.layout.type << dendl;
+	      no_zero = true;
+	    }
+	    if (!no_zero) {
+	      const int num_shards0 = log.layout.in_index.layout.num_shards;
+	      call(new CheckAllBucketShardStatusIsIncremental(sc, sync_pair,
+							      num_shards0,
+							      &all_incremental));
+	      if (retcode < 0) {
+		return set_cr_error(retcode);
+	      }
+	      if (all_incremental) {
+		// we can use existing status and resume incremental sync
+		status.state = BucketSyncState::Incremental;
+	      }
+	    } else {
+	      all_incremental = false;
+	    }
+	  }
+	}
       }
 
       if (status.state != BucketSyncState::Incremental) {
-        // initialize all shard sync status. this will populate the log marker
+	// initialize all shard sync status. this will populate the log marker
         // positions where incremental sync will resume after full sync
-        yield call(new InitBucketShardStatusCollectCR(sc, sync_pair, info.latest_gen, marker_mgr, num_shards));
-        if (retcode < 0) {
+	yield {
+	  const int num_shards = marker_mgr.get().size();
+	  call(new InitBucketShardStatusCollectCR(sc, sync_pair, info.latest_gen, marker_mgr, num_shards));
+	}
+	if (retcode < 0) {
           ldout(cct, 20) << "failed to init bucket shard status: "
-              << cpp_strerror(retcode) << dendl;
-          return set_cr_error(retcode);
+			 << cpp_strerror(retcode) << dendl;
+	  return set_cr_error(retcode);
         }
 
         if (sync_env->sync_module->should_full_sync()) {
@@ -3203,15 +3232,17 @@ public:
         }
       }
 
-      status.shards_done_with_gen.resize(num_shards);
+      status.shards_done_with_gen.resize(marker_mgr.get().size());
       status.incremental_gen = info.latest_gen;
 
       ldout(cct, 20) << "writing bucket sync status during init. state=" << status.state << ". marker=" << status.full.position.to_str() << dendl;
 
       // write bucket sync status
       using CR = RGWSimpleRadosWriteCR<rgw_bucket_sync_status>;
-      yield call(new CR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
-                        status_obj, status, &objv, false));
+      yield {
+	call(new CR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
+		    status_obj, status, &objv, false));
+      }
       if (retcode < 0) {
         ldout(cct, 20) << "failed to write bucket shard status: "
             << cpp_strerror(retcode) << dendl;
@@ -3226,9 +3257,9 @@ public:
 RGWCoroutine *RGWRemoteBucketManager::init_sync_status_cr(RGWObjVersionTracker& objv, rgw_bucket_index_marker_info& info)
 {
   constexpr bool check_compat = false;
-  const int num_shards = num_pipes();
   return new InitBucketFullSyncStatusCR(&sc, sync_pairs[0], full_status_obj,
-                                        full_status, objv, num_shards, check_compat, info);
+                                        full_status, objv, source_bucket_info,
+					check_compat, info);
 }
 
 #define OMAP_READ_MAX_ENTRIES 10
@@ -3303,7 +3334,7 @@ class RGWReadPendingBucketShardsCoroutine : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
   rgw::sal::RadosStore* store;
-  
+
   const int shard_id;
   int max_entries;
 
@@ -5171,8 +5202,6 @@ class RGWSyncBucketCR : public RGWCoroutine {
   rgw_bucket_index_marker_info info;
 
   RGWSyncTraceNodeRef tn;
-  rgw_bucket_index_marker_info remote_info;
-  BucketIndexShardsManager remote_markers;
 
 public:
   RGWSyncBucketCR(RGWDataSyncCtx *_sc,
@@ -5284,7 +5313,7 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
               yield set_sleeping(true);
             }
           }
-          
+
           // if state was incremental, remove all per-shard status objects
           if (bucket_status.state == BucketSyncState::Incremental) {
             yield {
@@ -5346,22 +5375,16 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
         yield call(new ReadCR(dpp, env->async_rados, env->svc->sysobj,
                             status_obj, &bucket_status, false, &objv));
         if (retcode < 0) {
-          RELEASE_LOCK(bucket_lease_cr);	
+          RELEASE_LOCK(bucket_lease_cr);
           tn->log(20, SSTR("ERROR: reading the status after acquiring the lock failed. error: " << retcode));
           return set_cr_error(retcode);
         }
         tn->log(20, SSTR("status after acquiring the lock is: " << bucket_status.state));
 
-        // init sync status
-        yield {
-          init_check_compat = objv.read_version.ver <= 1; // newly-created
-          rgw_read_remote_bilog_info(dpp, sc->conn, sync_pair.source_bs.bucket,
-                                      remote_info, remote_markers, null_yield);
-          const int num_shards = remote_markers.get().size();
-          call(new InitBucketFullSyncStatusCR(sc, sync_pair, status_obj,
-                                              bucket_status, objv, num_shards,
-                                              init_check_compat, info));
-        }
+	yield call(new InitBucketFullSyncStatusCR(sc, sync_pair, status_obj,
+						  bucket_status, objv,
+						  sync_pipe.source_bucket_info,
+						  init_check_compat, info));
 
         if (retcode < 0) {
           tn->log(20, SSTR("ERROR: init full sync failed. error: " << retcode));

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2807,6 +2807,7 @@ RGWRemoteBucketManager::RGWRemoteBucketManager(const DoutPrefixProvider *_dpp,
                                                const rgw_zone_id& _source_zone,
                                                RGWRESTConn *_conn,
                                                const RGWBucketInfo& source_bucket_info,
+					       const int num_shards,
                                                const rgw_bucket& dest_bucket)
   : dpp(_dpp), sync_env(_sync_env), conn(_conn), source_zone(_source_zone),
     full_status_obj(sync_env->svc->zone->get_zone_params().log_pool,
@@ -2815,23 +2816,15 @@ RGWRemoteBucketManager::RGWRemoteBucketManager(const DoutPrefixProvider *_dpp,
                                                                     dest_bucket)),
     source_bucket_info(source_bucket_info)
 {
-  rgw_bucket_index_marker_info remote_info;
-  BucketIndexShardsManager remote_markers;
-  rgw_read_remote_bilog_info(dpp, conn, source_bucket_info.bucket,
-                             remote_info, remote_markers, null_yield);
-  int num_shards = remote_markers.get().size();
-
   sync_pairs.resize(num_shards);
 
-  int cur_shard = std::min<int>(source_bucket_info.layout.current_index.layout.normal.num_shards, 0);
-
-  for (int i = 0; i < num_shards; ++i, ++cur_shard) {
-    auto& sync_pair = sync_pairs[i];
+  for (int cur_shard = 0; cur_shard < num_shards; ++cur_shard) {
+    auto& sync_pair = sync_pairs[cur_shard];
 
     sync_pair.source_bs.bucket = source_bucket_info.bucket;
     sync_pair.dest_bucket = dest_bucket;
 
-    sync_pair.source_bs.shard_id = (source_bucket_info.layout.current_index.layout.normal.num_shards > 0 ? cur_shard : -1);
+    sync_pair.source_bs.shard_id = cur_shard;
   }
 
   sc.init(sync_env, conn, source_zone);
@@ -5513,10 +5506,24 @@ int RGWBucketPipeSyncStatusManager::init(const DoutPrefixProvider *dpp)
       last_zone = szone;
     }
 
+    rgw_bucket_index_marker_info remote_info;
+    BucketIndexShardsManager remote_markers;
+    auto r = rgw_read_remote_bilog_info(dpp, conn, pipe.source.get_bucket_info().bucket,
+					remote_info, remote_markers,
+					null_yield);
+
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			<< " rgw_read_remote_bilog_info: r="
+			<< r << dendl;
+      return r;
+    }
+    const int num_shards = remote_markers.get().size();
     source_mgrs.push_back(new RGWRemoteBucketManager(this, &sync_env,
-                                                     szone, conn,
-                                                     pipe.source.get_bucket_info(),
-                                                     pipe.target.get_bucket()));
+						     szone, conn,
+						     pipe.source.get_bucket_info(),
+						     num_shards,
+						     pipe.target.get_bucket()));
   }
 
   return 0;

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -682,10 +682,11 @@ class RGWRemoteBucketManager {
 
 public:
   RGWRemoteBucketManager(const DoutPrefixProvider *_dpp,
-                     RGWDataSyncEnv *_sync_env,
-                     const rgw_zone_id& _source_zone, RGWRESTConn *_conn,
-                     const RGWBucketInfo& source_bucket_info,
-                     const rgw_bucket& dest_bucket);
+			 RGWDataSyncEnv *_sync_env,
+			 const rgw_zone_id& _source_zone, RGWRESTConn *_conn,
+			 const RGWBucketInfo& source_bucket_info,
+			 const int num_shards,
+			 const rgw_bucket& dest_bucket);
 
   RGWCoroutine *read_sync_status_cr(int num, rgw_bucket_shard_sync_info *sync_status);
   RGWCoroutine *init_sync_status_cr(RGWObjVersionTracker& objv_tracker, rgw_bucket_index_marker_info& info);

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -779,8 +779,6 @@ int rgw_read_bucket_full_sync_status(const DoutPrefixProvider *dpp,
 int rgw_read_bucket_inc_sync_status(const DoutPrefixProvider *dpp,
                                     rgw::sal::RadosStore *store,
                                     const rgw_sync_bucket_pipe& pipe,
-                                    const RGWBucketInfo& dest_bucket_info,
-                                    const RGWBucketInfo *psource_bucket_info,
                                     uint64_t gen,
                                     std::vector<rgw_bucket_shard_sync_info> *status);
 

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -674,9 +674,11 @@ class RGWRemoteBucketManager {
 
   RGWDataSyncCtx sc;
   rgw_bucket_sync_status full_status;
+  const RGWBucketInfo source_bucket_info;
   rgw_bucket_shard_sync_info shard_status;
 
   RGWBucketSyncCR *sync_cr{nullptr};
+
 
 public:
   RGWRemoteBucketManager(const DoutPrefixProvider *_dpp,

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -1006,6 +1006,7 @@ void RGWOp_BILog_Status::execute(optional_yield y)
       ldpp_dout(this, -1) << "ERROR: rgw_read_bucket_full_sync_status() on pipe=" << pipe << " returned ret=" << op_ret << dendl;
       return;
     }
+    status.inc_status.resize(status.sync_status.shards_done_with_gen.size());
 
     op_ret = rgw_read_bucket_inc_sync_status(
       this,
@@ -1073,6 +1074,7 @@ void RGWOp_BILog_Status::execute(optional_yield y)
       return;
     }
 
+    current_status.resize(status.sync_status.shards_done_with_gen.size());
     int r = rgw_read_bucket_inc_sync_status(this, static_cast<rgw::sal::RadosStore*>(store),
 					    pipe, *pinfo, &bucket->get_info(), status.sync_status.incremental_gen, &current_status);
     if (r < 0) {

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -996,17 +996,15 @@ void RGWOp_BILog_Status::execute(optional_yield y)
 
     ldpp_dout(this, 20) << "RGWOp_BILog_Status::execute(optional_yield y): getting sync status for pipe=" << pipe << dendl;
 
-    if (version > 1) {
-      op_ret = rgw_read_bucket_full_sync_status(
-	this,
-	static_cast<rgw::sal::RadosStore*>(store),
-	pipe,
-	&status.sync_status,
-	s->yield);
-      if (op_ret < 0) {
-	ldpp_dout(this, -1) << "ERROR: rgw_read_bucket_full_sync_status() on pipe=" << pipe << " returned ret=" << op_ret << dendl;
-	return;
-      }
+    op_ret = rgw_read_bucket_full_sync_status(
+      this,
+      static_cast<rgw::sal::RadosStore*>(store),
+      pipe,
+      &status.sync_status,
+      s->yield);
+    if (op_ret < 0) {
+      ldpp_dout(this, -1) << "ERROR: rgw_read_bucket_full_sync_status() on pipe=" << pipe << " returned ret=" << op_ret << dendl;
+      return;
     }
 
     op_ret = rgw_read_bucket_inc_sync_status(
@@ -1064,18 +1062,17 @@ void RGWOp_BILog_Status::execute(optional_yield y)
       pipe.dest.bucket = pinfo->bucket;
     }
 
-    if (version > 1) {
-      op_ret = rgw_read_bucket_full_sync_status(
-	this,
-	static_cast<rgw::sal::RadosStore*>(store),
-	pipe,
-	&status.sync_status,
-	s->yield);
-      if (op_ret < 0) {
-	ldpp_dout(this, -1) << "ERROR: rgw_read_bucket_full_sync_status() on pipe=" << pipe << " returned ret=" << op_ret << dendl;
-	return;
-      }
+    op_ret = rgw_read_bucket_full_sync_status(
+      this,
+      static_cast<rgw::sal::RadosStore*>(store),
+      pipe,
+      &status.sync_status,
+      s->yield);
+    if (op_ret < 0) {
+      ldpp_dout(this, -1) << "ERROR: rgw_read_bucket_full_sync_status() on pipe=" << pipe << " returned ret=" << op_ret << dendl;
+      return;
     }
+
     int r = rgw_read_bucket_inc_sync_status(this, static_cast<rgw::sal::RadosStore*>(store),
 					    pipe, *pinfo, &bucket->get_info(), status.sync_status.incremental_gen, &current_status);
     if (r < 0) {

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -1012,8 +1012,6 @@ void RGWOp_BILog_Status::execute(optional_yield y)
       this,
       static_cast<rgw::sal::RadosStore*>(store),
       pipe,
-      bucket->get_info(),
-      nullptr,
       status.sync_status.incremental_gen,
       &status.inc_status);
     if (op_ret < 0) {
@@ -1076,7 +1074,7 @@ void RGWOp_BILog_Status::execute(optional_yield y)
 
     current_status.resize(status.sync_status.shards_done_with_gen.size());
     int r = rgw_read_bucket_inc_sync_status(this, static_cast<rgw::sal::RadosStore*>(store),
-					    pipe, *pinfo, &bucket->get_info(), status.sync_status.incremental_gen, &current_status);
+					    pipe, status.sync_status.incremental_gen, &current_status);
     if (r < 0) {
       ldpp_dout(this, -1) << "ERROR: rgw_read_bucket_inc_sync_status() on pipe=" << pipe << " returned ret=" << r << dendl;
       op_ret = r;

--- a/src/rgw/rgw_sync_checkpoint.cc
+++ b/src/rgw/rgw_sync_checkpoint.cc
@@ -144,8 +144,8 @@ int bucket_source_sync_checkpoint(const DoutPrefixProvider* dpp,
 
   std::vector<rgw_bucket_shard_sync_info> status;
   status.resize(std::max<size_t>(1, num_shards));
-  r = rgw_read_bucket_inc_sync_status(dpp, store, pipe, bucket_info,
-                                      &source_bucket_info, full_status.incremental_gen, &status);
+  r = rgw_read_bucket_inc_sync_status(dpp, store, pipe,
+                                      full_status.incremental_gen, &status);
   if (r < 0) {
     return r;
   }
@@ -160,8 +160,8 @@ int bucket_source_sync_checkpoint(const DoutPrefixProvider* dpp,
         << "      local status: " << status << '\n'
         << "    remote markers: " << remote_markers << dendl;
     std::this_thread::sleep_until(delay_until);
-    r = rgw_read_bucket_inc_sync_status(dpp, store, pipe, bucket_info,
-                                        &source_bucket_info, full_status.incremental_gen, &status);
+    r = rgw_read_bucket_inc_sync_status(dpp, store, pipe,
+                                        full_status.incremental_gen, &status);
     if (r < 0) {
       return r;
     }

--- a/src/rgw/rgw_sync_checkpoint.cc
+++ b/src/rgw/rgw_sync_checkpoint.cc
@@ -88,8 +88,8 @@ int bucket_source_sync_checkpoint(const DoutPrefixProvider* dpp,
                                   ceph::timespan retry_delay,
                                   ceph::coarse_mono_time timeout_at)
 {
-  const auto num_shards = source_bucket_info.layout.current_index.layout.normal.num_shards;
 
+  const int num_shards = remote_markers.get().size();
   rgw_bucket_sync_status full_status;
   int r = rgw_read_bucket_full_sync_status(dpp, store, pipe, &full_status, null_yield);
   if (r < 0 && r != -ENOENT) { // retry on ENOENT


### PR DESCRIPTION
(followup to https://github.com/ceph/ceph/pull/41843)

if the full sync status object exists, use its `full_status.shards_done_with_gen.size()` as the shard count

when it doesn't exist, and we have a log gen 0, try to read those per-shard status objects for comparison. this is the backward-compat case where we haven't converted to the full status object

avoid crashing whenever remote shard count doesn't match what we expect

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
