### PR TITLE
rgw: fix the Content-Length in response header is inconsistent with response body size when rgw returns default html error page in static website

### DIFF
--- a/src/common/HTMLFormatter.cc
+++ b/src/common/HTMLFormatter.cc
@@ -30,7 +30,7 @@
 namespace ceph {
 
 HTMLFormatter::HTMLFormatter(bool pretty)
-: XMLFormatter(pretty), m_status(0), m_status_name(NULL)
+: XMLFormatter(pretty), m_pretty(pretty), m_status(0), m_status_name(NULL)
 {
 }
 
@@ -86,6 +86,12 @@ void HTMLFormatter::output_header() {
       m_ss << "\n";
     open_object_section("ul");
   }
+}
+
+void HTMLFormatter::flush(std::ostream& os)
+{
+  m_pretty = false;
+  XMLFormatter::flush(os);
 }
 
 template <typename T>

--- a/src/common/HTMLFormatter.h
+++ b/src/common/HTMLFormatter.h
@@ -14,7 +14,7 @@ namespace ceph {
 
     void set_status(int status, const char* status_name) override;
     void output_header() override;
-
+    void flush(std::ostream & os) override;
     void dump_unsigned(std::string_view name, uint64_t u) override;
     void dump_int(std::string_view name, int64_t u) override;
     void dump_float(std::string_view name, double d) override;
@@ -24,6 +24,8 @@ namespace ceph {
 
     /* with attrs */
     void dump_string_with_attrs(std::string_view name, std::string_view s, const FormatterAttrs& attrs) override;
+  protected:
+    bool m_pretty;
   private:
     template <typename T> void dump_template(std::string_view name, T arg);
 

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -608,6 +608,7 @@ void end_header(struct req_state* s, RGWOp* op, const char *content_type,
   if (!force_no_error && s->is_err()) {
     dump_start(s);
     dump(s);
+    s->formatter->output_footer();
     dump_content_length(s, s->formatter->get_len());
   } else {
     if (proposed_content_length == CHUNKED_TRANSFER_ENCODING) {


### PR DESCRIPTION
The default html error page as response body should be built completely include three ending html symbols(/ul, /body and /html) before rgw computes Content-Length in response header. The Content-Length in response header will be consistent with response body size. Client can get complete page.

Fixes: https://tracker.ceph.com/issues/52363
Signed-off-by: xiangrui meng mengxr@chinatelecom.cn
Signed-off-by: aicun hu huaicun@chinatelecom.cn
Signed-off-by: yupeng chen chenyupeng@chinatelecom.cn


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
