### PR TITLE
mgr/{prometheus,restful}: Fix url generation again

### DIFF
--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -435,7 +435,7 @@ def get_default_addr():
         return result
 
 
-def build_url(host: str, scheme: Optional[str] = None, port: Optional[int] = None) -> str:
+def build_url(host: str, scheme: Optional[str] = None, port: Optional[int] = None, path: str = '') -> str:
     """
     Build a valid URL. IPv6 addresses specified in host will be enclosed in brackets
     automatically.
@@ -448,6 +448,10 @@ def build_url(host: str, scheme: Optional[str] = None, port: Optional[int] = Non
 
     >>> build_url('fce:9af7:a667:7286:4917:b8d3:34df:8373', port=80, scheme='http')
     'http://[fce:9af7:a667:7286:4917:b8d3:34df:8373]:80'
+
+    >>> build_url('example.com', 'https', 443, path='/metrics')
+    'https://example.com:443/metrics'
+
 
     :param scheme: The scheme, e.g. http, https or ftp.
     :type scheme: str
@@ -463,7 +467,7 @@ def build_url(host: str, scheme: Optional[str] = None, port: Optional[int] = Non
     pr = urllib.parse.ParseResult(
         scheme=scheme if scheme else '',
         netloc=netloc,
-        path='',
+        path=path,
         params='',
         query='',
         fragment='')

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1382,7 +1382,7 @@ class Module(MgrModule):
         # about to start serving
         if server_addr in ['::', '0.0.0.0']:
             server_addr = self.get_mgr_ip()
-        self.set_uri(build_url(scheme='http', host=server_addr, port=server_port))
+        self.set_uri(build_url(scheme='http', host=server_addr, port=server_port, path='/'))
 
         cherrypy.config.update({
             'server.socket_host': server_addr,

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -313,7 +313,7 @@ class Module(MgrModule):
         # Publish the URI that others may use to access the service we're
         # about to start serving
         addr = self.get_mgr_ip() if server_addr == "::" else server_addr
-        self.set_uri(build_url(scheme='https', host=addr, port=server_port))
+        self.set_uri(build_url(scheme='https', host=addr, port=server_port, path='/'))
 
         # Create the HTTPS werkzeug server serving pecan app
         self.server = make_server(


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/52373
* Follow up  on #42793
* https://pulpito.ceph.com/yuriw-2021-08-21_15:05:03-rados-wip-yuri-master-8.20.21-distro-basic-smithi/6350733/

Fix for:
```
======================================================================
ERROR: test_standby (tasks.mgr.test_prometheus.TestPrometheus)
----------------------------------------------------------------------
urllib3.exceptions.LocationParseError: Failed to parse: http://172.21.15.71:7789metrics

```

Signed-off-by: Sebastian Wagner <sewagner@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
