### PR TITLE
pacific: mgr/dashboard: stats=false not working when listing buckets

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rgw.py
+++ b/qa/tasks/mgr/dashboard/test_rgw.py
@@ -211,6 +211,11 @@ class RgwBucketTest(RgwTestCase):
             'tenant': JLeaf(str),
         }, allow_unknown=True))
 
+        # List all buckets names without stats.
+        data = self._get('/api/rgw/bucket?stats=false')
+        self.assertStatus(200)
+        self.assertEqual(data, ['teuth-test-bucket'])
+
         # Get the bucket.
         data = self._get('/api/rgw/bucket/teuth-test-bucket')
         self.assertStatus(200)

--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -234,7 +234,7 @@ class RgwBucket(RgwRESTController):
 
     def list(self, stats=False, daemon_name=None):
         # type: (bool, Optional[str]) -> List[Any]
-        query_params = '?stats' if stats else ''
+        query_params = '?stats' if str_to_bool(stats) else ''
         result = self.proxy(daemon_name, 'GET', 'bucket{}'.format(query_params))
 
         if stats:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52378

---

backport of https://github.com/ceph/ceph/pull/42865
parent tracker: https://tracker.ceph.com/issues/51154

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh