### PR TITLE
mds: handle rctime updates for snaps

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -3913,6 +3913,7 @@ bool Locker::_do_cap_update(CInode *in, Capability *cap,
     wrlock_force(&in->xattrlock, mut);
   }
   
+  dout(20) << "rctime projections must stop at:" << follows << dendl;
   mut->auth_pin(in);
   mdcache->predirty_journal_parents(mut, &le->metablob, in, 0, PREDIRTY_PRIMARY, 0, follows);
   mdcache->journal_dirty_inode(mut.get(), &le->metablob, in, follows);


### PR DESCRIPTION
Conditionally update snap rctime only if snap btime is greater than new
rctime.

If snapshots are taken frequently when lazyio is being used, then the
rctime may not be updated for the snapshot for which the capabilities
are flushed by the client, but a subsequent snapshot. This is due to
the fact that this patch assumes that all relevant data writes have
been persisted to the OSDs and caps flushed to the MDS before the
snapshot is taken.

To avoid skipping a snapshot or two for correct rctime updates to
snapshot directories, the client should wait for at least twice the
client_oc_max_dirty_age duration before creating the snapshot dir.

Fixes: https://tracker.ceph.com/issues/50238
Signed-off-by: Milind Changire <mchangir@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
