### PR TITLE
pacific: cmake: exclude "grafonnet-lib" target from "all" 

### DIFF
--- a/monitoring/grafana/dashboards/CMakeLists.txt
+++ b/monitoring/grafana/dashboards/CMakeLists.txt
@@ -21,7 +21,8 @@ if(WITH_GRAFANA)
     URL_MD5 0798752ed40864fa8b3db40a3c970642
     BUILD_COMMAND ""
     CONFIGURE_COMMAND ""
-    INSTALL_COMMAND "")
+    INSTALL_COMMAND ""
+    EXCLUDE_FROM_ALL ON)
   add_dependencies(tests
     ${name})
   ExternalProject_Get_Property(${name} SOURCE_DIR)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52380

---

backport of https://github.com/ceph/ceph/pull/42871
parent tracker: https://tracker.ceph.com/issues/52338

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh