### PR TITLE
pacific: mds: create file system with specific ID

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -14,6 +14,10 @@
   If you want to return back the old behavior add 'ssl_options=' (empty) to
   ``rgw frontends`` configuration.
 
+* fs: A file system can be created with a specific ID ("fscid"). This is useful
+  in certain recovery scenarios, e.g., monitor database lost and rebuilt, and
+  the restored file system is expected to have the same ID as before.
+
 >=16.0.0
 --------
 

--- a/doc/cephfs/administration.rst
+++ b/doc/cephfs/administration.rst
@@ -379,3 +379,14 @@ This removes a rank from the failed set.
 
 This command resets the file system state to defaults, except for the name and
 pools. Non-zero ranks are saved in the stopped set.
+
+
+::
+
+    fs new <file system name> <metadata pool name> <data pool name> --fscid <fscid> --force
+
+This command creates a file system with a specific **fscid** (file system cluster ID).
+You may want to do this when an application expects the file system's ID to be
+stable after it has been recovered, e.g., after monitor databases are lost and
+rebuilt. Consequently, file system IDs don't always keep increasing with newer
+file systems.

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -404,7 +404,8 @@ public:
    */
   Filesystem::ref create_filesystem(
       std::string_view name, int64_t metadata_pool,
-      int64_t data_pool, uint64_t features);
+      int64_t data_pool, uint64_t features,
+      fs_cluster_id_t fscid);
 
   /**
    * Remove the filesystem (it must exist).  Caller should already

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -241,6 +241,18 @@ class FsNewHandler : public FileSystemCommandHandler
       }
     }
 
+    int64_t fscid = FS_CLUSTER_ID_NONE;
+    if (cmd_getval(cmdmap, "fscid", fscid)) {
+      if (!force) {
+        ss << "Pass --force to create a file system with a specific ID";
+        return -EINVAL;
+      }
+      if (fsmap.filesystem_exists(fscid)) {
+        ss << "filesystem already exists with id '" << fscid << "'";
+        return -EINVAL;
+      }
+    }
+
     pg_pool_t const *data_pool = mon->osdmon()->osdmap.get_pg_pool(data);
     ceph_assert(data_pool != NULL);  // Checked it existed above
     pg_pool_t const *metadata_pool = mon->osdmon()->osdmap.get_pg_pool(metadata);
@@ -280,7 +292,7 @@ class FsNewHandler : public FileSystemCommandHandler
 
     // All checks passed, go ahead and create.
     auto&& fs = fsmap.create_filesystem(fs_name, metadata, data,
-        mon->get_quorum_con_features());
+        mon->get_quorum_con_features(), fscid);
 
     ss << "new fs with metadata pool " << metadata << " and data pool " << data;
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -367,7 +367,8 @@ COMMAND("fs new "
 	"name=metadata,type=CephString "
 	"name=data,type=CephString "
 	"name=force,type=CephBool,req=false "
-	"name=allow_dangerous_metadata_overlay,type=CephBool,req=false",
+	"name=allow_dangerous_metadata_overlay,type=CephBool,req=false "
+	"name=fscid,type=CephInt,range=0,req=false",
 	"make new filesystem using named pools <metadata> and <data>",
 	"fs", "rw")
 COMMAND("fs fail "


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51834

---

backport of https://github.com/ceph/ceph/pull/42106
parent tracker: https://tracker.ceph.com/issues/51340

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh