### PR TITLE
Fix partial recovery become whole object recovery bug

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -942,8 +942,7 @@ void PGLog::_write_log_and_missing(
       if (!missing.is_missing(obj, &item)) {
 	to_remove.insert(key);
       } else {
-	uint64_t features = missing.may_include_deletes ? CEPH_FEATURE_OSD_RECOVERY_DELETES : 0;
-	encode(make_pair(obj, item), (*km)[key], features);
+	encode(make_pair(obj, item), (*km)[key], CEPH_FEATURES_SUPPORTED_DEFAULT);
       }
     });
   if (require_rollback) {


### PR DESCRIPTION
Problem: After the osd that is undergoing partial recovery is restarted, the data recovery is rolled back from the partial recovery to the whole object recovery.

```
Steps to reproduce:
1. ceph osd set noout
2. vdbench 5000 iops 8K 7:3 randrw
3. after 3 minutes, stop osd.0 running for 30 minutes
4. start osd.0   --> Note 1: At this time, it is a real partial recovery
5. During the parital recovery, again to stop osd.0
6. After stopping osd.0, immediately start osd.0 again --> Note 2: At this time, it becomes a whole object recovery
```


