### PR TITLE
python-common: improve OSD spec error messages

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -23,7 +23,7 @@ from prettytable import PrettyTable
 from ceph.deployment import inventory
 from ceph.deployment.drive_group import DriveGroupSpec
 from ceph.deployment.service_spec import \
-    ServiceSpec, PlacementSpec, assert_valid_host, \
+    ServiceSpec, PlacementSpec, \
     HostPlacementSpec, IngressSpec
 from ceph.utils import str_to_datetime, datetime_to_str, datetime_now
 from cephadm.serve import CephadmServe
@@ -1344,7 +1344,7 @@ Then run the following:
 
         :param host: host name
         """
-        assert_valid_host(spec.hostname)
+        spec.validate()
         ip_addr = self._check_valid_addr(spec.hostname, spec.addr)
         if spec.addr == spec.hostname and ip_addr:
             spec.addr = ip_addr

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1386,10 +1386,10 @@ class TestCephadm(object):
         _get_daemon_types.return_value = ['crash']
         _hosts.return_value = [hostname, 'other_host']
         cephadm_module.inventory.add_host(HostSpec(hostname))
-        # should raise an error which will get stored in OrchResult object
-        retval = cephadm_module.enter_host_maintenance(hostname)
-        assert retval.exception_str
-        assert not retval.result_str()
+
+        with pytest.raises(OrchestratorError, match='Failed to place host1 into maintenance for cluster fsid'):
+            cephadm_module.enter_host_maintenance(hostname)
+
         assert not cephadm_module.inventory._inventory[hostname]['status']
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -1418,10 +1418,10 @@ class TestCephadm(object):
         _get_daemon_types.return_value = ['crash']
         _hosts.return_value = [hostname, 'other_host']
         cephadm_module.inventory.add_host(HostSpec(hostname, status='maintenance'))
-        # should raise an error which will get stored in OrchResult object
-        retval = cephadm_module.exit_host_maintenance(hostname)
-        assert retval.exception_str
-        assert not retval.result_str()
+
+        with pytest.raises(OrchestratorError, match='Failed to exit maintenance state for host host1, cluster fsid'):
+            cephadm_module.exit_host_maintenance(hostname)
+
         assert cephadm_module.inventory._inventory[hostname]['status'] == 'maintenance'
 
     @mock.patch("cephadm.ssh.SSHManager._remote_connection")

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -125,6 +125,9 @@ def handle_orch_error(f: Callable[..., T]) -> Callable[..., 'OrchResult[T]']:
             return OrchResult(f(*args, **kwargs))
         except Exception as e:
             logger.exception(e)
+            import os
+            if 'UNITTEST' in os.environ:
+                raise  # This makes debugging of Tracebacks from unittests a bit easier
             return OrchResult(None, exception=e)
 
     return cast(Callable[..., OrchResult[T]], wrapper)

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -10,7 +10,7 @@ from prettytable import PrettyTable
 
 from ceph.deployment.inventory import Device
 from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection, OSDMethod
-from ceph.deployment.service_spec import PlacementSpec, ServiceSpec
+from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, service_spec_allow_invalid_from_json
 from ceph.deployment.hostspec import SpecValidationError
 from ceph.utils import datetime_now
 
@@ -563,11 +563,12 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         if len(services) == 0:
             return HandleCommandResult(stdout="No services reported")
         elif format != Format.plain:
-            if export:
-                data = [s.spec for s in services if s.deleted is None]
-                return HandleCommandResult(stdout=to_format(data, format, many=True, cls=ServiceSpec))
-            else:
-                return HandleCommandResult(stdout=to_format(services, format, many=True, cls=ServiceDescription))
+            with service_spec_allow_invalid_from_json():
+                if export:
+                    data = [s.spec for s in services if s.deleted is None]
+                    return HandleCommandResult(stdout=to_format(data, format, many=True, cls=ServiceSpec))
+                else:
+                    return HandleCommandResult(stdout=to_format(services, format, many=True, cls=ServiceDescription))
         else:
             now = datetime_now()
             table = PrettyTable(

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -1,5 +1,6 @@
 
 import json
+import textwrap
 
 import pytest
 import yaml
@@ -154,6 +155,24 @@ def test_orch_ls(_describe_service):
     r = m._handle_command(None, cmd)
     out = 'NAME  PORTS  RUNNING  REFRESHED  AGE  PLACEMENT  \n' \
           'osd              123  -          -               '
+    assert r == HandleCommandResult(retval=0, stdout=out, stderr='')
+
+    cmd = {
+        'prefix': 'orch ls',
+        'format': 'yaml',
+    }
+    m = OrchestratorCli('orchestrator', 0, 0)
+    r = m._handle_command(None, cmd)
+    out = textwrap.dedent("""
+        service_type: osd
+        service_name: osd
+        spec:
+          filter_logic: AND
+          objectstore: bluestore
+        status:
+          running: 123
+          size: 0
+        """).lstrip()
     assert r == HandleCommandResult(retval=0, stdout=out, stderr='')
 
 

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -73,11 +73,11 @@ def test_daemon_description():
 def test_apply():
     to = _TestOrchestrator('', 0, 0)
     completion = to.apply([
-        ServiceSpec(service_type='nfs'),
-        ServiceSpec(service_type='nfs'),
-        ServiceSpec(service_type='nfs'),
+        ServiceSpec(service_type='nfs', service_id='foo'),
+        ServiceSpec(service_type='nfs', service_id='foo'),
+        ServiceSpec(service_type='nfs', service_id='foo'),
     ])
-    res = '<NFSServiceSpec for service_name=nfs>'
+    res = '<NFSServiceSpec for service_name=nfs.foo>'
     assert completion.result == [res, res, res]
 
 

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -132,7 +132,8 @@ class DriveGroupValidationError(SpecValidationError):
     if it was raised in a different mgr module.
     """
 
-    def __init__(self, name: str, msg: str):
+    def __init__(self, name: Optional[str], msg: str):
+        name = name or "<unnamed>"
         super(DriveGroupValidationError, self).__init__(
             f'Failed to validate OSD spec "{name}": {msg}')
 
@@ -255,9 +256,7 @@ class DriveGroupSpec(ServiceSpec):
 
         args['service_type'] = json_drive_group.pop('service_type', 'osd')
 
-        # service_id was not required in early octopus.
-        args['service_id'] = json_drive_group.pop('service_id', '')
-        s_id = args['service_id']
+        s_id = args.get('service_id', '<unnamed>')
         try:
             args['placement'] = PlacementSpec.from_json(json_drive_group.pop('placement'))
         except KeyError:
@@ -301,9 +300,6 @@ class DriveGroupSpec(ServiceSpec):
     def validate(self):
         # type: () -> None
         super(DriveGroupSpec, self).validate()
-
-        if not self.service_id:
-            raise DriveGroupValidationError('', 'service_id is required')
 
         if not isinstance(self.placement.host_pattern, str) and \
                 self.placement.host_pattern is not None:

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -330,21 +330,5 @@ class DriveGroupSpec(ServiceSpec):
         if self.method == 'raw' and self.objectstore == 'filestore':
             raise DriveGroupValidationError('method raw only supports bluestore')
 
-    def __repr__(self) -> str:
-        keys = [
-            key for key in self._supported_features if getattr(self, key) is not None
-        ]
-        if 'encrypted' in keys and not self.encrypted:
-            keys.remove('encrypted')
-        if 'objectstore' in keys and self.objectstore == 'bluestore':
-            keys.remove('objectstore')
-        return "DriveGroupSpec(name={}->{})".format(
-            self.service_id,
-            ', '.join('{}={}'.format(key, repr(getattr(self, key))) for key in keys)
-        )
-
-    def __eq__(self, other: Any) -> bool:
-        return repr(self) == repr(other)
-
 
 yaml.add_representer(DriveGroupSpec, DriveGroupSpec.yaml_representer)

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -248,29 +248,21 @@ class DriveGroupSpec(ServiceSpec):
         :param json_drive_group: A valid json string with a Drive Group
                specification
         """
-        args: Dict[str, Any] = {}
+        args: Dict[str, Any] = json_drive_group.copy()
         # legacy json (pre Octopus)
-        if 'host_pattern' in json_drive_group and 'placement' not in json_drive_group:
-            json_drive_group['placement'] = {'host_pattern': json_drive_group['host_pattern']}
-            del json_drive_group['host_pattern']
-
-        args['service_type'] = json_drive_group.pop('service_type', 'osd')
+        if 'host_pattern' in args and 'placement' not in args:
+            args['placement'] = {'host_pattern': args['host_pattern']}
+            del args['host_pattern']
 
         s_id = args.get('service_id', '<unnamed>')
-        try:
-            args['placement'] = PlacementSpec.from_json(json_drive_group.pop('placement'))
-        except KeyError:
-            args['placement'] = PlacementSpec()
 
         # spec: was not mandatory in octopus
-        if 'spec' in json_drive_group:
-            args.update(cls._drive_group_spec_from_json(s_id, json_drive_group.pop('spec')))
+        if 'spec' in args:
+            args['spec'].update(cls._drive_group_spec_from_json(s_id, args['spec']))
         else:
-            args.update(cls._drive_group_spec_from_json(s_id, json_drive_group))
+            args.update(cls._drive_group_spec_from_json(s_id, args))
 
-        args['unmanaged'] = json_drive_group.pop('unmanaged', False)
-
-        return cls(**args)
+        return super(DriveGroupSpec, cls)._from_json_impl(args)
 
     @classmethod
     def _drive_group_spec_from_json(cls, name: str, json_drive_group: dict) -> dict:
@@ -301,9 +293,8 @@ class DriveGroupSpec(ServiceSpec):
         # type: () -> None
         super(DriveGroupSpec, self).validate()
 
-        if not isinstance(self.placement.host_pattern, str) and \
-                self.placement.host_pattern is not None:
-            raise DriveGroupValidationError(self.service_id, 'host_pattern must be of type string')
+        if self.placement.is_empty():
+            raise DriveGroupValidationError(self.service_id, '`placement` required')
 
         if self.data_devices is None:
             raise DriveGroupValidationError(self.service_id, "`data_devices` element is required.")

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -65,32 +65,30 @@ class DeviceSelection(object):
         #: Matches all devices. Can only be used for data devices
         self.all = all
 
-        self.validate()
-
-    def validate(self):
-        # type: () -> None
+    def validate(self, name: str) -> None:
         props = [self.model, self.vendor, self.size, self.rotational]  # type: List[Any]
         if self.paths and any(p is not None for p in props):
             raise DriveGroupValidationError(
-                'DeviceSelection: `paths` and other parameters are mutually exclusive')
+                name,
+                'device selection: `paths` and other parameters are mutually exclusive')
         is_empty = not any(p is not None and p != [] for p in [self.paths] + props)
         if not self.all and is_empty:
-            raise DriveGroupValidationError('DeviceSelection cannot be empty')
+            raise DriveGroupValidationError(name, 'device selection cannot be empty')
 
         if self.all and not is_empty:
             raise DriveGroupValidationError(
-                'DeviceSelection `all` and other parameters are mutually exclusive. {}'.format(
+                name,
+                'device selection: `all` and other parameters are mutually exclusive. {}'.format(
                     repr(self)))
 
     @classmethod
     def from_json(cls, device_spec):
         # type: (dict) -> Optional[DeviceSelection]
         if not device_spec:
-            return  # type: ignore
+            return None
         for applied_filter in list(device_spec.keys()):
             if applied_filter not in cls._supported_filters:
-                raise DriveGroupValidationError(
-                    "Filtering for <{}> is not supported".format(applied_filter))
+                raise KeyError(applied_filter)
 
         return cls(**device_spec)
 
@@ -134,8 +132,9 @@ class DriveGroupValidationError(SpecValidationError):
     if it was raised in a different mgr module.
     """
 
-    def __init__(self, msg: str):
-        super(DriveGroupValidationError, self).__init__('Failed to validate Drive Group: ' + msg)
+    def __init__(self, name: str, msg: str):
+        super(DriveGroupValidationError, self).__init__(
+            f'Failed to validate OSD spec "{name}": {msg}')
 
 
 class DriveGroupSpec(ServiceSpec):
@@ -254,81 +253,107 @@ class DriveGroupSpec(ServiceSpec):
             json_drive_group['placement'] = {'host_pattern': json_drive_group['host_pattern']}
             del json_drive_group['host_pattern']
 
+        args['service_type'] = json_drive_group.pop('service_type', 'osd')
+
+        # service_id was not required in early octopus.
+        args['service_id'] = json_drive_group.pop('service_id', '')
+        s_id = args['service_id']
         try:
             args['placement'] = PlacementSpec.from_json(json_drive_group.pop('placement'))
         except KeyError:
             args['placement'] = PlacementSpec()
 
-        args['service_type'] = json_drive_group.pop('service_type', 'osd')
-
-        # service_id was not required in early octopus.
-        args['service_id'] = json_drive_group.pop('service_id', '')
-
         # spec: was not mandatory in octopus
         if 'spec' in json_drive_group:
-            args.update(cls._drive_group_spec_from_json(json_drive_group.pop('spec')))
+            args.update(cls._drive_group_spec_from_json(s_id, json_drive_group.pop('spec')))
         else:
-            args.update(cls._drive_group_spec_from_json(json_drive_group))
+            args.update(cls._drive_group_spec_from_json(s_id, json_drive_group))
 
         args['unmanaged'] = json_drive_group.pop('unmanaged', False)
 
         return cls(**args)
 
     @classmethod
-    def _drive_group_spec_from_json(cls, json_drive_group: dict) -> dict:
+    def _drive_group_spec_from_json(cls, name: str, json_drive_group: dict) -> dict:
         for applied_filter in list(json_drive_group.keys()):
             if applied_filter not in cls._supported_features:
                 raise DriveGroupValidationError(
-                    "Feature <{}> is not supported".format(applied_filter))
+                    name,
+                    "Feature `{}` is not supported".format(applied_filter))
 
         try:
-            args = {k: (DeviceSelection.from_json(v) if k.endswith('_devices') else v) for k, v in
+            def to_selection(key: str, vals: dict) -> Optional[DeviceSelection]:
+                try:
+                    return DeviceSelection.from_json(vals)
+                except KeyError as e:
+                    raise DriveGroupValidationError(
+                        f'{name}.{key}',
+                        f"Filtering for `{e.args[0]}` is not supported")
+
+            args = {k: (to_selection(k, v) if k.endswith('_devices') else v) for k, v in
                     json_drive_group.items()}
             if not args:
-                raise DriveGroupValidationError("Didn't find Drivegroup specs")
+                raise DriveGroupValidationError(name, "Didn't find drive selections")
             return args
         except (KeyError, TypeError) as e:
-            raise DriveGroupValidationError(str(e))
+            raise DriveGroupValidationError(name, str(e))
 
     def validate(self):
         # type: () -> None
         super(DriveGroupSpec, self).validate()
 
         if not self.service_id:
-            raise DriveGroupValidationError('service_id is required')
+            raise DriveGroupValidationError('', 'service_id is required')
 
         if not isinstance(self.placement.host_pattern, str) and \
                 self.placement.host_pattern is not None:
-            raise DriveGroupValidationError('host_pattern must be of type string')
+            raise DriveGroupValidationError(self.service_id, 'host_pattern must be of type string')
 
         if self.data_devices is None:
-            raise DriveGroupValidationError("`data_devices` element is required.")
+            raise DriveGroupValidationError(self.service_id, "`data_devices` element is required.")
 
-        specs = [self.data_devices, self.db_devices, self.wal_devices, self.journal_devices]
-        for s in filter(None, specs):
-            s.validate()
+        specs_names = "data_devices db_devices wal_devices journal_devices".split()
+        specs = dict(zip(specs_names, [getattr(self, k) for k in specs_names]))
+        for k, s in [ks for ks in specs.items() if ks[1] is not None]:
+            assert s is not None
+            s.validate(f'{self.service_id}.{k}')
         for s in filter(None, [self.db_devices, self.wal_devices, self.journal_devices]):
             if s.all:
-                raise DriveGroupValidationError("`all` is only allowed for data_devices")
+                raise DriveGroupValidationError(
+                    self.service_id,
+                    "`all` is only allowed for data_devices")
 
         if self.objectstore not in ('bluestore'):
-            raise DriveGroupValidationError(f"{self.objectstore} is not supported. Must be "
+            raise DriveGroupValidationError(self.service_id,
+                                            f"{self.objectstore} is not supported. Must be "
                                             f"one of ('bluestore')")
 
         if self.block_wal_size is not None and type(self.block_wal_size) not in [int, str]:
-            raise DriveGroupValidationError('block_wal_size must be of type int or string')
+            raise DriveGroupValidationError(
+                self.service_id,
+                'block_wal_size must be of type int or string')
         if self.block_db_size is not None and type(self.block_db_size) not in [int, str]:
-            raise DriveGroupValidationError('block_db_size must be of type int or string')
+            raise DriveGroupValidationError(
+                self.service_id,
+                'block_db_size must be of type int or string')
         if self.journal_size is not None and type(self.journal_size) not in [int, str]:
-            raise DriveGroupValidationError('journal_size must be of type int or string')
+            raise DriveGroupValidationError(
+                self.service_id,
+                'journal_size must be of type int or string')
 
         if self.filter_logic not in ['AND', 'OR']:
-            raise DriveGroupValidationError('filter_logic must be either <AND> or <OR>')
+            raise DriveGroupValidationError(
+                self.service_id,
+                'filter_logic must be either <AND> or <OR>')
 
         if self.method not in [None, 'lvm', 'raw']:
-            raise DriveGroupValidationError('method must be one of None, lvm, raw')
+            raise DriveGroupValidationError(
+                self.service_id,
+                'method must be one of None, lvm, raw')
         if self.method == 'raw' and self.objectstore == 'filestore':
-            raise DriveGroupValidationError('method raw only supports bluestore')
+            raise DriveGroupValidationError(
+                self.service_id,
+                'method raw only supports bluestore')
 
 
 yaml.add_representer(DriveGroupSpec, DriveGroupSpec.yaml_representer)

--- a/src/python-common/ceph/deployment/drive_selection/matchers.py
+++ b/src/python-common/ceph/deployment/drive_selection/matchers.py
@@ -10,6 +10,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+class _MatchInvalid(Exception):
+    pass
+
+
 # pylint: disable=too-few-public-methods
 class Matcher(object):
     """ The base class to all Matchers
@@ -70,7 +74,7 @@ class Matcher(object):
         if disk_value:
             return disk_value[0]
         else:
-            raise Exception("No value found for {} or {}".format(
+            raise _MatchInvalid("No value found for {} or {}".format(
                 self.key, self.fallback_key))
 
     def compare(self, disk):
@@ -256,7 +260,7 @@ class SizeMatcher(Matcher):
         """
         suffix = suffix.upper()
         if suffix not in cls.supported_suffixes:
-            raise ValueError("Unit '{}' not supported".format(suffix))
+            raise _MatchInvalid("Unit '{}' not supported".format(suffix))
         return dict(zip(
             cls.SUFFIXES[1],
             cls.SUFFIXES[0],
@@ -327,7 +331,7 @@ class SizeMatcher(Matcher):
             self.exact = self._get_k_v(exact.group())
 
         if not self.low and not self.high and not self.exact:
-            raise Exception("Couldn't parse {}".format(self.value))
+            raise _MatchInvalid("Couldn't parse {}".format(self.value))
 
     @staticmethod
     # pylint: disable=inconsistent-return-statements
@@ -404,5 +408,5 @@ class SizeMatcher(Matcher):
             logger.debug("Disk didn't match for 'exact' filter")
         else:
             logger.debug("Neither high, low, nor exact was given")
-            raise Exception("No filters applied")
+            raise _MatchInvalid("No filters applied")
         return False

--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -1,16 +1,25 @@
 import logging
 
-try:
-    from typing import List, Optional, Dict
-except ImportError:
-    pass
+from typing import List, Optional, Dict, Callable
 
 from ..inventory import Device
-from ..drive_group import DriveGroupSpec, DeviceSelection
+from ..drive_group import DriveGroupSpec, DeviceSelection, DriveGroupValidationError
 
 from .filter import FilterGenerator
+from .matchers import _MatchInvalid
 
 logger = logging.getLogger(__name__)
+
+
+def to_dg_exception(f: Callable) -> Callable[['DriveSelection', str,
+                                              Optional['DeviceSelection']],
+                                             List['Device']]:
+    def wrapper(self: 'DriveSelection', name: str, ds: Optional['DeviceSelection']) -> List[Device]:
+        try:
+            return f(self, ds)
+        except _MatchInvalid as e:
+            raise DriveGroupValidationError(f'{self.spec.service_id}.{name}', e.args[0])
+    return wrapper
 
 
 class DriveSelection(object):
@@ -23,10 +32,10 @@ class DriveSelection(object):
         self.spec = spec
         self.existing_daemons = existing_daemons or 0
 
-        self._data = self.assign_devices(self.spec.data_devices)
-        self._wal = self.assign_devices(self.spec.wal_devices)
-        self._db = self.assign_devices(self.spec.db_devices)
-        self._journal = self.assign_devices(self.spec.journal_devices)
+        self._data = self.assign_devices('data_devices', self.spec.data_devices)
+        self._wal = self.assign_devices('wal_devices', self.spec.wal_devices)
+        self._db = self.assign_devices('db_devices', self.spec.db_devices)
+        self._journal = self.assign_devices('journal_devices', self.spec.journal_devices)
 
     def data_devices(self):
         # type: () -> List[Device]
@@ -79,6 +88,7 @@ class DriveSelection(object):
             raise Exception(
                 "Disk {} doesn't have a 'path' identifier".format(disk))
 
+    @to_dg_exception
     def assign_devices(self, device_filter):
         # type: (Optional[DeviceSelection]) -> List[Device]
         """ Assign drives based on used filters

--- a/src/python-common/ceph/deployment/hostspec.py
+++ b/src/python-common/ceph/deployment/hostspec.py
@@ -1,9 +1,19 @@
 from collections import OrderedDict
 import errno
-try:
-    from typing import Optional, List, Any, Dict
-except ImportError:
-    pass  # just for type checking
+import re
+from typing import Optional, List, Any, Dict
+
+
+def assert_valid_host(name: str) -> None:
+    p = re.compile('^[a-zA-Z0-9-]+$')
+    try:
+        assert len(name) <= 250, 'name is too long (max 250 chars)'
+        for part in name.split('.'):
+            assert len(part) > 0, '.-delimited name component must not be empty'
+            assert len(part) <= 63, '.-delimited name component must not be more than 63 chars'
+            assert p.match(part), 'name component must include only a-z, 0-9, and -'
+    except AssertionError as e:
+        raise SpecValidationError(str(e))
 
 
 class SpecValidationError(Exception):
@@ -44,6 +54,9 @@ class HostSpec(object):
         self.status = status or ''  # type: str
 
         self.location = location
+
+    def validate(self) -> None:
+        assert_valid_host(self.hostname)
 
     def to_json(self) -> Dict[str, Any]:
         r: Dict[str, Any] = {

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -295,8 +295,12 @@ class PlacementSpec(object):
             raise SpecValidationError(
                 "count-per-host cannot be combined explicit placement with names or networks"
             )
-        if self.host_pattern and self.hosts:
-            raise SpecValidationError('cannot combine host patterns and hosts')
+        if self.host_pattern:
+            if not isinstance(self.host_pattern, str):
+                raise SpecValidationError('host_pattern must be of type string')
+            if self.hosts:
+                raise SpecValidationError('cannot combine host patterns and hosts')
+
         for h in self.hosts:
             h.validate()
 

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -8,23 +8,11 @@ from typing import Optional, Dict, Any, List, Union, Callable, Iterable, Type, T
 
 import yaml
 
-from ceph.deployment.hostspec import HostSpec, SpecValidationError
+from ceph.deployment.hostspec import HostSpec, SpecValidationError, assert_valid_host
 from ceph.deployment.utils import unwrap_ipv6
 
 ServiceSpecT = TypeVar('ServiceSpecT', bound='ServiceSpec')
 FuncT = TypeVar('FuncT', bound=Callable)
-
-
-def assert_valid_host(name: str) -> None:
-    p = re.compile('^[a-zA-Z0-9-]+$')
-    try:
-        assert len(name) <= 250, 'name is too long (max 250 chars)'
-        for part in name.split('.'):
-            assert len(part) > 0, '.-delimited name component must not be empty'
-            assert len(part) <= 63, '.-delimited name component must not be more than 63 chars'
-            assert p.match(part), 'name component must include only a-z, 0-9, and -'
-    except AssertionError as e:
-        raise SpecValidationError(str(e))
 
 
 def handle_type_error(method: FuncT) -> FuncT:

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -668,7 +668,8 @@ class ServiceSpec(object):
                 )
 
     def __repr__(self) -> str:
-        return "{}({!r})".format(self.__class__.__name__, self.__dict__)
+        y = yaml.dump(cast(dict, self), default_flow_style=False)
+        return f"{self.__class__.__name__}.from_json(yaml.safe_load('''{y}'''))"
 
     def __eq__(self, other: Any) -> bool:
         return (self.__class__ == other.__class__

--- a/src/python-common/ceph/tests/test_disk_selector.py
+++ b/src/python-common/ceph/tests/test_disk_selector.py
@@ -344,11 +344,6 @@ class TestDriveGroup(object):
                 }
 
             dgo = DriveGroupSpec.from_json(raw_sample)
-            if disk_format == 'filestore':
-                with pytest.raises(DriveGroupValidationError):
-                    dgo.validate()
-            else:
-                dgo.validate()
             return dgo
 
         return make_sample_data
@@ -424,19 +419,9 @@ class TestDriveGroup(object):
             limit=0,
         )
 
-    def test_journal_device_prop(self, test_fix):
-        test_fix = test_fix(disk_format='filestore')
-        assert test_fix.journal_devices == DeviceSelection(
-            size=':20G'
-        )
-
     def test_wal_device_prop_empty(self, test_fix):
         test_fix = test_fix(empty=True)
         assert test_fix.wal_devices is None
-
-    def test_filestore_format_prop(self, test_fix):
-        test_fix = test_fix(disk_format='filestore')
-        assert test_fix.objectstore == 'filestore'
 
     def test_bluestore_format_prop(self, test_fix):
         test_fix = test_fix(disk_format='bluestore')
@@ -445,10 +430,6 @@ class TestDriveGroup(object):
     def test_default_format_prop(self, test_fix):
         test_fix = test_fix(empty=True)
         assert test_fix.objectstore == 'bluestore'
-
-    def test_journal_size(self, test_fix):
-        test_fix = test_fix(disk_format='filestore')
-        assert test_fix.journal_size == '5G'
 
     def test_osds_per_device(self, test_fix):
         test_fix = test_fix(osds_per_device='3')

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -14,20 +14,28 @@ from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection, \
 
 @pytest.mark.parametrize("test_input",
 [
+    (  # new style json
+        """service_type: osd
+service_id: testing_drivegroup
+placement:
+  host_pattern: hostname
+data_devices:
+  paths:
+  - /dev/sda 
+"""
+    ),
     (
-        [  # new style json
-            {
-                'service_type': 'osd',
-                'service_id': 'testing_drivegroup',
-                'placement': {'host_pattern': 'hostname'},
-                'data_devices': {'paths': ['/dev/sda']}
-            }
-        ]
+        """service_type: osd
+service_id: testing_drivegroup
+placement:
+  host_pattern: hostname
+data_devices:
+  paths:
+  - /dev/sda"""
     ),
 ])
 def test_DriveGroup(test_input):
-    dg = [DriveGroupSpec.from_json(inp) for inp in test_input][0]
-    assert dg.placement.filter_matching_hostspecs([HostSpec('hostname')]) == ['hostname']
+    dg = DriveGroupSpec.from_json(yaml.safe_load(test_input))
     assert dg.service_id == 'testing_drivegroup'
     assert all([isinstance(x, Device) for x in dg.data_devices.paths])
     assert dg.data_devices.paths[0].path == '/dev/sda'
@@ -39,7 +47,7 @@ def test_DriveGroup(test_input):
         ''
     ),
     (
-        'Failed to validate OSD spec "": `placement` key required',
+        'Failed to validate OSD spec "<unnamed>": `placement` required',
         """data_devices:
   all: True
 """

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -39,7 +39,8 @@ def test_DriveGroup(test_input):
         ''
     ),
     (
-        'Failed to validate Drive Group: DeviceSelection cannot be empty', """
+        "Failed to validate Drive Group: OSD spec needs a `placement` key.",
+        'Failed to validate OSD spec "mydg.data_devices": device selection cannot be empty', """
 service_type: osd
 service_id: mydg
 placement:
@@ -49,7 +50,7 @@ data_devices:
 """
     ),
     (
-        'Failed to validate Drive Group: filter_logic must be either <AND> or <OR>', """
+        'Failed to validate OSD spec "mydg": filter_logic must be either <AND> or <OR>', """
 service_type: osd
 service_id: mydg
 placement:
@@ -60,7 +61,7 @@ filter_logic: XOR
 """
     ),
     (
-        'Failed to validate Drive Group: `data_devices` element is required.', """
+        'Failed to validate OSD spec "mydg": `data_devices` element is required.', """
 service_type: osd
 service_id: mydg
 placement:
@@ -68,6 +69,29 @@ placement:
 spec:
   db_devices:
     model: model
+"""
+    ),
+    (
+        'Failed to validate OSD spec "mydg.db_devices": Filtering for `unknown_key` is not supported', """
+service_type: osd
+service_id: mydg
+placement:
+  host_pattern: '*'
+spec:
+  db_devices:
+    unknown_key: 1
+"""
+    ),
+    (
+        'Failed to validate OSD spec "mydg": Feature `unknown_key` is not supported', """
+service_type: osd
+service_id: mydg
+placement:
+  host_pattern: '*'
+spec:
+  db_devices:
+    all: true
+  unknown_key: 1
 """
     ),
 ])
@@ -95,7 +119,8 @@ def test_drive_selection():
     assert spec.data_devices.paths[0].path == '/dev/sda'
 
     with pytest.raises(DriveGroupValidationError, match='exclusive'):
-        DeviceSelection(paths=['/dev/sda'], rotational=False)
+        ds = DeviceSelection(paths=['/dev/sda'], rotational=False)
+        ds.validate('')
 
 
 def test_ceph_volume_command_0():

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -39,7 +39,12 @@ def test_DriveGroup(test_input):
         ''
     ),
     (
-        "Failed to validate Drive Group: OSD spec needs a `placement` key.",
+        'Failed to validate OSD spec "": `placement` key required',
+        """data_devices:
+  all: True
+"""
+    ),
+    (
         'Failed to validate OSD spec "mydg.data_devices": device selection cannot be empty', """
 service_type: osd
 service_id: mydg

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -342,6 +342,17 @@ def test_alertmanager_spec_2():
     assert 'default_webhook_urls' in spec.user_data.keys()
 
 
+
+def test_repr():
+    val = """ServiceSpec.from_json(yaml.safe_load('''service_type: crash
+service_name: crash
+placement:
+  count: 42
+'''))"""
+    obj = eval(val)
+    assert obj.service_type == 'crash'
+    assert val == repr(obj)
+
 @pytest.mark.parametrize("spec1, spec2, eq",
                          [
                              (


### PR DESCRIPTION
Extracted a patch from #42378: ServiceSpec yaml: Don't add empty placement

Problem was, it created a Teuthology error: 

> 2021-08-23T12:54:16.481 INFO:teuthology.orchestra.run.smithi061.stderr:Error EINVAL: Failed to validate Drive Group: OSD spec needs a placement key.

This PR attempts to find the offending test. 

Fixes: https://tracker.ceph.com/issues/47401
Fixes: https://tracker.ceph.com/issues/50685
Fixes: https://tracker.ceph.com/issues/46253


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
