### PR TITLE
mgr/orch: deprecated `ceph orch apply osd -i <osd_spec_file>`

### DIFF
--- a/doc/cephadm/services/osd.rst
+++ b/doc/cephadm/services/osd.rst
@@ -332,7 +332,7 @@ Alternatively, you can use your OSDSpec file:
 
 .. prompt:: bash #
 
-  ceph orch apply osd -i <osd_spec_file> --dry-run
+  ceph orch apply -i <osd_spec_file> --dry-run
 
 Expected output::
 
@@ -459,7 +459,7 @@ This means :
 
    .. prompt:: bash [monitor.1]#
 
-     ceph orch apply osd -i /path/to/osd_spec.yml
+     ceph orch apply -i /path/to/osd_spec.yml
 
    This instruction will be issued to all the matching hosts, and will deploy
    these OSDs.
@@ -474,7 +474,7 @@ Example
 
 .. prompt:: bash [monitor.1]#
 
-   ceph orch apply osd -i /path/to/osd_spec.yml --dry-run
+   ceph orch apply -i /path/to/osd_spec.yml --dry-run
 
 
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -705,61 +705,22 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
                    unmanaged: Optional[bool] = None,
                    dry_run: bool = False,
                    no_overwrite: bool = False,
-                   inbuf: Optional[str] = None) -> HandleCommandResult:
+                   inbuf: Optional[str] = None  # deprecated. Was deprecated before Quincy
+                   ) -> HandleCommandResult:
         """
-        Create OSD daemon(s) using a drive group spec
+        Create OSD daemon(s) on all available devices
         """
-        # Apply DriveGroupSpecs to create OSDs
-        usage = """
-usage:
-  ceph orch apply osd -i <json_file/yaml_file> [--dry-run]
-  ceph orch apply osd --all-available-devices [--dry-run] [--unmanaged]
-
-Restrictions:
-
-  Mutexes:
-  * -i, --all-available-devices
-  * -i, --unmanaged (this would overwrite the osdspec loaded from a file)
-
-  Parameters:
-
-  * --unmanaged
-     Only works with --all-available-devices.
-
-Description:
-
-  * -i
-    An inbuf object like a file or a json/yaml blob containing a valid OSDSpec
-
-  * --all-available-devices
-    The most simple OSDSpec there is. Takes all as 'available' marked devices
-    and creates standalone OSDs on them.
-
-  * --unmanaged
-    Set a the unmanaged flag for all--available-devices (default is False)
-
-Examples:
-
-   # ceph orch apply osd -i <file.yml|json>
-
-   Applies one or more OSDSpecs found in <file>
-
-   # ceph orch osd apply --all-available-devices --unmanaged=true
-
-   Creates and applies simple OSDSpec with the unmanaged flag set to <true>
-"""
 
         if inbuf and all_available_devices:
-            # mutually exclusive
-            return HandleCommandResult(-errno.EINVAL, stderr=usage)
+            return HandleCommandResult(-errno.EINVAL, '-i infile and --all-available-devices are mutually exclusive')
 
         if not inbuf and not all_available_devices:
             # one parameter must be present
-            return HandleCommandResult(-errno.EINVAL, stderr=usage)
+            return HandleCommandResult(-errno.EINVAL, '--all-available-devices is required')
 
         if inbuf:
             if unmanaged is not None:
-                return HandleCommandResult(-errno.EINVAL, stderr=usage)
+                return HandleCommandResult(-errno.EINVAL, stderr='-i infile and --unmanaged are mutually exclusive')
 
             try:
                 drivegroups = [_dg for _dg in yaml.safe_load_all(inbuf)]
@@ -791,7 +752,7 @@ Examples:
             ]
             return self._apply_misc(dg_specs, dry_run, format, no_overwrite)
 
-        return HandleCommandResult(-errno.EINVAL, stderr=usage)
+        return HandleCommandResult(-errno.EINVAL, stderr='--all-available-devices is required')
 
     @_cli_write_command('orch daemon add osd')
     def _daemon_add_osd(self,


### PR DESCRIPTION
Remove duplicated code and avoid user errors

Fixes: https://tracker.ceph.com/issues/47401
Signed-off-by: Sebastian Wagner <sewagner@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
