### PR TITLE
pacific: mon: Sanely set the default CRUSH rule when creating pools in stretch…

### DIFF
--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -858,6 +858,13 @@ public:
    * Sets the osdmap and pg_pool_t values back to healthy stretch mode status.
    */
   void trigger_healthy_stretch_mode();
+  /**
+   * Obtain the crush rule being used for stretch pools.
+   * Note that right now this is heuristic and simply selects the
+   * most-used rule on replicated stretch pools.
+   * @return the crush rule ID, or a negative errno
+   */
+  int get_replicated_stretch_crush_rule();
 private:
   utime_t stretch_recovery_triggered; // what time we committed a switch to recovery mode
 };

--- a/src/script/set_up_stretch_mode.sh
+++ b/src/script/set_up_stretch_mode.sh
@@ -24,6 +24,30 @@ rule stretch_rule {
         step chooseleaf firstn 2 type host
         step emit
 }
+rule stretch_rule2 {
+        id 2
+        type replicated
+        min_size 1
+        max_size 10
+        step take site1
+        step chooseleaf firstn 2 type host
+        step emit
+        step take site2
+        step chooseleaf firstn 2 type host
+        step emit
+}
+rule stretch_rule3 {
+        id 3
+        type replicated
+        min_size 1
+        max_size 10
+        step take site1
+        step chooseleaf firstn 2 type host
+        step emit
+        step take site2
+        step chooseleaf firstn 2 type host
+        step emit
+}
 EOF
 ./bin/crushtool -c crush.map.txt -o crush2.map.bin
 ./bin/ceph osd setcrushmap -i crush2.map.bin


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51290

---

backport of https://github.com/ceph/ceph/pull/41921
parent tracker: https://tracker.ceph.com/issues/51270

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh