### PR TITLE
ceph-volume: fix lvm activate --all --no-systemd

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -241,7 +241,7 @@ class Activate(object):
             terminal.warning('Verify OSDs are present with "ceph-volume lvm list"')
             return
         for osd_fsid, osd_id in osds.items():
-            if systemctl.osd_is_active(osd_id):
+            if not args.no_systemd and systemctl.osd_is_active(osd_id):
                 terminal.warning(
                     'OSD ID %s FSID %s process is active. Skipping activation' % (osd_id, osd_fsid)
                 )

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
@@ -345,10 +345,22 @@ class TestActivateAll(object):
         assert 'a8789a96ce8b process is active. Skipping activation' in err
         assert 'b8218eaa1634 process is active. Skipping activation' in err
 
-    def test_detects_osds_to_activate(self, is_root, capture, monkeypatch):
+    def test_detects_osds_to_activate_systemd(self, is_root, capture, monkeypatch):
         monkeypatch.setattr('ceph_volume.devices.lvm.activate.direct_report', lambda: direct_report)
         monkeypatch.setattr('ceph_volume.devices.lvm.activate.systemctl.osd_is_active', lambda x: False)
         args = ['--all']
+        activation = activate.Activate(args)
+        activation.activate = capture
+        activation.main()
+        calls = sorted(capture.calls, key=lambda x: x['kwargs']['osd_id'])
+        assert calls[0]['kwargs']['osd_id'] == '0'
+        assert calls[0]['kwargs']['osd_fsid'] == '957d22b7-24ce-466a-9883-b8218eaa1634'
+        assert calls[1]['kwargs']['osd_id'] == '1'
+        assert calls[1]['kwargs']['osd_fsid'] == 'd0f3e4ad-e52a-4520-afc0-a8789a96ce8b'
+
+    def test_detects_osds_to_activate_no_systemd(self, is_root, capture, monkeypatch):
+        monkeypatch.setattr('ceph_volume.devices.lvm.activate.direct_report', lambda: direct_report)
+        args = ['--all', '--no-systemd']
         activation = activate.Activate(args)
         activation.activate = capture
         activation.main()


### PR DESCRIPTION
When using a system without systemd then the `lvm activate --all --no-systemd`
subcommand still calls systemd.
We already allow users to activate a single OSD without systemd so there's
no reason to not do the same with --all (because activate_all calls activate).

Fixes: https://tracker.ceph.com/issues/25070

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
