### PR TITLE
crimson/os: Use operator[] in CyanStore when inserting values to omap

### DIFF
--- a/src/crimson/os/cyanstore/cyan_store.cc
+++ b/src/crimson/os/cyanstore/cyan_store.cc
@@ -576,7 +576,7 @@ int CyanStore::_omap_set_values(
 
   ObjectRef o = c->get_or_create_object(oid);
   for (auto &&i: aset) {
-    o->omap.insert(std::move(i));
+    o->omap[std::move(i.first)] = std::move(i.second);
   }
   return 0;
 }


### PR DESCRIPTION
std::map::insert() doesn't update the value associated with an existing
key, therefore we should use operator[] instead

Signed-off-by: Amnon Hanuhov <ahanukov@redhat.com>