### PR TITLE
mgr/cephadm: Also make ssh._reset_con async

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1441,7 +1441,7 @@ Then run the following:
 
         self.inventory.rm_host(host)
         self.cache.rm_host(host)
-        self.ssh._reset_con(host)
+        self.ssh.reset_con(host)
         self.event.set()  # refresh stray health check
         self.log.info('Removed host %s' % host)
         return "Removed {} host '{}'".format('offline' if offline else '', host)
@@ -1450,7 +1450,7 @@ Then run the following:
     def update_host_addr(self, host: str, addr: str) -> str:
         self._check_valid_addr(host, addr)
         self.inventory.set_addr(host, addr)
-        self.ssh._reset_con(host)
+        self.ssh.reset_con(host)
         self.event.set()  # refresh stray health check
         self.log.info('Set host %s addr to %s' % (host, addr))
         return "Updated host '{}' addr to '{}'".format(host, addr)

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1205,13 +1205,15 @@ class CephadmServe:
             cmd = [python, self.mgr.cephadm_binary_path] + final_args
 
             try:
-                out, err, code = self.mgr.ssh.execute_command(host, cmd, stdin=stdin.encode('utf-8') if stdin else None, addr=addr)
+                out, err, code = self.mgr.ssh.execute_command(
+                    host, cmd, stdin=stdin.encode('utf-8') if stdin else None, addr=addr)
                 if code == 2:
                     ls_cmd = ['ls', self.mgr.cephadm_binary_path]
                     out_ls, err_ls, code_ls = self.mgr.ssh.execute_command(host, ls_cmd, addr=addr)
                     if code_ls == 2:
                         self._deploy_cephadm_binary(host, addr)
-                        out, err, code = self.mgr.ssh.execute_command(host, cmd, stdin=stdin.encode('utf-8') if stdin else None, addr=addr)
+                        out, err, code = self.mgr.ssh.execute_command(
+                            host, cmd, stdin=stdin.encode('utf-8') if stdin else None, addr=addr)
 
             except Exception as e:
                 self.mgr.ssh._reset_con(host)
@@ -1222,7 +1224,8 @@ class CephadmServe:
         elif self.mgr.mode == 'cephadm-package':
             try:
                 cmd = ['/usr/bin/cephadm'] + final_args
-                out, err, code = self.mgr.ssh.execute_command(host, cmd, stdin=stdin.encode('utf-8') if stdin else None, addr=addr)
+                out, err, code = self.mgr.ssh.execute_command(
+                    host, cmd, stdin=stdin.encode('utf-8') if stdin else None, addr=addr)
             except Exception as e:
                 self.mgr.ssh._reset_con(host)
                 if error_ok:
@@ -1282,4 +1285,5 @@ class CephadmServe:
     def _deploy_cephadm_binary(self, host: str, addr: Optional[str] = None) -> None:
         # Use tee (from coreutils) to create a copy of cephadm on the target machine
         self.log.info(f"Deploying cephadm binary to {host}")
-        self.mgr.ssh.write_remote_file(host, self.mgr.cephadm_binary_path, self.mgr._cephadm.encode('utf-8'), addr=addr)
+        self.mgr.ssh.write_remote_file(host, self.mgr.cephadm_binary_path,
+                                       self.mgr._cephadm.encode('utf-8'), addr=addr)

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -126,7 +126,7 @@ class SSHManager:
     async def _execute_command(self,
                                host: str,
                                cmd: List[str],
-                               stdin: Optional[bytes] = b"",
+                               stdin: Optional[bytes] = None,
                                addr: Optional[str] = None,
                                ) -> Tuple[str, str, int]:
         conn = await self._remote_connection(host, addr)
@@ -148,7 +148,7 @@ class SSHManager:
     def execute_command(self,
                         host: str,
                         cmd: List[str],
-                        stdin: Optional[bytes] = b"",
+                        stdin: Optional[bytes] = None,
                         addr: Optional[str] = None,
                         ) -> Tuple[str, str, int]:
         return self.mgr.event_loop.get_result(self._execute_command(host, cmd, stdin, addr))
@@ -156,7 +156,7 @@ class SSHManager:
     async def _check_execute_command(self,
                                      host: str,
                                      cmd: List[str],
-                                     stdin: Optional[bytes] = b"",
+                                     stdin: Optional[bytes] = None,
                                      addr: Optional[str] = None,
                                      ) -> str:
         out, err, code = await self._execute_command(host, cmd, stdin, addr)
@@ -169,7 +169,7 @@ class SSHManager:
     def check_execute_command(self,
                               host: str,
                               cmd: List[str],
-                              stdin: Optional[bytes] = b"",
+                              stdin: Optional[bytes] = None,
                               addr: Optional[str] = None,
                               ) -> str:
         return self.mgr.event_loop.get_result(self._check_execute_command(host, cmd, stdin, addr))

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -117,15 +117,17 @@ class SSHManager:
             log_string.flush()
             asyncssh_logger.removeHandler(ch)
 
-    def remote_connection(self, *args: Any) -> "SSHClientConnection":
-        return self.mgr.event_loop.get_result(self._remote_connection(*args))
+    def remote_connection(self,
+                          host: str,
+                          addr: Optional[str] = None,
+                          ) -> "SSHClientConnection":
+        return self.mgr.event_loop.get_result(self._remote_connection(host, addr))
 
     async def _execute_command(self,
                                host: str,
                                cmd: List[str],
                                stdin: Optional[bytes] = b"",
                                addr: Optional[str] = None,
-                               **kwargs: Any,
                                ) -> Tuple[str, str, int]:
         conn = await self._remote_connection(host, addr)
         cmd = "sudo " + " ".join(quote(x) for x in cmd)
@@ -143,15 +145,19 @@ class SSHManager:
         err = r.stderr.rstrip('\n')
         return out, err, r.returncode
 
-    def execute_command(self, *args: Any, **kwargs: Any) -> Tuple[str, str, int]:
-        return self.mgr.event_loop.get_result(self._execute_command(*args, **kwargs))
+    def execute_command(self,
+                        host: str,
+                        cmd: List[str],
+                        stdin: Optional[bytes] = b"",
+                        addr: Optional[str] = None,
+                        ) -> Tuple[str, str, int]:
+        return self.mgr.event_loop.get_result(self._execute_command(host, cmd, stdin, addr))
 
     async def _check_execute_command(self,
                                      host: str,
                                      cmd: List[str],
                                      stdin: Optional[bytes] = b"",
                                      addr: Optional[str] = None,
-                                     **kwargs: Any,
                                      ) -> str:
         out, err, code = await self._execute_command(host, cmd, stdin, addr)
         if code != 0:
@@ -160,8 +166,13 @@ class SSHManager:
             raise OrchestratorError(msg)
         return out
 
-    def check_execute_command(self, *args: Any, **kwargs: Any) -> str:
-        return self.mgr.event_loop.get_result(self._check_execute_command(*args, **kwargs))
+    def check_execute_command(self,
+                              host: str,
+                              cmd: List[str],
+                              stdin: Optional[bytes] = b"",
+                              addr: Optional[str] = None,
+                              ) -> str:
+        return self.mgr.event_loop.get_result(self._check_execute_command(host, cmd, stdin, addr))
 
     async def _write_remote_file(self,
                                  host: str,
@@ -171,7 +182,6 @@ class SSHManager:
                                  uid: Optional[int] = None,
                                  gid: Optional[int] = None,
                                  addr: Optional[str] = None,
-                                 **kwargs: Any,
                                  ) -> None:
         try:
             dirname = os.path.dirname(path)
@@ -189,8 +199,16 @@ class SSHManager:
             logger.exception(msg)
             raise OrchestratorError(msg)
 
-    def write_remote_file(self, *args: Any, **kwargs: Any) -> None:
-        self.mgr.event_loop.get_result(self._write_remote_file(*args, **kwargs))
+    def write_remote_file(self,
+                          host: str,
+                          path: str,
+                          content: bytes,
+                          mode: Optional[int] = None,
+                          uid: Optional[int] = None,
+                          gid: Optional[int] = None,
+                          addr: Optional[str] = None,
+                          ) -> None:
+        self.mgr.event_loop.get_result(self._write_remote_file(host, path, content, mode, uid, gid, addr))
 
     async def _reset_con(self, host: str) -> None:
         conn = self.cons.get(host)

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -99,7 +99,8 @@ class SSHManager:
         except OSError as e:
             self.mgr.offline_hosts.add(host)
             log_content = log_string.getvalue()
-            msg = f"Can't communicate with remote host `{addr}`, possibly because python3 is not installed there. {str(e)}" + '\n' + f'Log: {log_content}'
+            msg = f"Can't communicate with remote host `{addr}`, possibly because python3 is not installed there. {str(e)}" + \
+                '\n' + f'Log: {log_content}'
             logger.exception(msg)
             raise OrchestratorError(msg)
         except asyncssh.Error as e:
@@ -112,7 +113,8 @@ class SSHManager:
             self.mgr.offline_hosts.add(host)
             log_content = log_string.getvalue()
             logger.exception(str(e))
-            raise OrchestratorError(f'Failed to connect to {host} ({addr}): {repr(e)}' + '\n' f'Log: {log_content}')
+            raise OrchestratorError(
+                f'Failed to connect to {host} ({addr}): {repr(e)}' + '\n' f'Log: {log_content}')
         finally:
             log_string.flush()
             asyncssh_logger.removeHandler(ch)
@@ -208,7 +210,8 @@ class SSHManager:
                           gid: Optional[int] = None,
                           addr: Optional[str] = None,
                           ) -> None:
-        self.mgr.event_loop.get_result(self._write_remote_file(host, path, content, mode, uid, gid, addr))
+        self.mgr.event_loop.get_result(self._write_remote_file(
+            host, path, content, mode, uid, gid, addr))
 
     async def _reset_con(self, host: str) -> None:
         conn = self.cons.get(host)


### PR DESCRIPTION
Otherwise `conn.close()` might raise: `RuntimeError:
Non-thread-safe operation invoked on an event loop
other than the current one`

Fixes: https://tracker.ceph.com/issues/52407
Signed-off-by: Sebastian Wagner <sewagner@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
