### PR TITLE
[Draft] os/bluestore/bluefs: Add ability for direct write mode

### DIFF
--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -269,6 +269,7 @@ public:
     int write_hint = WRITE_LIFE_NOT_SET) = 0;
   virtual int flush() = 0;
   virtual int discard(uint64_t offset, uint64_t len) { return 0; }
+  virtual int dontneed(uint64_t offset, uint64_t len) { return -1; }
   virtual int queue_discard(interval_set<uint64_t> &to_release) { return -1; }
   virtual void discard_drain() { return; }
 

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -1033,6 +1033,12 @@ int KernelDevice::discard(uint64_t offset, uint64_t len)
   return r;
 }
 
+int KernelDevice::dontneed(uint64_t offset, uint64_t len)
+{
+  int r = BlkDev{fd_directs[WRITE_LIFE_NOT_SET]}.dontneed((int64_t)offset, (int64_t)len);
+  return r;
+}
+
 int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
 		      IOContext *ioc,
 		      bool buffered)

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -139,6 +139,7 @@ public:
 		int write_hint = WRITE_LIFE_NOT_SET) override;
   int flush() override;
   int discard(uint64_t offset, uint64_t len) override;
+  int dontneed(uint64_t offset, uint64_t len) override;
 
   // for managing buffered readers/writers
   int invalidate_cache(uint64_t off, uint64_t len) override;

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -217,6 +217,12 @@ int BlkDev::discard(int64_t offset, int64_t len) const
   return ioctl(fd, BLKDISCARD, range);
 }
 
+int BlkDev::dontneed(int64_t offset, int64_t len) const
+{
+  int r = posix_fadvise(fd, offset, len, POSIX_FADV_DONTNEED);
+  return r;
+}
+
 bool BlkDev::is_rotational() const
 {
   return get_int_property("queue/rotational") > 0;
@@ -859,6 +865,11 @@ int BlkDev::discard(int64_t offset, int64_t len) const
   return -EOPNOTSUPP;
 }
 
+int BlkDev::dontneed(int64_t offset, int64_t len) const
+{
+  return -EOPNOTSUPP;
+}
+
 bool BlkDev::is_rotational() const
 {
   return false;
@@ -984,6 +995,11 @@ bool BlkDev::support_discard() const
 }
 
 int BlkDev::discard(int64_t offset, int64_t len) const
+{
+  return -EOPNOTSUPP;
+}
+
+int BlkDev::dontneed(int64_t offset, int64_t len) const
 {
   return -EOPNOTSUPP;
 }
@@ -1184,6 +1200,11 @@ bool BlkDev::support_discard() const
 }
 
 int BlkDev::discard(int fd, int64_t offset, int64_t len) const
+{
+  return -EOPNOTSUPP;
+}
+
+int BlkDev::dontneed(int fd, int64_t offset, int64_t len) const
 {
   return -EOPNOTSUPP;
 }

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -51,6 +51,8 @@ public:
 
   // from an fd
   int discard(int64_t offset, int64_t len) const;
+  /* signal page cache that region should not be cached anymore */
+  int dontneed(int64_t offset, int64_t len) const;
   int get_size(int64_t *psize) const;
   int get_devid(dev_t *id) const;
   int partition(char* partition, size_t max) const;

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4014,6 +4014,19 @@ options:
     that this recommendation may change in the future however.
   default: true
   with_legacy: true
+- name: bluefs_force_direct_write
+  type: bool
+  level: advanced
+  desc: Forces to use direct asynchronous io on write path.
+  long_desc: When this option is enabled, bluefs will use bluefs_buffered_io setting
+    only for reads, and all writes will be serviced by direct asynchronous io.
+    Requires AIO and posix_fadvise.
+  default: false
+  with_legacy: false
+  flags:
+  - startup
+  see_also:
+  - bluefs_buffered_io
 - name: bluefs_sync_write
   type: bool
   level: advanced

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -360,6 +360,7 @@ private:
   inline bool is_shared_alloc(unsigned id) const {
     return id == shared_alloc_id;
   }
+  bool forced_direct_writes = false;
 
   class SocketHook;
   SocketHook* asok_hook = nullptr;


### PR DESCRIPTION
Makes possible to use direct write mode and buffered read mode.
Option bluefs_force_direct_write=true uses direct write path, regardless of
value of bluefs_buffered_io. Bluefs_buffered_io is still in effect for signaling RocksDB.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
