### PR TITLE
Use consistent condition for ppc probing.

### DIFF
--- a/src/arch/probe.cc
+++ b/src/arch/probe.cc
@@ -15,7 +15,7 @@ int ceph_arch_probe(void)
   ceph_arch_intel_probe();
 #elif defined(__arm__) || defined(__aarch64__)
   ceph_arch_arm_probe();
-#elif defined(__powerpc__) || defined(__ppc__)
+#elif defined(HAVE_POWER8)
   ceph_arch_ppc_probe();
 #endif
   ceph_arch_probed = 1;

--- a/src/common/crc32c.cc
+++ b/src/common/crc32c.cc
@@ -32,7 +32,7 @@ ceph_crc32c_func_t ceph_choose_crc32(void)
     return ceph_crc32c_aarch64;
   }
 # endif
-#elif defined(__powerpc__) || defined(__ppc__)
+#elif defined(HAVE_POWER8)
   if (ceph_arch_ppc_crc32) {
     return ceph_crc32c_ppc;
   }


### PR DESCRIPTION
According to src/arch/CMakeLists.txt the ppc probing code is compiled
when HAVE_POWER8 is true. The condition for when checking the ppc
probe result in other places in the code must therfore also check
if HAVE_POWER8 is defined. Otherwise compilation fails with
```
/usr/bin/ld: ../lib/libceph-common.so.0: undefined reference to `ceph_arch_ppc_probe'
/usr/bin/ld: ../lib/libceph-common.so.0: undefined reference to `ceph_arch_ppc_crc32'
/usr/bin/ld: ../lib/libceph-common.so.0: undefined reference to `ceph_crc32c_ppc'
collect2: error: ld returned 1 exit status
```
The above error is from building on Debian for 32 bit powerpc.

Signed-off-by: Mattias Ellert <mattias.ellert@physics.uu.se>
