### PR TITLE
mgr/balancer:init weight-set of osd when use crush-compat balancer

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -1097,6 +1097,11 @@ class Module(MgrModule):
         bad_steps = 0
         next_ws = copy.deepcopy(best_ws)
         next_ow = copy.deepcopy(best_ow)
+        # osd may not in crush
+        osd_crush_weight = {}
+        for node in self.get('osd_map_tree')['nodes']:
+            if node['name'].startswith('osd'):
+                osd_crush_weight[node['id']] = node['crush_weight']
         while left > 0:
             # adjust
             self.log.debug('best_ws %s' % best_ws)
@@ -1126,7 +1131,11 @@ class Module(MgrModule):
                         if deviation == 0:
                             break
                         self.log.debug('osd.%d deviation %f', osd, deviation)
-                        weight = best_ws[osd]
+                        # osd may not in crush
+                        if osd not in best_ws:
+                            weight = osd_crush_weight[osd]
+                        else:
+                            weight = best_ws[osd]
                         ow = orig_osd_weight[osd]
                         if actual[osd] > 0:
                             calc_weight = target[osd] / actual[osd] * weight * ow


### PR DESCRIPTION
in som case, some osds do not have weight-set, when use balancer with crush-compat mode, the balancer will crash due a KeyError in do_crush_compat()

Fixes: https://tracker.ceph.com/issues/49576

Signed-off-by: lmgdlmgd 1105050771@qq.com


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
