### PR TITLE
pacific: rgw/notification: make notifications agnostic of bucket reshard

### DIFF
--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -603,7 +603,7 @@ class RGWPubSub
   }
 
   std::string bucket_meta_oid(const rgw_bucket& bucket) const {
-    return pubsub_oid_prefix + tenant + ".bucket." + bucket.name + "/" + bucket.bucket_id;
+    return pubsub_oid_prefix + tenant + ".bucket." + bucket.name + "/" + bucket.marker;
   }
 
   std::string sub_meta_oid(const string& name) const {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51350

---

backport of https://github.com/ceph/ceph/pull/41956
parent tracker: https://tracker.ceph.com/issues/51293

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh