### PR TITLE
nautilus: make-dist: bump node to 10.16.0

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -81,7 +81,7 @@ build_dashboard_frontend() {
 
   $CURR_DIR/src/tools/setup-virtualenv.sh $TEMP_DIR
   $TEMP_DIR/bin/pip install nodeenv
-  $TEMP_DIR/bin/nodeenv --verbose -p --node=10.13.0
+  $TEMP_DIR/bin/nodeenv --verbose -p --node=10.16.0
   cd src/pybind/mgr/dashboard/frontend
 
   DEFAULT_LANG=`jq -r .config.locale package.json`

--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -43,7 +43,7 @@ else()
     OUTPUT "${mgr-dashboard-nodeenv-dir}/bin/npm"
     COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=${MGR_PYTHON_EXECUTABLE} ${mgr-dashboard-nodeenv-dir}
     COMMAND ${mgr-dashboard-nodeenv-dir}/bin/pip install nodeenv
-    COMMAND ${mgr-dashboard-nodeenv-dir}/bin/nodeenv --verbose -p --node=10.13.0
+    COMMAND ${mgr-dashboard-nodeenv-dir}/bin/nodeenv --verbose -p --node=10.16.0
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "dashboard nodeenv is being installed"
   )


### PR DESCRIPTION
otherwise we have segfault when "npm ci", like

```
 Program terminated with signal SIGSEGV, Segmentation fault.
 #0  0x00007f77f89099ed in std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::string const&) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
 [Current thread is 1 (Thread 0x7f77f8496740 (LWP 4046307))]
 (gdb) bt
 #0  0x00007f77f89099ed in std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::string const&) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
 #1  0x00000000008c3127 in node::Environment::Environment(node::IsolateData*, v8::Local<v8::Context>, node::tracing::AgentWriterHandle*) ()
 #2  0x00000000008e4d4b in node::Start(v8::Isolate*, node::IsolateData*, std::vector<std::string, std::allocator<std::string> > const&, std::vector<std::string, std::allocator<std::string> > const&) ()
 #3  0x00000000008e34a2 in node::Start(int, char**) ()
 #4  0x00007f77f84c00b3 in __libc_start_main (main=0x89dc10 <main>, argc=3, argv=0x7ffd1dc8e8a8, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7ffd1dc8e898)
     at ../csu/libc-start.c:308
 #5  0x000000000089dd45 in _start ()
```

this change is not cherry-picked from master, because the change
introducing the 10.16.0 change of
7f7f8a443c820f3c77a6f267939c33891342a561 is way too large and touches
lots of places in dashboard. while we just need to get the dashboard
frontend npm packages ready with minimal change.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
