### PR TITLE
crimson: add object_info, log support to crimson-store-nbd, fix lba btree bugs

### DIFF
--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -11,7 +11,7 @@
 #include "crimson/common/log.h"
 #include "crimson/common/errorator.h"
 
-#define INTR_FUT_DEBUG(FMT_MSG, ...) crimson::get_logger(ceph_subsys_osd).debug(FMT_MSG, ##__VA_ARGS__)
+#define INTR_FUT_DEBUG(FMT_MSG, ...) crimson::get_logger(ceph_subsys_osd).trace(FMT_MSG, ##__VA_ARGS__)
 
 // The interrupt condition generally works this way:
 //

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -38,6 +38,8 @@ Cache::~Cache()
 Cache::retire_extent_ret Cache::retire_extent_addr(
   Transaction &t, paddr_t addr, extent_len_t length)
 {
+  assert(addr.is_real() && !addr.is_block_relative());
+
   LOG_PREFIX(Cache::retire_extent);
   CachedExtentRef ext;
   auto result = t.get_extent(addr, &ext);
@@ -49,6 +51,9 @@ Cache::retire_extent_ret Cache::retire_extent_addr(
     ERRORT("{} is already retired", t, addr);
     ceph_abort();
   }
+
+  // any relative addr must have been on the transaction
+  assert(!addr.is_relative());
 
   // absent from transaction
   // retiring is not included by the cache hit metrics

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
@@ -75,7 +75,9 @@ public:
     }
     lba_map_val_t get_val() const {
       assert(!is_end());
-      return leaf.node->iter_idx(leaf.pos).get_val();
+      auto ret = leaf.node->iter_idx(leaf.pos).get_val();
+      ret.paddr = ret.paddr.maybe_relative_to(leaf.node->get_paddr());
+      return ret;
     }
 
     bool is_end() const {
@@ -93,10 +95,12 @@ public:
 
     LBAPinRef get_pin() const {
       assert(!is_end());
+      auto val = get_val();
+      auto key = get_key();
       return std::make_unique<BtreeLBAPin>(
 	leaf.node,
-	get_val().paddr.maybe_relative_to(leaf.node->get_paddr()),
-	lba_node_meta_t{ get_key(), get_key() + get_val().len, 0 });
+	val.paddr,
+	lba_node_meta_t{ key, key + val.len, 0 });
     }
 
   private:

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -288,7 +288,6 @@ struct LBAInternalNode
   std::ostream &print_detail(std::ostream &out) const final;
 
   ceph::bufferlist get_delta() final {
-    assert(!delta_buffer.empty());
     ceph::buffer::ptr bptr(delta_buffer.get_bytes());
     delta_buffer.copy_out(bptr.c_str(), bptr.length());
     ceph::bufferlist bl;
@@ -500,7 +499,6 @@ struct LBALeafNode
   }
 
   ceph::bufferlist get_delta() final {
-    assert(!delta_buffer.empty());
     ceph::buffer::ptr bptr(delta_buffer.get_bytes());
     delta_buffer.copy_out(bptr.c_str(), bptr.length());
     ceph::bufferlist bl;

--- a/src/crimson/tools/store_nbd/block_driver.h
+++ b/src/crimson/tools/store_nbd/block_driver.h
@@ -28,9 +28,12 @@ public:
   struct config_t {
     std::string type;
     bool mkfs = false;
-    unsigned num_collections = 128;
+    unsigned num_pgs = 128;
+    unsigned log_size = 1000;
     unsigned object_size = 4<<20 /* 4MB, rbd default */;
     unsigned oi_size = 1<<9 /* 512b */;
+    unsigned log_entry_size = 1<<9 /* 512b */;
+    bool prepopulate_log = false;
     std::optional<std::string> path;
 
     bool is_futurized_store() const {
@@ -44,6 +47,14 @@ public:
 
     bool oi_enabled() const {
       return oi_size > 0;
+    }
+
+    bool log_enabled() const {
+      return log_entry_size > 0 && log_size > 0;
+    }
+
+    bool prepopulate_log_enabled() const {
+      return prepopulate_log;
     }
 
     void populate_options(
@@ -63,10 +74,28 @@ public:
 	 ->notifier([this](auto s) { path = s; }),
 	 "Path to device for backend"
 	)
-	("num-collections",
+	("num-pgs",
 	 po::value<unsigned>()
-	 ->notifier([this](auto s) { num_collections = s; }),
-	 "Number of collections to use for futurized_store backends"
+	 ->notifier([this](auto s) { num_pgs = s; }),
+	 "Number of pgs to use for futurized_store backends"
+	)
+	("log-size",
+	 po::value<unsigned>()
+	 ->notifier([this](auto s) { log_size = s; }),
+	 "Number of log entries per pg to use for futurized_store backends"
+	 ", 0 to disable"
+	)
+	("log-entry-size",
+	 po::value<unsigned>()
+	 ->notifier([this](auto s) { log_entry_size = s; }),
+	 "Size of each log entry per pg to use for futurized_store backends"
+	 ", 0 to disable"
+	)
+	("prepopulate-log",
+	 po::value<bool>()
+	 ->notifier([this](auto s) { prepopulate_log = s; }),
+	 "Prepopulate log on mount"
+	)
 	("object-info-size",
 	 po::value<unsigned>()
 	 ->notifier([this](auto s) { log_entry_size = s; }),

--- a/src/crimson/tools/store_nbd/block_driver.h
+++ b/src/crimson/tools/store_nbd/block_driver.h
@@ -30,6 +30,7 @@ public:
     bool mkfs = false;
     unsigned num_collections = 128;
     unsigned object_size = 4<<20 /* 4MB, rbd default */;
+    unsigned oi_size = 1<<9 /* 512b */;
     std::optional<std::string> path;
 
     bool is_futurized_store() const {
@@ -39,6 +40,10 @@ public:
     std::string get_fs_type() const {
       ceph_assert(is_futurized_store());
       return type;
+    }
+
+    bool oi_enabled() const {
+      return oi_size > 0;
     }
 
     void populate_options(
@@ -62,6 +67,11 @@ public:
 	 po::value<unsigned>()
 	 ->notifier([this](auto s) { num_collections = s; }),
 	 "Number of collections to use for futurized_store backends"
+	("object-info-size",
+	 po::value<unsigned>()
+	 ->notifier([this](auto s) { log_entry_size = s; }),
+	 "Size of each log entry per pg to use for futurized_store backends"
+	 ", 0 to disable"
 	)
 	("object-size",
 	 po::value<unsigned>()

--- a/src/crimson/tools/store_nbd/fs_driver.cc
+++ b/src/crimson/tools/store_nbd/fs_driver.cc
@@ -22,7 +22,7 @@ FSDriver::offset_mapping_t FSDriver::map_offset(off_t offset)
     ghobject_t(
       shard_id_t::NO_SHARD,
       0,
-      (objid << 16) | collid,
+      (collid << 16) | objid,
       "",
       "",
       0,

--- a/src/crimson/tools/store_nbd/fs_driver.cc
+++ b/src/crimson/tools/store_nbd/fs_driver.cc
@@ -47,6 +47,17 @@ seastar::future<> FSDriver::write(
     ptr.length(),
     bl,
     0);
+
+  if (config.oi_enabled() ) {
+    bufferlist attr;
+    attr.append(ceph::buffer::create(config.oi_size, '0'));
+    t.setattr(
+      mapping.chandle->get_cid(),
+      mapping.object,
+      "_",
+      attr);
+  }
+
   return fs->do_transaction(
     mapping.chandle,
     std::move(t));

--- a/src/crimson/tools/store_nbd/fs_driver.cc
+++ b/src/crimson/tools/store_nbd/fs_driver.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <boost/iterator/counting_iterator.hpp>
+#include <fmt/format.h>
 
 #include "os/Transaction.h"
 #include "fs_driver.h"
@@ -13,16 +14,94 @@ coll_t get_coll(unsigned num) {
   return coll_t(spg_t(pg_t(0, num)));
 }
 
+ghobject_t get_log_object(unsigned coll)
+{
+  return ghobject_t(
+    shard_id_t::NO_SHARD,
+    0,
+    (coll << 16),
+    "",
+    "",
+    0,
+    ghobject_t::NO_GEN);
+}
+
+std::string make_log_key(
+  unsigned i)
+{
+  return fmt::format("log_entry_{}", i);
+}
+
+void add_log_entry(
+  unsigned i,
+  unsigned entry_size,
+  std::map<std::string, ceph::buffer::list> *omap)
+{
+  assert(omap);
+  bufferlist bl;
+  bl.append(ceph::buffer::create('0', entry_size));
+
+  omap->emplace(std::make_pair(make_log_key(i), bl));
+}
+
+void populate_log(
+  ceph::os::Transaction &t,
+  FSDriver::pg_analogue_t &pg,
+  unsigned entry_size,
+  unsigned entries)
+{
+  t.touch(pg.collection->get_cid(), pg.log_object);
+  // omap_clear not yet implemented, TODO
+  // t.omap_clear(pg.collection->get_cid(), pg.log_object);
+
+  std::map<std::string, ceph::buffer::list> omap;
+  for (unsigned i = 0; i < entries; ++i) {
+    add_log_entry(i, entry_size, &omap);
+  }
+
+  t.omap_setkeys(
+    pg.collection->get_cid(),
+    pg.log_object,
+    omap);
+
+  pg.log_head = entries;
+}
+
+void update_log(
+  ceph::os::Transaction &t,
+  FSDriver::pg_analogue_t &pg,
+  unsigned entry_size,
+  unsigned entries)
+{
+  ++pg.log_head;
+  std::map<std::string, ceph::buffer::list> key;
+  add_log_entry(pg.log_head, entry_size, &key);
+
+  t.omap_setkeys(
+    pg.collection->get_cid(),
+    pg.log_object,
+    key);
+
+
+  while ((pg.log_head - pg.log_tail) > entries) {
+    t.omap_rmkey(
+      pg.collection->get_cid(),
+      pg.log_object,
+      make_log_key(pg.log_tail));
+    ++pg.log_tail;
+  }
+}
+
 FSDriver::offset_mapping_t FSDriver::map_offset(off_t offset)
 {
   uint32_t objid = offset / config.object_size;
-  uint32_t collid = objid % config.num_collections;
+  uint32_t collid = objid % config.num_pgs;
   return offset_mapping_t{
     collections[collid],
     ghobject_t(
       shard_id_t::NO_SHARD,
       0,
-      (collid << 16) | objid,
+      (collid << 16) | (objid + 1),
       "",
       "",
       0,
@@ -41,7 +120,7 @@ seastar::future<> FSDriver::write(
   bufferlist bl;
   bl.append(ptr);
   t.write(
-    mapping.chandle->get_cid(), 
+    mapping.pg.collection->get_cid(),
     mapping.object,
     mapping.offset,
     ptr.length(),
@@ -52,14 +131,22 @@ seastar::future<> FSDriver::write(
     bufferlist attr;
     attr.append(ceph::buffer::create(config.oi_size, '0'));
     t.setattr(
-      mapping.chandle->get_cid(),
+      mapping.pg.collection->get_cid(),
       mapping.object,
       "_",
       attr);
   }
 
+  if (config.log_enabled()) {
+    update_log(
+      t,
+      mapping.pg,
+      config.log_entry_size,
+      config.log_size);
+  }
+
   return fs->do_transaction(
-    mapping.chandle,
+    mapping.pg.collection,
     std::move(t));
 }
 
@@ -70,7 +157,7 @@ seastar::future<bufferlist> FSDriver::read(
   auto mapping = map_offset(offset);
   ceph_assert((mapping.offset + size) <= config.object_size);
   return fs->read(
-    mapping.chandle,
+    mapping.pg.collection,
     mapping.object,
     mapping.offset,
     size,
@@ -109,7 +196,7 @@ seastar::future<> FSDriver::mkfs()
   }).then([this] {
     return seastar::do_for_each(
       boost::counting_iterator<unsigned>(0),
-      boost::counting_iterator<unsigned>(config.num_collections),
+      boost::counting_iterator<unsigned>(config.num_pgs),
       [this](auto i) {
 	return fs->create_new_collection(get_coll(i)
 	).then([this, i](auto coll) {
@@ -141,12 +228,27 @@ seastar::future<> FSDriver::mount()
   }).then([this] {
     return seastar::do_for_each(
       boost::counting_iterator<unsigned>(0),
-      boost::counting_iterator<unsigned>(config.num_collections),
+      boost::counting_iterator<unsigned>(config.num_pgs),
       [this](auto i) {
 	return fs->open_collection(get_coll(i)
 	).then([this, i](auto ref) {
-	  collections[i] = ref;
-	  return seastar::now();
+	  collections[i].collection = ref;
+	  collections[i].log_object = get_log_object(i);
+	  if (config.log_enabled()) {
+	    ceph::os::Transaction t;
+	    if (config.prepopulate_log_enabled()) {
+	      populate_log(
+		t,
+		collections[i],
+		config.log_entry_size,
+		config.log_size);
+	    }
+	    return fs->do_transaction(
+	      collections[i].collection,
+	      std::move(t));
+	  } else {
+	    return seastar::now();
+	  }
 	});
       });
   }).then([this] {

--- a/src/crimson/tools/store_nbd/fs_driver.h
+++ b/src/crimson/tools/store_nbd/fs_driver.h
@@ -44,10 +44,18 @@ private:
   const config_t config;
   seastar::alien::instance& alien;
   std::unique_ptr<crimson::os::FuturizedStore> fs;
-  std::map<unsigned, crimson::os::CollectionRef> collections;
+
+  struct pg_analogue_t {
+    crimson::os::CollectionRef collection;
+
+    ghobject_t log_object;
+    unsigned log_tail = 0;
+    unsigned log_head = 0;
+  };
+  std::map<unsigned, pg_analogue_t> collections;
 
   struct offset_mapping_t {
-    crimson::os::CollectionRef chandle;
+    pg_analogue_t &pg;
     ghobject_t object;
     off_t offset;
   };
@@ -55,4 +63,16 @@ private:
 
   seastar::future<> mkfs();
   void init();
+
+  friend void populate_log(
+    ceph::os::Transaction &,
+    pg_analogue_t &,
+    unsigned,
+    unsigned);
+
+  friend void update_log(
+    ceph::os::Transaction &,
+    FSDriver::pg_analogue_t &,
+    unsigned,
+    unsigned);
 };


### PR DESCRIPTION
Should address https://tracker.ceph.com/issues/52434 and https://tracker.ceph.com/issues/52435 as noted in https://github.com/ceph/ceph/pull/42901