### PR TITLE
octopus: os/bluestore: cap omap naming scheme upgrade transactoin.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8217,6 +8217,7 @@ void BlueStore::_fsck_check_object_omap(FSCKDepth depth,
       string final_key;
       Onode::calc_omap_key(new_flags, o.get(), string(), &final_key);
       size_t base_key_len = final_key.size();
+      it->next();
       while (it->valid() && it->key() < tail) {
 	string user_key;
 	o->decode_omap_key(it->key(), &user_key);
@@ -8224,7 +8225,7 @@ void BlueStore::_fsck_check_object_omap(FSCKDepth depth,
 	  << " -> " << user_key << dendl;
 
 	final_key.resize(base_key_len);
-	final_key += it->key();
+	final_key += user_key;
 	auto v = it->value();
 	txn->set(new_omap_prefix, final_key, v);
 	txn_cost += final_key.length() + v.length();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8204,6 +8204,7 @@ void BlueStore::_fsck_check_object_omap(FSCKDepth depth,
 	  txn->set(new_omap_prefix, new_head, header);
 	  txn_cost += new_head.length() + header.length();
 	}
+	it->next();
       }
       // tail
       {
@@ -8217,7 +8218,6 @@ void BlueStore::_fsck_check_object_omap(FSCKDepth depth,
       string final_key;
       Onode::calc_omap_key(new_flags, o.get(), string(), &final_key);
       size_t base_key_len = final_key.size();
-      it->next();
       while (it->valid() && it->key() < tail) {
 	string user_key;
 	o->decode_omap_key(it->key(), &user_key);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1140,11 +1140,27 @@ public:
       return !pinned;
     }
 
-    const string& get_omap_prefix();
-    void get_omap_header(string *out);
-    void get_omap_key(const string& key, string *out);
+    static const std::string& calc_omap_prefix(uint8_t flags);
+    static void calc_omap_header(uint8_t flags, const Onode* o,
+      std::string* out);
+    static void calc_omap_key(uint8_t flags, const Onode* o,
+      const std::string& key, std::string* out);
+    static void calc_omap_tail(uint8_t flags, const Onode* o,
+      std::string* out);
+
+    const std::string& get_omap_prefix() {
+      return calc_omap_prefix(onode.flags);
+    }
+    void get_omap_header(std::string* out) {
+      calc_omap_header(onode.flags, this, out);
+    }
+    void get_omap_key(const std::string& key, std::string* out) {
+      calc_omap_key(onode.flags, this, key, out);
+    }
+    void get_omap_tail(std::string* out) {
+      calc_omap_tail(onode.flags, this, out);
+    }
     void rewrite_omap_key(const string& old, string *out);
-    void get_omap_tail(string *out);
     void decode_omap_key(const string& key, string *user_key);
   };
   typedef boost::intrusive_ptr<Onode> OnodeRef;
@@ -1183,7 +1199,7 @@ public:
 
     void trim() {
       std::lock_guard l(lock);
-      _trim();    
+      _trim();
     }
     void flush() {
       std::lock_guard l(lock);

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -955,6 +955,13 @@ struct bluestore_onode_t {
   bool has_omap() const {
     return has_flag(FLAG_OMAP);
   }
+
+  static bool is_pgmeta_omap(uint8_t flags) {
+    return flags & FLAG_PGMETA_OMAP;
+  }
+  static bool is_perpool_omap(uint8_t flags) {
+    return flags & FLAG_PERPOOL_OMAP;
+  }
   bool is_pgmeta_omap() const {
     return has_flag(FLAG_PGMETA_OMAP);
   }
@@ -962,8 +969,8 @@ struct bluestore_onode_t {
     return has_flag(FLAG_PERPOOL_OMAP);
   }
 
-  void set_omap_flags() {
-    set_flag(FLAG_OMAP | FLAG_PERPOOL_OMAP);
+  void set_omap_flags(bool legacy) {
+    set_flag(FLAG_OMAP | (legacy ? 0 : FLAG_PERPOOL_OMAP));
   }
   void set_omap_flags_pgmeta() {
     set_flag(FLAG_OMAP | FLAG_PGMETA_OMAP);


### PR DESCRIPTION
We shouldn't use single per-onode transaction for such an upgrade when onode's omap list is huge. This results in similarly sized WAL/SST files which are inefficient, might cause high memory usage and sometimes error-prone.

backport tracker: https://tracker.ceph.com/issues/52432
backport of #39377
parent tracker: https://tracker.ceph.com/issues/49170


Signed-off-by: Igor Fedotov <ifedotov@suse.com>
(cherry picked from commit e897fa243c1dd38329733b452872616023f14ac8)

 Conflicts (caused by lack of per-pg omap scheme):
	src/os/bluestore/BlueStore.cc
	src/os/bluestore/BlueStore.h
	src/os/bluestore/bluestore_types.h


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
