### PR TITLE
arch,cmake: compile ppc.c on all powerpc machines

### DIFF
--- a/cmake/modules/SIMDExt.cmake
+++ b/cmake/modules/SIMDExt.cmake
@@ -1,8 +1,13 @@
 # detect SIMD extensions
 #
+# HAVE_ARM
 # HAVE_ARMV8_CRC
+# HAVE_ARMV8_CRC_CRYPTO_INTRINSICS
+# HAVE_ARMV8_CRYPTO
 # HAVE_ARMV8_SIMD
 # HAVE_ARM_NEON
+#
+# HAVE_INTEL
 # HAVE_INTEL_SSE
 # HAVE_INTEL_SSE2
 # HAVE_INTEL_SSE3
@@ -10,6 +15,10 @@
 # HAVE_INTEL_PCLMUL
 # HAVE_INTEL_SSE4_1
 # HAVE_INTEL_SSE4_2
+#
+# HAVE_PPC64LE
+# HAVE_PPC64
+# HAVE_PPC
 #
 # SIMD_COMPILE_FLAGS
 #
@@ -79,14 +88,16 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i386|i686|amd64|x86_64|AMD64")
       endif()
     endif(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|AMD64")
   endif(CMAKE_SYSTEM_PROCESSOR MATCHES "i686|amd64|x86_64|AMD64")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(powerpc|ppc)64|(powerpc|ppc)64le")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(powerpc|ppc)")
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "(powerpc|ppc)64le")
     set(HAVE_PPC64LE 1)
     message(STATUS " we are ppc64le")
-  else()
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(powerpc|ppc)64")
     set(HAVE_PPC64 1)
     message(STATUS " we are ppc64")
-  endif(CMAKE_SYSTEM_PROCESSOR MATCHES "(powerpc|ppc)64le")
+  else()
+    set(HAVE_PPC 1)
+  endif()
   CHECK_C_COMPILER_FLAG("-maltivec" HAS_ALTIVEC)
   if(HAS_ALTIVEC)
     message(STATUS " HAS_ALTIVEC yes")

--- a/src/arch/CMakeLists.txt
+++ b/src/arch/CMakeLists.txt
@@ -5,7 +5,7 @@ if(HAVE_ARM)
   list(APPEND arch_srcs arm.c)
 elseif(HAVE_INTEL)
   list(APPEND arch_srcs intel.c)
-elseif(HAVE_POWER8)
+elseif(HAVE_PPC64LE OR HAVE_PPC64 OR HAVE_PPC)
   list(APPEND arch_srcs ppc.c)
 endif()
 


### PR DESCRIPTION
* cmake/modules/SIMDExt.cmake: define HAVE_PPC for 32-bit PowerPC.
* src/arch/CMakeLists.txt: compile ppc.c for all PowerPC architectures,
  including powerpc (32-bit PowerPC), ppc64el (64-bit Little Endian
  PowerPC) and ppc64 (64-bit Big Endian PowerPC).

before this change, ppc.c is only compiled if HAVE_POWER8 is defined.
but Power8 is a 64-bit PowerPC architecture. while in src/arch/probe.cc,
we check for `defined(__powerpc__) || defined(__ppc__)`, if this is
true, ceph_arch_ppc_probe() is used to check for the support of
Altivec. but on non-power8 PowerPC machines, the linker fails to find the
symbols like ceph_arch_ppc_probe(), as ppc.c is not compiled on them.

in this change, ppc.c is compiled on all PowerPC architectures, so that
ceph_arch_ppc_probe() is also available on non-power8 machines. this
change does not impact the behavior of non-power8 machines. because
on them, the runtime check would fail to detect the existence of
PPC_FEATURE2_VEC_CRYPTO instructions.

Reported-by: Mattias Ellert <mattias.ellert@physics.uu.se>
Signed-off-by: Kefu Chai <tchaikov@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
