### PR TITLE
cephfs_mirror: fix a locking statement

### DIFF
--- a/src/tools/cephfs_mirror/ClusterWatcher.cc
+++ b/src/tools/cephfs_mirror/ClusterWatcher.cc
@@ -172,7 +172,7 @@ void ClusterWatcher::handle_fsmap(const cref_t<MFSMap> &m) {
     }
   }
 
-  std::scoped_lock(m_lock);
+  std::scoped_lock locker(m_lock);
   if (!m_stopping) {
     m_monc->sub_got("fsmap", fsmap.get_epoch());
   } // else we have already done a sub_unwant()


### PR DESCRIPTION

Original statement wasn't actually locking.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
