### PR TITLE
pacific: krbd: escape udev_enumerate_add_match_sysattr values

### DIFF
--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -16,6 +16,7 @@
 #include <memory>
 #include <optional>
 #include <poll.h>
+#include <regex>
 #include <sstream>
 #include <stdio.h>
 #include <stdlib.h>
@@ -612,6 +613,13 @@ retry:
   return 0;
 }
 
+// wrap any of * ? [ between square brackets
+static std::string escape_glob(const std::string& s)
+{
+  std::regex glob_meta("([*?[])");
+  return std::regex_replace(s, glob_meta, "[$1]");
+}
+
 static int __enumerate_devices(struct udev *udev, const krbd_spec& spec,
                                bool match_nspace, udev_enumerate_uptr *penm)
 {
@@ -628,13 +636,13 @@ retry:
     return r;
 
   r = udev_enumerate_add_match_sysattr(enm.get(), "pool",
-                                       spec.pool_name.c_str());
+                                       escape_glob(spec.pool_name).c_str());
   if (r < 0)
     return r;
 
   if (match_nspace) {
     r = udev_enumerate_add_match_sysattr(enm.get(), "pool_ns",
-                                         spec.nspace_name.c_str());
+                                         escape_glob(spec.nspace_name).c_str());
   } else {
     /*
      * Match _only_ devices that don't have pool_ns attribute.
@@ -646,12 +654,12 @@ retry:
     return r;
 
   r = udev_enumerate_add_match_sysattr(enm.get(), "name",
-                                       spec.image_name.c_str());
+                                       escape_glob(spec.image_name).c_str());
   if (r < 0)
     return r;
 
   r = udev_enumerate_add_match_sysattr(enm.get(), "current_snap",
-                                       spec.snap_name.c_str());
+                                       escape_glob(spec.snap_name).c_str());
   if (r < 0)
     return r;
 

--- a/src/test/cli-integration/rbd/unmap.t
+++ b/src/test/cli-integration/rbd/unmap.t
@@ -460,6 +460,23 @@ pool/img@snap, custom pool:
   $ rbd device list
 
 
+Odd names
+=========
+
+  $ ceph osd pool create foo\* >/dev/null 2>&1
+  $ rbd pool init foo\*
+  $ rbd create --size 1 foo\*/[0.0.0.0]
+  $ rbd snap create foo\*/[0.0.0.0]@\?bar --no-progress
+  $ sudo rbd device map foo\*/[0.0.0.0]@\?bar
+  /dev/rbd? (glob)
+  $ rbd device list
+  id  pool  namespace  image      snap  device   
+  ?   foo*             [0.0.0.0]  ?bar  /dev/rbd? (glob)
+  $ sudo rbd device unmap foo\*/[0.0.0.0]@\?bar
+  $ rbd device list
+  $ ceph osd pool delete foo\* foo\* --yes-i-really-really-mean-it >/dev/null 2>&1
+
+
 Teardown
 ========
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52452

---

backport of https://github.com/ceph/ceph/pull/42959
parent tracker: https://tracker.ceph.com/issues/52425