### PR TITLE
pacific: mgr/dashboard: don't notify for suppressed alerts

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.spec.ts
@@ -131,17 +131,23 @@ describe('PrometheusAlertService', () => {
     });
 
     it('should notify on alert change', () => {
-      alerts = [prometheus.createAlert('alert0', 'suppressed')];
+      alerts = [prometheus.createAlert('alert0', 'resolved')];
       service.refresh();
       expect(notificationService.show).toHaveBeenCalledWith(
         new CdNotificationConfig(
-          NotificationType.info,
-          'alert0 (suppressed)',
-          'alert0 is suppressed ' + prometheus.createLink('http://alert0'),
+          NotificationType.success,
+          'alert0 (resolved)',
+          'alert0 is resolved ' + prometheus.createLink('http://alert0'),
           undefined,
           'Prometheus'
         )
       );
+    });
+
+    it('should not notify on change to suppressed', () => {
+      alerts = [prometheus.createAlert('alert0', 'suppressed')];
+      service.refresh();
+      expect(notificationService.show).not.toHaveBeenCalled();
     });
 
     it('should notify on a new alert', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.ts
@@ -75,7 +75,10 @@ export class PrometheusAlertService {
       this.alertFormatter.convertToCustomAlerts(alerts),
       this.alertFormatter.convertToCustomAlerts(oldAlerts)
     );
-    const notifications = changedAlerts.map((alert) =>
+    const suppressedFiltered = _.filter(changedAlerts, (alert) => {
+      return alert.status !== 'suppressed';
+    });
+    const notifications = suppressedFiltered.map((alert) =>
       this.alertFormatter.convertAlertToNotification(alert)
     );
     this.alertFormatter.sendNotifications(notifications);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52308

---

backport of https://github.com/ceph/ceph/pull/42768
parent tracker: https://tracker.ceph.com/issues/51987

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh