### PR TITLE
octopus: rbd-mirror: fix potential async op tracker leak in start_image_replayers

### DIFF
--- a/src/tools/rbd_mirror/InstanceReplayer.cc
+++ b/src/tools/rbd_mirror/InstanceReplayer.cc
@@ -371,6 +371,7 @@ void InstanceReplayer<I>::start_image_replayers(int r) {
 
   std::lock_guard locker{m_lock};
   if (m_on_shut_down != nullptr) {
+    m_async_op_tracker.finish_op();
     return;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52105

---

backport of https://github.com/ceph/ceph/pull/42662
parent tracker: https://tracker.ceph.com/issues/52063