### PR TITLE
mgr/cephadm: don't fail unit tests if can't import AsyncMock

### DIFF
--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -1,5 +1,6 @@
 import fnmatch
 import asyncio
+import sys
 from tempfile import NamedTemporaryFile
 from contextlib import contextmanager
 
@@ -37,7 +38,16 @@ def match_glob(val, pat):
 
 class MockEventLoopThread:
     def get_result(self, coro):
-        asyncio.run(coro)
+        if sys.version_info >= (3, 7):
+            return asyncio.run(coro)
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
 
 
 @contextmanager

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -3,7 +3,10 @@ try:
     # AsyncMock was not added until python 3.8
     from unittest.mock import AsyncMock
 except ImportError:
-    pass
+    from asyncmock import AsyncMock
+except ImportError:
+    AsyncMock = None
+
 from contextlib import contextmanager
 
 import pytest

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1,5 +1,9 @@
 import json
-from unittest.mock import AsyncMock
+try:
+    # AsyncMock was not added until python 3.8
+    from unittest.mock import AsyncMock
+except ImportError:
+    pass
 from contextlib import contextmanager
 
 import pytest
@@ -1083,6 +1087,9 @@ spec:
         check_execute_command.return_value = ''
         execute_command.return_value = '', '', 0
 
+        if not AsyncMock:
+            # can't run this test if we could not import AsyncMock
+            return
         mock_connect = AsyncMock(return_value='')
         with mock.patch("asyncssh.connect", new=mock_connect) as asyncssh_connect:
             with with_host(cephadm_module, 'test'):

--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -8,3 +8,4 @@ pyOpenSSL
 Jinja2
 pyfakefs
 asyncssh
+asyncmock


### PR DESCRIPTION
AsyncMock was added in python 3.8. We don't want unit tests to
be failing if somebody tries running them with python 3.7. Our
Jenkins job should be unaffected and still run the test.

Signed-off-by: Adam King <adking@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
