### PR TITLE
librbd/cache/pwl/ssd: Fix a race between get_cache_bl() and remove_ca…

### DIFF
--- a/src/librbd/cache/pwl/LogEntry.h
+++ b/src/librbd/cache/pwl/LogEntry.h
@@ -219,7 +219,6 @@ public:
   BlockExtent block_extent();
   virtual unsigned int reader_count() const = 0;
   /* Constructs a new bl containing copies of cache_bp */
-  void copy_cache_bl(bufferlist *out_bl) override {};
   bool can_retire() const override {
     return (this->completed && this->get_flushed() && (0 == reader_count()));
   }

--- a/src/librbd/cache/pwl/ssd/LogEntry.cc
+++ b/src/librbd/cache/pwl/ssd/LogEntry.cc
@@ -21,7 +21,6 @@ void WriteLogEntry::init_cache_bl(
 }
 
 buffer::list& WriteLogEntry::get_cache_bl() {
-  std::lock_guard locker(m_entry_bl_lock);
   return cache_bl;
 }
 

--- a/src/librbd/cache/pwl/ssd/LogEntry.cc
+++ b/src/librbd/cache/pwl/ssd/LogEntry.cc
@@ -25,6 +25,11 @@ buffer::list& WriteLogEntry::get_cache_bl() {
   return cache_bl;
 }
 
+void  WriteLogEntry::copy_cache_bl(bufferlist *out) {
+  std::lock_guard locker(m_entry_bl_lock);
+  *out = cache_bl;
+}
+
 void WriteLogEntry::remove_cache_bl() {
     std::lock_guard locker(m_entry_bl_lock);
     cache_bl.clear();

--- a/src/librbd/cache/pwl/ssd/LogEntry.h
+++ b/src/librbd/cache/pwl/ssd/LogEntry.h
@@ -38,6 +38,7 @@ public:
                  Context *ctx, ceph::bufferlist &&bl) override;
   void init_cache_bl(bufferlist &src_bl, uint64_t off, uint64_t len) override;
   buffer::list &get_cache_bl() override;
+  void copy_cache_bl(bufferlist *out) override;
   void remove_cache_bl() override;
   unsigned int get_aligned_data_size() const override;
   void inc_bl_refs() { bl_refs++; };

--- a/src/librbd/cache/pwl/ssd/WriteLog.cc
+++ b/src/librbd/cache/pwl/ssd/WriteLog.cc
@@ -33,9 +33,6 @@ namespace ssd {
 using namespace std;
 using namespace librbd::cache::pwl;
 
-// SSD: this number can be updated later
-const unsigned long int ops_appended_together = MAX_WRITES_PER_SYNC_POINT;
-
 static bool is_valid_pool_root(const WriteLogPoolRoot& root) {
   return root.pool_size % MIN_WRITE_ALLOC_SSD_SIZE == 0 &&
          root.first_valid_entry >= DATA_RING_BUFFER_OFFSET &&

--- a/src/librbd/cache/pwl/ssd/WriteLog.cc
+++ b/src/librbd/cache/pwl/ssd/WriteLog.cc
@@ -79,7 +79,7 @@ void WriteLog<I>::collect_read_extents(
   ldout(m_image_ctx.cct, 5) << dendl;
   auto write_entry = std::static_pointer_cast<WriteLogEntry>(map_entry.log_entry);
   buffer::list hit_bl;
-  hit_bl = write_entry->get_cache_bl();
+  write_entry->copy_cache_bl(&hit_bl);
   bool writesame = write_entry->is_writesame_entry();
   auto hit_extent_buf = std::make_shared<ImageExtentBuf>(
       hit_extent, hit_bl, true, read_buffer_offset, writesame);


### PR DESCRIPTION
…che_bl()

In fact, although in get_cache_bl it use lock to protect, it can't
protect function "list& operator= (const list& other)".
So we should use copy_cache_bl.

Fixes: https://tracker.ceph.com/issues/52400
Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
