### PR TITLE
crimson/os/seastore: misc improvements to metrics

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -103,7 +103,6 @@ void Cache::register_metrics()
   std::map<src_t, sm::label_instance> labels_by_src {
     {src_t::MUTATE,  src_label("MUTATE")},
     {src_t::READ,    src_label("READ")},
-    {src_t::INIT,    src_label("INIT")},
     {src_t::CLEANER, src_label("CLEANER")},
   };
 

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -95,7 +95,7 @@ BtreeLBAManager::get_mapping(
   laddr_t offset)
 {
   LOG_PREFIX(BtreeLBAManager::get_mapping);
-  DEBUGT(": {}", t, offset);
+  DEBUGT("{}", t, offset);
   auto c = get_context(t);
   return with_btree_ret<LBAPinRef>(
     c,
@@ -255,7 +255,7 @@ BtreeLBAManager::init_cached_extent_ret BtreeLBAManager::init_cached_extent(
   CachedExtentRef e)
 {
   LOG_PREFIX(BtreeLBAManager::init_cached_extent);
-  DEBUGT(": extent {}", t, *e);
+  DEBUGT("extent {}", t, *e);
   auto c = get_context(t);
   return with_btree(
     c,

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
@@ -253,7 +253,7 @@ LBABtree::init_cached_extent_ret LBABtree::init_cached_extent(
   CachedExtentRef e)
 {
   LOG_PREFIX(LBATree::init_cached_extent);
-  DEBUGT(": extent {}", c.trans, *e);
+  DEBUGT("extent {}", c.trans, *e);
   if (e->is_logical()) {
     auto logn = e->cast<LogicalCachedExtent>();
     return lower_bound(
@@ -267,10 +267,10 @@ LBABtree::init_cached_extent_ret LBABtree::init_cached_extent(
 	ceph_assert(iter.get_val().len == e->get_length());
 	c.pins.add_pin(
 	  static_cast<BtreeLBAPin&>(logn->get_pin()).pin);
-	DEBUGT(": logical extent {} live, initialized", c.trans, *logn);
+	DEBUGT("logical extent {} live, initialized", c.trans, *logn);
 	return e;
       } else {
-	DEBUGT(": logical extent {} not live, dropping", c.trans, *logn);
+	DEBUGT("logical extent {} not live, dropping", c.trans, *logn);
 	c.cache.drop_from_cache(logn);
 	return CachedExtentRef();
       }
@@ -284,10 +284,10 @@ LBABtree::init_cached_extent_ret LBABtree::init_cached_extent(
       depth_t cand_depth = eint->get_node_meta().depth;
       if (cand_depth <= iter.get_depth() &&
 	  &*iter.get_internal(cand_depth).node == &*eint) {
-	DEBUGT(": extent {} is live", c.trans, *eint);
+	DEBUGT("extent {} is live", c.trans, *eint);
 	return e;
       } else {
-	DEBUGT(": extent {} is not live", c.trans, *eint);
+	DEBUGT("extent {} is not live", c.trans, *eint);
 	c.cache.drop_from_cache(eint);
 	return CachedExtentRef();
       }
@@ -299,17 +299,17 @@ LBABtree::init_cached_extent_ret LBABtree::init_cached_extent(
     ).si_then([FNAME, c, e, eleaf](auto iter) {
       // Note, this check is valid even if iter.is_end()
       if (iter.leaf.node == &*eleaf) {
-	DEBUGT(": extent {} is live", c.trans, *eleaf);
+	DEBUGT("extent {} is live", c.trans, *eleaf);
 	return e;
       } else {
-	DEBUGT(": extent {} is not live", c.trans, *eleaf);
+	DEBUGT("extent {} is not live", c.trans, *eleaf);
 	c.cache.drop_from_cache(eleaf);
 	return CachedExtentRef();
       }
     });
   } else {
     DEBUGT(
-      ": found other extent {} type {}",
+      "found other extent {} type {}",
       c.trans,
       *e,
       e->get_type());

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
@@ -171,6 +171,7 @@ LBABtree::insert_ret LBABtree::insert(
 	    interruptible::ready_future_marker{},
 	    std::make_pair(ret, false));
 	} else {
+	  ++(c.trans.get_lba_tree_stats().num_inserts);
 	  return handle_split(
 	    c, ret
 	  ).si_then([c, laddr, val, &ret] {
@@ -230,6 +231,7 @@ LBABtree::remove_ret LBABtree::remove(
     c.trans,
     iter.is_end() ? L_ADDR_MAX : iter.get_key());
   assert(!iter.is_end());
+  ++(c.trans.get_lba_tree_stats().num_erases);
   return seastar::do_with(
     iter,
     [this, c](auto &ret) {

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -142,11 +142,8 @@ public:
   }
 
   enum class src_t : uint8_t {
-    // normal IO operations at seastore boundary or within a test
     MUTATE = 0,
-    READ,
-    // transaction manager level operations
-    INIT,
+    READ, // including weak and non-weak read transactions
     CLEANER,
     MAX
   };
@@ -282,8 +279,6 @@ inline std::ostream& operator<<(std::ostream& os,
     return os << "MUTATE";
   case Transaction::src_t::READ:
     return os << "READ";
-  case Transaction::src_t::INIT:
-    return os << "INIT";
   case Transaction::src_t::CLEANER:
     return os << "CLEANER";
   default:

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -36,7 +36,7 @@ TransactionManager::mkfs_ertr::future<> TransactionManager::mkfs()
     DEBUG("about to do_with");
     segment_cleaner->init_mkfs(addr);
     return with_transaction_intr(
-        Transaction::src_t::INIT, [this, FNAME](auto& t) {
+        Transaction::src_t::MUTATE, [this, FNAME](auto& t) {
       DEBUGT("about to cache->mkfs", t);
       cache->init();
       return cache->mkfs(t
@@ -70,7 +70,7 @@ TransactionManager::mount_ertr::future<> TransactionManager::mount()
   }).safe_then([this, FNAME](auto addr) {
     segment_cleaner->set_journal_head(addr);
     return seastar::do_with(
-      create_weak_transaction(Transaction::src_t::INIT),
+      create_weak_transaction(Transaction::src_t::READ),
       [this, FNAME](auto &tref) {
 	return with_trans_intr(
 	  *tref,


### PR DESCRIPTION
Should be no impact to the CBT metric parser.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
