### PR TITLE
Avoid assert when bluefs log runway exhausted

### DIFF
--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -431,7 +431,7 @@ private:
   void _clear_dirty_set_stable_D(uint64_t seq_stable);
   void _release_pending_allocations(std::vector<interval_set<uint64_t>>& to_release);
 
-  void _flush_and_sync_log_core(int64_t available_runway);
+  int _flush_and_sync_log_core(int64_t available_runway);
   int _flush_and_sync_log_jump_D(uint64_t jump_to,
 			       int64_t available_runway);
   int _flush_and_sync_log_LD(uint64_t want_seq = 0);
@@ -450,10 +450,18 @@ private:
   void compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
 					  uint64_t capture_before_seq);
 
+  void _compact_log_sync_N_D();
   void _compact_log_sync_LN_LD();
   void _compact_log_async_LD_NF_D();
 
   void _rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
+				    int super_dev,
+				    int log_dev,
+				    int new_log_dev,
+				    int flags,
+				    std::optional<bluefs_layout_t> layout);
+
+  void _rewrite_log_and_layout_sync_N_D(bool allocate_with_fallback,
 				    int super_dev,
 				    int log_dev,
 				    int new_log_dev,

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -330,6 +330,8 @@ private:
 
   bluefs_super_t super;        ///< latest superblock (as last written)
   uint64_t ino_last = 0;       ///< last assigned ino (this one is in use)
+  uint64_t bluefs_min_log_runway = 0; ///< copy from conf, so it can be modified
+  uint64_t bluefs_max_log_runway = 0;
 
   struct {
     ceph::mutex lock = ceph::make_mutex("BlueFS::log.lock");


### PR DESCRIPTION
When bluefs log tried to write more data then was available runway, it caused assert.
Now in this condition we compact log synchoronously.
It causes temporary spike in latency but averts assert.

This modification is almost trivial but it bases (first 2 commits) on bluefs fine grain locking refactor #42099.

Fixes: https://tracker.ceph.com/issues/51217

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
