### PR TITLE
pacific: pybind/mgr: Fix IPv6 url generation

### DIFF
--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -5,6 +5,7 @@ import string
 from typing import List, Dict, Any, Tuple, cast, Optional
 
 from ceph.deployment.service_spec import IngressSpec
+from mgr_util import build_url
 from cephadm.utils import resolve_ip
 from orchestrator import OrchestratorError
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephService
@@ -226,7 +227,7 @@ class IngressService(CephService):
                 if d.daemon_type == 'haproxy':
                     assert d.ports
                     port = d.ports[1]   # monitoring port
-                    script = f'/usr/bin/curl http://{d.ip or "localhost"}:{port}/health'
+                    script = f'/usr/bin/curl {build_url(scheme="http", host=d.ip or "localhost", port=port)}/health'
         assert script
 
         # set state. first host in placement is master all others backups

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -9,7 +9,7 @@ from orchestrator import DaemonDescription
 from ceph.deployment.service_spec import AlertManagerSpec
 from cephadm.services.cephadmservice import CephadmService, CephadmDaemonDeploySpec
 from cephadm.services.ingress import IngressSpec
-from mgr_util import verify_tls, ServerConfigException, create_self_signed_cert
+from mgr_util import verify_tls, ServerConfigException, create_self_signed_cert, build_url
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,7 @@ class GrafanaService(CephadmService):
         assert dd.hostname is not None
         addr = dd.ip if dd.ip else self._inventory_get_addr(dd.hostname)
         port = dd.ports[0] if dd.ports else self.DEFAULT_SERVICE_PORT
-        service_url = 'https://{}:{}'.format(addr, port)
+        service_url = build_url(scheme='https', host=addr, port=port)
         self._set_service_url_on_dashboard(
             'Grafana',
             'dashboard get-grafana-api-url',

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
 
 from mgr_module import CLIWriteCommand, HandleCommandResult, MgrModule, \
     MgrStandbyModule, Option, _get_localized_key
-from mgr_util import ServerConfigException, create_self_signed_cert, \
-    get_default_addr, verify_tls_files
+from mgr_util import ServerConfigException, build_url, \
+    create_self_signed_cert, get_default_addr, verify_tls_files
 
 from . import mgr
 from .controllers import generate_routes, json_error_page
@@ -192,13 +192,12 @@ class CherryPyConfig(object):
         self._url_prefix = prepare_url_prefix(self.get_module_option(  # type: ignore
             'url_prefix', default=''))
 
-        uri = "{0}://{1}:{2}{3}/".format(
-            'https' if use_ssl else 'http',
-            server_addr,
-            server_port,
-            self.url_prefix
+        base_url = build_url(
+            scheme='https' if use_ssl else 'http',
+            host=server_addr,
+            port=server_port,
         )
-
+        uri = f'{base_url}{self.url_prefix}/'
         return uri
 
     def await_configuration(self):

--- a/src/pybind/mgr/dashboard/rest_client.py
+++ b/src/pybind/mgr/dashboard/rest_client.py
@@ -18,21 +18,19 @@ import logging
 import re
 
 import requests
+from requests.auth import AuthBase
 from requests.exceptions import ConnectionError, InvalidURL, Timeout
 
 from .settings import Settings
-from .tools import build_url
 
 try:
     from requests.packages.urllib3.exceptions import SSLError
 except ImportError:
     from urllib3.exceptions import SSLError  # type: ignore
 
-try:
-    from typing import List
-except ImportError:
-    pass  # Just for type checking
+from typing import List, Optional
 
+from mgr_util import build_url
 
 logger = logging.getLogger('rest_client')
 
@@ -331,7 +329,13 @@ class _Request(object):
 
 
 class RestClient(object):
-    def __init__(self, host, port, client_name=None, ssl=False, auth=None, ssl_verify=True):
+    def __init__(self,
+                 host: str,
+                 port: int,
+                 client_name: Optional[str] = None,
+                 ssl: bool = False,
+                 auth: Optional[AuthBase] = None,
+                 ssl_verify: bool = True) -> None:
         super(RestClient, self).__init__()
         self.client_name = client_name if client_name else ''
         self.host = host

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -7,12 +7,14 @@ import re
 import xml.etree.ElementTree as ET  # noqa: N814
 from distutils.util import strtobool
 
+from mgr_util import build_url
+
 from .. import mgr
 from ..awsauth import S3Auth
 from ..exceptions import DashboardException
 from ..rest_client import RequestException, RestClient
 from ..settings import Settings
-from ..tools import build_url, dict_contains_path, dict_get, json_str_to_object
+from ..tools import dict_contains_path, dict_get, json_str_to_object
 
 try:
     from typing import Any, Dict, List, Optional, Tuple, Union
@@ -324,10 +326,10 @@ class RgwClient(RestClient):
                            service_url=self.service_url)
 
     def __init__(self,
-                 access_key,
-                 secret_key,
-                 daemon_name,
-                 user_id=None):
+                 access_key: str,
+                 secret_key: str,
+                 daemon_name: str,
+                 user_id: Optional[str] = None) -> None:
         try:
             daemon = RgwClient._daemons[daemon_name]
         except KeyError as error:

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta
 from distutils.util import strtobool
 
 import cherrypy
-from ceph.deployment.utils import wrap_ipv6
+from mgr_util import build_url
 
 from . import mgr
 from .exceptions import ViewCacheNoDataException
@@ -671,41 +671,6 @@ class Task(object):
     def begin_time(self) -> float:
         assert self._begin_time is not None
         return self._begin_time
-
-
-def build_url(host, scheme=None, port=None):
-    """
-    Build a valid URL. IPv6 addresses specified in host will be enclosed in brackets
-    automatically.
-
-    >>> build_url('example.com', 'https', 443)
-    'https://example.com:443'
-
-    >>> build_url(host='example.com', port=443)
-    '//example.com:443'
-
-    >>> build_url('fce:9af7:a667:7286:4917:b8d3:34df:8373', port=80, scheme='http')
-    'http://[fce:9af7:a667:7286:4917:b8d3:34df:8373]:80'
-
-    :param scheme: The scheme, e.g. http, https or ftp.
-    :type scheme: str
-    :param host: Consisting of either a registered name (including but not limited to
-                 a hostname) or an IP address.
-    :type host: str
-    :type port: int
-    :rtype: str
-    """
-    netloc = wrap_ipv6(host)
-    if port:
-        netloc += ':{}'.format(port)
-    pr = urllib.parse.ParseResult(
-        scheme=scheme if scheme else '',
-        netloc=netloc,
-        path='',
-        params='',
-        query='',
-        fragment='')
-    return pr.geturl()
 
 
 def prepare_url_prefix(url_prefix):

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -435,7 +435,7 @@ def get_default_addr():
         return result
 
 
-def build_url(host: str, scheme: Optional[str] = None, port: Optional[int] = None) -> str:
+def build_url(host: str, scheme: Optional[str] = None, port: Optional[int] = None, path: str = '') -> str:
     """
     Build a valid URL. IPv6 addresses specified in host will be enclosed in brackets
     automatically.
@@ -448,6 +448,10 @@ def build_url(host: str, scheme: Optional[str] = None, port: Optional[int] = Non
 
     >>> build_url('fce:9af7:a667:7286:4917:b8d3:34df:8373', port=80, scheme='http')
     'http://[fce:9af7:a667:7286:4917:b8d3:34df:8373]:80'
+
+    >>> build_url('example.com', 'https', 443, path='/metrics')
+    'https://example.com:443/metrics'
+
 
     :param scheme: The scheme, e.g. http, https or ftp.
     :type scheme: str
@@ -463,7 +467,7 @@ def build_url(host: str, scheme: Optional[str] = None, port: Optional[int] = Non
     pr = urllib.parse.ParseResult(
         scheme=scheme if scheme else '',
         netloc=netloc,
-        path='',
+        path=path,
         params='',
         query='',
         fragment='')

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -13,6 +13,7 @@ import logging
 import sys
 from threading import Lock, Condition, Event
 from typing import no_type_check
+import urllib
 from functools import wraps
 if sys.version_info >= (3, 3):
     from threading import Timer
@@ -20,6 +21,9 @@ else:
     from threading import _Timer as Timer
 
 from typing import Tuple, Any, Callable, Optional, Dict, TYPE_CHECKING, TypeVar, List, Iterable, Generator, Generic, Iterator
+
+from ceph.deployment.utils import wrap_ipv6
+
 T = TypeVar('T')
 
 if TYPE_CHECKING:
@@ -429,6 +433,41 @@ def get_default_addr():
         result = '::' if is_ipv6_enabled() else '0.0.0.0'
         get_default_addr.result = result  # type: ignore
         return result
+
+
+def build_url(host: str, scheme: Optional[str] = None, port: Optional[int] = None) -> str:
+    """
+    Build a valid URL. IPv6 addresses specified in host will be enclosed in brackets
+    automatically.
+
+    >>> build_url('example.com', 'https', 443)
+    'https://example.com:443'
+
+    >>> build_url(host='example.com', port=443)
+    '//example.com:443'
+
+    >>> build_url('fce:9af7:a667:7286:4917:b8d3:34df:8373', port=80, scheme='http')
+    'http://[fce:9af7:a667:7286:4917:b8d3:34df:8373]:80'
+
+    :param scheme: The scheme, e.g. http, https or ftp.
+    :type scheme: str
+    :param host: Consisting of either a registered name (including but not limited to
+                 a hostname) or an IP address.
+    :type host: str
+    :type port: int
+    :rtype: str
+    """
+    netloc = wrap_ipv6(host)
+    if port:
+        netloc += ':{}'.format(port)
+    pr = urllib.parse.ParseResult(
+        scheme=scheme if scheme else '',
+        netloc=netloc,
+        path='',
+        params='',
+        query='',
+        fragment='')
+    return pr.geturl()
 
 
 class ServerConfigException(Exception):

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -8,13 +8,11 @@ import re
 import threading
 import time
 from mgr_module import CLIReadCommand, MgrModule, MgrStandbyModule, PG_STATES, Option, ServiceInfoT
-from mgr_util import get_default_addr, profile_method
+from mgr_util import get_default_addr, profile_method, build_url
 from rbd import RBD
 from collections import namedtuple
-try:
-    from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List
-except ImportError:
-    pass
+
+from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List
 
 # Defaults for the Prometheus HTTP server.  Can also set in config-key
 # see https://github.com/prometheus/prometheus/wiki/Default-port-allocations
@@ -1365,10 +1363,10 @@ class Module(MgrModule):
                                              self.STALE_CACHE_RETURN]:
             self.stale_cache_strategy = self.STALE_CACHE_FAIL
 
-        server_addr = self.get_localized_module_option(
-            'server_addr', get_default_addr())
-        server_port = self.get_localized_module_option(
-            'server_port', DEFAULT_PORT)
+        server_addr = cast(str, self.get_localized_module_option(
+            'server_addr', get_default_addr()))
+        server_port = cast(int, self.get_localized_module_option(
+            'server_port', DEFAULT_PORT))
         self.log.info(
             "server_addr: %s server_port: %s" %
             (server_addr, server_port)
@@ -1380,7 +1378,7 @@ class Module(MgrModule):
         # about to start serving
         if server_addr in ['::', '0.0.0.0']:
             server_addr = self.get_mgr_ip()
-        self.set_uri('http://{0}:{1}/'.format(server_addr, server_port))
+        self.set_uri(build_url(scheme='http', host=server_addr, port=server_port))
 
         cherrypy.config.update({
             'server.socket_host': server_addr,

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1378,7 +1378,7 @@ class Module(MgrModule):
         # about to start serving
         if server_addr in ['::', '0.0.0.0']:
             server_addr = self.get_mgr_ip()
-        self.set_uri(build_url(scheme='http', host=server_addr, port=server_port))
+        self.set_uri(build_url(scheme='http', host=server_addr, port=server_port, path='/'))
 
         cherrypy.config.update({
             'server.socket_host': server_addr,

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -314,7 +314,7 @@ class Module(MgrModule):
         # Publish the URI that others may use to access the service we're
         # about to start serving
         addr = self.get_mgr_ip() if server_addr == "::" else server_addr
-        self.set_uri(build_url(scheme='https', host=addr, port=server_port))
+        self.set_uri(build_url(scheme='https', host=addr, port=server_port, path='/'))
 
         # Create the HTTPS werkzeug server serving pecan app
         self.server = make_server(

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -25,6 +25,7 @@ from werkzeug.serving import make_server, make_ssl_devcert
 
 from .hooks import ErrorHook
 from mgr_module import MgrModule, CommandResult
+from mgr_util import build_url
 
 
 class CannotServe(Exception):
@@ -312,10 +313,8 @@ class Module(MgrModule):
 
         # Publish the URI that others may use to access the service we're
         # about to start serving
-        self.set_uri("https://{0}:{1}/".format(
-            self.get_mgr_ip() if server_addr == "::" else server_addr,
-            server_port
-        ))
+        addr = self.get_mgr_ip() if server_addr == "::" else server_addr
+        self.set_uri(build_url(scheme='https', host=addr, port=server_port))
 
         # Create the HTTPS werkzeug server serving pecan app
         self.server = make_server(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52325

---

backport of https://github.com/ceph/ceph/pull/42793 and https://github.com/ceph/ceph/pull/42886
parent tracker: https://tracker.ceph.com/issues/52117

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh