### PR TITLE
mgr/rook: host add label in rook orchestrator

### DIFF
--- a/qa/suites/orch/rook/smoke/2-workload/radosbench.yaml
+++ b/qa/suites/orch/rook/smoke/2-workload/radosbench.yaml
@@ -3,3 +3,10 @@ tasks:
     host.a:
 - radosbench:
     clients: [client.a]
+- rook.shell:
+    commands:
+        - |
+          ceph orch host label add `hostname` foo
+          ceph orch host ls | grep foo
+          ceph orch host label rm `hostname` foo
+          ceph orch host ls | grep -v foo

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -222,7 +222,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
     @handle_orch_error
     def get_hosts(self):
         # type: () -> List[orchestrator.HostSpec]
-        return [orchestrator.HostSpec(n) for n in self.rook_cluster.get_node_names()]
+        return self.rook_cluster.get_hosts()
 
     @handle_orch_error
     def describe_service(self,
@@ -484,6 +484,11 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         res = self._rook_cluster.remove_osds(osd_ids, replace, force, self.mon_command)
         return OrchResult(res)
 
+    def add_host_label(self, host: str, label: str) -> OrchResult[str]:
+        return self.rook_cluster.add_host_label(host, label)
+    
+    def remove_host_label(self, host: str, label: str) -> OrchResult[str]:
+        return self.rook_cluster.remove_host_label(host, label)
     """
     @handle_orch_error
     def create_osds(self, drive_group):


### PR DESCRIPTION
This PR adds the functionality for adding labels to hosts
using the rook orchestrator and orch host label add. The labels
are added to the kubernetes node object as kubernetes labels.

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
