### PR TITLE
pacific: ceph.spec.in: drop gdbm from build deps

### DIFF
--- a/README.aix
+++ b/README.aix
@@ -19,7 +19,6 @@ The following AIX packages are required for developing and compilation, they hav
 	gettext
 	less
 	perl
-	gdbm
 	pcre
 	rsync
 	zlib

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -172,7 +172,6 @@ BuildRequires:	gcc-toolset-9-gcc-c++ >= 9.2.1-2.3
 %else
 BuildRequires:	gcc-c++
 %endif
-BuildRequires:	gdbm
 %if 0%{with tcmalloc}
 # libprofiler did not build on ppc64le until 2.7.90
 %if 0%{?fedora} || 0%{?rhel} >= 8


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52471

backport of #42822
