### PR TITLE
crimson: osd: do not capture std::error_code by reference

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -716,7 +716,7 @@ PG::do_osd_ops_execute(
             [rollbacker, failure_func_ptr]
             (const std::error_code& e) mutable {
             return rollbacker.rollback_obc_if_modified(e).then_interruptible(
-              [&e, failure_func_ptr] {
+              [e, failure_func_ptr] {
               return (*failure_func_ptr)(e);
             });
           })
@@ -728,7 +728,7 @@ PG::do_osd_ops_execute(
     return PG::do_osd_ops_iertr::make_ready_future<pg_rep_op_fut_t<Ret>>(
         seastar::now(),
         rollbacker.rollback_obc_if_modified(e).then_interruptible(
-          [&e, failure_func_ptr] {
+          [e, failure_func_ptr] {
           return (*failure_func_ptr)(e);
         }));
   }));


### PR DESCRIPTION
This is really a question-by-pull-request. As the commit says:
> I can't find any reason to assume error_code has a longer lifetime than
> the future we're creating has.

This turned up for me on commit c045701101e8e469618c6639486a3200a426c537, which had some
other now-resolved issues that eventually led to crashes appearing in this code.
@athanatos suggested he thought the ```error_code```s are all statically-allocated structs,
but I don't see any evidence of that being the case for either ```std::error_code``` nor crimson::osd::error.