### PR TITLE
pacific: os/bluestore: fix using incomplete bluefs log when dumping it.

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1421,6 +1421,9 @@ int BlueFS::_replay(bool noop, bool to_stdout)
                 return r;
               }
             }
+	  } else if (noop && fnode.ino == 1) {
+	    FileRef f = _get_file(fnode.ino);
+	    f->fnode = fnode;
 	  }
         }
 	break;
@@ -3299,6 +3302,10 @@ void BlueFS::_close_writer(FileWriter *h)
 	bdev[i]->queue_reap_ioc(h->iocv[i]);
       }
     }
+  }
+  // sanity
+  if (h->file->fnode.size >= (1ull << 30)) {
+    dout(10) << __func__ << " file is unexpectedly large:" << h->file->fnode << dendl;
   }
   delete h;
 }


### PR DESCRIPTION
BlueFS superblock might contain incomplete list of physical extents for
bluefs log. Hence we should alway replay ops for ino 1 to get them properly.

backport tracker: https://tracker.ceph.com/issues/52477
backport of #42831 
parent tracker: https://tracker.ceph.com/issues/52311


Signed-off-by: Igor Fedotov <ifedotov@suse.com>
(cherry picked from commit 47632fe9baf7f20921c3e6888e29c4478fa5ff2d)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
