### PR TITLE
msg: make Policy::features_supported static and constant.

### DIFF
--- a/src/msg/Policy.h
+++ b/src/msg/Policy.h
@@ -42,7 +42,12 @@ struct Policy {
   ThrottleType* throttler_messages;
   
   /// Specify features supported locally by the endpoint.
-  uint64_t features_supported;
+#ifdef MSG_POLICY_UNIT_TESTING
+  uint64_t features_supported{CEPH_FEATURES_SUPPORTED_DEFAULT};
+#else
+  static constexpr uint64_t features_supported{CEPH_FEATURES_SUPPORTED_DEFAULT};
+#endif
+
   /// Specify features any remotes must have to talk to this endpoint.
   uint64_t features_required;
   
@@ -50,7 +55,6 @@ struct Policy {
     : lossy(false), server(false), standby(false), resetcheck(true),
       throttler_bytes(NULL),
       throttler_messages(NULL),
-      features_supported(CEPH_FEATURES_SUPPORTED_DEFAULT),
       features_required(0) {}
 private:
   Policy(bool l, bool s, bool st, bool r, bool rlc, uint64_t req)
@@ -58,7 +62,6 @@ private:
       register_lossy_clients(rlc),
       throttler_bytes(NULL),
       throttler_messages(NULL),
-      features_supported(CEPH_FEATURES_SUPPORTED_DEFAULT),
       features_required(req) {}
   
 public:

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -28,6 +28,8 @@
 #include <boost/random/uniform_int.hpp>
 #include <gtest/gtest.h>
 
+#define MSG_POLICY_UNIT_TESTING
+
 #include "common/ceph_argparse.h"
 #include "common/ceph_mutex.h"
 #include "global/global_init.h"

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -16,27 +16,28 @@
 
 #include <atomic>
 #include <iostream>
+#include <list>
 #include <memory>
-#include <unistd.h>
+#include <set>
 #include <stdlib.h>
 #include <time.h>
-#include <set>
-#include <list>
-#include "common/ceph_mutex.h"
-#include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include "msg/Dispatcher.h"
-#include "msg/msg_types.h"
-#include "msg/Message.h"
-#include "msg/Messenger.h"
-#include "msg/Connection.h"
-#include "messages/MPing.h"
-#include "messages/MCommand.h"
+#include <unistd.h>
 
+#include <boost/random/binomial_distribution.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
-#include <boost/random/binomial_distribution.hpp>
 #include <gtest/gtest.h>
+
+#include "common/ceph_argparse.h"
+#include "common/ceph_mutex.h"
+#include "global/global_init.h"
+#include "messages/MCommand.h"
+#include "messages/MPing.h"
+#include "msg/Connection.h"
+#include "msg/Dispatcher.h"
+#include "msg/Message.h"
+#include "msg/Messenger.h"
+#include "msg/msg_types.h"
 
 typedef boost::mt11213b gen_type;
 


### PR DESCRIPTION
This is an offspring of a bug investigation that required proving
`Policy::features_supported` never changes.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
