### PR TITLE
ceph-volume: fix lvm activate arguments

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -265,6 +265,11 @@ class Activate(object):
             tags = {'ceph.osd_id': osd_id, 'ceph.osd_fsid': osd_fsid}
         elif not osd_id and osd_fsid:
             tags = {'ceph.osd_fsid': osd_fsid}
+        elif osd_id and not osd_fsid:
+            raise RuntimeError('could not activate osd.{}, please provide the '
+                               'osd_fsid too'.format(osd_id))
+        else:
+            raise RuntimeError('Please provide both osd_id and osd_fsid')
         lvs = api.get_lvs(tags=tags)
         if not lvs:
             raise RuntimeError('could not find osd.%s with osd_fsid %s' %

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
@@ -58,6 +58,18 @@ class TestActivate(object):
         with pytest.raises(RuntimeError):
             activate.Activate([]).activate(args)
 
+    def test_osd_id_no_osd_fsid(self, is_root):
+        args = Args(osd_id=42, osd_fsid=None)
+        with pytest.raises(RuntimeError) as result:
+            activate.Activate([]).activate(args)
+        assert result.value.args[0] == 'could not activate osd.42, please provide the osd_fsid too'
+
+    def test_no_osd_id_no_osd_fsid(self, is_root):
+        args = Args(osd_id=None, osd_fsid=None)
+        with pytest.raises(RuntimeError) as result:
+            activate.Activate([]).activate(args)
+        assert result.value.args[0] == 'Please provide both osd_id and osd_fsid'
+
     def test_filestore_no_systemd(self, is_root, monkeypatch, capture):
         monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         fake_enable = Capture()


### PR DESCRIPTION
When using the `lvm activate` subcommand without any osd ID or osd FSID
then ceph-volume fails.

Currently we can either activate with:
 - both osd ID and osd FSID
 - only the osd FSID (because it's unique)

The remaining scenarios aren't covered and generate a stack trace:
 - only the osd ID
 - no osd ID nor osd FSID

This ends up with an error like:

-->  UnboundLocalError: local variable 'tags' referenced before assignment

Fixes: https://tracker.ceph.com/issues/50665

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
