### PR TITLE
admin/build-doc: use venv module again

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -55,7 +55,7 @@ if test -f $md5 && md5sum --check $md5 > /dev/null; then
     # reusing existing venv
     :
 else
-    virtualenv --python=python3 $vdir
+    python3 -m venv $vdir
 
     $vdir/bin/pip install --quiet wheel
     $vdir/bin/pip install --quiet \


### PR DESCRIPTION
Commit 690ca1c5628af629a25a80611c20e56095f13352 accidentally re-introduced virtualenv. Switch back to the venv module in stdlib.