### PR TITLE
crimson/os/seastore/lba_manager/btree/lba_btree: fix FTBFS on gcc 9

### DIFF
--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
@@ -29,8 +29,11 @@ public:
 
   class iterator {
   public:
-    iterator(const iterator &) noexcept = default;
-    iterator(iterator &&) noexcept = default;
+    iterator(const iterator &rhs) noexcept :
+      internal(rhs.internal), leaf(rhs.leaf) {}
+    iterator(iterator &&rhs) noexcept :
+      internal(std::move(rhs.internal)), leaf(std::move(rhs.leaf)) {}
+
     iterator &operator=(const iterator &) = default;
     iterator &operator=(iterator &&) = default;
 
@@ -102,8 +105,8 @@ public:
     }
 
   private:
-    iterator() = default;
-    iterator(depth_t depth) : internal(depth - 1) {}
+    iterator() noexcept {}
+    iterator(depth_t depth) noexcept : internal(depth - 1) {}
 
     friend class LBABtree;
     static constexpr uint16_t INVALID = std::numeric_limits<uint16_t>::max();


### PR DESCRIPTION
gcc-9 doesn't seem to consider interator nothrow move constructible with
the default move constructor implementation yielding the following build
failure:

m/el8/BUILD/ceph-17.0.0-7373-gfc349212/src/seastar/include/seastar/core/future.hh:584:58: error: static assertion failed: Types must be no-throw move constructible
  584 |     static_assert(std::is_nothrow_move_constructible<T>::value,

Signed-off-by: Samuel Just <sjust@redhat.com>