### PR TITLE
crimson/onode-staged-tree: improve laddr hints during allocation

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -605,7 +605,7 @@ Node::try_merge_adjacent(
         // so use rebuild_extent() as a workaround to rebuild the node from a
         // fresh extent, thus no need to generate delta.
         auto left_addr = left_for_merge->impl->laddr();
-        return left_for_merge->rebuild_extent(c, L_ADDR_MIN
+        return left_for_merge->rebuild_extent(c
         ).si_then([c, update_index_after_merge,
                      left_addr,
                      merge_stage = merge_stage,
@@ -744,7 +744,7 @@ eagain_ifuture<Ref<Node>> Node::load(
   });
 }
 
-eagain_ifuture<NodeExtentMutable> Node::rebuild_extent(context_t c, laddr_t hint)
+eagain_ifuture<NodeExtentMutable> Node::rebuild_extent(context_t c)
 {
   LOG_PREFIX(OTree::Node::rebuild_extent);
   DEBUGT("{} ...", c.t, get_name());
@@ -753,7 +753,7 @@ eagain_ifuture<NodeExtentMutable> Node::rebuild_extent(context_t c, laddr_t hint
 
   // note: laddr can be changed after rebuild, but we don't fix the parent
   // mapping as it is part of the merge process.
-  return impl->rebuild_extent(c, hint);
+  return impl->rebuild_extent(c);
 }
 
 eagain_ifuture<> Node::retire(context_t c, Ref<Node>&& this_ref)

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -428,7 +428,7 @@ class Node
   eagain_ifuture<> erase_node(context_t, Ref<Node>&&);
   template <bool FORCE_MERGE = false>
   eagain_ifuture<> fix_parent_index(context_t, Ref<Node>&&, bool);
-  eagain_ifuture<NodeExtentMutable> rebuild_extent(context_t, laddr_t);
+  eagain_ifuture<NodeExtentMutable> rebuild_extent(context_t);
   eagain_ifuture<> retire(context_t, Ref<Node>&&);
   void make_tail(context_t);
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -681,7 +681,7 @@ class LeafNode final : public Node {
       context_t, const key_hobj_t&, value_config_t,
       const search_position_t&, const MatchHistory&,
       match_stat_t mstat);
-  static eagain_ifuture<Ref<LeafNode>> allocate_root(context_t, laddr_t, RootNodeTracker&);
+  static eagain_ifuture<Ref<LeafNode>> allocate_root(context_t, RootNodeTracker&);
   friend class Node;
 
  private:

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
@@ -90,7 +90,7 @@ class DummyNodeExtentManager final: public NodeExtentManager {
 
   alloc_iertr::future<NodeExtentRef> alloc_extent(
       Transaction& t, laddr_t hint, extent_len_t len) override {
-    TRACET("allocating {}B ...", t, len);
+    TRACET("allocating {}B with hint {:#x} ...", t, len, hint);
     if constexpr (SYNC) {
       return alloc_extent_sync(t, len);
     } else {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -122,7 +122,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
 
   alloc_iertr::future<NodeExtentRef> alloc_extent(
       Transaction& t, laddr_t hint, extent_len_t len) override {
-    TRACET("allocating {}B ...", t, len);
+    TRACET("allocating {}B with hint {:#x} ...", t, len, hint);
     if constexpr (INJECT_EAGAIN) {
       if (trigger_eagain()) {
         DEBUGT("allocating {}B: trigger eagain", t, len);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -90,7 +90,7 @@ class NodeImpl {
   virtual std::tuple<match_stage_t, search_position_t> erase(const search_position_t&) = 0;
   virtual std::tuple<match_stage_t, std::size_t> evaluate_merge(NodeImpl&) = 0;
   virtual search_position_t merge(NodeExtentMutable&, NodeImpl&, match_stage_t, extent_len_t) = 0;
-  virtual eagain_ifuture<NodeExtentMutable> rebuild_extent(context_t, laddr_t) = 0;
+  virtual eagain_ifuture<NodeExtentMutable> rebuild_extent(context_t) = 0;
   virtual eagain_ifuture<> retire_extent(context_t) = 0;
   virtual search_position_t make_tail() = 0;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -306,7 +306,12 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   }
 
   eagain_ifuture<NodeExtentMutable>
-  rebuild_extent(context_t c, laddr_t hint) override {
+  rebuild_extent(context_t c) override {
+    assert(!is_keys_empty());
+    full_key_t<KeyT::VIEW> first_index;
+    STAGE_T::template get_slot<true, false>(
+        extent.read(), position_t::begin(), &first_index, nullptr);
+    auto hint = first_index.get_hint();
     return extent.rebuild(c, hint).si_then([this] (auto mut) {
       // addr may change
       build_name();

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -908,7 +908,7 @@ class DummyChildPool {
       ceph_abort("impossible path"); }
     search_position_t merge(NodeExtentMutable&, NodeImpl&, match_stage_t, extent_len_t) override {
       ceph_abort("impossible path"); }
-    eagain_ifuture<NodeExtentMutable> rebuild_extent(context_t, laddr_t) override {
+    eagain_ifuture<NodeExtentMutable> rebuild_extent(context_t) override {
       ceph_abort("impossible path"); }
     node_stats_t get_stats() const override {
       ceph_abort("impossible path"); }


### PR DESCRIPTION
No significant impact to the transaction invalidate/commit ratio (under Rel build):
* Before: ![before](https://user-images.githubusercontent.com/7736006/131787698-48c96af3-b9cf-4904-a525-5f3f241d838b.png)
* After: ![after](https://user-images.githubusercontent.com/7736006/131787722-8f5ea76a-bb9e-44b0-a809-5c20b339dad9.png)
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
