### PR TITLE
mgr/dashboard: Incorrect MTU mismatch warning

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -233,7 +233,7 @@ groups:
             rate of the past 48 hours.
 
       - alert: MTU Mismatch
-        expr: node_network_mtu_bytes{device!="lo"} != on() group_left() (quantile(0.5, node_network_mtu_bytes{device!="lo"}))
+        expr: node_network_mtu_bytes{device!="lo"} * (node_network_up{device!="lo"} > 0) != on() group_left() (quantile(0.5, node_network_mtu_bytes{device!="lo"}))
         labels:
           severity: warning
           type: ceph_default

--- a/monitoring/prometheus/alerts/test_alerts.yml
+++ b/monitoring/prometheus/alerts/test_alerts.yml
@@ -680,13 +680,27 @@ tests:
     - series: 'node_network_mtu_bytes{device="eth4",instance="node-exporter",
       job="node-exporter"}'
       values: '9000 9000 9000 9000 9000'
+    - series: 'node_network_up{device="eth0",instance="node-exporter",
+      job="node-exporter"}'
+      values: '0 0 0 0 0'
+    - series: 'node_network_up{device="eth1",instance="node-exporter",
+      job="node-exporter"}'
+      values: '0 0 0 0 0'
+    - series: 'node_network_up{device="eth2",instance="node-exporter",
+      job="node-exporter"}'
+      values: '1 1 1 1 1'
+    - series: 'node_network_up{device="eth3",instance="node-exporter",
+      job="node-exporter"}'
+      values: '0 0 0 0 0'
+    - series: 'node_network_up{device="eth4",instance="node-exporter",
+      job="node-exporter"}'
+      values: '1 1 1 1 1'  
    promql_expr_test:
-     - expr: node_network_mtu_bytes{device!="lo"} != on() group_left()
+     - expr: node_network_mtu_bytes{device!="lo"} * (node_network_up{device!="lo"} > 0) != on() group_left()
              (quantile(0.5, node_network_mtu_bytes{device!="lo"}))
        eval_time: 1m
        exp_samples:
-         - labels: '{__name__="node_network_mtu_bytes", device="eth4",
-           instance="node-exporter", job="node-exporter"}'
+         - labels: '{device="eth4", instance="node-exporter", job="node-exporter"}'
            value: 9000
    alert_rule_test:
      - eval_time: 1m


### PR DESCRIPTION
The MTU mismatch warning is being fired for those NIC's as well that are in down state. This PR intends to fix this issue

Fixes:https://tracker.ceph.com/issues/52028
Signed-off-by: Aashish Sharma <aasharma@redhat.com>


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
