### PR TITLE
mgr/alerts: added emojis to status message

### DIFF
--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -40,11 +40,6 @@ class Alerts(MgrModule):
             default='>_<',
             desc='Emoji for HEALTH_ERR',
             runtime=True),
-        Option(
-            name='emoji_undef',
-            default='oO',
-            desc='Emoji for undefined HEALTH status',
-            runtime=True),
         # smtp
         Option(
             name='smtp_host',
@@ -227,20 +222,15 @@ class Alerts(MgrModule):
                          diff: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         # message
         self.log.debug('_send_alert_smtp')
+        # additional whitespace used to don't mess up formatting when disabled
+        emojis = {'HEALTH_OK': ' {}'.format(self.emoji_ok),
+                  'HEALTH_WARN': ' {}'.format(self.emoji_warn),
+                  'HEALTH_ERR': ' {}'.format(self.emoji_err)
+                 }
+        emote = ''
         if self.emojis:
-            if status['status']=='HEALTH_OK':
-                self.emote=' {}'.format(self.emoji_ok)
-            elif status['status']=='HEALTH_WARN':
-                self.emote=' {}'.format(self.emoji_warn)
-                self.emote='-_-'
-            elif status['status']=='HEALTH_ERR':
-                self.emote=' {}'.format(self.emoji_err)
-                self.emote='>_<'
-            else:
-                # If statement instead of dict mapping just for this
-                self.emote=' {}'.format(self.emoji_undef)
-        else:
-            self.emote=''
+            emote = emojis[status['status']]
+
         message = ('From: {from_name} <{sender}>\n'
                    'Subject: {status}{emote}\n'
                    'To: {target}\n'
@@ -250,7 +240,7 @@ class Alerts(MgrModule):
                        from_name=self.smtp_from_name,
                        status=status['status'],
                        target=self.smtp_destination,
-                       emote=self.emote))
+                       emote=emote))
 
         if 'new' in diff:
             message += ('\n--- New ---\n')

--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -18,6 +18,33 @@ class Alerts(MgrModule):
             default=60,
             desc='How frequently to reexamine health status',
             runtime=True),
+        # emojis
+        Option(
+            name='emojis',
+            type='bool',
+            default=False,
+            desc='Enables emojis to better reflect the status',
+            runtime=True),
+        Option(
+            name='emoji_ok',
+            default='^_^',
+            desc='Emoji for HEALTH_OK',
+            runtime=True),
+        Option(
+            name='emoji_warn',
+            default='-_-',
+            desc='Emoji for HEALTH_WARN',
+            runtime=True),
+        Option(
+            name='emoji_err',
+            default='>_<',
+            desc='Emoji for HEALTH_ERR',
+            runtime=True),
+        Option(
+            name='emoji_undef',
+            default='oO',
+            desc='Emoji for undefined HEALTH status',
+            runtime=True),
         # smtp
         Option(
             name='smtp_host',
@@ -200,15 +227,30 @@ class Alerts(MgrModule):
                          diff: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         # message
         self.log.debug('_send_alert_smtp')
+        if self.emojis:
+            if status['status']=='HEALTH_OK':
+                self.emote=' {}'.format(self.emoji_ok)
+            elif status['status']=='HEALTH_WARN':
+                self.emote=' {}'.format(self.emoji_warn)
+                self.emote='-_-'
+            elif status['status']=='HEALTH_ERR':
+                self.emote=' {}'.format(self.emoji_err)
+                self.emote='>_<'
+            else:
+                # If statement instead of dict mapping just for this
+                self.emote=' {}'.format(self.emoji_undef)
+        else:
+            self.emote=''
         message = ('From: {from_name} <{sender}>\n'
-                   'Subject: {status}\n'
+                   'Subject: {status}{emote}\n'
                    'To: {target}\n'
                    '\n'
                    '{status}\n'.format(
                        sender=self.smtp_sender,
                        from_name=self.smtp_from_name,
                        status=status['status'],
-                       target=self.smtp_destination))
+                       target=self.smtp_destination,
+                       emote=self.emote))
 
         if 'new' in diff:
             message += ('\n--- New ---\n')

--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -40,6 +40,11 @@ class Alerts(MgrModule):
             default='>_<',
             desc='Emoji for HEALTH_ERR',
             runtime=True),
+        Option(
+            name='emoji_undef',
+            default='o_O',
+            desc='Emoji for HEALTH_ERR',
+            runtime=True),
         # smtp
         Option(
             name='smtp_host',
@@ -229,7 +234,7 @@ class Alerts(MgrModule):
                  }
         emote = ''
         if self.emojis:
-            emote = emojis[status['status']]
+            emote = emojis.get(status['status'], ' {}'.format(self.emoji_undef))
 
         message = ('From: {from_name} <{sender}>\n'
                    'Subject: {status}{emote}\n'


### PR DESCRIPTION
This commit adds the important function to add emojis/emoticons to your alert mails.
You can define emojis for every HEALTH_ status.
I even added a failsafe for unknown status (if a new HEALTH_ status is added or the status can't be pulled)
Now you can finally easily see what the status of your cluster is without parsing Text.
Default is off.

Nobody asked for this but my wife. She assured me that they just didn't know that they need it.