### PR TITLE
backport-create-issue: set backport priority

### DIFF
--- a/src/script/backport-create-issue
+++ b/src/script/backport-create-issue
@@ -222,7 +222,7 @@ def update_relations(r, issue, dry_run):
         other = r.issue.create(project_id=issue['project']['id'],
                                tracker_id=backport_tracker_id,
                                subject=subject,
-                               priority='Normal',
+                               priority_id=issue['priority']['id'],
                                target_version=None,
                                custom_fields=[{
                                    "id": release_id,


### PR DESCRIPTION
Set backport issue priority based upon the priority of the original issue.

This PR is being submitted on behalf of @ldachary.

Fixes: https://tracker.ceph.com/issues/52387
Signed-off-by: Cory Snyder <csnyder@iland.com>
