### PR TITLE
doc: rados/ceph-conf.rst bootstrap options

### DIFF
--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -67,10 +67,11 @@ daemon or process startup will proceed.
 Bootstrap options
 -----------------
 
-Because some configuration options affect the process's ability to
-contact the monitors, authenticate, and retrieve the cluster-stored
-configuration, they may need to be stored locally on the node and set
-in a local configuration file.  These options include:
+Some configuration options affect the process's ability to contact the
+monitors, to authenticate, and to retrieve the cluster-stored configuration.
+For this reason, these options might need to be stored locally on the node, and
+set by means of a local configuration file. These options include the
+following:
 
 .. confval:: mon_host
 .. confval:: mon_host_override
@@ -84,20 +85,19 @@ in a local configuration file.  These options include:
   the monitor.  Note that in most cases the default keyring location
   is in the data directory specified above.
 
-In the vast majority of cases the default values of these are
-appropriate, with the exception of the :confval:`mon_host` option that
-identifies the addresses of the cluster's monitors.  When DNS is used
-to identify monitors a local ceph configuration file can be avoided
-entirely.
+In most cases, the default values of these options are suitable. There is one
+exception to this: the :confval:`mon_host` option that identifies the addresses
+of the cluster's monitors.  When DNS is used to identify monitors, a local Ceph
+configuration file can be avoided entirely.
 
 Skipping monitor config
 -----------------------
 
-Any process may be passed the option ``--no-mon-config`` to skip the
-step that retrieves configuration from the cluster monitors.  This is
-useful in cases where configuration is managed entirely via
-configuration files or where the monitor cluster is currently down but
-some maintenance activity needs to be done.
+Pass the option ``--no-mon-config`` to any process to skip the step that
+retrieves configuration information from the cluster monitors. This is useful
+in cases where configuration is managed entirely via configuration files, or
+when the monitor cluster is down and some maintenance activity needs to be
+done.
 
 
 .. _ceph-conf-file:


### PR DESCRIPTION
This is the editorial syntax and elegance PR for the "Bootstrap Options"
section in the "Configuring Ceph" chapter of the RADOS Guide.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
