### PR TITLE
mgr/dashboard: improve formatting of histograms in Telemetry preview form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -170,6 +170,36 @@ describe('TelemetryComponent', () => {
       expect(component).toBeTruthy();
     });
 
+    it ('should only replace the ranges and values of a JSON object', () => {
+      var report = component.replacerTest({'ranges': [[null, -1], [0, 511], [512, 1023]],
+                                           'values': [[0,0,0], [0,0,0], [0,0,0]],
+					   'other': [[0,0,0], [0,0,0], [0,0,0]]});
+      report = JSON.parse(report);
+
+      // Ensure that the outer arrays have remained untouched by replacer
+      expect(Array.isArray(report['ranges']) && Array.isArray(report['values']) && Array.isArray(report['other'])).toBeTruthy()
+
+      if (Array.isArray(report['ranges']) && Array.isArray(report['values']) && Array.isArray(report['other'])) {
+        var idx;
+
+        // Check that each range in 'ranges' was replaced by a string
+	for (idx=0; idx<report['ranges'].length; idx++) {
+		expect(typeof report['ranges'][idx] === 'string').toBeTruthy();
+        }
+
+	// Check that each value in 'values' was replaced by a string
+	for (idx=0; idx<report['values'].length; idx++) {
+                expect(typeof report['values'][idx] === 'string').toBeTruthy();
+        }
+
+	// Check that each value in 'other' has remained untouched, as it is not a value or range
+	for (idx=0; idx<report['other'].length; idx++) {
+                expect(Array.isArray(report['other'][idx])).toBeTruthy();
+        }
+
+      }
+    });
+
     it('should submit', () => {
       component.onSubmit();
       const req = httpTesting.expectOne('api/telemetry');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -170,33 +170,54 @@ describe('TelemetryComponent', () => {
       expect(component).toBeTruthy();
     });
 
-    it ('should only replace the ranges and values of a JSON object', () => {
-      var report = component.replacerTest({'ranges': [[null, -1], [0, 511], [512, 1023]],
-                                           'values': [[0,0,0], [0,0,0], [0,0,0]],
-					   'other': [[0,0,0], [0,0,0], [0,0,0]]});
+    it('should only replace the ranges and values of a JSON object', () => {
+      let report = component.replacerTest({
+        ranges: [
+          [null, -1],
+          [0, 511],
+          [512, 1023]
+        ],
+        values: [
+          [0, 0, 0],
+          [0, 0, 0],
+          [0, 0, 0]
+        ],
+        other: [
+          [0, 0, 0],
+          [0, 0, 0],
+          [0, 0, 0]
+        ]
+      });
       report = JSON.parse(report);
 
       // Ensure that the outer arrays have remained untouched by replacer
-      expect(Array.isArray(report['ranges']) && Array.isArray(report['values']) && Array.isArray(report['other'])).toBeTruthy()
+      expect(
+        Array.isArray(report['ranges']) &&
+          Array.isArray(report['values']) &&
+          Array.isArray(report['other'])
+      ).toBeTruthy();
 
-      if (Array.isArray(report['ranges']) && Array.isArray(report['values']) && Array.isArray(report['other'])) {
-        var idx;
+      if (
+        Array.isArray(report['ranges']) &&
+        Array.isArray(report['values']) &&
+        Array.isArray(report['other'])
+      ) {
+        let idx;
 
         // Check that each range in 'ranges' was replaced by a string
-	for (idx=0; idx<report['ranges'].length; idx++) {
-		expect(typeof report['ranges'][idx] === 'string').toBeTruthy();
+        for (idx = 0; idx < report['ranges'].length; idx++) {
+          expect(typeof report['ranges'][idx] === 'string').toBeTruthy();
         }
 
-	// Check that each value in 'values' was replaced by a string
-	for (idx=0; idx<report['values'].length; idx++) {
-                expect(typeof report['values'][idx] === 'string').toBeTruthy();
+        // Check that each value in 'values' was replaced by a string
+        for (idx = 0; idx < report['values'].length; idx++) {
+          expect(typeof report['values'][idx] === 'string').toBeTruthy();
         }
 
-	// Check that each value in 'other' has remained untouched, as it is not a value or range
-	for (idx=0; idx<report['other'].length; idx++) {
-                expect(Array.isArray(report['other'][idx])).toBeTruthy();
+        // Check that each value in 'other' has remained untouched, as it is not a value or range
+        for (idx = 0; idx < report['other'].length; idx++) {
+          expect(Array.isArray(report['other'][idx])).toBeTruthy();
         }
-
       }
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -171,54 +171,101 @@ describe('TelemetryComponent', () => {
     });
 
     it('should only replace the ranges and values of a JSON object', () => {
-      let report = component.replacerTest({
-        ranges: [
-          [null, -1],
-          [0, 511],
-          [512, 1023]
-        ],
-        values: [
-          [0, 0, 0],
-          [0, 0, 0],
-          [0, 0, 0]
-        ],
+      expect(
+        JSON.parse(
+          component.replacerTest({
+            ranges: [
+              [null, -1],
+              [0, 511],
+              [512, 1023]
+            ],
+            values: [
+              [0, 0, 0],
+              [0, 0, 0],
+              [0, 0, 0]
+            ],
+            other: [
+              [0, 0, 0],
+              [0, 0, 0],
+              [0, 0, 0]
+            ]
+          })
+        )
+      ).toStrictEqual({
+        ranges: ['[null,-1]', '[0,511]', '[512,1023]'],
+        values: ['[0,0,0]', '[0,0,0]', '[0,0,0]'],
         other: [
           [0, 0, 0],
           [0, 0, 0],
           [0, 0, 0]
         ]
       });
-      report = JSON.parse(report);
 
-      // Ensure that the outer arrays have remained untouched by replacer
       expect(
-        Array.isArray(report['ranges']) &&
-          Array.isArray(report['values']) &&
-          Array.isArray(report['other'])
-      ).toBeTruthy();
+        JSON.parse(
+          component.replacerTest({
+            ranges: [
+              [null, -1],
+              [0, 511],
+              [512, 1023]
+            ],
+            values: [
+              [0, 0, 0],
+              [0, 0, 0],
+              [0, 0, 0]
+            ],
+            other: true
+          })
+        )
+      ).toStrictEqual({
+        ranges: ['[null,-1]', '[0,511]', '[512,1023]'],
+        values: ['[0,0,0]', '[0,0,0]', '[0,0,0]'],
+        other: true
+      });
 
-      if (
-        Array.isArray(report['ranges']) &&
-        Array.isArray(report['values']) &&
-        Array.isArray(report['other'])
-      ) {
-        let idx;
+      expect(
+        JSON.parse(
+          component.replacerTest({
+            ranges: [
+              [null, -1],
+              [0, 511],
+              [512, 1023]
+            ],
+            values: [
+              [0, 0, 0],
+              [0, 0, 0],
+              [0, 0, 0]
+            ],
+            other: 1
+          })
+        )
+      ).toStrictEqual({
+        ranges: ['[null,-1]', '[0,511]', '[512,1023]'],
+        values: ['[0,0,0]', '[0,0,0]', '[0,0,0]'],
+        other: 1
+      });
 
-        // Check that each range in 'ranges' was replaced by a string
-        for (idx = 0; idx < report['ranges'].length; idx++) {
-          expect(typeof report['ranges'][idx] === 'string').toBeTruthy();
-        }
-
-        // Check that each value in 'values' was replaced by a string
-        for (idx = 0; idx < report['values'].length; idx++) {
-          expect(typeof report['values'][idx] === 'string').toBeTruthy();
-        }
-
-        // Check that each value in 'other' has remained untouched, as it is not a value or range
-        for (idx = 0; idx < report['other'].length; idx++) {
-          expect(Array.isArray(report['other'][idx])).toBeTruthy();
-        }
-      }
+      expect(
+        JSON.parse(
+          component.replacerTest({
+            ranges: [
+              [null, -1],
+              [0, 511],
+              [512, 1023]
+            ],
+            values: [
+              [0, 0, 0],
+              [0, 0, 0],
+              [0, 0, 0]
+            ],
+            other: { value: 0 }
+          })
+        )
+      ).toStrictEqual({
+        ranges: ['[null,-1]', '[0,511]', '[512,1023]'],
+        values: ['[0,0,0]', '[0,0,0]', '[0,0,0]'],
+        other: { value: 0 }
+      });
     });
 
     it('should submit', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -105,6 +105,10 @@ export class TelemetryComponent extends CdForm implements OnInit {
     return value;
   }
 
+  replacerTest(report: object) {
+    return JSON.stringify(report, this.replacer, 2);
+  }
+
   private createPreviewForm() {
     const controls = {
       report: JSON.stringify(this.report, this.replacer, 2),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -88,18 +88,15 @@ export class TelemetryComponent extends CdForm implements OnInit {
     this.configForm = this.formBuilder.group(controlsConfig);
   }
 
-  // Helper function used in createPreviewForm to display the ranges and values of `osd_perf_histograms`
-  // horizontally instead of vertically.
   private replacer(key: string, value: any) {
-    // Detect either the 'ranges' or 'values' 2D array (arr_2d), both of which
-    // need to be displayed horizontally. This will be done by converting the inner arrays
-    // of the 2D array into strings.
+    // Display the arrays of keys 'ranges' and 'values' horizontally as they take up too much space
+    // and Stringify displays it in vertical by default.
     if ((key === 'ranges' || key === 'values') && Array.isArray(value)) {
-      const arr_2d = [];
+      const elements = [];
       for (let i = 0; i < value.length; i++) {
-        arr_2d.push(JSON.stringify(value[i]));
+        elements.push(JSON.stringify(value[i]));
       }
-      return arr_2d;
+      return elements;
     }
     // Else, just return the value as is, without any formatting.
     return value;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -89,7 +89,7 @@ export class TelemetryComponent extends CdForm implements OnInit {
   }
 
   private replacer(key: string, value: any) {
-    if (key === 'ranges' || key === 'values') {
+    if ((key === 'ranges' || key === 'values') && (Array.isArray(value))) {
       const x = [];
       for (let i = 0; i < value.length; i++) {
         x.push(JSON.stringify(value[i]));

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -88,14 +88,20 @@ export class TelemetryComponent extends CdForm implements OnInit {
     this.configForm = this.formBuilder.group(controlsConfig);
   }
 
+  // Helper function used in createPreviewForm to display the ranges and values of `osd_perf_histograms`
+  // horizontally instead of vertically.
   private replacer(key: string, value: any) {
+    // Detect either the 'ranges' or 'values' 2D array (arr_2d), both of which
+    // need to be displayed horizontally. This will be done by converting the inner arrays
+    // of the 2D array into strings.
     if ((key === 'ranges' || key === 'values') && Array.isArray(value)) {
-      const x = [];
+      const arr_2d = [];
       for (let i = 0; i < value.length; i++) {
-        x.push(JSON.stringify(value[i]));
+        arr_2d.push(JSON.stringify(value[i]));
       }
-      return x;
+      return arr_2d;
     }
+    // Else, just return the value as is, without any formatting.
     return value;
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -89,7 +89,7 @@ export class TelemetryComponent extends CdForm implements OnInit {
   }
 
   private replacer(key: string, value: any) {
-    if ((key === 'ranges' || key === 'values') && (Array.isArray(value))) {
+    if ((key === 'ranges' || key === 'values') && Array.isArray(value)) {
       const x = [];
       for (let i = 0; i < value.length; i++) {
         x.push(JSON.stringify(value[i]));

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -88,9 +88,20 @@ export class TelemetryComponent extends CdForm implements OnInit {
     this.configForm = this.formBuilder.group(controlsConfig);
   }
 
+  private replacer(key: string, value: any) {
+    if (key === 'ranges' || key === 'values') {
+      const x = [];
+      for (let i = 0; i < value.length; i++) {
+        x.push(JSON.stringify(value[i]));
+      }
+      return x;
+    }
+    return value;
+  }
+
   private createPreviewForm() {
     const controls = {
-      report: JSON.stringify(this.report, null, 2),
+      report: JSON.stringify(this.report, this.replacer, 2),
       reportId: this.reportId,
       licenseAgrmt: [this.licenseAgrmt, Validators.requiredTrue]
     };


### PR DESCRIPTION
Histogram data in the Telemetry dashboard preview is displayed horizontally instead of vertically to improve readability.

Fixes: https://tracker.ceph.com/issues/52505
Signed-off-by: Laura Flores <lflores@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
