### PR TITLE
librbd: require exclusive lock for reads if pwl cache is enabled

### DIFF
--- a/src/librbd/exclusive_lock/PreReleaseRequest.cc
+++ b/src/librbd/exclusive_lock/PreReleaseRequest.cc
@@ -100,7 +100,8 @@ void PreReleaseRequest<I>::send_set_require_lock() {
   // setting the lock as required will automatically cause the IO
   // queue to re-request the lock if any IO is queued
   if (m_image_ctx.clone_copy_on_read ||
-      m_image_ctx.test_features(RBD_FEATURE_JOURNALING)) {
+      m_image_ctx.test_features(RBD_FEATURE_JOURNALING) ||
+      m_image_ctx.test_features(RBD_FEATURE_DIRTY_CACHE)) {
     m_image_dispatch->set_require_lock(m_shutting_down,
                                        io::DIRECTION_BOTH, ctx);
   } else {

--- a/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
@@ -102,9 +102,14 @@ public:
     if (!mock_image_ctx.clone_copy_on_read) {
       expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING,
                            ((mock_image_ctx.features & RBD_FEATURE_JOURNALING) != 0));
+      if ((mock_image_ctx.features & RBD_FEATURE_JOURNALING) == 0) {
+        expect_test_features(mock_image_ctx, RBD_FEATURE_DIRTY_CACHE,
+                             ((mock_image_ctx.features & RBD_FEATURE_DIRTY_CACHE) != 0));
+      }
     }
     if (mock_image_ctx.clone_copy_on_read ||
-        (mock_image_ctx.features & RBD_FEATURE_JOURNALING) != 0) {
+        (mock_image_ctx.features & RBD_FEATURE_JOURNALING) != 0 ||
+        (mock_image_ctx.features & RBD_FEATURE_DIRTY_CACHE) != 0) {
       expect_set_require_lock(mock_image_dispatch, init_shutdown,
                               librbd::io::DIRECTION_BOTH, r);
     } else {


### PR DESCRIPTION
TestLibRBD.TestFUA descript the following workload:
a)write/read the same image w/ pwl-cache
  write_image = open(image_name);
  read_image  = open(image_name);
b)i/o workload is:
   write(write_image)
      write need EXLock and require EXLOCK

  read(read_image)
     in ExclusiveLock<I>::init(), firstly read need EXLOCK
     so will require EXLOCK. write_image release EXLOCK(will
     flush data to osd and remove cache). read_image init pwl-cache
     and read-io firstly enter pwl-cache and missed and then read
     from osd.

   write(write_image)
     write need EXLOCK and require EXLOCK. This make read_image remove
     empty cache. write_image init cache pool and write data to cache.

   read(read_image)
       In send_set_require_lock(), it set write need EXLOCK.
       So read don't require EXLOCK and dirtyly read from osd.

Because second-read  don't need EXLOCK and make write_image don't
release EXLOCK(flush dirty data to osd and  shutdown pwl-cache).
This make second-read don't read the latest data.

So we should make read also need EXLOCK when enable pwl-cache.

Fixes: https://tracker.ceph.com/issues/51438

Tested-by: Feng Hualong <hualong.feng@intel.com>
Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
