### PR TITLE
mgr/dashboard: Create Cluster OSD Section Followups

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -282,7 +282,7 @@ class Host(RESTController):
         from_orchestrator = 'orchestrator' in _sources
         return get_hosts(from_ceph, from_orchestrator)
 
-    @raise_if_no_orchestrator([OrchFeature.HOST_LIST, OrchFeature.HOST_CREATE])
+    @raise_if_no_orchestrator([OrchFeature.HOST_LIST, OrchFeature.HOST_ADD])
     @handle_orchestrator_error('host')
     @host_task('add', {'hostname': '{hostname}'})
     @EndpointDoc('',
@@ -300,9 +300,9 @@ class Host(RESTController):
                status: Optional[str] = None):  # pragma: no cover - requires realtime env
         add_host(hostname, addr, labels, status)
 
-    @raise_if_no_orchestrator([OrchFeature.HOST_LIST, OrchFeature.HOST_DELETE])
+    @raise_if_no_orchestrator([OrchFeature.HOST_LIST, OrchFeature.HOST_REMOVE])
     @handle_orchestrator_error('host')
-    @host_task('delete', {'hostname': '{hostname}'})
+    @host_task('remove', {'hostname': '{hostname}'})
     @allow_empty_body
     def delete(self, hostname):  # pragma: no cover - requires realtime env
         orch_client = OrchClient.instance()

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/create-cluster.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/create-cluster.po.ts
@@ -74,7 +74,7 @@ export class CreateClusterWizardHelper extends PageHelper {
   }
 
   delete(hostname: string) {
-    super.delete(hostname, this.columnIndex.hostname);
+    super.delete(hostname, this.columnIndex.hostname, 'hosts');
   }
 
   // Add or remove labels on a host, then verify labels in the table

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
@@ -79,7 +79,7 @@ export class HostsPageHelper extends PageHelper {
 
   @PageHelper.restrictTo(pages.index.url)
   delete(hostname: string) {
-    super.delete(hostname, this.columnIndex.hostname);
+    super.delete(hostname, this.columnIndex.hostname, 'hosts');
   }
 
   // Add or remove labels on a host, then verify labels in the table

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/page-helper.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/page-helper.po.ts
@@ -256,19 +256,22 @@ export abstract class PageHelper {
    * @param name The string to search in table cells.
    * @param columnIndex If provided, search string in columnIndex column.
    */
-  delete(name: string, columnIndex?: number) {
+  delete(name: string, columnIndex?: number, section?: string) {
     // Selects row
     const getRow = columnIndex
       ? this.getTableCell.bind(this, columnIndex)
       : this.getFirstTableCell.bind(this);
     getRow(name).click();
+    let action: string;
+    section === 'hosts' ? (action = 'remove') : (action = 'delete');
 
-    // Clicks on table Delete button
-    this.clickActionButton('delete');
+    // Clicks on table Delete/Remove button
+    this.clickActionButton(action);
 
-    // Confirms deletion
+    // Convert action to SentenceCase and Confirms deletion
+    const actionUpperCase = action.charAt(0).toUpperCase() + action.slice(1);
     cy.get('cd-modal .custom-control-label').click();
-    cy.contains('cd-modal button', 'Delete').click();
+    cy.contains('cd-modal button', actionUpperCase).click();
 
     // Wait for modal to close
     cy.get('cd-modal').should('not.exist');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.html
@@ -12,9 +12,8 @@
         <tr>
           <td i18n
               class="bold">Storage Capacity</td>
-          <td><span i18n
-                    *ngIf="filteredDevices && capacity">Number of devices: {{ filteredDevices.length }}. Raw capacity:
-            {{ capacity | dimlessBinary }}.</span></td>
+          <td><span i18n>Number of devices: {{ totalDevices }}. Raw capacity:
+            {{ totalCapacity | dimlessBinary }}.</span></td>
         </tr>
       </table>
     </fieldset>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.ts
@@ -7,7 +7,6 @@ import { HostService } from '~/app/shared/api/host.service';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
 import { CephServiceSpec } from '~/app/shared/models/service.interface';
 import { WizardStepsService } from '~/app/shared/services/wizard-steps.service';
-import { InventoryDevice } from '../inventory/inventory-devices/inventory-device.model';
 
 @Component({
   selector: 'cd-create-cluster-review',
@@ -23,8 +22,8 @@ export class CreateClusterReviewComponent implements OnInit {
   serviceOccurrences = {};
   hostsCountPerService: object[] = [];
   uniqueServices: Set<string> = new Set();
-  filteredDevices: InventoryDevice[] = [];
-  capacity = 0;
+  totalDevices: number;
+  totalCapacity = 0;
   services: Array<CephServiceSpec> = [];
 
   constructor(
@@ -34,6 +33,12 @@ export class CreateClusterReviewComponent implements OnInit {
   ) {}
 
   ngOnInit() {
+    let dataDevices = 0;
+    let dataDeviceCapacity = 0;
+    let walDevices = 0;
+    let walDeviceCapacity = 0;
+    let dbDevices = 0;
+    let dbDeviceCapacity = 0;
     this.hostsDetails = {
       columns: [
         {
@@ -98,7 +103,23 @@ export class CreateClusterReviewComponent implements OnInit {
       this.hostsDetails['data'] = [...this.hosts];
     });
 
-    this.filteredDevices = this.wizardStepsService.osdDevices;
-    this.capacity = this.wizardStepsService.osdCapacity;
+    if (this.wizardStepsService.osdDevices['data']) {
+      dataDevices = this.wizardStepsService.osdDevices['data']?.length;
+      dataDeviceCapacity = this.wizardStepsService.osdDevices['data']['capacity'];
+    }
+
+    if (this.wizardStepsService.osdDevices['wal']) {
+      walDevices = this.wizardStepsService.osdDevices['wal']?.length;
+      walDeviceCapacity = this.wizardStepsService.osdDevices['wal']['capacity'];
+    }
+
+    if (this.wizardStepsService.osdDevices['db']) {
+      dbDevices = this.wizardStepsService.osdDevices['db']?.length;
+      dbDeviceCapacity = this.wizardStepsService.osdDevices['db']['capacity'];
+    }
+
+    this.totalDevices = dataDevices + walDevices + dbDevices;
+    this.wizardStepsService.osdDevices['totalDevices'] = this.totalDevices;
+    this.totalCapacity = dataDeviceCapacity + walDeviceCapacity + dbDeviceCapacity;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 import { CephServiceService } from '~/app/shared/api/ceph-service.service';
 import { HostService } from '~/app/shared/api/host.service';
+import { OsdService } from '~/app/shared/api/osd.service';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
 import { CephServiceSpec } from '~/app/shared/models/service.interface';
 import { WizardStepsService } from '~/app/shared/services/wizard-steps.service';
@@ -29,7 +30,8 @@ export class CreateClusterReviewComponent implements OnInit {
   constructor(
     public wizardStepsService: WizardStepsService,
     public cephServiceService: CephServiceService,
-    public hostService: HostService
+    public hostService: HostService,
+    private osdService: OsdService
   ) {}
 
   ngOnInit() {
@@ -103,23 +105,23 @@ export class CreateClusterReviewComponent implements OnInit {
       this.hostsDetails['data'] = [...this.hosts];
     });
 
-    if (this.wizardStepsService.osdDevices['data']) {
-      dataDevices = this.wizardStepsService.osdDevices['data']?.length;
-      dataDeviceCapacity = this.wizardStepsService.osdDevices['data']['capacity'];
+    if (this.osdService.osdDevices['data']) {
+      dataDevices = this.osdService.osdDevices['data']?.length;
+      dataDeviceCapacity = this.osdService.osdDevices['data']['capacity'];
     }
 
-    if (this.wizardStepsService.osdDevices['wal']) {
-      walDevices = this.wizardStepsService.osdDevices['wal']?.length;
-      walDeviceCapacity = this.wizardStepsService.osdDevices['wal']['capacity'];
+    if (this.osdService.osdDevices['wal']) {
+      walDevices = this.osdService.osdDevices['wal']?.length;
+      walDeviceCapacity = this.osdService.osdDevices['wal']['capacity'];
     }
 
-    if (this.wizardStepsService.osdDevices['db']) {
-      dbDevices = this.wizardStepsService.osdDevices['db']?.length;
-      dbDeviceCapacity = this.wizardStepsService.osdDevices['db']['capacity'];
+    if (this.osdService.osdDevices['db']) {
+      dbDevices = this.osdService.osdDevices['db']?.length;
+      dbDeviceCapacity = this.osdService.osdDevices['db']['capacity'];
     }
 
     this.totalDevices = dataDevices + walDevices + dbDevices;
-    this.wizardStepsService.osdDevices['totalDevices'] = this.totalDevices;
+    this.osdService.osdDevices['totalDevices'] = this.totalDevices;
     this.totalCapacity = dataDeviceCapacity + walDeviceCapacity + dbDeviceCapacity;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.html
@@ -40,7 +40,11 @@
           <h4 class="title"
               i18n>Add Hosts</h4>
           <br>
-          <cd-hosts [clusterCreation]="true"></cd-hosts>
+          <cd-hosts [hiddenColumns]="['services', 'ceph_version']"
+                    [hideTitle]="true"
+                    [hideSubmitBtn]="true"
+                    [hasTableDetails]="false"
+                    [showGeneralActionsOnly]="true"></cd-hosts>
         </div>
         <div *ngSwitchCase="'2'"
              class="ml-5">
@@ -48,7 +52,9 @@
               i18n>Create OSDs</h4>
           <br>
           <div class="alignForm">
-            <cd-osd-form [clusterCreation]="true"></cd-osd-form>
+            <cd-osd-form [hideTitle]="true"
+                         [hideSubmitBtn]="true"
+                         (emitDriveGroup)="getDriveGroup($event)"></cd-osd-form>
           </div>
         </div>
         <div *ngSwitchCase="'3'"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.spec.ts
@@ -8,6 +8,7 @@ import { ToastrModule } from 'ngx-toastr';
 import { CephModule } from '~/app/ceph/ceph.module';
 import { CoreModule } from '~/app/core/core.module';
 import { HostService } from '~/app/shared/api/host.service';
+import { OsdService } from '~/app/shared/api/osd.service';
 import { ConfirmationModalComponent } from '~/app/shared/components/confirmation-modal/confirmation-modal.component';
 import { LoadingPanelComponent } from '~/app/shared/components/loading-panel/loading-panel.component';
 import { AppConstants } from '~/app/shared/constants/app.constants';
@@ -22,6 +23,7 @@ describe('CreateClusterComponent', () => {
   let fixture: ComponentFixture<CreateClusterComponent>;
   let wizardStepService: WizardStepsService;
   let hostService: HostService;
+  let osdService: OsdService;
   let modalServiceShowSpy: jasmine.Spy;
   const projectConstants: typeof AppConstants = AppConstants;
 
@@ -44,6 +46,7 @@ describe('CreateClusterComponent', () => {
     component = fixture.componentInstance;
     wizardStepService = TestBed.inject(WizardStepsService);
     hostService = TestBed.inject(HostService);
+    osdService = TestBed.inject(OsdService);
     modalServiceShowSpy = spyOn(TestBed.inject(ModalService), 'show').and.returnValue({
       // mock the close function, it might be called if there are async tests.
       close: jest.fn()
@@ -127,5 +130,20 @@ describe('CreateClusterComponent', () => {
     expect(submitBtnLabel).toEqual('Expand Cluster');
     cancelBtnLabel = component.showCancelButtonLabel();
     expect(cancelBtnLabel).toEqual('Back');
+  });
+
+  it('should ensure osd creation did not happen when no devices are selected', () => {
+    const osdServiceSpy = spyOn(osdService, 'create').and.callThrough();
+    component.onSubmit();
+    fixture.detectChanges();
+    expect(osdServiceSpy).toBeCalledTimes(0);
+  });
+
+  it('should ensure osd creation did happen when devices are selected', () => {
+    const osdServiceSpy = spyOn(osdService, 'create').and.callThrough();
+    wizardStepService.osdDevices['totalDevices'] = 1;
+    component.onSubmit();
+    fixture.detectChanges();
+    expect(osdServiceSpy).toBeCalledTimes(1);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.spec.ts
@@ -92,13 +92,11 @@ describe('CreateClusterComponent', () => {
 
   it('should move to next step and show the second page', () => {
     const wizardStepServiceSpy = spyOn(wizardStepService, 'moveToNextStep').and.callThrough();
-    const hostServiceSpy = spyOn(hostService, 'list').and.callThrough();
     component.createCluster();
     fixture.detectChanges();
     component.onNextStep();
     fixture.detectChanges();
     expect(wizardStepServiceSpy).toHaveBeenCalledTimes(1);
-    expect(hostServiceSpy).toBeCalledTimes(1);
   });
 
   it('should show the button labels correctly', () => {
@@ -141,9 +139,15 @@ describe('CreateClusterComponent', () => {
 
   it('should ensure osd creation did happen when devices are selected', () => {
     const osdServiceSpy = spyOn(osdService, 'create').and.callThrough();
-    wizardStepService.osdDevices['totalDevices'] = 1;
+    osdService.osdDevices['totalDevices'] = 1;
     component.onSubmit();
     fixture.detectChanges();
     expect(osdServiceSpy).toBeCalledTimes(1);
+  });
+
+  it('should ensure host list call happened', () => {
+    const hostServiceSpy = spyOn(hostService, 'list').and.callThrough();
+    component.onSubmit();
+    expect(hostServiceSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.ts
@@ -109,19 +109,21 @@ export class CreateClusterComponent implements OnDestroy {
         error: (error) => error.preventDefault()
       });
 
-    this.taskWrapper
-      .wrapTaskAroundCall({
-        task: new FinishedTask('osd/' + URLVerbs.CREATE, {
-          tracking_id: _.join(_.map(this.driveGroups, 'service_id'), ', ')
-        }),
-        call: this.osdService.create(this.driveGroups)
-      })
-      .subscribe({
-        error: (error) => error.preventDefault(),
-        complete: () => {
-          this.submitAction.emit();
-        }
-      });
+    if (this.wizardStepService.osdDevices['totalDevices'] > 0) {
+      this.taskWrapper
+        .wrapTaskAroundCall({
+          task: new FinishedTask('osd/' + URLVerbs.CREATE, {
+            tracking_id: _.join(_.map(this.driveGroups, 'service_id'), ', ')
+          }),
+          call: this.osdService.create(this.driveGroups)
+        })
+        .subscribe({
+          error: (error) => error.preventDefault(),
+          complete: () => {
+            this.submitAction.emit();
+          }
+        });
+    }
   }
 
   onNextStep() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.ts
@@ -46,7 +46,7 @@ export class CreateClusterComponent implements OnDestroy {
 
   constructor(
     private authStorageService: AuthStorageService,
-    private stepsService: WizardStepsService,
+    private wizardStepsService: WizardStepsService,
     private router: Router,
     private hostService: HostService,
     private notificationService: NotificationService,
@@ -54,13 +54,14 @@ export class CreateClusterComponent implements OnDestroy {
     private clusterService: ClusterService,
     private modalService: ModalService,
     private taskWrapper: TaskWrapperService,
-    private osdService: OsdService,
-    private wizardStepService: WizardStepsService
+    private osdService: OsdService
   ) {
     this.permissions = this.authStorageService.getPermissions();
-    this.currentStepSub = this.stepsService.getCurrentStep().subscribe((step: WizardStepModel) => {
-      this.currentStep = step;
-    });
+    this.currentStepSub = this.wizardStepsService
+      .getCurrentStep()
+      .subscribe((step: WizardStepModel) => {
+        this.currentStep = step;
+      });
     this.currentStep.stepIndex = 1;
   }
 
@@ -93,23 +94,37 @@ export class CreateClusterComponent implements OnDestroy {
   }
 
   onSubmit() {
-    forkJoin(this.observables)
-      .pipe(
-        finalize(() =>
-          this.clusterService.updateStatus('POST_INSTALLED').subscribe(() => {
-            this.notificationService.show(
-              NotificationType.success,
-              $localize`Cluster expansion was successful`
-            );
-            this.router.navigate(['/dashboard']);
-          })
-        )
-      )
-      .subscribe({
-        error: (error) => error.preventDefault()
+    this.hostService.list().subscribe((hosts) => {
+      hosts.forEach((host) => {
+        const index = host['labels'].indexOf('_no_schedule', 0);
+        if (index > -1) {
+          host['labels'].splice(index, 1);
+          this.observables.push(this.hostService.update(host['hostname'], true, host['labels']));
+        }
       });
+      forkJoin(this.observables)
+        .pipe(
+          finalize(() =>
+            this.clusterService.updateStatus('POST_INSTALLED').subscribe(() => {
+              this.notificationService.show(
+                NotificationType.success,
+                $localize`Cluster expansion was successful`
+              );
+              this.router.navigate(['/dashboard']);
+            })
+          )
+        )
+        .subscribe({
+          error: (error) => error.preventDefault()
+        });
+    });
+    if (this.driveGroup) {
+      const user = this.authStorageService.getUsername();
+      this.driveGroup.setName(`dashboard-${user}-${_.now()}`);
+      this.driveGroups.push(this.driveGroup.spec);
+    }
 
-    if (this.wizardStepService.osdDevices['totalDevices'] > 0) {
+    if (this.osdService.osdDevices['totalDevices'] > 0) {
       this.taskWrapper
         .wrapTaskAroundCall({
           task: new FinishedTask('osd/' + URLVerbs.CREATE, {
@@ -121,51 +136,45 @@ export class CreateClusterComponent implements OnDestroy {
           error: (error) => error.preventDefault(),
           complete: () => {
             this.submitAction.emit();
+            this.osdService.osdDevices = [];
           }
         });
     }
   }
 
+  getDriveGroup(driveGroup: DriveGroup) {
+    this.driveGroup = driveGroup;
+  }
+
   onNextStep() {
-    if (!this.stepsService.isLastStep()) {
-      this.hostService.list().subscribe((hosts) => {
-        hosts.forEach((host) => {
-          const index = host['labels'].indexOf('_no_schedule', 0);
-          if (index > -1) {
-            host['labels'].splice(index, 1);
-            this.observables.push(this.hostService.update(host['hostname'], true, host['labels']));
-          }
-        });
-      });
-      this.driveGroup = this.wizardStepService.sharedData;
-      this.stepsService.getCurrentStep().subscribe((step: WizardStepModel) => {
+    if (!this.wizardStepsService.isLastStep()) {
+      this.wizardStepsService.getCurrentStep().subscribe((step: WizardStepModel) => {
         this.currentStep = step;
       });
-      if (this.currentStep.stepIndex === 2 && this.driveGroup) {
-        const user = this.authStorageService.getUsername();
-        this.driveGroup.setName(`dashboard-${user}-${_.now()}`);
-        this.driveGroups.push(this.driveGroup.spec);
-      }
-      this.stepsService.moveToNextStep();
+      this.wizardStepsService.moveToNextStep();
     } else {
       this.onSubmit();
     }
   }
 
   onPreviousStep() {
-    if (!this.stepsService.isFirstStep()) {
-      this.stepsService.moveToPreviousStep();
+    if (!this.wizardStepsService.isFirstStep()) {
+      this.wizardStepsService.moveToPreviousStep();
     } else {
       this.router.navigate(['/dashboard']);
     }
   }
 
   showSubmitButtonLabel() {
-    return !this.stepsService.isLastStep() ? this.actionLabels.NEXT : $localize`Expand Cluster`;
+    return !this.wizardStepsService.isLastStep()
+      ? this.actionLabels.NEXT
+      : $localize`Expand Cluster`;
   }
 
   showCancelButtonLabel() {
-    return !this.stepsService.isFirstStep() ? this.actionLabels.BACK : this.actionLabels.CANCEL;
+    return !this.wizardStepsService.isFirstStep()
+      ? this.actionLabels.BACK
+      : this.actionLabels.CANCEL;
   }
 
   ngOnDestroy(): void {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
@@ -11,7 +11,7 @@
                 columnMode="flex"
                 (fetchData)="getHosts($event)"
                 selectionType="single"
-                [hasDetails]="!clusterCreation"
+                [hasDetails]="hasTableDetails"
                 (setExpandedRow)="setExpandedRow($event)"
                 (updateSelection)="updateSelection($event)">
         <div class="table-actions btn-toolbar">
@@ -30,7 +30,7 @@
     </ng-template>
   </li>
   <li ngbNavItem
-      *ngIf="permissions.grafana.read && !clusterCreation">
+      *ngIf="permissions.grafana.read">
     <a ngbNavLink
        i18n>Overall Performance</a>
     <ng-template ngbNavContent>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -185,7 +185,7 @@ describe('HostsComponent', () => {
           expectResults: {
             Add: { disabled: false, disableDesc: '' },
             Edit: { disabled: true, disableDesc: '' },
-            Delete: { disabled: true, disableDesc: '' }
+            Remove: { disabled: true, disableDesc: '' }
           }
         },
         {
@@ -193,7 +193,7 @@ describe('HostsComponent', () => {
           expectResults: {
             Add: { disabled: false, disableDesc: '' },
             Edit: { disabled: true, disableDesc: component.messages.nonOrchHost },
-            Delete: { disabled: true, disableDesc: component.messages.nonOrchHost }
+            Remove: { disabled: true, disableDesc: component.messages.nonOrchHost }
           }
         },
         {
@@ -201,15 +201,15 @@ describe('HostsComponent', () => {
           expectResults: {
             Add: { disabled: false, disableDesc: '' },
             Edit: { disabled: false, disableDesc: '' },
-            Delete: { disabled: false, disableDesc: '' }
+            Remove: { disabled: false, disableDesc: '' }
           }
         }
       ];
 
       const features = [
-        OrchestratorFeature.HOST_CREATE,
+        OrchestratorFeature.HOST_ADD,
         OrchestratorFeature.HOST_LABEL_ADD,
-        OrchestratorFeature.HOST_DELETE,
+        OrchestratorFeature.HOST_REMOVE,
         OrchestratorFeature.HOST_LABEL_REMOVE
       ];
       await testTableActions(true, features, tests);
@@ -225,7 +225,7 @@ describe('HostsComponent', () => {
           expectResults: {
             Add: resultNoOrchestrator,
             Edit: { disabled: true, disableDesc: '' },
-            Delete: { disabled: true, disableDesc: '' }
+            Remove: { disabled: true, disableDesc: '' }
           }
         },
         {
@@ -233,7 +233,7 @@ describe('HostsComponent', () => {
           expectResults: {
             Add: resultNoOrchestrator,
             Edit: { disabled: true, disableDesc: component.messages.nonOrchHost },
-            Delete: { disabled: true, disableDesc: component.messages.nonOrchHost }
+            Remove: { disabled: true, disableDesc: component.messages.nonOrchHost }
           }
         },
         {
@@ -241,7 +241,7 @@ describe('HostsComponent', () => {
           expectResults: {
             Add: resultNoOrchestrator,
             Edit: resultNoOrchestrator,
-            Delete: resultNoOrchestrator
+            Remove: resultNoOrchestrator
           }
         }
       ];
@@ -258,7 +258,7 @@ describe('HostsComponent', () => {
           expectResults: {
             Add: resultMissingFeatures,
             Edit: { disabled: true, disableDesc: '' },
-            Delete: { disabled: true, disableDesc: '' }
+            Remove: { disabled: true, disableDesc: '' }
           }
         },
         {
@@ -266,7 +266,7 @@ describe('HostsComponent', () => {
           expectResults: {
             Add: resultMissingFeatures,
             Edit: { disabled: true, disableDesc: component.messages.nonOrchHost },
-            Delete: { disabled: true, disableDesc: component.messages.nonOrchHost }
+            Remove: { disabled: true, disableDesc: component.messages.nonOrchHost }
           }
         },
         {
@@ -274,7 +274,7 @@ describe('HostsComponent', () => {
           expectResults: {
             Add: resultMissingFeatures,
             Edit: resultMissingFeatures,
-            Delete: resultMissingFeatures
+            Remove: resultMissingFeatures
           }
         }
       ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -72,7 +72,6 @@ describe('HostsComponent', () => {
     showForceMaintenanceModal = new MockShowForceMaintenanceModal();
     fixture = TestBed.createComponent(HostsComponent);
     component = fixture.componentInstance;
-    component.clusterCreation = false;
     hostListSpy = spyOn(TestBed.inject(HostService), 'list');
     orchService = TestBed.inject(OrchestratorService);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -72,9 +72,9 @@ export class HostsComponent extends ListWithDetails implements OnInit {
 
   orchStatus: OrchestratorStatus;
   actionOrchFeatures = {
-    add: [OrchestratorFeature.HOST_CREATE],
+    add: [OrchestratorFeature.HOST_ADD],
     edit: [OrchestratorFeature.HOST_LABEL_ADD, OrchestratorFeature.HOST_LABEL_REMOVE],
-    delete: [OrchestratorFeature.HOST_DELETE],
+    remove: [OrchestratorFeature.HOST_REMOVE],
     maintenance: [
       OrchestratorFeature.HOST_MAINTENANCE_ENTER,
       OrchestratorFeature.HOST_MAINTENANCE_EXIT
@@ -103,11 +103,11 @@ export class HostsComponent extends ListWithDetails implements OnInit {
         disable: (selection: CdTableSelection) => this.getDisable('edit', selection)
       },
       {
-        name: this.actionLabels.DELETE,
+        name: this.actionLabels.REMOVE,
         permission: 'delete',
         icon: Icons.destroy,
         click: () => this.deleteAction(),
-        disable: (selection: CdTableSelection) => this.getDisable('delete', selection)
+        disable: (selection: CdTableSelection) => this.getDisable('remove', selection)
       },
       {
         name: this.actionLabels.ENTER_MAINTENANCE,
@@ -124,7 +124,7 @@ export class HostsComponent extends ListWithDetails implements OnInit {
         icon: Icons.exit,
         click: () => this.hostMaintenance(),
         disable: (selection: CdTableSelection) =>
-          this.getDisable('maintenance', selection) || this.isExecuting || this.enableButton,
+          this.getDisable('maintenance', selection) || this.isExecuting || !this.enableButton,
         visible: () => !this.clusterCreation
       }
     ];
@@ -305,10 +305,10 @@ export class HostsComponent extends ListWithDetails implements OnInit {
   }
 
   getDisable(
-    action: 'add' | 'edit' | 'delete' | 'maintenance',
+    action: 'add' | 'edit' | 'remove' | 'maintenance',
     selection: CdTableSelection
   ): boolean | string {
-    if (action === 'delete' || action === 'edit' || action === 'maintenance') {
+    if (action === 'remove' || action === 'edit' || action === 'maintenance') {
       if (!selection?.hasSingleSelection) {
         return true;
       }
@@ -327,10 +327,10 @@ export class HostsComponent extends ListWithDetails implements OnInit {
     this.modalRef = this.modalService.show(CriticalConfirmationModalComponent, {
       itemDescription: 'Host',
       itemNames: [hostname],
-      actionDescription: 'delete',
+      actionDescription: 'remove',
       submitActionObservable: () =>
         this.taskWrapper.wrapTaskAroundCall({
-          task: new FinishedTask('host/delete', { hostname: hostname }),
+          task: new FinishedTask('host/remove', { hostname: hostname }),
           call: this.hostService.delete(hostname)
         })
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.html
@@ -19,7 +19,7 @@
               (click)="showSelectionModal()"
               data-toggle="tooltip"
               [title]="addButtonTooltip"
-              [disabled]="availDevices.length === 0 || !canSelect">
+              [disabled]="availDevices.length === 0 || !canSelect || expansionCanSelect">
         <i [ngClass]="[icons.add]"></i>
         <ng-container i18n>Add</ng-container>
       </button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-groups/osd-devices-selection-groups.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { ToastrModule } from 'ngx-toastr';
 
@@ -34,7 +35,8 @@ describe('OsdDevicesSelectionGroupsComponent', () => {
       FormsModule,
       HttpClientTestingModule,
       SharedModule,
-      ToastrModule.forRoot()
+      ToastrModule.forRoot(),
+      RouterTestingModule
     ],
     declarations: [OsdDevicesSelectionGroupsComponent, InventoryDevicesComponent]
   });
@@ -92,8 +94,10 @@ describe('OsdDevicesSelectionGroupsComponent', () => {
 
   describe('with devices selected', () => {
     beforeEach(() => {
+      component.isOsdPage = true;
       component.availDevices = [];
       component.devices = devices;
+      component.ngOnInit();
       fixture.detectChanges();
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-modal/osd-devices-selection-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-modal/osd-devices-selection-modal.component.ts
@@ -82,8 +82,6 @@ export class OsdDevicesSelectionModalComponent implements AfterViewInit {
       this.filteredDevices = event.data;
       this.capacity = _.sumBy(this.filteredDevices, 'sys_api.size');
       this.event = event;
-      this.wizardStepService.osdDevices = this.filteredDevices;
-      this.wizardStepService.osdCapacity = this.capacity;
     }
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
@@ -9,14 +9,13 @@
     <div class="card">
       <div i18n="form title|Example: Create Pool@@formTitle"
            class="card-header"
-           *ngIf="!clusterCreation">{{ action | titlecase }} {{ resource | upperFirst }}</div>
+           *ngIf="!hideTitle">{{ action | titlecase }} {{ resource | upperFirst }}</div>
       <div class="card-body">
         <fieldset>
           <cd-osd-devices-selection-groups #dataDeviceSelectionGroups
                                            name="Primary"
                                            type="data"
                                            [availDevices]="availDevices"
-                                           [clusterCreation]="clusterCreation"
                                            [canSelect]="availDevices.length !== 0"
                                            (selected)="onDevicesSelected($event)"
                                            (cleared)="onDevicesCleared($event)">
@@ -32,7 +31,6 @@
                                            name="WAL"
                                            type="wal"
                                            [availDevices]="availDevices"
-                                           [clusterCreation]="clusterCreation"
                                            [canSelect]="dataDeviceSelectionGroups.devices.length !== 0"
                                            (selected)="onDevicesSelected($event)"
                                            (cleared)="onDevicesCleared($event)">
@@ -68,7 +66,6 @@
                                            name="DB"
                                            type="db"
                                            [availDevices]="availDevices"
-                                           [clusterCreation]="clusterCreation"
                                            [canSelect]="dataDeviceSelectionGroups.devices.length !== 0"
                                            (selected)="onDevicesSelected($event)"
                                            (cleared)="onDevicesCleared($event)">
@@ -126,7 +123,7 @@
         </fieldset>
       </div>
       <div class="card-footer"
-           *ngIf="!clusterCreation">
+           *ngIf="!hideSubmitBtn">
         <cd-form-button-panel #previewButtonPanel
                               (submitActionEvent)="submit()"
                               [form]="form"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
@@ -16,6 +16,7 @@
                                            name="Primary"
                                            type="data"
                                            [availDevices]="availDevices"
+                                           [clusterCreation]="clusterCreation"
                                            [canSelect]="availDevices.length !== 0"
                                            (selected)="onDevicesSelected($event)"
                                            (cleared)="onDevicesCleared($event)">
@@ -31,6 +32,7 @@
                                            name="WAL"
                                            type="wal"
                                            [availDevices]="availDevices"
+                                           [clusterCreation]="clusterCreation"
                                            [canSelect]="dataDeviceSelectionGroups.devices.length !== 0"
                                            (selected)="onDevicesSelected($event)"
                                            (cleared)="onDevicesCleared($event)">
@@ -66,6 +68,7 @@
                                            name="DB"
                                            type="db"
                                            [availDevices]="availDevices"
+                                           [clusterCreation]="clusterCreation"
                                            [canSelect]="dataDeviceSelectionGroups.devices.length !== 0"
                                            (selected)="onDevicesSelected($event)"
                                            (cleared)="onDevicesCleared($event)">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 
@@ -41,6 +41,14 @@ export class OsdFormComponent extends CdForm implements OnInit {
   @ViewChild('previewButtonPanel')
   previewButtonPanel: FormButtonPanelComponent;
 
+  @Input()
+  hideTitle = false;
+
+  @Input()
+  hideSubmitBtn = false;
+
+  @Output() emitDriveGroup: EventEmitter<DriveGroup> = new EventEmitter();
+
   icons = Icons;
 
   form: CdFormGroup;
@@ -62,8 +70,6 @@ export class OsdFormComponent extends CdForm implements OnInit {
   featureList: OsdFeature[] = [];
 
   hasOrchestrator = true;
-  @Input()
-  clusterCreation = false;
 
   constructor(
     public actionLabels: ActionLabelsI18n,
@@ -186,9 +192,8 @@ export class OsdFormComponent extends CdForm implements OnInit {
       this.enableFeatures();
     }
     this.driveGroup.setDeviceSelection(event.type, event.filters);
-    if (this.clusterCreation) {
-      this.wizardStepService.sharedData = this.driveGroup;
-    }
+
+    this.emitDriveGroup.emit(this.driveGroup);
   }
 
   onDevicesCleared(event: DevicesSelectionClearEvent) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import { map } from 'rxjs/operators';
 
 import { CdDevice } from '../models/devices';
+import { InventoryDeviceType } from '../models/inventory-device-type.model';
 import { SmartDataResponseV1 } from '../models/smart';
 import { DeviceService } from '../services/device.service';
 
@@ -13,6 +14,7 @@ import { DeviceService } from '../services/device.service';
 })
 export class OsdService {
   private path = 'api/osd';
+  osdDevices: InventoryDeviceType[] = [];
 
   osdRecvSpeedModalPriorities = {
     KNOWN_PRIORITIES: [

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/inventory-device-type.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/inventory-device-type.model.ts
@@ -1,0 +1,9 @@
+import { InventoryDevice } from '~/app/ceph/cluster/inventory/inventory-devices/inventory-device.model';
+
+export interface InventoryDeviceType {
+  type: string;
+  capacity: number;
+  devices: InventoryDevice[];
+  canSelect: boolean;
+  totalDevices: number;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/orchestrator.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/orchestrator.enum.ts
@@ -1,7 +1,7 @@
 export enum OrchestratorFeature {
   HOST_LIST = 'get_hosts',
-  HOST_CREATE = 'add_host',
-  HOST_DELETE = 'remove_host',
+  HOST_ADD = 'add_host',
+  HOST_REMOVE = 'remove_host',
   HOST_LABEL_ADD = 'add_host_label',
   HOST_LABEL_REMOVE = 'remove_host_label',
   HOST_MAINTENANCE_ENTER = 'enter_host_maintenance',

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -115,7 +115,7 @@ export class TaskMessageService {
   messages = {
     // Host tasks
     'host/add': this.newTaskMessage(this.commonOperations.add, (metadata) => this.host(metadata)),
-    'host/delete': this.newTaskMessage(this.commonOperations.delete, (metadata) =>
+    'host/remove': this.newTaskMessage(this.commonOperations.remove, (metadata) =>
       this.host(metadata)
     ),
     'host/identify_device': this.newTaskMessage(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/wizard-steps.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/wizard-steps.service.ts
@@ -2,9 +2,9 @@ import { Injectable } from '@angular/core';
 
 import { BehaviorSubject, Observable } from 'rxjs';
 
-import { InventoryDevice } from '~/app/ceph/cluster/inventory/inventory-devices/inventory-device.model';
 import { DriveGroup } from '~/app/ceph/cluster/osd/osd-form/drive-group.model';
 import { WizardStepModel } from '~/app/shared/models/wizard-steps';
+import { InventoryDeviceType } from '../models/inventory-device-type.model';
 
 const initialStep = [{ stepIndex: 1, isComplete: false }];
 
@@ -14,9 +14,10 @@ const initialStep = [{ stepIndex: 1, isComplete: false }];
 export class WizardStepsService {
   steps$: BehaviorSubject<WizardStepModel[]>;
   currentStep$: BehaviorSubject<WizardStepModel> = new BehaviorSubject<WizardStepModel>(null);
+
+  // Expansion Wizard OSD Section datas
   sharedData = new DriveGroup();
-  osdDevices: InventoryDevice[] = [];
-  osdCapacity = 0;
+  osdDevices: InventoryDeviceType[] = [];
 
   constructor() {
     this.steps$ = new BehaviorSubject<WizardStepModel[]>(initialStep);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/wizard-steps.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/wizard-steps.service.ts
@@ -2,9 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { BehaviorSubject, Observable } from 'rxjs';
 
-import { DriveGroup } from '~/app/ceph/cluster/osd/osd-form/drive-group.model';
 import { WizardStepModel } from '~/app/shared/models/wizard-steps';
-import { InventoryDeviceType } from '../models/inventory-device-type.model';
 
 const initialStep = [{ stepIndex: 1, isComplete: false }];
 
@@ -14,10 +12,6 @@ const initialStep = [{ stepIndex: 1, isComplete: false }];
 export class WizardStepsService {
   steps$: BehaviorSubject<WizardStepModel[]>;
   currentStep$: BehaviorSubject<WizardStepModel> = new BehaviorSubject<WizardStepModel>(null);
-
-  // Expansion Wizard OSD Section datas
-  sharedData = new DriveGroup();
-  osdDevices: InventoryDeviceType[] = [];
 
   constructor() {
     this.steps$ = new BehaviorSubject<WizardStepModel[]>(initialStep);

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -192,8 +192,8 @@ class OrchClient(object):
 
 class OrchFeature(object):
     HOST_LIST = 'get_hosts'
-    HOST_CREATE = 'add_host'
-    HOST_DELETE = 'remove_host'
+    HOST_ADD = 'add_host'
+    HOST_REMOVE = 'remove_host'
     HOST_LABEL_ADD = 'add_host_label'
     HOST_LABEL_REMOVE = 'remove_host_label'
     HOST_MAINTENANCE_ENTER = 'enter_host_maintenance'


### PR DESCRIPTION
**Things this PR addresses:**
1. The device preview disappearing when going to next step and coming back to the previous step
2. Even when clearing the device preview, the Storage Capacity count and the drive group spec doesn't get cleared.
3. Expanding the cluster without selecting any devices gives a 400
   error.
4. Renamed "Delete Host" to "Remove Host"
Also adapted e2e tests
5. If I use the left side navigation control button for going to each step, the cluster creation doesn't happen as expected. I needed to hit the Next button every time for each step to be updated properly. 

Fixes: https://tracker.ceph.com/issues/52499
Signed-off-by: Nizamudeen A <nia@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
