### PR TITLE
mgr/rook: placement spec translate to node selector and rook testing

### DIFF
--- a/src/pybind/mgr/rook/__init__.py
+++ b/src/pybind/mgr/rook/__init__.py
@@ -1,2 +1,5 @@
+import os
+if 'UNITTEST' in os.environ:
+    import tests
 
 from .module import RookOrchestrator

--- a/src/pybind/mgr/rook/tests/test_placement.py
+++ b/src/pybind/mgr/rook/tests/test_placement.py
@@ -1,0 +1,100 @@
+# flake8: noqa
+
+from rook.rook_cluster import placement_spec_to_node_selector, node_selector_to_placement_spec
+from rook.rook_client.ceph.cephcluster import MatchExpressionsItem, MatchExpressionsList, NodeSelectorTermsItem
+import pytest
+from orchestrator import HostSpec
+from ceph.deployment.service_spec import PlacementSpec
+
+@pytest.mark.parametrize("hosts",
+    [   # noqa: E128
+        [
+            HostSpec(
+                hostname="node1",
+                labels=["label1"]
+            ),
+            HostSpec(
+                hostname="node2",
+                labels=[]
+            ),
+            HostSpec(
+                hostname="node3",
+                labels=["label1"]
+            )
+        ]
+    ])
+@pytest.mark.parametrize("expected_placement_spec, expected_node_selector",
+    [   # noqa: E128
+        (
+            PlacementSpec(
+                label="label1"
+            ), 
+            NodeSelectorTermsItem(
+                matchExpressions=MatchExpressionsList(
+                    [
+                        MatchExpressionsItem(
+                            key="ceph-label/label1",
+                            operator="Exists"
+                        )
+                    ]
+                )
+            )
+        ),
+        (
+            PlacementSpec(
+                label="label1",
+                host_pattern="*"
+            ), 
+            NodeSelectorTermsItem(
+                matchExpressions=MatchExpressionsList(
+                    [
+                        MatchExpressionsItem(
+                            key="ceph-label/label1",
+                            operator="Exists"
+                        ),
+                        MatchExpressionsItem(
+                            key="kubernetes.io/hostname",
+                            operator="Exists",
+                        )
+                    ]
+                )
+            )
+        ),
+        (
+            PlacementSpec(
+                host_pattern="*"
+            ), 
+            NodeSelectorTermsItem(
+                matchExpressions=MatchExpressionsList(
+                    [
+                        MatchExpressionsItem(
+                            key="kubernetes.io/hostname",
+                            operator="Exists",
+                        )
+                    ]
+                )
+            )
+        ),
+        (
+            PlacementSpec(
+                hosts=["node1", "node2", "node3"]
+            ), 
+            NodeSelectorTermsItem(
+                matchExpressions=MatchExpressionsList(
+                    [
+                        MatchExpressionsItem(
+                            key="kubernetes.io/hostname",
+                            operator="In",
+                            values=["node1", "node2", "node3"]
+                        )
+                    ]
+                )
+            )
+        ),
+    ])
+def test_placement_spec_translate(hosts, expected_placement_spec, expected_node_selector):
+    node_selector = placement_spec_to_node_selector(expected_placement_spec, hosts)
+    assert [(getattr(expression, 'key', None), getattr(expression, 'operator', None), getattr(expression, 'values', None)) for expression in node_selector.matchExpressions] == [(getattr(expression, 'key', None), getattr(expression, 'operator', None), getattr(expression, 'values', None)) for expression in expected_node_selector.matchExpressions]
+    placement_spec = node_selector_to_placement_spec(expected_node_selector)
+    assert placement_spec == expected_placement_spec
+    assert (getattr(placement_spec, 'label', None), getattr(placement_spec, 'hosts', None), getattr(placement_spec, 'host_pattern', None)) == (getattr(expected_placement_spec, 'label', None), getattr(expected_placement_spec, 'hosts', None), getattr(expected_placement_spec, 'host_pattern', None))

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -42,6 +42,7 @@ setenv =
 deps =
     cython
     -rrequirements.txt
+    -rrook/requirements.txt
 commands =
     pytest --doctest-modules {posargs:}
 


### PR DESCRIPTION
This PR does two things: 
1. Creates methods for translating PlacementSpecs to NodeSelectors and vice versa to be used when a orch command supports the placement option.
2. Creates a unit test folder for Rook and creates a unit test to test the function for translating PlacementSpecs to Node Selectors, also configurates tox.ini for this.

Depends on #42998 
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
