### PR TITLE
mgr/rook: update `ceph orch apply nfs` 

### DIFF
--- a/qa/suites/orch/rook/smoke/3-final.yaml
+++ b/qa/suites/orch/rook/smoke/3-final.yaml
@@ -9,3 +9,4 @@ tasks:
       - ceph orch apply rgw foo
       - ceph orch apply mds foo
       - ceph orch apply rbd-mirror
+      - ceph orch apply nfs foo --port 12777

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -33,7 +33,7 @@ except ImportError:
     client = None
     config = None
 
-from mgr_module import MgrModule, Option
+from mgr_module import MgrModule, Option, NFS_POOL_NAME
 import orchestrator
 from orchestrator import handle_orch_error, OrchResult, raise_if_exception
 
@@ -349,6 +349,8 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             # CephNFSes
             all_nfs = self.rook_cluster.get_resource("cephnfses")
             for nfs in all_nfs:
+                if nfs['spec']['rados']['pool'] != NFS_POOL_NAME:
+                    continue
                 nfs_name = nfs['metadata']['name']
                 svc = 'nfs.' + nfs_name
                 if svc in spec:

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -512,6 +512,9 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                 del self._drive_group_map[service_id]
                 self._save_drive_groups()
             return f'Removed {service_name}'
+        elif service_type == 'ingress':
+            self.log.info("{0} service '{1}' does not exist".format('ingress', service_id))
+            return 'The Rook orchestrator does not currently support ingress'
         else:
             raise orchestrator.OrchestratorError(f'Service type {service_type} not supported')
 
@@ -553,7 +556,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
     @handle_orch_error
     def apply_nfs(self, spec):
         # type: (NFSServiceSpec) -> str
-        return self.rook_cluster.apply_nfsgw(spec)
+        return self.rook_cluster.apply_nfsgw(spec, self)
 
     @handle_orch_error
     def remove_daemons(self, names: List[str]) -> List[str]:

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -776,7 +776,7 @@ class RookCluster(object):
                             "osd": ("ceph-osd-id", service_id),
                             "mon": ("mon", service_id),
                             "mgr": ("mgr", service_id),
-                            "ceph_nfs": ("ceph_nfs", service_id),
+                            "nfs": ("nfs", service_id),
                             "rgw": ("ceph_rgw", service_id),
                         }[service_type]
                     except KeyError:

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -26,6 +26,9 @@ from ceph.deployment.drive_group import DriveGroupSpec
 from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec, PlacementSpec, HostPlacementSpec
 from ceph.utils import datetime_now
 from ceph.deployment.drive_selection.matchers import SizeMatcher
+from nfs.cluster import create_ganesha_pool
+from nfs.module import Module
+from nfs.export import NFSRados
 from mgr_module import NFS_POOL_NAME
 from mgr_util import merge_dicts
 
@@ -49,7 +52,7 @@ from .rook_client._helper import CrdClass
 import orchestrator
 
 try:
-    from rook.module import RookEnv
+    from rook.module import RookEnv, RookOrchestrator
 except ImportError:
     pass  # just used for type checking.
 
@@ -1027,12 +1030,15 @@ class RookCluster(object):
             cos.CephObjectStore, 'cephobjectstores', name,
             _update_zone, _create_zone)
 
-    def apply_nfsgw(self, spec: NFSServiceSpec) -> str:
+    def apply_nfsgw(self, spec: NFSServiceSpec, mgr: 'RookOrchestrator') -> str:
         # TODO use spec.placement
         # TODO warn if spec.extended has entries we don't kow how
         #      to action.
         # TODO Number of pods should be based on the list of hosts in the
         #      PlacementSpec.
+        assert spec.service_id, "service id in NFS service spec cannot be an empty string or None " # for mypy typing
+        service_id = spec.service_id
+        mgr_module = cast(Module, mgr)
         count = spec.placement.count or 1
         def _update_nfs(new: cnfs.CephNFS) -> cnfs.CephNFS:
             new.spec.server.active = count
@@ -1047,7 +1053,7 @@ class RookCluster(object):
                         ),
                     spec=cnfs.Spec(
                         rados=cnfs.Rados(
-                            namespace=self.rook_env.namespace,
+                            namespace=service_id,
                             pool=NFS_POOL_NAME,
                             ),
                         server=cnfs.Server(
@@ -1056,12 +1062,12 @@ class RookCluster(object):
                         )
                     )
 
-            rook_nfsgw.spec.rados.namespace = cast(str, spec.service_id)
 
             return rook_nfsgw
 
-        assert spec.service_id is not None
-        return self._create_or_patch(cnfs.CephNFS, 'cephnfses', spec.service_id,
+        create_ganesha_pool(mgr)
+        NFSRados(mgr_module, service_id).write_obj('', f'conf-nfs.{spec.service_id}')
+        return self._create_or_patch(cnfs.CephNFS, 'cephnfses', service_id,
                 _update_nfs, _create_nfs)
 
     def rm_service(self, rooktype: str, service_id: str) -> str:


### PR DESCRIPTION
This PR updates the `ceph orch apply nfs` command in the Rook orchestrator to keep up with the changes made to the NFS module by preventing the creation of NFS daemons not using the '.nfs' RADOS pool and creating the pool if it doesn't exist when a user tries to create an NFS daemon.

Depends on [rook #8501](https://github.com/rook/rook/pull/8501)
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
