### PR TITLE
ceph-volume: fix raw list with logical partition

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -72,7 +72,7 @@ class List(object):
             # the parent disk has a bluestore header, but children may be the most appropriate
             # devices to return if the parent disk does not have a bluestore header.
             out, err, ret = process.call([
-                'lsblk', '--paths', '--output=NAME', '--noheadings',
+                'lsblk', '--paths', '--output=NAME', '--noheadings', '--list'
             ])
             assert not ret
             devs = out

--- a/src/ceph-volume/ceph_volume/tests/devices/raw/test_list.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/raw/test_list.py
@@ -199,6 +199,7 @@ class TestList(object):
         patched_get_devices.side_effect = _devices_side_effect
 
         result = raw.list.List([]).generate()
+        patched_call.assert_any_call(['lsblk', '--paths', '--output=NAME', '--noheadings', '--list'])
         assert len(result) == 2
 
         sdb = result['sdb-uuid']


### PR DESCRIPTION
This is a regression introduced by 9212420, when the host is using a
logical partition then lsblk reports that partition as a child from the
physical device.
That logical partition is prefixed by the `└─` character.

This leads the `raw list` subcommand to show the lsblk error on the stderr.

```
$ ceph-volume raw list
{}
 stderr: lsblk: `-/dev/sda1: not a block device
```

The lsblk command output looks like:

```
$ lsblk --paths --output=NAME --noheadings
/dev/sda
└─/dev/sda1
/dev/sdb
/dev/sdc
/dev/sdd
```

Using the `--list` option with lsblk solves the issue.

```
$ lsblk --list --paths --output=NAME --noheadings
/dev/sda
/dev/sda1
/dev/sdb
/dev/sdc
/dev/sdd
```

Fixes: https://tracker.ceph.com/issues/52504

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
