### PR TITLE
ceph-volume: remove --all ref from deactivate help

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/deactivate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/deactivate.py
@@ -54,8 +54,6 @@ class Deactivate(object):
 
             ceph-volume lvm deactivate {ID} {FSID}
 
-        To deactivate all volumes use the --all flag.
-            ceph-volume lvm deactivate --all
         """)
         parser = argparse.ArgumentParser(
             prog='ceph-volume lvm deactivate',


### PR DESCRIPTION
Until the `--all` feature is implemented.

This was partially removed in c13901f but not from the help command.

Fixes: https://tracker.ceph.com/issues/50109

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
