### PR TITLE
rgw: Add option to configure backend store

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3220,6 +3220,17 @@ options:
   see_also:
   - rgw_thread_pool_size
   with_legacy: true
+- name: rgw_backend_store
+  type: str
+  level: advanced
+  desc: experimental Option to set backend store type
+  long_desc: defaults to rados. Other valid values are dbstore(experimental).
+  default: rados
+  services:
+  - rgw
+  enum_values:
+  - rados
+  - dbstore
 - name: rgw_luarocks_location
   type: str
   level: advanced

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -346,9 +346,18 @@ int radosgw_Main(int argc, const char **argv)
   }
   lsubdout(cct, rgw, 1) << "D3N datacache enabled: " << rgw_d3n_datacache_enabled << dendl;
 
+  std::string rgw_store = (!rgw_d3n_datacache_enabled) ? "rados" : "d3n";
+
+  const auto& config_store = g_conf().get_val<std::string>("rgw_backend_store");
+#ifdef WITH_RADOSGW_DBSTORE
+  if (config_store == "dbstore") {
+    rgw_store = "dbstore";
+  }
+#endif
+
   rgw::sal::Store* store =
     StoreManager::get_storage(&dp, g_ceph_context,
-				 (!rgw_d3n_datacache_enabled) ? "rados" : "d3n",
+				 rgw_store,
 				 g_conf()->rgw_enable_gc_threads,
 				 g_conf()->rgw_enable_lc_threads,
 				 g_conf()->rgw_enable_quota_threads,

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -53,6 +53,9 @@
 #ifdef WITH_RADOSGW_LUA_PACKAGES
 #include "rgw_lua.h"
 #endif
+#ifdef WITH_RADOSGW_DBSTORE
+#include "rgw_sal_dbstore.h"
+#endif
 
 #include "services/svc_zone.h"
 

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -83,6 +83,19 @@ rgw::sal::Store* StoreManager::init_storage_provider(const DoutPrefixProvider* d
     /* Initialize the dbstore with cct & dpp */
     DB *db = static_cast<rgw::sal::DBStore *>(store)->getDB();
     db->set_context(cct);
+
+    /* XXX: temporary - create testid user */
+    rgw_user testid_user("", "testid", "");
+    std::unique_ptr<rgw::sal::User> user = store->get_user(testid_user);
+    user->get_info().display_name = "M. Tester";
+    user->get_info().user_email = "tester@ceph.com";
+    RGWAccessKey k1("0555b35654ad1656d804", "h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q==");
+    user->get_info().access_keys["0555b35654ad1656d804"] = k1;
+
+    int r = user->store_user(dpp, null_yield, true);
+    if (r < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: failed inserting testid user in dbstore error r=" << r << dendl;
+    }
     return store;
 #endif
   }


### PR DESCRIPTION
Include a config option to be able to configure backend store type. Also till there is CLI available to configure options for dbstore, insert testID user during startup.

Signed-off-by: Soumya Koduri <skoduri@redhat.com>