### PR TITLE
rgw/lua: Install the packages only for RadosStore

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -9561,7 +9561,7 @@ next:
       cerr << "ERROR: lua package name was not provided (via --package)" << std::endl;
       return EINVAL;
     }
-    const auto rc = rgw::lua::add_package(dpp(), store, null_yield, *script_package, bool(allow_compilation));
+    const auto rc = rgw::lua::add_package(dpp(), static_cast<rgw::sal::RadosStore*>(store), null_yield, *script_package, bool(allow_compilation));
     if (rc < 0) {
       cerr << "ERROR: failed to add lua package: " << script_package << " .error: " << rc << std::endl;
       return -rc;
@@ -9578,7 +9578,7 @@ next:
       cerr << "ERROR: lua package name was not provided (via --package)" << std::endl;
       return EINVAL;
     }
-    const auto rc = rgw::lua::remove_package(dpp(), store, null_yield, *script_package);
+    const auto rc = rgw::lua::remove_package(dpp(), static_cast<rgw::sal::RadosStore*>(store), null_yield, *script_package);
     if (rc == -ENOENT) {
       cerr << "WARNING: package " << script_package << " did not exists or already removed" << std::endl;
       return 0;
@@ -9596,7 +9596,7 @@ next:
   if (opt_cmd == OPT::SCRIPT_PACKAGE_LIST) {
 #ifdef WITH_RADOSGW_LUA_PACKAGES
     rgw::lua::packages_t packages;
-    const auto rc = rgw::lua::list_packages(dpp(), store, null_yield, packages);
+    const auto rc = rgw::lua::list_packages(dpp(), static_cast<rgw::sal::RadosStore*>(store), null_yield, packages);
     if (rc == -ENOENT) {
       std::cout << "no lua packages in allowlist" << std::endl;
     } else if (rc < 0) {

--- a/src/rgw/rgw_lua.cc
+++ b/src/rgw/rgw_lua.cc
@@ -90,7 +90,7 @@ const std::string PACKAGE_LIST_OBJECT_NAME = "lua_package_allowlist";
 
 namespace bp = boost::process;
 
-int add_package(const DoutPrefixProvider *dpp, rgw::sal::Store* store, optional_yield y, const std::string& package_name, bool allow_compilation) {
+int add_package(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, optional_yield y, const std::string& package_name, bool allow_compilation) {
   // verify that luarocks can load this package
   const auto p = bp::search_path("luarocks");
   if (p.empty()) {
@@ -130,7 +130,7 @@ int add_package(const DoutPrefixProvider *dpp, rgw::sal::Store* store, optional_
   std::map<std::string, bufferlist> new_package{{package_name, empty_bl}};
   librados::ObjectWriteOperation op;
   op.omap_set(new_package);
-  ret = rgw_rados_operate(dpp, *(static_cast<rgw::sal::RadosStore*>(store)->getRados()->get_lc_pool_ctx()),
+  ret = rgw_rados_operate(dpp, *(store->getRados()->get_lc_pool_ctx()),
       PACKAGE_LIST_OBJECT_NAME, &op, y);
 
   if (ret < 0) {
@@ -139,13 +139,13 @@ int add_package(const DoutPrefixProvider *dpp, rgw::sal::Store* store, optional_
   return 0;
 }
 
-int remove_package(const DoutPrefixProvider *dpp, rgw::sal::Store* store, optional_yield y, const std::string& package_name) {
+int remove_package(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, optional_yield y, const std::string& package_name) {
   librados::ObjectWriteOperation op;
   size_t pos = package_name.find(" ");
   if (pos != package_name.npos) {
     // remove specfic version of the the package
     op.omap_rm_keys(std::set<std::string>({package_name}));
-    auto ret = rgw_rados_operate(dpp, *(static_cast<rgw::sal::RadosStore*>(store)->getRados()->get_lc_pool_ctx()),
+    auto ret = rgw_rados_operate(dpp, *(store->getRados()->get_lc_pool_ctx()),
         PACKAGE_LIST_OBJECT_NAME, &op, y);
     if (ret < 0) {
         return ret;
@@ -162,7 +162,7 @@ int remove_package(const DoutPrefixProvider *dpp, rgw::sal::Store* store, option
     const std::string package_no_version = package.substr(0, package.find(" "));
     if (package_no_version.compare(package_name) == 0) {
         op.omap_rm_keys(std::set<std::string>({package}));
-        ret = rgw_rados_operate(dpp, *(static_cast<rgw::sal::RadosStore*>(store)->getRados()->get_lc_pool_ctx()),
+        ret = rgw_rados_operate(dpp, *(store->getRados()->get_lc_pool_ctx()),
             PACKAGE_LIST_OBJECT_NAME, &op, y);
         if (ret < 0) {
             return ret;
@@ -172,7 +172,7 @@ int remove_package(const DoutPrefixProvider *dpp, rgw::sal::Store* store, option
   return 0;
 }
 
-int list_packages(const DoutPrefixProvider *dpp, rgw::sal::Store* store, optional_yield y, packages_t& packages) {
+int list_packages(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, optional_yield y, packages_t& packages) {
   constexpr auto max_chunk = 1024U;
   std::string start_after;
   bool more = true;
@@ -181,7 +181,7 @@ int list_packages(const DoutPrefixProvider *dpp, rgw::sal::Store* store, optiona
     librados::ObjectReadOperation op;
     packages_t packages_chunk;
     op.omap_get_keys2(start_after, max_chunk, &packages_chunk, &more, &rval);
-    const auto ret = rgw_rados_operate(dpp, *(static_cast<rgw::sal::RadosStore*>(store)->getRados()->get_lc_pool_ctx()),
+    const auto ret = rgw_rados_operate(dpp, *(store->getRados()->get_lc_pool_ctx()),
       PACKAGE_LIST_OBJECT_NAME, &op, nullptr, y);
   
     if (ret < 0) {
@@ -194,7 +194,7 @@ int list_packages(const DoutPrefixProvider *dpp, rgw::sal::Store* store, optiona
   return 0;
 }
 
-int install_packages(const DoutPrefixProvider *dpp, rgw::sal::Store* store, optional_yield y, packages_t& failed_packages, std::string& output) {
+int install_packages(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, optional_yield y, packages_t& failed_packages, std::string& output) {
   // luarocks directory cleanup
   std::error_code ec;
   const auto& luarocks_path = store->get_luarocks_path();

--- a/src/rgw/rgw_lua.h
+++ b/src/rgw/rgw_lua.h
@@ -7,6 +7,7 @@ class lua_State;
 class rgw_user;
 namespace rgw::sal {
   class Store;
+  class RadosStore;
 }
 
 namespace rgw::lua {
@@ -40,17 +41,17 @@ int delete_script(const DoutPrefixProvider *dpp, rgw::sal::Store* store, const s
 using packages_t = std::set<std::string>;
 
 // add a lua package to the allowlist
-int add_package(const DoutPrefixProvider *dpp, rgw::sal::Store* store, optional_yield y, const std::string& package_name, bool allow_compilation);
+int add_package(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, optional_yield y, const std::string& package_name, bool allow_compilation);
 
 // remove a lua package from the allowlist
-int remove_package(const DoutPrefixProvider *dpp, rgw::sal::Store* store, optional_yield y, const std::string& package_name);
+int remove_package(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, optional_yield y, const std::string& package_name);
 
 // list lua packages in the allowlist
-int list_packages(const DoutPrefixProvider *dpp, rgw::sal::Store* store, optional_yield y, packages_t& packages);
+int list_packages(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, optional_yield y, packages_t& packages);
 
 // install all packages from the allowlist
 // return the list of packages that failed to install and the output of the install command
-int install_packages(const DoutPrefixProvider *dpp, rgw::sal::Store* store, optional_yield y, packages_t& failed_packages, std::string& output);
+int install_packages(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, optional_yield y, packages_t& failed_packages, std::string& output);
 #endif
 }
 

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -434,17 +434,20 @@ int radosgw_Main(int argc, const char **argv)
     store->set_luarocks_path(luarocks_path+"/"+g_conf()->name.to_str());
   }
 #ifdef WITH_RADOSGW_LUA_PACKAGES
-  rgw::lua::packages_t failed_packages;
-  std::string output;
-  r = rgw::lua::install_packages(&dp, store, null_yield, failed_packages, output);
-  if (r < 0) {
-    dout(1) << "ERROR: failed to install lua packages from allowlist" << dendl;
-  }
-  if (!output.empty()) {
-    dout(10) << "INFO: lua packages installation output: \n" << output << dendl; 
-  }
-  for (const auto& p : failed_packages) {
-    dout(5) << "WARNING: failed to install lua package: " << p << " from allowlist" << dendl;
+  rgw::sal::RadosStore *rados = dynamic_cast<rgw::sal::RadosStore*>(store);
+  if (rados) { /* Supported for only RadosStore */
+    rgw::lua::packages_t failed_packages;
+    std::string output;
+    r = rgw::lua::install_packages(&dp, rados, null_yield, failed_packages, output);
+    if (r < 0) {
+      dout(1) << "ERROR: failed to install lua packages from allowlist" << dendl;
+    }
+    if (!output.empty()) {
+      dout(10) << "INFO: lua packages installation output: \n" << output << dendl; 
+    }
+    for (const auto& p : failed_packages) {
+      dout(5) << "WARNING: failed to install lua package: " << p << " from allowlist" << dendl;
+    }
   }
 #endif
 


### PR DESCRIPTION
Since LUA is supported for only RadosStore, confirm the same
before accessing the package.

Signed-off-by: Soumya Koduri <skoduri@redhat.com>

