### PR TITLE
mgr/prometheus: Added `avail_raw` field for Pools DF Prometheus mgr module

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -69,7 +69,7 @@ def health_status_to_number(status: str) -> int:
 
 DF_CLUSTER = ['total_bytes', 'total_used_bytes', 'total_used_raw_bytes']
 
-DF_POOL = ['max_avail', 'stored', 'stored_raw', 'objects', 'dirty',
+DF_POOL = ['max_avail', 'avail_raw', 'stored', 'stored_raw', 'objects', 'dirty',
            'quota_bytes', 'quota_objects', 'rd', 'rd_bytes', 'wr', 'wr_bytes',
            'compress_bytes_used', 'compress_under_bytes', 'bytes_used', 'percent_used']
 


### PR DESCRIPTION
Currently, Nautilus & Octopus lack of `bytes_used` field, so after upgrade from Luminous we can't expose our real space usage on hardware. So I plan to backport this with `bytes_used` field (available on Pacific again)

Fixes: https://tracker.ceph.com/issues/52512