### PR TITLE
mgr/cephadm: osd should not be zap when it is running

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1976,6 +1976,23 @@ Then run the following:
     @handle_orch_error
     def zap_device(self, host: str, path: str) -> str:
         self.log.info('Zap device %s:%s' % (host, path))
+
+        out, err, code = CephadmServe(self)._run_cephadm(
+            host, 'osd.', 'ceph-volume',
+            ['--', 'lvm', 'list', path, '--format', 'json'],
+            error_ok=True)
+        if code:
+            raise OrchestratorError('Zap failed: ceph-volume lvm list %s' % '\n'.join(path))
+        osd_info = json.loads('\n'.join(out))
+
+        for osd_id in osd_info.keys():
+            out, err, code = CephadmServe(self)._run_cephadm(
+                host, 'osd.', 'unit',
+                ['is-active', '--name', 'osd.%s' % osd_id],
+                error_ok=True)
+            if code == 0:
+                raise OrchestratorError('The systemctl unit of osd is active. Rm osd first')
+
         out, err, code = CephadmServe(self)._run_cephadm(
             host, 'osd', 'ceph-volume',
             ['--', 'lvm', 'zap', '--destroy', path],


### PR DESCRIPTION
When osd is running, we exec the command of "ceph orch device zap".
Then ceph-volume will exec dd command which cause the osd of lvs to be destroyed.
If the osd of systemctl unit restarts, it will be unable to boot.

Signed-off-by: jianglong01 <jianglong01@qianxin.com>

Fixes: https://tracker.ceph.com/issues/51028

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
