### PR TITLE
ceph-volume: remove trailing spaces in code

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/test_inventory.py
+++ b/src/ceph-volume/ceph_volume/tests/test_inventory.py
@@ -196,7 +196,7 @@ def lsm_info(monkeypatch):
         return query_map.get(func, 'Unknown')
 
     # mocked states and settings taken from the libstoragemgmt code base
-    # c_binding/include/libstoragemgmt/libstoragemgmt_types.h at 
+    # c_binding/include/libstoragemgmt/libstoragemgmt_types.h at
     # https://github.com/libstorage/libstoragemgmt/
     mock_health_map = {
             -1: "Unknown",
@@ -222,7 +222,7 @@ def lsm_info(monkeypatch):
         LED_STATUS_UNKNOWN = 1
         LED_STATUS_IDENT_ON = 2
         LED_STATUS_IDENT_OFF = 4
-        LED_STATUS_IDENT_UNKNOWN = 8 
+        LED_STATUS_IDENT_UNKNOWN = 8
         LED_STATUS_FAULT_ON = 16
         LED_STATUS_FAULT_OFF = 32
         LED_STATUS_FAULT_UNKNOWN = 64
@@ -249,6 +249,6 @@ class TestLSM(object):
     def test_lsmdisk_led_fault_support(self, lsm_info):
         assert lsm_info.led_fault_support == 'Supported'
     def test_lsmdisk_led_fault(self, lsm_info):
-        assert lsm_info.led_fault_state == 'Off'    
+        assert lsm_info.led_fault_state == 'Off'
     def test_lsmdisk_report(self, lsm_info):
         assert isinstance(lsm_info.json_report(), dict)

--- a/src/ceph-volume/ceph_volume/util/lsmdisk.py
+++ b/src/ceph-volume/ceph_volume/util/lsmdisk.py
@@ -1,5 +1,5 @@
-""" 
-This module handles the interaction with libstoragemgmt for local disk 
+"""
+This module handles the interaction with libstoragemgmt for local disk
 devices. Interaction may fail with LSM for a number of issues, but the
 intent here is to make this a soft fail, since LSM related data is not
 a critical component of ceph-volume.
@@ -67,7 +67,7 @@ class LSMDisk:
         # if disk is None, lsm is unavailable so all calls should return None
         if self.disk is None:
             return None
-        
+
         method = getattr(self.disk, func)
         try:
             output = method(path)
@@ -98,7 +98,7 @@ class LSMDisk:
             return "Off"
         elif self.led_status & lsm_Disk.LED_STATUS_IDENT_UNKNOWN == lsm_Disk.LED_STATUS_IDENT_UNKNOWN:
             return "Unknown"
-        
+
         return "Unsupported"
 
     @property
@@ -112,7 +112,7 @@ class LSMDisk:
             return "Off"
         elif self.led_status & lsm_Disk.LED_STATUS_FAULT_UNKNOWN == lsm_Disk.LED_STATUS_FAULT_UNKNOWN:
             return "Unknown"
-        
+
         return "Unsupported"
 
     @property
@@ -122,14 +122,14 @@ class LSMDisk:
             return "Unknown"
 
         ident_states = (
-            lsm_Disk.LED_STATUS_IDENT_ON + 
-            lsm_Disk.LED_STATUS_IDENT_OFF + 
+            lsm_Disk.LED_STATUS_IDENT_ON +
+            lsm_Disk.LED_STATUS_IDENT_OFF +
             lsm_Disk.LED_STATUS_IDENT_UNKNOWN
         )
 
         if (self.led_status & ident_states) == 0:
             return "Unsupported"
-        
+
         return "Supported"
 
     @property
@@ -139,8 +139,8 @@ class LSMDisk:
             return "Unknown"
 
         fail_states = (
-            lsm_Disk.LED_STATUS_FAULT_ON + 
-            lsm_Disk.LED_STATUS_FAULT_OFF + 
+            lsm_Disk.LED_STATUS_FAULT_ON +
+            lsm_Disk.LED_STATUS_FAULT_OFF +
             lsm_Disk.LED_STATUS_FAULT_UNKNOWN
         )
 

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/inventory.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/inventory.py
@@ -44,7 +44,7 @@ class Inventory(object):
 
         self.args = parser.parse_args(self.argv)
         if self.args.path:
-            self.format_report(Disks(self.args.path)) 
+            self.format_report(Disks(self.args.path))
         else:
-            self.format_report(Disks()) 
+            self.format_report(Disks())
 

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/disk.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/disk.py
@@ -57,7 +57,7 @@ def get_disk(diskname):
 
     command = ['/sbin/geom', 'disk', 'list', re.sub('/dev/', '', diskname)]
     out, err, rc = process.call(command)
-    geom_block = "" 
+    geom_block = ""
     for line in out:
         line.strip()
         geom_block += ";" + line
@@ -82,7 +82,7 @@ class Disks(object):
         self.disks = {}
         for k in sys_info.devices:
             if path != None:
-                if path in k: 
+                if path in k:
                     self.disks[k] = Disk(k)
             else:
                 self.disks[k] = Disk(k)
@@ -99,7 +99,7 @@ class Disks(object):
         for disk in sorted(self.disks):
             output.append(self.disks[disk].report())
         return ''.join(output)
-        
+
     def json_report(self):
         output = []
         for disk in sorted(self.disks):

--- a/src/ceph-volume/tox.ini
+++ b/src/ceph-volume/tox.ini
@@ -11,7 +11,7 @@ commands=py.test -v {posargs:ceph_volume/tests} --ignore=ceph_volume/tests/funct
 
 [testenv:py3-flake8]
 deps=flake8
-commands=flake8 {posargs:ceph_volume}
+commands=flake8 --select F,E9,W291 {posargs:ceph_volume}
 
 [tool:pytest]
 norecursedirs = .* _* virtualenv


### PR DESCRIPTION
This commit removes all trailing white spaces in ceph-volume code.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
