### PR TITLE
 crimson/common: explicitly reraise handled signal in FatalSignal

### DIFF
--- a/src/crimson/common/fatal_signal.cc
+++ b/src/crimson/common/fatal_signal.cc
@@ -36,13 +36,13 @@ template <int SigNum>
 void FatalSignal::install_oneshot_signal_handler()
 {
   struct sigaction sa;
-  sa.sa_sigaction = [](int sig, siginfo_t *info, void *p) {
+  sa.sa_sigaction = [](int signum, siginfo_t *info, void *p) {
     if (static std::atomic_bool handled{false}; handled.exchange(true)) {
       return;
     }
     assert(info);
-    FatalSignal::signaled(sig, *info);
-    ::signal(sig, SIG_DFL);
+    FatalSignal::signaled(signum, *info);
+    ::signal(signum, SIG_DFL);
   };
   sigfillset(&sa.sa_mask);
   sa.sa_flags = SA_SIGINFO | SA_RESTART;


### PR DESCRIPTION
Over the current approach where we just reset the handler to default and allow CPU to re-execute the segfaulting instruction, the explicit `::reraise()` is:
1. immune to a race condition if multiple threads run into troubles the same time;
2. easier to understand and similar to the classic OSD.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
