### PR TITLE
mgr/cephadm: the display of 'orch osd rm status' is incorrect

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -858,7 +858,7 @@ Usage:
             table.right_padding_width = 2
             for osd in sorted(report, key=lambda o: o.osd_id):
                 table.add_row([osd.osd_id, osd.hostname, osd.drain_status_human(),
-                               osd.get_pg_count(), osd.replace, osd.replace, osd.drain_started_at])
+                               osd.get_pg_count(), osd.replace, osd.force, osd.drain_started_at])
             out = table.get_string()
 
         return HandleCommandResult(stdout=out)


### PR DESCRIPTION
After exec 'ceph orch osd rm --replace', 'orch osd rm status' has an wrong display.

wrong display:
OSD_ID  HOST                              STATE     PG_COUNT  REPLACE  FORCE  DRAIN_STARTED_AT
15      cephqa08.cpp.zzbm.qianxin-inc.cn  draining  0         True     True   2021-09-07 07:54:05.776906

correct display:
OSD_ID  HOST                              STATE     PG_COUNT  REPLACE  FORCE  DRAIN_STARTED_AT
15      cephqa08.cpp.zzbm.qianxin-inc.cn  draining  0         True     False  2021-09-07 07:35:34.731417

Signed-off-by: jianglong01 <jianglong01@qianxin.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
