### PR TITLE
librbd: fix use-after-free on ictx in list_descendants()

### DIFF
--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -318,8 +318,8 @@ int Image<I>::list_descendants(
       return 0;
     }
     lderr(cct) << "failed to open descendant " << image_id
-                     << " from pool " << io_ctx.get_pool_name() << ":"
-                     << cpp_strerror(r) << dendl;
+               << " from pool " << io_ctx.get_pool_name() << ":"
+               << cpp_strerror(r) << dendl;
     return r;
   }
 
@@ -328,8 +328,8 @@ int Image<I>::list_descendants(
   int r1 = ictx->state->close();
   if (r1 < 0) {
     lderr(cct) << "error when closing descendant " << image_id
-                     << " from pool " << io_ctx.get_pool_name() << ":"
-                     << cpp_strerror(r) << dendl;
+               << " from pool " << io_ctx.get_pool_name() << ":"
+               << cpp_strerror(r1) << dendl;
   }
 
   return r;

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -311,12 +311,13 @@ int Image<I>::list_descendants(
     std::vector<librbd::linked_image_spec_t> *images) {
   ImageCtx *ictx = new librbd::ImageCtx("", image_id, nullptr,
                                         io_ctx, true);
+  CephContext *cct = ictx->cct;
   int r = ictx->state->open(OPEN_FLAG_SKIP_OPEN_PARENT);
   if (r < 0) {
     if (r == -ENOENT) {
       return 0;
     }
-    lderr(ictx->cct) << "failed to open descendant " << image_id
+    lderr(cct) << "failed to open descendant " << image_id
                      << " from pool " << io_ctx.get_pool_name() << ":"
                      << cpp_strerror(r) << dendl;
     return r;
@@ -326,7 +327,7 @@ int Image<I>::list_descendants(
 
   int r1 = ictx->state->close();
   if (r1 < 0) {
-    lderr(ictx->cct) << "error when closing descendant " << image_id
+    lderr(cct) << "error when closing descendant " << image_id
                      << " from pool " << io_ctx.get_pool_name() << ":"
                      << cpp_strerror(r) << dendl;
   }


### PR DESCRIPTION

Ictx is deleted when "ictx->state->open()" and "ictx->state->close()" fail,
and then "lderr(ictx->cct)" crashes.

Fixes:https://tracker.ceph.com/issues/52522

Review-by: wuxuehan@chinatelecom.cn
Review-by: lijiawei1@chinatelecom.cn
Signed-off-by: Wang ShuaiChao <wangshuaich@chinatelecom.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
