### PR TITLE
octopus: ceph-volume: pvs --noheadings replace pvs --no-heading

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -463,7 +463,7 @@ def get_pvs(fields=PV_FIELDS, filters='', tags=None):
     :returns: list of class PVolume object representing pvs on the system
     """
     filters = make_filters_lvmcmd_ready(filters, tags)
-    args = ['pvs', '--no-heading', '--readonly', '--separator=";"', '-S',
+    args = ['pvs', '--noheadings', '--readonly', '--separator=";"', '-S',
             filters, '-o', fields]
 
     stdout, stderr, returncode = process.call(args, verbose_on_failure=False)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52524

---

backport of https://github.com/ceph/ceph/pull/43009
parent tracker: https://tracker.ceph.com/issues/52482

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh