### PR TITLE
mgr/rook: use osd_pool_default_size in `orch apply rgw`

### DIFF
--- a/qa/suites/orch/rook/smoke/3-final.yaml
+++ b/qa/suites/orch/rook/smoke/3-final.yaml
@@ -6,3 +6,4 @@ tasks:
       - ceph orch ls
       - ceph orch host ls
       - ceph orch device ls
+      - ceph orch apply rgw foo

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -450,7 +450,9 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
     @handle_orch_error
     def apply_rgw(self, spec):
         # type: (RGWSpec) -> str
-        return self.rook_cluster.apply_objectstore(spec)
+        num_of_osds = self.get_ceph_option('osd_pool_default_size')
+        assert type(num_of_osds) is int
+        return self.rook_cluster.apply_objectstore(spec, num_of_osds)
 
     @handle_orch_error
     def apply_nfs(self, spec):

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -907,7 +907,7 @@ class RookCluster(object):
             # translate . to - (fingers crossed!) instead.
             name = spec.service_id.replace('.', '-')
 
-
+        all_hosts = self.get_hosts()
         def _create_zone() -> cos.CephObjectStore:
             port = None
             secure_port = None
@@ -926,7 +926,16 @@ class RookCluster(object):
                             port=port,
                             securePort=secure_port,
                             instances=spec.placement.count or 1,
-                        )
+                            placement=ccl.NodeAffinity(
+                                requiredDuringSchedulingIgnoredDuringExecution=ccl.RequiredDuringSchedulingIgnoredDuringExecution(
+                                    nodeSelectorTerms=ccl.NodeSelectorTermsList(
+                                        [
+                                            placement_spec_to_node_selector(spec.placement, all_hosts)
+                                        ]
+                                    )
+                                )
+                            )
+                        ),
                     )
                 )
             if spec.rgw_zone:


### PR DESCRIPTION
This PR makes `orch apply rgw` set the data pool and metadata pool replication sizes in the ObjectStore spec to the osd_pool_default_size ceph option.

Depends on #43044 
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
