### PR TITLE
crimson/os/seastore/.../lba_btree: fix handle_split internal nodes

### DIFF
--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
@@ -566,6 +566,17 @@ private:
       });
   }
 
+  /**
+   * handle_split
+   *
+   * Prepare iter for insertion.  iter should begin pointing at
+   * the valid insertion point (lower_bound(laddr)).
+   *
+   * Upon completion, iter will point at the
+   * position at which laddr should be inserted.  iter may, upon completion,
+   * point at the end of a leaf other than the end leaf if that's the correct
+   * insertion point.
+   */
   using find_insertion_iertr = base_iertr;
   using find_insertion_ret = find_insertion_iertr::future<>;
   static find_insertion_ret find_insertion(
@@ -573,6 +584,16 @@ private:
     laddr_t laddr,
     iterator &iter);
 
+  /**
+   * handle_split
+   *
+   * Split nodes in iter as needed for insertion. First, scan iter from leaf
+   * to find first non-full level.  Then, split from there towards leaf.
+   *
+   * Upon completion, iter will point at the newly split insertion point.  As
+   * with find_insertion, iter's leaf pointer may be end without iter being
+   * end.
+   */
   using handle_split_iertr = base_iertr;
   using handle_split_ret = handle_split_iertr::future<>;
   handle_split_ret handle_split(

--- a/src/crimson/tools/store_nbd/fs_driver.cc
+++ b/src/crimson/tools/store_nbd/fs_driver.cc
@@ -276,6 +276,5 @@ void FSDriver::init()
   fs = FuturizedStore::create(
     config.get_fs_type(),
     *config.path,
-    crimson::common::local_conf().get_config_values(),
-    alien);
+    crimson::common::local_conf().get_config_values());
 }


### PR DESCRIPTION
crimson/os/seastore/.../lba_btree: fix handle_split internal nodes
    
Internal node pointers aren't actually allowed to point to end() -- that's
specific to the leaf pointer

Fixes: https://tracker.ceph.com/issues/52532
Signed-off-by: Samuel Just <sjust@redhat.com>
