### PR TITLE
crimson/os/seastore/.../lba_btree: fix handle_split internal nodes

### DIFF
--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
@@ -536,20 +536,7 @@ LBABtree::handle_split_ret LBABtree::handle_split(
 
     c.cache.retire_extent(c.trans, pos.node);
 
-    /* right->get_node_meta().begin == pivot == right->begin()->get_key()
-     * Thus, if pos.pos == left->get_size(), we want iter to point to
-     * left with pos.pos at the end rather than right with pos.pos = 0
-     * since the insertion would be to the left of the first element
-     * of right and thus necessarily less than right->get_node_meta().begin.
-     */
-    if (pos.pos <= left->get_size()) {
-      pos.node = left;
-    } else {
-      pos.node = right;
-      pos.pos -= left->get_size();
-
-      parent_pos.pos += 1;
-    }
+    return std::make_pair(left, right);
   };
 
   for (; split_from > 0; --split_from) {
@@ -563,11 +550,35 @@ LBABtree::handle_split_ret LBABtree::handle_split(
     if (split_from > 1) {
       auto &pos = iter.get_internal(split_from);
       DEBUGT("splitting internal {} at depth {}", c.trans, *pos.node, split_from);
-      split_level(parent_pos, pos);
+      auto [left, right] = split_level(parent_pos, pos);
+
+      if (pos.pos < left->get_size()) {
+	pos.node = left;
+      } else {
+	pos.node = right;
+	pos.pos -= left->get_size();
+
+	parent_pos.pos += 1;
+      }
     } else {
       auto &pos = iter.leaf;
       DEBUGT("splitting leaf {}", c.trans, *pos.node);
-      split_level(parent_pos, pos);
+      auto [left, right] = split_level(parent_pos, pos);
+
+      /* right->get_node_meta().begin == pivot == right->begin()->get_key()
+       * Thus, if pos.pos == left->get_size(), we want iter to point to
+       * left with pos.pos at the end rather than right with pos.pos = 0
+       * since the insertion would be to the left of the first element
+       * of right and thus necessarily less than right->get_node_meta().begin.
+       */
+      if (pos.pos <= left->get_size()) {
+	pos.node = left;
+      } else {
+	pos.node = right;
+	pos.pos -= left->get_size();
+
+	parent_pos.pos += 1;
+      }
     }
   }
 

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
@@ -566,6 +566,17 @@ private:
       });
   }
 
+  /**
+   * handle_split
+   *
+   * Prepare iter for insertion.  iter should begin pointing at
+   * the valid insertion point (lower_bound(laddr)).
+   *
+   * Upon completion, iter will point at the
+   * position at which laddr should be inserted.  iter may, upon completion,
+   * point at the end of a leaf other than the end leaf if that's the correct
+   * insertion point.
+   */
   using find_insertion_iertr = base_iertr;
   using find_insertion_ret = find_insertion_iertr::future<>;
   static find_insertion_ret find_insertion(
@@ -573,6 +584,16 @@ private:
     laddr_t laddr,
     iterator &iter);
 
+  /**
+   * handle_split
+   *
+   * Split nodes in iter as needed for insertion. First, scan iter from leaf
+   * to find first non-full level.  Then, split from there towards leaf.
+   *
+   * Upon completion, iter will point at the newly split insertion point.  As
+   * with find_insertion, iter's leaf pointer may be end without iter being
+   * end.
+   */
   using handle_split_iertr = base_iertr;
   using handle_split_ret = handle_split_iertr::future<>;
   handle_split_ret handle_split(

--- a/src/crimson/tools/store_nbd/fs_driver.cc
+++ b/src/crimson/tools/store_nbd/fs_driver.cc
@@ -276,6 +276,5 @@ void FSDriver::init()
   fs = FuturizedStore::create(
     config.get_fs_type(),
     *config.path,
-    crimson::common::local_conf().get_config_values(),
-    alien);
+    crimson::common::local_conf().get_config_values());
 }


### PR DESCRIPTION
Internal node pointers aren't actually allowed to point to end() -- that's
specific to the leaf pointer

Fixes: https://tracker.ceph.com/issues/52532
Signed-off-by: Samuel Just <sjust@redhat.com>
