### PR TITLE
pacific: ceph-volume: fix raw list with logical partition

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -72,7 +72,7 @@ class List(object):
             # the parent disk has a bluestore header, but children may be the most appropriate
             # devices to return if the parent disk does not have a bluestore header.
             out, err, ret = process.call([
-                'lsblk', '--paths', '--output=NAME', '--noheadings',
+                'lsblk', '--paths', '--output=NAME', '--noheadings', '--list'
             ])
             assert not ret
             devs = out

--- a/src/ceph-volume/ceph_volume/tests/devices/raw/test_list.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/raw/test_list.py
@@ -199,6 +199,7 @@ class TestList(object):
         patched_get_devices.side_effect = _devices_side_effect
 
         result = raw.list.List([]).generate()
+        patched_call.assert_any_call(['lsblk', '--paths', '--output=NAME', '--noheadings', '--list'])
         assert len(result) == 2
 
         sdb = result['sdb-uuid']


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52538

---

backport of https://github.com/ceph/ceph/pull/43050
parent tracker: https://tracker.ceph.com/issues/52504

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh