### PR TITLE
mon/MonCommands: Fix wrong help message for osd pool rm

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1065,8 +1065,8 @@ COMMAND_WITH_FLAG("osd pool delete "
     FLAG(DEPRECATED))
 COMMAND("osd pool rm "
 	"name=pool,type=CephPoolname "
-	"name=pool2,type=CephPoolname,req=false "
-	"name=yes_i_really_really_mean_it,type=CephBool,req=false "
+	"name=confirm_pool,type=CephPoolname "
+	"name=yes_i_really_really_mean_it,type=CephBool "
 	"name=yes_i_really_really_mean_it_not_faking,type=CephBool,req=false ",
 	"remove pool",
 	"osd", "rw")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -12863,7 +12863,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     // osd pool delete/rm <poolname> <poolname again> --yes-i-really-really-mean-it
     string poolstr, poolstr2, sure;
     cmd_getval(cmdmap, "pool", poolstr);
-    cmd_getval(cmdmap, "pool2", poolstr2);
+    cmd_getval(cmdmap, "confirm_pool", poolstr2);
     int64_t pool = osdmap.lookup_pg_pool_name(poolstr.c_str());
     if (pool < 0) {
       ss << "pool '" << poolstr << "' does not exist";


### PR DESCRIPTION
- ceph osd pool rm --help | grep "osd pool rm"
osd pool rm <pool> [<pool2>] [--yes-i-really-really-mean-it] [--yes-i-really-really-mean-it-not-faking]   remove pool

- ceph osd pool rm i_pool_er_1 i_pool_rep --yes-i-really-really-mean-it --yes-i-really-really-mean-it-not-faking
Error EPERM: WARNING: this will *PERMANENTLY DESTROY* all data stored in pool i_pool_er_1.  If you are *ABSOLUTELY CERTAIN* that is what you want, pass the pool name *twice*, followed by --yes-i-really-really-mean-it.

As of now osd pool rm help messgae is wrong or misleading
This PR is intended to fix the help message

Fixes - https://tracker.ceph.com/issues/52578
Signed-off-by: VasishtaShastry <vipin.indiasmg@gmail.com>