### PR TITLE
crimson: add support for ms_bind_retry_{delay,count}

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -1128,6 +1128,7 @@ namespace ct_error {
   using file_too_large =
     ct_error_code<std::errc::file_too_large>;
   using address_in_use = ct_error_code<std::errc::address_in_use>;
+  using address_not_available = ct_error_code<std::errc::address_not_available>;
 
   struct pass_further_all {
     template <class ErrorT>

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -69,10 +69,6 @@ public:
   /// bind to the given address
   virtual bind_ertr::future<> bind(const entity_addrvec_t& addr) = 0;
 
-  /// try to bind to the first unused port of given address
-  virtual bind_ertr::future<> try_bind(const entity_addrvec_t& addr,
-                                       uint32_t min_port, uint32_t max_port) = 0;
-
   /// start the messenger
   virtual seastar::future<> start(const dispatchers_t&) = 0;
 

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -63,7 +63,8 @@ public:
   }
 
   using bind_ertr = crimson::errorator<
-    crimson::ct_error::address_in_use // The address (range) is already bound
+    crimson::ct_error::address_in_use, // The address (range) is already bound
+    crimson::ct_error::address_not_available
     >;
   /// bind to the given address
   virtual bind_ertr::future<> bind(const entity_addrvec_t& addr) = 0;

--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -198,7 +198,7 @@ void Socket::set_trap(bp_type_t type, bp_action_t action, socket_blocker* blocke
 }
 #endif
 
-FixedCPUServerSocket::listen_ertr::future<>
+crimson::net::listen_ertr::future<>
 FixedCPUServerSocket::listen(entity_addr_t addr)
 {
   assert(seastar::this_shard_id() == cpu);

--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -217,6 +217,10 @@ FixedCPUServerSocket::listen(entity_addr_t addr)
     if (e.code() == std::errc::address_in_use) {
       logger().trace("FixedCPUServerSocket::listen({}): address in use", addr);
       return crimson::ct_error::address_in_use::make();
+    } else if (e.code() == std::errc::address_not_available) {
+      logger().trace("FixedCPUServerSocket::listen({}): address not available",
+                     addr);
+      return crimson::ct_error::address_not_available::make();
     }
     logger().error("FixedCPUServerSocket::listen({}): "
                    "got unexpeted error {}", addr, e);

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -161,7 +161,8 @@ class Socket
 };
 
 using listen_ertr = crimson::errorator<
-  crimson::ct_error::address_in_use // The address is already bound
+  crimson::ct_error::address_in_use, // The address is already bound
+  crimson::ct_error::address_not_available // https://techoverflow.net/2021/08/06/how-i-fixed-python-oserror-errno-99-cannot-assign-requested-address/
   >;
 
 class FixedCPUServerSocket

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -160,6 +160,10 @@ class Socket
   friend class FixedCPUServerSocket;
 };
 
+using listen_ertr = crimson::errorator<
+  crimson::ct_error::address_in_use // The address is already bound
+  >;
+
 class FixedCPUServerSocket
     : public seastar::peering_sharded_service<FixedCPUServerSocket> {
   const seastar::shard_id cpu;
@@ -196,9 +200,6 @@ public:
   FixedCPUServerSocket(const FixedCPUServerSocket&) = delete;
   FixedCPUServerSocket& operator=(const FixedCPUServerSocket&) = delete;
 
-  using listen_ertr = crimson::errorator<
-    crimson::ct_error::address_in_use // The address is already bound
-    >;
   listen_ertr::future<> listen(entity_addr_t addr);
 
   // fn_accept should be a nothrow function of type

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -24,6 +24,7 @@
 
 #include "crimson/net/chained_dispatchers.h"
 #include "Messenger.h"
+#include "Socket.h"
 #include "SocketConnection.h"
 
 namespace crimson::net {
@@ -49,6 +50,10 @@ class SocketMessenger final : public Messenger {
   bool started = false;
 
   listen_ertr::future<> do_listen(const entity_addrvec_t& addr);
+  /// try to bind to the first unused port of given address
+  bind_ertr::future<> try_bind(const entity_addrvec_t& addr,
+                               uint32_t min_port, uint32_t max_port);
+
 
  public:
   SocketMessenger(const entity_name_t& myname,
@@ -61,9 +66,6 @@ class SocketMessenger final : public Messenger {
   // Messenger interfaces are assumed to be called from its own shard, but its
   // behavior should be symmetric when called from any shard.
   bind_ertr::future<> bind(const entity_addrvec_t& addr) override;
-
-  bind_ertr::future<> try_bind(const entity_addrvec_t& addr,
-                               uint32_t min_port, uint32_t max_port) override;
 
   seastar::future<> start(const dispatchers_t& dispatchers) override;
 

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -48,7 +48,7 @@ class SocketMessenger final : public Messenger {
   uint32_t global_seq = 0;
   bool started = false;
 
-  bind_ertr::future<> do_listen(const entity_addrvec_t& addr);
+  listen_ertr::future<> do_listen(const entity_addrvec_t& addr);
 
  public:
   SocketMessenger(const entity_name_t& myname,

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -48,7 +48,7 @@ class SocketMessenger final : public Messenger {
   uint32_t global_seq = 0;
   bool started = false;
 
-  bind_ertr::future<> do_bind(const entity_addrvec_t& addr);
+  bind_ertr::future<> do_listen(const entity_addrvec_t& addr);
 
  public:
   SocketMessenger(const entity_name_t& myname,

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -73,14 +73,11 @@ seastar::future<>
 Heartbeat::start_messenger(crimson::net::Messenger& msgr,
                            const entity_addrvec_t& addrs)
 {
-  return msgr.try_bind(addrs,
-                       local_conf()->ms_bind_port_min,
-                       local_conf()->ms_bind_port_max)
-  .safe_then([this, &msgr]() mutable {
+  return msgr.bind(addrs).safe_then([this, &msgr]() mutable {
     return msgr.start({this});
   }, crimson::net::Messenger::bind_ertr::all_same_way(
       [] (const std::error_code& e) {
-    logger().error("heartbeat messenger try_bind(): address range is unavailable.");
+    logger().error("heartbeat messenger bind(): address range is unavailable.");
     ceph_abort();
   }));
 }

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -298,24 +298,20 @@ seastar::future<> OSD::start()
 
     crimson::net::dispatchers_t dispatchers{this, monc.get(), mgrc.get()};
     return seastar::when_all_succeed(
-      cluster_msgr->try_bind(pick_addresses(CEPH_PICK_ADDRESS_CLUSTER),
-                             local_conf()->ms_bind_port_min,
-                             local_conf()->ms_bind_port_max)
+      cluster_msgr->bind(pick_addresses(CEPH_PICK_ADDRESS_CLUSTER))
         .safe_then([this, dispatchers]() mutable {
 	  return cluster_msgr->start(dispatchers);
         }, crimson::net::Messenger::bind_ertr::all_same_way(
             [] (const std::error_code& e) {
-          logger().error("cluster messenger try_bind(): address range is unavailable.");
+          logger().error("cluster messenger bind(): address range is unavailable.");
           ceph_abort();
         })),
-      public_msgr->try_bind(pick_addresses(CEPH_PICK_ADDRESS_PUBLIC),
-                            local_conf()->ms_bind_port_min,
-                            local_conf()->ms_bind_port_max)
+      public_msgr->bind(pick_addresses(CEPH_PICK_ADDRESS_PUBLIC))
         .safe_then([this, dispatchers]() mutable {
 	  return public_msgr->start(dispatchers);
         }, crimson::net::Messenger::bind_ertr::all_same_way(
             [] (const std::error_code& e) {
-          logger().error("public messenger try_bind(): address range is unavailable.");
+          logger().error("public messenger bind(): address range is unavailable.");
           ceph_abort();
         })));
   }).then_unpack([this] {

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -21,6 +21,7 @@ using seastar::engine;
 using seastar::future;
 using crimson::net::error;
 using crimson::net::FixedCPUServerSocket;
+using crimson::net::listen_ertr;
 using crimson::net::Socket;
 using crimson::net::SocketRef;
 using crimson::net::stop_t;
@@ -75,7 +76,7 @@ future<> test_bind_same() {
         return pss2->listen(saddr).safe_then([] {
           logger.error("test_bind_same() should raise address_in_use");
           ceph_abort();
-        }, FixedCPUServerSocket::listen_ertr::all_same_way(
+        }, listen_ertr::all_same_way(
             [] (const std::error_code& e) {
           if (e == std::errc::address_in_use) {
             // successful!
@@ -91,7 +92,7 @@ future<> test_bind_same() {
           return pss2->destroy();
         });
       });
-    }, FixedCPUServerSocket::listen_ertr::all_same_way(
+    }, listen_ertr::all_same_way(
         [saddr] (const std::error_code& e) {
       logger.error("test_bind_same(): there is another instance running at {}",
                    saddr);
@@ -116,7 +117,7 @@ future<> test_accept() {
           return socket->close().finally([cleanup = std::move(socket)] {});
         });
       });
-    }, FixedCPUServerSocket::listen_ertr::all_same_way(
+    }, listen_ertr::all_same_way(
         [saddr] (const std::error_code& e) {
       logger.error("test_accept(): there is another instance running at {}",
                    saddr);
@@ -162,7 +163,7 @@ class SocketFactory {
       return FixedCPUServerSocket::create().then([psf, saddr] (auto pss) {
         psf->pss = pss;
         return pss->listen(saddr
-        ).safe_then([]{}, FixedCPUServerSocket::listen_ertr::all_same_way(
+        ).safe_then([]{}, listen_ertr::all_same_way(
             [saddr] (const std::error_code& e) {
           logger.error("dispatch_sockets(): there is another instance running at {}",
                        saddr);


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
