### PR TITLE
pacific: librbd: fix pool validation lockup

### DIFF
--- a/src/librbd/api/Pool.cc
+++ b/src/librbd/api/Pool.cc
@@ -252,11 +252,8 @@ int Pool<I>::init(librados::IoCtx& io_ctx, bool force) {
     return 0;
   }
 
-  AsioEngine asio_engine(io_ctx);
-
   C_SaferCond ctx;
-  auto req = image::ValidatePoolRequest<I>::create(
-    io_ctx, asio_engine.get_work_queue(), &ctx);
+  auto req = image::ValidatePoolRequest<I>::create(io_ctx, &ctx);
   req->send();
 
   return ctx.wait();

--- a/src/librbd/image/CreateRequest.cc
+++ b/src/librbd/image/CreateRequest.cc
@@ -283,8 +283,7 @@ void CreateRequest<I>::validate_data_pool() {
 
   auto ctx = create_context_callback<
     CreateRequest<I>, &CreateRequest<I>::handle_validate_data_pool>(this);
-  auto req = ValidatePoolRequest<I>::create(m_data_io_ctx, m_op_work_queue,
-                                            ctx);
+  auto req = ValidatePoolRequest<I>::create(m_data_io_ctx, ctx);
   req->send();
 }
 

--- a/src/librbd/image/ValidatePoolRequest.cc
+++ b/src/librbd/image/ValidatePoolRequest.cc
@@ -31,10 +31,9 @@ using util::create_async_context_callback;
 
 template <typename I>
 ValidatePoolRequest<I>::ValidatePoolRequest(librados::IoCtx& io_ctx,
-                                            asio::ContextWQ *op_work_queue,
                                             Context *on_finish)
     : m_cct(reinterpret_cast<CephContext*>(io_ctx.cct())),
-      m_op_work_queue(op_work_queue), m_on_finish(on_finish) {
+      m_on_finish(on_finish) {
     // validatation should occur in default namespace
     m_io_ctx.dup(io_ctx);
     m_io_ctx.set_namespace("");

--- a/src/librbd/image/ValidatePoolRequest.cc
+++ b/src/librbd/image/ValidatePoolRequest.cc
@@ -97,11 +97,11 @@ void ValidatePoolRequest<I>::create_snapshot() {
 
   // allocate a self-managed snapshot id if this a new pool to force
   // self-managed snapshot mode
-  auto ctx = new LambdaContext([this](int r) {
-      r = m_io_ctx.selfmanaged_snap_create(&m_snap_id);
-      handle_create_snapshot(r);
-    });
-  m_op_work_queue->queue(ctx, 0);
+  auto comp = create_rados_callback<
+    ValidatePoolRequest<I>,
+    &ValidatePoolRequest<I>::handle_create_snapshot>(this);
+  m_io_ctx.aio_selfmanaged_snap_create(&m_snap_id, comp);
+  comp->release();
 }
 
 template <typename I>
@@ -161,11 +161,11 @@ template <typename I>
 void ValidatePoolRequest<I>::remove_snapshot() {
   ldout(m_cct, 5) << dendl;
 
-  auto ctx = new LambdaContext([this](int r) {
-      r = m_io_ctx.selfmanaged_snap_remove(m_snap_id);
-      handle_remove_snapshot(r);
-    });
-  m_op_work_queue->queue(ctx, 0);
+  auto comp = create_rados_callback<
+    ValidatePoolRequest<I>,
+    &ValidatePoolRequest<I>::handle_remove_snapshot>(this);
+  m_io_ctx.aio_selfmanaged_snap_remove(m_snap_id, comp);
+  comp->release();
 }
 
 template <typename I>

--- a/src/librbd/image/ValidatePoolRequest.h
+++ b/src/librbd/image/ValidatePoolRequest.h
@@ -21,13 +21,11 @@ template <typename ImageCtxT>
 class ValidatePoolRequest {
 public:
   static ValidatePoolRequest* create(librados::IoCtx& io_ctx,
-                                     asio::ContextWQ *op_work_queue,
                                      Context *on_finish) {
-    return new ValidatePoolRequest(io_ctx, op_work_queue, on_finish);
+    return new ValidatePoolRequest(io_ctx, on_finish);
   }
 
-  ValidatePoolRequest(librados::IoCtx& io_ctx, asio::ContextWQ *op_work_queue,
-                      Context *on_finish);
+  ValidatePoolRequest(librados::IoCtx& io_ctx, Context *on_finish);
 
   void send();
 
@@ -62,7 +60,6 @@ private:
 
   librados::IoCtx m_io_ctx;
   CephContext* m_cct;
-  asio::ContextWQ* m_op_work_queue;
   Context* m_on_finish;
 
   int m_ret_val = 0;

--- a/src/test/librbd/image/test_mock_ValidatePoolRequest.cc
+++ b/src/test/librbd/image/test_mock_ValidatePoolRequest.cc
@@ -110,8 +110,7 @@ TEST_F(TestMockImageValidatePoolRequest, Success) {
   expect_write_rbd_info(mock_io_ctx, "overwrite validated", 0);
 
   C_SaferCond ctx;
-  auto req = new MockValidatePoolRequest(m_ioctx, image_ctx->op_work_queue,
-                                         &ctx);
+  auto req = new MockValidatePoolRequest(m_ioctx, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -124,8 +123,7 @@ TEST_F(TestMockImageValidatePoolRequest, AlreadyValidated) {
   expect_read_rbd_info(mock_io_ctx, "overwrite validated", 0);
 
   C_SaferCond ctx;
-  auto req = new MockValidatePoolRequest(m_ioctx, image_ctx->op_work_queue,
-                                         &ctx);
+  auto req = new MockValidatePoolRequest(m_ioctx, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -139,8 +137,7 @@ TEST_F(TestMockImageValidatePoolRequest, SnapshotsValidated) {
   expect_write_rbd_info(mock_io_ctx, "overwrite validated", 0);
 
   C_SaferCond ctx;
-  auto req = new MockValidatePoolRequest(m_ioctx, image_ctx->op_work_queue,
-                                         &ctx);
+  auto req = new MockValidatePoolRequest(m_ioctx, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -153,8 +150,7 @@ TEST_F(TestMockImageValidatePoolRequest, ReadError) {
   expect_read_rbd_info(mock_io_ctx, "", -EPERM);
 
   C_SaferCond ctx;
-  auto req = new MockValidatePoolRequest(m_ioctx, image_ctx->op_work_queue,
-                                         &ctx);
+  auto req = new MockValidatePoolRequest(m_ioctx, &ctx);
   req->send();
   ASSERT_EQ(-EPERM, ctx.wait());
 }
@@ -168,8 +164,7 @@ TEST_F(TestMockImageValidatePoolRequest, CreateSnapshotError) {
   expect_allocate_snap_id(mock_io_ctx, -EPERM);
 
   C_SaferCond ctx;
-  auto req = new MockValidatePoolRequest(m_ioctx, image_ctx->op_work_queue,
-                                         &ctx);
+  auto req = new MockValidatePoolRequest(m_ioctx, &ctx);
   req->send();
   ASSERT_EQ(-EPERM, ctx.wait());
 }
@@ -185,8 +180,7 @@ TEST_F(TestMockImageValidatePoolRequest, WriteError) {
   expect_release_snap_id(mock_io_ctx, -EINVAL);
 
   C_SaferCond ctx;
-  auto req = new MockValidatePoolRequest(m_ioctx, image_ctx->op_work_queue,
-                                         &ctx);
+  auto req = new MockValidatePoolRequest(m_ioctx, &ctx);
   req->send();
   ASSERT_EQ(-EPERM, ctx.wait());
 }
@@ -203,8 +197,7 @@ TEST_F(TestMockImageValidatePoolRequest, RemoveSnapshotError) {
   expect_write_rbd_info(mock_io_ctx, "overwrite validated", 0);
 
   C_SaferCond ctx;
-  auto req = new MockValidatePoolRequest(m_ioctx, image_ctx->op_work_queue,
-                                         &ctx);
+  auto req = new MockValidatePoolRequest(m_ioctx, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -221,8 +214,7 @@ TEST_F(TestMockImageValidatePoolRequest, OverwriteError) {
   expect_write_rbd_info(mock_io_ctx, "overwrite validated", -EOPNOTSUPP);
 
   C_SaferCond ctx;
-  auto req = new MockValidatePoolRequest(m_ioctx, image_ctx->op_work_queue,
-                                         &ctx);
+  auto req = new MockValidatePoolRequest(m_ioctx, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52559

---

backport of https://github.com/ceph/ceph/pull/43086
parent tracker: https://tracker.ceph.com/issues/52537