### PR TITLE
Revert "rgw: permit logging of list-bucket (and any other no-bucket op)"

### DIFF
--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -367,33 +367,32 @@ int rgw_log_op(rgw::sal::Store* store, RGWREST* const rest, struct req_state *s,
     return 0;
 
   if (s->bucket_name.empty()) {
-    /* this case is needed for, e.g., list_buckets */
-  } else {
-    if (s->err.ret == -ERR_NO_SUCH_BUCKET ||
-	rgw::sal::Bucket::empty(s->bucket.get())) {
-      if (!s->cct->_conf->rgw_log_nonexistent_bucket) {
-	ldout(s->cct, 5) << "bucket " << s->bucket_name << " doesn't exist, not logging" << dendl;
-	return 0;
-      }
-      bucket_id = "";
-    } else {
-      bucket_id = s->bucket->get_bucket_id();
-    }
-    entry.bucket = rgw_make_bucket_entry_name(s->bucket_tenant, s->bucket_name);
-
-    if (check_utf8(entry.bucket.c_str(), entry.bucket.size()) != 0) {
-      ldpp_dout(s, 5) << "not logging op on bucket with non-utf8 name" << dendl;
+    ldpp_dout(s, 5) << "nothing to log for operation" << dendl;
+    return -EINVAL;
+  }
+  if (s->err.ret == -ERR_NO_SUCH_BUCKET || rgw::sal::Bucket::empty(s->bucket.get())) {
+    if (!s->cct->_conf->rgw_log_nonexistent_bucket) {
+      ldpp_dout(s, 5) << "bucket " << s->bucket_name << " doesn't exist, not logging" << dendl;
       return 0;
     }
+    bucket_id = "";
+  } else {
+    bucket_id = s->bucket->get_bucket_id();
+  }
+  entry.bucket = rgw_make_bucket_entry_name(s->bucket_tenant, s->bucket_name);
 
-    if (!rgw::sal::Object::empty(s->object.get())) {
-      entry.obj = s->object->get_key();
-    } else {
-      entry.obj = rgw_obj_key("-");
-    }
+  if (check_utf8(entry.bucket.c_str(), entry.bucket.size()) != 0) {
+    ldpp_dout(s, 5) << "not logging op on bucket with non-utf8 name" << dendl;
+    return 0;
+  }
 
-    entry.obj_size = s->obj_size;
-  } /* !bucket empty */
+  if (!rgw::sal::Object::empty(s->object.get())) {
+    entry.obj = s->object->get_key();
+  } else {
+    entry.obj = rgw_obj_key("-");
+  }
+
+  entry.obj_size = s->obj_size;
 
   if (s->cct->_conf->rgw_remote_addr_param.length())
     set_param_str(s, s->cct->_conf->rgw_remote_addr_param.c_str(),


### PR DESCRIPTION
This reverts commit 3863eb89512f1698b8e56f1f1ffc78a6ca8d5826.

The commit correlates with segfaults:

*** Caught signal (Segmentation fault) **
 in thread 7fbf42c36700 thread_name:radosgw
 ceph version 17.0.0-7472-g0eb1a794 (0eb1a7943dd70e2a0b3086ea680284137a187e73) quincy (dev)
 1: /lib64/libpthread.so.0(+0x12b20) [0x7fbf98735b20]
 2: (rgw_log_op(rgw::sal::Store*, RGWREST*, req_state*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, OpsLogSocket*)+0x5be) [0x7fbf9b33276e]
 3: (process_request(rgw::sal::Store*, RGWREST*, RGWRequest*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rgw::auth::StrategyRegistry const&, RGWRestfulIO*, OpsLogSocket*, optional_yield, rgw::dmclock::Scheduler*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >*, int*)+0x1864) [0x7fbf9b3504d4]
 4: /lib64/libradosgw.so.2(+0x533c3d) [0x7fbf9b283c3d]
 5: /lib64/libradosgw.so.2(+0x535220) [0x7fbf9b285220]
 6: /lib64/libradosgw.so.2(+0x53537c) [0x7fbf9b28537c]
 7: make_fcontext()

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>

Fixes: https://tracker.ceph.com/issues/52530