### PR TITLE
cephadm: raise error during `pull` failure

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3491,12 +3491,12 @@ def _pull_image(ctx, image):
             return
 
         if not any(pattern in err for pattern in ignorelist):
-            raise RuntimeError('Failed command: %s' % cmd_str)
+            raise Error('Failed command: %s' % cmd_str)
 
         logger.info('`%s` failed transiently. Retrying. waiting %s seconds...' % (cmd_str, sleep_secs))
         time.sleep(sleep_secs)
 
-    raise RuntimeError('Failed command: %s: maximum retries reached' % cmd_str)
+    raise Error('Failed command: %s: maximum retries reached' % cmd_str)
 
 ##################################
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1568,3 +1568,29 @@ class TestRmRepo:
 
         ctx.container_engine = mock_docker()
         cd.command_rm_repo(ctx)
+
+
+class TestPull:
+
+    @mock.patch('time.sleep')
+    @mock.patch('cephadm.call', return_value=('', '', 0))
+    @mock.patch('cephadm.get_image_info_from_inspect', return_value={})
+    def test_error(self, get_image_info_from_inspect, call, sleep):
+        ctx = cd.CephadmContext()
+        ctx.container_engine = mock_podman()
+
+        call.return_value = ('', '', 0)
+        retval = cd.command_pull(ctx)
+        assert retval == 0
+
+        err = 'maximum retries reached'
+
+        call.return_value = ('', 'foobar', 1)
+        with pytest.raises(cd.Error) as e:
+            cd.command_pull(ctx)
+        assert err not in str(e.value)
+
+        call.return_value = ('', 'net/http: TLS handshake timeout', 1)
+        with pytest.raises(cd.Error) as e:
+            cd.command_pull(ctx)
+        assert err in str(e.value)


### PR DESCRIPTION
instead of a traceback to the console

```
$ cephadm --image foobar pull
Pulling container image foobar...
Non-zero exit code 125 from /usr/bin/podman pull foobar
/usr/bin/podman: stderr Resolving "foobar" using unqualified-search registries (/etc/containers/registries.conf)
/usr/bin/podman: stderr Trying to pull registry.opensuse.org/foobar:latest...
/usr/bin/podman: stderr Trying to pull docker.io/library/foobar:latest...
/usr/bin/podman: stderr Error: 2 errors occurred while pulling:
/usr/bin/podman: stderr  * Error initializing source docker://registry.opensuse.org/foobar:latest: Error reading manifest latest in registry.opensuse.org/foobar: name unknown
/usr/bin/podman: stderr  * Error initializing source docker://foobar:latest: Error reading manifest latest in docker.io/library/foobar: errors:
/usr/bin/podman: stderr denied: requested access to the resource is denied
/usr/bin/podman: stderr unauthorized: authentication required
/usr/bin/podman: stderr 
Traceback (most recent call last):
  File "../src/cephadm/cephadm", line 8510, in <module>
    main()
  File "../src/cephadm/cephadm", line 8498, in main
    r = ctx.func(ctx)
  File "../src/cephadm/cephadm", line 1768, in _infer_image
    return func(ctx)
  File "../src/cephadm/cephadm", line 3469, in command_pull
    _pull_image(ctx, ctx.image)
  File "../src/cephadm/cephadm", line 3494, in _pull_image
    raise RuntimeError('Failed command: %s' % cmd_str)
RuntimeError: Failed command: /usr/bin/podman pull foobar 
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
