### PR TITLE
doc/radosgw/adminops: add PHP binding libraries 

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -1976,7 +1976,7 @@ Binding libraries
  - `QuentinPerez/go-radosgw`_
 
 ``Java``
- 
+
  - `twonote/radosgw-admin4j`_
 
 ``PHP``
@@ -2000,4 +2000,3 @@ Binding libraries
 .. _myENA/php-rgw-api: https://github.com/myENA/php-rgw-api
 .. _UMIACS/rgwadmin: https://github.com/UMIACS/rgwadmin
 .. _valerytschopp/python-radosgw-admin: https://github.com/valerytschopp/python-radosgw-admin
-

--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -1979,6 +1979,11 @@ Binding libraries
  
  - `twonote/radosgw-admin4j`_
 
+``PHP``
+
+ - `lbausch/php-ceph-radosgw-admin`_
+ - `myENA/php-rgw-api`_
+
 ``Python``
 
  - `UMIACS/rgwadmin`_
@@ -1991,6 +1996,8 @@ Binding libraries
 .. _IrekFasikhov/go-rgwadmin: https://github.com/IrekFasikhov/go-rgwadmin
 .. _QuentinPerez/go-radosgw: https://github.com/QuentinPerez/go-radosgw
 .. _twonote/radosgw-admin4j: https://github.com/twonote/radosgw-admin4j
+.. _lbausch/php-ceph-radosgw-admin: https://github.com/lbausch/php-ceph-radosgw-admin
+.. _myENA/php-rgw-api: https://github.com/myENA/php-rgw-api
 .. _UMIACS/rgwadmin: https://github.com/UMIACS/rgwadmin
 .. _valerytschopp/python-radosgw-admin: https://github.com/valerytschopp/python-radosgw-admin
 


### PR DESCRIPTION
This adds some PHP binding libraries for the Admin OPS API. Disclaimer: I maintain one of them (`lbausch/php-ceph-radosgw-admin`).

## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
