### PR TITLE
crimson/os/seastore: minimize the static size of onode_layout_t 

### DIFF
--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -14,11 +14,8 @@
 namespace crimson::os::seastore {
 
 struct onode_layout_t {
-  // around 350 bytes for fixed fields in object_info_t,
-  // the left are for the variable-sized fields like oid
-  // FIXME: object_info_t may need to shrinked, at least
-  // 	    oid doesn't need to be held in it.
-  static constexpr int MAX_OI_LENGTH = 1024;
+  // The expected decode size of object_info_t without oid.
+  static constexpr int MAX_OI_LENGTH = 232;
   // We might want to move the ss field out of onode_layout_t.
   // The reason is that ss_attr may grow to relative large, as
   // its clone_overlap may grow to a large size, if applications
@@ -26,7 +23,9 @@ struct onode_layout_t {
   // the number of objects per OSD, so that all objects' metadata
   // can be cached in memory) and do many modifications between
   // snapshots.
-  static constexpr int MAX_SS_LENGTH = 128;
+  // TODO: implement flexible-sized onode value to store inline ss_attr
+  // effectively.
+  static constexpr int MAX_SS_LENGTH = 1;
 
   ceph_le32 size{0};
   ceph_le32 oi_size{0};

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -83,7 +83,7 @@ PGBackend::load_metadata(const hobject_t& oid)
 	if (auto oiiter = attrs.find(OI_ATTR); oiiter != attrs.end()) {
 	  bufferlist bl = std::move(oiiter->second);
 	  ret->os = ObjectState(
-	    object_info_t(bl),
+	    object_info_t(bl, oid),
 	    true);
 	} else {
 	  logger().error(
@@ -151,7 +151,7 @@ PGBackend::mutate_object(
     // object_info_t
     {
       ceph::bufferlist osv;
-      encode(obc->obs.oi, osv, CEPH_FEATURES_ALL);
+      obc->obs.oi.encode_no_oid(osv, CEPH_FEATURES_ALL);
       // TODO: get_osdmap()->get_features(CEPH_ENTITY_TYPE_OSD, nullptr));
       txn.setattr(coll->get_cid(), ghobject_t{obc->obs.oi.soid}, OI_ATTR, osv);
     }

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -462,7 +462,7 @@ ReplicatedRecoveryBackend::read_metadata_for_push_op(
     }
     logger().debug("read_metadata_for_push_op: {}", push_op->attrset[OI_ATTR]);
     object_info_t oi;
-    oi.decode(push_op->attrset[OI_ATTR]);
+    oi.decode_no_oid(push_op->attrset[OI_ATTR]);
     new_progress.first = false;
     return oi.version;
   });
@@ -656,7 +656,7 @@ ReplicatedRecoveryBackend::_handle_pull_response(
       pi.recovery_info.soid, [&pi, &recovery_waiter, &pop](auto obc) {
         pi.obc = obc;
         recovery_waiter.obc = obc;
-        obc->obs.oi.decode(pop.attrset.at(OI_ATTR));
+        obc->obs.oi.decode_no_oid(pop.attrset.at(OI_ATTR), pop.soid);
         pi.recovery_info.oi = obc->obs.oi;
         return crimson::osd::PG::load_obc_ertr::now();
       }).handle_error_interruptible(crimson::ct_error::assert_all{});
@@ -955,7 +955,8 @@ ReplicatedRecoveryBackend::prep_push_target(
   if (!complete || !recovery_info.object_exist) {
     t->remove(coll->get_cid(), target_oid);
     t->touch(coll->get_cid(), target_oid);
-    object_info_t oi(attrs.at(OI_ATTR));
+    object_info_t oi;
+    oi.decode_no_oid(attrs.at(OI_ATTR));
     t->set_alloc_hint(coll->get_cid(), target_oid,
                       oi.expected_object_size,
                       oi.expected_write_size,

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5912,6 +5912,28 @@ struct object_info_t {
     auto p = std::cbegin(bl);
     decode(p);
   }
+
+  void encode_no_oid(ceph::buffer::list& bl, uint64_t features) {
+    // TODO: drop soid field and remove the denc no_oid methods
+    auto tmp_oid = hobject_t(hobject_t::get_max());
+    tmp_oid.swap(soid);
+    encode(bl, features);
+    soid = tmp_oid;
+  }
+  void decode_no_oid(ceph::buffer::list::const_iterator& bl) {
+    decode(bl);
+    ceph_assert(soid.is_max());
+  }
+  void decode_no_oid(const ceph::buffer::list& bl) {
+    auto p = std::cbegin(bl);
+    decode_no_oid(p);
+  }
+  void decode_no_oid(const ceph::buffer::list& bl, const hobject_t& _soid) {
+    auto p = std::cbegin(bl);
+    decode_no_oid(p);
+    soid = _soid;
+  }
+
   void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<object_info_t*>& o);
 
@@ -5934,6 +5956,11 @@ struct object_info_t {
 
   explicit object_info_t(const ceph::buffer::list& bl) {
     decode(bl);
+  }
+
+  explicit object_info_t(const ceph::buffer::list& bl, const hobject_t& _soid) {
+    decode_no_oid(bl);
+    soid = _soid;
   }
 };
 WRITE_CLASS_ENCODER_FEATURES(object_info_t)


### PR DESCRIPTION
This reduces the onode-tree write amplification (MUTATE transaction) from ~1.6 to ~0.3, which is 5+ times better:
Before:
![before-1](https://user-images.githubusercontent.com/7736006/132826506-de0e8a31-3182-485b-aabb-3fc8bf24c398.png)
After:
![after-1](https://user-images.githubusercontent.com/7736006/132826533-9d4dc0d9-c003-4eb9-b9e5-e43b4c270574.png)

However, the test doesn't write other types of attrs. We still need to implement flexible-sized onode value for better performance in more common scenarios.

Apart from that, the major write amplification now comes from inefficient cleaning and high transaction conflict rate, see:
![after-2](https://user-images.githubusercontent.com/7736006/132828000-df6d44ad-8c42-4112-9355-97c1a2f99434.png)
![invalidate-ratio](https://user-images.githubusercontent.com/7736006/132828029-e09f436d-58d2-44ef-8725-9cb2be05cf14.png)

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
