### PR TITLE
client: choose the auth mds to avoid possible forward traffics

### DIFF
--- a/src/client/MetaRequest.h
+++ b/src/client/MetaRequest.h
@@ -202,9 +202,15 @@ public:
   bool auth_is_best() {
     if ((head.op & CEPH_MDS_OP_WRITE) || head.op == CEPH_MDS_OP_OPEN ||
         (head.op == CEPH_MDS_OP_GETATTR && (head.args.getattr.mask & CEPH_STAT_RSTAT)) ||
-	head.op == CEPH_MDS_OP_READDIR || send_to_auth) 
+	head.op == CEPH_MDS_OP_READDIR || head.op == CEPH_MDS_OP_MKNOD ||
+	head.op == CEPH_MDS_OP_SYMLINK || head.op == CEPH_MDS_OP_LINK ||
+	head.op == CEPH_MDS_OP_UNLINK || head.op == CEPH_MDS_OP_RENAME ||
+	head.op == CEPH_MDS_OP_SETLAYOUT || head.op == CEPH_MDS_OP_SETDIRLAYOUT ||
+	head.op == CEPH_MDS_OP_SETXATTR || head.op == CEPH_MDS_OP_RMXATTR ||
+	head.op == CEPH_MDS_OP_SETFILELOCK || head.op == CEPH_MDS_OP_SETATTR ||
+	send_to_auth)
       return true;
-    return false;    
+    return false;
   }
 
   void dump(Formatter *f) const;


### PR DESCRIPTION
For some client requests if we send them to the none auth mds, then
in the mds side it may forward that requst to auth mds directly or
when if it needs to do the authpin or xlock it will send extra
requests to the auth mds, which will slow down the perf.

In client side always try to use the auth mds first if possible for
those requests.

Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
