### PR TITLE
qa/tasks/rook: test reapplication of drive groups stored in mgr

### DIFF
--- a/qa/suites/orch/rook/smoke/3-final.yaml
+++ b/qa/suites/orch/rook/smoke/3-final.yaml
@@ -1,4 +1,38 @@
 tasks:
+- exec:
+    host.a:
+      - |
+        set -ex
+        toolbox() {
+            kubectl -n rook-ceph exec -it deploy/rook-ceph-tools --  "$@"
+        }
+        orig_num_osd=`toolbox ceph osd stat | cut -f3 -d " "`
+        toolbox ceph orch osd rm 0 --force
+        removed_pv=""
+        while [ "$removed_pv" = "" ]
+        do
+            removed_pv=`kubectl get pv | grep Released | cut -f1 -d " "`
+            sleep 3s
+        done
+        target_path=`kubectl get pv $removed_pv -o jsonpath='{.spec.local.path}'`
+        host=`echo $removed_pv | cut -f1 -d "-"`
+        toolbox ceph orch device zap $host $target_path --force
+        zap_completion="0"
+        while [ "$zap_completion" = "0"  ]
+        do
+            zap_completion=`kubectl get job -n rook-ceph rook-ceph-device-zap -o jsonpath='{.status.succeeded.path}'`
+            sleep 3s
+        done
+        kubectl patch pv $removed_pv -p '{"spec":{"claimRef": null}}'
+        toolbox ceph orch apply osd --all-available-devices
+        kubectl delete job rook-ceph-device-zap -n rook-ceph
+        num_osd="0"
+        while [ "$num_osd" != "$orig_num_osd" ]
+        do
+            echo "waiting for osd to come back up"
+            num_osd=`toolbox ceph osd stat | cut -f3 -d " "`
+            sleep 30s
+        done
 - rook.shell:
     commands:
       - ceph orch status

--- a/qa/suites/orch/rook/smoke/rook/1.7.0.yaml
+++ b/qa/suites/orch/rook/smoke/rook/1.7.0.yaml
@@ -1,4 +1,0 @@
-overrides:
-  rook:
-    rook_image: rook/ceph:v1.7.0
-    rook_branch: v1.7.0

--- a/qa/suites/orch/rook/smoke/rook/1.7.2.yaml
+++ b/qa/suites/orch/rook/smoke/rook/1.7.2.yaml
@@ -1,0 +1,4 @@
+overrides:
+  rook:
+    rook_image: rook/ceph:v1.7.2
+    rook_branch: v1.7.2

--- a/qa/tasks/kubeadm.py
+++ b/qa/tasks/kubeadm.py
@@ -468,7 +468,7 @@ def setup_pvs(ctx, config):
                     'volumeMode': 'Block',
                     'accessModes': ['ReadWriteOnce'],
                     'capacity': {'storage': '100Gi'},  # doesn't matter?
-                    'persistentVolumeReclaimPolicy': 'Recycle',
+                    'persistentVolumeReclaimPolicy': 'Retain',
                     'storageClassName': 'scratch',
                     'local': {'path': dev},
                     'nodeAffinity': {

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -423,7 +423,6 @@ class DefaultCreator():
             ]
             for device in to_create:
                 new_scds = self.device_to_device_set(drive_group, device)
-                new_cluster.spec.storage.storageClassDeviceSets.append(new_scds)
                 if new_scds.name not in existing_scds:
                     new_cluster.spec.storage.storageClassDeviceSets.append(new_scds)
             return new_cluster
@@ -1187,6 +1186,7 @@ class RookCluster(object):
                                     )
                                 ],
                                 security_context=client.V1SecurityContext(
+                                    run_as_user=0,
                                     privileged=True
                                 ),
                                 volume_mounts=[


### PR DESCRIPTION
This commit adds testing for the drive_group_loop in the Rook orchestrator
that reapplies drive groups that were applied previously.

This test removes an OSD, zaps the underlying device then waits for the OSD
to be re-created by the drive_group_loop.

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>

Depends on  #43138

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
