### PR TITLE
crimson/os: allow to build crimson when WITH_BLUESTORE=OFF

### DIFF
--- a/src/crimson/os/CMakeLists.txt
+++ b/src/crimson/os/CMakeLists.txt
@@ -5,11 +5,12 @@ add_subdirectory(cyanstore)
 
 if(WITH_BLUESTORE)
   add_subdirectory(alienstore)
+  set(alienstore_lib crimson-alienstore)
 endif()
 
 add_subdirectory(seastore)
 target_link_libraries(crimson-os
   crimson-cyanstore
-  crimson-alienstore
+  ${alienstore_lib}
   crimson-seastore
   crimson)

--- a/src/crimson/os/futurized_store.cc
+++ b/src/crimson/os/futurized_store.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "futurized_store.h"
 #include "cyanstore/cyan_store.h"
 #ifdef WITH_BLUESTORE

--- a/src/crimson/os/futurized_store.cc
+++ b/src/crimson/os/futurized_store.cc
@@ -1,6 +1,8 @@
 #include "futurized_store.h"
 #include "cyanstore/cyan_store.h"
+#ifdef WITH_BLUESTORE
 #include "alienstore/alien_store.h"
+#endif
 #include "seastore/seastore.h"
 
 namespace crimson::os {
@@ -15,9 +17,14 @@ FuturizedStore::create(const std::string& type,
   } else if (type == "seastore") {
     return crimson::os::seastore::make_seastore(data, values);
   } else {
+#ifdef WITH_BLUESTORE
     // use AlienStore as a fallback. It adapts e.g. BlueStore.
     return std::make_unique<crimson::os::AlienStore>(
       type, data, values);
+#else
+    ceph_abort_msgf("unsupported objectstore type: %s", type.c_str());
+    return {};
+#endif
   }
 }
 


### PR DESCRIPTION
This lets to ensure nobody is accidentally linking with the alienized version of `common`.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
