### PR TITLE
pacific: cmake: link Threads::Threads instead of CMAKE_THREAD_LIBS_INIT

### DIFF
--- a/cmake/modules/Buildpmem.cmake
+++ b/cmake/modules/Buildpmem.cmake
@@ -33,10 +33,11 @@ function(build_pmem)
   add_library(pmem::pmem STATIC IMPORTED)
   add_dependencies(pmem::pmem pmdk_ext)
   file(MAKE_DIRECTORY ${PMDK_INCLUDE})
+  find_package(Threads)
   set_target_properties(pmem::pmem PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES ${PMDK_INCLUDE}
     IMPORTED_LOCATION "${PMDK_LIB}/libpmem.a"
-    INTERFACE_LINK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+    INTERFACE_LINK_LIBRARIES Threads::Threads)
 
   # libpmemobj
   add_library(pmem::pmemobj STATIC IMPORTED)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52610

---

backport of https://github.com/ceph/ceph/pull/42870
parent tracker: https://tracker.ceph.com/issues/52353