### PR TITLE
workunits/rgw: semicolon terminates perl statements

### DIFF
--- a/qa/workunits/rgw/s3_utilities.pm
+++ b/qa/workunits/rgw/s3_utilities.pm
@@ -154,7 +154,7 @@ sub ceph_os_info
         my $ceph_v = get_command_output ( "ceph -v" );
         my @ceph_arr = split(" ",$ceph_v);
         $ceph_v = "Ceph Version:   $ceph_arr[2]";
-        my $os_distro = os_pretty_name()
+        my $os_distro = os_pretty_name();
         $os_distro = "Linux Flavor:$os_distro";
         return ($ceph_v, $os_distro);
 }


### PR DESCRIPTION
Fixes a lexical error in one line of code added in
90e9307ab0a52da260bc1ebb50329cd8ff942eb9, removing the dependency
on lsb_release, on 8/16/2021.

Fixes: https://tracker.ceph.com/issues/52613

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
(cherry picked from commit 221fdb858be083a981697cdb59c19f0659be3f1d)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
