### PR TITLE
ceph-volume: lvm/activate fix args parsing

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -265,13 +265,8 @@ class Activate(object):
 
         if osd_id and osd_fsid:
             tags = {'ceph.osd_id': osd_id, 'ceph.osd_fsid': osd_fsid}
-        elif not osd_id and osd_fsid:
-            tags = {'ceph.osd_fsid': osd_fsid}
-        elif osd_id and not osd_fsid:
-            raise RuntimeError('could not activate osd.{}, please provide the '
-                               'osd_fsid too'.format(osd_id))
         else:
-            raise RuntimeError('Please provide both osd_id and osd_fsid')
+            raise RuntimeError('Please provide both osd_id and osd_fsid.')
         lvs = api.get_lvs(tags=tags)
         if not lvs:
             raise RuntimeError('could not find osd.%s with osd_fsid %s' %

--- a/src/ceph-volume/ceph_volume/devices/lvm/create.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/create.py
@@ -25,6 +25,8 @@ class Create(object):
         prepare_step = Prepare([])
         prepare_step.safe_prepare(args)
         osd_id = prepare_step.osd_id
+        if not args.osd_id:
+            args.osd_id = osd_id
         try:
             # we try this for activate only when 'creating' an OSD, because a rollback should not
             # happen when doing normal activation. For example when starting an OSD, systemd will call


### PR DESCRIPTION
In 'lvm activate', both osd_id and osd_fsid are required.
See the documentation [1].
By the way, they are positional arguments. It means it would be
difficult for ceph-volume to detect which one would be passed when only
passing one of those two parameters.

[1] https://docs.ceph.com/en/pacific/ceph-volume/lvm/activate/

Fixes: https://tracker.ceph.com/issues/52619

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
