### PR TITLE
cmake,rgw: use jaeger-base target, as a dependency for building dbstore

### DIFF
--- a/cmake/modules/BuildJaeger.cmake
+++ b/cmake/modules/BuildJaeger.cmake
@@ -79,7 +79,7 @@ function(build_jaeger)
     INSTALL_COMMAND ${install_cmd}
     DEPENDS ${dependencies}
     BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/external/lib/libjaegertracing.so
-    )
+    LOG_BUILD ON)
 
   set_library_properties_for_external_project(opentracing::libopentracing
   opentracing)

--- a/cmake/modules/BuildOpenTracing.cmake
+++ b/cmake/modules/BuildOpenTracing.cmake
@@ -32,5 +32,5 @@ function(build_opentracing)
     BUILD_COMMAND ${make_cmd}
     INSTALL_COMMAND ${install_cmd}
     BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/external/lib/libopentracing.so
-    )
+    LOG_BUILD ON)
 endfunction()

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -169,6 +169,9 @@ if(WITH_RADOSGW_DBSTORE)
   add_subdirectory(store/dbstore)
   list(APPEND librgw_common_srcs rgw_sal_dbstore.cc)
 endif()
+if(WITH_JAEGER)
+  list(APPEND librgw_common_srcs rgw_tracer.cc)
+endif()
 
 add_library(rgw_common STATIC ${librgw_common_srcs})
 
@@ -240,6 +243,7 @@ endif()
 
 if(WITH_JAEGER)
   add_dependencies(rgw_common jaeger-base)
+  target_link_libraries(rgw_common PUBLIC jaeger-base)
 endif()
 
 if(WITH_RADOSGW_DBSTORE)

--- a/src/rgw/store/dbstore/CMakeLists.txt
+++ b/src/rgw/store/dbstore/CMakeLists.txt
@@ -19,7 +19,11 @@ set(dbstore_mgr_srcs
 add_library(dbstore_lib ${dbstore_srcs})
 target_include_directories(dbstore_lib PUBLIC "${CMAKE_SOURCE_DIR}/src/fmt/include")
 target_include_directories(dbstore_lib PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw")
-target_link_libraries(dbstore_lib PUBLIC spawn)
+set(link_targets spawn)
+if(WITH_JAEGER)
+  list(APPEND link_targets jaeger-base)
+endif()
+target_link_libraries(dbstore_lib PUBLIC ${link_targets})
 
 set (CMAKE_LINK_LIBRARIES ${CMAKE_LINK_LIBRARIES} dbstore_lib)
 


### PR DESCRIPTION
Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
