### PR TITLE
crimson/os/seastore/cache: Cache::get_root check for invalid

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -623,14 +623,15 @@ void Cache::invalidate(CachedExtent &extent)
   for (auto &&i: extent.transactions) {
     if (!i.t->conflicted) {
       assert(!i.t->is_weak());
-      invalidate(*i.t, extent);
+      mark_transaction_conflicted(*i.t, extent);
     }
   }
   DEBUG("invalidate end");
   extent.state = CachedExtent::extent_state_t::INVALID;
 }
 
-void Cache::invalidate(Transaction& t, CachedExtent& conflicting_extent)
+void Cache::mark_transaction_conflicted(
+  Transaction& t, CachedExtent& conflicting_extent)
 {
   LOG_PREFIX(Cache::invalidate);
   assert(!t.conflicted);
@@ -1127,7 +1128,7 @@ Cache::get_next_dirty_extents_ret Cache::get_next_dirty_extents(
 	    ext->wait_io()
 	  ).then_interruptible([FNAME, this, ext, &t, &ret] {
 	    if (!ext->is_valid()) {
-	      invalidate(t, *ext);
+	      mark_transaction_conflicted(t, *ext);
 	      return;
 	    }
 

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1171,12 +1171,18 @@ Cache::get_root_ret Cache::get_root(Transaction &t)
   } else {
     auto ret = root;
     DEBUGT("waiting root {}", t, *ret);
-    return ret->wait_io().then([FNAME, ret, &t] {
+    return ret->wait_io().then([this, FNAME, ret, &t] {
       DEBUGT("got root read {}", t, *ret);
-      t.root = ret;
-      t.add_to_read_set(ret);
-      return get_root_iertr::make_ready_future<RootBlockRef>(
-	ret);
+      if (!ret->is_valid()) {
+	DEBUGT("root became invalid: {}", t, *ret);
+	mark_transaction_conflicted(t, *ret);
+	return get_root_iertr::make_ready_future<RootBlockRef>();
+      } else {
+	t.root = ret;
+	t.add_to_read_set(ret);
+	return get_root_iertr::make_ready_future<RootBlockRef>(
+	  ret);
+      }
     });
   }
 }

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -320,7 +320,7 @@ public:
 	(void)this; // silence incorrect clang warning about capture
 	if (!ref->is_valid()) {
 	  DEBUGT("got invalid extent: {}", t, ref);
-	  invalidate(t, *ref);
+	  mark_transaction_conflicted(t, *ref);
 	  return get_extent_iertr::make_ready_future<TCachedExtentRef<T>>();
 	} else {
 	  DEBUGT(
@@ -372,7 +372,7 @@ public:
         if (!ret->is_valid()) {
           LOG_PREFIX(Cache::get_extent_by_type);
           DEBUGT("got invalid extent: {}", t, ret);
-          invalidate(t, *ret.get());
+          mark_transaction_conflicted(t, *ret.get());
           return get_extent_ertr::make_ready_future<CachedExtentRef>();
         } else {
           t.add_to_read_set(ret);
@@ -756,7 +756,8 @@ private:
   void invalidate(CachedExtent &extent);
 
   /// Mark a valid transaction as conflicted
-  void invalidate(Transaction& t, CachedExtent& conflicting_extent);
+  void mark_transaction_conflicted(
+    Transaction& t, CachedExtent& conflicting_extent);
 
   /// Introspect transaction when it is being destructed
   void on_transaction_destruct(Transaction& t);


### PR DESCRIPTION
As with Cache::get_extent, we need to check that the ref
is still valid after wait_io since it's not in the
read set yet.

Fixes: https://tracker.ceph.com/issues/52623
Signed-off-by: Samuel Just <sjust@redhat.com>