### PR TITLE
crimson/onode-staged-tree: evaluate transacaction conflicts due to fix_parent_index()

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -700,6 +700,14 @@ private:
     uint64_t lba_tree_depth;
     counter_by_src_t<tree_efforts_t> committed_lba_tree_efforts;
     counter_by_src_t<tree_efforts_t> invalidated_lba_tree_efforts;
+
+    uint64_t invalidated_trans = 0;
+    uint64_t invalidated_trans_due_to_onode_fix = 0;
+    uint64_t num_committed_onode_modify = 0;
+    uint64_t num_committed_onode_modify_with_fix = 0;
+    uint64_t num_trans_committed = 0;
+    uint64_t num_trans_committed_with_onode_modify = 0;
+    uint64_t num_trans_committed_with_onode_modify_with_fix = 0;
   } stats;
 
   template <typename CounterT>

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -99,7 +99,18 @@ class CachedExtent : public boost::intrusive_ref_counter<
   // Points at current version while in state MUTATION_PENDING
   CachedExtentRef prior_instance;
 
+  bool is_marked_onode_fixing = false;
+
 public:
+  void onode_mark_fixing() {
+    ceph_assert(!is_marked_onode_fixing);
+    is_marked_onode_fixing = true;
+  }
+
+  bool onode_get_is_marked_fixing() const {
+    return is_marked_onode_fixing;
+  }
+
   /**
    *  duplicate_for_write
    *

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
@@ -48,6 +48,11 @@ NodeExtentRef SeastoreNodeExtent::mutate(
     context_t c, DeltaRecorderURef&& _recorder)
 {
   DEBUGT("mutate {} ...", c.t, *this);
+  if (c.t.onode_is_fixing()) {
+    if (this->get_header().level >= c.t.onode_get_fixing_level()) {
+      c.t.onode_mark_extent_fixing(this);
+    }
+  }
   auto p_handle = static_cast<TransactionManagerHandle*>(&c.nm);
   auto extent = p_handle->tm.get_mutable_extent(c.t, this);
   auto ret = extent->cast<SeastoreNodeExtent>();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -147,6 +147,11 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
 
   retire_iertr::future<> retire_extent(
       Transaction& t, NodeExtentRef _extent) override {
+    if (t.onode_is_fixing()) {
+      if (_extent->get_header().level >= t.onode_get_fixing_level()) {
+        t.onode_mark_extent_fixing(_extent);
+      }
+    }
     LogicalCachedExtentRef extent = _extent;
     auto addr = extent->get_laddr();
     auto len = extent->get_length();


### PR DESCRIPTION
This PR is aimed to understand the transaction conflicts due to recursive call to `fix_parent_index()`, not target to merge.

The current result shows `fix_parent_index()` is rare (0 during 100s random write) during rados-bench, because `fix_parent_index()` is mostly called during tree erase-merge operations rather than the insert-split operations.

@athanatos is there a common workload from rados-bench or rbd-bench that involves frequent onode-erase operations?

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
