### PR TITLE
pacific: mgr/prometheus: Fix metric types from gauge to counter

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -475,7 +475,7 @@ class Module(MgrModule):
         for state in DF_POOL:
             path = 'pool_{}'.format(state)
             metrics[path] = Metric(
-                'gauge',
+                'counter' if state in ('rd', 'rd_bytes', 'wr', 'wr_bytes') else 'gauge',
                 path,
                 'DF pool {}'.format(state),
                 ('pool_id',)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51979

---

backport of https://github.com/ceph/ceph/pull/42506
parent tracker: https://tracker.ceph.com/issues/51868

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh