### PR TITLE
pacific: mgr/dashboard: cephfs MDS Workload to use rate for counter type metric

### DIFF
--- a/monitoring/grafana/dashboards/cephfs-overview.json
+++ b/monitoring/grafana/dashboards/cephfs-overview.json
@@ -89,14 +89,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(ceph_objecter_op_r{ceph_daemon=~\"($mds_servers).*\"})",
+          "expr": "sum(rate(ceph_objecter_op_r{ceph_daemon=~\"($mds_servers).*\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Read Ops",
           "refId": "A"
         },
         {
-          "expr": "sum(ceph_objecter_op_w{ceph_daemon=~\"($mds_servers).*\"})",
+          "expr": "sum(rate(ceph_objecter_op_w{ceph_daemon=~\"($mds_servers).*\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Write Ops",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52251

---

backport of https://github.com/ceph/ceph/pull/41570
parent tracker: https://tracker.ceph.com/issues/51954

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh