### PR TITLE
osd/scrub: collecting scrub-related files into a separate directory

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -20,10 +20,10 @@
 #include "common/config.h"
 #include "OSD.h"
 #include "OpRequest.h"
-#include "scrubber/ScrubStore.h"
-#include "scrubber/pg_scrubber.h"
-#include "Session.h"
+#include "osd/scrubber/ScrubStore.h"
+#include "osd/scrubber/pg_scrubber.h"
 #include "osd/scheduler/OpSchedulerItem.h"
+#include "Session.h"
 
 #include "common/Timer.h"
 #include "common/perf_counters.h"

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -19,7 +19,7 @@
 #include "common/errno.h"
 #include "common/scrub_types.h"
 #include "ReplicatedBackend.h"
-#include "scrubber/ScrubStore.h"
+#include "osd/scrubber/ScrubStore.h"
 #include "ECBackend.h"
 #include "PGBackend.h"
 #include "OSD.h"

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -25,6 +25,8 @@
 #include <boost/intrusive_ptr.hpp>
 #include <boost/tuple/tuple.hpp>
 
+#include "PrimaryLogPG.h"
+
 #include "cls/cas/cls_cas_ops.h"
 #include "common/CDC.h"
 #include "common/EventTrace.h"
@@ -52,9 +54,9 @@
 #include "objclass/objclass.h"
 #include "osd/ClassHandler.h"
 #include "osdc/Objecter.h"
-#include "scrubber/PrimaryLogScrub.h"
-#include "scrubber/ScrubStore.h"
-#include "scrubber/pg_scrubber.h"
+#include "osd/scrubber/PrimaryLogScrub.h"
+#include "osd/scrubber/ScrubStore.h"
+#include "osd/scrubber/pg_scrubber.h"
 
 #include "OSD.h"
 #include "OpRequest.h"


### PR DESCRIPTION
NOTE - no logic change in this PR. Just moving some source files around.

Cleaning src/osd from scrub implementation files. Triggered by:
- the proliferation of scrub related code files (including multiple that are added in coming PRs);
- the conventions used in Crimson code, as some of the code will be shared;

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
