### PR TITLE
crimson/net: fix dangling addrvec in SocketMessenger::bind().

### DIFF
--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -134,7 +134,7 @@ SocketMessenger::bind(const entity_addrvec_t& addrs)
 {
   using crimson::common::local_conf;
   return seastar::do_with(int64_t{local_conf()->ms_bind_retry_count},
-                          [this, &addrs] (auto& count) {
+                          [this, addrs] (auto& count) {
     return seastar::repeat_until_value([this, &addrs, &count] {
       assert(count >= 0);
       return try_bind(addrs,


### PR DESCRIPTION
`SocketMessenger::bind()` takes the address vector by `const&`.
while the callers in `OSD` are passing a temporary:

  ```cpp
  cluster_msgr->bind(pick_addresses(CEPH_PICK_ADDRESS_CLUSTER))
    // ...
  public_msgr->bind(pick_addresses(CEPH_PICK_ADDRESS_PUBLIC))
    // ...
  ```

  ```cpp
  entity_addrvec_t pick_addresses(int what) {
    // ...
    return addrs;
  }
  ```

The net result is a life-time mismatch and crashes like the following
one:

  ```
  WARN  2021-09-10 20:01:57,791 [shard 0] ms - [osd.0(client) v2:172.17.0.1:6800/3172806564@59988 >> mgr.? v2:172.17.0.7:6800/3846062660] waiting 3.2 seconds ...
  /opt/rh/gcc-toolset-9/root/usr/include/c++/9/bits/stl_iterator.h:820:17: runtime error: reference binding to misaligned address 0x000041b58ab3 for type 'const struct entity_addr_t', which requires 4 byte alignment
  0x000041b58ab3: note: pointer points here
  <memory cannot be printed>
  /opt/rh/gcc-toolset-9/root/usr/include/c++/9/bits/stl_vector.h:1132:16: runtime error: reference binding to misaligned address 0x000041b58ab3 for type 'const struct value_type', which requires 4 byte alignment
  0x000041b58ab3: note: pointer points here
  <memory cannot be printed>
  /home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/17.0.0-7486-g27cb19ed/rpm/el8/BUILD/ceph-17.0.0-7486-g27cb19ed/src/msg/msg_types.h:561:22: runtime error: reference binding to misaligned address 0x000041b58ab3 for type 'const struct entity_addr_t', which requires 4 byte alignment
  0x000041b58ab3: note: pointer points here
  <memory cannot be printed>
  Segmentation fault on shard 0.
  ```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
