### PR TITLE
pacific: cephfs-mirror: shutdown ClusterWatcher on termination

### DIFF
--- a/src/tools/cephfs_mirror/ClusterWatcher.cc
+++ b/src/tools/cephfs_mirror/ClusterWatcher.cc
@@ -172,7 +172,7 @@ void ClusterWatcher::handle_fsmap(const cref_t<MFSMap> &m) {
     }
   }
 
-  std::scoped_lock(m_lock);
+  std::scoped_lock locker(m_lock);
   if (!m_stopping) {
     m_monc->sub_got("fsmap", fsmap.get_epoch());
   } // else we have already done a sub_unwant()

--- a/src/tools/cephfs_mirror/ClusterWatcher.h
+++ b/src/tools/cephfs_mirror/ClusterWatcher.h
@@ -65,6 +65,7 @@ private:
   ServiceDaemon *m_service_daemon;
   Listener &m_listener;
 
+  bool m_stopping = false;
   std::map<Filesystem, Peers> m_filesystem_peers;
 
   void handle_fsmap(const cref_t<MFSMap> &m);

--- a/src/tools/cephfs_mirror/Mirror.cc
+++ b/src/tools/cephfs_mirror/Mirror.cc
@@ -222,7 +222,6 @@ Mirror::~Mirror() {
   {
     std::scoped_lock locker(m_lock);
     m_thread_pool->stop();
-    m_cluster_watcher.reset();
   }
 }
 
@@ -285,6 +284,7 @@ int Mirror::init(std::string &reason) {
 void Mirror::shutdown() {
   dout(20) << dendl;
   m_stopping = true;
+  m_cluster_watcher->shutdown();
   m_cond.notify_all();
 }
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/52444

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
