### PR TITLE
pacific: mgr/mirroring: remove unnecessary fs_name arg from daemon status command

### DIFF
--- a/doc/cephfs/cephfs-mirroring.rst
+++ b/doc/cephfs/cephfs-mirroring.rst
@@ -165,7 +165,7 @@ Mirroring Status
 
 CephFS mirroring module provides `mirror daemon status` interface to check mirror daemon status::
 
-  $ ceph fs snapshot mirror daemon status <fs_name>
+  $ ceph fs snapshot mirror daemon status
   [
     {
       "daemon_id": 284167,

--- a/doc/dev/cephfs-mirroring.rst
+++ b/doc/dev/cephfs-mirroring.rst
@@ -215,11 +215,11 @@ and/or peer updates.
 CephFS mirroring module provides `mirror daemon status` interface to check mirror daemon
 status::
 
-  $ ceph fs snapshot mirror daemon status <fs_name>
+  $ ceph fs snapshot mirror daemon status
 
 E.g::
 
-  $ ceph fs snapshot mirror daemon status a | jq
+  $ ceph fs snapshot mirror daemon status | jq
   [
     {
       "daemon_id": 284167,

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -237,8 +237,8 @@ class TestMirroring(CephFSTestCase):
         log.debug(f'command returned={res}')
         return json.loads(res)
 
-    def get_mirror_daemon_status(self, fs_name, fs_id):
-        daemon_status = json.loads(self.mgr_cluster.mon_manager.raw_cluster_cmd("fs", "snapshot", "mirror", "daemon", "status", fs_name))
+    def get_mirror_daemon_status(self):
+        daemon_status = json.loads(self.mgr_cluster.mon_manager.raw_cluster_cmd("fs", "snapshot", "mirror", "daemon", "status"))
         log.debug(f'daemon_status: {daemon_status}')
         # running a single mirror daemon is supported
         status = daemon_status[0]
@@ -657,7 +657,7 @@ class TestMirroring(CephFSTestCase):
         self.peer_add(self.primary_fs_name, self.primary_fs_id, "client.mirror_remote@ceph", self.secondary_fs_name)
 
         time.sleep(30)
-        status = self.get_mirror_daemon_status(self.primary_fs_name, self.primary_fs_id)
+        status = self.get_mirror_daemon_status()
 
         # assumption for this test: mirroring enabled for a single filesystem w/ single
         # peer
@@ -673,7 +673,7 @@ class TestMirroring(CephFSTestCase):
         self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
 
         time.sleep(120)
-        status = self.get_mirror_daemon_status(self.primary_fs_name, self.primary_fs_id)
+        status = self.get_mirror_daemon_status()
         # we added one
         peer = status['filesystems'][0]['peers'][0]
         self.assertEquals(status['filesystems'][0]['directory_count'], 1)
@@ -685,7 +685,7 @@ class TestMirroring(CephFSTestCase):
         self.mount_a.run_shell(["mkdir", "d0"])
 
         time.sleep(120)
-        status = self.get_mirror_daemon_status(self.primary_fs_name, self.primary_fs_id)
+        status = self.get_mirror_daemon_status()
         peer = status['filesystems'][0]['peers'][0]
         self.assertEquals(status['filesystems'][0]['directory_count'], 1)
         # failure and recovery count should be reflected

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -749,14 +749,9 @@ class FSSnapshotMirror:
         except MirrorException as me:
             return me.args[0], '', me.args[1]
 
-    def daemon_status(self, filesystem):
+    def daemon_status(self):
         try:
             with self.lock:
-                if not self.filesystem_exist(filesystem):
-                    raise MirrorException(-errno.ENOENT, f'filesystem {filesystem} does not exist')
-                fspolicy = self.pool_policy.get(filesystem, None)
-                if not fspolicy:
-                    raise MirrorException(-errno.EINVAL, f'filesystem {filesystem} is not mirrored')
                 daemons = []
                 sm = self.mgr.get('service_map')
                 daemon_entry = sm['services'].get('cephfs-mirror', None)

--- a/src/pybind/mgr/mirroring/module.py
+++ b/src/pybind/mgr/mirroring/module.py
@@ -97,7 +97,6 @@ class Module(MgrModule):
         return self.fs_snapshot_mirror.show_distribution(fs_name)
 
     @CLIReadCommand('fs snapshot mirror daemon status')
-    def snapshot_mirror_daemon_status(self,
-                                      fs_name: str):
+    def snapshot_mirror_daemon_status(self):
         """Get mirror daemon status"""
-        return self.fs_snapshot_mirror.daemon_status(fs_name)
+        return self.fs_snapshot_mirror.daemon_status()


### PR DESCRIPTION
https://tracker.ceph.com/issues/52627

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
