### PR TITLE
examples/librados: avoid a memory leak

### DIFF
--- a/examples/librados/hello_world.cc
+++ b/examples/librados/hello_world.cc
@@ -156,6 +156,7 @@ int main(int argc, const char **argv)
     if (ret < 0) {
       std::cerr << "couldn't start read object! error " << ret << std::endl;
       ret = EXIT_FAILURE;
+      read_completion->release();
       goto out;
     }
     // wait for the request to complete, and check that it succeeded.
@@ -164,6 +165,7 @@ int main(int argc, const char **argv)
     if (ret < 0) {
       std::cerr << "couldn't read object! error " << ret << std::endl;
       ret = EXIT_FAILURE;
+      read_completion->release();
       goto out;
     }
     std::cout << "we read our object " << object_name
@@ -171,6 +173,7 @@ int main(int argc, const char **argv)
     std::string read_string;
     read_buf.begin().copy(ret, read_string);
     std::cout << read_string << std::endl;
+    read_completion->release();
   }
 
   /*


### PR DESCRIPTION
Avoid a memory leak by deallocating the pre-allocated aio completion.

Signed-off-by: Injae Kang <abcinje@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
