### PR TITLE
tests/crimson: don't be so verbose when run by the 'make check' bot.

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -102,7 +102,7 @@ function main() {
     configure "$cmake_opts" "$@"
     build tests
     echo "make check: successful build on $(git rev-parse HEAD)"
-    run
+    FOR_MAKE_CHECK=1 run
 }
 
 main "$@"

--- a/src/test/crimson/gtest_seastar.cc
+++ b/src/test/crimson/gtest_seastar.cc
@@ -1,6 +1,9 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <cstdlib>
+#include <iostream>
+
 #include "include/ceph_assert.h"
 #include "gtest_seastar.h"
 
@@ -16,9 +19,16 @@ int main(int argc, char **argv)
 
   seastar_test_suite_t::seastar_env.init(argc, argv);
 
-  seastar::global_logger_registry().set_all_loggers_level(
-    seastar::log_level::debug
-  );
+  // HACK: differntiate between the `make check` bot and human user
+  // for the sake of log flooding
+  if (std::getenv("FOR_MAKE_CHECK")) {
+    std::cout << "WARNING: bumping log level skipped due to FOR_MAKE_CHECK!"
+              << std::endl;
+  } else {
+    seastar::global_logger_registry().set_all_loggers_level(
+      seastar::log_level::debug
+    );
+  }
 
   seastar_test_suite_t::seastar_env.run([] {
     return crimson::common::sharded_conf().start(


### PR DESCRIPTION
This commit is a try to balance crimson's debug facilities with overwhelming some hosts the `make check` bot runs on with huge number of log entries; see https://jenkins.ceph.com/job/ceph-pull-requests-arm64/17127/ for an exemplification of the problem.

This is achieved by differentiating debug levels depending upon the `FOR_MAKE_CHECK` env variable. It's a hack / a makeshift solution only. IMHO ultimately we should introduce a dedicated target for the bot while leaving `ninja test` for humans which would allow for more debugs and maybe also for running `vstart.sh`-dependent tests.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
