### PR TITLE
mgr/dashboard: Fix failing config dashboard e2e check

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/configuration.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/configuration.e2e-spec.ts
@@ -31,6 +31,7 @@ describe('Configuration page', () => {
 
     beforeEach(() => {
       configuration.clearTableSearchInput();
+      configuration.getTableCount('found').as('configFound');
     });
 
     after(() => {
@@ -49,14 +50,29 @@ describe('Configuration page', () => {
       );
     });
 
-    it('should show only modified configurations', () => {
-      configuration.filterTable('Modified', 'yes');
-      configuration.getTableCount('found').should('eq', 2);
-    });
-
-    it('should hide all modified configurations', () => {
+    it('should verify modified filter is applied properly', () => {
       configuration.filterTable('Modified', 'no');
-      configuration.getTableCount('found').should('gt', 1);
+      configuration.getTableCount('found').as('unmodifiedConfigs');
+
+      // Modified filter value to yes
+      configuration.filterTable('Modified', 'yes');
+      configuration.getTableCount('found').as('modifiedConfigs');
+
+      cy.get('@configFound').then((configFound) => {
+        cy.get('@unmodifiedConfigs').then((unmodifiedConfigs) => {
+          const modifiedConfigs = Number(configFound) - Number(unmodifiedConfigs);
+          configuration.getTableCount('found').should('eq', modifiedConfigs);
+        });
+      });
+
+      // Modified filter value to no
+      configuration.filterTable('Modified', 'no');
+      cy.get('@configFound').then((configFound) => {
+        cy.get('@modifiedConfigs').then((modifiedConfigs) => {
+          const unmodifiedConfigs = Number(configFound) - Number(modifiedConfigs);
+          configuration.getTableCount('found').should('eq', unmodifiedConfigs);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Recently a new osd config has been added in
6ca32bde2e1d0dd58df168126582a570ac09aad6 and this is getting Modified.
So on our dashboard e2e config check which checks for the Modified
filter, this is also coming as one of the entry. So we need to increase the
count.

Fixes: https://tracker.ceph.com/issues/52649
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
