### PR TITLE
src/script/ceph-release-notes: replace breaklink w span

### DIFF
--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -289,7 +289,7 @@ def make_release_notes(gh, repo, ref, plaintext, html, markdown, verbose, strict
                 )
             )
         elif markdown:
-            markdown_title = title.replace('_', '\_').replace('.', '<!-- breaklink >.')
+            markdown_title = title.replace('_', '\_').replace('.', '<span></span>.')
             print ("- {title} ({issues}[pr#{pr}](https://github.com/ceph/ceph/pull/{pr}), {author})\n".format(
                     title=markdown_title,
                     issues=issues,


### PR DESCRIPTION
Not sure why but the <!-- breaklink > was getting rendered as plaintext.

Putting <span></span> breaks the auto hyperlinking.

Signed-off-by: David Galloway <dgallowa@redhat.com>