### PR TITLE
mon/OSDMonitor: make weight set create safer

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10236,6 +10236,10 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       goto update;
   } else if (prefix == "osd crush weight-set create" ||
 	     prefix == "osd crush weight-set create-compat") {
+    if (_have_pending_crush()) {
+      dout(10) << " first waiting for pending crush changes to commit" << dendl;
+      goto wait;
+    }
     CrushWrapper newcrush = _get_pending_crush();
     int64_t pool;
     int positions;


### PR DESCRIPTION
We cannot return early success based on uncommitted state.

Signed-off-by: Sage Weil <sage@newdream.net>