### PR TITLE
[POC] crimson/os/seastore: optimize transaction conflicts

### DIFF
--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -267,7 +267,7 @@ OMapInnerNode::split_children_ret
 OMapInnerNode:: make_split_children(omap_context_t oc)
 {
   logger().debug("OMapInnerNode: {}", __func__);
-  return oc.tm.alloc_extents<OMapInnerNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE, 2)
+  return oc.tm.alloc_extents<OMapInnerNode>(oc.t, oc.hint, OMAP_BLOCK_SIZE, 2)
     .si_then([this] (auto &&ext_pair) {
       auto left = ext_pair.front();
       auto right = ext_pair.back();
@@ -295,7 +295,7 @@ OMapInnerNode::make_balanced(omap_context_t oc, OMapNodeRef _right)
 {
   logger().debug("OMapInnerNode: {}", __func__);
   ceph_assert(_right->get_type() == TYPE);
-  return oc.tm.alloc_extents<OMapInnerNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE, 2)
+  return oc.tm.alloc_extents<OMapInnerNode>(oc.t, oc.hint, OMAP_BLOCK_SIZE, 2)
     .si_then([this, _right] (auto &&replacement_pair){
       auto replacement_left = replacement_pair.front();
       auto replacement_right = replacement_pair.back();
@@ -556,7 +556,7 @@ OMapLeafNode::split_children_ret
 OMapLeafNode::make_split_children(omap_context_t oc)
 {
   logger().debug("OMapLeafNode: {}", __func__);
-  return oc.tm.alloc_extents<OMapLeafNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE, 2)
+  return oc.tm.alloc_extents<OMapLeafNode>(oc.t, oc.hint, OMAP_BLOCK_SIZE, 2)
     .si_then([this] (auto &&ext_pair) {
       auto left = ext_pair.front();
       auto right = ext_pair.back();
@@ -585,7 +585,7 @@ OMapLeafNode::make_balanced(omap_context_t oc, OMapNodeRef _right)
 {
   ceph_assert(_right->get_type() == TYPE);
   logger().debug("OMapLeafNode: {}",  __func__);
-  return oc.tm.alloc_extents<OMapLeafNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE, 2)
+  return oc.tm.alloc_extents<OMapLeafNode>(oc.t, oc.hint, OMAP_BLOCK_SIZE, 2)
     .si_then([this, _right] (auto &&replacement_pair) {
       auto replacement_left = replacement_pair.front();
       auto replacement_right = replacement_pair.back();

--- a/src/crimson/os/seastore/onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager.h
@@ -12,6 +12,7 @@
 #include "include/buffer_fwd.h"
 #include "include/ceph_assert.h"
 #include "common/hobject.h"
+#include "osd/osd_types.h"
 
 #include "crimson/common/errorator.h"
 #include "crimson/os/seastore/onode.h"
@@ -32,6 +33,7 @@ public:
   using contains_onode_ret = contains_onode_iertr::future<bool>;
   virtual contains_onode_ret contains_onode(
     Transaction &trans,
+    ps_t ps,
     const ghobject_t &hoid) = 0;
 
   using get_onode_iertr = base_iertr::extend<
@@ -40,6 +42,7 @@ public:
     OnodeRef>;
   virtual get_onode_ret get_onode(
     Transaction &trans,
+    ps_t ps,
     const ghobject_t &hoid) = 0;
 
   using get_or_create_onode_iertr = base_iertr::extend<
@@ -48,6 +51,7 @@ public:
     OnodeRef>;
   virtual get_or_create_onode_ret get_or_create_onode(
     Transaction &trans,
+    ps_t ps,
     const ghobject_t &hoid) = 0;
 
   using get_or_create_onodes_iertr = base_iertr::extend<
@@ -56,6 +60,7 @@ public:
     std::vector<OnodeRef>>;
   virtual get_or_create_onodes_ret get_or_create_onodes(
     Transaction &trans,
+    ps_t ps,
     const std::vector<ghobject_t> &hoids) = 0;
 
   using write_dirty_iertr = base_iertr;
@@ -75,6 +80,7 @@ public:
   using list_onodes_ret = list_onodes_iertr::future<list_onodes_bare_ret>;
   virtual list_onodes_ret list_onodes(
     Transaction &trans,
+    ps_t ps,
     const ghobject_t& start,
     const ghobject_t& end,
     uint64_t limit) = 0;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -115,18 +115,22 @@ public:
 
   contains_onode_ret contains_onode(
     Transaction &trans,
+    ps_t ps,
     const ghobject_t &hoid) final;
 
   get_onode_ret get_onode(
     Transaction &trans,
+    ps_t ps,
     const ghobject_t &hoid) final;
 
   get_or_create_onode_ret get_or_create_onode(
     Transaction &trans,
+    ps_t ps,
     const ghobject_t &hoid) final;
 
   get_or_create_onodes_ret get_or_create_onodes(
     Transaction &trans,
+    ps_t ps,
     const std::vector<ghobject_t> &hoids) final;
 
   write_dirty_ret write_dirty(
@@ -139,6 +143,7 @@ public:
 
   list_onodes_ret list_onodes(
     Transaction &trans,
+    ps_t ps,
     const ghobject_t& start,
     const ghobject_t& end,
     uint64_t limit) final;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
@@ -10,8 +10,12 @@
 #include <ostream>
 #include <string>
 
+#include "common/hobject.h"
+#include "osd/osd_types.h"
+
 #include "crimson/common/errorator.h"
 #include "crimson/os/seastore/cached_extent.h"
+#include "crimson/os/seastore/onode.h"
 #include "crimson/os/seastore/seastore_types.h"
 #include "crimson/os/seastore/transaction.h"
 
@@ -28,6 +32,11 @@ using crimson::os::seastore::laddr_t;
 using crimson::os::seastore::L_ADDR_MIN;
 using crimson::os::seastore::L_ADDR_NULL;
 using crimson::os::seastore::extent_len_t;
+
+struct tree_key_t {
+  ps_t ps;
+  ghobject_t oid;
+};
 
 class DeltaRecorder;
 class NodeExtent;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -544,7 +544,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
       if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
         if (result_raw.mstat == MSTAT_LT2) {
           auto cmp = compare_to<KeyT::HOBJ>(
-              key, node_stage[result_raw.position.index].shard_pool);
+              key, node_stage[result_raw.position.index].shard_pool_seed);
           assert(cmp != MatchKindCMP::GT);
           if (cmp != MatchKindCMP::EQ) {
             result_raw.mstat = MSTAT_LT3;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
@@ -53,11 +53,11 @@ inline std::ostream& operator<<(std::ostream& os, const laddr_packed_t& laddr) {
 using match_stat_t = int8_t;
 constexpr match_stat_t MSTAT_END = -2; // index is search_position_t::end()
 constexpr match_stat_t MSTAT_EQ  = -1; // key == index
-constexpr match_stat_t MSTAT_LT0 =  0; // key == index [pool/shard crush ns/oid]; key < index [snap/gen]
-constexpr match_stat_t MSTAT_LT1 =  1; // key == index [pool/shard crush]; key < index [ns/oid]
-constexpr match_stat_t MSTAT_LT2 =  2; // key < index [pool/shard crush ns/oid] ||
-                                       // key == index [pool/shard]; key < index [crush]
-constexpr match_stat_t MSTAT_LT3 =  3; // key < index [pool/shard]
+constexpr match_stat_t MSTAT_LT0 =  0; // key == index [pool/shard/seed crush ns/oid]; key < index [snap/gen]
+constexpr match_stat_t MSTAT_LT1 =  1; // key == index [pool/shard/seed crush]; key < index [ns/oid]
+constexpr match_stat_t MSTAT_LT2 =  2; // key < index [pool/shard/seed crush ns/oid] ||
+                                       // key == index [pool/shard/seed]; key < index [crush]
+constexpr match_stat_t MSTAT_LT3 =  3; // key < index [pool/shard/seed]
 constexpr match_stat_t MSTAT_MIN = MSTAT_END;
 constexpr match_stat_t MSTAT_MAX = MSTAT_LT3;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
@@ -77,7 +77,7 @@ struct _slot_t {
   key_t key;
   node_offset_t right_offset;
 } __attribute__((packed));
-using slot_0_t = _slot_t<shard_pool_crush_t, field_type_t::N0>;
+using slot_0_t = _slot_t<shard_pool_seed_crush_t, field_type_t::N0>;
 using slot_1_t = _slot_t<crush_t, field_type_t::N1>;
 using slot_3_t = _slot_t<snap_gen_t, field_type_t::N3>;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
@@ -68,9 +68,9 @@ inline bool matchable(field_type_t type, match_stat_t mstat) {
   /*
    * compressed prefix by field type:
    * N0: NONE
-   * N1: pool/shard
-   * N2: pool/shard crush
-   * N3: pool/shard crush ns/oid
+   * N1: pool/shard/seed
+   * N2: pool/shard/seed crush
+   * N3: pool/shard/seed crush ns/oid
    *
    * if key matches the node's compressed prefix, return true
    * else, return false
@@ -99,9 +99,9 @@ inline void assert_mstat(
     assert(compare_to<KeyT::HOBJ>(key, index.ns_oid_view()) == MatchKindCMP::LT);
     break;
    case MSTAT_LT2:
-    if (index.has_shard_pool()) {
-      assert(compare_to<KeyT::HOBJ>(key, shard_pool_crush_t{
-               index.shard_pool_packed(), index.crush_packed()}) == MatchKindCMP::LT);
+    if (index.has_shard_pool_seed()) {
+      assert(compare_to<KeyT::HOBJ>(key, shard_pool_seed_crush_t{
+               index.shard_pool_seed_packed(), index.crush_packed()}) == MatchKindCMP::LT);
     } else {
       assert(compare_to<KeyT::HOBJ>(key, index.crush_packed()) == MatchKindCMP::LT);
     }
@@ -122,9 +122,9 @@ inline void assert_mstat(
     if (!index.has_crush())
       break;
     assert(compare_to<KeyT::HOBJ>(key, index.crush_packed()) == MatchKindCMP::EQ);
-    if (!index.has_shard_pool())
+    if (!index.has_shard_pool_seed())
       break;
-    assert(compare_to<KeyT::HOBJ>(key, index.shard_pool_packed()) == MatchKindCMP::EQ);
+    assert(compare_to<KeyT::HOBJ>(key, index.shard_pool_seed_packed()) == MatchKindCMP::EQ);
    default:
     break;
   }
@@ -145,7 +145,7 @@ enum class TrimType { BEFORE, AFTER, AT };
  *
  * Multi-stage is designed to index different portions of onode keys
  * stage-by-stage. There are at most 3 stages for a node:
- * - STAGE_LEFT:   index shard-pool-crush for N0, or index crush for N1 node;
+ * - STAGE_LEFT:   index shard-pool-seed-crush for N0, or index crush for N1 node;
  * - STAGE_STRING: index ns-oid for N0/N1/N2 nodes;
  * - STAGE_RIGHT:  index snap-gen for N0/N1/N2/N3 nodes;
  *

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
@@ -14,7 +14,7 @@
 namespace crimson::os::seastore::onode {
 
 using match_stage_t = int8_t;
-constexpr match_stage_t STAGE_LEFT = 2;   // shard/pool/crush
+constexpr match_stage_t STAGE_LEFT = 2;   // shard/pool/seed/crush
 constexpr match_stage_t STAGE_STRING = 1; // nspace/oid
 constexpr match_stage_t STAGE_RIGHT = 0;  // snap/gen
 constexpr auto STAGE_TOP = STAGE_LEFT;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -133,7 +133,7 @@ void validate_tree_config(const tree_conf_t& conf)
     //   max-ns/oid-split-overhead <= node-size
 
     auto obj = ghobject_t{shard_id_t{0}, 0, 0, "", "", 0, 0};
-    key_hobj_t key(obj);
+    key_hobj_t key({0, obj});
     auto max_str_size = conf.max_ns_size + conf.max_oid_size;
 #define _STAGE_T(NodeType) node_to_stage_t<typename NodeType::node_stage_t>
 #define NXT_T(StageType)  staged<typename StageType::next_param_t>

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -211,11 +211,16 @@ private:
     auto begin_time = std::chrono::steady_clock::now();
     return seastar::do_with(
         oid, Ret{}, OnodeRef(), std::forward<F>(f),
-        [this, src, op_type, begin_time](auto &oid, auto &ret, auto &onode, auto &f) {
-      return repeat_eagain([&, this, src] {
+        [this, ch, src, op_type, begin_time](
+           auto &oid, auto &ret, auto &onode, auto &f) {
+      return repeat_eagain([&, this, ch, src] {
         return transaction_manager->with_transaction_intr(
-            src, [&, this](auto& t) {
-          return onode_manager->get_onode(t, oid
+            src,
+            [&, this, ch](auto& t) {
+          return onode_manager->get_onode(
+            t,
+            ch->get_cid().demo_get_ps(),
+            oid
           ).si_then([&](auto onode_ret) {
             onode = std::move(onode_ret);
             return f(t, *onode);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -804,6 +804,14 @@ public:
     return 0;  // whatever.
   }
 
+  ps_t demo_get_ps() const {
+    if (type == TYPE_META) {
+      return std::numeric_limits<ps_t>::max();
+    } else {
+      return pgid.ps();
+    }
+  }
+
   void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<coll_t*>& o);
 };


### PR DESCRIPTION
This PR demonstrates that the current intense transaction conflicts can be resolved by:
* Reorder onodes by shard-pool-[seed]-hash-ns-oid-snap-gen;
* Change laddr hints to shard-pool-[seed]-hash
* Add missing hints in the omap tree;

The results are significant:
1. Conflicts in both onode tree and lba tree are almost addressed;
    * before: ![before_conflicts_mutate](https://user-images.githubusercontent.com/7736006/133881563-1a15f4a5-12f6-44ff-b653-3ebe1ddcc2be.png)
    * after: ![after_conflicts_mutate](https://user-images.githubusercontent.com/7736006/133881582-c46ebb91-1eb6-40ce-ba6e-8b7401cde7b5.png)

2. The overall conflict rate is dropped from ~180% down to only ~5%
    * before: ![before_conflicts](https://user-images.githubusercontent.com/7736006/133881670-18ee0aa2-456b-4e20-be90-265b89654569.png)
    * after: ![after_conflicts](https://user-images.githubusercontent.com/7736006/133881684-715cf9ad-f0ad-4fab-b540-7453d1c028fd.png)

3. The overall throughtput is improved from 6\~2MB/s to 11\~6MB/s in a local test. (The throughput graph doesn't look very accurate now, not sure why)

4. CPU utility looks better:
    * before: ![before_cpu](https://user-images.githubusercontent.com/7736006/133881937-d3a9715e-60ee-4302-8038-77c615fc6945.png)
    * after: ![after_cpu](https://user-images.githubusercontent.com/7736006/133881946-c5e167f7-ecd2-4f62-9bc6-742124da3ab8.png)

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
