### PR TITLE
mgr: prometheus: use nsec unit in desc for RBD _read_latency and _write_latency metrics

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -636,9 +636,9 @@ class Module(MgrModule):
                 'read_bytes': {'type': self.PERFCOUNTER_COUNTER,
                                'desc': 'RBD image bytes read'},
                 'write_latency': {'type': self.PERFCOUNTER_LONGRUNAVG,
-                                  'desc': 'RBD image writes latency (msec)'},
+                                  'desc': 'RBD image writes latency (nsec)'},
                 'read_latency': {'type': self.PERFCOUNTER_LONGRUNAVG,
-                                 'desc': 'RBD image reads latency (msec)'},
+                                 'desc': 'RBD image reads latency (nsec)'},
             },
         }  # type: Dict[str, Any]
         global _global_instance


### PR DESCRIPTION
mgr: prometheus: use nsec unit in desc for RBD _read_latency and _write_latency metrics

The source of truth - [grafana dashboards](https://github.com/ceph/ceph/blob/master/monitoring/grafana/dashboards/rbd-overview.json#L593)

Fixes: https://tracker.ceph.com/issues/44321
