### PR TITLE
doc/iscsi: fix some typos

### DIFF
--- a/doc/rbd/iscsi-target-cli.rst
+++ b/doc/rbd/iscsi-target-cli.rst
@@ -179,8 +179,8 @@ to create a iSCSI target and export a RBD image as LUN 0.
 
    .. code-block:: console
 
-       > /> cd /iscsi-target
-       > /iscsi-target>  create iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
+       > /> cd /iscsi-targets
+       > /iscsi-targets>  create iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw
 
 #. Create the iSCSI gateways. The IPs used below are the ones that will be
    used for iSCSI data like READ and WRITE commands. They can be the
@@ -189,7 +189,7 @@ to create a iSCSI target and export a RBD image as LUN 0.
 
    .. code-block:: console
 
-       > /iscsi-target> cd iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/gateways
+       > /iscsi-targets> cd iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/gateways
        > /iscsi-target...-igw/gateways>  create ceph-gw-1 10.172.19.21
        > /iscsi-target...-igw/gateways>  create ceph-gw-2 10.172.19.22
 
@@ -199,7 +199,7 @@ to create a iSCSI target and export a RBD image as LUN 0.
 
    .. code-block:: console
 
-       > /iscsi-target> cd iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/gateways
+       > /iscsi-targets> cd iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/gateways
        > /iscsi-target...-igw/gateways>  create ceph-gw-1 10.172.19.21 skipchecks=true
        > /iscsi-target...-igw/gateways>  create ceph-gw-2 10.172.19.22 skipchecks=true
 
@@ -214,7 +214,7 @@ to create a iSCSI target and export a RBD image as LUN 0.
 
    .. code-block:: console
 
-       > /disks> cd /iscsi-target/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/hosts
+       > /disks> cd /iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:iscsi-igw/hosts
        > /iscsi-target...eph-igw/hosts>  create iqn.1994-05.com.redhat:rh7-client
 
 #. Set the client's CHAP username to myiscsiusername and password to


### PR DESCRIPTION
This fixes some typos in the iscsi documentation.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
