### PR TITLE
qa/suites/orch/cephadm: avoid centos 8.2 + container tools 3.0

### DIFF
--- a/qa/suites/orch/cephadm/smoke/distro/centos_8.2_container_tools_3.0.yaml
+++ b/qa/suites/orch/cephadm/smoke/distro/centos_8.2_container_tools_3.0.yaml
@@ -1,1 +1,0 @@
-.qa/distros/podman/centos_8.2_container_tools_3.0.yaml

--- a/qa/suites/orch/cephadm/workunits/0-distro/centos_8.2_container_tools_3.0.yaml
+++ b/qa/suites/orch/cephadm/workunits/0-distro/centos_8.2_container_tools_3.0.yaml
@@ -1,1 +1,0 @@
-.qa/distros/podman/centos_8.2_container_tools_3.0.yaml

--- a/qa/suites/orch/cephadm/workunits/0-distro/centos_8.3_container_tools_3.0.yaml
+++ b/qa/suites/orch/cephadm/workunits/0-distro/centos_8.3_container_tools_3.0.yaml
@@ -1,0 +1,1 @@
+.qa/distros/podman/centos_8.3_container_tools_3.0.yaml


### PR DESCRIPTION
This seems to be the failing combination...

Signed-off-by: Sage Weil <sage@newdream.net>