### PR TITLE
osd: detect multi-actuator OSDs and reflect in CRUSH map

### DIFF
--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -21,6 +21,9 @@ extern std::string get_device_id(const std::string& devname,
 extern std::string get_device_path(const std::string& devname,
 				   std::string *err=0);
 
+extern int get_device_num_luns(const std::string& devname,
+			       std::string *err);
+
 // populate daemon metadata map with device info
 extern void get_device_metadata(
   const std::set<std::string>& devnames,

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -2390,7 +2390,7 @@ options:
   desc: default chooseleaf type for osdmaptool --create
   fmt_desc: The bucket type to use for ``chooseleaf`` in a CRUSH rule. Uses
     ordinal rank rather than name.
-  default: 1
+  default: 3
   flags:
   - cluster_create
   with_legacy: true

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -655,6 +655,17 @@ options:
   default: -1
   with_legacy: true
 # Allows the "peered" state for recovery and backfill below min_size
+- name: osd_crush_detect_multilun_devices
+  type: bool
+  default: true
+  level: advanced
+  desc: detect multi-LUN devices and incorporate device id into CRUSH location
+  long_desc: Some multi-LUN devices, such as multi-actuator HDDs, present multiple LUNs
+    from the same physical device.  When this option is enabled, the OSD will detect
+    such devices on startup and, when multiple LUNs are present, incorporate the device
+    id into the CRUSH location, so that data placement can consider that multiple
+    OSDs may reside on the same device.
+  with_legacy: true
 - name: osd_allow_recovery_below_min_size
   type: bool
   level: dev

--- a/src/crush/CrushLocation.h
+++ b/src/crush/CrushLocation.h
@@ -7,6 +7,7 @@
 #include <iosfwd>
 #include <map>
 #include <string>
+#include <mutex>
 
 #include "common/ceph_mutex.h"
 #include "include/common_fwd.h"
@@ -24,6 +25,11 @@ public:
   int init_on_startup();
 
   std::multimap<std::string,std::string> get_location() const;
+
+  void annotate(const std::string& key, const std::string& val) {
+    std::scoped_lock l(lock);
+    loc.insert(make_pair(key, val));
+  }
 
 private:
   int _parse(const std::string& s);

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4283,18 +4283,20 @@ int OSDMap::get_erasure_code_profile_default(CephContext *cct,
 int OSDMap::_build_crush_types(CrushWrapper& crush)
 {
   crush.set_type_name(0, "osd");
-  crush.set_type_name(1, "host");
-  crush.set_type_name(2, "chassis");
-  crush.set_type_name(3, "rack");
-  crush.set_type_name(4, "row");
-  crush.set_type_name(5, "pdu");
-  crush.set_type_name(6, "pod");
-  crush.set_type_name(7, "room");
-  crush.set_type_name(8, "datacenter");
-  crush.set_type_name(9, "zone");
-  crush.set_type_name(10, "region");
-  crush.set_type_name(11, "root");
-  return 11;
+  crush.set_type_name(1, "device");
+  crush.set_type_name(2, "array");
+  crush.set_type_name(3, "host");
+  crush.set_type_name(4, "chassis");
+  crush.set_type_name(5, "rack");
+  crush.set_type_name(6, "row");
+  crush.set_type_name(7, "pdu");
+  crush.set_type_name(8, "pod");
+  crush.set_type_name(9, "room");
+  crush.set_type_name(10, "datacenter");
+  crush.set_type_name(11, "zone");
+  crush.set_type_name(12, "region");
+  crush.set_type_name(13, "root");
+  return 13;
 }
 
 int OSDMap::build_simple_crush_map(CephContext *cct, CrushWrapper& crush,

--- a/src/test/cli/crushtool/arg-order-checks.t
+++ b/src/test/cli/crushtool/arg-order-checks.t
@@ -4,7 +4,7 @@
   tunable straw_calc_version 1
 # build then reweight-item then tree
   $ map="$TESTDIR/foo"
-  $ crushtool --outfn "$map" --build --set-chooseleaf-vary-r 0 --set-chooseleaf-stable 0 --num_osds 25 node straw 5 rack straw 1 root straw 0 --reweight-item osd.2 99 -o "$map" --tree
+  $ CEPH_ARGS="--osd-crush-chooseleaf-type 1" crushtool --outfn "$map" --build --set-chooseleaf-vary-r 0 --set-chooseleaf-stable 0 --num_osds 25 node straw 5 rack straw 1 root straw 0 --reweight-item osd.2 99 -o "$map" --tree
   crushtool reweighting item osd.2 to 99
   ID   CLASS  WEIGHT     TYPE NAME         
   -11         123.00000  root root         

--- a/src/test/cli/crushtool/build.t
+++ b/src/test/cli/crushtool/build.t
@@ -8,12 +8,12 @@
 #  
 # silence all messages with --debug-crush 0
 #
-  $ CEPH_ARGS="--debug-crush 0" crushtool --outfn "$map" --build --num_osds 5 node straw 2 rack straw 1 root straw 0
+  $ CEPH_ARGS="--debug-crush 0 --osd-crush-chooseleaf-type 1" crushtool --outfn "$map" --build --num_osds 5 node straw 2 rack straw 1 root straw 0
 
 #
 # display a warning if there is more than one root
 #
-  $ crushtool --outfn "$map" --build --num_osds 5 node straw 2 rack straw 1 
+  $ CEPH_ARGS="--osd-crush-chooseleaf-type 1" crushtool --outfn "$map" --build --num_osds 5 node straw 2 rack straw 1 
   The crush rules will use the root rack0 (re)
   and ignore the others.
   There are 3 roots, they can be
@@ -23,7 +23,7 @@
 #
 # crush rules are generated using the OSDMap helpers
 #
-  $ CEPH_ARGS="--debug-crush 0" crushtool --outfn "$map" --set-straw-calc-version 0 --build --num_osds 1 root straw 0 --set-chooseleaf-stable 0
+  $ CEPH_ARGS="--debug-crush 0 --osd-crush-chooseleaf-type 1" crushtool --outfn "$map" --set-straw-calc-version 0 --build --num_osds 1 root straw 0 --set-chooseleaf-stable 0
   $ crushtool -o "$map.txt" -d "$map"
   $ cat "$map.txt"
   # begin crush map
@@ -65,7 +65,7 @@
 #
 # Wrong number of arguments 
 #
-  $ crushtool --outfn "$map" --debug-crush 0 --build --num_osds 5 node straw 0
+  $ CEPH_ARGS="--osd-crush-chooseleaf-type 1" crushtool --outfn "$map" --debug-crush 0 --build --num_osds 5 node straw 0
   remaining args: [--debug-crush,0,node,straw,0]
   layers must be specified with 3-tuples of (name, buckettype, size)
   [1]

--- a/src/test/cli/osdmaptool/create-print.t
+++ b/src/test/cli/osdmaptool/create-print.t
@@ -23,17 +23,19 @@
   
   # types
   type 0 osd
-  type 1 host
-  type 2 chassis
-  type 3 rack
-  type 4 row
-  type 5 pdu
-  type 6 pod
-  type 7 room
-  type 8 datacenter
-  type 9 zone
-  type 10 region
-  type 11 root
+  type 1 device
+  type 2 array
+  type 3 host
+  type 4 chassis
+  type 5 rack
+  type 6 row
+  type 7 pdu
+  type 8 pod
+  type 9 room
+  type 10 datacenter
+  type 11 zone
+  type 12 region
+  type 13 root
   
   # buckets
   host localhost {

--- a/src/test/cli/osdmaptool/create-racks.t
+++ b/src/test/cli/osdmaptool/create-racks.t
@@ -257,17 +257,19 @@
   
   # types
   type 0 osd
-  type 1 host
-  type 2 chassis
-  type 3 rack
-  type 4 row
-  type 5 pdu
-  type 6 pod
-  type 7 room
-  type 8 datacenter
-  type 9 zone
-  type 10 region
-  type 11 root
+  type 1 device
+  type 2 array
+  type 3 host
+  type 4 chassis
+  type 5 rack
+  type 6 row
+  type 7 pdu
+  type 8 pod
+  type 9 room
+  type 10 datacenter
+  type 11 zone
+  type 12 region
+  type 13 root
   
   # buckets
   host cephstore5522 {

--- a/src/test/cli/osdmaptool/crush.t
+++ b/src/test/cli/osdmaptool/crush.t
@@ -6,7 +6,7 @@
   osdmaptool: exported crush map to oc
   $ osdmaptool --import-crush oc myosdmap
   osdmaptool: osdmap file 'myosdmap'
-  osdmaptool: imported 497 byte crush map from oc
+  osdmaptool: imported 524 byte crush map from oc
   osdmaptool: writing epoch 3 to myosdmap
   $ osdmaptool --adjust-crush-weight 0:5 myosdmap
   osdmaptool: osdmap file 'myosdmap'

--- a/src/test/cli/osdmaptool/test-map-pgs.t
+++ b/src/test/cli/osdmaptool/test-map-pgs.t
@@ -9,7 +9,7 @@
   $ osdmaptool --osd_pool_default_size $SIZE --pg_bits $PG_BITS --createsimple $NUM_OSDS "$OSD_MAP" > /dev/null --with-default-pool
   osdmaptool: osdmap file 'osdmap'
   $ CRUSH_MAP="crushmap"
-  $ CEPH_ARGS="--debug-crush 0" crushtool --outfn "$CRUSH_MAP" --build --num_osds $NUM_OSDS node straw 10 rack straw 10 root straw 0
+  $ CEPH_ARGS="--debug-crush 0 --osd-crush-chooseleaf-type 1" crushtool --outfn "$CRUSH_MAP" --build --num_osds $NUM_OSDS node straw 10 rack straw 10 root straw 0
   $ osdmaptool --import-crush "$CRUSH_MAP" "$OSD_MAP" > /dev/null
   osdmaptool: osdmap file 'osdmap'
   $ OUT="$TESTDIR/out"

--- a/src/test/cli/osdmaptool/tree.t
+++ b/src/test/cli/osdmaptool/tree.t
@@ -20,7 +20,7 @@
               "id": -1,
               "name": "default",
               "type": "root",
-              "type_id": 11,
+              "type_id": 13,
               "children": [
                   -3
               ]
@@ -29,7 +29,7 @@
               "id": -3,
               "name": "localrack",
               "type": "rack",
-              "type_id": 3,
+              "type_id": 5,
               "pool_weights": {},
               "children": [
                   -2
@@ -39,7 +39,7 @@
               "id": -2,
               "name": "localhost",
               "type": "host",
-              "type_id": 1,
+              "type_id": 3,
               "pool_weights": {},
               "children": [
                   2,

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -1526,7 +1526,7 @@ TEST_F(TestClsRbd, metadata)
   ASSERT_EQ(0, strncmp("value2", pairs["key2"].c_str(), 6));
 
   pairs.clear();
-  char key[10], val[20];
+  char key[20], val[20];
   for (int i = 0; i < 1024; i++) {
     sprintf(key, "key%d", i);
     sprintf(val, "value%d", i);

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -414,7 +414,7 @@ TEST_F(cls_rgw, index_list)
   /* insert 998 omap key starts with BI_PREFIX_CHAR,
    * so bucket list first time will get one key before 0x80 and one key after */
   for (int i = 0; i < 998; ++i) {
-    char buf[10];
+    char buf[20];
     snprintf(buf, sizeof(buf), "%c%s%d", 0x80, "1000_", i);
     entries.emplace(string{buf}, bufferlist{});
   }

--- a/src/test/librados/misc_cxx.cc
+++ b/src/test/librados/misc_cxx.cc
@@ -372,7 +372,7 @@ TEST_F(LibRadosMiscPP, BigAttrPP) {
     got.clear();
     bl.append(buffer::create(std::min<uint64_t>(g_conf()->osd_max_attr_size,
 						1024)));
-    char n[10];
+    char n[20];
     snprintf(n, sizeof(n), "a%d", i);
     ASSERT_EQ(0, ioctx.setxattr("foo", n, bl));
     ASSERT_EQ((int)bl.length(), ioctx.getxattr("foo", n, got));

--- a/src/tools/psim.cc
+++ b/src/tools/psim.cc
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
     snprintf(nspace, sizeof(nspace), "n%d", n);
   for (int f = 0; f < 5000; f++) {  // files
     for (int b = 0; b < 4; b++) {   // blocks
-      char foo[20];
+      char foo[30];
       snprintf(foo, sizeof(foo), "%d.%d", f, b);
       object_t oid(foo);
       ceph_object_layout l = osdmap.make_object_layout(oid, 0, nspace);


### PR DESCRIPTION
This will produce a CRUSH location for an OSD like so:

```
-1         0.09859  root default                                         
-4         0.09859      host dael                                        
-3         0.09859          device INTEL_SSDPE2KX040T7_PHLF720400SD4P0IGN
 0    hdd  0.09859              osd.0                                    
 1    hdd  0.09859              osd.1                                    
```

The underlying assumption here is that if the device has multiple LUNs (as reported by
sg_luns) then we should annotate the crush_location in this way.

TODO:
- [ ] add the 'device' crush type on upgraded clusters?
- [ ] confirm that this won't cause problems for other environments... perhaps other cases where there are multiple LUNs?


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>