### PR TITLE
Revert "rpm, debian: drop xmlstarlet from build deps"

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -229,6 +229,7 @@ BuildRequires:	pkgconfig(udev)
 BuildRequires:	valgrind-devel
 BuildRequires:	which
 BuildRequires:	xfsprogs-devel
+BuildRequires:	xmlstarlet
 BuildRequires:	nasm
 BuildRequires:	lua-devel
 %if 0%{with seastar} || 0%{with jaeger}

--- a/debian/control
+++ b/debian/control
@@ -104,6 +104,7 @@ Build-Depends: automake,
                uuid-runtime,
                valgrind,
                xfslibs-dev,
+               xmlstarlet <pkg.ceph.check>,
                nasm [amd64],
                zlib1g-dev,
 Standards-Version: 4.4.0


### PR DESCRIPTION
This reverts commit 707edc0b2d5283104aeb472131ee94dd59544290.

This commit was somewhat premature in removing the xmlstarlet
dependency.

Fixes: https://tracker.ceph.com/issues/52681


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
