### PR TITLE
pacific: mgr/dashboard: visual tests: Add more ignore regions for dashboard component

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/visualTests/dashboard.vrt-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/visualTests/dashboard.vrt-spec.ts
@@ -1,0 +1,22 @@
+import { LoginPageHelper } from '../ui/login.po';
+
+describe('Dashboard Landing Page', () => {
+  const login = new LoginPageHelper();
+
+  beforeEach(() => {
+    cy.eyesOpen({
+      testName: 'Dashboard Component'
+    });
+  });
+
+  afterEach(() => {
+    cy.eyesClose();
+  });
+
+  it('should take screenshot of dashboard landing page', () => {
+    login.navigateTo();
+    login.doLogin();
+    cy.get('.card-text').should('be.visible');
+    cy.eyesCheckWindow({ tag: 'Dashboard landing page', ignore: { selector: '.card-text' } });
+  });
+});


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52292

---

backport of https://github.com/ceph/ceph/pull/42786
parent tracker: https://tracker.ceph.com/issues/52282

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh