### PR TITLE
.github: fix path to cephadm suite

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,7 +28,7 @@
 /qa/tasks/cephadm_cases                         @ceph/orchestrators
 /qa/tasks/mgr/test_orchestrator_cli.py          @ceph/orchestrators
 /qa/tasks/mgr/test_cephadm_orchestrator.py      @ceph/orchestrators
-/qa/suites/rados/cephadm                        @ceph/orchestrators
+/qa/suites/orch                                 @ceph/orchestrators
 /doc/mgr/orchestrator.rst                       @ceph/orchestrators
 /doc/mgr/orchestrator_modules.rst               @ceph/orchestrators
 /doc/cephadm                                    @ceph/orchestrators

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -76,7 +76,7 @@ cephadm:
   - doc/cephadm/**
   - doc/dev/cephadm/**
   - doc/man/8/cephadm.rst
-  - qa/suites/rados/cephadm/**
+  - qa/suites/orch/cephadm/**
   - qa/tasks/cephadm.py
   - qa/tasks/cephadm_cases
   - qa/tasks/mgr/test_cephadm_orchestrator.py


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sewagner@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
