### PR TITLE
osd: make 'pg deep-scrub' command initiate a scrub

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1178,9 +1178,8 @@ void PrimaryLogPG::do_command(
       stamp -= 100.0;  // push back last scrub more for good measure
       if (deep) {
         set_last_deep_scrub_stamp(stamp);
-      } else {
-        set_last_scrub_stamp(stamp); // also for 'deep', as we use this value to order scrubs
       }
+      set_last_scrub_stamp(stamp); // for 'deep' as well, as we use this value to order scrubs
       f->open_object_section("result");
       f->dump_bool("deep", deep);
       f->dump_stream("stamp") << stamp;


### PR DESCRIPTION
as the 'pg scrub' command does so.

Both commands push the 'last [deep] scrub' (respectively) back, to
cause the relevant type of scrub to be selected the next time we look for a PG to
scrub. But only the 'shallow' scrub timestamp is considered when deciding whether
a pg should be scrubbed.

Fixes: https://tracker.ceph.com/issues/52686

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

