### PR TITLE
mgr/cephadm: populate trusted_ip_list in iscsi-gateway.cfg with mgr ips

### DIFF
--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -58,8 +58,19 @@ class IscsiService(CephService):
                 'val': key_data,
             })
 
+        #add mgr ip address to trusted list with dashboard
+        mgr_ips = []
+        trusted_ip_list = spec.trusted_ip_list if spec.trusted_ip_list else ''
+        for dd in self.mgr.cache.get_daemons_by_service('mgr'):
+            assert dd.hostname is not None
+            mgr_ips.append(self.mgr.inventory.get_addr(dd.hostname))
+        if trusted_ip_list:
+            trusted_ip_list += ','
+        trusted_ip_list += ",".join(mgr_ips)
+
         context = {
             'client_name': '{}.{}'.format(utils.name_to_config_section('iscsi'), igw_id),
+            'trusted_ip_list': trusted_ip_list,
             'spec': spec
         }
         igw_conf = self.mgr.template.render('services/iscsi/iscsi-gateway.cfg.j2', context)

--- a/src/pybind/mgr/cephadm/templates/services/iscsi/iscsi-gateway.cfg.j2
+++ b/src/pybind/mgr/cephadm/templates/services/iscsi/iscsi-gateway.cfg.j2
@@ -2,7 +2,7 @@
 [config]
 cluster_client_name = {{ client_name }}
 pool = {{ spec.pool }}
-trusted_ip_list = {{ spec.trusted_ip_list|default("''", true) }}
+trusted_ip_list = {{ trusted_ip_list|default("''", true) }}
 minimum_gateways = 1
 api_port = {{ spec.api_port|default("''", true) }}
 api_user = {{ spec.api_user|default("''", true) }}


### PR DESCRIPTION
populate trusted_ip_list in iscsi-gateway.cfg with mgr ips
Iscsi gateways do not show "UP" in dashboard without this

this was already done in ceph-ansible https://github.com/ceph/ceph-ansible/commit/d050391cbbe8a56d1cf44e744a02e4aa3f0583e5

fixes: https://tracker.ceph.com/issues/52692
Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>