### PR TITLE
crimson/common: add safe_then_unpack() to errorated futures. 

### DIFF
--- a/src/crimson/common/utility.h
+++ b/src/crimson/common/utility.h
@@ -5,12 +5,16 @@
 
 #include <type_traits>
 
+namespace _impl {
+  template <class T> struct always_false : std::false_type {};
+};
+
 template <class T>
 void assert_moveable(T& t) {
     // It's fine
 }
 template <class T>
 void assert_moveable(const T& t) {
-    static_assert(always_false<T>::value, "unable to move-out from T");
+    static_assert(_impl::always_false<T>::value, "unable to move-out from T");
 }
 


### PR DESCRIPTION
It was a prerequisite for another commit I finally thrown away. However, this little bit can be still be useful even for the sake of compliance with the interruptible variant.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
