### PR TITLE
pacific: mds: Add new flag to MClientSession

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -613,8 +613,8 @@ void Server::handle_client_session(const cref_t<MClientSession> &m)
         dout(2) << css->strv() << dendl;
       };
 
-      auto send_reject_message = [this, &session, &log_session_status](std::string_view err_str) {
-	auto m = make_message<MClientSession>(CEPH_SESSION_REJECT);
+      auto send_reject_message = [this, &session, &log_session_status](std::string_view err_str, unsigned flags=0) {
+	auto m = make_message<MClientSession>(CEPH_SESSION_REJECT, 0, flags);
 	if (session->info.has_feature(CEPHFS_FEATURE_MIMIC))
 	  m->metadata["error_string"] = err_str;
 	mds->send_message_client(m, session);
@@ -633,7 +633,9 @@ void Server::handle_client_session(const cref_t<MClientSession> &m)
 	// has been blocklisted.  If mounted with recover_session=clean
 	// (since 5.4), it tries to automatically recover itself from
 	// blocklisting.
-	send_reject_message("blocklisted (blacklisted)");
+        unsigned flags = 0;
+	flags |= MClientSession::SESSION_BLOCKLISTED;
+	send_reject_message("blocklisted (blacklisted)", flags);
 	session->clear();
 	break;
       }

--- a/src/messages/MClientSession.h
+++ b/src/messages/MClientSession.h
@@ -20,12 +20,14 @@
 
 class MClientSession final : public SafeMessage {
 private:
-  static constexpr int HEAD_VERSION = 4;
+  static constexpr int HEAD_VERSION = 5;
   static constexpr int COMPAT_VERSION = 1;
 
 public:
   ceph_mds_session_head head;
+  static constexpr unsigned SESSION_BLOCKLISTED = (1<<0);
 
+  unsigned flags = 0;
   std::map<std::string, std::string> metadata;
   feature_bitset_t supported_features;
   metric_spec_t metric_spec;
@@ -38,8 +40,9 @@ public:
 
 protected:
   MClientSession() : SafeMessage{CEPH_MSG_CLIENT_SESSION, HEAD_VERSION, COMPAT_VERSION} { }
-  MClientSession(int o, version_t s=0) : 
-    SafeMessage{CEPH_MSG_CLIENT_SESSION, HEAD_VERSION, COMPAT_VERSION} {
+  MClientSession(int o, version_t s=0, unsigned msg_flags=0) :
+    SafeMessage{CEPH_MSG_CLIENT_SESSION, HEAD_VERSION, COMPAT_VERSION},
+    flags(msg_flags) {
     memset(&head, 0, sizeof(head));
     head.op = o;
     head.seq = s;
@@ -75,6 +78,9 @@ public:
     if (header.version >= 4) {
       decode(metric_spec, p);
     }
+    if (header.version >= 5) {
+      decode(flags, p);
+    }
   }
   void encode_payload(uint64_t features) override { 
     using ceph::encode;
@@ -89,6 +95,7 @@ public:
       encode(metadata, payload);
       encode(supported_features, payload);
       encode(metric_spec, payload);
+      encode(flags, payload);
     }
   }
 private:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52633

---

backport of https://github.com/ceph/ceph/pull/42846
parent tracker: https://tracker.ceph.com/issues/52382

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh