### PR TITLE
crimson/onode-staged-tree: convert hash to the reversed version

### DIFF
--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -146,6 +146,13 @@ public:
     build_hash_cache();
   }
 
+  // used by Crimson
+  hobject_t(const std::string &key, snapid_t snap, uint32_t reversed_hash,
+            int64_t pool, const std::string& nspace)
+    : oid(key), snap(snap), max(false), pool(pool), nspace(nspace) {
+    set_bitwise_key_u32(reversed_hash);
+  }
+
   /// @return min hobject_t ret s.t. ret.hash == this->hash
   hobject_t get_boundary() const {
     if (is_max())
@@ -397,10 +404,11 @@ public:
       shard_id(shard),
       max(false) {}
 
-  ghobject_t(shard_id_t shard, int64_t pool, uint32_t hash,
+  // used by Crimson
+  ghobject_t(shard_id_t shard, int64_t pool, uint32_t reversed_hash,
              const std::string& nspace, const std::string& oid,
              snapid_t snap, gen_t gen)
-    : hobj(object_t(oid), "", snap, hash, pool, nspace),
+    : hobj(oid, snap, reversed_hash, pool, nspace),
       generation(gen),
       shard_id(shard),
       max(false) {}

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -88,7 +88,7 @@ struct crush_t {
   crush_hash_t crush;
 } __attribute__((packed));
 inline std::ostream& operator<<(std::ostream& os, const crush_t& c) {
-  return os << c.crush;
+  return os << "0x" << std::hex << c.crush << std::dec;
 }
 inline MatchKindCMP compare_to(const crush_t& l, const crush_t& r) {
   return toMatchKindCMP(l.crush, r.crush);
@@ -107,7 +107,7 @@ struct shard_pool_crush_t {
   crush_t crush;
 } __attribute__((packed));
 inline std::ostream& operator<<(std::ostream& os, const shard_pool_crush_t& spc) {
-  return os << spc.shard_pool << "," << spc.crush;
+  return os << spc.shard_pool << ",0x" << std::hex << spc.crush << std::dec;
 }
 inline MatchKindCMP compare_to(
     const shard_pool_crush_t& l, const shard_pool_crush_t& r) {
@@ -559,7 +559,7 @@ class key_hobj_t {
 
   std::ostream& dump(std::ostream& os) const {
     os << "key_hobj(" << (int)shard() << ","
-       << pool() << "," << crush() << "; "
+       << pool() << ",0x" << std::hex << crush() << std::dec << "; "
        << string_view_masked_t{nspace()} << ","
        << string_view_masked_t{oid()} << "; "
        << snap() << "," << gen() << ")";
@@ -745,7 +745,7 @@ class key_view_t {
       os << "X,X,";
     }
     if (has_crush()) {
-      os << crush() << "; ";
+      os << "0x" << std::hex << crush() << std::dec << "; ";
     } else {
       os << "X; ";
     }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -42,14 +42,13 @@ template<> struct _full_key_type<KeyT::HOBJ> { using type = key_hobj_t; };
 template <KeyT type>
 using full_key_t = typename _full_key_type<type>::type;
 
-static laddr_t get_lba_hint(shard_t shard, pool_t pool, crush_hash_t crush)
-{
-  if (shard == shard_id_t::NO_SHARD) {
-    return (uint64_t)(pool & 0xFF)<<56 | (uint64_t)(crush)<<24;
-  } else {
-    return (uint64_t)(shard & 0X7F)<<56 | (uint64_t)(pool& 0xFF)<<48 |
-	   (uint64_t)(crush)<<16;
-  }
+static laddr_t get_lba_hint(shard_t shard, pool_t pool, crush_hash_t crush) {
+  // FIXME: It is possible that PGs from different pools share the same prefix
+  // if the mask 0xFF is not long enough, result in unexpected transaction
+  // conflicts.
+  return ((uint64_t)(shard & 0XFF)<<56 |
+          (uint64_t)(pool  & 0xFF)<<48 |
+          (uint64_t)(crush       )<<16);
 }
 
 struct node_offset_packed_t {


### PR DESCRIPTION
The profiling proves that result is as expected (combined with the changes in https://github.com/ceph/ceph/pull/43249):
![1](https://user-images.githubusercontent.com/7736006/134308856-e0c6ed42-c62b-4361-9264-9747848a7272.png)

But hit a new issue during test (seems not related to this PR).

There is an unexpect conflict surge at the end of the test, from CLEANER transactions, and from LBA tree extents:
![2](https://user-images.githubusercontent.com/7736006/134308889-43277399-806c-4615-b4df-3b7cf8046e87.png)

This is also when the CLEANER started to work on OBJECT_DATA_BLOCK extents:
![3](https://user-images.githubusercontent.com/7736006/134312837-1bc70a2b-628b-44ea-ba3f-a23b49713251.png)

And around the same time, rados bench stopped working at 293 seconds:
```
  ...
  291      16    533532    533516   7.16053   6.30859  0.00670649  0.00872449
  292      16    535177    535161   7.15801   6.42578   0.0270258  0.00872744
  293      16    535632    535616   7.13964   1.77734  0.00682839  0.00872831
  294      16    535632    535616   7.11536         0           -  0.00872831
  295      16    535632    535616   7.09124         0           -  0.00872831
```
... followed with an assertion failure from logs:
```
57880 ERROR 2021-09-22 16:14:59,163 [shard 0] none - ../src/crimson/os/seastore/object_data_handler.cc:127 : In function 'crimson::os::seastore::do_insertions(crimson::os::seastore::context_t, crimson::os::seastore::extent_to_write_list_t&)::<lambda(auto:118&)>::<lambda(auto: 120)> [with auto:120 = std::unique_ptr<crimson::os::seastore::LBAPin>]', ceph_assert(%s)
57881 pin->get_laddr() == region.addr
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
