### PR TITLE
pacific: cmake: s/Python_EXECUTABLE/Python3_EXECUTABLE/

### DIFF
--- a/src/ceph-volume/CMakeLists.txt
+++ b/src/ceph-volume/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CEPH_VOLUME_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-volume-virtualenv)
 
 add_custom_command(
   OUTPUT ${CEPH_VOLUME_VIRTUALENV}/bin/python
-  COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=${Python_EXECUTABLE} ${CEPH_VOLUME_VIRTUALENV}
+  COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=${Python3_EXECUTABLE} ${CEPH_VOLUME_VIRTUALENV}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/ceph-volume
   COMMENT "ceph-volume venv is being created")
 

--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -50,6 +50,11 @@ while true ; do
     esac
 done
 
+if ! $PYTHON -VV; then
+    echo "$SCRIPTNAME: unable to locate a valid PYTHON_BINARY"
+    usage
+fi
+
 DIR=$1
 if [ -z "$DIR" ] ; then
     echo "$SCRIPTNAME: need a directory path, but none was provided"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52332

---

backport of https://github.com/ceph/ceph/pull/42823
parent tracker: https://tracker.ceph.com/issues/52304

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh