### PR TITLE
octopus: ceph-volume: fix lvm activate --all --no-systemd

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -245,7 +245,7 @@ class Activate(object):
             terminal.warning('Verify OSDs are present with "ceph-volume lvm list"')
             return
         for osd_fsid, osd_id in osds.items():
-            if systemctl.osd_is_active(osd_id):
+            if not args.no_systemd and systemctl.osd_is_active(osd_id):
                 terminal.warning(
                     'OSD ID %s FSID %s process is active. Skipping activation' % (osd_id, osd_fsid)
                 )

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
@@ -357,10 +357,22 @@ class TestActivateAll(object):
         assert 'a8789a96ce8b process is active. Skipping activation' in err
         assert 'b8218eaa1634 process is active. Skipping activation' in err
 
-    def test_detects_osds_to_activate(self, is_root, capture, monkeypatch):
+    def test_detects_osds_to_activate_systemd(self, is_root, capture, monkeypatch):
         monkeypatch.setattr('ceph_volume.devices.lvm.activate.direct_report', lambda: direct_report)
         monkeypatch.setattr('ceph_volume.devices.lvm.activate.systemctl.osd_is_active', lambda x: False)
         args = ['--all']
+        activation = activate.Activate(args)
+        activation.activate = capture
+        activation.main()
+        calls = sorted(capture.calls, key=lambda x: x['kwargs']['osd_id'])
+        assert calls[0]['kwargs']['osd_id'] == '0'
+        assert calls[0]['kwargs']['osd_fsid'] == '957d22b7-24ce-466a-9883-b8218eaa1634'
+        assert calls[1]['kwargs']['osd_id'] == '1'
+        assert calls[1]['kwargs']['osd_fsid'] == 'd0f3e4ad-e52a-4520-afc0-a8789a96ce8b'
+
+    def test_detects_osds_to_activate_no_systemd(self, is_root, capture, monkeypatch):
+        monkeypatch.setattr('ceph_volume.devices.lvm.activate.direct_report', lambda: direct_report)
+        args = ['--all', '--no-systemd']
         activation = activate.Activate(args)
         activation.activate = capture
         activation.main()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52587

---

backport of https://github.com/ceph/ceph/pull/42912
parent tracker: https://tracker.ceph.com/issues/25070

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh