### PR TITLE
octopus: pybind/mgr/volumes: avoid deadlock in ceph-mgr Finisher thread

### DIFF
--- a/qa/suites/fs/basic_functional/tasks/volumes.yaml
+++ b/qa/suites/fs/basic_functional/tasks/volumes.yaml
@@ -2,8 +2,11 @@ overrides:
   ceph:
     conf:
       mgr:
-        debug client: 10
-    log-ignorelist:
+        debug mgr: 20
+        debug ms: 1
+        debug finisher: 20
+        debug client: 20
+    log-whitelist:
       - OSD full dropping all updates
       - OSD near full
       - pausewr flag

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2276,10 +2276,12 @@ bool DaemonServer::_handle_command(
     return true;
   }
 
-  dout(10) << "passing through " << cmdctx->cmdmap.size() << dendl;
+  dout(10) << "passing through command '" << prefix << "' size " << cmdctx->cmdmap.size() << dendl;
   finisher.queue(new LambdaContext([this, cmdctx, session, py_command, prefix]
                                    (int r_) mutable {
     std::stringstream ss;
+
+    dout(10) << "dispatching command '" << prefix << "' size " << cmdctx->cmdmap.size() << dendl;
 
     // Validate that the module is enabled
     auto& py_handler_name = py_command.module_name;
@@ -2336,6 +2338,7 @@ bool DaemonServer::_handle_command(
 
     cmdctx->odata.append(ds);
     cmdctx->reply(r, ss);
+    dout(10) << " command returned " << r << dendl;
   }));
   return true;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50126

---

backport of https://github.com/ceph/ceph/pull/40316
parent tracker: https://tracker.ceph.com/issues/49605

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh