### PR TITLE
mds: fix typo in the comments and log when setting new loner

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -1324,7 +1324,7 @@ bool Locker::eval(CInode *in, int mask, bool caps_imported)
     if (in->try_drop_loner()) {
       need_issue = true;
       if (in->get_wanted_loner() >= 0) {
-	dout(10) << "eval end set loner to client." << in->get_loner() << dendl;
+	dout(10) << "eval end set loner to client." << in->get_wanted_loner() << dendl;
 	bool ok = in->try_set_loner();
 	ceph_assert(ok);
 	mask = -1;

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -1969,7 +1969,7 @@ void Migrator::export_notify_abort(CDir *dir, export_state_t& stat, set<CDir*>& 
 }
 
 /*
- * this happens if hte dest failes after i send teh export data but before it is acked
+ * this happens if the dest failes after i send the export data but before it is acked
  * that is, we don't know they safely received and logged it, so we reverse our changes
  * and go on.
  */


### PR DESCRIPTION
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
