### PR TITLE
mds: reduce memory usage during scrubbing

### DIFF
--- a/src/mds/Migrator.h
+++ b/src/mds/Migrator.h
@@ -20,6 +20,7 @@
 #include "include/types.h"
 
 #include "MDSContext.h"
+#include "ScrubHeader.h"
 
 #include <map>
 #include <list>
@@ -216,11 +217,10 @@ public:
 			        std::map<client_t,Capability::Import>& peer_imported);
 
 
-  void encode_export_dir(bufferlist& exportbl,
-			CDir *dir,
+  uint64_t encode_export_dir(bufferlist& exportbl, CDir *dir,
 			std::map<client_t,entity_inst_t>& exported_client_map,
 			std::map<client_t,client_metadata_t>& exported_client_metadata_map,
-                        uint64_t &num_exported);
+                        std::set<ScrubHeaderRef>& scrub_headers);
   void finish_export_dir(CDir *dir, mds_rank_t target,
 			 std::map<inodeno_t,std::map<client_t,Capability::Import> >& peer_imported,
 			 MDSContext::vec& finished, int *num_dentries);
@@ -239,13 +239,10 @@ public:
 				const std::map<client_t,std::pair<Session*,uint64_t> >& smap,
 				const std::map<client_t,Capability::Export> &export_map,
 				std::map<client_t,Capability::Import> &import_map);
-  void decode_import_dir(bufferlist::const_iterator& blp,
-			mds_rank_t oldauth,
-			CDir *import_root,
-			EImportStart *le, 
-			LogSegment *ls,
+  uint64_t decode_import_dir(bufferlist::const_iterator& blp, CDir *import_root,
+			mds_rank_t oldauth, EImportStart *le, LogSegment *ls,
 			std::map<CInode*, std::map<client_t,Capability::Export> >& cap_imports,
-			std::list<ScatterLock*>& updated_scatterlocks, int &num_imported);
+			std::list<ScatterLock*>& updated_scatterlocks);
 
   void import_reverse(CDir *dir);
 

--- a/src/mds/ScrubHeader.h
+++ b/src/mds/ScrubHeader.h
@@ -26,17 +26,16 @@ namespace ceph {
 class Formatter;
 };
 
-class CInode;
-
 /**
  * Externally input parameters for a scrub, associated with the root
  * of where we are doing a recursive scrub
  */
 class ScrubHeader {
 public:
-  ScrubHeader(std::string_view tag_, bool is_tag_internal_, bool force_,
+  ScrubHeader() {}
+  ScrubHeader(std::string_view tag_, bool tag_internal_, bool force_,
               bool recursive_, bool repair_)
-    : tag(tag_), is_tag_internal(is_tag_internal_), force(force_),
+    : tag(tag_), tag_internal(tag_internal_), force(force_),
       recursive(recursive_), repair(repair_) {}
 
   // Set after construction because it won't be known until we've
@@ -46,7 +45,7 @@ public:
   bool get_recursive() const { return recursive; }
   bool get_repair() const { return repair; }
   bool get_force() const { return force; }
-  bool is_internal_tag() const { return is_tag_internal; }
+  bool is_internal_tag() const { return tag_internal; }
   inodeno_t get_origin() const { return origin; }
   const std::string& get_tag() const { return tag; }
 
@@ -63,18 +62,42 @@ public:
   }
   unsigned get_num_pending() const { return num_pending; }
 
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    using ceph::encode;
+    encode(tag, bl);
+    encode(tag_internal, bl);
+    encode(origin, bl);
+    encode(force, bl);
+    encode(recursive, bl);
+    encode(repair, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(ceph::buffer::list::const_iterator& p) {
+    DECODE_START(1, p);
+    using ceph::decode;
+    decode(tag, p);
+    decode(tag_internal, p);
+    decode(origin, p);
+    decode(force, p);
+    decode(recursive, p);
+    decode(repair, p);
+    DECODE_FINISH(p);
+  }
+
 protected:
-  const std::string tag;
-  bool is_tag_internal;
-  const bool force;
-  const bool recursive;
-  const bool repair;
+  std::string tag;
+  bool tag_internal = true;
+  bool force = false;
+  bool recursive = false;
+  bool repair = false;
   inodeno_t origin;
 
   bool repaired = false;  // May be set during scrub if repairs happened
   unsigned epoch_last_forwarded = 0;
   unsigned num_pending = 0;
 };
+WRITE_CLASS_ENCODER(ScrubHeader)
 
 typedef std::shared_ptr<ScrubHeader> ScrubHeaderRef;
 typedef std::shared_ptr<const ScrubHeader> ScrubHeaderRefConst;

--- a/src/messages/MExportDir.h
+++ b/src/messages/MExportDir.h
@@ -24,6 +24,7 @@ public:
   ceph::buffer::list export_data;
   std::vector<dirfrag_t> bounds;
   ceph::buffer::list client_map;
+  ceph::buffer::list scrub_headers;
 
 protected:
   MExportDir() : MMDSOp{MSG_MDS_EXPORTDIR} {}
@@ -49,6 +50,7 @@ public:
     encode(bounds, payload);
     encode(export_data, payload);
     encode(client_map, payload);
+    encode(scrub_headers, payload);
   }
   void decode_payload() override {
     using ceph::decode;
@@ -57,6 +59,7 @@ public:
     decode(bounds, p);
     decode(export_data, p);
     decode(client_map, p);
+    decode(scrub_headers, p);
   }
 private:
   template<class T, typename... Args>


### PR DESCRIPTION
Breadth-first search may queue lots of inodes. Change scrub traverse
to depth-First search.

The new scrub code no long pins dirfrag in scrub stack. If a dirfrag
gets exported, the old auth mds should abort scrub, the new auth mds
should continue to scrub.

Fixes: https://tracker.ceph.com/issues/52715
Signed-off-by: "Erqi Chen" <chenerqi@kuaishou.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
