### PR TITLE
mds: add mds_bal_rank_mask config option

### DIFF
--- a/doc/cephfs/multimds.rst
+++ b/doc/cephfs/multimds.rst
@@ -225,3 +225,48 @@ For the reverse situation:
 
 The ``home/patrick`` directory and its children will be pinned to rank 2
 because its export pin overrides the policy on ``home``.
+
+
+Dynamic subtree partitioning with Balancer on specific ranks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The CephFS file system provides the ``bal_rank_mask`` option to enable the balancer
+to dynamically rebalance subtrees within particular active MDS ranks. This
+allows administrators to employ both the dynamic subtree partitioning and
+static pining schemes in different active MDS ranks so that metadata loads
+are optimized based on user demand. For instance, in realistic cloud
+storage environments, where a lot of subvolumes are allotted to multiple
+computing nodes (e.g., VMs and containers), some subvolumes that require
+high performance are managed by static partitioning, whereas most subvolumes
+that experience a moderate workload are managed by the balancer. As the balancer
+evenly spreads the metadata workload to all active MDS ranks, performance of
+static pinned subvolumes inevitably may be affected or degraded. If this option
+is enabled, subtrees managed by the balancer are not affected by
+static pinned subtrees.
+
+This option can be configured with the ``ceph fs set`` command. For example:
+
+::
+
+    ceph fs set <fs_name> bal_rank_mask <hex> 
+
+Each bitfield of the ``<hex>`` number represents a dedicated rank. If the ``<hex>`` is
+set to ``0x3``, the balancer runs on active ``0`` and ``1`` ranks. For example:
+
+::
+
+    ceph fs set <fs_name> bal_rank_mask 0x3
+
+If the ``bal_rank_mask`` is set to ``-1`` or ``all``, all active ranks are masked
+and utilized by the balancer. As an example:
+
+::
+
+    ceph fs set <fs_name> bal_rank_mask -1
+
+On the other hand, if the balancer needs to be disabled,
+the ``bal_rank_mask`` should be set to ``0x0``. For example:
+
+::
+
+    ceph fs set <fs_name> bal_rank_mask 0x0

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -594,6 +594,9 @@ class Filesystem(MDSCluster):
     def set_allow_new_snaps(self, yes):
         self.set_var("allow_new_snaps", yes, '--yes-i-really-mean-it')
 
+    def set_bal_rank_mask(self, bal_rank_mask):
+        self.set_var("bal_rank_mask", bal_rank_mask)
+
     def compat(self, *args):
         a = map(lambda x: str(x).lower(), args)
         self.mon_manager.raw_cluster_cmd("fs", "compat", self.name, *a)

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1387,3 +1387,80 @@ class TestAdminCommandDumpLoads(CephFSTestCase):
         self.assertIn("dirfrags", loads)
         for d in loads["dirfrags"]:
             self.assertLessEqual(d["path"].count("/"), 1)
+
+class TestFsBalRankMask(CephFSTestCase):
+    """
+    Tests ceph fs set <fs_name> bal_rank_mask
+    """
+
+    CLIENTS_REQUIRED = 0
+    MDSS_REQUIRED = 2
+
+    def test_bal_rank_mask(self):
+        """
+        check whether a specified bal_rank_mask value is valid or not.
+        """
+        bal_rank_mask = '0x0'
+        log.info(f"set bal_rank_mask {bal_rank_mask}")
+        self.fs.set_bal_rank_mask(bal_rank_mask)
+        self.assertEqual(bal_rank_mask, self.fs.get_var('bal_rank_mask'))
+
+        bal_rank_mask = '0'
+        log.info(f"set bal_rank_mask {bal_rank_mask}")
+        self.fs.set_bal_rank_mask(bal_rank_mask)
+        self.assertEqual(bal_rank_mask, self.fs.get_var('bal_rank_mask'))
+
+        bal_rank_mask = '-1'
+        log.info(f"set bal_rank_mask {bal_rank_mask}")
+        self.fs.set_bal_rank_mask(bal_rank_mask)
+        self.assertEqual(bal_rank_mask, self.fs.get_var('bal_rank_mask'))
+
+        bal_rank_mask = 'all'
+        log.info(f"set bal_rank_mask {bal_rank_mask}")
+        self.fs.set_bal_rank_mask(bal_rank_mask)
+        self.assertEqual(bal_rank_mask, self.fs.get_var('bal_rank_mask'))
+
+        bal_rank_mask = '0x1'
+        log.info(f"set bal_rank_mask {bal_rank_mask}")
+        self.fs.set_bal_rank_mask(bal_rank_mask)
+        self.assertEqual(bal_rank_mask, self.fs.get_var('bal_rank_mask'))
+
+        bal_rank_mask = '1'
+        log.info(f"set bal_rank_mask {bal_rank_mask}")
+        self.fs.set_bal_rank_mask(bal_rank_mask)
+        self.assertEqual(bal_rank_mask, self.fs.get_var('bal_rank_mask'))
+
+        bal_rank_mask = 'f0'
+        log.info(f"set bal_rank_mask {bal_rank_mask}")
+        self.fs.set_bal_rank_mask(bal_rank_mask)
+        self.assertEqual(bal_rank_mask, self.fs.get_var('bal_rank_mask'))
+
+        bal_rank_mask = 'ab'
+        log.info(f"set bal_rank_mask {bal_rank_mask}")
+        self.fs.set_bal_rank_mask(bal_rank_mask)
+        self.assertEqual(bal_rank_mask, self.fs.get_var('bal_rank_mask'))
+
+        bal_rank_mask = '0xfff0'
+        log.info(f"set bal_rank_mask {bal_rank_mask}")
+        self.fs.set_bal_rank_mask(bal_rank_mask)
+        self.assertEqual(bal_rank_mask, self.fs.get_var('bal_rank_mask'))
+
+        MAX_MDS = 256
+        bal_rank_mask = '0x' + 'f' * int(MAX_MDS / 4)
+        log.info(f"set bal_rank_mask {bal_rank_mask}")
+        self.fs.set_bal_rank_mask(bal_rank_mask)
+        self.assertEqual(bal_rank_mask, self.fs.get_var('bal_rank_mask'))
+
+        bal_rank_mask = ''
+        log.info("set bal_rank_mask to empty string")
+        try:
+            self.fs.set_bal_rank_mask(bal_rank_mask)
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.EINVAL)
+
+        bal_rank_mask = '0x1' + 'f' * int(MAX_MDS / 4)
+        log.info(f"set bal_rank_mask {bal_rank_mask}")
+        try:
+            self.fs.set_bal_rank_mask(bal_rank_mask)
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.EINVAL)

--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -23,6 +23,7 @@ class HealthTest(DashboardTestCase):
     __mdsmap_schema = JObj({
         'session_autoclose': int,
         'balancer': str,
+        'bal_rank_mask': str,
         'up': JObj({}, allow_unknown=True),
         'last_failure_osd_epoch': int,
         'in': JList(int),

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -102,11 +102,11 @@ private:
                    mds_rank_t ex, double& maxex,
                    mds_rank_t im, double& maxim);
 
-  double get_maxim(balance_state_t &state, mds_rank_t im) {
-    return target_load - mds_meta_load[im] - state.imported[im];
+  double get_maxim(balance_state_t &state, mds_rank_t im, double im_target_load) {
+    return im_target_load - mds_meta_load[im] - state.imported[im];
   }
-  double get_maxex(balance_state_t &state, mds_rank_t ex) {
-    return mds_meta_load[ex] - target_load - state.exported[ex];
+  double get_maxex(balance_state_t &state, mds_rank_t ex, double ex_target_load) {
+    return mds_meta_load[ex] - ex_target_load - state.exported[ex];
   }
 
   /**
@@ -117,6 +117,7 @@ private:
    * export targets message again.
    */
   void try_rebalance(balance_state_t& state);
+  bool test_rank_mask(mds_rank_t rank);
 
   bool bal_fragment_dirs;
   int64_t bal_fragment_interval;

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -275,6 +275,21 @@ public:
   const std::string get_balancer() const { return balancer; }
   void set_balancer(std::string val) { balancer.assign(val); }
 
+  const std::bitset<MAX_MDS>& get_bal_rank_mask_bitset() const;
+  void set_bal_rank_mask(std::string val);
+  unsigned get_num_mdss_in_rank_mask_bitset() const { return num_mdss_in_rank_mask_bitset; }
+  void update_num_mdss_in_rank_mask_bitset();
+  int hex2bin(std::string hex_string, std::string &bin_string, unsigned int max_bits, std::ostream& ss) const;
+
+  typedef enum
+  {
+    BAL_RANK_MASK_TYPE_ANY = 0,
+    BAL_RANK_MASK_TYPE_ALL = 1,
+    BAL_RANK_MASK_TYPE_NONE = 2,
+  } bal_rank_mask_type_t;
+
+  const bool check_special_bal_rank_mask(std::string val, bal_rank_mask_type_t type) const;
+
   mds_rank_t get_tableserver() const { return tableserver; }
   mds_rank_t get_root() const { return root; }
 
@@ -625,6 +640,10 @@ protected:
   mds_rank_t old_max_mds = 0; /* Value to restore when MDS cluster is marked up */
   mds_rank_t standby_count_wanted = -1;
   std::string balancer;    /* The name/version of the mantle balancer (i.e. the rados obj name) */
+
+  std::string bal_rank_mask = "-1";
+  std::bitset<MAX_MDS> bal_rank_mask_bitset;
+  uint32_t num_mdss_in_rank_mask_bitset;
 
   std::set<mds_rank_t> in;              // currently defined cluster
 

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -424,6 +424,28 @@ public:
           fs->mds_map.set_balancer(val);
         });
       return true;
+    } else if (var == "bal_rank_mask") {
+      if (val.empty()) {
+        ss << "bal_rank_mask may not be empty";
+	return -EINVAL;
+      }
+
+      if (fs->mds_map.check_special_bal_rank_mask(val, MDSMap::BAL_RANK_MASK_TYPE_ANY) == false) {
+	std::string bin_string;
+	int r = fs->mds_map.hex2bin(val, bin_string, MAX_MDS, ss);
+	if (r != 0) {
+	  return r;
+	}
+      }
+      ss << "setting the metadata balancer rank mask to " << val;
+
+      fsmap.modify_filesystem(
+	fs->fscid,
+	[val](std::shared_ptr<Filesystem> fs)
+        {
+          fs->mds_map.set_bal_rank_mask(val);
+        });
+      return true;
     } else if (var == "max_file_size") {
       if (interr.length()) {
 	ss << var << " requires an integer value";

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -365,7 +365,7 @@ COMMAND("fs set "
 	"name=var,type=CephChoices,strings=max_mds|max_file_size"
         "|allow_new_snaps|inline_data|cluster_down|allow_dirfrags|balancer"
         "|standby_count_wanted|session_timeout|session_autoclose"
-        "|allow_standby_replay|down|joinable|min_compat_client "
+        "|allow_standby_replay|down|joinable|min_compat_client|bal_rank_mask "
 	"name=val,type=CephString "
 	"name=yes_i_really_mean_it,type=CephBool,req=false "
 	"name=yes_i_really_really_mean_it,type=CephBool,req=false",


### PR DESCRIPTION
This PR introduces mds_bal_rank_mask option to rebalance subtrees within certain active MDSs. With this option, some active ranks are used for statically pinned subdirs, whereas the rest ranks are for subtrees to be rebalanced dynamically by MDBalancer.

fixes: https://tracker.ceph.com/issues/52720

Signed-off-by: Yongseok Oh <yongseok.oh@linecorp.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
