### PR TITLE
qa/tasks/rook, mgr/rook: remove running daemons before teardown

### DIFF
--- a/qa/suites/orch/rook/smoke/3-final.yaml
+++ b/qa/suites/orch/rook/smoke/3-final.yaml
@@ -6,3 +6,4 @@ tasks:
       - ceph orch ls
       - ceph orch host ls
       - ceph orch device ls
+      - ceph orch apply rgw foo

--- a/qa/tasks/rook.py
+++ b/qa/tasks/rook.py
@@ -646,4 +646,28 @@ def task(ctx, config):
             yield
 
         finally:
+            to_remove = []
+            ret = _shell(ctx, config, ['ceph', 'orch', 'ls', '-f', 'json'], stdout=BytesIO())
+            if ret.exitstatus == 0:
+                r = json.loads(ret.stdout.getvalue().decode('utf-8'))
+                for service in r:
+                    removal_name = None
+                    if service['service_type'] == 'rgw':
+                        removal_name = 'rgw.' + service['spec']['rgw_realm']
+                    elif service['service_type'] == 'mds':
+                        removal_name = service['service_name']
+                    elif service['service_type'] == 'nfs':
+                        removal_name = service['service_name']
+                    if removal_name != None:
+                        _shell(ctx, config, ['ceph', 'orch', 'rm', removal_name])
+                        to_remove.append(service['service_name'])
+                with safe_while(sleep=10, tries=90, action="waiting for service removal") as proceed:
+                    while proceed():
+                        ret = _shell(ctx, config, ['ceph', 'orch', 'ls', '-f', 'json'], stdout=BytesIO())
+                        if ret.exitstatus == 0:
+                            r = json.loads(ret.stdout.getvalue().decode('utf-8'))
+                            still_up = [service['service_name'] for service in r]
+                            matches = set(still_up).intersection(to_remove)
+                            if not matches:
+                                break
             log.info('Tearing down rook')

--- a/qa/tasks/rook.py
+++ b/qa/tasks/rook.py
@@ -651,15 +651,8 @@ def task(ctx, config):
             if ret.exitstatus == 0:
                 r = json.loads(ret.stdout.getvalue().decode('utf-8'))
                 for service in r:
-                    removal_name = None
-                    if service['service_type'] == 'rgw':
-                        removal_name = 'rgw.' + service['spec']['rgw_realm']
-                    elif service['service_type'] == 'mds':
-                        removal_name = service['service_name']
-                    elif service['service_type'] == 'nfs':
-                        removal_name = service['service_name']
-                    if removal_name != None:
-                        _shell(ctx, config, ['ceph', 'orch', 'rm', removal_name])
+                    if service['service_type'] in ['rgw', 'mds', 'nfs']:
+                        _shell(ctx, config, ['ceph', 'orch', 'rm', service['service_name']])
                         to_remove.append(service['service_name'])
                 with safe_while(sleep=10, tries=90, action="waiting for service removal") as proceed:
                     while proceed():

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -450,7 +450,9 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
     @handle_orch_error
     def apply_rgw(self, spec):
         # type: (RGWSpec) -> str
-        return self.rook_cluster.apply_objectstore(spec)
+        num_of_osds = self.get_ceph_option('osd_pool_default_size')
+        assert type(num_of_osds) is int
+        return self.rook_cluster.apply_objectstore(spec, num_of_osds)
 
     @handle_orch_error
     def apply_nfs(self, spec):

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -274,10 +274,8 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         if service_type == 'mds' or service_type is None:
             # CephFilesystems
-            all_fs = self.rook_cluster.rook_api_get(
-                "cephfilesystems/")
-            self.log.debug('CephFilesystems %s' % all_fs)
-            for fs in all_fs.get('items', []):
+            all_fs = self.rook_cluster.get_resource("cephfilesystems")
+            for fs in all_fs:
                 svc = 'mds.' + fs['metadata']['name']
                 if svc in spec:
                     continue
@@ -299,13 +297,11 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         if service_type == 'rgw' or service_type is None:
             # CephObjectstores
-            all_zones = self.rook_cluster.rook_api_get(
-                "cephobjectstores/")
-            self.log.debug('CephObjectstores %s' % all_zones)
-            for zone in all_zones.get('items', []):
+            all_zones = self.rook_cluster.get_resource("cephobjectstores")
+            for zone in all_zones:
                 rgw_realm = zone['metadata']['name']
                 rgw_zone = rgw_realm
-                svc = 'rgw.' + rgw_realm + '.' + rgw_zone
+                svc = 'rgw.' + rgw_realm
                 if svc in spec:
                     continue
                 active = zone['spec']['gateway']['instances'];
@@ -317,7 +313,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                     port = zone['spec']['gateway']['port'] or 80
                 spec[svc] = orchestrator.ServiceDescription(
                     spec=RGWSpec(
-                        service_id=rgw_realm + '.' + rgw_zone,
+                        service_id=zone['metadata']['name'],
                         rgw_realm=rgw_realm,
                         rgw_zone=rgw_zone,
                         ssl=ssl,
@@ -331,10 +327,8 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         if service_type == 'nfs' or service_type is None:
             # CephNFSes
-            all_nfs = self.rook_cluster.rook_api_get(
-                "cephnfses/")
-            self.log.warning('CephNFS %s' % all_nfs)
-            for nfs in all_nfs.get('items', []):
+            all_nfs = self.rook_cluster.get_resource("cephnfses")
+            for nfs in all_nfs:
                 nfs_name = nfs['metadata']['name']
                 svc = 'nfs.' + nfs_name
                 if svc in spec:

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -907,7 +907,7 @@ class RookCluster(object):
             # translate . to - (fingers crossed!) instead.
             name = spec.service_id.replace('.', '-')
 
-
+        all_hosts = self.get_hosts()
         def _create_zone() -> cos.CephObjectStore:
             port = None
             secure_port = None
@@ -926,7 +926,16 @@ class RookCluster(object):
                             port=port,
                             securePort=secure_port,
                             instances=spec.placement.count or 1,
-                        )
+                            placement=ccl.NodeAffinity(
+                                requiredDuringSchedulingIgnoredDuringExecution=ccl.RequiredDuringSchedulingIgnoredDuringExecution(
+                                    nodeSelectorTerms=ccl.NodeSelectorTermsList(
+                                        [
+                                            placement_spec_to_node_selector(spec.placement, all_hosts)
+                                        ]
+                                    )
+                                )
+                            )
+                        ),
                     )
                 )
             if spec.rgw_zone:

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -1007,18 +1007,8 @@ class RookCluster(object):
                 _update_nfs, _create_nfs)
 
     def rm_service(self, rooktype: str, service_id: str) -> str:
-
+        self.customObjects_api.delete_namespaced_custom_object(group="ceph.rook.io", version="v1", namespace="rook-ceph", plural=rooktype, name=service_id)
         objpath = "{0}/{1}".format(rooktype, service_id)
-
-        try:
-            self.rook_api_delete(objpath)
-        except ApiException as e:
-            if e.status == 404:
-                log.info("{0} service '{1}' does not exist".format(rooktype, service_id))
-                # Idempotent, succeed.
-            else:
-                raise
-
         return f'Removed {objpath}'
 
     def can_create_osd(self) -> bool:

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -1297,7 +1297,7 @@ def placement_spec_to_node_selector(spec: PlacementSpec, all_hosts: List) -> ccl
                 values=ccl.CrdObjectList(host_list)
             )
         ) 
-    if spec.host_pattern == "*":
+    if spec.host_pattern == "*" or (not spec.label and not spec.hosts and not spec.host_pattern):
         res.matchExpressions.append(
             ccl.MatchExpressionsItem(
                 key="kubernetes.io/hostname",

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -1011,6 +1011,10 @@ class RookCluster(object):
         objpath = "{0}/{1}".format(rooktype, service_id)
         return f'Removed {objpath}'
 
+    def get_resource(self, resource_type: str) -> Iterable:
+        custom_objects: KubernetesCustomResource = KubernetesCustomResource(self.customObjects_api.list_namespaced_custom_object, group="ceph.rook.io", version="v1", namespace="rook-ceph", plural=resource_type)
+        return custom_objects.items
+
     def can_create_osd(self) -> bool:
         current_cluster = self.rook_api_get(
             "cephclusters/{0}".format(self.rook_env.cluster_name))


### PR DESCRIPTION
This PR includes a fix for the Ceph cluster not being deleted when daemons are still running during the test. It also includes a fix for `orch rm` that stops using the Rook API and deletes CRs using the Kubernetes API. Finally it fixes a small edge case for translating Placement Specs to Node Selectors when an empty Placement Spec is passed.

Depends on: #43081 

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
