### PR TITLE
.github/pull_request_template: update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,58 +1,38 @@
 
+
 <!--
-Thank you for opening a pull request!  Here are some tips on creating
-a well formatted contribution.
+  - Please give your pull request a title like
 
-Please give your pull request a title like "[component]: [short description]"
+      [component]: [short description]
 
-This is the format for commit messages:
+  - Please use this format for each git commit message:
 
-"""
-[component]: [short description]
+      [component]: [short description]
 
-[A longer multiline description]
+      [A longer multiline description]
 
-Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
-Signed-off-by: [Your Name] <[your email]>
-"""
+      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
+      Signed-off-by: [Your Name] <[your email]>
 
-The Signed-off-by line is important, and it is your certification that
-your contributions satisfy the Developers Certificate or Origin.  For
-more detail, see SubmittingPatches.rst.
+    For examples, use "git log".
 
-The component is the short name of a major daemon or subsystem,
-something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
-give the component as "mgr/<module name>" rather than a path into pybind.
-
-For more examples, simply use "git log" and look at some historical commits.
-
-This was just a quick overview.  More information for contributors is available here:
-https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst
-
+  - The Signed-off-by line in every git commit is important; see SubmittingPatches.rst.
 -->
+
 ## Checklist
-- [ ] References tracker ticket
-- [ ] Updates documentation if necessary
-- [ ] Includes tests for new functionality or reproducer for bug
-
----
-
-<details>
-<summary>Show available Jenkins commands</summary>
-
-- `jenkins retest this please`
-- `jenkins test classic perf`
-- `jenkins test crimson perf`
-- `jenkins test signed`
-- `jenkins test make check`
-- `jenkins test make check arm64`
-- `jenkins test submodules`
-- `jenkins test dashboard`
-- `jenkins test dashboard cephadm`
-- `jenkins test api`
-- `jenkins test docs`
-- `jenkins render docs`
-- `jenkins test ceph-volume all`
-- `jenkins test ceph-volume tox`
-
-</details>
+- Tracker (select at least one)
+  - [ ] Very recent bug; references commit where it was introduced
+  - [ ] New feature (no ticket)
+  - [ ] References tracker ticket
+  - [ ] Doc update (no ticket)
+- Documentation (select at least one)
+  - [ ] Updates relevant documentation
+  - [ ] No doc update is appropriate
+- Tests (select at least one)
+  - [ ] Includes unit test(s)
+  - [ ] Includes integration test(s)
+  - [ ] Includes bug reproducer
+  - [ ] No tests
+- Teuthology
+  - [ ] Completed teuthology run
+  - [ ] No teuthology test necessary (e.g., documentation)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
 
 
+
+
 <!--
   - Please give your pull request a title like
 
@@ -16,23 +18,47 @@
 
     For examples, use "git log".
 
-  - The Signed-off-by line in every git commit is important; see SubmittingPatches.rst.
+  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
 -->
 
 ## Checklist
 - Tracker (select at least one)
-  - [ ] Very recent bug; references commit where it was introduced
-  - [ ] New feature (no ticket)
   - [ ] References tracker ticket
-  - [ ] Doc update (no ticket)
+  - [ ] Very recent bug; references commit where it was introduced
+  - [ ] New feature (ticket optional)
+  - [ ] Doc update (no ticket needed)
+- Component impact
+  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
+  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
+  - [ ] No impact that needs to be tracked
 - Documentation (select at least one)
   - [ ] Updates relevant documentation
   - [ ] No doc update is appropriate
 - Tests (select at least one)
-  - [ ] Includes unit test(s)
-  - [ ] Includes integration test(s)
+  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
+  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
   - [ ] Includes bug reproducer
   - [ ] No tests
 - Teuthology
   - [ ] Completed teuthology run
   - [ ] No teuthology test necessary (e.g., documentation)
+
+<details>
+<summary>Show available Jenkins commands</summary>
+
+- `jenkins retest this please`
+- `jenkins test classic perf`
+- `jenkins test crimson perf`
+- `jenkins test signed`
+- `jenkins test make check`
+- `jenkins test make check arm64`
+- `jenkins test submodules`
+- `jenkins test dashboard`
+- `jenkins test dashboard cephadm`
+- `jenkins test api`
+- `jenkins test docs`
+- `jenkins render docs`
+- `jenkins test ceph-volume all`
+- `jenkins test ceph-volume tox`
+
+</details>

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,16 @@
+---
+name: "Pull Request Checklist"
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - reopened
+jobs:
+  pr_checklist:
+    runs-on: ubuntu-latest
+    name: Verify
+    steps:
+      - name: Action
+        id: checklist
+        uses: ceph/ceph-pr-checklist-action@32e92d1a2a7c9991ed51de5fccb2296551373d60


### PR DESCRIPTION
- Update PR template to so that we have to check at least one box in each section, as a matter of habit (instead of ignoring the checklist alltogether).
- add an action/check that prevents merge if the checklist isn't done

Pros:
- always have to actively say "i did this" or "i don't need to do this", so that hopefully the "i'm too lazy to think about this" cases are forced into one of those first two categories.
- there's a check that forces you to do it

Cons:
- I wish there were radio buttons.  The checklist takes up a lot of vertical space, and in the pull request list it'll say "4/12 tasks completed" or similar.

TODO:
- [ ] remove comment explaining how to format commits and pull request descriptions?  we can enforce the style via another action...
- [ ] make sure the jenkins action list is up to date
- [ ] link to where in jenkins this list is defined for others doing this later

You can make any checklist that looks like the below.  Basically, it must start with ``## Checklist`` and the action will stop processing it when it reaches a newline.

## Checklist
- First group (the part in parens is ignored)
  - [x] first option 1
  - [x] first option 2
- Second thing (blah blah)
  - [ ] a
  - [x] b
  - [ ] c
- Third (...)
  - [x] 3a
  - [ ] 3b

Stuff down here below the checklist is ignored by the action.