### PR TITLE
Dockerfile.in: add simplified Dockerfile

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,0 +1,159 @@
+## Ceph base image (input)
+
+# NOTE: final Dockerfiles appear at container/{default,crimson}/Dockerfile
+# under the the cmake build dir.
+
+FROM centos:8
+
+LABEL maintainer="Ceph developers <dev@ceph.io>"
+LABEL ceph="True"
+LABEL CEPH_GIT_REPO="git@github.com:ceph/ceph"
+LABEL CEPH_RELEASE="@CEPH_RELEASE_NAME@"
+LABEL CEPH_GIT_COMMIT="@CEPH_GIT_VER@"
+LABEL CEPH_FLAVOR="@CEPH_FLAVOR@"
+
+# these are for pulling packages from shaman
+ENV FLAVOR @CEPH_FLAVOR@
+ENV CEPH_GIT_COMMIT @CEPH_GIT_VER@
+
+
+## Install all the things
+
+RUN \
+    echo "Installing initial packages..." && \
+    yum install -y \
+        epel-release \
+	jq \
+	dnf-plugins-core && \
+    \
+    echo "Setting up repos..." && \
+    bash -c ' \
+        # ganesha
+    	echo "[ganesha]" > /etc/yum.repos.d/ganesha.repo ; \
+    	echo "name=ganesha" >> /etc/yum.repos.d/ganesha.repo ; \
+    	echo "baseurl=https://buildlogs.centos.org/centos/\$releasever/storage/\$basearch/nfsganesha-3/" >> /etc/yum.repos.d/ganesha.repo ; \
+    	echo "gpgcheck=0" >> /etc/yum.repos.d/ganesha.repo ; \
+    	echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo  ; \
+    	# iscsi
+    	curl -s -L https://shaman.ceph.com/api/repos/tcmu-runner/master/latest/centos/8/repo?arch=$(arch) -o /etc/yum.repos.d/tcmu-runner.repo ; \
+    	curl -s -L https://shaman.ceph.com/api/repos/ceph-iscsi/master/latest/centos/8/repo -o /etc/yum.repos.d/ceph-iscsi.repo \
+   	' && \
+    \
+    yum copr enable -y tchaikov/python-scikit-learn && \
+    yum copr enable -y tchaikov/python3-asyncssh && \
+    \
+    rpm --import 'https://download.ceph.com/keys/release.asc' && \
+    \
+    echo "Updating..." && \
+    yum update -y --setopt=install_weak_deps=False && \
+    \
+    echo "Installing ceph packages..." && \
+    ARCH=$(arch) && \
+    if [[ "${ARCH}" == "aarch64" ]]; then ARCH="arm64"; fi && \
+    \
+    # figure shaman repo URL
+    REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/8/${ARCH}&flavor=${FLAVOR}&sha1=${CEPH_GIT_COMMIT}" | jq -r .[0].url) && \
+    \
+    RELEASE_VER=0 && \
+    rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${RELEASE_VER}.el8.noarch.rpm" && \
+    \
+    PKGS="\
+        ca-certificates \
+        e2fsprogs \
+        ceph-common  \
+        ceph-mon  \
+        ceph-osd \
+        ceph-mds \
+	cephfs-mirror \
+        rbd-mirror  \
+        ceph-mgr \
+	ceph-mgr-cephadm \
+	ceph-mgr-dashboard \
+	ceph-mgr-diskprediction-local \
+	ceph-mgr-k8sevents \
+	ceph-mgr-rook \
+	python3-saml\
+        ceph-grafana-dashboards \
+        kmod \
+        lvm2 \
+        gdisk \
+        smartmontools \
+        nvme-cli \
+        libstoragemgmt \
+        ceph-radosgw \
+	libradosstriper1 \
+        nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-rados-grace nfs-ganesha-rados-urls \
+        tcmu-runner \
+	ceph-iscsi \
+	python3-rtslib \
+        attr \
+	ceph-fuse \
+	rbd-nbd \
+        ceph-immutable-object-cache \
+        python3-scikit-learn \
+    	https://apache.jfrog.io/artifactory/arrow/centos/8/apache-arrow-release-latest.rpm \
+        ceph-volume" && \
+    \
+    # crimson?
+    if [[ "${OSD_FLAVOR}" == "crimson" ]]; then PKGS += " ceph-crimson-osd" ; fi && \
+    \
+    yum install -y --setopt=install_weak_deps=False --enablerepo=powertools $PKGS && \
+    \
+    echo 'Postinall cleanup...' && \
+    \
+    # Clean container, starting with record of current size (strip / from end)
+    INITIAL_SIZE="$(bash -c 'sz="$(du -sm --exclude=/proc /)" ; echo "${sz%*/}"')" && \
+    \
+    # Perform any final cleanup actions like package manager cleaning, etc.
+    ( \
+        rm -rf "/usr/bin/hyperkube /usr/bin/etcd /usr/bin/systemd-analyze /usr/share/hwdata/{iab.txt,oui.txt} /etc/profile.d/lang.sh" && \
+	yum clean all && \
+    	# Tweak some configuration files on the container system
+    	# disable sync with udev since the container can not contact udev
+	sed -i -e 's/udev_rules = 1/udev_rules = 0/' -e 's/udev_sync = 1/udev_sync = 0/' -e 's/obtain_device_list_from_udev = 1/obtain_device_list_from_udev = 0/' /etc/lvm/lvm.conf && \
+	# validate the sed command worked as expected
+	grep -sqo "udev_sync = 0" /etc/lvm/lvm.conf && \
+	grep -sqo "udev_rules = 0" /etc/lvm/lvm.conf && \
+	grep -sqo "obtain_device_list_from_udev = 0" /etc/lvm/lvm.conf && \
+    	# Clean common files like /tmp, /var/lib, etc.
+    	rm -rf \
+            /etc/{selinux,systemd,udev} \
+            /lib/{lsb,udev} \
+            /tmp/* \
+            /usr/lib{,64}/{locale,udev,dracut} \
+            /usr/share/{doc,info,locale,man} \
+            /usr/share/{bash-completion,pkgconfig/bash-completion.pc} \
+            /var/log/* \
+            /var/tmp/* && \
+    	find  / -xdev -name "*.pyc" -o -name "*.pyo" -exec rm -f {} \; && \
+    	# ceph-dencoder is only used for debugging, compressing it saves 10MB
+    	# If needed it will be decompressed
+    	# TODO: Is ceph-dencoder safe to remove as rook was trying to do?
+    	# rm -f /usr/bin/ceph-dencoder && \
+    	if [ -f /usr/bin/ceph-dencoder ]; then gzip -9 /usr/bin/ceph-dencoder; fi && \
+    	# TODO: What other ceph stuff needs removed/stripped/zipped here?
+    	# TODO: There was some overlap between this and the ceph clean? Where does it belong?
+    	#       If it's idempotent, it can *always* live here, even if it doesn't always apply
+    	# TODO: Should we even strip ceph libs at all?
+    	bash -c ' \
+	    function ifstrip () { if compgen -g "$1"; then strip -s "$1"; fi } && \
+      	    ifstrip /usr/lib{,64}/ceph/erasure-code/* && \
+      	    ifstrip /usr/lib{,64}/rados-classes/* && \
+      	    ifstrip /usr/lib{,64}/python*/{dist,site}-packages/{rados,rbd,rgw}.*.so && \
+      	    ifstrip /usr/bin/{crushtool,monmaptool,osdmaptool} \
+	' && \
+    	# Photoshop files inside a container ?
+    	rm -f /usr/lib/ceph/mgr/dashboard/static/AdminLTE-*/plugins/datatables/extensions/TableTools/images/psd/* && \
+    	# Some logfiles are not empty, there is no need to keep them
+    	find /var/log/ -type f -exec truncate -s 0 {} \; && \
+    	#
+    	# Report size savings (strip / from end)
+    	FINAL_SIZE="$(bash -c 'sz="$(du -sm --exclude=/proc /)" ; echo "${sz%*/}"')" && \
+    	REMOVED_SIZE=$((INITIAL_SIZE - FINAL_SIZE)) && \
+    	echo "Cleaning process removed ${REMOVED_SIZE}MB" && \
+    	echo "Dropped container size from ${INITIAL_SIZE}MB to ${FINAL_SIZE}MB" && \
+    	#
+    	# Verify that the packages installed haven't been accidentally cleaned
+    	rpm -q $PKGS && \
+	echo 'Packages verified successfully' \
+    )

--- a/make-dist
+++ b/make-dist
@@ -29,6 +29,10 @@ else
     rpm_release=0
 fi
 
+git_ver=`git rev-parse HEAD`
+flavor="default"
+release_name=`cat src/ceph_release | head -n 2 | tail -n 1`
+
 outfile="ceph-$version"
 echo "version $version"
 
@@ -164,18 +168,26 @@ bin/git-archive-all.sh --prefix ceph-$version/ \
 		       $outfile.tar
 
 # populate files with version strings
-echo "including src/.git_version, ceph.spec"
+echo "including src/.git_version, ceph.spec, Dockerfile"
 
 (git rev-parse HEAD ; echo $version) 2> /dev/null > src/.git_version
 
-for spec in ceph.spec.in; do
-    cat $spec |
+for fn in ceph.spec.in Dockerfile.in; do
+    cat $fn |
+	sed "s/@CEPH_GIT_VER@/$git_ver/g" |
+	sed "s/@CEPH_FLAVOR@/$flavor/g" |
+	sed "s/@CEPH_RELEASE_NAME@/$release_name/g" |
         sed "s/@PROJECT_VERSION@/$rpm_version/g" |
         sed "s/@RPM_RELEASE@/$rpm_release/g" |
-        sed "s/@TARBALL_BASENAME@/ceph-$version/g" > `echo $spec | sed 's/.in$//'`
+        sed "s/@TARBALL_BASENAME@/ceph-$version/g" > `echo $fn | sed 's/.in$//'`
 done
 ln -s . $outfile
-tar cvf $outfile.version.tar $outfile/src/.git_version $outfile/ceph.spec
+tar cvf \
+    $outfile.version.tar \
+    $outfile/src/.git_version \
+    $outfile/ceph.spec \
+    $outfile/Dockerfile
+
 # NOTE: If you change this version number make sure the package is available
 # at the three URLs referenced below (may involve uploading to download.ceph.com)
 boost_version=1.75.0

--- a/make-rpms
+++ b/make-rpms
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+dist="$1"
+if [ ! -e "$dist" ]; then
+   dist=$(ls -t ceph-*.tar.bz2 | head -n 1)
+fi
+if [ ! -e "$dist" ]; then
+   echo "usage: make-rpm [<ceph-dist-tarball>]"
+   echo "  - run ./make-dist first"
+   echo "  - optionally pass tarball filename, or we'll use the latest"
+   exit 1
+fi 
+
+echo "Building from $dist"
+
+rpmdev-setuptree
+
+cp $dist ~/rpmbuild/SOURCES
+tar --strip-components=1 -C ~/rpmbuild/SPECS/ --no-anchored -xvjf \
+    ~/rpmbuild/SOURCES/$dist ceph.spec
+
+rpmbuild -ba ~/rpmbuild/SPECS/ceph.spec

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,16 @@ list(GET CEPH_RELEASE_FILE 2 CEPH_RELEASE_TYPE)
 configure_file(${CMAKE_SOURCE_DIR}/src/ceph.in
   ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph @ONLY)
 
+set(CEPH_FLAVOR "default")
+configure_file(
+  ${CMAKE_SOURCE_DIR}/Dockerfile.in
+  ${PROJECT_BINARY_DIR}/container/default/Dockerfile @ONLY)
+set(CEPH_FLAVOR "crimson")
+configure_file(
+  ${CMAKE_SOURCE_DIR}/Dockerfile.in
+  ${PROJECT_BINARY_DIR}/container/crimson/Dockerfile @ONLY)
+unset(CEPH_FLAVOR)
+
 # Common infrastructure
 configure_file(
   ${CMAKE_SOURCE_DIR}/src/ceph_ver.h.in.cmake


### PR DESCRIPTION
This is based on the ceph-container resulting Dockerfile, but
cleaned up and simplified to remove the conditional checks based
on version etc.

Next steps?
- [ ] adjust ceph-build job to use the Dockerfile in the build dir to generate the container(s). possibly only for master, initially?
- [ ] generate pacific and octopus branch versions
- [ ] make ceph.git script that builds usable RPMs, and a Dockerfile version or variant that uses those (instead of shaman) to construct the package.
- [ ] make sure cephadm can use the ceph version label on the container (instead of running ``ceph --version`` inside) to speed up ``cephadm ls``