### PR TITLE
mgr/dashboard: More robust handling of timedelta() representation

### DIFF
--- a/src/python-common/ceph/utils.py
+++ b/src/python-common/ceph/utils.py
@@ -77,17 +77,17 @@ def parse_timedelta(delta: str) -> Optional[datetime.timedelta]:
 
     >>> parse_timedelta('foo')
 
-    >>> parse_timedelta('2d')
-    datetime.timedelta(days=2)
+    >>> parse_timedelta('2d') == datetime.timedelta(days=2)
+    True
 
-    >>> parse_timedelta("4w")
-    datetime.timedelta(days=28)
+    >>> parse_timedelta("4w") == datetime.timedelta(days=28)
+    True
 
-    >>> parse_timedelta("5s")
-    datetime.timedelta(seconds=5)
+    >>> parse_timedelta("5s") == datetime.timedelta(seconds=5)
+    True
 
-    >>> parse_timedelta("-5s")
-    datetime.timedelta(days=-1, seconds=86395)
+    >>> parse_timedelta("-5s") == datetime.timedelta(days=-1, seconds=86395)
+    True
 
     :param delta: The string to process, e.g. '2h', '10d', '30s'.
     :return: The `datetime.timedelta` object or `None` in case of


### PR DESCRIPTION
The representation of timedelta() appears to have changed recently so
we should try and be more accommodating in that regard.

Fixes: https://tracker.ceph.com/issues/52696

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
