### PR TITLE
init-ceph: create /var/run/ceph for sysvinit

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -295,9 +295,12 @@ for name in $what; do
 
     get_conf pid_file "$run_dir/$type.$id.pid" "pid file"
 
+    if [ ! -d $run_dir ]; then
+        install -d -m0770 -o ceph -g ceph /var/run/ceph
+    fi
+
     if [ "$command" = "start" -o "$command" = "onestart" ]; then
 	if [ -n "$pid_file" ]; then
-	    do_cmd "mkdir -p "`dirname $pid_file`
 	    cmd="$cmd --pid-file $pid_file"
 	fi
 
@@ -423,10 +426,6 @@ for name in $what; do
 	    fi
 
 	    echo Starting Ceph $name on $host...
-	    if [ ! -d $run_dir ]; then
-		# assume /var/run exists
-		install -d -m0770 -o ceph -g ceph /var/run/ceph
-	    fi
 	    get_conf pre_start_eval "" "pre start eval"
 	    [ -n "$pre_start_eval" ] && $pre_start_eval
 	    get_conf pre_start "" "pre start command"


### PR DESCRIPTION
/var/run is mounted as tmpfs and will be cleared after reboot.
On sysvinit ceph init service creates this directory for pid with root ownership, which leads to a failure to start any services.
Systemd has ceph.tmpfiles.d to prevent this, but sysvinit doesn't.

Fixes: https://tracker.ceph.com/issues/19242
Signed-off-by: Elena Chernikova <elena.chernikoff@gmail.com>