### PR TITLE
octopus: auth,mon: don't log "unable to find a keyring" error when key is given

### DIFF
--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -41,7 +41,7 @@ int KeyRing::from_ceph_context(CephContext *cct)
     if (ret < 0)
       lderr(cct) << "failed to load " << filename
 		 << ": " << cpp_strerror(ret) << dendl;
-  } else {
+  } else if (conf->key.empty() && conf->keyfile.empty()) {
     lderr(cct) << "unable to find a keyring on " << conf->keyring
 	       << ": " << cpp_strerror(ret) << dendl;
   }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -5906,8 +5906,6 @@ int Monitor::mkfs(bufferlist& osdmapbl)
 
     r = ceph_resolve_file_search(g_conf()->keyring, keyring_filename);
     if (r) {
-      derr << "unable to find a keyring file on " << g_conf()->keyring
-	   << ": " << cpp_strerror(r) << dendl;
       if (g_conf()->key != "") {
 	string keyring_plaintext = "[mon.]\n\tkey = " + g_conf()->key +
 	  "\n\tcaps mon = \"allow *\"\n";
@@ -5923,7 +5921,9 @@ int Monitor::mkfs(bufferlist& osdmapbl)
 	  return -EINVAL;
 	}
       } else {
-	return -ENOENT;
+	derr << "unable to find a keyring on " << g_conf()->keyring
+	     << ": " << cpp_strerror(r) << dendl;
+	return r;
       }
     } else {
       r = keyring.load(g_ceph_context, keyring_filename);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52736

---

backport of https://github.com/ceph/ceph/pull/43220
parent tracker: https://tracker.ceph.com/issues/51628