### PR TITLE
pacific: rbd-mirror: unbreak one-way snapshot-based mirroring

### DIFF
--- a/qa/suites/rbd/mirror/workloads/rbd-mirror-journal-bootstrap-workunit.yaml
+++ b/qa/suites/rbd/mirror/workloads/rbd-mirror-journal-bootstrap-workunit.yaml
@@ -1,0 +1,13 @@
+meta:
+- desc: run the rbd_mirror_bootstrap.sh workunit to test the rbd-mirror daemon
+tasks:
+- workunit:
+    clients:
+      cluster1.client.mirror: [rbd/rbd_mirror_bootstrap.sh]
+    env:
+      # override workunit setting of CEPH_ARGS='--cluster'
+      CEPH_ARGS: ''
+      RBD_MIRROR_INSTANCES: '1'
+      RBD_MIRROR_USE_EXISTING_CLUSTER: '1'
+      MIRROR_POOL_MODE: 'pool'
+      MIRROR_IMAGE_MODE: 'journal'

--- a/qa/suites/rbd/mirror/workloads/rbd-mirror-snapshot-bootstrap-workunit.yaml
+++ b/qa/suites/rbd/mirror/workloads/rbd-mirror-snapshot-bootstrap-workunit.yaml
@@ -9,3 +9,5 @@ tasks:
       CEPH_ARGS: ''
       RBD_MIRROR_INSTANCES: '1'
       RBD_MIRROR_USE_EXISTING_CLUSTER: '1'
+      MIRROR_POOL_MODE: 'image'
+      MIRROR_IMAGE_MODE: 'snapshot'

--- a/qa/workunits/rbd/rbd_mirror_bootstrap.sh
+++ b/qa/workunits/rbd/rbd_mirror_bootstrap.sh
@@ -27,7 +27,7 @@ testlog "TEST: verify rx-only direction"
 [ "$(rbd --cluster ${CLUSTER1} --pool ${POOL} mirror pool info --format xml |
 	${XMLSTARLET} sel -t -v  '//mirror/peers/peer[1]/uuid')" = "" ]
 
-create_image ${CLUSTER1} ${POOL} image1
+create_image_and_enable_mirror ${CLUSTER1} ${POOL} image1
 
 wait_for_image_replay_started ${CLUSTER2} ${POOL} image1
 write_image ${CLUSTER1} ${POOL} image1 100

--- a/src/tools/rbd_mirror/RemotePoolPoller.cc
+++ b/src/tools/rbd_mirror/RemotePoolPoller.cc
@@ -183,7 +183,7 @@ void RemotePoolPoller<I>::handle_mirror_peer_list(int r) {
 
   cls::rbd::MirrorPeer* matched_peer = nullptr;
   for (auto& peer : peers) {
-    if (peer.mirror_peer_direction == cls::rbd::MIRROR_PEER_DIRECTION_TX) {
+    if (peer.mirror_peer_direction == cls::rbd::MIRROR_PEER_DIRECTION_RX) {
       continue;
     }
 

--- a/src/tools/rbd_mirror/RemotePoolPoller.cc
+++ b/src/tools/rbd_mirror/RemotePoolPoller.cc
@@ -16,7 +16,7 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
-#define dout_prefix *_dout << "rbd::mirror::RemotePollPoller: " << this << " " \
+#define dout_prefix *_dout << "rbd::mirror::RemotePoolPoller: " << this << " " \
                            << __func__ << ": "
 
 namespace rbd {

--- a/src/tools/rbd_mirror/Types.cc
+++ b/src/tools/rbd_mirror/Types.cc
@@ -19,7 +19,7 @@ std::ostream& operator<<(std::ostream& lhs,
 std::ostream& operator<<(std::ostream& lhs,
                          const RemotePoolMeta& rhs) {
   return lhs << "mirror_uuid=" << rhs.mirror_uuid << ", "
-                "mirror_pool_uuid=" << rhs.mirror_peer_uuid;
+                "mirror_peer_uuid=" << rhs.mirror_peer_uuid;
 }
 
 std::ostream& operator<<(std::ostream& lhs, const PeerSpec &peer) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52733

---

backport of https://github.com/ceph/ceph/pull/43228
parent tracker: https://tracker.ceph.com/issues/52675