### PR TITLE
[RFC] osd: make replicas persist their missing sets

### DIFF
--- a/qa/suites/rados/singleton/all/ec-backfill-unfound.yaml
+++ b/qa/suites/rados/singleton/all/ec-backfill-unfound.yaml
@@ -1,0 +1,34 @@
+roles:
+- - mon.a
+  - mon.b
+  - mon.c
+  - mgr.x
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+openstack:
+  - volumes: # attached to each instance
+      count: 4
+      size: 10 # GB
+tasks:
+- install:
+- ceph:
+    create_rbd_pool: false
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+    log-ignorelist:
+      - objects unfound and apparently lost
+      - Error
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(OBJECT_
+      - \(SLOW_OPS\)
+      - slow request
+    conf:
+      osd:
+        osd min pg log entries: 5
+        osd max pg log entries: 5
+- ec_backfill_unfound:

--- a/qa/tasks/ec_backfill_unfound.py
+++ b/qa/tasks/ec_backfill_unfound.py
@@ -1,0 +1,182 @@
+"""
+Backfill_unfound
+"""
+import logging
+import time
+from tasks import ceph_manager
+from tasks.util.rados import rados
+from teuthology import misc as teuthology
+from teuthology.orchestra import run
+
+log = logging.getLogger(__name__)
+
+def wait_till_backfilling_complete(manager, pgid, from_osd, to_osd):
+    log.info("waiting till pg %s backfill from osd.%s to osd.%s complete" %
+             (pgid, from_osd, to_osd))
+    while True:
+        time.sleep(5)
+        manager.flush_pg_stats([0, 1, 2, 3])
+        pgs = manager.get_pg_stats()
+        pg = next((pg for pg in pgs if pg['pgid'] == pgid), None)
+        log.info('pg=%s' % pg);
+        assert pg
+        status = pg['state'].split('+')
+        if 'active' not in status:
+            log.debug('not active')
+            continue
+        if 'backfilling' in status:
+            assert from_osd in pg['acting'] and to_osd in pg['up']
+            log.debug('backfilling')
+            continue
+        if to_osd not in pg['up']:
+            log.debug('backfill not started yet')
+            continue
+        log.debug('backfilled!')
+        break
+
+def task(ctx, config):
+    """
+    Test handling of unfound objects during backfill on an ec pool.
+
+    A pretty rigid cluster is brought up and tested by this task
+    """
+    if config is None:
+        config = {}
+    assert isinstance(config, dict), \
+        'lost_unfound task only accepts a dict for configuration'
+    first_mon = teuthology.get_first_mon(ctx, config)
+    (mon,) = ctx.cluster.only(first_mon).remotes.keys()
+
+    manager = ceph_manager.CephManager(
+        mon,
+        ctx=ctx,
+        logger=log.getChild('ceph_manager'),
+        )
+
+    profile = config.get('erasure_code_profile', {
+        'k': '2',
+        'm': '1',
+        'crush-failure-domain': 'osd'
+    })
+    profile_name = profile.get('name', 'backfill_unfound')
+    manager.create_erasure_code_profile(profile_name, profile)
+    pool = manager.create_pool_with_unique_name(
+        pg_num=1,
+        erasure_code_profile_name=profile_name,
+        min_size=2)
+    manager.raw_cluster_cmd('osd', 'pool', 'set', pool,
+                            'pg_autoscale_mode', 'off')
+
+    manager.flush_pg_stats([0, 1, 2, 3])
+    manager.wait_for_clean()
+
+    pool_id = manager.get_pool_num(pool)
+    pgid = '%d.0' % pool_id
+    pgs = manager.get_pg_stats()
+    acting = next((pg['acting'] for pg in pgs if pg['pgid'] == pgid), None)
+    log.info("acting=%s" % acting)
+    assert acting
+    primary = acting[0]
+
+    # something that is always there, readable and never empty
+    dummyfile = '/etc/group'
+
+    # kludge to make sure they get a map
+    rados(ctx, mon, ['-p', pool, 'put', 'dummy', dummyfile])
+
+    manager.flush_pg_stats([0, 1])
+    manager.wait_for_recovery()
+
+    log.info("create test object")
+    obj = 'test'
+    rados(ctx, mon, ['-p', pool, 'put', obj, dummyfile])
+
+    log.info("write some data")
+    rados(ctx, mon, ['-p', pool, 'bench', '30', 'write', '-b', '4096',
+                          '--no-cleanup'])
+
+    log.info("remove object from one non-primary shard and start backfill")
+    victim = acting[1]
+
+    manager.objectstore_tool(pool, options='', args='remove',
+                             object_name=obj, osd=victim)
+
+    # mark the osd out to trigger a rebalance/backfill
+    manager.mark_out_osd(victim)
+
+    # wait for everything to peer, backfill and recover
+    target = [x for x in [0, 1, 2, 3] if x not in acting][0]
+    wait_till_backfilling_complete(manager, pgid, victim, target)
+    manager.wait_for_clean()
+
+    manager.flush_pg_stats([0, 1, 2, 3])
+    pgs = manager.get_pg_stats()
+    pg = next((pg for pg in pgs if pg['pgid'] == pgid), None)
+    log.info('pg=%s' % pg)
+    assert pg
+    assert 'clean' in pg['state'].split('+')
+    unfound = manager.get_num_unfound_objects()
+    log.info("there are %d unfound objects" % unfound)
+    assert unfound == 0
+
+    log.info("remove object from all non-primary shards and start backfill")
+    acting = pg['acting']
+    assert acting[0] == primary
+    assert victim not in acting
+    victims = acting[1:]
+
+    for i in victims:
+        manager.objectstore_tool(pool, options='', args='remove',
+                                 object_name=obj, osd=i)
+
+    # mark the out osd in to trigger a rebalance/backfill
+    manager.mark_in_osd(victim)
+    source, target = target, victim
+
+    # wait for everything to peer, backfill and detect unfound object
+    wait_till_backfilling_complete(manager, pgid, source, target)
+
+    # verify that there is unfound object
+    manager.flush_pg_stats([0, 1, 2, 3])
+    pgs = manager.get_pg_stats()
+    pg = next((pg for pg in pgs if pg['pgid'] == pgid), None)
+    log.info('pg=%s' % pg)
+    assert pg
+    assert 'backfill_unfound' in pg['state'].split('+')
+    unfound = manager.get_num_unfound_objects()
+    log.info("there are %d unfound objects" % unfound)
+    assert unfound == 1
+    m = manager.list_pg_unfound(pgid)
+    log.info('list_pg_unfound=%s' % m)
+    assert m['num_unfound'] == pg['stat_sum']['num_objects_unfound']
+
+    acting = pg['acting']
+    victim = acting[1]
+    log.info("restart non-primary osd %d" % victim)
+    manager.kill_osd(victim)
+    manager.mark_down_osd(victim)
+    manager.wait_till_active()
+    manager.revive_osd(victim)
+    manager.wait_till_osd_is_up(victim)
+    wait_till_backfilling_complete(manager, pgid, source, target)
+
+    manager.flush_pg_stats([0, 1, 2, 3])
+    pgs = manager.get_pg_stats()
+    pg = next((pg for pg in pgs if pg['pgid'] == pgid), None)
+    log.info('pg=%s' % pg)
+    assert pg
+    assert 'backfill_unfound' in pg['state'].split('+')
+    unfound = manager.get_num_unfound_objects()
+    log.info("there are %d unfound objects" % unfound)
+    assert unfound == 1
+    m = manager.list_pg_unfound(pgid)
+    log.info('list_pg_unfound=%s' % m)
+    assert m['num_unfound'] == pg['stat_sum']['num_objects_unfound']
+
+    # mark stuff lost
+    pgs = manager.get_pg_stats()
+    manager.raw_cluster_cmd('pg', pgid, 'mark_unfound_lost', 'delete')
+
+    # wait for everything to peer and be happy...
+    manager.flush_pg_stats([0, 1, 2, 3])
+    manager.wait_for_recovery()

--- a/src/messages/MOSDPGForceObjectMissing.h
+++ b/src/messages/MOSDPGForceObjectMissing.h
@@ -1,0 +1,81 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_MOSDPGFORCEOBJECTMISSING_H
+#define CEPH_MOSDPGFORCEOBJECTMISSING_H
+
+#include "MOSDFastDispatchOp.h"
+
+class MOSDPGForceObjectMissing final : public MOSDFastDispatchOp {
+private:
+  static constexpr int HEAD_VERSION = 1;
+  static constexpr int COMPAT_VERSION = 1;
+
+public:
+  epoch_t map_epoch = 0, min_epoch = 0;
+  spg_t pgid;
+  pg_shard_t from;
+  hobject_t oid;
+  eversion_t oid_version;
+
+  epoch_t get_map_epoch() const override {
+    return map_epoch;
+  }
+  epoch_t get_min_epoch() const override {
+    return min_epoch;
+  }
+  spg_t get_spg() const override {
+    return pgid;
+  }
+
+  MOSDPGForceObjectMissing()
+    : MOSDFastDispatchOp{MSG_OSD_PG_FORCE_OBJECT_MISSING, HEAD_VERSION,
+			 COMPAT_VERSION} {
+  }
+  MOSDPGForceObjectMissing(spg_t pgid, epoch_t epoch, epoch_t min_epoch,
+                           const pg_shard_t &from, const hobject_t &oid,
+                           eversion_t version)
+    : MOSDFastDispatchOp{MSG_OSD_PG_FORCE_OBJECT_MISSING, HEAD_VERSION,
+			 COMPAT_VERSION},
+      map_epoch(epoch), min_epoch(min_epoch), pgid(pgid), from(from), oid(oid),
+      oid_version(version) {
+  }
+
+private:
+  ~MOSDPGForceObjectMissing() final {}
+
+public:
+  std::string_view get_type_name() const override {
+    return "PGForceObjectMissing";
+  }
+  void print(std::ostream& out) const override {
+    out << "pg_force_object_missing(" << pgid << " epoch " << map_epoch
+	<< "/" << min_epoch << " from " << from << " oid " << oid << " version "
+        << oid_version << ")";
+  }
+
+  void encode_payload(uint64_t features) override {
+    using ceph::encode;
+    encode(map_epoch, payload);
+    encode(min_epoch, payload);
+    encode(pgid, payload);
+    encode(from, payload);
+    encode(oid, payload);
+    encode(oid_version, payload);
+  }
+  void decode_payload() override {
+    using ceph::decode;
+    auto p = payload.cbegin();
+    decode(map_epoch, p);
+    decode(min_epoch, p);
+    decode(pgid, p);
+    decode(from, p);
+    decode(oid, p);
+    decode(oid_version, p);
+  }
+private:
+  template<class T, typename... Args>
+  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+};
+
+#endif

--- a/src/messages/MOSDPGForceObjectMissingReply.h
+++ b/src/messages/MOSDPGForceObjectMissingReply.h
@@ -1,0 +1,81 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_MOSDPGFORCEOBJECTMISSINGREPLY_H
+#define CEPH_MOSDPGFORCEOBJECTMISSINGREPLY_H
+
+#include "MOSDFastDispatchOp.h"
+
+class MOSDPGForceObjectMissingReply final : public MOSDFastDispatchOp {
+private:
+  static constexpr int HEAD_VERSION = 1;
+  static constexpr int COMPAT_VERSION = 1;
+
+public:
+  epoch_t map_epoch = 0, min_epoch = 0;
+  spg_t pgid;
+  shard_id_t from;
+  hobject_t oid;
+  eversion_t oid_version;
+
+  epoch_t get_map_epoch() const override {
+    return map_epoch;
+  }
+  epoch_t get_min_epoch() const override {
+    return min_epoch;
+  }
+  spg_t get_spg() const override {
+    return pgid;
+  }
+
+  MOSDPGForceObjectMissingReply()
+    : MOSDFastDispatchOp{MSG_OSD_PG_FORCE_OBJECT_MISSING_REPLY, HEAD_VERSION,
+			 COMPAT_VERSION} {
+  }
+  MOSDPGForceObjectMissingReply(spg_t pgid, epoch_t epoch, epoch_t min_epoch,
+                                const shard_id_t &from, const hobject_t &oid,
+                                eversion_t version)
+    : MOSDFastDispatchOp{MSG_OSD_PG_FORCE_OBJECT_MISSING_REPLY, HEAD_VERSION,
+			 COMPAT_VERSION},
+      map_epoch(epoch), min_epoch(min_epoch), pgid(pgid), from(from), oid(oid),
+      oid_version(version) {
+  }
+
+private:
+  ~MOSDPGForceObjectMissingReply() final {}
+
+public:
+  std::string_view get_type_name() const override {
+    return "PGForceObjectMissingReply";
+  }
+  void print(std::ostream& out) const override {
+    out << "pg_force_object_missing_reply(" << pgid << " epoch " << map_epoch
+        << "/" << min_epoch << " from " << from << " oid " << oid << " version "
+        << oid_version << ")";
+  }
+
+  void encode_payload(uint64_t features) override {
+    using ceph::encode;
+    encode(map_epoch, payload);
+    encode(min_epoch, payload);
+    encode(pgid, payload);
+    encode(from, payload);
+    encode(oid, payload);
+    encode(oid_version, payload);
+  }
+  void decode_payload() override {
+    using ceph::decode;
+    auto p = payload.cbegin();
+    decode(map_epoch, p);
+    decode(min_epoch, p);
+    decode(pgid, p);
+    decode(from, p);
+    decode(oid, p);
+    decode(oid_version, p);
+  }
+private:
+  template<class T, typename... Args>
+  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+};
+
+#endif

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -217,6 +217,9 @@
 #include "messages/MOSDPGUpdateLogMissing.h"
 #include "messages/MOSDPGUpdateLogMissingReply.h"
 
+#include "messages/MOSDPGForceObjectMissing.h"
+#include "messages/MOSDPGForceObjectMissingReply.h"
+
 #ifdef WITH_BLKIN
 #include "Messenger.h"
 #endif
@@ -530,6 +533,12 @@ Message *decode_message(CephContext *cct,
     break;
   case MSG_OSD_PG_UPDATE_LOG_MISSING_REPLY:
     m = make_message<MOSDPGUpdateLogMissingReply>();
+    break;
+  case MSG_OSD_PG_FORCE_OBJECT_MISSING:
+    m = make_message<MOSDPGForceObjectMissing>();
+    break;
+  case MSG_OSD_PG_FORCE_OBJECT_MISSING_REPLY:
+    m = make_message<MOSDPGForceObjectMissingReply>();
     break;
   case CEPH_MSG_OSD_BACKOFF:
     m = make_message<MOSDBackoff>();

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -146,6 +146,9 @@
 #define MSG_OSD_PG_LEASE        133
 #define MSG_OSD_PG_LEASE_ACK    134
 
+#define MSG_OSD_PG_FORCE_OBJECT_MISSING  136
+#define MSG_OSD_PG_FORCE_OBJECT_MISSING_REPLY  137
+
 // *** MDS ***
 
 #define MSG_MDS_BEACON             100  // to monitor

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1981,6 +1981,8 @@ private:
     case MSG_OSD_PG_RECOVERY_DELETE_REPLY:
     case MSG_OSD_PG_LEASE:
     case MSG_OSD_PG_LEASE_ACK:
+    case MSG_OSD_PG_FORCE_OBJECT_MISSING:
+    case MSG_OSD_PG_FORCE_OBJECT_MISSING_REPLY:
       return true;
     default:
       return false;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -50,6 +50,8 @@
 #include "messages/MOSDRepScrubMap.h"
 #include "messages/MOSDPGRecoveryDelete.h"
 #include "messages/MOSDPGRecoveryDeleteReply.h"
+#include "messages/MOSDPGForceObjectMissing.h"
+#include "messages/MOSDPGForceObjectMissingReply.h"
 
 #include "common/BackTrace.h"
 #include "common/EventTrace.h"
@@ -2435,6 +2437,13 @@ bool PG::can_discard_request(OpRequestRef& op)
   case MSG_OSD_PG_BACKFILL_REMOVE:
     return can_discard_replica_op<MOSDPGBackfillRemove,
 				  MSG_OSD_PG_BACKFILL_REMOVE>(op);
+
+  case MSG_OSD_PG_FORCE_OBJECT_MISSING:
+    return can_discard_replica_op<
+      MOSDPGForceObjectMissing, MSG_OSD_PG_FORCE_OBJECT_MISSING>(op);
+  case MSG_OSD_PG_FORCE_OBJECT_MISSING_REPLY:
+    return can_discard_replica_op<
+      MOSDPGForceObjectMissingReply, MSG_OSD_PG_FORCE_OBJECT_MISSING_REPLY>(op);
   }
   return true;
 }

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4277,6 +4277,11 @@ void PeeringState::force_object_missing(
     }
   }
 
+  if (!info.last_backfill.is_max()) {
+    // backfilling
+    return;
+  }
+
   missing_loc.rebuild(
     soid,
     pg_whoami,

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -12472,6 +12472,11 @@ void PrimaryLogPG::_force_object_missing(const pg_shard_t &from,
 
   recovery_state.force_object_missing(from, oid, version);
 
+  if (!HAVE_FEATURE(min_peer_features(), SERVER_QUINCY)) {
+    dout(20) << __func__ << " skipping notifying peers" << dendl;
+    return;
+  }
+
   for (auto &peer : get_acting_recovery_backfill()) {
     if (peer == pg_whoami) {
       continue;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1075,6 +1075,9 @@ protected:
   std::set<hobject_t> backfills_in_flight;
   std::map<hobject_t, pg_stat_t> pending_backfill_updates;
 
+  typedef std::pair<int8_t, int32_t> ShardOsdPair;
+  std::map<hobject_t, std::set<ShardOsdPair>> force_object_missing_in_flight;
+
   void dump_recovery_info(ceph::Formatter *f) const override {
     f->open_array_section("waiting_on_backfill");
     for (std::set<pg_shard_t>::const_iterator p = waiting_on_backfill.begin();
@@ -1830,6 +1833,10 @@ private:
   int _rollback_to(OpContext *ctx, OSDOp& op);
   void _do_rollback_to(OpContext *ctx, ObjectContextRef rollback_to,
 				    OSDOp& op);
+
+  void _force_object_missing(const pg_shard_t &peer, const hobject_t &oid,
+                             eversion_t version);
+
 public:
   bool is_missing_object(const hobject_t& oid) const;
   bool is_unreadable_object(const hobject_t &oid) const {
@@ -1887,6 +1894,9 @@ public:
 
   void do_update_log_missing_reply(
     OpRequestRef &op);
+
+  void do_force_object_missing(OpRequestRef &op);
+  void do_force_object_missing_reply(OpRequestRef &op);
 
   void plpg_on_role_change() override;
   void plpg_on_pool_change() override;


### PR DESCRIPTION
Now when primary detects a missing object it sends a new type
message to peers to persist the object missing error.

The oid is erased from backfills_in_flight (i.e. allowing to
advance last_backfill position) only after acks from all peers
are recieved.

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
