### PR TITLE
doc/dev/cephx: fix typo

### DIFF
--- a/doc/dev/cephx.rst
+++ b/doc/dev/cephx.rst
@@ -10,7 +10,7 @@ Intro
 The protocol design looks a lot like kerberos.  The authorizer "KDC"
 role is served by the monitor, who has a database of shared secrets
 for each entity.  Clients and non-monitor daemons all start by
-authenticating with the monitor to obtain tickets, mostly referreed to
+authenticating with the monitor to obtain tickets, mostly referred to
 in the code as authorizers.  These tickets provide both
 *authentication* and *authorization* in that they include a
 description of the *capabilities* for the entity, a concise structured
@@ -402,5 +402,5 @@ That is, the new rotating key is simply protected by the daemon's
 rotating secret.
 
 Note that, as an implementation detail, the services keep the current
-key and the prior key on hand so that the can continue to validate
+key and the prior key on hand so that they can continue to validate
 requests while the key is being rotated.


### PR DESCRIPTION
Signed-off-by: Prashant D <pdhange@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
