### PR TITLE
mgr/cephadm: use json-pretty for ceph-volume calls

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -470,7 +470,7 @@ class CephadmServe:
     def _refresh_host_devices(self, host: str) -> Optional[str]:
         with_lsm = self.mgr.get_module_option('device_enhanced_scan')
         inventory_args = ['--', 'inventory',
-                          '--format=json',
+                          '--format=json-pretty',
                           '--filter-for-batch']
         if with_lsm:
             inventory_args.insert(-1, "--with-lsm")

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1355,10 +1355,10 @@ Traceback (most recent call last):
 
             assert _run_cephadm.mock_calls == [
                 mock.call('test', 'osd', 'ceph-volume',
-                          ['--', 'inventory', '--format=json', '--filter-for-batch'], image='',
+                          ['--', 'inventory', '--format=json-pretty', '--filter-for-batch'], image='',
                           no_fsid=False),
                 mock.call('test', 'osd', 'ceph-volume',
-                          ['--', 'inventory', '--format=json'], image='',
+                          ['--', 'inventory', '--format=json-pretty'], image='',
                           no_fsid=False),
             ]
 


### PR DESCRIPTION
To avoid a single line json string that is too long
and causes a chunk longer than limit error

Fixes: https://tracker.ceph.com/issues/52745

Signed-off-by: Adam King <adking@redhat.com>

When messing with tried using cephadm's call to cat out a large json file and
then converted the file to a json pretty format (multi-line with indent) and tried again.
Saw the regular json one threw an error about chunk size and the one using a
json-pretty format did not. The test code and output here (NOTE: the warnings
about the loop being detached are irrelevant): https://pastebin.com/raw/vyHZhEsF
I did notice that the error thrown in the normal json case differed slightly from that in the
tracker, going from separator being found but chunk longer than limit to separator not
found and chunk longer than limit. Not sure if that makes the test invalid, although I feel
it doesn't.

Thoughts?

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
