### PR TITLE
tools/crushdiff: support old format json dump

### DIFF
--- a/src/tools/crushdiff
+++ b/src/tools/crushdiff
@@ -104,7 +104,8 @@ def get_erasure_code_profiles(osdmap):
 
 def get_pgmap(pg_dump_file):
     with open(pg_dump_file, "r") as f:
-        return json.load(f)['pg_map']
+        dump = json.load(f)
+        return dump.get('pg_map', dump)
 
 def get_pg_stats(pgmap):
     return {pg['pgid']: pg for pg in pgmap['pg_stats']}


### PR DESCRIPTION
Someone may try running crushdiff against osdmap and pg dump
collected for an older cluster.

In general it is not guaranteed to work as not tested well, but
still we can do our best to make it work if possible.

One know issue is that for older versions `ceph pg dump` json
output does not have a separate 'pg_map' section, where actual
data is stored. This change makes crushdiff to support this old
format too.

Signed-off-by: Mykola Golub <mykola.golub@clyso.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
