### PR TITLE
pacific: qa/mgr/dashboard: add extra wait to test

### DIFF
--- a/qa/tasks/mgr/dashboard/test_user.py
+++ b/qa/tasks/mgr/dashboard/test_user.py
@@ -412,6 +412,9 @@ class UserTest(DashboardTestCase):
         user_1 = self._get('/api/user/user1')
         self.assertStatus(200)
 
+        # Let's wait 1 s to ensure pwd expiration date is not the same
+        time.sleep(1)
+
         self.login('user1', 'mypassword10#')
         self._post('/api/user/user1/change_password', {
             'old_password': 'mypassword10#',


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52772

---

backport of https://github.com/ceph/ceph/pull/43255
parent tracker: https://tracker.ceph.com/issues/49344

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh