### PR TITLE
doc/cephadm/services: unindent note section

### DIFF
--- a/doc/cephadm/services/index.rst
+++ b/doc/cephadm/services/index.rst
@@ -207,53 +207,55 @@ or in a YAML files.
 
    cephadm will not deploy daemons on hosts with the ``_no_schedule`` label; see :ref:`cephadm-special-host-labels`.
 
-  .. note::
-     The **apply** command can be confusing. For this reason, we recommend using
-     YAML specifications.
+.. note::
+   The **apply** command can be confusing. For this reason, we recommend using
+   YAML specifications.
 
-     Each ``ceph orch apply <service-name>`` command supersedes the one before it.
-     If you do not use the proper syntax, you will clobber your work
-     as you go.
+   Each ``ceph orch apply <service-name>`` command supersedes the one before it.
+   If you do not use the proper syntax, you will clobber your work
+   as you go.
 
-     For example:
+   For example:
 
-     .. prompt:: bash #
+   .. prompt:: bash #
 
-          ceph orch apply mon host1
-          ceph orch apply mon host2
-          ceph orch apply mon host3
+        ceph orch apply mon host1
+        ceph orch apply mon host2
+        ceph orch apply mon host3
 
-     This results in only one host having a monitor applied to it: host 3.
+   This results in only one host having a monitor applied to it: host 3.
 
-     (The first command creates a monitor on host1. Then the second command
-     clobbers the monitor on host1 and creates a monitor on host2. Then the
-     third command clobbers the monitor on host2 and creates a monitor on
-     host3. In this scenario, at this point, there is a monitor ONLY on
-     host3.)
+   (The first command creates a monitor on host1. Then the second command
+   clobbers the monitor on host1 and creates a monitor on host2. Then the
+   third command clobbers the monitor on host2 and creates a monitor on
+   host3. In this scenario, at this point, there is a monitor ONLY on
+   host3.)
 
-     To make certain that a monitor is applied to each of these three hosts,
-     run a command like this:
+   To make certain that a monitor is applied to each of these three hosts,
+   run a command like this:
 
-     .. prompt:: bash #
+   .. prompt:: bash #
 
-       ceph orch apply mon "host1,host2,host3"
+     ceph orch apply mon "host1,host2,host3"
 
-     There is another way to apply monitors to multiple hosts: a ``yaml`` file
-     can be used. Instead of using the "ceph orch apply mon" commands, run a
-     command of this form:
+   There is another way to apply monitors to multiple hosts: a ``yaml`` file
+   can be used. Instead of using the "ceph orch apply mon" commands, run a
+   command of this form:
 
-     .. prompt:: bash #
+   .. prompt:: bash #
 
-        ceph orch apply -i file.yaml
+      ceph orch apply -i file.yaml
 
-     Here is a sample **file.yaml** file::
+   Here is a sample **file.yaml** file
 
-          service_type: mon
-          placement:
-            hosts:
-             - host1
-             - host2
-             - host3
+   .. code-block:: yaml
+
+        service_type: mon
+        placement:
+          hosts:
+           - host1
+           - host2
+           - host3
 
 Explicit placements
 -------------------


### PR DESCRIPTION
before this change the note on "apply" command is embedded in the note
on "_no_schedule". and they are not related. so let's move the former
out. also, highlight the yaml file sample in YAML.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
