### PR TITLE
mgr/cephadm: move handling of use_agent setting into agent.py

### DIFF
--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -319,6 +319,29 @@ class CephadmAgentHelpers:
         )
         self.mgr.spec_store.save(spec)
 
+    def _handle_use_agent_setting(self) -> bool:
+        need_apply = False
+        if self.mgr.use_agent:
+            # on the off chance there are still agents hanging around from
+            # when we turned the config option off, we need to redeploy them
+            # we can tell they're in that state if we don't have a keyring for
+            # them in the host cache
+            for agent in self.mgr.cache.get_daemons_by_service('agent'):
+                if agent.hostname not in self.mgr.cache.agent_keys:
+                    self.mgr._schedule_daemon_action(agent.name(), 'redeploy')
+            if 'agent' not in self.mgr.spec_store:
+                self.mgr.agent_helpers._apply_agent()
+                need_apply = True
+        else:
+            if 'agent' in self.mgr.spec_store:
+                self.mgr.spec_store.rm('agent')
+                need_apply = True
+            self.mgr.cache.agent_counter = {}
+            self.mgr.cache.agent_timestamp = {}
+            self.mgr.cache.agent_keys = {}
+            self.mgr.cache.agent_ports = {}
+        return need_apply
+
 
 class SSLCerts:
     def __init__(self, mgr: "CephadmOrchestrator") -> None:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -91,23 +91,8 @@ class CephadmServe:
 
                     self._purge_deleted_services()
 
-                    if self.mgr.use_agent:
-                        # on the off chance there are still agents hanging around from
-                        # when we turned the config option off, we need to redeploy them
-                        # we can tell they're in that state if we don't have a keyring for
-                        # them in the host cache
-                        for agent in self.mgr.cache.get_daemons_by_service('agent'):
-                            if agent.hostname not in self.mgr.cache.agent_keys:
-                                self.mgr._schedule_daemon_action(agent.name(), 'redeploy')
-                        if 'agent' not in self.mgr.spec_store:
-                            self.mgr.agent_helpers._apply_agent()
-                    else:
-                        if 'agent' in self.mgr.spec_store:
-                            self.mgr.spec_store.rm('agent')
-                        self.mgr.cache.agent_counter = {}
-                        self.mgr.cache.agent_timestamp = {}
-                        self.mgr.cache.agent_keys = {}
-                        self.mgr.cache.agent_ports = {}
+                    if self.mgr.agent_helpers._handle_use_agent_setting():
+                        continue
 
                     if self.mgr.upgrade.continue_upgrade():
                         continue


### PR DESCRIPTION
The serve function itself should only really be
calling other functions. The actual handling of
the setting is better placed in the agent's own file.

Signed-off-by: Adam King <adking@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
