### PR TITLE
mgr/telemetry: remove pool name from telemetry perf report

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -306,18 +306,16 @@ class Module(MgrModule):
         # Initialize 'result' list
         result: List[dict] = []
 
-        # Create a list of tuples containing pool ids and their associated names
-        # that will later act as a queue, i.e.:
-        #   pool_queue = [('1', '.mgr'), ('2', 'cephfs.a.meta'), ('3', 'cephfs.a.data')]
+        # Create a list of pool ids that will later act as a queue, i.e.:
+        #   pool_queue = [1, 2, 3]
         osd_map = self.get('osd_map')
-        pool_queue: List[tuple] = []
+        pool_queue = []
         for pool in osd_map['pools']:
-            pool_queue.append((str(pool['pool']), pool['pool_name']))
+            pool_queue.append(str(pool['pool']))
 
         # Populate 'result', i.e.:
         #   {
         #       'pool_id': '1'
-        #       'pool_name': '.mgr'
         #       'stats_sum': {
         #           'num_bytes': 36,
         #           'num_bytes_hit_set_archive': 0,
@@ -327,11 +325,8 @@ class Module(MgrModule):
         #       }
         #   }
         while pool_queue:
-            # Pop a pool out of pool_queue
-            curr_pool = pool_queue.pop(0)
-
-            # Get the current pool's id and name
-            curr_pool_id, curr_pool_name = curr_pool[0], curr_pool[1]
+            # Pop the current pool id out of pool_queue
+            curr_pool_id = pool_queue.pop(0)
 
             # Initialize a dict that will hold aggregated stats for the current pool
             compiled_stats_dict: Dict[str, Any] = defaultdict(lambda: defaultdict(int))
@@ -343,7 +338,6 @@ class Module(MgrModule):
                 pool_id = pg['pgid'].split('.')[0]
                 if pool_id == curr_pool_id:
                     compiled_stats_dict['pool_id'] = int(pool_id)
-                    compiled_stats_dict['pool_name'] = curr_pool_name
                     for metric in pg['stat_sum']:
                         compiled_stats_dict['stats_sum'][metric] += pg['stat_sum'][metric]
                 else:


### PR DESCRIPTION
It is best to remove the pool names from the telemetry perf report, as these names could potentially count as sensitive information.

Signed-off-by: Laura Flores <lflores@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
