### PR TITLE
MetricCollector.h: Add check to prevent mgr from crashing

### DIFF
--- a/src/mgr/MetricCollector.h
+++ b/src/mgr/MetricCollector.h
@@ -42,7 +42,9 @@ public:
       auto result_it = result.insert({query, {}}).first;
       if (is_limited(limits)) {
         for (auto& limit : limits) {
-          result_it->second.insert(*limit.second);
+          if (limit.second) {
+            result_it->second.insert(*limit.second);
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/52801
Signed-off-by: Aswin Toni <aswin.toni@cern.ch>