### PR TITLE
mgr/volumes/fs/operations: fix flake8 issues

### DIFF
--- a/src/pybind/mgr/volumes/fs/operations/trash.py
+++ b/src/pybind/mgr/volumes/fs/operations/trash.py
@@ -6,10 +6,10 @@ from contextlib import contextmanager
 import cephfs
 
 from .template import GroupTemplate
-from ..fs_util import listdir
 from ..exception import VolumeException
 
 log = logging.getLogger(__name__)
+
 
 class Trash(GroupTemplate):
     GROUP_NAME = "_deleting"
@@ -114,6 +114,7 @@ class Trash(GroupTemplate):
         except cephfs.Error as e:
             raise VolumeException(-e.args[0], e.args[1])
 
+
 def create_trashcan(fs, vol_spec):
     """
     create a trash can.
@@ -127,6 +128,7 @@ def create_trashcan(fs, vol_spec):
         fs.mkdirs(trashcan.path, 0o700)
     except cephfs.Error as e:
         raise VolumeException(-e.args[0], e.args[1])
+
 
 @contextmanager
 def open_trashcan(fs, vol_spec):


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/51400
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
