### PR TITLE
src/cephadm: Add support for mariner

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6341,6 +6341,7 @@ class YumDnf(Packager):
         'rocky': ('centos', 'el'),
         'almalinux': ('centos', 'el'),
         'fedora': ('fedora', 'fc'),
+        'mariner': ('mariner', 'cm'),
     }
 
     def __init__(self, ctx: CephadmContext,
@@ -6357,6 +6358,8 @@ class YumDnf(Packager):
         if (self.distro_code == 'fc' and self.major >= 30) or \
            (self.distro_code == 'el' and self.major >= 8):
             self.tool = 'dnf'
+        elif (self.distro_code == 'cm'):
+            self.tool = 'tdnf'
         else:
             self.tool = 'yum'
 


### PR DESCRIPTION
Cephadm: Add mariner as a supported distro.

Using cephadm install commands on [Mariner](https://github.com/microsoft/CBL-Mariner) will result in an error "Distro not supported" though the packages are supported and can be installed manually. This change adds mariner as a supported distro.
Fixed validated on mariner.

Fixes: [pending tracker account approval]
Signed-off-by: Roaa Sakr romoh@microsoft.com

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
