### PR TITLE
mon: simplify 'mgr module ls' output

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -580,7 +580,7 @@ Subcommand ``module ls`` will list currently enabled manager modules (plugins).
 
 Usage::
 
-  ceph mgr module ls
+  ceph mgr module ls {detail}
 
 Subcommand ``module enable`` will enable a manager module.  Available modules are included in MgrMap and visible via ``mgr dump``.
 

--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -580,7 +580,7 @@ Subcommand ``module ls`` will list currently enabled manager modules (plugins).
 
 Usage::
 
-  ceph mgr module ls {detail}
+  ceph mgr module ls
 
 Subcommand ``module enable`` will enable a manager module.  Available modules are included in MgrMap and visible via ``mgr dump``.
 

--- a/doc/mgr/administrator.rst
+++ b/doc/mgr/administrator.rst
@@ -57,7 +57,7 @@ Using modules
 -------------
 
 Use the command ``ceph mgr module ls`` to see which modules are
-available, and which are currently enabled. Use ``ceph mgr module ls detail``
+available, and which are currently enabled. Use ``ceph mgr module ls --format=json-pretty``
 to view detailed metadata about disabled modules. Enable or disable modules
 using the commands ``ceph mgr module enable <module>`` and
 ``ceph mgr module disable <module>`` respectively.

--- a/doc/mgr/administrator.rst
+++ b/doc/mgr/administrator.rst
@@ -57,7 +57,8 @@ Using modules
 -------------
 
 Use the command ``ceph mgr module ls`` to see which modules are
-available, and which are currently enabled.  Enable or disable modules
+available, and which are currently enabled. Use ``ceph mgr module ls detail``
+to view detailed metadata about disabled modules. Enable or disable modules
 using the commands ``ceph mgr module enable <module>`` and
 ``ceph mgr module disable <module>`` respectively.
 

--- a/qa/tasks/mgr/mgr_test_case.py
+++ b/qa/tasks/mgr/mgr_test_case.py
@@ -74,7 +74,7 @@ class MgrTestCase(CephTestCase):
 
         # Unload all non-default plugins
         loaded = json.loads(cls.mgr_cluster.mon_manager.raw_cluster_cmd(
-                   "mgr", "module", "ls"))['enabled_modules']
+                   "mgr", "module", "ls", "--format=json-pretty"))['enabled_modules']
         unload_modules = set(loaded) - {"cephadm", "restful"}
 
         for m in unload_modules:
@@ -111,7 +111,7 @@ class MgrTestCase(CephTestCase):
     def _unload_module(cls, module_name):
         def is_disabled():
             enabled_modules = json.loads(cls.mgr_cluster.mon_manager.raw_cluster_cmd(
-                'mgr', 'module', 'ls'))['enabled_modules']
+                'mgr', 'module', 'ls', "--format=json-pretty"))['enabled_modules']
             return module_name not in enabled_modules
 
         if is_disabled():
@@ -124,7 +124,7 @@ class MgrTestCase(CephTestCase):
     @classmethod
     def _load_module(cls, module_name):
         loaded = json.loads(cls.mgr_cluster.mon_manager.raw_cluster_cmd(
-            "mgr", "module", "ls"))['enabled_modules']
+            "mgr", "module", "ls", "--format=json-pretty"))['enabled_modules']
         if module_name in loaded:
             # The enable command is idempotent, but our wait for a restart
             # isn't, so let's return now if it's already loaded

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -953,6 +953,7 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
 
   string prefix;
   cmd_getval(cmdmap, "prefix", prefix);
+
   int r = 0;
 
   if (prefix == "mgr stat") {
@@ -982,6 +983,9 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
     }
     f->flush(rdata);
   } else if (prefix == "mgr module ls") {
+    string detail;
+    cmd_getval(cmdmap, "detail", detail);
+
     f->open_object_section("modules");
     {
       f->open_array_section("always_on_modules");
@@ -1002,9 +1006,14 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
       for (auto& p : map.available_modules) {
         if (map.modules.count(p.name) == 0 &&
             map.get_always_on_modules().count(p.name) == 0) {
-          // For disabled modules, we show the full info, to
-          // give a hint about whether enabling it will work
-          p.dump(f.get());
+	  if (detail == "detail") {
+	    // For disabled modules, we show the full info if the detail
+	    // parameter is enabled, to give a hint about whether enabling it will work
+	    p.dump(f.get());
+	  } else {
+	    // Otherwise, we give a shortened summary by default
+	    f->dump_string("module", p.name);
+	  }
         }
       }
       f->close_section();

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -25,7 +25,6 @@
 #include "HealthMonitor.h"
 
 #include "common/TextTable.h"
-#include "common/cmdparse.h"
 #include "include/stringify.h"
 
 #include "MgrMonitor.h"
@@ -955,7 +954,6 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
 
   string prefix;
   cmd_getval(cmdmap, "prefix", prefix);
-
   int r = 0;
 
   if (prefix == "mgr stat") {
@@ -991,12 +989,7 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
     }
     f->flush(rdata);
   } else if (prefix == "mgr module ls") {
-    string detail;
-    cmd_getval(cmdmap, "detail", detail);
-    if (f || (detail == "detail")) {
-      if (!f) {
-        f.reset(Formatter::create(format, "json-pretty", "json-pretty"));
-      }
+    if (f) {
       f->open_object_section("modules");
       {
         f->open_array_section("always_on_modules");
@@ -1017,14 +1010,9 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
         for (auto& p : map.available_modules) {
           if (map.modules.count(p.name) == 0 &&
             map.get_always_on_modules().count(p.name) == 0) {
-            if (detail == "detail") {
-              // For disabled modules, we show the full info if the detail
-              // parameter is enabled, to give a hint about whether enabling it will work
-              p.dump(f.get());
-            } else {
-              // Otherwise, we give a shortened summary by default
-              f->dump_string("module", p.name);
-            }
+            // For disabled modules, we show the full info if the detail
+            // parameter is enabled, to give a hint about whether enabling it will work
+            p.dump(f.get());
           }
         }
         f->close_section();

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -24,6 +24,10 @@
 #include "ConfigMonitor.h"
 #include "HealthMonitor.h"
 
+#include "common/TextTable.h"
+#include "common/cmdparse.h"
+#include "include/stringify.h"
+
 #include "MgrMonitor.h"
 
 #define MGR_METADATA_PREFIX "mgr_metadata"
@@ -946,10 +950,8 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
     return true;
   }
 
-  string format;
-  cmd_getval(cmdmap, "format", format);
-  boost::scoped_ptr<Formatter> f(Formatter::create(format, "json-pretty",
-						   "json-pretty"));
+  string format = cmd_getval_or<string>(cmdmap, "format", "plain");
+  boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   string prefix;
   cmd_getval(cmdmap, "prefix", prefix);
@@ -957,6 +959,9 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
   int r = 0;
 
   if (prefix == "mgr stat") {
+    if (!f) {
+      f.reset(Formatter::create(format, "json-pretty", "json-pretty"));
+    }
     f->open_object_section("stat");
     f->dump_unsigned("epoch", map.get_epoch());
     f->dump_bool("available", map.get_available());
@@ -965,6 +970,9 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
     f->close_section();
     f->flush(rdata);
   } else if (prefix == "mgr dump") {
+    if (!f) {
+      f.reset(Formatter::create(format, "json-pretty", "json-pretty"));
+    }
     int64_t epoch = cmd_getval_or<int64_t>(cmdmap, "epoch", map.get_epoch());
     if (epoch == (int64_t)map.get_epoch()) {
       f->dump_object("mgrmap", map);
@@ -985,42 +993,75 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
   } else if (prefix == "mgr module ls") {
     string detail;
     cmd_getval(cmdmap, "detail", detail);
-
-    f->open_object_section("modules");
-    {
-      f->open_array_section("always_on_modules");
-      for (auto& p : map.get_always_on_modules()) {
-        f->dump_string("module", p);
+    if (f || (detail == "detail")) {
+      if (!f) {
+        f.reset(Formatter::create(format, "json-pretty", "json-pretty"));
+      }
+      f->open_object_section("modules");
+      {
+        f->open_array_section("always_on_modules");
+        for (auto& p : map.get_always_on_modules()) {
+          f->dump_string("module", p);
+        }
+        f->close_section();
+        f->open_array_section("enabled_modules");
+        for (auto& p : map.modules) {
+          if (map.get_always_on_modules().count(p) > 0)
+            continue;
+          // We only show the name for enabled modules.  The any errors
+          // etc will show up as a health checks.
+          f->dump_string("module", p);
+        }
+        f->close_section();
+        f->open_array_section("disabled_modules");
+        for (auto& p : map.available_modules) {
+          if (map.modules.count(p.name) == 0 &&
+            map.get_always_on_modules().count(p.name) == 0) {
+            if (detail == "detail") {
+              // For disabled modules, we show the full info if the detail
+              // parameter is enabled, to give a hint about whether enabling it will work
+              p.dump(f.get());
+            } else {
+              // Otherwise, we give a shortened summary by default
+              f->dump_string("module", p.name);
+            }
+          }
+        }
+        f->close_section();
       }
       f->close_section();
-      f->open_array_section("enabled_modules");
+      f->flush(rdata);
+    } else {
+      TextTable tbl;
+      tbl.define_column("MODULE", TextTable::LEFT, TextTable::LEFT);
+      tbl.define_column("      ", TextTable::LEFT, TextTable::LEFT);
+
+      for (auto& p : map.get_always_on_modules()) {
+        tbl << p;
+        tbl << "on (always on)";
+        tbl << TextTable::endrow;
+      }
       for (auto& p : map.modules) {
         if (map.get_always_on_modules().count(p) > 0)
           continue;
-        // We only show the name for enabled modules.  The any errors
-        // etc will show up as a health checks.
-        f->dump_string("module", p);
+        tbl << p;
+        tbl << "on";
+        tbl << TextTable::endrow;
       }
-      f->close_section();
-      f->open_array_section("disabled_modules");
       for (auto& p : map.available_modules) {
         if (map.modules.count(p.name) == 0 &&
             map.get_always_on_modules().count(p.name) == 0) {
-	  if (detail == "detail") {
-	    // For disabled modules, we show the full info if the detail
-	    // parameter is enabled, to give a hint about whether enabling it will work
-	    p.dump(f.get());
-	  } else {
-	    // Otherwise, we give a shortened summary by default
-	    f->dump_string("module", p.name);
-	  }
+          tbl << p.name;
+          tbl << "-";
+          tbl << TextTable::endrow;
         }
       }
-      f->close_section();
+      rdata.append(stringify(tbl));
     }
-    f->close_section();
-    f->flush(rdata);
   } else if (prefix == "mgr services") {
+    if (!f) {
+      f.reset(Formatter::create(format, "json-pretty", "json-pretty"));
+    }
     f->open_object_section("services");
     for (const auto &i : map.services) {
       f->dump_string(i.first.c_str(), i.second);
@@ -1028,6 +1069,9 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
     f->close_section();
     f->flush(rdata);
   } else if (prefix == "mgr metadata") {
+    if (!f) {
+      f.reset(Formatter::create(format, "json-pretty", "json-pretty"));
+    }
     string name;
     cmd_getval(cmdmap, "who", name);
     if (name.size() > 0 && !map.have_name(name)) {
@@ -1035,9 +1079,6 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
       r = -ENOENT;
       goto reply;
     }
-    string format;
-    cmd_getval(cmdmap, "format", format);
-    boost::scoped_ptr<Formatter> f(Formatter::create(format, "json-pretty", "json-pretty"));
     if (name.size()) {
       f->open_object_section("mgr_metadata");
       f->dump_string("name", name);
@@ -1066,10 +1107,16 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
     }
     f->flush(rdata);
   } else if (prefix == "mgr versions") {
+    if (!f) {
+      f.reset(Formatter::create(format, "json-pretty", "json-pretty"));
+    }
     count_metadata("ceph_version", f.get());
     f->flush(rdata);
     r = 0;
   } else if (prefix == "mgr count-metadata") {
+    if (!f) {
+      f.reset(Formatter::create(format, "json-pretty", "json-pretty"));
+    }
     string field;
     cmd_getval(cmdmap, "property", field);
     count_metadata(field, f.get());

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1231,7 +1231,7 @@ COMMAND("mgr dump "
 	"mgr", "r")
 COMMAND("mgr fail name=who,type=CephString,req=false",
 	"treat the named manager daemon as failed", "mgr", "rw")
-COMMAND("mgr module ls name=detail,type=CephChoices,strings=detail,req=false",
+COMMAND("mgr module ls",
         "list active mgr modules", "mgr", "r")
 COMMAND("mgr services",
 	"list service endpoints provided by mgr modules",

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1231,8 +1231,8 @@ COMMAND("mgr dump "
 	"mgr", "r")
 COMMAND("mgr fail name=who,type=CephString,req=false",
 	"treat the named manager daemon as failed", "mgr", "rw")
-COMMAND("mgr module ls",
-	"list active mgr modules", "mgr", "r")
+COMMAND("mgr module ls name=detail,type=CephChoices,strings=detail,req=false",
+        "list active mgr modules", "mgr", "r")
 COMMAND("mgr services",
 	"list service endpoints provided by mgr modules",
         "mgr", "r")


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45322
Signed-off-by: Laura Flores <lflores@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
