### PR TITLE
mgr/devicehealth: fix missing timezone from time delta calculation

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -9,7 +9,7 @@ import operator
 import rados
 import re
 from threading import Event
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import cast, Any, Dict, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 TIME_FORMAT = '%Y%m%d-%H%M%S'
@@ -588,7 +588,7 @@ CREATE TABLE DeviceHealthMetrics (
         devs = self.get("devices")
         osds_in = {}
         osds_out = {}
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)  # e.g. '2021-09-22 13:18:45.021712+00:00'
         osdmap = self.get("osd_map")
         assert osdmap is not None
         for dev in devs['devices']:
@@ -602,7 +602,7 @@ CREATE TABLE DeviceHealthMetrics (
                 continue
             # life_expectancy_(min/max) is in the format of:
             # '%Y-%m-%dT%H:%M:%S.%f%z', e.g.:
-            # '2019-01-20T21:12:12.000000Z'
+            # '2019-01-20 21:12:12.000000+00:00'
             life_expectancy_max = datetime.strptime(
                 dev['life_expectancy_max'],
                 '%Y-%m-%dT%H:%M:%S.%f%z')


### PR DESCRIPTION
An error occurs when subtracting a datetime object that is offset-naive
(i.e. unaware of timezone) from a datetime object which is offset-aware.

datetime.utcnow() is missing timezone info, e.g.:
'2021-09-22 13:18:45.021712',
while life_expectancy_max is in the format of:
'2021-09-28 00:00:00.000000+00:00',
hence we need to add timezone info to the former when calculating
their time delta.

Please note that we calculate time delta using `datetime.utcnow()` in
`serve()` in this module, but there we refer to the delta in seconds,
which works fine.

Fixes: https://tracker.ceph.com/issues/52327
Signed-off-by: Yaarit Hatuka <yaarit@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
