### PR TITLE
pacific: osd/OSD: mkfs need wait for transcation completely finish

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2101,6 +2101,7 @@ int OSD::mkfs(CephContext *cct, ObjectStore *store, uuid_d fsid, int whoami, str
 	   << "queue_transaction returned " << cpp_strerror(ret) << dendl;
       goto umount_store;
     }
+    ch->flush();
   }
 
   ret = write_meta(cct, store, sb.cluster_fsid, sb.osd_fsid, whoami, osdspec_affinity);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51646

---

backport of https://github.com/ceph/ceph/pull/41889
parent tracker: https://tracker.ceph.com/issues/51623

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh