### PR TITLE
rgw/dbstore: Use DB transactions for I/O atomicity

### DIFF
--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -546,6 +546,13 @@ class DBOp {
     const string DropQ = "DROP TABLE IF EXISTS '{}'";
     const string ListAllQ = "SELECT  * from '{}'";
 
+ protected:
+    /* transaction schema */
+    const string BeginQ = "BEGIN TRANSACTION";
+    const string CommitQ = "COMMIT";
+    const string EndQ = "END TRANSACTION";
+    const string RollbackQ = "ROLLBACK";
+
   public:
     DBOp() {};
     virtual ~DBOp() {};
@@ -1220,6 +1227,11 @@ class DB {
     virtual int InitializeDBOps(const DoutPrefixProvider *dpp) { return 0; }
     virtual int FreeDBOps(const DoutPrefixProvider *dpp) { return 0; }
     virtual int InitPrepareParams(const DoutPrefixProvider *dpp, DBOpPrepareParams &params) = 0;
+
+    virtual int beginTransaction(const DoutPrefixProvider *dpp) { return 0; }
+    virtual int endTransaction(const DoutPrefixProvider *dpp) { return 0; }
+    virtual int commitTransaction(const DoutPrefixProvider *dpp) { return 0; }
+    virtual int rollbackTransaction(const DoutPrefixProvider *dpp) { return 0; }
 
     virtual int ListAllBuckets(const DoutPrefixProvider *dpp, DBOpParams *params) = 0;
     virtual int ListAllUsers(const DoutPrefixProvider *dpp, DBOpParams *params) = 0;

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.cc
@@ -543,6 +543,54 @@ int SQLiteDB::closeDB(const DoutPrefixProvider *dpp)
   return 0;
 }
 
+int SQLiteDB::beginTransaction(const DoutPrefixProvider *dpp) {
+  int ret = -1;
+
+  ret = exec(dpp, BeginQ.c_str(), NULL);
+  if (ret)
+    ldpp_dout(dpp, 0)<<"BeginTransaction failed" << dendl;
+
+  ldpp_dout(dpp, 20)<<"BeginTransaction suceeded" << dendl;
+
+  return ret;
+}
+
+int SQLiteDB::rollbackTransaction(const DoutPrefixProvider *dpp) {
+  int ret = -1;
+
+  ret = exec(dpp, RollbackQ.c_str(), NULL);
+  if (ret)
+    ldpp_dout(dpp, 0)<<"RollbackTransaction failed" << dendl;
+
+  ldpp_dout(dpp, 20)<<"RollbackTransaction suceeded" << dendl;
+
+  return ret;
+}
+
+int SQLiteDB::endTransaction(const DoutPrefixProvider *dpp) {
+  int ret = -1;
+
+  ret = exec(dpp, EndQ.c_str(), NULL);
+  if (ret)
+    ldpp_dout(dpp, 0)<<"EndTransaction failed" << dendl;
+
+  ldpp_dout(dpp, 20)<<"EndTransaction suceeded" << dendl;
+
+  return ret;
+}
+
+int SQLiteDB::commitTransaction(const DoutPrefixProvider *dpp) {
+  int ret = -1;
+
+  ret = exec(dpp, CommitQ.c_str(), NULL);
+  if (ret)
+    ldpp_dout(dpp, 0)<<"CommitTransaction failed" << dendl;
+
+  ldpp_dout(dpp, 20)<<"CommitTransaction suceeded" << dendl;
+
+  return ret;
+}
+
 int SQLiteDB::Reset(const DoutPrefixProvider *dpp, sqlite3_stmt *stmt)
 {
   int ret = -1;

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.h
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.h
@@ -41,6 +41,11 @@ class SQLiteDB : public DB, public DBOp{
 
     int InitPrepareParams(const DoutPrefixProvider *dpp, DBOpPrepareParams &params) override { return 0; }
 
+    int beginTransaction(const DoutPrefixProvider *dpp) override;
+    int endTransaction(const DoutPrefixProvider *dpp) override;
+    int commitTransaction(const DoutPrefixProvider *dpp) override;
+    int rollbackTransaction(const DoutPrefixProvider *dpp) override;
+
     int exec(const DoutPrefixProvider *dpp, const char *schema,
         int (*callback)(void*,int,char**,char**));
     int Step(const DoutPrefixProvider *dpp, DBOpInfo &op, sqlite3_stmt *stmt,


### PR DESCRIPTION
Use SQLite transactions for atomic read & write of the objects.

Signed-off-by: Soumya Koduri <skoduri@redhat.com>

