### PR TITLE
rgw/dbstore: handle lc related state

### DIFF
--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -80,9 +80,10 @@ rgw::sal::Store* StoreManager::init_storage_provider(const DoutPrefixProvider* d
 #ifdef WITH_RADOSGW_DBSTORE
     rgw::sal::Store* store = newDBStore(cct);
 
-    /* Initialize the dbstore with cct & dpp */
-    DB *db = static_cast<rgw::sal::DBStore *>(store)->getDB();
-    db->set_context(cct);
+    if ((*(rgw::sal::DBStore*)store).set_run_lc_thread(use_lc_thread)
+                                    .initialize(cct, dpp) < 0) {
+      delete store; store = nullptr;
+    }
 
     /* XXX: temporary - create testid user */
     rgw_user testid_user("", "testid", "");

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1177,7 +1177,7 @@ namespace rgw::sal {
 
   std::unique_ptr<Lifecycle> DBStore::get_lifecycle(void)
   {
-    return 0;
+    return std::make_unique<DBLifecycle>(this);
   }
 
   std::unique_ptr<Completions> DBStore::get_completions(void)
@@ -1185,11 +1185,58 @@ namespace rgw::sal {
     return 0;
   }
 
+  int DBLifecycle::get_entry(const std::string& oid, const std::string& marker,
+			      LCEntry& entry)
+  {
+    return 0;
+  }
+
+  int DBLifecycle::get_next_entry(const std::string& oid, std::string& marker,
+				   LCEntry& entry)
+  {
+    return 0;
+  }
+
+  int DBLifecycle::set_entry(const std::string& oid, const LCEntry& entry)
+  {
+    return 0;
+  }
+
+  int DBLifecycle::list_entries(const std::string& oid, const std::string& marker,
+  				 uint32_t max_entries, vector<LCEntry>& entries)
+  {
+    return 0;
+  }
+
+  int DBLifecycle::rm_entry(const std::string& oid, const LCEntry& entry)
+  {
+    return 0;
+  }
+
+  int DBLifecycle::get_head(const std::string& oid, LCHead& head)
+  {
+    return 0;
+  }
+
+  int DBLifecycle::put_head(const std::string& oid, const LCHead& head)
+  {
+    return 0;
+  }
+
+  LCSerializer* DBLifecycle::get_serializer(const std::string& lock_name, const std::string& oid, const std::string& cookie)
+  {
+    return new LCDBSerializer(store, oid, lock_name, cookie);
+  }
+
   std::unique_ptr<Notification> DBStore::get_notification(rgw::sal::Object* obj,
       struct req_state* s,
       rgw::notify::EventType event_type, const std::string* object_name)
   {
     return std::make_unique<DBNotification>(obj, event_type);
+  }
+
+  RGWLC* DBStore::get_rgwlc(void) {
+    return lc;
   }
 
   int DBStore::log_usage(const DoutPrefixProvider *dpp, map<rgw_user_bucket, RGWUsageBatch>& usage_info)
@@ -1310,6 +1357,21 @@ namespace rgw::sal {
     return 0;
   }
 
+  int DBStore::initialize(CephContext *_cct, const DoutPrefixProvider *_dpp) {
+    int ret = 0;
+    cct = _cct;
+    dpp = _dpp;
+
+    lc = new RGWLC();
+    lc->initialize(cct, this);
+
+    if (use_lc_thread) {
+      ret = db->createLCTables(dpp);
+      lc->start_processor();
+    }
+
+    return ret;
+  }
 } // namespace rgw::sal
 
 extern "C" {
@@ -1333,6 +1395,7 @@ extern "C" {
       store->setDBStoreManager(dbsm);
       store->setDB(db);
       db->set_store((rgw::sal::Store*)store);
+      db->set_context(cct);
     }
 
     return store;

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1188,39 +1188,39 @@ namespace rgw::sal {
   int DBLifecycle::get_entry(const std::string& oid, const std::string& marker,
 			      LCEntry& entry)
   {
-    return 0;
+    return store->getDB()->get_entry(oid, marker, entry);
   }
 
   int DBLifecycle::get_next_entry(const std::string& oid, std::string& marker,
 				   LCEntry& entry)
   {
-    return 0;
+    return store->getDB()->get_next_entry(oid, marker, entry);
   }
 
   int DBLifecycle::set_entry(const std::string& oid, const LCEntry& entry)
   {
-    return 0;
+    return store->getDB()->set_entry(oid, entry);
   }
 
   int DBLifecycle::list_entries(const std::string& oid, const std::string& marker,
   				 uint32_t max_entries, vector<LCEntry>& entries)
   {
-    return 0;
+    return store->getDB()->list_entries(oid, marker, max_entries, entries);
   }
 
   int DBLifecycle::rm_entry(const std::string& oid, const LCEntry& entry)
   {
-    return 0;
+    return store->getDB()->rm_entry(oid, entry);
   }
 
   int DBLifecycle::get_head(const std::string& oid, LCHead& head)
   {
-    return 0;
+    return store->getDB()->get_head(oid, head);
   }
 
   int DBLifecycle::put_head(const std::string& oid, const LCHead& head)
   {
-    return 0;
+    return store->getDB()->put_head(oid, head);
   }
 
   LCSerializer* DBLifecycle::get_serializer(const std::string& lock_name, const std::string& oid, const std::string& cookie)

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -18,6 +18,7 @@
 #include "rgw_sal.h"
 #include "rgw_oidc_provider.h"
 #include "rgw_role.h"
+#include "rgw_lc.h"
 
 #include "store/dbstore/common/dbstore.h"
 #include "store/dbstore/dbstore_mgr.h"
@@ -25,6 +26,35 @@
 namespace rgw { namespace sal {
 
   class DBStore;
+
+class LCDBSerializer : public LCSerializer {
+  const std::string oid;
+
+public:
+  LCDBSerializer(DBStore* store, const std::string& oid, const std::string& lock_name, const std::string& cookie) {}
+
+  virtual int try_lock(const DoutPrefixProvider *dpp, utime_t dur, optional_yield y) override { return 0; }
+  virtual int unlock() override {
+    return 0;
+  }
+};
+
+class DBLifecycle : public Lifecycle {
+  DBStore* store;
+
+public:
+  DBLifecycle(DBStore* _st) : store(_st) {}
+
+  virtual int get_entry(const std::string& oid, const std::string& marker, LCEntry& entry) override;
+  virtual int get_next_entry(const std::string& oid, std::string& marker, LCEntry& entry) override;
+  virtual int set_entry(const std::string& oid, const LCEntry& entry) override;
+  virtual int list_entries(const std::string& oid, const std::string& marker,
+			   uint32_t max_entries, std::vector<LCEntry>& entries) override;
+  virtual int rm_entry(const std::string& oid, const LCEntry& entry) override;
+  virtual int get_head(const std::string& oid, LCHead& head) override;
+  virtual int put_head(const std::string& oid, const LCHead& head) override;
+  virtual LCSerializer* get_serializer(const std::string& lock_name, const std::string& oid, const std::string& cookie) override;
+};
 
 class DBNotification : public Notification {
 protected:
@@ -461,11 +491,22 @@ protected:
       string luarocks_path;
       DBZone zone;
       RGWSyncModuleInstanceRef sync_module;
+      RGWLC* lc;
+      CephContext *cct;
+      const DoutPrefixProvider *dpp;
+      bool use_lc_thread;
 
     public:
-      DBStore(): dbsm(nullptr), zone(this) {}
+      DBStore(): dbsm(nullptr), zone(this), cct(nullptr), dpp(nullptr),
+                 use_lc_thread(false) {}
       ~DBStore() { delete dbsm; }
 
+      DBStore& set_run_lc_thread(bool _use_lc_thread) {
+        use_lc_thread = _use_lc_thread;
+        return *this;
+      }
+
+      int initialize(CephContext *cct, const DoutPrefixProvider *dpp);
       virtual std::unique_ptr<User> get_user(const rgw_user& u) override;
       virtual int get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) override;
       virtual int get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user) override;
@@ -486,7 +527,7 @@ protected:
       virtual std::unique_ptr<Completions> get_completions(void) override;
       virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj, struct req_state* s, 
           rgw::notify::EventType event_type, const std::string* object_name=nullptr) override;
-      virtual RGWLC* get_rgwlc(void) override { return NULL; }
+      virtual RGWLC* get_rgwlc(void) override;
       virtual RGWCoroutinesManagerRegistry* get_cr_registry() override { return NULL; }
 
       virtual int log_usage(const DoutPrefixProvider *dpp, map<rgw_user_bucket, RGWUsageBatch>& usage_info) override;

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.cc
@@ -274,6 +274,19 @@ enum GetObjectData {
   MultipartPartNum
 };
 
+enum GetLCEntry {
+  LCEntryIndex,
+  LCEntryBucketName,
+  LCEntryStartTime,
+  LCEntryStatus
+};
+
+enum GetLCHead {
+  LCHeadIndex,
+  LCHeadMarker,
+  LCHeadStartDate
+};
+
 static int list_user(const DoutPrefixProvider *dpp, DBOpInfo &op, sqlite3_stmt *stmt) {
   if (!stmt)
     return -1;
@@ -474,6 +487,32 @@ static int get_objectdata(const DoutPrefixProvider *dpp, DBOpInfo &op, sqlite3_s
   return 0;
 }
 
+static int list_lc_entry(const DoutPrefixProvider *dpp, DBOpInfo &op, sqlite3_stmt *stmt) {
+  if (!stmt)
+    return -1;
+
+  op.lc_entry.index = (const char*)sqlite3_column_text(stmt, LCEntryIndex);
+  op.lc_entry.entry.bucket = (const char*)sqlite3_column_text(stmt, LCEntryBucketName);
+  op.lc_entry.entry.start_time = sqlite3_column_int(stmt, LCEntryStartTime);
+  op.lc_entry.entry.status = sqlite3_column_int(stmt, LCEntryStatus);
+ 
+  op.lc_entry.list_entries.push_back(op.lc_entry.entry);
+
+  return 0;
+}
+
+static int list_lc_head(const DoutPrefixProvider *dpp, DBOpInfo &op, sqlite3_stmt *stmt) {
+  if (!stmt)
+    return -1;
+
+  op.lc_head.index = (const char*)sqlite3_column_text(stmt, LCHeadIndex);
+  op.lc_head.head.marker = (const char*)sqlite3_column_text(stmt, LCHeadMarker);
+ 
+  SQL_DECODE_BLOB_PARAM(dpp, stmt, LCHeadStartDate, op.lc_head.head.start_date, sdb);
+
+  return 0;
+}
+
 int SQLiteDB::InitializeDBOps(const DoutPrefixProvider *dpp)
 {
   (void)createTables(dpp);
@@ -485,6 +524,13 @@ int SQLiteDB::InitializeDBOps(const DoutPrefixProvider *dpp)
   dbops.RemoveBucket = new SQLRemoveBucket(&this->db, this->getDBname(), cct);
   dbops.GetBucket = new SQLGetBucket(&this->db, this->getDBname(), cct);
   dbops.ListUserBuckets = new SQLListUserBuckets(&this->db, this->getDBname(), cct);
+  dbops.InsertLCEntry = new SQLInsertLCEntry(&this->db, this->getDBname(), cct);
+  dbops.RemoveLCEntry = new SQLRemoveLCEntry(&this->db, this->getDBname(), cct);
+  dbops.GetLCEntry = new SQLGetLCEntry(&this->db, this->getDBname(), cct);
+  dbops.ListLCEntries = new SQLListLCEntries(&this->db, this->getDBname(), cct);
+  dbops.InsertLCHead = new SQLInsertLCHead(&this->db, this->getDBname(), cct);
+  dbops.RemoveLCHead = new SQLRemoveLCHead(&this->db, this->getDBname(), cct);
+  dbops.GetLCHead = new SQLGetLCHead(&this->db, this->getDBname(), cct);
 
   return 0;
 }
@@ -499,6 +545,13 @@ int SQLiteDB::FreeDBOps(const DoutPrefixProvider *dpp)
   delete dbops.RemoveBucket;
   delete dbops.GetBucket;
   delete dbops.ListUserBuckets;
+  delete dbops.InsertLCEntry;
+  delete dbops.RemoveLCEntry;
+  delete dbops.GetLCEntry;
+  delete dbops.ListLCEntries;
+  delete dbops.InsertLCHead;
+  delete dbops.RemoveLCHead;
+  delete dbops.GetLCHead;
 
   return 0;
 }
@@ -2383,6 +2436,335 @@ int SQLDeleteObjectData::Execute(const DoutPrefixProvider *dpp, struct DBOpParam
   int ret = -1;
 
   SQL_EXECUTE(dpp, params, stmt, NULL);
+out:
+  return ret;
+}
+
+int SQLInsertLCEntry::Prepare(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (!*sdb) {
+    ldpp_dout(dpp, 0)<<"In SQLInsertLCEntry - no db" << dendl;
+    goto out;
+  }
+
+  p_params.lc_entry_table = params->lc_entry_table;
+
+  SQL_PREPARE(dpp, p_params, sdb, stmt, ret, "PrepareInsertLCEntry");
+
+out:
+  return ret;
+}
+
+int SQLInsertLCEntry::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int index = -1;
+  int rc = 0;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.index.c_str(), sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_entry.index.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.bucket_name.c_str(), sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_entry.entry.bucket.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.status.c_str(), sdb);
+  SQL_BIND_INT(dpp, stmt, index, params->op.lc_entry.entry.status, sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.start_time.c_str(), sdb);
+  SQL_BIND_INT(dpp, stmt, index, params->op.lc_entry.entry.start_time, sdb);
+
+out:
+  return rc;
+}
+
+int SQLInsertLCEntry::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+
+  SQL_EXECUTE(dpp, params, stmt, NULL);
+out:
+  return ret;
+}
+
+int SQLRemoveLCEntry::Prepare(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (!*sdb) {
+    ldpp_dout(dpp, 0)<<"In SQLRemoveLCEntry - no db" << dendl;
+    goto out;
+  }
+
+  p_params.lc_entry_table = params->lc_entry_table;
+
+  SQL_PREPARE(dpp, p_params, sdb, stmt, ret, "PrepareRemoveLCEntry");
+
+out:
+  return ret;
+}
+
+int SQLRemoveLCEntry::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int index = -1;
+  int rc = 0;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.index.c_str(), sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_entry.index.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.bucket_name.c_str(), sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_entry.entry.bucket.c_str(), sdb);
+
+out:
+  return rc;
+}
+
+int SQLRemoveLCEntry::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+
+  SQL_EXECUTE(dpp, params, stmt, NULL);
+out:
+  return ret;
+}
+
+int SQLGetLCEntry::Prepare(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+  sqlite3_stmt** pstmt = NULL; // Prepared statement
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (!*sdb) {
+    ldpp_dout(dpp, 0)<<"In SQLGetLCEntry - no db" << dendl;
+    goto out;
+  }
+
+  p_params.lc_entry_table = params->lc_entry_table;
+  p_params.op.query_str = params->op.query_str;
+
+  if (params->op.query_str == "get_next_entry") {
+    pstmt = &next_stmt;
+  } else {
+    pstmt = &stmt;
+  }
+  SQL_PREPARE(dpp, p_params, sdb, *pstmt, ret, "PrepareGetLCEntry");
+
+out:
+  return ret;
+}
+
+int SQLGetLCEntry::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int index = -1;
+  int rc = 0;
+  struct DBOpPrepareParams p_params = PrepareParams;
+  sqlite3_stmt** pstmt = NULL; // Prepared statement
+
+  if (params->op.query_str == "get_next_entry") {
+    pstmt = &next_stmt;
+  } else {
+    pstmt = &stmt;
+  }
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.index.c_str(), sdb);
+  SQL_BIND_TEXT(dpp, *pstmt, index, params->op.lc_entry.index.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.bucket_name.c_str(), sdb);
+  SQL_BIND_TEXT(dpp, *pstmt, index, params->op.lc_entry.entry.bucket.c_str(), sdb);
+
+out:
+  return rc;
+}
+
+int SQLGetLCEntry::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+  sqlite3_stmt** pstmt = NULL; // Prepared statement
+
+  if (params->op.query_str == "get_next_entry") {
+    pstmt = &next_stmt;
+  } else {
+    pstmt = &stmt;
+  }
+
+  SQL_EXECUTE(dpp, params, *pstmt, list_lc_entry);
+out:
+  return ret;
+}
+
+int SQLListLCEntries::Prepare(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (!*sdb) {
+    ldpp_dout(dpp, 0)<<"In SQLListLCEntries - no db" << dendl;
+    goto out;
+  }
+
+  p_params.lc_entry_table = params->lc_entry_table;
+
+  SQL_PREPARE(dpp, p_params, sdb, stmt, ret, "PrepareListLCEntries");
+
+out:
+  return ret;
+}
+
+int SQLListLCEntries::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int index = -1;
+  int rc = 0;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.index.c_str(), sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_entry.index.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.min_marker.c_str(), sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_entry.min_marker.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.list_max_count.c_str(), sdb);
+  SQL_BIND_INT(dpp, stmt, index, params->op.list_max_count, sdb);
+
+out:
+  return rc;
+}
+
+int SQLListLCEntries::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+
+  SQL_EXECUTE(dpp, params, stmt, list_lc_entry);
+out:
+  return ret;
+}
+
+int SQLInsertLCHead::Prepare(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (!*sdb) {
+    ldpp_dout(dpp, 0)<<"In SQLInsertLCHead - no db" << dendl;
+    goto out;
+  }
+
+  p_params.lc_head_table = params->lc_head_table;
+
+  SQL_PREPARE(dpp, p_params, sdb, stmt, ret, "PrepareInsertLCHead");
+
+out:
+  return ret;
+}
+
+int SQLInsertLCHead::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int index = -1;
+  int rc = 0;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.index.c_str(), sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_head.index.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.marker.c_str(), sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_head.head.marker.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.start_date.c_str(), sdb);
+  SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.lc_head.head.start_date, sdb);
+
+out:
+  return rc;
+}
+
+int SQLInsertLCHead::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+
+  SQL_EXECUTE(dpp, params, stmt, NULL);
+out:
+  return ret;
+}
+
+int SQLRemoveLCHead::Prepare(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (!*sdb) {
+    ldpp_dout(dpp, 0)<<"In SQLRemoveLCHead - no db" << dendl;
+    goto out;
+  }
+
+  p_params.lc_head_table = params->lc_head_table;
+
+  SQL_PREPARE(dpp, p_params, sdb, stmt, ret, "PrepareRemoveLCHead");
+
+out:
+  return ret;
+}
+
+int SQLRemoveLCHead::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int index = -1;
+  int rc = 0;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.index.c_str(), sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_head.index.c_str(), sdb);
+
+out:
+  return rc;
+}
+
+int SQLRemoveLCHead::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+
+  SQL_EXECUTE(dpp, params, stmt, NULL);
+out:
+  return ret;
+}
+
+int SQLGetLCHead::Prepare(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (!*sdb) {
+    ldpp_dout(dpp, 0)<<"In SQLGetLCHead - no db" << dendl;
+    goto out;
+  }
+
+  p_params.lc_head_table = params->lc_head_table;
+
+  SQL_PREPARE(dpp, p_params, sdb, stmt, ret, "PrepareGetLCHead");
+
+out:
+  return ret;
+}
+
+int SQLGetLCHead::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int index = -1;
+  int rc = 0;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.index.c_str(), sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_head.index.c_str(), sdb);
+
+out:
+  return rc;
+}
+
+int SQLGetLCHead::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+
+  // clear the params before fetching the entry
+  params->op.lc_head.head = {};
+  SQL_EXECUTE(dpp, params, stmt, list_lc_head);
 out:
   return ret;
 }

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.h
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.h
@@ -376,4 +376,120 @@ class SQLDeleteObjectData : public SQLiteDB, public DeleteObjectDataOp {
     int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
     int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
 };
+
+class SQLInsertLCEntry : public SQLiteDB, public InsertLCEntryOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+
+  public:
+    SQLInsertLCEntry(void **db, string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
+    ~SQLInsertLCEntry() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
+};
+
+class SQLRemoveLCEntry : public SQLiteDB, public RemoveLCEntryOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+
+  public:
+    SQLRemoveLCEntry(void **db, string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
+    ~SQLRemoveLCEntry() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
+};
+
+class SQLGetLCEntry : public SQLiteDB, public GetLCEntryOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+    sqlite3_stmt *next_stmt = NULL; // Prepared statement
+
+  public:
+    SQLGetLCEntry(void **db, string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
+    ~SQLGetLCEntry() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+      if (next_stmt)
+        sqlite3_finalize(next_stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
+};
+
+class SQLListLCEntries : public SQLiteDB, public ListLCEntriesOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+
+  public:
+    SQLListLCEntries(void **db, string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
+    ~SQLListLCEntries() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
+};
+
+class SQLInsertLCHead : public SQLiteDB, public InsertLCHeadOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+
+  public:
+    SQLInsertLCHead(void **db, string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
+    ~SQLInsertLCHead() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
+};
+
+class SQLRemoveLCHead : public SQLiteDB, public RemoveLCHeadOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+
+  public:
+    SQLRemoveLCHead(void **db, string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
+    ~SQLRemoveLCHead() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
+};
+
+class SQLGetLCHead : public SQLiteDB, public GetLCHeadOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+
+  public:
+    SQLGetLCHead(void **db, string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
+    ~SQLGetLCHead() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
+};
+
 #endif

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.h
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.h
@@ -55,10 +55,15 @@ class SQLiteDB : public DB, public DBOp{
     int createObjectDataTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int createQuotaTable(const DoutPrefixProvider *dpp, DBOpParams *params);
 
+    int createLCTables(const DoutPrefixProvider *dpp) override;
+
     int DeleteBucketTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int DeleteUserTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int DeleteObjectTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int DeleteObjectDataTable(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int DeleteQuotaTable(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int DeleteLCEntryTable(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int DeleteLCHeadTable(const DoutPrefixProvider *dpp, DBOpParams *params);
 
     int ListAllBuckets(const DoutPrefixProvider *dpp, DBOpParams *params) override;
     int ListAllUsers(const DoutPrefixProvider *dpp, DBOpParams *params) override;

--- a/src/rgw/store/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/store/dbstore/tests/dbstore_tests.cc
@@ -100,7 +100,6 @@ namespace {
         GlobalParams.op.obj.state.obj.key.instance = "inst1";
         GlobalParams.op.obj_data.part_num = 0;
 
-
         /* As of now InitializeParams doesnt do anything
          * special based on fop. Hence its okay to do
          * global initialization once.
@@ -997,6 +996,113 @@ TEST_F(DBStoreTest, DeleteObject) {
   ASSERT_EQ(ret, 0);
 }
 
+TEST_F(DBStoreTest, LCTables) {
+  struct DBOpParams params = GlobalParams;
+  int ret = -1;
+
+  ret = db->createLCTables(dpp);
+  ASSERT_GE(ret, 0);
+}
+
+TEST_F(DBStoreTest, LCHead) {
+  struct DBOpParams params = GlobalParams;
+  int ret = -1;
+  std::string index1 = "bucket1";
+  std::string index2 = "bucket2";
+  time_t lc_time = ceph_clock_now();
+  rgw::sal::Lifecycle::LCHead head;
+  std::string ents[] = {"entry1", "entry2", "entry3"};
+  rgw::sal::Lifecycle::LCHead head1 = {lc_time, ents[0]};
+  rgw::sal::Lifecycle::LCHead head2 = {lc_time, ents[1]};
+  rgw::sal::Lifecycle::LCHead head3 = {lc_time, ents[2]};
+
+  ret = db->put_head(index1, head1);
+  ASSERT_EQ(ret, 0);
+  ret = db->put_head(index2, head2);
+  ASSERT_EQ(ret, 0);
+
+  ret = db->get_head(index1, head);
+  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(head.marker, "entry1");
+
+  ret = db->get_head(index2, head);
+  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(head.marker, "entry2");
+
+  // update index1
+  ret = db->put_head(index1, head3);
+  ASSERT_EQ(ret, 0);
+  ret = db->get_head(index1, head);
+  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(head.marker, "entry3");
+
+}
+TEST_F(DBStoreTest, LCEntry) {
+  struct DBOpParams params = GlobalParams;
+  int ret = -1;
+  uint64_t lc_time = ceph_clock_now();
+  std::string index1 = "lcindex1";
+  std::string index2 = "lcindex2";
+  typedef enum {lc_uninitial = 1, lc_complete} status;
+  std::string ents[] = {"bucket1", "bucket2", "bucket3", "bucket4"};
+  rgw::sal::Lifecycle::LCEntry entry;
+  rgw::sal::Lifecycle::LCEntry entry1 = {ents[0], lc_time, lc_uninitial};
+  rgw::sal::Lifecycle::LCEntry entry2 = {ents[1], lc_time, lc_uninitial};
+  rgw::sal::Lifecycle::LCEntry entry3 = {ents[2], lc_time, lc_uninitial};
+  rgw::sal::Lifecycle::LCEntry entry4 = {ents[3], lc_time, lc_uninitial};
+
+  vector<rgw::sal::Lifecycle::LCEntry> lc_entries;
+
+  ret = db->set_entry(index1, entry1);
+  ASSERT_EQ(ret, 0);
+  ret = db->set_entry(index1, entry2);
+  ASSERT_EQ(ret, 0);
+  ret = db->set_entry(index1, entry3);
+  ASSERT_EQ(ret, 0);
+  ret = db->set_entry(index2, entry4);
+  ASSERT_EQ(ret, 0);
+
+  // get entry index1, entry1
+  ret = db->get_entry(index1, ents[0], entry); 
+  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(entry.status, lc_uninitial);
+  ASSERT_EQ(entry.start_time, lc_time);
+
+  // get next entry index1, entry2
+  ret = db->get_next_entry(index1, ents[1], entry); 
+  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(entry.bucket, ents[2]);
+  ASSERT_EQ(entry.status, lc_uninitial);
+  ASSERT_EQ(entry.start_time, lc_time);
+
+  // update entry4 to entry5
+  entry4.status = lc_complete;
+  ret = db->set_entry(index2, entry4);
+  ASSERT_EQ(ret, 0);
+  ret = db->get_entry(index2, ents[3], entry); 
+  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(entry.status, lc_complete);
+
+  // list entries
+  ret = db->list_entries(index1, "", 5, lc_entries);
+  ASSERT_EQ(ret, 0);
+  for (const auto& ent: lc_entries) {
+    cout << "###################### \n";
+    cout << "lc entry.bucket : " << ent.bucket << "\n";
+    cout << "lc entry.status : " << ent.status << "\n";
+  }
+
+  // remove index1, entry3
+  ret = db->rm_entry(index1, entry3); 
+  ASSERT_EQ(ret, 0);
+
+  // get next entry index1, entry2.. should be null
+  entry = {};
+  ret = db->get_next_entry(index1, ents[1], entry); 
+  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(entry.start_time, 0);
+}
+
 TEST_F(DBStoreTest, RemoveBucket) {
   struct DBOpParams params = GlobalParams;
   int ret = -1;
@@ -1027,14 +1133,6 @@ TEST_F(DBStoreTest, InsertTestIDUser) {
   params.op.user.user_version.tag = "UserTAG";    
 
   ret = db->ProcessOp(dpp, "InsertUser", &params);
-  ASSERT_EQ(ret, 0);
-}
-
-TEST_F(DBStoreTest, LCTables) {
-  struct DBOpParams params = GlobalParams;
-  int ret = -1;
-
-  ret = db->createLCTables(dpp);
   ASSERT_EQ(ret, 0);
 }
 

--- a/src/rgw/store/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/store/dbstore/tests/dbstore_tests.cc
@@ -1030,6 +1030,14 @@ TEST_F(DBStoreTest, InsertTestIDUser) {
   ASSERT_EQ(ret, 0);
 }
 
+TEST_F(DBStoreTest, LCTables) {
+  struct DBOpParams params = GlobalParams;
+  int ret = -1;
+
+  ret = db->createLCTables(dpp);
+  ASSERT_EQ(ret, 0);
+}
+
 int main(int argc, char **argv)
 {
   int ret = -1;


### PR DESCRIPTION
If 'use_lc_thread' is enabled, initialize & start LC thread. Also added APIs to set, remove and fetch LCEntries in dbstore. 

Signed-off-by: Soumya Koduri <skoduri@redhat.com>
