### PR TITLE
pacific: snap-schedule: count retained snapshots per retention policy

### DIFF
--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -79,6 +79,7 @@ def get_prune_set(candidates, retention):
         if not period_count:
             continue
         last = None
+        kept_for_this_period = 0
         for snap in sorted(candidates, key=lambda x: x[0].d_name,
                            reverse=True):
             snap_ts = snap[1].strftime(date_pattern)
@@ -87,8 +88,10 @@ def get_prune_set(candidates, retention):
                 if snap not in keep:
                     log.debug(f'keeping {snap[0].d_name} due to {period_count}{period}')
                     keep.append(snap)
-                    if len(keep) == period_count:
-                        log.debug(f'found enough snapshots for {period_count}{period}')
+                    kept_for_this_period += 1
+                    if kept_for_this_period == period_count:
+                        log.debug(('found enough snapshots for '
+                                   f'{period_count}{period}'))
                         break
     if len(keep) > MAX_SNAPS_PER_PATH:
         log.info(f'Would keep more then {MAX_SNAPS_PER_PATH}, pruning keep set')

--- a/src/pybind/mgr/snap_schedule/tests/fs/test_schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/tests/fs/test_schedule_client.py
@@ -18,3 +18,20 @@ class TestScheduleClient(object):
         prune_set = get_prune_set(candidates, ret)
         assert prune_set == set(), 'candidates are pruned despite empty retention'
 
+    def test_get_prune_set_two_retention_specs(self):
+        now = datetime.now()
+        candidates = set()
+        for i in range(10):
+            ts = now - timedelta(hours=i*1)
+            fake_dir = MagicMock()
+            fake_dir.d_name = f'scheduled-{ts.strftime(SNAPSHOT_TS_FORMAT)}'
+            candidates.add((fake_dir, ts))
+        for i in range(10):
+            ts = now - timedelta(days=i*1)
+            fake_dir = MagicMock()
+            fake_dir.d_name = f'scheduled-{ts.strftime(SNAPSHOT_TS_FORMAT)}'
+            candidates.add((fake_dir, ts))
+        # should keep 8 snapshots
+        ret = {'h': 6, 'd': 2}
+        prune_set = get_prune_set(candidates, ret)
+        assert len(prune_set) == len(candidates) - 8, 'wrong size of prune set'


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52412

---

backport of https://github.com/ceph/ceph/pull/42893
parent tracker: https://tracker.ceph.com/issues/52388

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh