### PR TITLE
rgw/notification: allow sending bucket notifications secrets in cleartext

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3575,3 +3575,18 @@ options:
   - rgw
   - osd
   with_legacy: true
+- name: rgw_allow_notification_secrets_in_cleartext
+  type: bool
+  level: advanced
+  desc: Allows sending secrets (e.g. passwords) over non encrypted HTTP messages.
+  long_desc: When bucket notification endpoint require secrets (e.g. passwords),
+    we allow the topic creation only over HTTPS messages. 
+    This parameter can be set to "true" to bypass this check.
+    Use this only if radosgw is on a trusted private network, and the message 
+    broker cannot be configured without password authentication. Otherwise, this will 
+    leak the credentials of your message broker and compromise its security.
+  default: false
+  services:
+  - rgw
+  see_also:
+  - rgw_trust_forwarded_https

--- a/src/rgw/rgw_rest_pubsub_common.cc
+++ b/src/rgw/rgw_rest_pubsub_common.cc
@@ -10,6 +10,15 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
+bool verify_transport_security(CephContext *cct, const RGWEnv& env) {
+  const auto is_secure = rgw_transport_is_secure(cct, env);
+  if (!is_secure && g_conf().get_val<bool>("rgw_allow_notification_secrets_in_cleartext")) {
+    ldout(cct, 0) << "WARNING: bypassing endpoint validation, allow sending password over insecure transport" << dendl;
+    return true;
+  }
+  return is_secure;
+}
+
 bool validate_and_update_endpoint_secret(rgw_pubsub_sub_dest& dest, CephContext *cct, const RGWEnv& env) {
   if (dest.push_endpoint.empty()) {
       return true;
@@ -24,7 +33,7 @@ bool validate_and_update_endpoint_secret(rgw_pubsub_sub_dest& dest, CephContext 
   ceph_assert(user.empty() == password.empty());
   if (!user.empty()) {
       dest.stored_secret = true;
-      if (!rgw_transport_is_secure(cct, env)) {
+      if (!verify_transport_security(cct, env)) {
         ldout(cct, 1) << "endpoint validation error: sending password over insecure transport" << dendl;
         return false;
       }
@@ -71,7 +80,7 @@ void RGWPSListTopicsOp::execute(optional_yield y) {
     ldpp_dout(this, 1) << "failed to get topics, ret=" << op_ret << dendl;
     return;
   }
-  if (topics_has_endpoint_secret(result) && !rgw_transport_is_secure(s->cct, *(s->info.env))) {
+  if (topics_has_endpoint_secret(result) && !verify_transport_security(s->cct, *(s->info.env))) {
     ldpp_dout(this, 1) << "topics contain secret and cannot be sent over insecure transport" << dendl;
     op_ret = -EPERM;
     return;
@@ -86,7 +95,7 @@ void RGWPSGetTopicOp::execute(optional_yield y) {
   }
   ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   op_ret = ps->get_topic(topic_name, &result);
-  if (topic_has_endpoint_secret(result) && !rgw_transport_is_secure(s->cct, *(s->info.env))) {
+  if (topic_has_endpoint_secret(result) && !verify_transport_security(s->cct, *(s->info.env))) {
     ldpp_dout(this, 1) << "topic '" << topic_name << "' contain secret and cannot be sent over insecure transport" << dendl;
     op_ret = -EPERM;
     return;
@@ -135,7 +144,7 @@ void RGWPSGetSubOp::execute(optional_yield y) {
   ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   auto sub = ps->get_sub(sub_name);
   op_ret = sub->get_conf(&result);
-  if (subscription_has_endpoint_secret(result) && !rgw_transport_is_secure(s->cct, *(s->info.env))) {
+  if (subscription_has_endpoint_secret(result) && !verify_transport_security(s->cct, *(s->info.env))) {
     ldpp_dout(this, 1) << "subscription '" << sub_name << "' contain secret and cannot be sent over insecure transport" << dendl;
     op_ret = -EPERM;
     return;


### PR DESCRIPTION
rgw_allow_secrets_in_cleartext conf parameter was added for that

Fixes: https://tracker.ceph.com/issues/50611

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

## Testing
run vstart cluster:
```
MON=1 OSD=1 MDS=0 MGR=0 RGW=1 ../src/vstart.sh -n -d
```
behavior should not change by default, so the following command should fail:
```
aws --endpoint-url http://localhost:8000 sns create-topic --name=fishtopic2 --attributes='{"push-endpoint": "amqp://hello:world@localhost:10900", "amqp-exchange": "ex1"}'
```
however, after setting the parameter to "true":
```
bin/ceph -c ceph.conf config set client.rgw.8000 rgw_allow_notification_secrets_in_cleartext true
```
topic creation with user and password over non-secure connection should be ok:
```
# aws --endpoint-url http://localhost:8000 sns create-topic --name=fishtopic2 --attributes='{"push-endpoint": "amqp://hello:world@localhost:10900", "amqp-exchange": "ex1"}'
{
    "TopicArn": "arn:aws:sns:default::fishtopic2"
}
```
---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
