### PR TITLE
librados,librbd: make it clear that replica reads are safe for general use

### DIFF
--- a/src/common/options/rbd.yaml.in
+++ b/src/common/options/rbd.yaml.in
@@ -206,6 +206,8 @@ options:
   default: false
   services:
   - rbd
+  see_also:
+  - rbd_read_from_replica_policy
 - name: rbd_localize_snap_reads
   type: bool
   level: advanced
@@ -213,6 +215,8 @@ options:
   default: false
   services:
   - rbd
+  see_also:
+  - rbd_read_from_replica_policy
 - name: rbd_balance_parent_reads
   type: bool
   level: advanced
@@ -220,6 +224,8 @@ options:
   default: false
   services:
   - rbd
+  see_also:
+  - rbd_read_from_replica_policy
 - name: rbd_localize_parent_reads
   type: bool
   level: advanced
@@ -227,6 +233,8 @@ options:
   default: false
   services:
   - rbd
+  see_also:
+  - rbd_read_from_replica_policy
 - name: rbd_sparse_read_threshold_bytes
   type: size
   level: advanced
@@ -355,9 +363,11 @@ options:
     for read operations. If set to ``balance``, read operations will
     be sent to a randomly selected OSD within the replica set. If set
     to ``localize``, read operations will be sent to the closest OSD
-    as determined by the CRUSH map. Note: this feature requires the
-    cluster to be configured with a minimum compatible OSD release of
-    Octopus.
+    as determined by the CRUSH map. Unlike ``rbd_balance_snap_reads``
+    and ``rbd_localize_snap_reads`` or ``rbd_balance_parent_reads`` and
+    ``rbd_localize_parent_reads``, it affects all read operations, not
+    just snap or parent. Note: this feature requires the cluster to
+    be configured with a minimum compatible OSD release of Octopus.
   default: default
   services:
   - rbd

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -246,9 +246,11 @@ inline namespace v14_2_0 {
   /**
    * These flags apply to the ObjectOperation as a whole.
    *
-   * BALANCE_READS and LOCALIZE_READS should only be used
-   * when reading from data you're certain won't change,
-   * like a snapshot, or where eventual consistency is ok.
+   * Prior to octopus BALANCE_READS and LOCALIZE_READS should only
+   * be used when reading from data you're certain won't change, like
+   * a snapshot, or where eventual consistency is ok.  Since octopus
+   * (get_min_compatible_osd() >= CEPH_RELEASE_OCTOPUS) both are safe
+   * for general use.
    *
    * ORDER_READS_WRITES will order reads the same way writes are
    * ordered (e.g., waiting for degraded objects).  In particular, it


### PR DESCRIPTION
A late follow up for https://github.com/ceph/ceph/pull/32381.