### PR TITLE
monmap: fix wrong service name in a debug of init_with_dns_srv().

### DIFF
--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -873,24 +873,24 @@ int MonMap::init_with_monmap(const std::string& monmap, std::ostream& errout)
 }
 
 int MonMap::init_with_dns_srv(CephContext* cct,
-                              std::string srv_name,
+                              std::string name,
 			      bool for_mkfs,
                               std::ostream& errout)
 {
+  string service = name;
   string domain;
-  // check if domain is also provided and extract it from srv_name
-  size_t idx = srv_name.find("_");
-  if (idx != string::npos) {
-    domain = srv_name.substr(idx + 1);
-    srv_name = srv_name.substr(0, idx);
+  // check if domain is also provided and extract it from the service name
+  if (size_t idx = name.find("_"); idx != name.npos) {
+    service = name.substr(0, idx);
+    domain = name.substr(idx + 1);
   }
 
   map<string, DNSResolver::Record> records;
-  if (DNSResolver::get_instance()->resolve_srv_hosts(cct, srv_name,
+  if (DNSResolver::get_instance()->resolve_srv_hosts(cct, service,
         DNSResolver::SRV_Protocol::TCP, domain, &records) != 0) {
 
     errout << "unable to get monitor info from DNS SRV with service name: "
-           << "ceph-mon" << std::endl;
+           << name << std::endl;
     return -1;
   } else {
     for (auto& record : records) {


### PR DESCRIPTION
It was always assuming `ceph-mon` which ignores `mon_dns_srv_name` and could be quite misleading.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
