### PR TITLE
mds:  use make_move_iterator instead of copying  logseg_destroyed_inos

### DIFF
--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -1127,7 +1127,6 @@ void OpenFileTable::_prefetch_inodes()
   if (destroyed_inos_set.empty()) {
     for (auto& it : logseg_destroyed_inos)
       destroyed_inos_set.insert(std::make_move_iterator(it.second.begin()), std::make_move_iterator(it.second.end()));
-
   }
 
   for (auto& [ino, anchor] : loaded_anchor_map) {


### PR DESCRIPTION
OpenFileTable.cc use make_move_iterator instead of copying  logseg_destroyed_inos
Signed-off-by: "PPBOND" <zywcoder@gmail.com>