### PR TITLE
mgr/dashboard: Fix orchestrator/01-hosts.e2e-spec.ts failure

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/01-hosts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/01-hosts.e2e-spec.ts
@@ -21,8 +21,20 @@ describe('Hosts page', () => {
       hosts.add(hostname, true);
     });
 
-    it('should delete a host and add it back', function () {
+    it('should drain and delete a host and then add it back', function () {
       const host = Cypress._.last(this.hosts)['name'];
+
+      // should drain the host first before deleting
+      hosts.editLabels(host, ['_no_schedule'], true);
+      hosts.clickHostTab(host, 'Daemons');
+      cy.get('cd-host-details').within(() => {
+        // draining will take some time to complete.
+        // since we don't know how many daemons will be
+        // running in this host in future putting the wait
+        // to 15s
+        cy.wait(15000);
+        hosts.getTableCount('total').should('be.eq', 0);
+      });
       hosts.delete(host);
 
       // add it back


### PR DESCRIPTION
The test is failing on deleting a host because the agent daemon is
present in that host. Its not possible to simply delete a host. We need
to drain it first and then delete it. Since there is no drain option from the dashboard,
just adding a `_no_schedule` label to the host will trigger a drain.

Depends on #43331
Fixes: https://tracker.ceph.com/issues/52764
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
