### PR TITLE
pacific: mon: Allow specifying new tiebreaker monitors

### DIFF
--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -112,7 +112,8 @@ When stretch mode is enabled, the OSDs wlll only take PGs active when
 they peer across data centers (or whatever other CRUSH bucket type
 you specified), assuming both are alive. Pools will increase in size
 from the default 3 to 4, expecting 2 copies in each site. OSDs will only
-be allowed to connect to monitors in the same data center.
+be allowed to connect to monitors in the same data center. New monitors
+will not be allowed to join the cluster if they do not specify a location.
 
 If all the OSDs and monitors from a data center become inaccessible
 at once, the surviving data center will enter a degraded stretch mode. This
@@ -158,6 +159,22 @@ running with more than 2 full sites.
 
 Other commands
 ==============
+Starting in Pacific v16.2.8, if your tiebreaker monitor fails for some reason,
+you can replace it. Turn on a new monitor and run ::
+
+  $ ceph mon set_new_tiebreaker mon.<new_mon_name>
+
+This command will protest if the new monitor is in the same location as existing
+non-tiebreaker monitors. This command WILL NOT remove the previous tiebreaker
+monitor; you should do so yourself.
+
+Also in 16.2.7, if you are writing your own tooling for deploying Ceph, you can use a new
+``--set-crush-location`` option when booting monitors, instead of running
+``ceph mon set_location``. This option accepts only a single "bucket=loc" pair, eg
+``ceph-mon --set-crush-location 'datacenter=a'``, which must match the
+bucket type you specified when running ``enable_stretch_mode``.
+
+
 When in stretch degraded mode, the cluster will go into "recovery" mode automatically
 when the disconnected data center comes back. If that doesn't work, or you want to
 enable recovery mode early, you can invoke ::

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -534,6 +534,11 @@ COMMAND("mon enable_stretch_mode " \
 	"as the tiebreaker and setting <dividing_bucket> locations "
 	"as the units for stretching across",
 	"mon", "rw")
+COMMAND("mon set_new_tiebreaker " \
+	"name=name,type=CephString "
+	"name=yes_i_really_mean_it,type=CephBool,req=false",
+	"switch the stretch tiebreaker to be the named mon", \
+	"mon", "rw")
 
 /*
  * OSD commands

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -369,7 +369,9 @@ void MonMap::print(ostream& out) const
   out << "min_mon_release " << to_integer<unsigned>(min_mon_release)
       << " (" << min_mon_release << ")\n";
   out << "election_strategy: " << strategy << "\n";
-  if (disallowed_leaders.size()) {
+  if (stretch_mode_enabled) {
+    out << "stretch_mode_enabled " << stretch_mode_enabled << "\n";
+    out << "tiebreaker_mon " << tiebreaker_mon << "\n";
     out << "disallowed_leaders " << disallowed_leaders << "\n";
   }
   unsigned i = 0;
@@ -395,6 +397,7 @@ void MonMap::dump(Formatter *f) const
   f->dump_int ("election_strategy", strategy);
   f->dump_stream("disallowed_leaders: ") << disallowed_leaders;
   f->dump_bool("stretch_mode", stretch_mode_enabled);
+  f->dump_string("tiebreaker_mon", tiebreaker_mon);
   f->open_object_section("features");
   persistent_features.dump(f, "persistent");
   optional_features.dump(f, "optional");

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -757,6 +757,7 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
 
     entity_addrvec_t addrs = pending_map.get_addrs(name);
     pending_map.remove(name);
+    pending_map.disallowed_leaders.erase(name);
     pending_map.last_changed = ceph_clock_now();
     ss << "removing mon." << name << " at " << addrs
        << ", there will be " << pending_map.size() << " monitors" ;

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -720,6 +720,12 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
       goto reply;
     }
 
+    if (pending_map.stretch_mode_enabled &&
+	name == pending_map.tiebreaker_mon) {
+      err = -EINVAL;
+      ss << "you cannot remove stretch mode's tiebreaker monitor";
+      goto reply;
+    }
     /* At the time of writing, there is no risk of races when multiple clients
      * attempt to use the same name. The reason is simple but may not be
      * obvious.

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -1026,9 +1026,6 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
       goto reply;
     }
 
-    if (!mon.osdmon()->is_readable()) {
-      mon.osdmon()->wait_for_readable(op, new Monitor::C_RetryMessage(&mon, op));
-    }
     vector<string> argvec;
     map<string, string> loc;
     cmd_getval(cmdmap, "args", argvec);

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -947,6 +947,7 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
     }
     err = 0;
     pending_map.strategy = strategy;
+    pending_map.last_changed = ceph_clock_now();
     propose = true;
   } else if (prefix == "mon add disallowed_leader") {
     if (!mon.get_quorum_mon_features().contains_all(
@@ -982,6 +983,7 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
       goto reply;
     }
     pending_map.disallowed_leaders.insert(name);
+    pending_map.last_changed = ceph_clock_now();
     err = 0;
     propose = true;
   } else if (prefix == "mon rm disallowed_leader") {
@@ -1013,6 +1015,7 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
       goto reply;
     }
     pending_map.disallowed_leaders.erase(name);
+    pending_map.last_changed = ceph_clock_now();
     err = 0;
     propose = true;
   } else if (prefix == "mon set_location") {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52868

---

backport of https://github.com/ceph/ceph/pull/43373
parent tracker: https://tracker.ceph.com/issues/52126

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh