### PR TITLE
mgr/cephadm: use `asyncssh.scp` to write remote files

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1270,14 +1270,14 @@ class CephadmServe:
 
             try:
                 out, err, code = self.mgr.ssh.execute_command(
-                    host, cmd, stdin=stdin.encode('utf-8') if stdin else None, addr=addr)
+                    host, cmd, stdin=stdin, addr=addr)
                 if code == 2:
                     ls_cmd = ['ls', self.mgr.cephadm_binary_path]
                     out_ls, err_ls, code_ls = self.mgr.ssh.execute_command(host, ls_cmd, addr=addr)
                     if code_ls == 2:
                         self._deploy_cephadm_binary(host, addr)
                         out, err, code = self.mgr.ssh.execute_command(
-                            host, cmd, stdin=stdin.encode('utf-8') if stdin else None, addr=addr)
+                            host, cmd, stdin=stdin, addr=addr)
 
             except Exception as e:
                 self.mgr.ssh._reset_con(host)
@@ -1289,7 +1289,7 @@ class CephadmServe:
             try:
                 cmd = ['/usr/bin/cephadm'] + final_args
                 out, err, code = self.mgr.ssh.execute_command(
-                    host, cmd, stdin=stdin.encode('utf-8') if stdin else None, addr=addr)
+                    host, cmd, stdin=stdin, addr=addr)
             except Exception as e:
                 self.mgr.ssh._reset_con(host)
                 if error_ok:

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -128,14 +128,14 @@ class SSHManager:
     async def _execute_command(self,
                                host: str,
                                cmd: List[str],
-                               stdin: Optional[bytes] = None,
+                               stdin: Optional[str] = None,
                                addr: Optional[str] = None,
                                ) -> Tuple[str, str, int]:
         conn = await self._remote_connection(host, addr)
         cmd = "sudo " + " ".join(quote(x) for x in cmd)
         logger.debug(f'Running command: {cmd}')
         try:
-            r = await conn.run(cmd, input=stdin.decode() if stdin else None)
+            r = await conn.run(cmd, input=stdin)
         # handle these Exceptions otherwise you might get a weird error like TypeError: __init__() missing 1 required positional argument: 'reason' (due to the asyncssh error interacting with raise_if_exception)
         except (asyncssh.ChannelOpenError, Exception) as e:
             # SSH connection closed or broken, will create new connection next call
@@ -150,7 +150,7 @@ class SSHManager:
     def execute_command(self,
                         host: str,
                         cmd: List[str],
-                        stdin: Optional[bytes] = None,
+                        stdin: Optional[str] = None,
                         addr: Optional[str] = None,
                         ) -> Tuple[str, str, int]:
         return self.mgr.event_loop.get_result(self._execute_command(host, cmd, stdin, addr))
@@ -158,7 +158,7 @@ class SSHManager:
     async def _check_execute_command(self,
                                      host: str,
                                      cmd: List[str],
-                                     stdin: Optional[bytes] = None,
+                                     stdin: Optional[str] = None,
                                      addr: Optional[str] = None,
                                      ) -> str:
         out, err, code = await self._execute_command(host, cmd, stdin, addr)
@@ -171,7 +171,7 @@ class SSHManager:
     def check_execute_command(self,
                               host: str,
                               cmd: List[str],
-                              stdin: Optional[bytes] = None,
+                              stdin: Optional[str] = None,
                               addr: Optional[str] = None,
                               ) -> str:
         return self.mgr.event_loop.get_result(self._check_execute_command(host, cmd, stdin, addr))


### PR DESCRIPTION
`tee` via stdin happens to work when the file is a utf-8 byte encoded
string, but won't work if the file happens to be binary data

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
