### PR TITLE
crimson/os/seastore: reduce write amplification from record overhead and implement placement hint

### DIFF
--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -328,7 +328,7 @@ public:
   device_type_t backend_type = device_type_t::NONE;
 
   /// hint for allocators
-  ool_placement_hint_t hint;
+  placement_hint_t hint = placement_hint_t::NUM_HINTS;
 
   bool is_inline() const {
     return poffset.is_relative();

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -307,12 +307,14 @@ public:
     Transaction& t,
     extent_types_t type,
     segment_off_t length,
-    placement_hint_t hint = placement_hint_t::NONE) {
+    placement_hint_t hint) {
     // only logical extents should fall in this path
     assert(is_logical_type(type));
     assert(hint < placement_hint_t::NUM_HINTS);
     auto dtype = get_allocator_type(hint);
-    bool delay = can_delay_allocation(dtype);
+    // FIXME: set delay for COLD extent when the record overhead is low
+    bool delay = (hint > placement_hint_t::COLD &&
+                  can_delay_allocation(dtype));
     CachedExtentRef extent = cache.alloc_new_extent_by_type(
         t, type, length, delay);
     extent->backend_type = dtype;
@@ -326,12 +328,14 @@ public:
   TCachedExtentRef<T> alloc_new_extent(
     Transaction& t,
     segment_off_t length,
-    placement_hint_t hint = placement_hint_t::NONE) {
+    placement_hint_t hint) {
     // only logical extents should fall in this path
     static_assert(is_logical_type(T::TYPE));
     assert(hint < placement_hint_t::NUM_HINTS);
     auto dtype = get_allocator_type(hint);
-    bool delay = can_delay_allocation(dtype);
+    // FIXME: set delay for COLD extent when the record overhead is low
+    bool delay = (hint > placement_hint_t::COLD &&
+                  can_delay_allocation(dtype));
     TCachedExtentRef<T> extent = cache.alloc_new_extent<T>(
         t, length, delay);
     extent->backend_type = dtype;
@@ -351,9 +355,8 @@ public:
     LOG_PREFIX(ExtentPlacementManager::delayed_alloc_or_ool_write);
     DEBUGT("start", t);
     return seastar::do_with(
-      std::map<ExtentAllocator*, std::list<LogicalCachedExtentRef>>(),
-      std::list<std::pair<paddr_t, LogicalCachedExtentRef>>(),
-      [this, &t](auto& alloc_map, auto& inline_list) mutable {
+        std::map<ExtentAllocator*, std::list<LogicalCachedExtentRef>>(),
+        [this, &t](auto& alloc_map) {
       LOG_PREFIX(ExtentPlacementManager::delayed_alloc_or_ool_write);
       auto& alloc_list = t.get_delayed_alloc_list();
       uint64_t num_ool_extents = 0;
@@ -363,38 +366,18 @@ public:
           t.increment_delayed_invalid_extents();
           continue;
         }
-        if (should_be_inline(extent)) {
-          auto old_addr = extent->get_paddr();
-          cache.mark_delayed_extent_inline(t, extent);
-          inline_list.emplace_back(old_addr, extent);
-        } else {
-	  auto& allocator_ptr = get_allocator(
-	    extent->backend_type, extent->hint
-	  );
-	  alloc_map[allocator_ptr.get()].emplace_back(extent);
-	  num_ool_extents++;
-	}
+        // For now, just do ool allocation for any delayed extent
+        auto& allocator_ptr = get_allocator(
+          extent->backend_type, extent->hint
+        );
+        alloc_map[allocator_ptr.get()].emplace_back(extent);
+        num_ool_extents++;
       }
-      DEBUGT("{} inline extents, {} ool extents",
-        t,
-        inline_list.size(),
-        num_ool_extents);
+      DEBUGT("{} ool extents", t, num_ool_extents);
       return trans_intr::do_for_each(alloc_map, [&t](auto& p) {
         auto allocator = p.first;
         auto& extents = p.second;
         return allocator->alloc_ool_extents_paddr(t, extents);
-      }).si_then([&inline_list, this, &t] {
-        LOG_PREFIX(ExtentPlacementManager::delayed_alloc_or_ool_write);
-        DEBUGT("processing {} inline extents", t, inline_list.size());
-        return trans_intr::do_for_each(inline_list, [this, &t](auto& p) {
-          auto old_addr = p.first;
-          auto& extent = p.second;
-          return lba_manager.update_mapping(
-            t,
-            extent->get_laddr(),
-            old_addr,
-            extent->get_paddr());
-        });
       });
     });
   }
@@ -406,10 +389,6 @@ public:
 private:
   device_type_t get_allocator_type(placement_hint_t hint) {
     return device_type_t::SEGMENTED;
-  }
-
-  bool should_be_inline(LogicalCachedExtentRef& extent) {
-    return (std::rand() % 2) == 0;
   }
 
   ExtentAllocatorRef& get_allocator(

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -252,7 +252,7 @@ public:
     Journal& journal,
     Cache& cache);
 
-  Writer &get_writer(ool_placement_hint_t hint) {
+  Writer &get_writer(placement_hint_t hint) {
     return writers[std::rand() % writers.size()];
   }
 
@@ -307,9 +307,10 @@ public:
     Transaction& t,
     extent_types_t type,
     segment_off_t length,
-    ool_placement_hint_t hint = ool_placement_hint_t::NONE) {
+    placement_hint_t hint = placement_hint_t::NONE) {
     // only logical extents should fall in this path
     assert(is_logical_type(type));
+    assert(hint < placement_hint_t::NUM_HINTS);
     auto dtype = get_allocator_type(hint);
     CachedExtentRef extent;
     // for extents that would be stored in NVDIMM/PMEM, no delayed
@@ -332,8 +333,8 @@ public:
   TCachedExtentRef<T> alloc_new_extent(
     Transaction& t,
     segment_off_t length,
-    ool_placement_hint_t hint = ool_placement_hint_t::NONE)
-  {
+    placement_hint_t hint = placement_hint_t::NONE) {
+    assert(hint < placement_hint_t::NUM_HINTS);
     auto dtype = get_allocator_type(hint);
     TCachedExtentRef<T> extent;
     if (need_delayed_allocation(dtype)) {
@@ -413,7 +414,7 @@ public:
   }
 
 private:
-  device_type_t get_allocator_type(ool_placement_hint_t hint) {
+  device_type_t get_allocator_type(placement_hint_t hint) {
     return device_type_t::SEGMENTED;
   }
 
@@ -423,7 +424,7 @@ private:
 
   ExtentAllocatorRef& get_allocator(
     device_type_t type,
-    ool_placement_hint_t hint) {
+    placement_hint_t hint) {
     auto& devices = allocators[type];
     return devices[std::rand() % devices.size()];
   }

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -198,7 +198,8 @@ ceph::bufferlist encode_record(
   return bl;
 }
 
-bool need_delayed_allocation(device_type_t type) {
+bool can_delay_allocation(device_type_t type) {
+  // Some types of device may not support delayed allocation, for example PMEM.
   return type <= RANDOM_BLOCK;
 }
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -257,7 +257,7 @@ enum device_type_t {
   NUM_TYPES
 };
 
-bool need_delayed_allocation(device_type_t type);
+bool can_delay_allocation(device_type_t type);
 
 /* Monotonically increasing identifier for the location of a
  * journal_record.
@@ -367,7 +367,7 @@ enum class extent_types_t : uint8_t {
 };
 constexpr auto EXTENT_TYPES_MAX = static_cast<uint8_t>(extent_types_t::NONE);
 
-inline bool is_logical_type(extent_types_t type) {
+constexpr bool is_logical_type(extent_types_t type) {
   switch (type) {
   case extent_types_t::ROOT:
   case extent_types_t::LADDR_INTERNAL:

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -245,8 +245,10 @@ constexpr objaddr_t OBJ_ADDR_MAX = std::numeric_limits<objaddr_t>::max();
 constexpr objaddr_t OBJ_ADDR_NULL = OBJ_ADDR_MAX - 1;
 
 enum class placement_hint_t {
-  NONE,     /// Denotes empty hint
-  NUM_HINTS /// Constant for number of hints
+  HOT = 0,   // Most of the metadata
+  COLD,      // Object data
+  REWRITE,   // Cold metadata and data (probably need further splits)
+  NUM_HINTS  // Constant for number of hints
 };
 
 enum device_type_t {

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -244,7 +244,7 @@ using objaddr_t = uint32_t;
 constexpr objaddr_t OBJ_ADDR_MAX = std::numeric_limits<objaddr_t>::max();
 constexpr objaddr_t OBJ_ADDR_NULL = OBJ_ADDR_MAX - 1;
 
-enum class ool_placement_hint_t {
+enum class placement_hint_t {
   NONE,     /// Denotes empty hint
   NUM_HINTS /// Constant for number of hints
 };

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -323,7 +323,8 @@ TransactionManager::rewrite_logical_extent(
   auto nlextent = epm->alloc_new_extent_by_type(
     t,
     lextent->get_type(),
-    lextent->get_length())->cast<LogicalCachedExtent>();
+    lextent->get_length(),
+    placement_hint_t::REWRITE)->cast<LogicalCachedExtent>();
   lextent->get_bptr().copy_out(
     0,
     lextent->get_length(),


### PR DESCRIPTION
This is a follow-up PR try to address the write gap observed from https://github.com/ceph/ceph/pull/41803#issuecomment-922243566.

This PR decides to inline allocate non-REWRITE extents in order to reduce the ool record overhead. The observation shows the transactions from user is usually very small and doesn't deserve to be written in ool records, which requires at least a block to store the record metadata.

The overall throughput is also improved in local tests.

## Results
1. This almost removes the write amplifaction from `OOL_RECORD_OVERHEAD` that takes ~0.7 * user-write-size:
Before:
![before_1](https://user-images.githubusercontent.com/7736006/136492050-21ec96f0-0fb6-4480-a7ed-54163f5ebcaa.png)
After:
![after_1](https://user-images.githubusercontent.com/7736006/136492058-59889335-e090-4b0a-9144-3ad166a8a051.png)
(not sure why the rate of `INLINE_RETIRED` is higher than before)

2. The overall gap between `SEGMENTED_WRITE` and `VALID_EXTENT_WRITE` is reduced by ~50%:
Before:
![before_2](https://user-images.githubusercontent.com/7736006/136492535-82b0959c-c16a-4df3-9fab-800708ed3e28.png)
After:
![after_2](https://user-images.githubusercontent.com/7736006/136492544-dea61086-a24b-4927-bdac-06b2a39eac2d.png)

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
