### PR TITLE
qa: support isal ec test for aarch64

### DIFF
--- a/qa/standalone/erasure-code/test-erasure-code-plugins.sh
+++ b/qa/standalone/erasure-code/test-erasure-code-plugins.sh
@@ -14,7 +14,7 @@ case $arch in
     aarch64*|arm*)
         legacy_jerasure_plugins=(jerasure_generic jerasure_neon)
         legacy_shec_plugins=(shec_generic shec_neon)
-        plugins=(jerasure shec lrc)
+        plugins=(jerasure shec lrc isa)
         ;;
     *)
         echo "unsupported platform ${arch}."

--- a/qa/suites/rados/thrash-erasure-code-isa/arch/aarch64.yaml
+++ b/qa/suites/rados/thrash-erasure-code-isa/arch/aarch64.yaml
@@ -1,0 +1,1 @@
+arch: aarch64


### PR DESCRIPTION
	modified:   qa/standalone/erasure-code/test-erasure-code-plugins.sh
	new file:   qa/suites/rados/thrash-erasure-code-isa/arch/aarch64.yaml

Signed-off-by: Dai Zhiwei <daizhiwei3@huawei.com>
