### PR TITLE
crimson/os/seastore: implement Sprite LFS' gc and extent placement strategy to lower gc cost

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -40,10 +40,10 @@ options:
   default: true
   see_also:
   - seastore_device_size
-- name: seastore_init_rewrite_segments_num_per_device
+- name: seastore_init_write_segments_num_per_device
   type: uint
   level: dev
-  desc: Initial number of segments for rewriting extents per device
+  desc: Initial number of segments for writing new extents per device
   default: 6
 - name: seastore_journal_batch_capacity
   type: uint

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -1239,7 +1239,7 @@ public:
       return make_interruptible(
 	  ::crimson::repeat(
 	    [action=std::move(action),
-	    interrupt_condition=interrupt_cond<InterruptCond>.interrupt_cond] {
+	    interrupt_condition=interrupt_cond<InterruptCond>.interrupt_cond]() mutable {
 	    return call_with_interruption(
 		      interrupt_condition,
 		      std::move(action)).to_future();

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -596,7 +596,8 @@ public:
   replay_delta_ret replay_delta(
     journal_seq_t seq,
     paddr_t record_block_base,
-    const delta_info_t &delta);
+    const delta_info_t &delta,
+    seastar::lowres_system_clock::time_point& last_modified);
 
   /**
    * init_cached_extents

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -100,7 +100,36 @@ class CachedExtent : public boost::intrusive_ref_counter<
   // Points at current version while in state MUTATION_PENDING
   CachedExtentRef prior_instance;
 
+  // time of the last modification
+  seastar::lowres_system_clock::time_point last_modified;
+
+  // time of the last rewrite
+  seastar::lowres_system_clock::time_point last_rewritten;
 public:
+
+  void set_last_modified(seastar::lowres_system_clock::duration d) {
+    last_modified = seastar::lowres_system_clock::time_point(d);
+  }
+
+  void set_last_modified(seastar::lowres_system_clock::time_point t) {
+    last_modified = t;
+  }
+
+  seastar::lowres_system_clock::time_point get_last_modified() const {
+    return last_modified;
+  }
+
+  void set_last_rewritten(seastar::lowres_system_clock::duration d) {
+    last_rewritten = seastar::lowres_system_clock::time_point(d);
+  }
+
+  void set_last_rewritten(seastar::lowres_system_clock::time_point t) {
+    last_rewritten = t;
+  }
+
+  seastar::lowres_system_clock::time_point get_last_rewritten() const {
+    return last_rewritten;
+  }
   /**
    *  duplicate_for_write
    *
@@ -170,6 +199,8 @@ public:
 	<< ", type=" << get_type()
 	<< ", version=" << version
 	<< ", dirty_from_or_retired_at=" << dirty_from_or_retired_at
+	<< ", last_modified=" << last_modified.time_since_epoch()
+	<< ", last_rewritten=" << last_rewritten.time_since_epoch()
 	<< ", paddr=" << get_paddr()
 	<< ", length=" << get_length()
 	<< ", state=" << state

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -80,7 +80,11 @@ SegmentedAllocator::Writer::do_write(
   }
   assert(segment_allocator.can_write());
 
-  ool_record_t record(segment_allocator.get_block_size());
+  ool_record_t record(
+    segment_allocator.get_block_size(),
+    (t.get_src() == Transaction::src_t::MUTATE)
+      ? record_commit_type_t::MODIFY
+      : record_commit_type_t::REWRITE);
   for (auto it = extents.begin(); it != extents.end();) {
     auto& extent = *it;
     auto wouldbe_length = record.get_wouldbe_encoded_record_length(extent);

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -10,11 +10,12 @@ namespace crimson::os::seastore {
 SegmentedAllocator::SegmentedAllocator(
   SegmentProvider& sp,
   SegmentManager& sm)
+  : rewriter(sp, sm)
 {
   std::generate_n(
     std::back_inserter(writers),
     crimson::common::get_conf<uint64_t>(
-      "seastore_init_rewrite_segments_num_per_device"),
+      "seastore_init_write_segments_num_per_device"),
     [&] {
       return Writer{sp, sm};
     }

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -220,7 +220,11 @@ public:
     SegmentManager& sm);
 
   Writer &get_writer(placement_hint_t hint) {
-    return writers[std::rand() % writers.size()];
+    if (hint == placement_hint_t::REWRITE) {
+      return rewriter;
+    } else {
+      return writers[std::rand() % writers.size()];
+    }
   }
 
   alloc_paddr_iertr::future<> alloc_ool_extents_paddr(
@@ -249,6 +253,7 @@ public:
     });
   }
 private:
+  Writer rewriter;
   std::vector<Writer> writers;
 };
 

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -28,6 +28,7 @@ class ool_record_t {
   public:
     OolExtent(LogicalCachedExtentRef& lextent)
       : lextent(lextent) {}
+
     void set_ool_paddr(paddr_t addr) {
       ool_offset = addr;
     }
@@ -46,7 +47,11 @@ class ool_record_t {
   };
 
 public:
-  ool_record_t(size_t block_size) : block_size(block_size) {}
+  ool_record_t(
+    size_t block_size,
+    record_commit_type_t commit_type)
+    : block_size(block_size),
+      commit_type(commit_type) {}
   record_group_size_t get_encoded_record_length() {
     assert(extents.size() == record.extents.size());
     return record_group_size_t(record.size, block_size);
@@ -60,11 +65,20 @@ public:
                           segment_nonce_t nonce) {
     assert(extents.size() == record.extents.size());
     assert(!record.deltas.size());
+    auto commit_time = seastar::lowres_system_clock::now();
+    record.commit_time = commit_time.time_since_epoch().count();
+    record.commit_type = commit_type;
     auto record_group = record_group_t(std::move(record), block_size);
     seastore_off_t extent_offset = base + record_group.size.get_mdlength();
     for (auto& extent : extents) {
       extent.set_ool_paddr(
         paddr_t::make_seg_paddr(segment, extent_offset));
+      if (commit_type == record_commit_type_t::MODIFY) {
+        extent.get_lextent()->set_last_modified(commit_time);
+      } else {
+        assert(commit_type == record_commit_type_t::REWRITE);
+        extent.get_lextent()->set_last_rewritten(commit_time);
+      }
       extent_offset += extent.get_bptr().length();
     }
     assert(extent_offset ==
@@ -78,7 +92,8 @@ public:
     record.push_back(extent_t{
       extent->get_type(),
       extent->get_laddr(),
-      std::move(bl)});
+      std::move(bl),
+      extent->get_last_modified().time_since_epoch().count()});
   }
   std::vector<OolExtent>& get_extents() {
     return extents;
@@ -103,6 +118,8 @@ private:
   record_t record;
   size_t block_size;
   seastore_off_t base = MAX_SEG_OFF;
+  record_commit_type_t commit_type =
+    record_commit_type_t::NONE;
 };
 
 /**

--- a/src/crimson/os/seastore/extent_reader.h
+++ b/src/crimson/os/seastore/extent_reader.h
@@ -34,6 +34,16 @@ public:
     segment_header_t>;
   read_segment_header_ret read_segment_header(segment_id_t segment);
 
+  using read_segment_tail_ertr = read_segment_header_ertr;
+  using read_segment_tail_ret = read_segment_tail_ertr::future<
+    segment_tail_t>;
+  read_segment_tail_ret  read_segment_tail(segment_id_t segment);
+
+  struct commit_info_t {
+    mod_time_point_t commit_time;
+    record_commit_type_t commit_type;
+  };
+
   /**
    * scan_extents
    *
@@ -45,7 +55,8 @@ public:
    */
   using scan_extents_cursor = scan_valid_records_cursor;
   using scan_extents_ertr = read_ertr::extend<crimson::ct_error::enodata>;
-  using scan_extents_ret_bare = std::list<std::pair<paddr_t, extent_info_t>>;
+  using scan_extents_ret_bare =
+    std::list<std::pair<paddr_t, std::pair<commit_info_t, extent_info_t>>>;
   using scan_extents_ret = scan_extents_ertr::future<scan_extents_ret_bare>;
   scan_extents_ret scan_extents(
     scan_extents_cursor &cursor,

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -79,7 +79,8 @@ public:
   using replay_ret = replay_ertr::future<>;
   using delta_handler_t = std::function<
     replay_ret(const record_locator_t&,
-	       const delta_info_t&)>;
+	       const delta_info_t&,
+	       seastar::lowres_system_clock::time_point last_modified)>;
   virtual replay_ret replay(
     delta_handler_t &&delta_handler) = 0;
 

--- a/src/crimson/os/seastore/journal/segment_allocator.cc
+++ b/src/crimson/os/seastore/journal/segment_allocator.cc
@@ -224,7 +224,11 @@ SegmentAllocator::close_segment(bool is_rolling)
     cur_segment_seq,
     close_segment_id,
     cur_journal_tail,
-    current_segment_nonce};
+    current_segment_nonce,
+    segment_provider.get_last_modified(
+      close_segment_id).time_since_epoch().count(),
+    segment_provider.get_last_rewritten(
+      close_segment_id).time_since_epoch().count()};
   ceph::bufferlist bl;
   encode(tail, bl);
 

--- a/src/crimson/os/seastore/journal/segment_allocator.h
+++ b/src/crimson/os/seastore/journal/segment_allocator.h
@@ -70,7 +70,8 @@ class SegmentAllocator {
   // returns true iff the current segment has insufficient space
   bool needs_roll(std::size_t length) const {
     assert(can_write());
-    auto write_capacity = current_segment->get_write_capacity();
+    auto write_capacity = current_segment->get_write_capacity()
+      - segment_manager.get_rounded_tail_length();
     return length + written_to > std::size_t(write_capacity);
   }
 

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -191,8 +191,10 @@ SegmentedJournal::replay_segment(
             [locator,
              this,
              FNAME,
-             &handler](delta_info_t& delta)
+             &handler](auto &p)
           {
+	    auto& commit_time = p.first;
+	    auto& delta = p.second;
             /* The journal may validly contain deltas for extents in
              * since released segments.  We can detect those cases by
              * checking whether the segment in question currently has a
@@ -216,7 +218,11 @@ SegmentedJournal::replay_segment(
                 return replay_ertr::now();
               }
             }
-            return handler(locator, delta);
+	    return handler(
+	      locator,
+	      delta,
+	      seastar::lowres_system_clock::time_point(
+		seastar::lowres_system_clock::duration(commit_time)));
           });
         });
       });

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
@@ -421,6 +421,7 @@ LBABtree::rewrite_lba_extent_ret LBABtree::rewrite_lba_extent(
       lba_extent.get_length(),
       nlba_extent->get_bptr().c_str());
     nlba_extent->pin.set_range(nlba_extent->get_node_meta());
+    nlba_extent->set_last_modified(lba_extent.get_last_modified());
 
     /* This is a bit underhanded.  Any relative addrs here must necessarily
      * be record relative as we are rewriting a dirty extent.  Thus, we

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1291,6 +1291,8 @@ struct segment_header_t {
 };
 std::ostream &operator<<(std::ostream &out, const segment_header_t &header);
 
+using segment_tail_t = segment_header_t;
+
 struct record_size_t {
   extent_len_t plain_mdlength = 0; // mdlength without the record header
   extent_len_t dlength = 0;

--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -49,14 +49,14 @@ bool SpaceTrackerSimple::equals(const SpaceTrackerI &_other) const
   bool all_match = true;
   for (auto i = live_bytes_by_segment.begin(), j = other.live_bytes_by_segment.begin();
        i != live_bytes_by_segment.end(); ++i, ++j) {
-    if (i->second != j->second) {
+    if (i->second.live_bytes != j->second.live_bytes) {
       all_match = false;
       logger().debug(
 	"{}: segment_id {} live bytes mismatch *this: {}, other: {}",
 	__func__,
 	i->first,
-	i->second,
-	j->second);
+	i->second.live_bytes,
+	j->second.live_bytes);
     }
   }
   return all_match;
@@ -176,13 +176,20 @@ SegmentCleaner::SegmentCleaner(
     config(config),
     scanner(std::move(scr)),
     gc_process(*this)
-{
-  register_metrics();
-}
+{}
 
 void SegmentCleaner::register_metrics()
 {
   namespace sm = seastar::metrics;
+  stats.segment_util.buckets.resize(11);
+  for (int i = 0; i < 11; i++) {
+    stats.segment_util.buckets[i].upper_bound = ((double)(i + 1)) / 10;
+    if (!i) {
+      stats.segment_util.buckets[i].count = segments.num_segments();
+    } else {
+      stats.segment_util.buckets[i].count = 0;
+    }
+  }
   metrics.add_group("segment_cleaner", {
     sm::make_counter("segments_released", stats.segments_released,
 		     sm::description("total number of extents released by SegmentCleaner")),
@@ -205,7 +212,12 @@ void SegmentCleaner::register_metrics()
 		    [this] {
 		      return segments.get_opened_segments();
 		    },
-		    sm::description("the number of segments whose state is open"))
+		    sm::description("the number of segments whose state is open")),
+    sm::make_histogram("segment_utilization_distribution",
+		       [this]() -> seastar::metrics::histogram& {
+		         return stats.segment_util;
+		       },
+		       sm::description("utilization distribution of all segments"))
   });
 }
 

--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -168,6 +168,14 @@ void SpaceTrackerDetailed::dump_usage(segment_id_t id) const
     block_size_by_segment_manager[id.device_id()]);
 }
 
+void SpaceTrackerSimple::dump_usage(segment_id_t id) const
+{
+  logger().info(
+    "SpaceTrackerSimple::dump_usage id: {}, live_bytes: {}",
+    id,
+    live_bytes_by_segment[id].live_bytes);
+}
+
 SegmentCleaner::SegmentCleaner(
   config_t config,
   ExtentReaderRef&& scr,

--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -402,7 +402,10 @@ SegmentCleaner::gc_reclaim_space_ret SegmentCleaner::gc_reclaim_space()
           return trans_intr::do_for_each(
               extents,
               [this, &t](auto &extent) {
-            auto &[addr, info] = extent;
+	    auto &addr = extent.first;
+	    auto commit_time = extent.second.first.commit_time;
+	    auto commit_type = extent.second.first.commit_type;
+	    auto &info = extent.second.second;
             logger().debug(
               "SegmentCleaner::gc_reclaim_space: checking extent {}",
               info);
@@ -412,7 +415,8 @@ SegmentCleaner::gc_reclaim_space_ret SegmentCleaner::gc_reclaim_space()
               addr,
               info.addr,
               info.len
-            ).si_then([addr=addr, &t, this](CachedExtentRef ext) {
+            ).si_then([&info, commit_type, commit_time, addr=addr, &t, this]
+	      (CachedExtentRef ext) {
               if (!ext) {
                 logger().debug(
                   "SegmentCleaner::gc_reclaim_space: addr {} dead, skipping",
@@ -423,6 +427,34 @@ SegmentCleaner::gc_reclaim_space_ret SegmentCleaner::gc_reclaim_space()
                   "SegmentCleaner::gc_reclaim_space: addr {} alive, gc'ing {}",
                   addr,
                   *ext);
+		assert(commit_time);
+		assert(info.last_modified);
+		assert(commit_type == record_commit_type_t::MODIFY
+		  || commit_type == record_commit_type_t::REWRITE);
+		if (ext->get_last_modified() ==
+		    seastar::lowres_system_clock::time_point()) {
+		  assert(ext->get_last_rewritten() ==
+		    seastar::lowres_system_clock::time_point());
+		  ext->set_last_modified(
+		    seastar::lowres_system_clock::duration(
+		      info.last_modified));
+		}
+		if (commit_type == record_commit_type_t::REWRITE
+		    && ext->get_last_rewritten() ==
+		      seastar::lowres_system_clock::time_point()) {
+		  ext->set_last_rewritten(
+		    seastar::lowres_system_clock::duration(
+		      commit_time));
+		}
+
+		assert(
+		  (commit_type == record_commit_type_t::MODIFY
+		    && commit_time <=
+		      ext->get_last_modified().time_since_epoch().count())
+		  || (commit_type == record_commit_type_t::REWRITE
+		      && commit_time ==
+			ext->get_last_rewritten().time_since_epoch().count()));
+
                 return ecb->rewrite_extent(
                   t,
                   ext);
@@ -479,37 +511,147 @@ SegmentCleaner::mount_ret SegmentCleaner::mount(
   register_metrics();
 
   logger().debug("SegmentCleaner::mount: {} segments", segments.size());
-  return crimson::do_for_each(
-    segments.begin(),
-    segments.end(),
-    [this](auto& it) {
-      auto segment_id = it.first;
-      return scanner->read_segment_header(
-	segment_id
-      ).safe_then([segment_id, this](auto header) {
-	logger().debug(
-	  "ExtentReader::mount: segment_id={} -- {}",
-	  segment_id, header);
-	auto s_type = header.get_type();
-	if (s_type == segment_type_t::NULL_SEG) {
-	  logger().error(
-	    "ExtentReader::mount: got null segment, segment_id={} -- {}",
+  return seastar::do_with(
+    std::vector<std::pair<segment_id_t, segment_header_t>>(),
+    [this](auto& segment_set) {
+    return crimson::do_for_each(
+      segments.begin(),
+      segments.end(),
+      [this, &segment_set](auto& it) {
+	auto segment_id = it.first;
+	return scanner->read_segment_header(
+	  segment_id
+	).safe_then([segment_id, this, &segment_set](auto header) {
+	  logger().debug(
+	    "ExtentReader::mount: segment_id={} -- {}",
 	    segment_id, header);
-	  ceph_abort();
+	  auto s_type = header.get_type();
+	  if (s_type == segment_type_t::NULL_SEG) {
+	    logger().error(
+	      "ExtentReader::mount: got null segment, segment_id={} -- {}",
+	      segment_id, header);
+	    ceph_abort();
+	  }
+	  return scanner->read_segment_tail(
+	    segment_id
+	  ).safe_then([this, segment_id, &segment_set, header](auto tail)
+	    -> scan_extents_ertr::future<> {
+	    if (tail.segment_nonce != header.segment_nonce) {
+	      return scan_nonfull_segment(header, segment_set, segment_id);
+	    }
+	    seastar::lowres_system_clock::time_point last_modified(
+	      seastar::lowres_system_clock::duration(tail.last_modified));
+	    seastar::lowres_system_clock::time_point last_rewritten(
+	      seastar::lowres_system_clock::duration(tail.last_rewritten));
+	    if (segments[segment_id].last_modified < last_modified) {
+	      segments[segment_id].last_modified = last_modified;
+	    }
+	    if (segments[segment_id].last_rewritten < last_rewritten) {
+	      segments[segment_id].last_rewritten = last_rewritten;
+	    }
+	    init_mark_segment_closed(
+	      segment_id,
+	      header.journal_segment_seq);
+	    return seastar::now();
+	  }).handle_error(
+	    crimson::ct_error::enodata::handle(
+	      [this, header, segment_id, &segment_set](auto) {
+	      return scan_nonfull_segment(header, segment_set, segment_id);
+	    }),
+	    crimson::ct_error::pass_further_all{}
+	  );
+	}).handle_error(
+	  crimson::ct_error::enoent::handle([](auto) {
+	    return mount_ertr::now();
+	  }),
+	  crimson::ct_error::enodata::handle([](auto) {
+	    return mount_ertr::now();
+	  }),
+	  crimson::ct_error::input_output_error::pass_further{},
+	  crimson::ct_error::assert_all{"unexpected error"}
+	);
+      });
+  });
+}
+
+SegmentCleaner::scan_extents_ret SegmentCleaner::scan_nonfull_segment(
+  const segment_header_t& header,
+  scan_extents_ret_bare& segment_set,
+  segment_id_t segment_id)
+{
+  if (header.get_type() == segment_type_t::OOL) {
+    logger().info(
+      "ExtentReader::init_segments: out-of-line segment {}",
+      segment_id);
+    return seastar::do_with(
+      scan_valid_records_cursor({
+	segments[segment_id].journal_segment_seq,
+	paddr_t::make_seg_paddr(segment_id, 0)}),
+      [this, segment_id, header](auto& cursor) {
+      return seastar::do_with(
+	ExtentReader::found_record_handler_t([this, segment_id](
+	    record_locator_t locator,
+	    const record_group_header_t& header,
+	    const bufferlist& mdbuf
+	  ) mutable -> ExtentReader::scan_valid_records_ertr::future<> {
+	  LOG_PREFIX(SegmentCleaner::scan_nonfull_segment);
+	  DEBUG("decodeing {} records", header.records);
+	  auto maybe_headers = try_decode_record_headers(header, mdbuf);
+	  if (!maybe_headers) {
+	    ERROR("unable to decode record headers for record group {}",
+	      locator.record_block_base);
+	    return crimson::ct_error::input_output_error::make();
+	  }
+
+	  for (auto& header : *maybe_headers) {
+	    mod_time_point_t ctime = header.commit_time;
+	    auto commit_type = header.commit_type;
+	    if (!ctime) {
+	      ERROR("Scanner::init_segments: extent {} 0 commit_time",
+		ctime);
+	      ceph_abort("0 commit_time");
+	    }
+	    seastar::lowres_system_clock::time_point commit_time{
+	      seastar::lowres_system_clock::duration(ctime)};
+	    assert(commit_type == record_commit_type_t::MODIFY
+	      || commit_type == record_commit_type_t::REWRITE);
+	    if (commit_type == record_commit_type_t::MODIFY
+		&& this->segments[segment_id].last_modified < commit_time) {
+	      this->segments[segment_id].last_modified = commit_time;
+	    }
+	    if (commit_type == record_commit_type_t::REWRITE
+		&& this->segments[segment_id].last_rewritten < commit_time) {
+	      this->segments[segment_id].last_rewritten = commit_time;
+	    }
+	  }
+	  return seastar::now();
+	}),
+	[&cursor, header, segment_id, this](auto& handler) {
+	  return scanner->scan_valid_records(
+	    cursor,
+	    header.segment_nonce,
+	    segments[segment_id.device_id()]->segment_size,
+	    handler);
 	}
-	init_mark_segment_closed(
-	  segment_id,
-	  header.journal_segment_seq);
-      }).handle_error(
-	crimson::ct_error::enoent::handle([](auto) {
-	  return mount_ertr::now();
-	}),
-	crimson::ct_error::enodata::handle([](auto) {
-	  return mount_ertr::now();
-	}),
-	crimson::ct_error::input_output_error::pass_further{}
       );
+    }).safe_then([this, segment_id, header](auto) {
+      init_mark_segment_closed(
+	segment_id,
+	header.journal_segment_seq);
+      return seastar::now();
     });
+  } else if (header.get_type() == segment_type_t::JOURNAL) {
+    logger().info(
+      "ExtentReader::init_segments: journal segment {}",
+      segment_id);
+    segment_set.emplace_back(std::make_pair(segment_id, std::move(header)));
+  } else {
+    ceph_abort("unexpected segment type");
+  }
+  init_mark_segment_closed(
+    segment_id,
+    header.journal_segment_seq);
+  return seastar::now();
 }
 
 }

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -390,7 +390,7 @@ public:
     return (double)seg_bytes.live_bytes / (double)seg_bytes.total_bytes;
   }
 
-  void dump_usage(segment_id_t) const final {}
+  void dump_usage(segment_id_t) const final;
 
   void reset() final {
     for (auto &i : live_bytes_by_segment) {

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -692,6 +692,9 @@ private:
     uint64_t accumulated_blocked_ios = 0;
     uint64_t empty_segments = 0;
     int64_t ios_blocking = 0;
+    uint64_t reclaimed_segments = 0;
+    uint64_t reclaim_rewrite_bytes = 0;
+    uint64_t reclaiming_bytes = 0;
     seastar::metrics::histogram segment_util;
   } stats;
   seastar::metrics::metric_group metrics;

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -895,28 +895,41 @@ private:
 
   // journal status helpers
 
+  double calc_gc_benefit_cost(segment_id_t id) const {
+    double util = space_tracker->calc_utilization(id);
+    auto cur_time = seastar::lowres_system_clock::now();
+    auto segment = segments[id];
+    assert(cur_time >= segment.last_modified);
+    auto segment_age =
+      cur_time - std::max(segment.last_modified, segment.last_rewritten);
+    uint64_t age = segment_age.count();
+    return (1 - util) * age / (1 + util);
+  }
+
   journal_seq_t get_next_gc_target() const {
     segment_id_t id = NULL_SEG_ID;
     segment_seq_t seq = NULL_SEG_SEQ;
-    int64_t least_live_bytes = std::numeric_limits<int64_t>::max();
+    double max_benefit_cost = 0;
     for (auto it = segments.begin();
 	 it != segments.end();
 	 ++it) {
       auto _id = it->first;
       const auto& segment_info = it->second;
+      double benefit_cost = calc_gc_benefit_cost(_id);
       if (segment_info.is_closed() &&
 	  !segment_info.is_in_journal(journal_tail_committed) &&
-	  space_tracker->get_usage(_id) < least_live_bytes) {
+	  benefit_cost > max_benefit_cost) {
 	id = _id;
 	seq = segment_info.journal_segment_seq;
-	least_live_bytes = space_tracker->get_usage(id);
+	max_benefit_cost = benefit_cost;
       }
     }
     if (id != NULL_SEG_ID) {
       crimson::get_logger(ceph_subsys_seastore_cleaner).debug(
-	"SegmentCleaner::get_next_gc_target: segment {} seq {}",
+	"SegmentCleaner::get_next_gc_target: segment {} seq {}, benefit_cost {}",
 	id,
-	seq);
+	seq,
+	max_benefit_cost);
       return journal_seq_t{seq, paddr_t::make_seg_paddr(id, 0)};
     } else {
       return JOURNAL_SEQ_NULL;

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -555,9 +555,9 @@ public:
 	  .9,   // available_ratio_gc_max
 	  .8,   // reclaim_ratio_hard_limit
 	  .6,   // reclaim_ratio_gc_threshhold
-	  .1,   // available_ratio_hard_limit
-	  1<<20,// reclaim 1MB per gc cycle
-	  1<<20 // rewrite 1MB of journal entries per gc cycle
+	  .2,   // available_ratio_hard_limit
+	  1<<25,// reclaim 64MB per gc cycle
+	  1<<25 // rewrite 64MB of journal entries per gc cycle
 	};
     }
   };

--- a/src/crimson/os/seastore/segment_manager.h
+++ b/src/crimson/os/seastore/segment_manager.h
@@ -238,6 +238,11 @@ public:
     ceph_assert(get_size() % get_segment_size() == 0);
     return ((device_segment_id_t)(get_size() / get_segment_size()));
   }
+  seastore_off_t get_rounded_tail_length() const {
+    return p2roundup(
+      ceph::encoded_sizeof_bounded<segment_tail_t>(),
+      (size_t)get_block_size());
+  }
   virtual const seastore_meta_t &get_meta() const = 0;
 
   virtual device_id_t get_device_id() const = 0;

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -41,6 +41,15 @@ struct btree_test_base :
 
   btree_test_base() = default;
 
+  seastar::lowres_system_clock::time_point get_last_modified(
+    segment_id_t id) const final {
+    return seastar::lowres_system_clock::time_point();
+  }
+
+  seastar::lowres_system_clock::time_point get_last_rewritten(
+    segment_id_t id) const final {
+    return seastar::lowres_system_clock::time_point();
+  }
   void update_segment_avail_bytes(paddr_t offset) final {}
 
   segment_id_t get_segment(device_id_t id, segment_seq_t seq) final {

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -82,6 +82,16 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
 
   journal_test_t() = default;
 
+  seastar::lowres_system_clock::time_point get_last_modified(
+    segment_id_t id) const final {
+    return seastar::lowres_system_clock::time_point();
+  }
+
+  seastar::lowres_system_clock::time_point get_last_rewritten(
+    segment_id_t id) const final {
+    return seastar::lowres_system_clock::time_point();
+  }
+
   void update_segment_avail_bytes(paddr_t offset) final {}
 
   segment_id_t get_segment(device_id_t id, segment_seq_t seq) final {
@@ -157,7 +167,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
     replay(
       [&advance,
        &delta_checker]
-      (const auto &offsets, const auto &di) mutable {
+      (const auto &offsets, const auto &di, auto t) mutable {
 	if (!delta_checker) {
 	  EXPECT_FALSE("No Deltas Left");
 	}
@@ -193,7 +203,10 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
     char contents = distribution(generator);
     bufferlist bl;
     bl.append(buffer::ptr(buffer::create(blocks * block_size, contents)));
-    return extent_t{extent_types_t::TEST_BLOCK, L_ADDR_NULL, bl};
+    return extent_t{
+      extent_types_t::TEST_BLOCK,
+      L_ADDR_NULL,
+      bl};
   }
 
   delta_info_t generate_delta(size_t bytes) {


### PR DESCRIPTION
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
