### PR TITLE
common/options: document rgw_lc_debug_interval configuration option

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -406,6 +406,10 @@ options:
 - name: rgw_lc_debug_interval
   type: int
   level: dev
+  desc: Lifecycle processing interval
+  long_desc: When set to greater than 0, treat this many seconds as a day.
+    This facilitates debugging and testing of lifecycle code without lengthy
+    delays.
   default: -1
   services:
   - rgw


### PR DESCRIPTION
common/options: document rgw_lc_debug_interval configuration option

Fixes: https://tracker.ceph.com/issues/52830
Signed-off-by: Anthony D'Atri <anthony.datri@gmail.com>

