### PR TITLE
src/pybind/mgr/prometheus: correct latency metric description units

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -327,9 +327,9 @@ class Module(MgrModule):
                 'read_bytes': {'type': self.PERFCOUNTER_COUNTER,
                                'desc': 'RBD image bytes read'},
                 'write_latency': {'type': self.PERFCOUNTER_LONGRUNAVG,
-                                  'desc': 'RBD image writes latency (msec)'},
+                                  'desc': 'RBD image writes latency (nsec)'},
                 'read_latency': {'type': self.PERFCOUNTER_LONGRUNAVG,
-                                 'desc': 'RBD image reads latency (msec)'},
+                                 'desc': 'RBD image reads latency (nsec)'},
             },
         }  # type: Dict[str, Any]
         global _global_instance


### PR DESCRIPTION
src/pybind/mgr/prometheus: correct latency metric description units

Fixes: https://tracker.ceph.com/issues/52656
Signed-off-by: Anthony D'Atri <anthony.datri@gmail.com>

