### PR TITLE
tool: add repair command to ceph-dedup-tool

### DIFF
--- a/qa/workunits/rados/test_dedup_tool.sh
+++ b/qa/workunits/rados/test_dedup_tool.sh
@@ -48,28 +48,38 @@ OBJ=test_rados_obj
 [ -x "$CEPH_TOOL" ] || die "couldn't find $CEPH_TOOL binary to test"
 
 run_expect_succ "$CEPH_TOOL" osd pool create "$POOL" 8
+sleep 5
 
 function test_dedup_ratio_fixed()
 {
   # case 1
   dd if=/dev/urandom of=dedup_object_1k bs=1K count=1
-  dd if=dedup_object_1k of=dedup_object_100k bs=1K count=100
+  for num in `seq 1 50`
+  do
+    dd if=dedup_object_1k of=dedup_object_100k bs=1K oflag=append conv=notrunc
+  done
+  for num in `seq 1 50`
+  do
+    dd if=/dev/zero of=dedup_object_100k bs=1K count=1 oflag=append conv=notrunc
+  done
 
   $RADOS_TOOL -p $POOL put $OBJ ./dedup_object_100k
-  RESULT=$($DEDUP_TOOL --op estimate --pool $POOL --chunk-size 1024  --chunk-algorithm fixed --fingerprint-algorithm sha1 --debug | grep result | awk '{print$4}')
-  if [ 1024 -ne $RESULT ];
+  RESULT=$($DEDUP_TOOL --op estimate --pool $POOL --chunk-size 1024  --chunk-algorithm fixed --fingerprint-algorithm sha1 | grep chunk_size_average | awk '{print$2}' | sed "s/\,//g")
+  # total size / the number of deduped object = 100K / 1
+  if [ 51200 -ne $RESULT ];
   then
-    die "Estimate failed expecting 1024 result $RESULT"
+    die "Estimate failed expecting 51200 result $RESULT"
   fi
 
   # case 2
   dd if=/dev/zero of=dedup_object_10m bs=10M count=1
 
   $RADOS_TOOL -p $POOL put $OBJ ./dedup_object_10m
-  RESULT=$($DEDUP_TOOL --op estimate --pool $POOL --chunk-size 4096  --chunk-algorithm fixed --fingerprint-algorithm sha1 --debug | grep result | awk '{print$4}')
-  if [ 4096 -ne $RESULT ];
+  RESULT=$($DEDUP_TOOL --op estimate --pool $POOL --chunk-size 4096  --chunk-algorithm fixed --fingerprint-algorithm sha1 | grep examined_bytes | awk '{print$2}')
+  # 10485760
+  if [ 10485760 -ne $RESULT ];
   then
-    die "Estimate failed expecting 4096 result $RESULT"
+    die "Estimate failed expecting 10485760 result $RESULT"
   fi
 
   # case 3 max_thread
@@ -79,7 +89,7 @@ function test_dedup_ratio_fixed()
     $RADOS_TOOL -p $POOL put dedup_object_$num ./dedup_object_$num
   done
 
-  RESULT=$($DEDUP_TOOL --op estimate --pool $POOL --chunk-size 4096  --chunk-algorithm fixed --fingerprint-algorithm sha1 --max-thread 4 --debug | grep result | awk '{print$2}')
+  RESULT=$($DEDUP_TOOL --op estimate --pool $POOL --chunk-size 4096  --chunk-algorithm fixed --fingerprint-algorithm sha1 --max-thread 4 | grep chunk_size_average | awk '{print$2}' | sed "s/\,//g")
 
   if [ 98566144 -ne $RESULT ];
   then
@@ -133,10 +143,10 @@ function test_dedup_chunk_scrub()
   $RADOS_TOOL -p $POOL tier-flush foo
   sleep 2
 
-  rados ls -p $CHUNK_POOL
+  $RADOS_TOOL ls -p $CHUNK_POOL
   CHUNK_OID=$(echo -n "There hi" | sha1sum | awk '{print $1}')
 
-  POOL_ID=$(ceph osd pool ls detail | grep $POOL |  awk '{print$2}')
+  POOL_ID=$($CEPH_TOOL osd pool ls detail | grep $POOL |  awk '{print$2}')
   $DEDUP_TOOL --op chunk-get-ref --chunk-pool $CHUNK_POOL --object $CHUNK_OID --target-ref bar --target-ref-pool-id $POOL_ID
   RESULT=$($DEDUP_TOOL --op dump-chunk-refs --chunk-pool $CHUNK_POOL --object $CHUNK_OID)
 
@@ -191,9 +201,11 @@ function test_dedup_chunk_repair()
   CHUNK_OID=$(echo -n "hi there" | sha1sum | awk '{print $1}')
 
   POOL_ID=$($CEPH_TOOL osd pool ls detail | grep $POOL |  awk '{print$2}')
-
+  $RADOS_TOOL -p $CHUNK_POOL put $CHUNK_OID ./foo
 
   # increase ref count by two, resuling in mismatch
+  $DEDUP_TOOL --op chunk-get-ref --chunk-pool $CHUNK_POOL --object $CHUNK_OID --target-ref foo --target-ref-pool-id $POOL_ID
+  $DEDUP_TOOL --op chunk-get-ref --chunk-pool $CHUNK_POOL --object $CHUNK_OID --target-ref foo --target-ref-pool-id $POOL_ID
   $DEDUP_TOOL --op chunk-get-ref --chunk-pool $CHUNK_POOL --object $CHUNK_OID --target-ref foo --target-ref-pool-id $POOL_ID
   $DEDUP_TOOL --op chunk-get-ref --chunk-pool $CHUNK_POOL --object $CHUNK_OID --target-ref foo --target-ref-pool-id $POOL_ID
   $DEDUP_TOOL --op chunk-get-ref --chunk-pool $CHUNK_POOL --object bar-chunk --target-ref bar --target-ref-pool-id $POOL_ID
@@ -201,7 +213,7 @@ function test_dedup_chunk_repair()
 
   RESULT=$($DEDUP_TOOL --op dump-chunk-refs --chunk-pool $CHUNK_POOL --object $CHUNK_OID)
   RESULT=$($DEDUP_TOOL --op chunk-scrub --chunk-pool $CHUNK_POOL | grep "Damaged object" | awk '{print$4}')
-  if [ $RESULT -ne "1" ] ; then
+  if [ $RESULT -ne "2" ] ; then
     $CEPH_TOOL osd pool delete $POOL $POOL --yes-i-really-really-mean-it
     $CEPH_TOOL osd pool delete $CHUNK_POOL $CHUNK_POOL --yes-i-really-really-mean-it
     die "Chunk-scrub failed expecting damaged objects is not 1"
@@ -210,15 +222,14 @@ function test_dedup_chunk_repair()
   $DEDUP_TOOL --op chunk-repair --chunk-pool $CHUNK_POOL --object $CHUNK_OID --target-ref foo --target-ref-pool-id $POOL_ID
   $DEDUP_TOOL --op chunk-repair --chunk-pool $CHUNK_POOL --object bar-chunk --target-ref bar --target-ref-pool-id $POOL_ID
 
-  $DEDUP_TOOL --op dump-chunk-refs --chunk-pool $CHUNK_POOL --object $CHUNK_OID | grep foo
   RESULT=$($DEDUP_TOOL --op dump-chunk-refs --chunk-pool $CHUNK_POOL --object $CHUNK_OID | grep foo | wc -l)
-  if [ -n "$RESULT" ] ; then
+  if [ 0 -ne "$RESULT" ] ; then
     $CEPH_TOOL osd pool delete $POOL $POOL --yes-i-really-really-mean-it
     $CEPH_TOOL osd pool delete $CHUNK_POOL $CHUNK_POOL --yes-i-really-really-mean-it
     die "Scrub failed expecting bar is removed"
   fi
-  RESULT=$($DEDUP_TOOL --op dump-chunk-refs --chunk-pool $CHUNK_POOL --object bar-chunk | grep bar)
-  if [ -n "$RESULT" ] ; then
+  RESULT=$($DEDUP_TOOL --op dump-chunk-refs --chunk-pool $CHUNK_POOL --object bar-chunk | grep bar | wc -l)
+  if [ 0 -ne "$RESULT" ] ; then
     $CEPH_TOOL osd pool delete $POOL $POOL --yes-i-really-really-mean-it
     $CEPH_TOOL osd pool delete $CHUNK_POOL $CHUNK_POOL --yes-i-really-really-mean-it
     die "Scrub failed expecting bar is removed"
@@ -239,5 +250,3 @@ $CEPH_TOOL osd pool delete $POOL $POOL --yes-i-really-really-mean-it
 
 echo "SUCCESS!"
 exit 0
-
-

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -133,7 +133,17 @@ ceph::mutex glock = ceph::make_mutex("glock");
 
 void usage()
 {
-  cout << " usage: [--op <estimate|chunk-scrub|chunk-get-ref|chunk-put-ref|chunk-repair|dump-chunk-refs>] [--pool <pool_name> ] " << std::endl;
+  cout <<
+"usage: \n"
+"  ceph-dedup-tool \n"
+"    [--op estimate --pool POOL --chunk-size CHUNK_SIZE --chunk-algorithm ALGO --fingerprint-algorithm FP_ALGO] \n"
+"    [--op chunk-scrub --op chunk-scrub --chunk-pool POOL] \n"
+"    [--op chunk-get-ref --chunk-pool POOL --object OID --target-ref OID --target-ref-pool-id POOL_ID] \n"
+"    [--op chunk-put-ref --chunk-pool POOL --object OID --target-ref OID --target-ref-pool-id POOL_ID] \n"
+"    [--op chunk-repair --chunk-pool POOL --object OID --target-ref OID --target-ref-pool-id POOL_ID] \n"
+"    [--op dump-chunk-refs --chunk-pool POOL --object OID] \n"
+  << std::endl;
+  cout << "optional arguments: " << std::endl;
   cout << "   --object <object_name> " << std::endl;
   cout << "   --chunk-size <size> chunk-size (byte) " << std::endl;
   cout << "   --chunk-algorithm <fixed|fastcdc> " << std::endl;


### PR DESCRIPTION
Until now, ceph-dedup-tool only provides chunk-scrub
,which reports how many dangling references the object has,
but there is no cli command to fix the reference mismach.

Therefore, this commit adds repair command to correct detected
reference mismatch.

Signed-off-by: Myoungwon Oh <myoungwon.oh@samsung.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
