### PR TITLE
osd: optimize pg peering latency when add new osd that need backfill

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4811,7 +4811,7 @@ PGRef OSD::handle_pg_create_info(const OSDMapRef& osdmap,
     acting_primary,
     info->history,
     info->past_intervals,
-    false,
+    true,
     rctx.transaction);
 
   pg->init_collection_pool_opts();
@@ -9344,6 +9344,8 @@ void OSD::handle_pg_query_nopg(const MQuery& q)
 
   dout(10) << " pg " << pgid << " dne" << dendl;
   pg_info_t empty(spg_t(pgid.pgid, q.query.to));
+  empty.set_last_backfill(hobject_t());
+
   ConnectionRef con = service.get_con_osd_cluster(q.from.osd, osdmap->get_epoch());
   if (con) {
     Message *m;


### PR DESCRIPTION
Reproduce:
(1) ceph cluster not running any client IO
(2) only ceph osd in osd.14 operation ( add new osd to cluster)

Reason:
(1) There is no data on the new OSD, it is empty OSD;
(2) The new OSD requires a full copy from primary OSD;
(3) If primary OSD's PGlog entries count < osd_min_pg_log_entries(3000),   /// this is the case important point
     The primary OSD thinks the new OSD can recovery by PGlog
(4) primary OSD send PGlog to new  OSD,
(5) new OSD receive PGlog, it has two ways to handle these PGlog:
```
boost::statechart::result PeeringState::Stray::react(const MLogRec& logevt)
{
  DECLARE_LOCALS;
  MOSDPGLog *msg = logevt.msg.get();
  psdout(10) << "got info+log from osd." << logevt.from << " " << msg->info << " " << msg->log << dendl;

  ObjectStore::Transaction &t = context<PeeringMachine>().get_cur_transaction();
  if (msg->info.last_backfill == hobject_t()) {                  /// one way is backfill, directly claim pglog
    // restart backfill
    ps->info = msg->info;
    pl->on_info_history_change();
    ps->dirty_info = true;
    ps->dirty_big_info = true;  // maybe.

    PGLog::LogEntryHandlerRef rollbacker{pl->get_log_handler(t)};
    ps->pg_log.reset_backfill_claim_log(msg->log, rollbacker.get());

    ps->pg_log.reset_backfill();
  } else {                                                        /// one way is recovery, loop pglog to merge
    ps->merge_log(t, msg->info, msg->log, logevt.from);
  }
  if (logevt.msg->lease) {
    ps->proc_lease(*logevt.msg->lease);
  }

  ceph_assert(ps->pg_log.get_head() == ps->info.last_update);

  post_event(Activate(logevt.msg->info.last_epoch_started));
  return transit<ReplicaActive>();
}
```
(6) The recovery way(loop pglog to merge ) average handle latency is 109ms
     The backfill way(directly claim pglog) average handle latency is 14ms

(7) So we should use  backfill instead of recovery for add new OSD


Signed-off-by: Jianwei Zhang <jianwei1216@qq.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

--->


