### PR TITLE
doc/cephadm: document setting ssh-user during adopt

### DIFF
--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -118,6 +118,12 @@ Adoption process
      document for instructions that describe how to import existing
      ssh keys.
 
+   .. note::
+     It is also possible to have cephadm use a non-root user to ssh
+     into cluster hosts. This user needs to have passwordless sudo access.
+     Use ``ceph cephadm set-user <user>`` and copy the ssh key to that user.
+     See :ref:`cephadm-ssh-user`
+
 #. Tell cephadm which hosts to manage:
 
    .. prompt:: bash #

--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -233,6 +233,8 @@ You will then need to restart the mgr daemon to reload the configuration with::
 
   ceph mgr fail
 
+.. _cephadm-ssh-user:
+
 Configuring a different SSH user
 ----------------------------------
 


### PR DESCRIPTION
A user on the mailing list was asking how to do this so ive added a note to the adopt docs

Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>
