### PR TITLE
test: increase retry duration when calculating manifest ref. count

### DIFF
--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -177,7 +177,8 @@ void is_intended_refcount_state(librados::IoCtx& src_ioctx,
     }
     dst_refcount = refs.count();
   }
-  for (int tries = 0; tries < 15; ++tries) {
+  int tries = 0;
+  for (; tries < 30; ++tries) {
     r = cls_cas_references_chunk(src_ioctx, src_oid, dst_oid);
     if (r == -ENOENT || r == -ENOLINK) {
       src_refcount = 0;
@@ -189,6 +190,7 @@ void is_intended_refcount_state(librados::IoCtx& src_ioctx,
     }
     break;
   }
+  ASSERT_TRUE(tries < 30);
   ASSERT_TRUE(src_refcount >= 0);
   ASSERT_TRUE(src_refcount == expected_refcount);
   ASSERT_TRUE(src_refcount <= dst_refcount);


### PR DESCRIPTION
In situation where the object is degraded and delayed,
retry time can expire before the object is recovered
---it takes almost 6 minutes to be recovered according to
the log.

fixes: https://tracker.ceph.com/issues/52872, 
         https://tracker.ceph.com/issues/53219

Signed-off-by: Myoungwon Oh <myoungwon.oh@samsung.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
