### PR TITLE
mds: improve description for mds session command

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -373,14 +373,14 @@ void MDSDaemon::set_up_admin_socket()
 				     "Enumerate connected CephFS clients");
   ceph_assert(r == 0);
   r = admin_socket->register_command("session config "
-				     "name=client_id,type=CephInt,req=true "
+				     "name=client_id,type=CephString,req=true "
 				     "name=option,type=CephString,req=true "
 				     "name=value,type=CephString,req=false ",
 				     asok_hook,
 				     "Config a CephFS client session");
   ceph_assert(r == 0);
   r = admin_socket->register_command("client config "
-				     "name=client_id,type=CephInt,req=true "
+				     "name=client_id,type=CephString,req=true "
 				     "name=option,type=CephString,req=true "
 				     "name=value,type=CephString,req=false ",
 				     asok_hook,

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2612,7 +2612,12 @@ void MDSRankDispatcher::handle_asok_command(
     }
   } else if (command == "session config" ||
 	     command == "client config") {
-    int64_t client_id;
+    std::string client_id;
+    if (!cmd_getval(cmdmap, "client_id", client_id)) {
+      *css << "Invalid client_id specified";
+      r = -CEPHFS_ENOENT;
+      goto out;
+    }
     std::string option;
     std::string value;
 
@@ -2621,7 +2626,7 @@ void MDSRankDispatcher::handle_asok_command(
     bool got_value = cmd_getval(cmdmap, "value", value);
 
     std::lock_guard l(mds_lock);
-    r = config_client(client_id, !got_value, option, value, *css);
+    r = config_client(strtol(client_id.c_str(), 0, 10), !got_value, option, value, *css);
   } else if (command == "scrub start" ||
 	     command == "scrub_start") {
     if (whoami != 0) {


### PR DESCRIPTION
session config  command first arg view as '<int>', it is indistinct, now change CephInt to CephString,
it can view as '<client_id>'. 

session config <int> <option> [<value>] --> session config <client_id> <option> [<value>]
client config <int> <option> [<value>] --> client config <client_id> <option> [<value>]

Signed-off-by: krunerge <krunerge@tencent.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
