### PR TITLE
cephadm: allow pulling from insecure registries

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3725,12 +3725,12 @@ def command_version(ctx):
 def command_pull(ctx):
     # type: (CephadmContext) -> int
 
-    _pull_image(ctx, ctx.image)
+    _pull_image(ctx, ctx.image, ctx.insecure)
     return command_inspect_image(ctx)
 
 
-def _pull_image(ctx, image):
-    # type: (CephadmContext, str) -> None
+def _pull_image(ctx, image, insecure=False):
+    # type: (CephadmContext, str, bool) -> None
     logger.info('Pulling container image %s...' % image)
 
     ignorelist = [
@@ -3740,8 +3740,12 @@ def _pull_image(ctx, image):
     ]
 
     cmd = [ctx.container_engine.path, 'pull', image]
-    if isinstance(ctx.container_engine, Podman) and os.path.exists('/etc/ceph/podman-auth.json'):
-        cmd.append('--authfile=/etc/ceph/podman-auth.json')
+    if isinstance(ctx.container_engine, Podman):
+        if insecure:
+            cmd.append('--tls-verify=false')
+
+        if os.path.exists('/etc/ceph/podman-auth.json'):
+            cmd.append('--authfile=/etc/ceph/podman-auth.json')
     cmd_str = ' '.join(cmd)
 
     for sleep_secs in [1, 4, 25]:
@@ -7401,6 +7405,11 @@ def _get_parser():
     parser_pull = subparsers.add_parser(
         'pull', help='pull latest image version')
     parser_pull.set_defaults(func=command_pull)
+    parser_pull.add_argument(
+        '--insecure',
+        action='store_true',
+        help=argparse.SUPPRESS,
+    )
 
     parser_inspect_image = subparsers.add_parser(
         'inspect-image', help='inspect local container image')

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1362,6 +1362,7 @@ class TestPull:
     def test_error(self, get_image_info_from_inspect, call, sleep):
         ctx = cd.CephadmContext()
         ctx.container_engine = mock_podman()
+        ctx.insecure = False
 
         call.return_value = ('', '', 0)
         retval = cd.command_pull(ctx)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -296,6 +296,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Custom repository password'
         ),
         Option(
+            'registry_insecure',
+            type='bool',
+            default=False,
+            desc='Registry is to be considered insecure (no TLS available). Only for development purposes.'
+        ),
+        Option(
             'use_repo_digest',
             type='bool',
             default=True,
@@ -402,6 +408,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.registry_url: Optional[str] = None
             self.registry_username: Optional[str] = None
             self.registry_password: Optional[str] = None
+            self.registry_insecure: bool = False
             self.use_repo_digest = True
             self.default_registry = ''
             self.autotune_memory_target_ratio = 0.0

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1309,7 +1309,11 @@ class CephadmServe:
             self._registry_login(host, self.mgr.registry_url,
                                  self.mgr.registry_username, self.mgr.registry_password)
 
-        j = self._run_cephadm_json(host, '', 'pull', [], image=image_name, no_fsid=True)
+        pullargs: List[str] = []
+        if self.mgr.registry_insecure:
+            pullargs.append("--insecure")
+
+        j = self._run_cephadm_json(host, '', 'pull', pullargs, image=image_name, no_fsid=True)
 
         r = ContainerInspectInfo(
             j['image_id'],


### PR DESCRIPTION
This patch set introduces new command line options to `cephadm pull` and `cephadm bootstrap` to allow pulling from insecure registries. Also adds support on the orchestrator's cephadm module to specify such an option at time of `pull` if a specific config option has been set to `true`.

This is meant for development environments, as it makes it easier to pull images from local, insecure registries.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>