### PR TITLE
crimson: osd operations respect interruptor's InterruptCondition.

### DIFF
--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -1034,6 +1034,8 @@ template <typename InterruptCond>
 struct interruptor
 {
 public:
+  using condition = InterruptCond;
+
   template <typename FutureType>
   [[gnu::always_inline]]
   static interruptible_future_detail<InterruptCond, FutureType>

--- a/src/crimson/osd/osd_operations/background_recovery.cc
+++ b/src/crimson/osd/osd_operations/background_recovery.cc
@@ -70,7 +70,7 @@ UrgentRecovery::do_recovery()
 {
   logger().debug("{}: {}", __func__, *this);
   if (!pg->has_reset_since(epoch_started)) {
-    return with_blocking_future_interruptible<IOInterruptCondition>(
+    return with_blocking_future_interruptible<interruptor::condition>(
       pg->get_recovery_handler()->recover_missing(soid, need)
     ).then_interruptible([] {
       return seastar::make_ready_future<bool>(false);
@@ -113,7 +113,7 @@ PglogBasedRecovery::do_recovery()
 {
   if (pg->has_reset_since(epoch_started))
     return seastar::make_ready_future<bool>(false);
-  return with_blocking_future_interruptible<IOInterruptCondition>(
+  return with_blocking_future_interruptible<interruptor::condition>(
     pg->get_recovery_handler()->start_recovery_ops(
       crimson::common::local_conf()->osd_recovery_max_single_start));
 }
@@ -134,7 +134,7 @@ BackfillRecovery::do_recovery()
     return seastar::make_ready_future<bool>(false);
   }
   // TODO: limits
-  return with_blocking_future_interruptible<IOInterruptCondition>(
+  return with_blocking_future_interruptible<interruptor::condition>(
     // process_event() of our boost::statechart machine is non-reentrant.
     // with the backfill_pipeline we protect it from a second entry from
     // the implementation of BackfillListener.

--- a/src/crimson/osd/osd_operations/background_recovery.cc
+++ b/src/crimson/osd/osd_operations/background_recovery.cc
@@ -111,8 +111,9 @@ PglogBasedRecovery::PglogBasedRecovery(
 PglogBasedRecovery::interruptible_future<bool>
 PglogBasedRecovery::do_recovery()
 {
-  if (pg->has_reset_since(epoch_started))
+  if (pg->has_reset_since(epoch_started)) {
     return seastar::make_ready_future<bool>(false);
+  }
   return with_blocking_future_interruptible<interruptor::condition>(
     pg->get_recovery_handler()->start_recovery_ops(
       crimson::common::local_conf()->osd_recovery_max_single_start));

--- a/src/crimson/osd/osd_operations/peering_event.cc
+++ b/src/crimson/osd/osd_operations/peering_event.cc
@@ -70,18 +70,18 @@ seastar::future<> PeeringEvent::start()
         return complete_rctx(pg);
       }
       logger().debug("{}: pg present", *this);
-      return with_blocking_future_interruptible<IOInterruptCondition>(
+      return with_blocking_future_interruptible<interruptor::condition>(
         handle.enter(pp(*pg).await_map)
       ).then_interruptible([this, pg] {
-        return with_blocking_future_interruptible<IOInterruptCondition>(
+        return with_blocking_future_interruptible<interruptor::condition>(
           pg->osdmap_gate.wait_for_map(evt.get_epoch_sent()));
       }).then_interruptible([this, pg](auto) {
-        return with_blocking_future_interruptible<IOInterruptCondition>(
+        return with_blocking_future_interruptible<interruptor::condition>(
           handle.enter(pp(*pg).process));
       }).then_interruptible([this, pg] {
         // TODO: likely we should synchronize also with the pg log-based
         // recovery.
-        return with_blocking_future_interruptible<IOInterruptCondition>(
+        return with_blocking_future_interruptible<interruptor::condition>(
           handle.enter(BackfillRecovery::bp(*pg).process));
       }).then_interruptible([this, pg] {
         pg->do_peering_event(evt, ctx);


### PR DESCRIPTION
For the sake of DRY.
It's a follow-up to https://github.com/ceph/ceph/pull/43449.

CC: @liu-chunmei.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
