### PR TITLE
mds/FSMap: do not assert allow_standby_replay on old FSMaps

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -850,8 +850,12 @@ const MDSMap::mds_info_t* FSMap::find_replacement_for(mds_role_t role) const
   return get_available_standby(*fs);
 }
 
-void FSMap::sanity() const
+void FSMap::sanity(bool pending) const
 {
+  /* Only do some sanity checks on **new** FSMaps. Older versions may not be
+   * compliant.
+   */
+
   if (legacy_client_fscid != FS_CLUSTER_ID_NONE) {
     ceph_assert(filesystems.count(legacy_client_fscid) == 1);
   }
@@ -868,7 +872,7 @@ void FSMap::sanity() const
         ceph_assert(fs->mds_map.failed.count(info.rank) == 0);
         ceph_assert(fs->mds_map.damaged.count(info.rank) == 0);
       } else {
-        ceph_assert(fs->mds_map.allows_standby_replay());
+        ceph_assert(!pending || fs->mds_map.allows_standby_replay());
       }
       ceph_assert(info.compat.writeable(fs->mds_map.compat));
     }

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -568,7 +568,7 @@ public:
    * Assert that the FSMap, Filesystem, MDSMap, mds_info_t relations are
    * all self-consistent.
    */
-  void sanity() const;
+  void sanity(bool pending=false) const;
 
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& p);

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -190,7 +190,7 @@ void MDSMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   // print map iff 'debug mon = 30' or higher
   print_map<30>(pending);
   if (!g_conf()->mon_mds_skip_sanity) {
-    pending.sanity();
+    pending.sanity(true);
   }
 
   // Set 'modified' on maps modified this epoch


### PR DESCRIPTION
Octopus and older may have standby-replay daemons with
allow_standby_replay==false.

Fixes: https://tracker.ceph.com/issues/52874
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
