### PR TITLE
Revert "qa: support isal ec test for aarch64"

### DIFF
--- a/qa/standalone/erasure-code/test-erasure-code-plugins.sh
+++ b/qa/standalone/erasure-code/test-erasure-code-plugins.sh
@@ -14,7 +14,7 @@ case $arch in
     aarch64*|arm*)
         legacy_jerasure_plugins=(jerasure_generic jerasure_neon)
         legacy_shec_plugins=(shec_generic shec_neon)
-        plugins=(jerasure shec lrc isa)
+        plugins=(jerasure shec lrc)
         ;;
     *)
         echo "unsupported platform ${arch}."

--- a/qa/suites/rados/thrash-erasure-code-isa/arch/aarch64.yaml
+++ b/qa/suites/rados/thrash-erasure-code-isa/arch/aarch64.yaml
@@ -1,1 +1,0 @@
-arch: aarch64


### PR DESCRIPTION
Reverts ceph/ceph#43462

This has been causing major problems in sepia; smithi jobs are being scheduled that are asking for aarch64 nodes. smithis are all amd64.