### PR TITLE
pacific:  mgr/dashboard: replace "Ceph-cluster" Client connections with active-standby MGRs

### DIFF
--- a/monitoring/grafana/dashboards/ceph-cluster.json
+++ b/monitoring/grafana/dashboards/ceph-cluster.json
@@ -678,7 +678,7 @@
       "type": "vonage-status-panel"
     },
     {
-      "colorMode": "Disabled",
+      "colorMode": "Panel",
       "colors": {
         "crit": "rgba(245, 54, 54, 0.9)",
         "disable": "rgba(128, 128, 128, 0.9)",
@@ -706,21 +706,36 @@
       "targets": [
         {
           "aggregation": "Last",
-          "alias": "Clients",
+          "alias": "Active",
           "decimals": 2,
           "displayAliasType": "Always",
           "displayType": "Regular",
           "displayValueWithAlias": "When Alias Displayed",
-          "expr": "ceph_mds_server_handle_client_session",
+          "expr": "count(ceph_mgr_status == 1) or vector(0)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Clients",
+          "legendFormat": "Active",
           "refId": "A",
+          "units": "none",
+          "valueHandler": "Number Threshold"
+        },
+        {
+          "aggregation": "Last",
+          "alias": "Standby",
+          "decimals": 2,
+          "displayAliasType": "Always",
+          "displayType": "Regular",
+          "displayValueWithAlias": "When Alias Displayed",
+          "expr": "count(ceph_mgr_status == 0) or vector(0)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Standby",
+          "refId": "B",
           "units": "none",
           "valueHandler": "Number Threshold"
         }
       ],
-      "title": "Client connections",
+      "title": "MGRs",
       "type": "vonage-status-panel"
     },
     {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52911

---

backport of https://github.com/ceph/ceph/pull/43377
parent tracker: https://tracker.ceph.com/issues/52121

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh