### PR TITLE
src/rgw: Fix for malformed url

### DIFF
--- a/src/rgw/rgw_url.cc
+++ b/src/rgw/rgw_url.cc
@@ -14,7 +14,7 @@ namespace {
   const std::string schema_re = "([[:alpha:]]+:\\/\\/)";
   const std::string user_pass_re = "(([^:\\s]+):([^@\\s]+)@)?";
   const std::string host_port_re = "([[:alnum:].:-]+)";
-  const std::string path_re = "(/[[:print:]]+)?";
+  const std::string path_re = "(/[[:print:]]*)?";
 }
 
 bool parse_url_authority(const std::string& url, std::string& host, std::string& user, std::string& password) {

--- a/src/test/rgw/test_rgw_url.cc
+++ b/src/test/rgw/test_rgw_url.cc
@@ -19,6 +19,18 @@ TEST(TestURL, SimpleAuthority)
     EXPECT_STREQ(host.c_str(), "example.com"); 
 }
 
+TEST(TestURL, SimpleAuthority_1)
+{
+    std::string host;
+    std::string user;
+    std::string password;
+    const std::string url = "http://example.com/";
+    ASSERT_TRUE(parse_url_authority(url, host, user, password));
+    ASSERT_TRUE(user.empty());
+    ASSERT_TRUE(password.empty());
+    EXPECT_STREQ(host.c_str(), "example.com");
+}
+
 TEST(TestURL, IPAuthority)
 {
     std::string host;


### PR DESCRIPTION
This PR solves: https://tracker.ceph.com/issues/52738
It is solved by making changes to rgw_url.cc
A test is also added to check it's working.

Signed-off-by: Kalpesh Pandya <kapandya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
