### PR TITLE
librbd/cache/pwl: make flush all overlap writes.

### DIFF
--- a/src/librbd/BlockGuard.h
+++ b/src/librbd/BlockGuard.h
@@ -125,6 +125,13 @@ public:
     m_free_detained_block_extents.push_back(detained_block_extent);
   }
 
+  /**
+   * Whether has io.
+   */
+  bool empty() {
+    std::lock_guard locker{m_lock};
+    return m_detained_block_extents.empty();
+  }
 private:
   struct DetainedBlockExtent : public boost::intrusive::list_base_hook<>,
                                public boost::intrusive::set_base_hook<> {

--- a/src/librbd/cache/pwl/AbstractWriteLog.h
+++ b/src/librbd/cache/pwl/AbstractWriteLog.h
@@ -191,7 +191,6 @@ private:
 
   /* Use m_blockguard_lock for the following 3 things */
   bool m_barrier_in_progress = false;
-  BlockGuardCell *m_barrier_cell = nullptr;
 
   bool m_wake_up_enabled = true;
 


### PR DESCRIPTION
Currently, flush can't flush overlap-writes. This mean finish of flush
can't guarantee the previous writes persist.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
