### PR TITLE
cmake: only pass --verbose when VERBOSE env variable is set

### DIFF
--- a/cmake/modules/Distutils.cmake
+++ b/cmake/modules/Distutils.cmake
@@ -75,6 +75,9 @@ function(distutils_add_cython_module target name src)
   endif()
   set(output_dir "${CYTHON_MODULE_DIR}/lib.3")
   set(setup_py ${CMAKE_CURRENT_SOURCE_DIR}/setup.py)
+  if(DEFINED ENV{VERBOSE})
+    set(maybe_verbose --verbose)
+  endif()
   add_custom_command(
     OUTPUT ${output_dir}/${name}${ext_suffix}
     COMMAND
@@ -89,7 +92,7 @@ function(distutils_add_cython_module target name src)
     CYTHON_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
     CEPH_LIBDIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
     ${Python3_EXECUTABLE} ${setup_py}
-    build --verbose --build-base ${CYTHON_MODULE_DIR}
+    build ${maybe_verbose} --build-base ${CYTHON_MODULE_DIR}
     --build-platlib ${output_dir}
     MAIN_DEPENDENCY ${src}
     DEPENDS ${setup_py}
@@ -106,6 +109,9 @@ function(distutils_install_cython_module name)
   cmake_parse_arguments(DU "DISABLE_VTA" "" "" ${ARGN})
   if(DU_DISABLE_VTA AND HAS_VTA)
     set(CFLAG_DISABLE_VTA -fno-var-tracking-assignments)
+  endif()
+  if(DEFINED ENV{VERBOSE})
+    set(maybe_verbose --verbose)
   endif()
   install(CODE "
     set(ENV{CC} \"${PY_CC}\")
@@ -130,12 +136,12 @@ function(distutils_install_cython_module name)
     execute_process(
        COMMAND
            ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
-           build --verbose --build-base ${CYTHON_MODULE_DIR}
+           build ${maybe_verbose} --build-base ${CYTHON_MODULE_DIR}
            --build-platlib ${CYTHON_MODULE_DIR}/lib.3
            build_ext --cython-c-in-temp --build-temp ${CMAKE_CURRENT_BINARY_DIR} --cython-include-dirs ${PROJECT_SOURCE_DIR}/src/pybind/rados
            install \${options} --single-version-externally-managed --record /dev/null
            egg_info --egg-base ${CMAKE_CURRENT_BINARY_DIR}
-           --verbose
+           ${maybe_verbose}
        WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\"
        RESULT_VARIABLE install_res)
     if(NOT \"\${install_res}\" STREQUAL 0)


### PR DESCRIPTION
so that the setuptools is less chatty by default when building python
bindings.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
