### PR TITLE
osd/PG: store osd_async_recovery_min_cost in pg_info_t

### DIFF
--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1631,13 +1631,15 @@ public:
     const pg_info_t &auth_info,
     std::vector<int> *want,
     std::set<pg_shard_t> *async_recovery,
-    const OSDMapRef osdmap) const;
+    const OSDMapRef osdmap,
+    const uint64_t async_recovery_min_cost) const;
   void choose_async_recovery_replicated(
     const std::map<pg_shard_t, pg_info_t> &all_info,
     const pg_info_t &auth_info,
     std::vector<int> *want,
     std::set<pg_shard_t> *async_recovery,
-    const OSDMapRef osdmap) const;
+    const OSDMapRef osdmap,
+    const uint64_t async_recovery_min_cost) const;
 
   bool recoverable(const std::vector<int> &want) const;
   bool choose_acting(pg_shard_t &auth_log_shard,

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3445,7 +3445,7 @@ void pg_history_t::generate_test_instances(list<pg_history_t*>& o)
 
 void pg_info_t::encode(ceph::buffer::list &bl) const
 {
-  ENCODE_START(32, 26, bl);
+  ENCODE_START(33, 26, bl);
   encode(pgid.pgid, bl);
   encode(last_update, bl);
   encode(last_complete, bl);
@@ -3461,12 +3461,13 @@ void pg_info_t::encode(ceph::buffer::list &bl) const
   encode(last_backfill, bl);
   encode(true, bl); // was last_backfill_bitwise
   encode(last_interval_started, bl);
+  encode(last_async_recovery_min_cost, bl);
   ENCODE_FINISH(bl);
 }
 
 void pg_info_t::decode(ceph::buffer::list::const_iterator &bl)
 {
-  DECODE_START(32, bl);
+  DECODE_START(33, bl);
   decode(pgid.pgid, bl);
   decode(last_update, bl);
   decode(last_complete, bl);
@@ -3494,6 +3495,9 @@ void pg_info_t::decode(ceph::buffer::list::const_iterator &bl)
     decode(last_interval_started, bl);
   } else {
     last_interval_started = last_epoch_started;
+  }
+  if (struct_v >= 33) {
+    decode(last_async_recovery_min_cost, bl);
   }
   DECODE_FINISH(bl);
 }

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2965,6 +2965,8 @@ struct pg_info_t {
   pg_history_t history;
   pg_hit_set_history_t hit_set;
 
+  uint64_t last_async_recovery_min_cost;
+
   friend bool operator==(const pg_info_t& l, const pg_info_t& r) {
     return
       l.pgid == r.pgid &&
@@ -2985,7 +2987,8 @@ struct pg_info_t {
     : last_epoch_started(0),
       last_interval_started(0),
       last_user_version(0),
-      last_backfill(hobject_t::get_max())
+      last_backfill(hobject_t::get_max()),
+      last_async_recovery_min_cost(0)
   { }
   // cppcheck-suppress noExplicitConstructor
   pg_info_t(spg_t p)
@@ -2993,7 +2996,8 @@ struct pg_info_t {
       last_epoch_started(0),
       last_interval_started(0),
       last_user_version(0),
-      last_backfill(hobject_t::get_max())
+      last_backfill(hobject_t::get_max()),
+      last_async_recovery_min_cost(0)
   { }
   
   void set_last_backfill(hobject_t pos) {
@@ -3005,6 +3009,11 @@ struct pg_info_t {
 
   bool has_missing() const { return last_complete != last_update; }
   bool is_incomplete() const { return !last_backfill.is_max(); }
+
+  void set_last_async_recovery_min_cost (uint64_t cur_async_recovery_min_cost) {
+    last_async_recovery_min_cost = cur_async_recovery_min_cost;
+  }
+  uint64_t get_last_async_recovery_min_cost() const { return last_async_recovery_min_cost; }
 
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
@@ -3031,6 +3040,7 @@ inline std::ostream& operator<<(std::ostream& out, const pg_info_t& pgi)
   //out << " c " << pgi.epoch_created;
   out << " local-lis/les=" << pgi.last_interval_started
       << "/" << pgi.last_epoch_started;
+  out << " local-larmc=" << pgi.last_async_recovery_min_cost;
   out << " n=" << pgi.stats.stats.sum.num_objects;
   out << " " << pgi.history
       << ")";


### PR DESCRIPTION
    pg peering forever when trigger async recovery if single osd
    config value that "osd_async_recovery_min_cost" differ peer osd.
    
    For example, up[9, 8, 27] acting[9, 8, 27]. osd.9 osd_async_recovery_min_cost
    is 20, but osd.8 and osd.27 osd_async_recovery_min_cost is 100. If osd.9 down,
    and then restart after some time, osd.9 acting is [8, 27] because of
    choose async recovery. So osd.8 is primary, but osd.9 will not be erase in want set
    of osd.8, so osd.8 report mon pg_temp[9, 8, 27]. pg will peering forever.
    
    Select min value of osd_async_recovery_min_cost in each peer shard when choose async
    recovery.

    Fixes: https://tracker.ceph.com/issues/52925
    Signed-off-by: Yite Gu <ess_gyt@qq.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>