### PR TITLE
msg/async: support disabling data crc for protocol v2

### DIFF
--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -124,8 +124,12 @@ class ProtocolV2 final : public Protocol {
 
   ceph::crypto::onwire::rxtx_t session_stream_handlers;
   ceph::compression::onwire::rxtx_t session_comp_handlers;
-  ceph::msgr::v2::FrameAssembler tx_frame_asm{&session_stream_handlers, false, &session_comp_handlers};
-  ceph::msgr::v2::FrameAssembler rx_frame_asm{&session_stream_handlers, false, &session_comp_handlers};
+  ceph::msgr::v2::FrameAssembler tx_frame_asm{
+    &session_stream_handlers, false, common::local_conf()->ms_crc_data,
+    &session_comp_handlers};
+  ceph::msgr::v2::FrameAssembler rx_frame_asm{
+    &session_stream_handlers, false, common::local_conf()->ms_crc_data,
+    &session_comp_handlers};
   ceph::bufferlist rx_preamble;
   ceph::msgr::v2::segment_bls_t rx_segments_data;
 

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -96,8 +96,10 @@ ProtocolV2::ProtocolV2(AsyncConnection *connection)
       replacing(false),
       can_write(false),
       bannerExchangeCallback(nullptr),
-      tx_frame_asm(&session_stream_handlers, false, &session_compression_handlers),
-      rx_frame_asm(&session_stream_handlers, false, &session_compression_handlers),
+      tx_frame_asm(&session_stream_handlers, false, cct->_conf->ms_crc_data,
+                   &session_compression_handlers),
+      rx_frame_asm(&session_stream_handlers, false, cct->_conf->ms_crc_data,
+                   &session_compression_handlers),
       next_tag(static_cast<Tag>(0)),
       keepalive(false) {
 }

--- a/src/msg/async/frames_v2.h
+++ b/src/msg/async/frames_v2.h
@@ -188,8 +188,9 @@ class FrameAssembler {
 public:
   // crypto must be non-null
   FrameAssembler(const ceph::crypto::onwire::rxtx_t* crypto, bool is_rev1, 
-    const ceph::compression::onwire::rxtx_t* compression)
-      : m_crypto(crypto), m_is_rev1(is_rev1), m_compression(compression) {}
+    bool with_data_crc, const ceph::compression::onwire::rxtx_t* compression)
+      : m_crypto(crypto), m_is_rev1(is_rev1), m_with_data_crc(with_data_crc),
+        m_compression(compression) {}
 
   void set_is_rev1(bool is_rev1) {
     m_descs.clear();
@@ -401,6 +402,7 @@ private:
   __u8 m_flags;
   const ceph::crypto::onwire::rxtx_t* m_crypto;
   bool m_is_rev1;  // msgr2.1?
+  bool m_with_data_crc;
   const ceph::compression::onwire::rxtx_t* m_compression;
 };
 

--- a/src/test/msgr/test_frames_v2.cc
+++ b/src/test/msgr/test_frames_v2.cc
@@ -176,8 +176,10 @@ class RoundTripTestBase : public ::testing::TestWithParam<
                               std::tuple<round_trip_instance_t, mode_t>> {
 protected:
   RoundTripTestBase()
-      : m_tx_frame_asm(&m_tx_crypto, std::get<1>(GetParam()).is_rev1, &m_tx_comp),
-        m_rx_frame_asm(&m_rx_crypto, std::get<1>(GetParam()).is_rev1, &m_rx_comp),
+      : m_tx_frame_asm(&m_tx_crypto, std::get<1>(GetParam()).is_rev1, true,
+                                                 &m_tx_comp),
+        m_rx_frame_asm(&m_rx_crypto, std::get<1>(GetParam()).is_rev1, true,
+                                                 &m_rx_comp),
         m_header(make_bufferlist(std::get<0>(GetParam()).header_len, 'H')),
         m_front(make_bufferlist(std::get<0>(GetParam()).front_len, 'F')),
         m_middle(make_bufferlist(std::get<0>(GetParam()).middle_len, 'M')),


### PR DESCRIPTION
In protocol v1, the ms_crc_data config option allowed for globally disabling
the crc calculation and verification for data segments.
This option was so far ignored in protocol v2 implementation.
This commit extends v2 to respect this configuration option.
When the data crc is disabled, zeros will be sent instead of the supposed calculated crc.

Signed-off-by: Or Ozeri <oro@il.ibm.com>

Enabling this option can greatly decrease cpu load on client (as well as OSDs).

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
