### PR TITLE
test/msgr: remove DPDK Non-runtime configure items

### DIFF
--- a/src/test/msgr/test_async_networkstack.cc
+++ b/src/test/msgr/test_async_networkstack.cc
@@ -76,15 +76,11 @@ class NetworkWorkerTest : public ::testing::TestWithParam<const char*> {
       addr = "127.0.0.1:15000";
       port_addr = "127.0.0.1:15001";
     } else {
-      g_ceph_context->_conf.set_val_or_die("ms_type", "async+dpdk");
       g_ceph_context->_conf.set_val_or_die("ms_dpdk_debug_allow_loopback", "true");
       g_ceph_context->_conf.set_val_or_die("ms_async_op_threads", "2");
-      g_ceph_context->_conf.set_val_or_die("ms_dpdk_coremask", "0x7");
-      g_ceph_context->_conf.set_val_or_die("ms_dpdk_host_ipv4_addr", "172.16.218.3");
-      g_ceph_context->_conf.set_val_or_die("ms_dpdk_gateway_ipv4_addr", "172.16.218.2");
-      g_ceph_context->_conf.set_val_or_die("ms_dpdk_netmask_ipv4_addr", "255.255.255.0");
-      addr = "172.16.218.3:15000";
-      port_addr = "172.16.218.3:15001";
+      string ipv4_addr = g_ceph_context->_conf.get_val<std::string>("ms_dpdk_host_ipv4_addr");
+      addr = ipv4_addr + std::string(":15000");
+      port_addr = ipv4_addr + std::string(":15001");
     }
     stack = NetworkStack::create(g_ceph_context, GetParam());
     stack->start();


### PR DESCRIPTION
The non-runtime configure items of the DPDK must be configured in the
ceph.conf to avoid assert in the _conf.set_val_or_die.
Here's a ceph.conf example
[global]
ms_type=async+dpdk
ms_dpdk_gateway_ipv4_addr=172.19.36.151
ms_dpdk_netmask_ipv4_addr=255.255.255.0
ms_dpdk_hugepages=/dev/hugepages
ms_dpdk_hw_flow_control=false
ms_dpdk_lro=false
ms_dpdk_hw_queue_weight=1
ms_dpdk_memory_channel=4
ms_dpdk_coremask=0xff
public_addr=172.19.36.100
cluster_addr=172.19.36.100
ms_dpdk_host_ipv4_addr=172.19.36.101


Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>

