### PR TITLE
pacific: mgr/dashboard: Fix orchestrator/01-hosts.e2e-spec.ts failure

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/01-hosts.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/01-hosts.e2e-spec.ts
@@ -21,8 +21,20 @@ describe('Hosts page', () => {
       hosts.add(hostname, true);
     });
 
-    it('should delete a host and add it back', function () {
+    it('should drain and delete a host and then add it back', function () {
       const host = Cypress._.last(this.hosts)['name'];
+
+      // should drain the host first before deleting
+      hosts.editLabels(host, ['_no_schedule'], true);
+      hosts.clickHostTab(host, 'Daemons');
+      cy.get('cd-host-details').within(() => {
+        // draining will take some time to complete.
+        // since we don't know how many daemons will be
+        // running in this host in future putting the wait
+        // to 15s
+        cy.wait(15000);
+        hosts.getTableCount('total').should('be.eq', 0);
+      });
       hosts.delete(host);
 
       // add it back


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52931

---

backport of https://github.com/ceph/ceph/pull/43453
parent tracker: https://tracker.ceph.com/issues/52764

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh