### PR TITLE
pacific: osd: handle inconsistent hash info during backfill and deep scrub gracefully

### DIFF
--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -4673,8 +4673,6 @@ EOF
           "primary": false
         },
         {
-          "data_digest": "0x00000000",
-          "omap_digest": "0xffffffff",
           "object_info": {
             "oid": {
               "oid": "EOBJ5",
@@ -4711,6 +4709,7 @@ EOF
           },
           "size": 4096,
           "errors": [
+            "read_error",
             "size_mismatch_info",
             "obj_size_info_mismatch"
           ],
@@ -4763,6 +4762,7 @@ EOF
         "watchers": {}
       },
       "union_shard_errors": [
+        "read_error",
         "size_mismatch_info",
         "obj_size_info_mismatch"
       ],
@@ -5441,8 +5441,8 @@ EOF
           "size": 4096,
           "shard": 0,
           "errors": [
+            "read_error",
             "size_mismatch_info",
-            "ec_size_error",
             "obj_size_info_mismatch"
           ],
           "osd": 1,
@@ -5493,8 +5493,8 @@ EOF
         "watchers": {}
       },
       "union_shard_errors": [
+        "read_error",
         "size_mismatch_info",
-        "ec_size_error",
         "obj_size_info_mismatch"
       ],
       "errors": [

--- a/qa/suites/rados/singleton/all/ec-inconsistent-hinfo.yaml
+++ b/qa/suites/rados/singleton/all/ec-inconsistent-hinfo.yaml
@@ -1,0 +1,36 @@
+roles:
+- - mon.a
+  - mon.b
+  - mon.c
+  - mgr.x
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+openstack:
+  - volumes: # attached to each instance
+      count: 4
+      size: 10 # GB
+tasks:
+- install:
+- ceph:
+    create_rbd_pool: false
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+    log-ignorelist:
+      - \(OBJECT_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(SLOW_OPS\)
+      - deep-scrub
+      - missing
+      - overall HEALTH_
+      - repair
+      - slow request
+      - unfound
+    conf:
+      osd:
+        osd min pg log entries: 5
+        osd max pg log entries: 5
+- ec_inconsistent_hinfo:

--- a/qa/tasks/ec_inconsistent_hinfo.py
+++ b/qa/tasks/ec_inconsistent_hinfo.py
@@ -1,0 +1,225 @@
+"""
+Inconsistent_hinfo
+"""
+import logging
+import time
+from dateutil.parser import parse
+from tasks import ceph_manager
+from tasks.util.rados import rados
+from teuthology import misc as teuthology
+
+log = logging.getLogger(__name__)
+
+def wait_for_deep_scrub_complete(manager, pgid, check_time_now, inconsistent):
+    log.debug("waiting for pg %s deep-scrub complete (check_time_now=%s)" %
+              (pgid, check_time_now))
+    for i in range(300):
+        time.sleep(5)
+        manager.flush_pg_stats([0, 1, 2, 3])
+        pgs = manager.get_pg_stats()
+        pg = next((pg for pg in pgs if pg['pgid'] == pgid), None)
+        log.debug('pg=%s' % pg);
+        assert pg
+
+        last_deep_scrub_time = parse(pg['last_deep_scrub_stamp']).strftime('%s')
+        if last_deep_scrub_time < check_time_now:
+            log.debug('not scrubbed')
+            continue
+
+        status = pg['state'].split('+')
+        if inconsistent:
+            assert 'inconsistent' in status
+        else:
+            assert 'inconsistent' not in status
+        return
+
+    assert False, 'not scrubbed'
+
+
+def wait_for_backfilling_complete(manager, pgid, from_osd, to_osd):
+    log.debug("waiting for pg %s backfill from osd.%s to osd.%s complete" %
+              (pgid, from_osd, to_osd))
+    for i in range(300):
+        time.sleep(5)
+        manager.flush_pg_stats([0, 1, 2, 3])
+        pgs = manager.get_pg_stats()
+        pg = next((pg for pg in pgs if pg['pgid'] == pgid), None)
+        log.info('pg=%s' % pg);
+        assert pg
+        status = pg['state'].split('+')
+        if 'active' not in status:
+            log.debug('not active')
+            continue
+        if 'backfilling' in status:
+            assert from_osd in pg['acting'] and to_osd in pg['up']
+            log.debug('backfilling')
+            continue
+        if to_osd not in pg['up']:
+            log.debug('backfill not started yet')
+            continue
+        log.debug('backfilled!')
+        break
+
+def task(ctx, config):
+    """
+    Test handling of objects with inconsistent hash info during backfill and deep-scrub.
+
+    A pretty rigid cluster is brought up and tested by this task
+    """
+    if config is None:
+        config = {}
+    assert isinstance(config, dict), \
+        'ec_inconsistent_hinfo task only accepts a dict for configuration'
+    first_mon = teuthology.get_first_mon(ctx, config)
+    (mon,) = ctx.cluster.only(first_mon).remotes.keys()
+
+    manager = ceph_manager.CephManager(
+        mon,
+        ctx=ctx,
+        logger=log.getChild('ceph_manager'),
+        )
+
+    profile = config.get('erasure_code_profile', {
+        'k': '2',
+        'm': '1',
+        'crush-failure-domain': 'osd'
+    })
+    profile_name = profile.get('name', 'backfill_unfound')
+    manager.create_erasure_code_profile(profile_name, profile)
+    pool = manager.create_pool_with_unique_name(
+        pg_num=1,
+        erasure_code_profile_name=profile_name,
+        min_size=2)
+    manager.raw_cluster_cmd('osd', 'pool', 'set', pool,
+                            'pg_autoscale_mode', 'off')
+
+    manager.flush_pg_stats([0, 1, 2, 3])
+    manager.wait_for_clean()
+
+    pool_id = manager.get_pool_num(pool)
+    pgid = '%d.0' % pool_id
+    pgs = manager.get_pg_stats()
+    acting = next((pg['acting'] for pg in pgs if pg['pgid'] == pgid), None)
+    log.info("acting=%s" % acting)
+    assert acting
+    primary = acting[0]
+
+    # something that is always there, readable and never empty
+    dummyfile = '/etc/group'
+
+    # kludge to make sure they get a map
+    rados(ctx, mon, ['-p', pool, 'put', 'dummy', dummyfile])
+
+    manager.flush_pg_stats([0, 1])
+    manager.wait_for_recovery()
+
+    log.debug("create test object")
+    obj = 'test'
+    rados(ctx, mon, ['-p', pool, 'put', obj, dummyfile])
+
+    victim = acting[1]
+
+    log.info("remove test object hash info from osd.%s shard and test deep-scrub and repair"
+             % victim)
+
+    manager.objectstore_tool(pool, options='', args='rm-attr hinfo_key',
+                             object_name=obj, osd=victim)
+    check_time_now = time.strftime('%s')
+    manager.raw_cluster_cmd('pg', 'deep-scrub', pgid)
+    wait_for_deep_scrub_complete(manager, pgid, check_time_now, True)
+
+    check_time_now = time.strftime('%s')
+    manager.raw_cluster_cmd('pg', 'repair', pgid)
+    wait_for_deep_scrub_complete(manager, pgid, check_time_now, False)
+
+    log.info("remove test object hash info from primary osd.%s shard and test backfill"
+             % primary)
+
+    log.debug("write some data")
+    rados(ctx, mon, ['-p', pool, 'bench', '30', 'write', '-b', '4096',
+                     '--no-cleanup'])
+
+    manager.objectstore_tool(pool, options='', args='rm-attr hinfo_key',
+                             object_name=obj, osd=primary)
+
+    # mark the osd out to trigger a rebalance/backfill
+    source = acting[1]
+    target = [x for x in [0, 1, 2, 3] if x not in acting][0]
+    manager.mark_out_osd(source)
+
+    # wait for everything to peer, backfill and recover
+    wait_for_backfilling_complete(manager, pgid, source, target)
+    manager.wait_for_clean()
+
+    manager.flush_pg_stats([0, 1, 2, 3])
+    pgs = manager.get_pg_stats()
+    pg = next((pg for pg in pgs if pg['pgid'] == pgid), None)
+    log.debug('pg=%s' % pg)
+    assert pg
+    assert 'clean' in pg['state'].split('+')
+    assert 'inconsistent' not in pg['state'].split('+')
+    unfound = manager.get_num_unfound_objects()
+    log.debug("there are %d unfound objects" % unfound)
+    assert unfound == 0
+
+    source, target = target, source
+    log.info("remove test object hash info from non-primary osd.%s shard and test backfill"
+             % source)
+
+    manager.objectstore_tool(pool, options='', args='rm-attr hinfo_key',
+                             object_name=obj, osd=source)
+
+    # mark the osd in to trigger a rebalance/backfill
+    manager.mark_in_osd(target)
+
+    # wait for everything to peer, backfill and recover
+    wait_for_backfilling_complete(manager, pgid, source, target)
+    manager.wait_for_clean()
+
+    manager.flush_pg_stats([0, 1, 2, 3])
+    pgs = manager.get_pg_stats()
+    pg = next((pg for pg in pgs if pg['pgid'] == pgid), None)
+    log.debug('pg=%s' % pg)
+    assert pg
+    assert 'clean' in pg['state'].split('+')
+    assert 'inconsistent' not in pg['state'].split('+')
+    unfound = manager.get_num_unfound_objects()
+    log.debug("there are %d unfound objects" % unfound)
+    assert unfound == 0
+
+    log.info("remove hash info from two shards and test backfill")
+
+    source = acting[2]
+    target = [x for x in [0, 1, 2, 3] if x not in acting][0]
+    manager.objectstore_tool(pool, options='', args='rm-attr hinfo_key',
+                             object_name=obj, osd=primary)
+    manager.objectstore_tool(pool, options='', args='rm-attr hinfo_key',
+                             object_name=obj, osd=source)
+
+    # mark the osd out to trigger a rebalance/backfill
+    manager.mark_out_osd(source)
+
+    # wait for everything to peer, backfill and detect unfound object
+    wait_for_backfilling_complete(manager, pgid, source, target)
+
+    # verify that there is unfound object
+    manager.flush_pg_stats([0, 1, 2, 3])
+    pgs = manager.get_pg_stats()
+    pg = next((pg for pg in pgs if pg['pgid'] == pgid), None)
+    log.debug('pg=%s' % pg)
+    assert pg
+    assert 'backfill_unfound' in pg['state'].split('+')
+    unfound = manager.get_num_unfound_objects()
+    log.debug("there are %d unfound objects" % unfound)
+    assert unfound == 1
+    m = manager.list_pg_unfound(pgid)
+    log.debug('list_pg_unfound=%s' % m)
+    assert m['num_unfound'] == pg['stat_sum']['num_objects_unfound']
+
+    # mark stuff lost
+    pgs = manager.get_pg_stats()
+    manager.raw_cluster_cmd('pg', pgid, 'mark_unfound_lost', 'delete')
+
+    # wait for everything to peer and be happy...
+    manager.flush_pg_stats([0, 1, 2, 3])
+    manager.wait_for_recovery()

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1826,7 +1826,7 @@ void ECBackend::do_read_op(ReadOp &op)
 }
 
 ECUtil::HashInfoRef ECBackend::get_hash_info(
-  const hobject_t &hoid, bool checks, const map<string,bufferptr> *attrs)
+  const hobject_t &hoid, bool create, const map<string,bufferptr> *attrs)
 {
   dout(10) << __func__ << ": Getting attr on " << hoid << dendl;
   ECUtil::HashInfoRef ref = unstable_hashinfo_registry.lookup(hoid);
@@ -1838,7 +1838,6 @@ ECUtil::HashInfoRef ECBackend::get_hash_info(
       ghobject_t(hoid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
       &st);
     ECUtil::HashInfo hinfo(ec_impl->get_chunk_count());
-    // XXX: What does it mean if there is no object on disk?
     if (r >= 0) {
       dout(10) << __func__ << ": found on disk, size " << st.st_size << dendl;
       bufferlist bl;
@@ -1868,7 +1867,7 @@ ECUtil::HashInfoRef ECBackend::get_hash_info(
 	  dout(0) << __func__ << ": Can't decode hinfo for " << hoid << dendl;
 	  return ECUtil::HashInfoRef();
         }
-	if (checks && hinfo.get_total_chunk_size() != (uint64_t)st.st_size) {
+	if (hinfo.get_total_chunk_size() != (uint64_t)st.st_size) {
 	  dout(0) << __func__ << ": Mismatch of total_chunk_size "
 			       << hinfo.get_total_chunk_size() << dendl;
 	  return ECUtil::HashInfoRef();
@@ -1876,6 +1875,10 @@ ECUtil::HashInfoRef ECBackend::get_hash_info(
       } else if (st.st_size > 0) { // If empty object and no hinfo, create it
 	return ECUtil::HashInfoRef();
       }
+    } else if (r != -ENOENT || !create) {
+      derr << __func__ << ": stat " << hoid << " failed: " << cpp_strerror(r)
+           << dendl;
+      return ECUtil::HashInfoRef();
     }
     ref = unstable_hashinfo_registry.lookup_or_create(hoid, hinfo);
   }
@@ -1890,7 +1893,7 @@ void ECBackend::start_rmw(Op *op, PGTransactionUPtr &&t)
     sinfo,
     std::move(t),
     [&](const hobject_t &i) {
-      ECUtil::HashInfoRef ref = get_hash_info(i, false);
+      ECUtil::HashInfoRef ref = get_hash_info(i, true);
       if (!ref) {
 	derr << __func__ << ": get_hash_info(" << i << ")"
 	     << " returned a null pointer and there is no "

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -604,7 +604,16 @@ void ECBackend::continue_recovery_op(
       if (op.recovery_progress.first && op.obc) {
 	/* We've got the attrs and the hinfo, might as well use them */
 	op.hinfo = get_hash_info(op.hoid);
-	ceph_assert(op.hinfo);
+	if (!op.hinfo) {
+          derr << __func__ << ": " << op.hoid << " has inconsistent hinfo"
+               << dendl;
+          ceph_assert(recovery_ops.count(op.hoid));
+          eversion_t v = recovery_ops[op.hoid].v;
+          recovery_ops.erase(op.hoid);
+          get_parent()->on_failed_pull({get_parent()->whoami_shard()},
+                                       op.hoid, v);
+          return;
+        }
 	op.xattrs = op.obc->attr_cache;
 	encode(*(op.hinfo), op.xattrs[ECUtil::get_hinfo_key()]);
       }

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2587,7 +2587,11 @@ int ECBackend::be_deep_scrub(
     return 0;
   } else {
     if (!get_parent()->get_pool().allows_ecoverwrites()) {
-      ceph_assert(hinfo->has_chunk_hash());
+      if (!hinfo->has_chunk_hash()) {
+        dout(0) << "_scan_list  " << poid << " got invalid hash info" << dendl;
+        o.ec_size_mismatch = true;
+        return 0;
+      }
       if (hinfo->get_total_chunk_size() != (unsigned)pos.data_pos) {
 	dout(0) << "_scan_list  " << poid << " got incorrect size on read 0x"
 		<< std::hex << pos

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -629,7 +629,7 @@ public:
   const ECUtil::stripe_info_t sinfo;
   /// If modified, ensure that the ref is held until the update is applied
   SharedPtrRegistry<hobject_t, ECUtil::HashInfo> unstable_hashinfo_registry;
-  ECUtil::HashInfoRef get_hash_info(const hobject_t &hoid, bool checks = true,
+  ECUtil::HashInfoRef get_hash_info(const hobject_t &hoid, bool create = false,
 				    const std::map<std::string, ceph::buffer::ptr> *attr = NULL);
 
 public:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52936

---

backport of https://github.com/ceph/ceph/pull/43239
parent tracker: https://tracker.ceph.com/issues/48959

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh