### PR TITLE
cephadm: agent: cache ls output

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3528,6 +3528,7 @@ class CephadmAgent():
         self.device_enhanced_scan = False
         self.recent_iteration_run_times: List[float] = [0.0, 0.0, 0.0]
         self.recent_iteration_index: int = 0
+        self.cached_ls_values: Dict[str, Dict[str, str]] = {}
 
     def deploy_daemon_unit(self, config: Dict[str, str] = {}) -> None:
         if not config:
@@ -3654,7 +3655,7 @@ WantedBy=ceph-{fsid}.target
                     networks_list[key] = {k: list(v)}
 
             data = json.dumps({'host': self.host,
-                              'ls': list_daemons(self.ctx),
+                              'ls': self._get_ls(),
                                'networks': networks_list,
                                'facts': HostFacts(self.ctx).dump(),
                                'volume': volume,
@@ -3695,6 +3696,121 @@ WantedBy=ceph-{fsid}.target
             return stdout
         else:
             raise Exception('ceph-volume returned empty value')
+
+    def _daemon_ls_subset(self) -> Dict[str, Dict[str, Any]]:
+        # gets a subset of ls info quickly. The results of this will tell us if our
+        # cached info is still good or if we need to run the full ls again.
+        # for legacy containers, we just grab the full info. For cephadmv1 containers,
+        # we only grab enabled, state, mem_usage and container id. If container id has
+        # not changed for any daemon, we assume our cached info is good.
+        daemons: Dict[str, Dict[str, Any]] = {}
+        data_dir = self.ctx.data_dir
+        seen_memusage = {}  # type: Dict[str, int]
+        out, err, code = call(
+            self.ctx,
+            [self.ctx.container_engine.path, 'stats', '--format', '{{.ID}},{{.MemUsage}}', '--no-stream'],
+            verbosity=CallVerbosity.DEBUG
+        )
+        seen_memusage_cid_len, seen_memusage = _parse_mem_usage(code, out)
+        # we need a mapping from container names to ids. Later we will convert daemon
+        # names to container names to get daemons container id to see if it has changed
+        out, err, code = call(
+            self.ctx,
+            [self.ctx.container_engine.path, 'ps', '--format', '{{.ID}},{{.Names}}', '--no-trunc'],
+            verbosity=CallVerbosity.DEBUG
+        )
+        name_id_mapping: Dict[str, str] = self._parse_container_id_name(code, out)
+        for i in os.listdir(data_dir):
+            if i in ['mon', 'osd', 'mds', 'mgr']:
+                daemon_type = i
+                for j in os.listdir(os.path.join(data_dir, i)):
+                    if '-' not in j:
+                        continue
+                    (cluster, daemon_id) = j.split('-', 1)
+                    legacy_unit_name = 'ceph-%s@%s' % (daemon_type, daemon_id)
+                    (enabled, state, _) = check_unit(self.ctx, legacy_unit_name)
+                    daemons[f'{daemon_type}.{daemon_id}'] = {
+                        'style': 'legacy',
+                        'name': '%s.%s' % (daemon_type, daemon_id),
+                        'fsid': self.ctx.fsid if self.ctx.fsid is not None else 'unknown',
+                        'systemd_unit': legacy_unit_name,
+                        'enabled': 'true' if enabled else 'false',
+                        'state': state,
+                    }
+            elif is_fsid(i):
+                fsid = str(i)  # convince mypy that fsid is a str here
+                for j in os.listdir(os.path.join(data_dir, i)):
+                    if '.' in j and os.path.isdir(os.path.join(data_dir, fsid, j)):
+                        (daemon_type, daemon_id) = j.split('.', 1)
+                        unit_name = get_unit_name(fsid, daemon_type, daemon_id)
+                        (enabled, state, _) = check_unit(self.ctx, unit_name)
+                        daemons[j] = {
+                            'style': 'cephadm:v1',
+                            'systemd_unit': unit_name,
+                            'enabled': 'true' if enabled else 'false',
+                            'state': state,
+                        }
+                        c = CephContainer.for_daemon(self.ctx, self.ctx.fsid, daemon_type, daemon_id, 'bash')
+                        container_id: Optional[str] = None
+                        for name in (c.cname, c.old_cname):
+                            if name in name_id_mapping:
+                                container_id = name_id_mapping[name]
+                                break
+                        daemons[j]['container_id'] = container_id
+                        if container_id:
+                            daemons[j]['memory_usage'] = seen_memusage.get(container_id[0:seen_memusage_cid_len])
+        return daemons
+
+    def _parse_container_id_name(self, code: int, out: str) -> Dict[str, str]:
+        # map container names to ids from ps output
+        name_id_mapping = {}  # type: Dict[str, str]
+        if not code:
+            for line in out.splitlines():
+                id, name = line.split(',')
+                name_id_mapping[name] = id
+        return name_id_mapping
+
+    def _get_ls(self) -> List[Dict[str, str]]:
+        if not self.cached_ls_values:
+            logger.info('No cached ls output. Running full daemon ls')
+            ls = list_daemons(self.ctx)
+            for d in ls:
+                self.cached_ls_values[d['name']] = d
+        else:
+            ls_subset = self._daemon_ls_subset()
+            need_full_ls = False
+            if set(self.cached_ls_values.keys()) != set(ls_subset.keys()):
+                # case for a new daemon in ls or an old daemon no longer appearing.
+                # If that happens we need a full ls
+                logger.info('Change detected in state of daemons. Running full daemon ls')
+                ls = list_daemons(self.ctx)
+                for d in ls:
+                    self.cached_ls_values[d['name']] = d
+                return ls
+            for daemon, info in self.cached_ls_values.items():
+                if info['style'] == 'legacy':
+                    # for legacy containers, ls_subset just grabs all the info
+                    self.cached_ls_values[daemon] = ls_subset[daemon]
+                else:
+                    if info['container_id'] != ls_subset[daemon]['container_id']:
+                        # case for container id having changed. We need full ls as
+                        # info we didn't grab like version and start time could have changed
+                        need_full_ls = True
+                        break
+                    # if we reach here, container id matched. Update the few values we do track
+                    # from ls subset: state, enabled, memory_usage.
+                    self.cached_ls_values[daemon]['enabled'] = ls_subset[daemon]['enabled']
+                    self.cached_ls_values[daemon]['state'] = ls_subset[daemon]['state']
+                    if 'memory_usage' in ls_subset[daemon]:
+                        self.cached_ls_values[daemon]['memory_usage'] = ls_subset[daemon]['memory_usage']
+            if need_full_ls:
+                logger.info('Change detected in state of daemons. Running full daemon ls')
+                ls = list_daemons(self.ctx)
+                for d in ls:
+                    self.cached_ls_values[d['name']] = d
+            else:
+                ls = [info for daemon, info in self.cached_ls_values.items()]
+        return ls
 
 
 def command_agent(ctx: CephadmContext) -> None:

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -261,6 +261,7 @@ class AgentMessageThread(threading.Thread):
                 secure_agent_socket.sendall(msg.encode('utf-8'))
                 agent_response = secure_agent_socket.recv(1024).decode()
                 self.mgr.log.info(f'Received "{agent_response}" from agent on host {self.host}')
+                self.mgr.cache.sending_agent_message[self.host] = False
                 return
             except ConnectionError as e:
                 # if it's a connection error, possibly try to connect again.


### PR DESCRIPTION
ls is really slow, but we can cache the info and only run
the full thing if we find a new or removed container or if
one of the daemons' container id changes

Signed-off-by: Adam King <adking@redhat.com>


Tested this with some lines that checked how long _get_ls was taking and logged it. Output came out to

```
Oct 14 16:48:54 vm-00 systemd[1]: Started cephadm agent for cluster f16b8c48-2d0d-11ec-bbcc-525400340480.
Oct 14 16:48:55 vm-00 bash[33066]: Verifying port 4721 ...
Oct 14 16:48:55 vm-00 bash[33066]: Inferring config /var/lib/ceph/f16b8c48-2d0d-11ec-bbcc-525400340480/mon.vm-00/config
Oct 14 16:48:55 vm-00 bash[33066]: Using recent ceph image docker.io/amk3798/ceph@sha256:0cfd4a01b2712a56c1bfff9a6519c38cf68a235419425b4133503d7d6cc41fed
Oct 14 16:48:59 vm-00 bash[33066]: No cached ls output. Running full daemon ls
Oct 14 16:49:03 vm-00 bash[33066]: 0:00:04.079162
Oct 14 16:49:06 vm-00 bash[33066]: 0:00:00.550092
Oct 14 16:49:25 vm-00 bash[33066]: Change detected in state of daemons. Running full daemon ls
Oct 14 16:49:30 vm-00 bash[33066]: 0:00:05.695958
Oct 14 16:49:32 vm-00 bash[33066]: 0:00:00.488622
Oct 14 16:49:35 vm-00 bash[33066]: 0:00:00.470037
Oct 14 16:49:53 vm-00 bash[33066]: 0:00:00.485822
Oct 14 16:50:13 vm-00 bash[33066]: 0:00:00.458818
Oct 14 16:50:33 vm-00 bash[33066]: 0:00:00.452312
Oct 14 16:50:55 vm-00 bash[33066]: 0:00:00.722616
Oct 14 16:51:16 vm-00 bash[33066]: Change detected in state of daemons. Running full daemon ls
Oct 14 16:51:25 vm-00 bash[33066]: 0:00:09.811636
Oct 14 16:51:44 vm-00 bash[33066]: Change detected in state of daemons. Running full daemon ls
Oct 14 16:51:52 vm-00 bash[33066]: 0:00:08.551960
Oct 14 16:52:06 vm-00 bash[33066]: Change detected in state of daemons. Running full daemon ls
Oct 14 16:52:12 vm-00 bash[33066]: 0:00:06.003456
Oct 14 16:52:23 vm-00 bash[33066]: 0:00:00.561562
Oct 14 16:52:39 vm-00 bash[33066]: 0:00:00.635199
Oct 14 16:52:57 vm-00 bash[33066]: 0:00:00.522346
Oct 14 16:53:18 vm-00 bash[33066]: 0:00:00.512388
Oct 14 16:53:38 vm-00 bash[33066]: 0:00:00.516074
Oct 14 16:53:59 vm-00 bash[33066]: 0:00:00.558797
Oct 14 16:54:19 vm-00 bash[33066]: 0:00:00.519928
Oct 14 16:54:40 vm-00 bash[33066]: 0:00:00.501840
Oct 14 16:55:01 vm-00 bash[33066]: 0:00:00.510403
Oct 14 16:55:21 vm-00 bash[33066]: 0:00:00.530882
Oct 14 16:55:41 vm-00 bash[33066]: 0:00:00.500698
Oct 14 16:56:02 vm-00 bash[33066]: 0:00:00.526346
Oct 14 16:56:22 vm-00 bash[33066]: 0:00:00.509945
Oct 14 16:56:43 vm-00 bash[33066]: 0:00:00.536812
Oct 14 16:57:03 vm-00 bash[33066]: 0:00:00.525838
Oct 14 16:57:24 vm-00 bash[33066]: 0:00:00.524812
Oct 14 16:57:44 vm-00 bash[33066]: 0:00:00.557036
Oct 14 16:58:05 vm-00 bash[33066]: 0:00:00.624717
Oct 14 16:58:25 vm-00 bash[33066]: Change detected in state of daemons. Running full daemon ls
Oct 14 16:58:30 vm-00 bash[33066]: 0:00:05.684958
Oct 14 16:58:49 vm-00 bash[33066]: 0:00:00.545025
Oct 14 16:59:09 vm-00 bash[33066]: Change detected in state of daemons. Running full daemon ls
Oct 14 16:59:14 vm-00 bash[33066]: 0:00:05.669259
Oct 14 16:59:30 vm-00 bash[33066]: 0:00:00.522568
Oct 14 16:59:49 vm-00 bash[33066]: 0:00:00.526753
Oct 14 17:00:07 vm-00 bash[33066]: 0:00:00.530335
Oct 14 17:00:28 vm-00 bash[33066]: 0:00:00.569182
```

The times with a line about changes detected or no cached data present above them are ones where the full ls had to be run (purposely triggered this by deploying new daemons or redeploying daemons on the host). The other timestamps are when the cached data was used. Typically, using the cached data took around 0.5-0.7 seconds while the full ls took 4-9 seconds (number of daemons on the host varied from 5 to 9). It should be kept in mind the full ls time still includes the time to check whether we can use the cached info, which is most of the 0.5-0.7 seconds from the cached runs.

Also, this may need to be revisited if https://github.com/ceph/ceph/pull/43230 is finished up.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
