### PR TITLE
rgw: pass "force check filter" through SAL in bucket listing

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -295,12 +295,13 @@ void check_bad_user_bucket_mapping(rgw::sal::Store* store, rgw::sal::User* user,
   } while (user_buckets.is_truncated());
 }
 
-// note: function type conforms to RGWRados::check_filter_t
-bool rgw_bucket_object_check_filter(const string& oid)
+// returns true if entry is in the empty namespace. note: function
+// type conforms to type RGWBucketListNameFilter
+bool rgw_bucket_object_check_filter(const std::string& oid)
 {
-  rgw_obj_key key;
-  string ns;
-  return rgw_obj_key::oid_to_key_in_ns(oid, &key, ns);
+  const static std::string empty_ns;
+  rgw_obj_key key; // thrown away but needed for parsing
+  return rgw_obj_key::oid_to_key_in_ns(oid, &key, empty_ns);
 }
 
 int rgw_remove_object(const DoutPrefixProvider *dpp, rgw::sal::Store* store, rgw::sal::Bucket* bucket, rgw_obj_key& key)
@@ -604,6 +605,7 @@ int RGWBucket::check_object_index(const DoutPrefixProvider *dpp,
   while (results.is_truncated) {
     rgw::sal::Bucket::ListParams params;
     params.marker = results.next_marker;
+    params.force_check_filter = rgw_bucket_object_check_filter;
 
     int r = bucket->list(dpp, params, listing_max_entries, results, y);
 

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -50,7 +50,7 @@ extern void rgw_parse_url_bucket(const std::string& bucket,
                                  std::string &tenant_name, std::string &bucket_name);
 
 // this is used as a filter to RGWRados::cls_bucket_list_ordered; it
-// conforms to the type declaration of RGWRados::check_filter_t.
+// conforms to the type RGWBucketListNameFilter
 extern bool rgw_bucket_object_check_filter(const std::string& oid);
 
 void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -837,7 +837,7 @@ int RGWLC::handle_multipart_expiration(rgw::sal::Bucket* target,
    * operating on one shard at a time */
   params.allow_unordered = true;
   params.ns = RGW_OBJ_NS_MULTIPART;
-  params.filter = &mp_filter;
+  params.access_list_filter = &mp_filter;
 
   auto pf = [&](RGWLC::LCWorker* wk, WorkQ* wq, WorkItem& wi) {
     auto wt = boost::get<std::tuple<lc_op, rgw_bucket_dir_entry>>(wi);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -986,13 +986,14 @@ public:
         rgw_obj_key end_marker;
         std::string ns;
         bool enforce_ns;
-        RGWAccessListFilter *filter;
+        RGWAccessListFilter* access_list_filter;
+	RGWBucketListNameFilter force_check_filter;
         bool list_versions;
 	bool allow_unordered;
 
         Params() :
 	  enforce_ns(true),
-	  filter(NULL),
+	  access_list_filter(nullptr),
 	  list_versions(false),
 	  allow_unordered(false)
 	{}
@@ -1361,8 +1362,6 @@ public:
   using ent_map_t =
     boost::container::flat_map<std::string, rgw_bucket_dir_entry>;
 
-  using check_filter_t = bool (*)(const std::string&);
-
   int cls_bucket_list_ordered(const DoutPrefixProvider *dpp,
                               RGWBucketInfo& bucket_info,
 			      const int shard_id,
@@ -1377,7 +1376,7 @@ public:
 			      bool* cls_filtered,
 			      rgw_obj_index_key *last_entry,
                               optional_yield y,
-			      check_filter_t force_check_filter = nullptr);
+			      RGWBucketListNameFilter force_check_filter = {});
   int cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
                                 RGWBucketInfo& bucket_info,
 				int shard_id,
@@ -1389,7 +1388,7 @@ public:
 				bool *is_truncated,
 				rgw_obj_index_key *last_entry,
                                 optional_yield y,
-				check_filter_t = nullptr);
+				RGWBucketListNameFilter force_check_filter = {});
   int cls_bucket_head(const DoutPrefixProvider *dpp,
 		      const RGWBucketInfo& bucket_info,
 		      int shard_id,

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -38,6 +38,10 @@ class RGWSyncModuleInstance;
 typedef std::shared_ptr<RGWSyncModuleInstance> RGWSyncModuleInstanceRef;
 class RGWCompressionInfo;
 
+
+using RGWBucketListNameFilter = std::function<bool (const std::string&)>;
+
+
 namespace rgw {
   class Aio;
   namespace IAM { struct Policy; }
@@ -378,7 +382,8 @@ class Bucket {
       rgw_obj_key end_marker;
       std::string ns;
       bool enforce_ns{true};
-      RGWAccessListFilter* filter{nullptr};
+      RGWAccessListFilter* access_list_filter{nullptr};
+      RGWBucketListNameFilter force_check_filter;
       bool list_versions{false};
       bool allow_unordered{false};
       int shard_id{RGW_NO_SHARD};

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -349,7 +349,8 @@ namespace rgw::sal {
     list_op.params.end_marker = params.end_marker;
     list_op.params.ns = params.ns;
     list_op.params.enforce_ns = params.enforce_ns;
-    list_op.params.filter = params.filter;
+    list_op.params.access_list_filter = params.access_list_filter;
+    list_op.params.force_check_filter = params.force_check_filter;
     list_op.params.list_versions = params.list_versions;
     list_op.params.allow_unordered = params.allow_unordered;
 

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -736,7 +736,8 @@ int RadosBucket::list(const DoutPrefixProvider* dpp, ListParams& params, int max
   list_op.params.end_marker = params.end_marker;
   list_op.params.ns = params.ns;
   list_op.params.enforce_ns = params.enforce_ns;
-  list_op.params.filter = params.filter;
+  list_op.params.access_list_filter = params.access_list_filter;
+  list_op.params.force_check_filter = params.force_check_filter;
   list_op.params.list_versions = params.list_versions;
   list_op.params.allow_unordered = params.allow_unordered;
 
@@ -766,7 +767,7 @@ int RadosBucket::list_multiparts(const DoutPrefixProvider *dpp,
   params.delim = delim;
   params.marker = marker;
   params.ns = RGW_OBJ_NS_MULTIPART;
-  params.filter = &mp_filter;
+  params.access_list_filter = &mp_filter;
 
   int ret = list(dpp, params, max_uploads, results, null_yield);
 

--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -1378,13 +1378,14 @@ class DB {
           rgw_obj_key end_marker;
           string ns;
           bool enforce_ns;
-          RGWAccessListFilter *filter;
+          RGWAccessListFilter* access_list_filter;
+          RGWBucketListNameFilter force_check_filter;
           bool list_versions;
-	      bool allow_unordered;
+	  bool allow_unordered;
 
           Params() :
 	        enforce_ns(true),
-	        filter(NULL),
+	        access_list_filter(nullptr),
 	        list_versions(false),
 	        allow_unordered(false)
 	        {}


### PR DESCRIPTION
rgw: pass "force check filter" through SAL in bucket listing

As a result of inserting the SAL layer in bucket listing, "radosgw-admin bucket check --fix" does not fix. We need to pass a force check filter through the SAL to regain this.

This issue does not appear in any upstream branches (e.g., pacific), so no backport is needed.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>