### PR TITLE
msg/async/dpdk: add dpdk port list config

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1421,6 +1421,10 @@ options:
   level: advanced
   default: ib
   with_legacy: true
+- name: ms_dpdk_port_list
+  type: str
+  level: advanced
+  with_legacy: true
 - name: ms_dpdk_port_id
   type: int
   level: advanced

--- a/src/msg/async/dpdk/dpdk_rte.cc
+++ b/src/msg/async/dpdk/dpdk_rte.cc
@@ -127,6 +127,19 @@ namespace dpdk {
         args.push_back(string2vector("--no-huge"));
       }
 
+      std::optional<std::string> port_list;
+      if (!c->_conf->ms_dpdk_port_list.empty()) {
+	port_list.emplace(c->_conf->ms_dpdk_port_list);
+      }
+      if (port_list) {
+	char *port = strtok(const_cast<char *>(port_list->c_str()), ",");
+	while(port) {
+	  args.push_back(string2vector("--pci-whitelist"));
+	  args.push_back(string2vector(port));
+	  port = strtok(NULL, ",");
+	}
+      }
+
       std::string rte_file_prefix;
       rte_file_prefix = "rte_";
       rte_file_prefix += c->_conf->name.to_str();


### PR DESCRIPTION
Each DPDK process works independently and uses different ethernet ports.
Therefore, add ms_dpdk_port_list configure item.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>

