### PR TITLE
librbd: honor FUA op flag for write_same() in write-around cache

### DIFF
--- a/src/librbd/cache/WriteAroundObjectDispatch.cc
+++ b/src/librbd/cache/WriteAroundObjectDispatch.cc
@@ -113,8 +113,8 @@ bool WriteAroundObjectDispatch<I>::write_same(
   ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
                  << object_off << "~" << object_len << dendl;
 
-  return dispatch_io(object_no, object_off, object_len, 0, dispatch_result,
-                     on_finish, on_dispatched);
+  return dispatch_io(object_no, object_off, object_len, op_flags,
+                     dispatch_result, on_finish, on_dispatched);
 }
 
 template <typename I>


### PR DESCRIPTION
WriteAroundObjectDispatch::write_same() should pass op_flags through
to dispatch_io() so that it can bypass the cache if needed.

Fixes: https://tracker.ceph.com/issues/52956
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>