### PR TITLE
mgr/orchestrator: clean up 'orch device ls' output

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -461,27 +461,27 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
                 "On": "On",
                 "Off": "Off",
                 True: "Yes",
-                False: "No",
+                False: "",
             }
 
             out = []
             if wide:
                 table = PrettyTable(
-                    ['Hostname', 'Path', 'Type', 'Transport', 'RPM', 'Vendor', 'Model',
-                     'Serial', 'Size', 'Health', 'Ident', 'Fault', 'Available',
-                     'Reject Reasons'],
+                    ['HOST', 'PATH', 'TYPE', 'TRANSPORT', 'RPM', 'DEVICE ID', 'SIZE',
+                     'HEALTH', 'IDENT', 'FAULT',
+                     'AVAILABLE', 'REJECT REASONS'],
                     border=False)
             else:
                 table = PrettyTable(
-                    ['Hostname', 'Path', 'Type', 'Serial', 'Size',
-                     'Health', 'Ident', 'Fault', 'Available'],
+                    ['HOST', 'PATH', 'TYPE', 'DEVICE ID', 'SIZE',
+                     'AVAILABLE', 'REJECT REASONS'],
                     border=False)
             table.align = 'l'
             table._align['SIZE'] = 'r'
             table.left_padding_width = 0
             table.right_padding_width = 2
             for host_ in sorted(inv_hosts, key=lambda h: h.name):  # type: InventoryHost
-                for d in host_.devices.devices:  # type: Device
+                for d in sorted(host_.devices.devices, key=lambda d: d.path):  # type: Device
 
                     led_ident = 'N/A'
                     led_fail = 'N/A'
@@ -489,24 +489,17 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
                         led_ident = d.lsm_data['ledSupport']['IDENTstatus']
                         led_fail = d.lsm_data['ledSupport']['FAILstatus']
 
-                    if d.device_id is not None:
-                        fallback_serial = d.device_id.split('_')[-1]
-                    else:
-                        fallback_serial = ""
-
                     if wide:
                         table.add_row(
                             (
                                 host_.name,
                                 d.path,
                                 d.human_readable_type,
-                                d.lsm_data.get('transport', 'Unknown'),
-                                d.lsm_data.get('rpm', 'Unknown'),
-                                d.sys_api.get('vendor') or 'N/A',
-                                d.sys_api.get('model') or 'N/A',
-                                d.lsm_data.get('serialNum', fallback_serial),
+                                d.lsm_data.get('transport', ''),
+                                d.lsm_data.get('rpm', ''),
+                                d.device_id,
                                 format_dimless(d.sys_api.get('size', 0), 5),
-                                d.lsm_data.get('health', 'Unknown'),
+                                d.lsm_data.get('health', ''),
                                 display_map[led_ident],
                                 display_map[led_fail],
                                 display_map[d.available],
@@ -519,12 +512,10 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
                                 host_.name,
                                 d.path,
                                 d.human_readable_type,
-                                d.lsm_data.get('serialNum', fallback_serial),
+                                d.device_id,
                                 format_dimless(d.sys_api.get('size', 0), 5),
-                                d.lsm_data.get('health', 'Unknown'),
-                                display_map[led_ident],
-                                display_map[led_fail],
-                                display_map[d.available]
+                                display_map[d.available],
+                                ', '.join(d.rejected_reasons)
                             )
                         )
             out.append(table.get_string())


### PR DESCRIPTION
- headings in CAPS
- DEVICE ID, not just serial or model/vendor
- drop the health, LED fields from non-wide view
- sort devices
- 'Yes' or '', for easier visual parsing




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>