### PR TITLE
mgr/telemetry: modify stats_per_pool and add stats_per_pg

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -904,6 +904,7 @@ class Module(MgrModule):
             report['perf_counters_separated'] = self.gather_perf_counters('separated')
 
             report['stats_per_pool'] = self.get('pg_dump')['pool_stats']
+            report['stats_per_pg'] = self.get('pg_dump')['pg_stats']
 
             report['io_rate'] = self.get_io_rate()
 


### PR DESCRIPTION
We decided that it might be more useful to report data on a pg level in addition to what we were reporting for pool level. In the process of adding `stats_per_pg`, I realized that there was a much easier way to collect `stats_per_pool` than the current implementation. Fetching `pg_dump` from the mgr module already provides a field called `pool_stats` that is the same as aggregated pg stats.

All in all, this solution should provide the information we want, with a much cleaner implementation.

Signed-off-by: Laura Flores <lflores@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
