### PR TITLE
ceph-volume: fix a typo causing AttributeError

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/migrate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/migrate.py
@@ -414,7 +414,7 @@ class Migrate(object):
         target_lv = api.get_lv_by_fullname(self.args.target)
         if not target_lv:
             mlogger.error(
-                'Target path "{}" is not a Logical Volume'.formaat(
+                'Target path "{}" is not a Logical Volume'.format(
                     self.args.target))
             raise SystemExit(
                 'Unable to migrate to : {}'.format(self.args.target))


### PR DESCRIPTION
Fixes a small bug fix in `ceph-volume lvm migrate` when target is not a logical volume

Fixes: https://tracker.ceph.com/issues/53187