### PR TITLE
docs: fix case and spelling of Proxmox VE

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -76,7 +76,7 @@ reflect either technical terms or legacy ways of referring to Ceph systems.
 	Cloud Platforms
 	Cloud Stacks
 		Third party cloud provisioning platforms such as OpenStack, CloudStack,
-		OpenNebula, ProxMox, etc.
+		OpenNebula, Proxmox VE, etc.
 
 	Object Storage Device
 	OSD


### PR DESCRIPTION
There's no such thing as ProxMox, the hypervisor product with build
in ceph server management and RBD client access is named `Proxmox VE`
and the company behind it is named Proxmox Server Solutions GmbH

Signed-off-by: Thomas Lamprecht <t.lamprecht@proxmox.com>

Reference: See "The Proxmox Name" in https://www.proxmox.com/images/proxmox/Proxmox-Corporate-Brandguideline-2021.pdf

## Checklist
- [ ] References tracker ticket
- [X] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
jenkins test docs
jenkins render docs