### PR TITLE
common: hide internal logger configuration strings from clients

### DIFF
--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -39,16 +39,17 @@ namespace logging {
 }
 }
 
-int parse_log_client_options(CephContext *cct,
-			     std::map<std::string,std::string> &log_to_monitors,
-			     std::map<std::string,std::string> &log_to_syslog,
-			     std::map<std::string,std::string> &log_channels,
-			     std::map<std::string,std::string> &log_prios,
-			     std::map<std::string,std::string> &log_to_graylog,
-			     std::map<std::string,std::string> &log_to_graylog_host,
-			     std::map<std::string,std::string> &log_to_graylog_port,
-			     uuid_d &fsid,
-			     std::string &host);
+struct clog_targets_conf_t {
+  std::string log_to_monitors;
+  std::string log_to_syslog;
+  std::string log_channels;
+  std::string log_prios;
+  std::string log_to_graylog;
+  std::string log_to_graylog_host;
+  std::string log_to_graylog_port;
+  uuid_d fsid; // only 16B. Simpler as a copy.
+  std::string host;
+};
 
 /** Manage where we output to and at which priority
  *
@@ -153,19 +154,13 @@ public:
   typedef std::shared_ptr<LogChannel> Ref;
 
   /**
-   * update config values from parsed k/v std::map for each config option
+   * Query the configuration database in conf_cct for configuration
+   * parameters. Pick out the relevant values based on our channel name.
+   * Update the logger configuration based on these values.
    *
-   * Pick out the relevant value based on our channel.
+   * Return a collection of configuration strings.
    */
-  void update_config(std::map<std::string,std::string> &log_to_monitors,
-		     std::map<std::string,std::string> &log_to_syslog,
-		     std::map<std::string,std::string> &log_channels,
-		     std::map<std::string,std::string> &log_prios,
-		     std::map<std::string,std::string> &log_to_graylog,
-		     std::map<std::string,std::string> &log_to_graylog_host,
-		     std::map<std::string,std::string> &log_to_graylog_port,
-		     uuid_d &fsid,
-		     std::string &host);
+  clog_targets_conf_t parse_client_options(CephContext* conf_cct);
 
   void do_log(clog_type prio, std::stringstream& ss);
   void do_log(clog_type prio, const std::string& s);
@@ -181,6 +176,12 @@ private:
   bool log_to_monitors;
   std::shared_ptr<ceph::logging::Graylog> graylog;
 
+  /**
+   * update config values from parsed k/v std::map for each config option
+   */
+  void update_config(const clog_targets_conf_t& conf_strings);
+
+  clog_targets_conf_t parse_log_client_options(CephContext* conf_cct);
 };
 
 typedef LogChannel::Ref LogChannelRef;

--- a/src/common/str_list.cc
+++ b/src/common/str_list.cc
@@ -57,6 +57,8 @@ void get_str_vec(const string& str, vector<string>& str_vec)
 vector<string> get_str_vec(const string& str, const char *delims)
 {
   vector<string> result;
-  get_str_vec(str, delims, result);
+  for_each_substr(str, delims, [&result] (auto token) {
+      result.emplace_back(token.begin(), token.end());
+    });
   return result;
 }

--- a/src/common/str_map.cc
+++ b/src/common/str_map.cc
@@ -26,7 +26,7 @@ using namespace std;
 int get_json_str_map(
     const string &str,
     ostream &ss,
-    map<string,string> *str_map,
+    str_map_t *str_map,
     bool fallback_to_plain)
 {
   json_spirit::mValue json;
@@ -69,31 +69,54 @@ string trim(const string& str) {
 
 int get_str_map(
     const string &str,
-    map<string,string> *str_map,
+    str_map_t* str_map,
     const char *delims)
 {
-  list<string> pairs;
-  get_str_list(str, delims, pairs);
-  for (list<string>::iterator i = pairs.begin(); i != pairs.end(); ++i) {
-    size_t equal = i->find('=');
+  auto pairs = get_str_list(str, delims);
+  for (const auto& pr : pairs) {
+    size_t equal = pr.find('=');
     if (equal == string::npos)
-      (*str_map)[*i] = string();
+      (*str_map)[pr] = string();
     else {
-      const string key = trim(i->substr(0, equal));
+      const string key = trim(pr.substr(0, equal));
       equal++;
-      const string value = trim(i->substr(equal));
+      const string value = trim(pr.substr(equal));
       (*str_map)[key] = value;
     }
   }
   return 0;
 }
 
+str_map_t get_str_map(
+  const string& str,
+  const char* delim)
+{
+  auto pairs = get_str_list(str, delim);
+  str_map_t str_map;
+
+  for (const auto& pr : pairs) {
+    auto equal = pr.find('=');
+
+    // is the format 'K=V' or just 'K'?
+    if (equal == std::string::npos) {
+      str_map[pr] = std::string{};
+    } else {
+      const string key = trim(pr.substr(0, equal));
+      equal++;
+      const string value = trim(pr.substr(equal));
+      str_map[key] = value;
+    }
+  }
+
+  return str_map;
+}
+
 string get_str_map_value(
-    const map<string,string> &str_map,
+    const str_map_t &str_map,
     const string &key,
     const string *def_val)
 {
-  map<string,string>::const_iterator p = str_map.find(key);
+  auto p = str_map.find(key);
 
   // key exists in str_map
   if (p != str_map.end()) {
@@ -105,7 +128,7 @@ string get_str_map_value(
   }
 
   // key DNE in str_map and def_val was specified
-  if (def_val != NULL)
+  if (def_val != nullptr)
     return *def_val;
 
   // key DNE in str_map, no def_val was specified
@@ -113,15 +136,15 @@ string get_str_map_value(
 }
 
 string get_str_map_key(
-    const map<string,string> &str_map,
+    const str_map_t &str_map,
     const string &key,
     const string *fallback_key)
 {
-  map<string,string>::const_iterator p = str_map.find(key);
+  auto p = str_map.find(key);
   if (p != str_map.end())
     return p->second;
 
-  if (fallback_key != NULL) {
+  if (fallback_key != nullptr) {
     p = str_map.find(*fallback_key);
     if (p != str_map.end())
       return p->second;
@@ -138,22 +161,62 @@ string get_str_map_key(
 int get_conf_str_map_helper(
     const string &str,
     ostringstream &oss,
-    map<string,string> *m,
-    const string &def_key)
+    str_map_t* str_map,
+    const string &default_key)
 {
-  int r = get_str_map(str, m);
+  get_str_map(str, str_map);
 
-  if (r < 0) {
-    return r;
-  }
-
-  if (r >= 0 && m->size() == 1) {
-    map<string,string>::iterator p = m->begin();
+  if (str_map->size() == 1) {
+    auto p = str_map->begin();
     if (p->second.empty()) {
       string s = p->first;
-      m->erase(s);
-      (*m)[def_key] = s;
+      str_map->erase(s);
+      (*str_map)[default_key] = s;
     }
   }
-  return r;
+  return 0;
+}
+
+std::string get_value_via_strmap(
+  const string& conf_string,
+  std::string_view default_key)
+{
+  auto mp = get_str_map(conf_string);
+  if (mp.size() != 1) {
+    return "";
+  }
+
+  // if the one-elem "map" is of the form { 'value' : '' }
+  // replace it with { 'default_key' : 'value' }
+  const auto& [k, v] = *(mp.begin());
+  if (v.empty()) {
+    return k;
+  }
+  return v;
+}
+
+std::string get_value_via_strmap(
+  const string& conf_string,
+  const string& key,
+  std::string_view default_key)
+{
+  auto mp = get_str_map(conf_string);
+  if (mp.size() != 1) {
+    return std::string{};
+  }
+
+  // if the one-elem "map" is of the form { 'value' : '' }
+  // replace it with { 'default_key' : 'value' }
+  const auto& [k, v] = *(mp.begin());
+  if (v.empty()) {
+    return k;
+  }
+  if (k == key) {
+    return k;
+  }
+  if (k == default_key) {
+    return v;
+  }
+
+  return string{};
 }

--- a/src/include/str_map.h
+++ b/src/include/str_map.h
@@ -23,6 +23,8 @@
 #include <string>
 #include <sstream>
 
+using str_map_t = std::map<std::string,std::string>;
+
 /**
  * Parse **str** and set **str_map** with the key/value pairs read
  * from it. The format of **str** is either a well formed JSON object
@@ -45,10 +47,10 @@
  * @param [in] fallback_to_plain attempt parsing as plain-text if json fails
  * @return **0** on success or a -EINVAL on error.
  */
-extern int get_json_str_map(
+int get_json_str_map(
     const std::string &str,
     std::ostream &ss,
-    std::map<std::string,std::string> *str_map,
+    str_map_t* str_map,
     bool fallback_to_plain = true);
 
 /**
@@ -89,10 +91,15 @@ extern int get_json_str_map(
  * @param [out] str_map key/value pairs parsed from str
  * @return **0**
  */
-extern int get_str_map(
+int get_str_map(
     const std::string &str,
-    std::map<std::string,std::string> *str_map,
+    str_map_t* str_map,
     const char *delims = CONST_DELIMS);
+
+// an alternate form (as we never fail):
+str_map_t get_str_map(
+    const std::string& str,
+    const char* delim = CONST_DELIMS);
 
 /**
  * Returns the value of **key** in **str_map** if available.
@@ -106,10 +113,10 @@ extern int get_str_map(
  * @param[in] key The key to search for in the map
  * @param[in] def_val The value to return in case **key** is not present
  */
-extern std::string get_str_map_value(
-    const std::map<std::string,std::string> &str_map,
+std::string get_str_map_value(
+    const str_map_t& str_map,
     const std::string &key,
-    const std::string *def_val = NULL);
+    const std::string *def_val = nullptr);
 
 /**
  * Returns the value of **key** in **str_map** if available.
@@ -127,11 +134,10 @@ extern std::string get_str_map_value(
  * @param[in] def_key Key to fallback to if **key** is not present
  *                    in **str_map**
  */
-extern std::string get_str_map_key(
-    const std::map<std::string,std::string> &str_map,
+std::string get_str_map_key(
+    const str_map_t& str_map,
     const std::string &key,
-    const std::string *fallback_key = NULL);
-
+    const std::string *fallback_key = nullptr);
 
 // This function's only purpose is to check whether a given map has only
 // ONE key with an empty value (which would mean that 'get_str_map()' read
@@ -142,7 +148,16 @@ extern std::string get_str_map_key(
 int get_conf_str_map_helper(
     const std::string &str,
     std::ostringstream &oss,
-    std::map<std::string,std::string> *m,
-    const std::string &def_key);
+    str_map_t* str_map,
+    const std::string &default_key);
+
+std::string get_value_via_strmap(
+  const std::string& conf_string,
+  std::string_view default_key);
+
+std::string get_value_via_strmap(
+  const std::string& conf_string,
+  const std::string& key,
+  std::string_view default_key);
 
 #endif

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3267,25 +3267,8 @@ void MDSRank::dump_clientreplay_status(Formatter *f) const
 
 void MDSRankDispatcher::update_log_config()
 {
-  map<string,string> log_to_monitors;
-  map<string,string> log_to_syslog;
-  map<string,string> log_channel;
-  map<string,string> log_prio;
-  map<string,string> log_to_graylog;
-  map<string,string> log_to_graylog_host;
-  map<string,string> log_to_graylog_port;
-  uuid_d fsid;
-  string host;
-
-  if (parse_log_client_options(g_ceph_context, log_to_monitors, log_to_syslog,
-			       log_channel, log_prio, log_to_graylog,
-			       log_to_graylog_host, log_to_graylog_port,
-			       fsid, host) == 0)
-    clog->update_config(log_to_monitors, log_to_syslog,
-			log_channel, log_prio, log_to_graylog,
-			log_to_graylog_host, log_to_graylog_port,
-			fsid, host);
-  dout(10) << __func__ << " log_to_monitors " << log_to_monitors << dendl;
+  auto parsed_options = clog->parse_client_options(g_ceph_context);
+  dout(10) << __func__ << " log_to_monitors " << parsed_options.log_to_monitors << dendl;
 }
 
 void MDSRank::create_logger()

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -1422,23 +1422,7 @@ void ActivePyModules::cluster_log(const std::string &channel, clog_type prio,
   std::lock_guard l(lock);
 
   auto cl = monc.get_log_client()->create_channel(channel);
-  map<string,string> log_to_monitors;
-  map<string,string> log_to_syslog;
-  map<string,string> log_channel;
-  map<string,string> log_prio;
-  map<string,string> log_to_graylog;
-  map<string,string> log_to_graylog_host;
-  map<string,string> log_to_graylog_port;
-  uuid_d fsid;
-  string host;
-  if (parse_log_client_options(g_ceph_context, log_to_monitors, log_to_syslog,
-			       log_channel, log_prio, log_to_graylog,
-			       log_to_graylog_host, log_to_graylog_port,
-			       fsid, host) == 0)
-    cl->update_config(log_to_monitors, log_to_syslog,
-		      log_channel, log_prio, log_to_graylog,
-		      log_to_graylog_host, log_to_graylog_port,
-		      fsid, host);
+  cl->parse_client_options(g_ceph_context);
   cl->do_log(prio, message);
 }
 

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -169,8 +169,8 @@ class DaemonState
     metadata = m;
     auto p = m.find("device_ids");
     if (p != m.end()) {
-      std::map<std::string,std::string> devs, paths; // devname -> id or path
-      get_str_map(p->second, &devs, ",; ");
+      std::map<std::string,std::string> paths; // devname -> id or path
+      auto devs = get_str_map(p->second, ",; ");
       auto q = m.find("device_paths");
       if (q != m.end()) {
 	get_str_map(q->second, &paths, ",; ");

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -375,29 +375,8 @@ void MgrStandby::respawn()
 
 void MgrStandby::_update_log_config()
 {
-  map<string,string> log_to_monitors;
-  map<string,string> log_to_syslog;
-  map<string,string> log_channel;
-  map<string,string> log_prio;
-  map<string,string> log_to_graylog;
-  map<string,string> log_to_graylog_host;
-  map<string,string> log_to_graylog_port;
-  uuid_d fsid;
-  string host;
-
-  if (parse_log_client_options(cct, log_to_monitors, log_to_syslog,
-			       log_channel, log_prio, log_to_graylog,
-			       log_to_graylog_host, log_to_graylog_port,
-			       fsid, host) == 0) {
-    clog->update_config(log_to_monitors, log_to_syslog,
-			log_channel, log_prio, log_to_graylog,
-			log_to_graylog_host, log_to_graylog_port,
-			fsid, host);
-    audit_clog->update_config(log_to_monitors, log_to_syslog,
-			      log_channel, log_prio, log_to_graylog,
-			      log_to_graylog_host, log_to_graylog_port,
-			      fsid, host);
-  }
+  clog->parse_client_options(cct);
+  audit_clog->parse_client_options(cct);
 }
 
 void MgrStandby::handle_mgr_map(ref_t<MMgrMap> mmap)

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -674,31 +674,8 @@ void Monitor::handle_conf_change(const ConfigProxy& conf,
 
 void Monitor::update_log_clients()
 {
-  map<string,string> log_to_monitors;
-  map<string,string> log_to_syslog;
-  map<string,string> log_channel;
-  map<string,string> log_prio;
-  map<string,string> log_to_graylog;
-  map<string,string> log_to_graylog_host;
-  map<string,string> log_to_graylog_port;
-  uuid_d fsid;
-  string host;
-
-  if (parse_log_client_options(g_ceph_context, log_to_monitors, log_to_syslog,
-			       log_channel, log_prio, log_to_graylog,
-			       log_to_graylog_host, log_to_graylog_port,
-			       fsid, host))
-    return;
-
-  clog->update_config(log_to_monitors, log_to_syslog,
-		      log_channel, log_prio, log_to_graylog,
-		      log_to_graylog_host, log_to_graylog_port,
-		      fsid, host);
-
-  audit_clog->update_config(log_to_monitors, log_to_syslog,
-			    log_channel, log_prio, log_to_graylog,
-			    log_to_graylog_host, log_to_graylog_port,
-			    fsid, host);
+  clog->parse_client_options(g_ceph_context);
+  audit_clog->parse_client_options(g_ceph_context);
 }
 
 int Monitor::sanitize_options()
@@ -6643,7 +6620,7 @@ void Monitor::do_stretch_mode_election_work()
   dout(20) << "prior dead_mon_buckets: " << old_dead_buckets
 	   << "; down_mon_buckets: " << down_mon_buckets
 	   << "; up_mon_buckets: " << up_mon_buckets << dendl;
-  for (auto di : down_mon_buckets) {
+  for (const auto& di : down_mon_buckets) {
     if (!up_mon_buckets.count(di.first)) {
       dead_mon_buckets[di.first] = di.second;
     }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10124,25 +10124,8 @@ int OSD::mon_cmd_set_config(const std::string &key, const std::string &val)
 
 void OSD::update_log_config()
 {
-  map<string,string> log_to_monitors;
-  map<string,string> log_to_syslog;
-  map<string,string> log_channel;
-  map<string,string> log_prio;
-  map<string,string> log_to_graylog;
-  map<string,string> log_to_graylog_host;
-  map<string,string> log_to_graylog_port;
-  uuid_d fsid;
-  string host;
-
-  if (parse_log_client_options(cct, log_to_monitors, log_to_syslog,
-			       log_channel, log_prio, log_to_graylog,
-			       log_to_graylog_host, log_to_graylog_port,
-			       fsid, host) == 0)
-    clog->update_config(log_to_monitors, log_to_syslog,
-			log_channel, log_prio, log_to_graylog,
-			log_to_graylog_host, log_to_graylog_port,
-			fsid, host);
-  derr << "log_to_monitors " << log_to_monitors << dendl;
+  auto parsed_options = clog->parse_client_options(cct);
+  derr << "log_to_monitors " << parsed_options.log_to_monitors << dendl;
 }
 
 void OSD::check_config()

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -733,14 +733,6 @@ public:
   }
 };
 
-
-static map<string,string> get_str_map(const string &str) {
-  map<string,string> m;
-  get_str_map(str, &m, ";, \t");
-  return m;
-}
-
-
 static int get_actual_key_from_conf(const DoutPrefixProvider* dpp,
                                     CephContext *cct,
                                     std::string_view key_id,

--- a/src/rgw/rgw_kms.h
+++ b/src/rgw/rgw_kms.h
@@ -8,6 +8,8 @@
 #ifndef CEPH_RGW_KMS_H
 #define CEPH_RGW_KMS_H
 
+#include <string>
+
 static const std::string RGW_SSE_KMS_BACKEND_TESTING = "testing";
 static const std::string RGW_SSE_KMS_BACKEND_BARBICAN = "barbican";
 static const std::string RGW_SSE_KMS_BACKEND_VAULT = "vault";


### PR DESCRIPTION
Replace the common pattern used by clients of the logger, of:
- creating multiple "one element maps" for all config options;
- passing them, untouched, to the logger's update config.

with one that hides the configuration handling details from
the users.

Note: a follow-up PR, bypassing the strmaps construction altogether,
should be considered.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
