### PR TITLE
Fix corruption in BlueFS allocator caused by No-Column-B 

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7280,6 +7280,8 @@ int BlueStore::umount()
     int ret = store_allocator(shared_alloc.a);
     if (ret != 0) {
       derr << __func__ << "::NCB::store_allocator() failed (continue with bitmapFreelistManager)" << dendl;
+      _close_db_and_around(false);
+      // should we run fsck ???
       return ret;
     }
     dout(5) << __func__ << "::NCB::store_allocator() completed successfully" << dendl;
@@ -18312,7 +18314,11 @@ int BlueStore::commit_to_real_manager()
   dout(5) << "Set FreelistManager to Real FM..." << dendl;
   ceph_assert(!fm->is_null_manager());
   freelist_type = "bitmap";
-  return commit_freelist_type(db, freelist_type, cct, path);
+  int ret = commit_freelist_type(db, freelist_type, cct, path);
+  if (ret == 0) {
+
+  }
+  return ret;
 }
 
 //================================================================================================================

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3547,6 +3547,7 @@ private:
   int  copy_allocator(Allocator* src_alloc, Allocator *dest_alloc, uint64_t* p_num_entries);
   int  store_allocator(Allocator* allocator);
   int  invalidate_allocation_file_on_bluefs();
+  int  __restore_allocator(Allocator* allocator, uint64_t *num, uint64_t *bytes);
   int  restore_allocator(Allocator* allocator, uint64_t *num, uint64_t *bytes);
   int  read_allocation_from_drive_on_startup();
   int  reconstruct_allocations(Allocator* allocator, read_alloc_stats_t &stats);


### PR DESCRIPTION
os/bluestore/BlueStore::NCB - Fix corruption in BlueFS allocator

On startup NCB code will load extents from the allocation-file into shared_alloc.a while walking the allocation file it might find a corruption and the process will be aborted.
We will then run a full recovery building a temp allocator from RocksDB::ONodes and finally copying it into shared_alloc.a **which has still some allocation from the first attempt**

This issue was fixed by changing restore-allocator code to load allocation into a temp-allocator (lie we already do in the recovery flow) and only when everything was found to be valid copy the allocations into shared_alloc.a.

Fixes: https://tracker.ceph.com/issues/52399
Signed-off-by: Gabriel Benhanokh <gbenhano@redhat.com>