### PR TITLE
common/options: fix typo

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3180,7 +3180,7 @@ options:
   type: bool
   level: dev
   default: false
-  with_legacy: truen
+  with_legacy: true
 - name: osd_debug_pretend_recovery_active
   type: bool
   level: dev


### PR DESCRIPTION
common/options: fix typo

Signed-off-by: Anthony D'Atri <anthony.datri@gmail.com>

@tchaikov Is this value of `truen` deliberate instead of the  typo I suspect it is?
