### PR TITLE
mds: add truncate size handling support for fscrypt

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3498,8 +3498,10 @@ int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
       waitfor_caps = true;
     }
 
-    if ((need & CEPH_CAP_FILE_WR) && in->auth_cap &&
-	in->auth_cap->session->readonly)
+    if ((need & CEPH_CAP_FILE_WR) &&
+	((in->auth_cap && in->auth_cap->session->readonly) ||
+	 // userland clients are only allowed to read if fscrypt enabled
+	 in->is_fscrypt_enabled()))
       return -CEPHFS_EROFS;
 
     if (in->flags & I_CAP_DROPPED) {

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -954,6 +954,7 @@ Inode * Client::add_update_inode(InodeStat *st, utime_t from,
     in->btime = st->btime;
     in->snap_btime = st->snap_btime;
     in->snap_metadata = st->snap_metadata;
+    in->fscrypt_auth = st->fscrypt_auth;
   }
 
   if ((new_version || (new_issued & CEPH_CAP_LINK_SHARED)) &&
@@ -969,6 +970,7 @@ Inode * Client::add_update_inode(InodeStat *st, utime_t from,
   if (new_version ||
       (new_issued & (CEPH_CAP_ANY_FILE_RD | CEPH_CAP_ANY_FILE_WR))) {
     in->layout = st->layout;
+    in->fscrypt_file = st->fscrypt_file;
     update_inode_file_size(in, issued, st->size, st->truncate_seq, st->truncate_size);
   }
 
@@ -1050,7 +1052,6 @@ Inode * Client::add_update_inode(InodeStat *st, utime_t from,
     in->snap_caps |= st->cap.caps;
   }
 
-  in->fscrypt = st->fscrypt;
   return in;
 }
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1238,6 +1238,8 @@ private:
   struct VXattr {
     const std::string name;
     size_t (Client::*getxattr_cb)(Inode *in, char *val, size_t size);
+    int (Client::*setxattr_cb)(Inode *in, const void *val, size_t size,
+			       const UserPerm& perms);
     bool readonly;
     bool (Client::*exists_cb)(Inode *in);
     unsigned int flags;
@@ -1318,7 +1320,8 @@ private:
   int _mknod(Inode *dir, const char *name, mode_t mode, dev_t rdev,
 	     const UserPerm& perms, InodeRef *inp = 0);
   int _do_setattr(Inode *in, struct ceph_statx *stx, int mask,
-		  const UserPerm& perms, InodeRef *inp);
+		  const UserPerm& perms, InodeRef *inp,
+		  std::vector<uint8_t>* aux=nullptr);
   void stat_to_statx(struct stat *st, struct ceph_statx *stx);
   int __setattrx(Inode *in, struct ceph_statx *stx, int mask,
 		 const UserPerm& perms, InodeRef *inp = 0);
@@ -1392,6 +1395,12 @@ private:
 
   vinodeno_t _get_vino(Inode *in);
 
+  bool _vxattrcb_fscrypt_auth_exists(Inode *in);
+  size_t _vxattrcb_fscrypt_auth(Inode *in, char *val, size_t size);
+  int _vxattrcb_fscrypt_auth_set(Inode *in, const void *val, size_t size, const UserPerm& perms);
+  bool _vxattrcb_fscrypt_file_exists(Inode *in);
+  size_t _vxattrcb_fscrypt_file(Inode *in, char *val, size_t size);
+  int _vxattrcb_fscrypt_file_set(Inode *in, const void *val, size_t size, const UserPerm& perms);
   bool _vxattrcb_quota_exists(Inode *in);
   size_t _vxattrcb_quota(Inode *in, char *val, size_t size);
   size_t _vxattrcb_quota_max_bytes(Inode *in, char *val, size_t size);

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -165,6 +165,9 @@ struct Inode : RefCountedObject {
 
   std::vector<uint8_t> fscrypt_auth;
   std::vector<uint8_t> fscrypt_file;
+  bool is_fscrypt_enabled() {
+    return !!fscrypt_auth.size();
+  }
 
   bool is_root()    const { return ino == CEPH_INO_ROOT; }
   bool is_symlink() const { return (mode & S_IFMT) == S_IFLNK; }

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -163,7 +163,8 @@ struct Inode : RefCountedObject {
   version_t  inline_version = 0;
   bufferlist inline_data;
 
-  bool fscrypt = false; // fscrypt enabled ?
+  std::vector<uint8_t> fscrypt_auth;
+  std::vector<uint8_t> fscrypt_file;
 
   bool is_root()    const { return ino == CEPH_INO_ROOT; }
   bool is_symlink() const { return (mode & S_IFMT) == S_IFLNK; }

--- a/src/client/MetaRequest.h
+++ b/src/client/MetaRequest.h
@@ -30,6 +30,8 @@ public:
   ceph_mds_request_head head;
   filepath path, path2;
   std::string alternate_name;
+  std::vector<uint8_t>	fscrypt_auth;
+  std::vector<uint8_t>	fscrypt_file;
   bufferlist data;
   int inode_drop = 0;   //the inode caps this operation will drop
   int inode_unless = 0; //unless we have these caps already

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -11,6 +11,16 @@ options:
   - mds
   flags:
   - runtime
+- name: mds_fscrypt_last_block_max_size
+  type: size
+  level: advanced
+  desc: maximum size of the last block without the header along with a truncate
+    request when the fscrypt is enabled.
+  default: 4_K
+  services:
+  - mds
+  flags:
+  - runtime
 - name: mds_valgrind_exit
   type: bool
   level: dev

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -426,19 +426,22 @@ enum {
 
 extern const char *ceph_mds_op_name(int op);
 
+// setattr mask is an int
 #ifndef CEPH_SETATTR_MODE
-#define CEPH_SETATTR_MODE	(1 << 0)
-#define CEPH_SETATTR_UID	(1 << 1)
-#define CEPH_SETATTR_GID	(1 << 2)
-#define CEPH_SETATTR_MTIME	(1 << 3)
-#define CEPH_SETATTR_ATIME	(1 << 4)
-#define CEPH_SETATTR_SIZE	(1 << 5)
-#define CEPH_SETATTR_CTIME	(1 << 6)
-#define CEPH_SETATTR_MTIME_NOW	(1 << 7)
-#define CEPH_SETATTR_ATIME_NOW	(1 << 8)
-#define CEPH_SETATTR_BTIME	(1 << 9)
+#define CEPH_SETATTR_MODE		(1 << 0)
+#define CEPH_SETATTR_UID		(1 << 1)
+#define CEPH_SETATTR_GID		(1 << 2)
+#define CEPH_SETATTR_MTIME		(1 << 3)
+#define CEPH_SETATTR_ATIME		(1 << 4)
+#define CEPH_SETATTR_SIZE		(1 << 5)
+#define CEPH_SETATTR_CTIME		(1 << 6)
+#define CEPH_SETATTR_MTIME_NOW		(1 << 7)
+#define CEPH_SETATTR_ATIME_NOW		(1 << 8)
+#define CEPH_SETATTR_BTIME		(1 << 9)
+#define CEPH_SETATTR_KILL_SGUID		(1 << 10)
+#define CEPH_SETATTR_FSCRYPT_AUTH	(1 << 11)
+#define CEPH_SETATTR_FSCRYPT_FILE	(1 << 12)
 #endif
-#define CEPH_SETATTR_KILL_SGUID	(1 << 10)
 
 /*
  * open request flags

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -112,18 +112,21 @@ struct snap_info {
   struct snap_metadata *snap_metadata;
 };
 
-/* setattr mask bits */
+/* setattr mask bits (up to an int in size) */
 #ifndef CEPH_SETATTR_MODE
-# define CEPH_SETATTR_MODE	1
-# define CEPH_SETATTR_UID	2
-# define CEPH_SETATTR_GID	4
-# define CEPH_SETATTR_MTIME	8
-# define CEPH_SETATTR_ATIME	16
-# define CEPH_SETATTR_SIZE	32
-# define CEPH_SETATTR_CTIME	64
-# define CEPH_SETATTR_MTIME_NOW	128
-# define CEPH_SETATTR_ATIME_NOW	256
-# define CEPH_SETATTR_BTIME	512
+#define CEPH_SETATTR_MODE		(1 << 0)
+#define CEPH_SETATTR_UID		(1 << 1)
+#define CEPH_SETATTR_GID		(1 << 2)
+#define CEPH_SETATTR_MTIME		(1 << 3)
+#define CEPH_SETATTR_ATIME		(1 << 4)
+#define CEPH_SETATTR_SIZE		(1 << 5)
+#define CEPH_SETATTR_CTIME		(1 << 6)
+#define CEPH_SETATTR_MTIME_NOW		(1 << 7)
+#define CEPH_SETATTR_ATIME_NOW		(1 << 8)
+#define CEPH_SETATTR_BTIME		(1 << 9)
+#define CEPH_SETATTR_KILL_SGUID		(1 << 10)
+#define CEPH_SETATTR_FSCRYPT_AUTH	(1 << 11)
+#define CEPH_SETATTR_FSCRYPT_FILE	(1 << 12)
 #endif
 
 /* define error codes for the mount function*/

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -246,6 +246,23 @@ inline void encode(const char *s, bufferlist& bl)
   encode(std::string_view(s, strlen(s)), bl);
 }
 
+// opaque byte vectors
+inline void encode(std::vector<uint8_t>& v, bufferlist& bl)
+{
+  uint32_t len = v.size();
+  encode(len, bl);
+  if (len)
+    bl.append((char *)v.data(), len);
+}
+
+inline void decode(std::vector<uint8_t>& v, bufferlist::const_iterator& p)
+{
+  uint32_t len;
+
+  decode(len, p);
+  v.resize(len);
+  p.copy(len, (char *)v.data());
+}
 
 // -----------------------------
 // buffers

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4010,7 +4010,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
    * note: encoding matches MClientReply::InodeStat
    */
   if (session->info.has_feature(CEPHFS_FEATURE_REPLY_ENCODING)) {
-    ENCODE_START(6, 1, bl);
+    ENCODE_START(7, 1, bl);
     encode(oi->ino, bl);
     encode(snapid, bl);
     encode(oi->rdev, bl);
@@ -4056,6 +4056,8 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     encode(file_i->rstat.rsnaps, bl);
     encode(snap_metadata, bl);
     encode(!file_i->fscrypt_auth.empty(), bl);
+    encode(file_i->fscrypt_auth, bl);
+    encode(file_i->fscrypt_file, bl);
     ENCODE_FINISH(bl);
   }
   else {

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4150,6 +4150,8 @@ void CInode::encode_cap_message(const ref_t<MClientCaps> &m, Capability *cap)
   m->size = i->size;
   m->truncate_seq = i->truncate_seq;
   m->truncate_size = i->truncate_size;
+  m->fscrypt_file = i->fscrypt_file;
+  m->fscrypt_auth = i->fscrypt_auth;
   m->mtime = i->mtime;
   m->atime = i->atime;
   m->ctime = i->ctime;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4055,7 +4055,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     encode(snap_btime, bl);
     encode(file_i->rstat.rsnaps, bl);
     encode(snap_metadata, bl);
-    encode(file_i->fscrypt, bl);
+    encode(!file_i->fscrypt_auth.empty(), bl);
     ENCODE_FINISH(bl);
   }
   else {

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -3717,6 +3717,8 @@ void Locker::_update_cap_fields(CInode *in, int dirty, const cref_t<MClientCaps>
 	      << " for " << *in << dendl;
       pi->time_warp_seq = m->get_time_warp_seq();
     }
+    if (m->fscrypt_file.size())
+      pi->fscrypt_file = m->fscrypt_file;
   }
   // auth
   if (dirty & CEPH_CAP_AUTH_EXCL) {
@@ -3744,6 +3746,8 @@ void Locker::_update_cap_fields(CInode *in, int dirty, const cref_t<MClientCaps>
 	      << " for " << *in << dendl;
       pi->btime = m->get_btime();
     }
+    if (m->fscrypt_auth.size())
+      pi->fscrypt_auth = m->fscrypt_auth;
   }
 }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -102,27 +102,6 @@ public:
   explicit MDCacheContext(MDCache *mdc_) : mdcache(mdc_) {}
 };
 
-
-/**
- * Only for contexts called back from an I/O completion
- *
- * Note: duplication of members wrt MDCacheContext, because
- * it'ls the lesser of two evils compared with introducing
- * yet another piece of (multiple) inheritance.
- */
-class MDCacheIOContext : public virtual MDSIOContextBase {
-protected:
-  MDCache *mdcache;
-  MDSRank *get_mds() override
-  {
-    ceph_assert(mdcache != NULL);
-    return mdcache->mds;
-  }
-public:
-  explicit MDCacheIOContext(MDCache *mdc_, bool track=true) :
-    MDSIOContextBase(track), mdcache(mdc_) {}
-};
-
 class MDCacheLogContext : public virtual MDSLogContextBase {
 protected:
   MDCache *mdcache;

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -734,6 +734,8 @@ class MDCache {
   void truncate_inode(CInode *in, LogSegment *ls);
   void _truncate_inode(CInode *in, LogSegment *ls);
   void truncate_inode_finish(CInode *in, LogSegment *ls);
+  void truncate_inode_write_finish(CInode *in, LogSegment *ls,
+                                   uint32_t block_size);
   void truncate_inode_logged(CInode *in, MutationRef& mut);
 
   void add_recovered_truncate(CInode *in, LogSegment *ls);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1369,4 +1369,24 @@ private:
   bool drop_locks;
 };
 
+/**
+ * Only for contexts called back from an I/O completion
+ *
+ * Note: duplication of members wrt MDCacheContext, because
+ * it'ls the lesser of two evils compared with introducing
+ * yet another piece of (multiple) inheritance.
+ */
+class MDCacheIOContext : public virtual MDSIOContextBase {
+protected:
+  MDCache *mdcache;
+  MDSRank *get_mds() override
+  {
+    ceph_assert(mdcache != NULL);
+    return mdcache->mds;
+  }
+public:
+  explicit MDCacheIOContext(MDCache *mdc_, bool track=true) :
+    MDSIOContextBase(track), mdcache(mdc_) {}
+};
+
 #endif

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1259,6 +1259,9 @@ void Server::handle_conf_change(const std::set<std::string>& changed) {
   if (changed.count("mds_alternate_name_max")) {
     alternate_name_max  = g_conf().get_val<Option::size_t>("mds_alternate_name_max");
   }
+  if (changed.count("mds_fscrypt_last_block_max_size")) {
+    fscrypt_last_block_max_size = g_conf().get_val<Option::size_t>("mds_fscrypt_last_block_max_size");
+  }
   if (changed.count("mds_dir_max_entries")) {
     dir_max_entries = g_conf().get_val<uint64_t>("mds_dir_max_entries");
     dout(20) << __func__ << " max entries per directory changed to "

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3367,6 +3367,11 @@ CInode* Server::prepare_new_inode(MDRequestRef& mdr, CDir *dir, inodeno_t useino
   _inode->change_attr = 0;
 
   const cref_t<MClientRequest> &req = mdr->client_request;
+
+  dout(10) << "copying fscrypt_auth len " << req->fscrypt_auth.size() << dendl;
+  _inode->fscrypt_auth = req->fscrypt_auth;
+  _inode->fscrypt_file = req->fscrypt_file;
+
   if (req->get_data().length()) {
     auto p = req->get_data().cbegin();
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3374,9 +3374,6 @@ CInode* Server::prepare_new_inode(MDRequestRef& mdr, CDir *dir, inodeno_t useino
     auto _xattrs = CInode::allocate_xattr_map();
     decode_noshare(*_xattrs, p);
     dout(10) << "prepare_new_inode setting xattrs " << *_xattrs << dendl;
-    if (_xattrs->count("encryption.ctx")) {
-      _inode->fscrypt = true;
-    }
     in->reset_xattrs(std::move(_xattrs));
   }
 
@@ -6200,8 +6197,6 @@ void Server::handle_client_setxattr(MDRequestRef& mdr)
   pi.inode->ctime = mdr->get_op_stamp();
   if (mdr->get_op_stamp() > pi.inode->rstat.rctime)
     pi.inode->rstat.rctime = mdr->get_op_stamp();
-  if (name == "encryption.ctx"sv)
-    pi.inode->fscrypt = true;
   pi.inode->change_attr++;
   pi.inode->xattr_version++;
 

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -475,6 +475,7 @@ private:
   double caps_throttle_retry_request_timeout;
 
   size_t alternate_name_max = g_conf().get_val<Option::size_t>("mds_alternate_name_max");
+  size_t fscrypt_last_block_max_size = g_conf().get_val<Option::size_t>("mds_fscrypt_last_block_max_size");
 };
 
 static inline constexpr auto operator|(Server::RecallFlags a, Server::RecallFlags b) {

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -470,9 +470,10 @@ private:
       sr->encode(snapbl);
 
     lump.nfull++;
-    lump.add_dfull(dn->get_name(), dn->get_alternate_name(), dn->first, dn->last, dn->get_projected_version(),
-		   pi, in->dirfragtree, in->get_projected_xattrs(), in->symlink,
-		   in->oldest_snap, snapbl, state, in->get_old_inodes());
+    lump.add_dfull(dn->get_name(), dn->get_alternate_name(), dn->first, dn->last,
+                   dn->get_projected_version(), pi, in->dirfragtree,
+                   in->get_projected_xattrs(), in->symlink, in->oldest_snap, snapbl,
+                   state, in->get_old_inodes());
 
     // make note of where this inode was last journaled
     in->last_journaled = event_seq;

--- a/src/mds/fscrypt.h
+++ b/src/mds/fscrypt.h
@@ -1,0 +1,41 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPHFS_FSCRYPT_H
+#define CEPHFS_FSCRYPT_H
+
+struct ceph_fscrypt_last_block_header {
+        __u8  ver;
+        __u8  compat;
+
+        /* If the last block is located in a file hole the length
+	 * will be sizeof(i_version + file_offset + block_size),
+	 * or will plus to extra BLOCK SIZE.
+	 */
+        uint32_t data_len;
+
+	/* inode change attr version */
+        uint64_t change_attr;
+
+	/*
+	 * For a file hole, this will be 0, or it will be the offset from
+	 * which will write the last block
+	 */
+        uint64_t file_offset;
+
+	/* It should always be the fscrypt block size */
+        uint32_t block_size;
+};
+
+#endif

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -635,7 +635,7 @@ private:
 template<template<typename> class Allocator>
 void inode_t<Allocator>::encode(ceph::buffer::list &bl, uint64_t features) const
 {
-  ENCODE_START(17, 6, bl);
+  ENCODE_START(18, 6, bl);
 
   encode(ino, bl);
   encode(rdev, bl);
@@ -691,14 +691,15 @@ void inode_t<Allocator>::encode(ceph::buffer::list &bl, uint64_t features) const
   encode(export_ephemeral_distributed_pin, bl);
 
   encode(!fscrypt_auth.empty(), bl);
-
+  encode(fscrypt_auth, bl);
+  encode(fscrypt_file, bl);
   ENCODE_FINISH(bl);
 }
 
 template<template<typename> class Allocator>
 void inode_t<Allocator>::decode(ceph::buffer::list::const_iterator &p)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(17, 6, 6, p);
+  DECODE_START_LEGACY_COMPAT_LEN(18, 6, 6, p);
 
   decode(ino, p);
   decode(rdev, p);
@@ -798,9 +799,13 @@ void inode_t<Allocator>::decode(ceph::buffer::list::const_iterator &p)
 
   if (struct_v >= 17) {
     bool fscrypt_flag;
-    decode(fscrypt_flag, p);
+    decode(fscrypt_flag, p); // ignored
   }
 
+  if (struct_v >= 18) {
+    decode(fscrypt_auth, p);
+    decode(fscrypt_file, p);
+  }
   DECODE_FINISH(p);
 }
 

--- a/src/messages/MClientCaps.h
+++ b/src/messages/MClientCaps.h
@@ -22,7 +22,7 @@
 class MClientCaps final : public SafeMessage {
 private:
 
-  static constexpr int HEAD_VERSION = 11;
+  static constexpr int HEAD_VERSION = 12;
   static constexpr int COMPAT_VERSION = 1;
 
  public:
@@ -58,6 +58,9 @@ private:
 
   /* advisory CLIENT_CAPS_* flags to send to mds */
   unsigned flags = 0;
+
+  std::vector<uint8_t> fscrypt_auth;
+  std::vector<uint8_t> fscrypt_file;
 
   int      get_caps() const { return head.caps; }
   int      get_wanted() const { return head.wanted; }
@@ -270,6 +273,10 @@ public:
       decode(nfiles, p);
       decode(nsubdirs, p);
     }
+    if (header.version >= 12) {
+      decode(fscrypt_auth, p);
+      decode(fscrypt_file, p);
+    }
   }
   void encode_payload(uint64_t features) override {
     using ceph::encode;
@@ -338,6 +345,8 @@ public:
     encode(flags, payload);
     encode(nfiles, payload);
     encode(nsubdirs, payload);
+    encode(fscrypt_auth, payload);
+    encode(fscrypt_file, payload);
   }
 private:
   template<class T, typename... Args>

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -146,7 +146,8 @@ struct InodeStat {
   mds_rank_t dir_pin;
   std::map<std::string,std::string> snap_metadata;
 
-  bool fscrypt = false; // fscrypt enabled ?
+  std::vector<uint8_t> fscrypt_auth;
+  std::vector<uint8_t> fscrypt_file;
 
  public:
   InodeStat() {}
@@ -212,7 +213,9 @@ struct InodeStat {
         decode(snap_metadata, p);
       }
       if (struct_v >= 6) {
-        decode(fscrypt, p);
+        bool fscrypt_flag;
+
+        decode(fscrypt_flag, p);
       }
       DECODE_FINISH(p);
     }

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -158,7 +158,7 @@ struct InodeStat {
   void decode(ceph::buffer::list::const_iterator &p, const uint64_t features) {
     using ceph::decode;
     if (features == (uint64_t)-1) {
-      DECODE_START(6, p);
+      DECODE_START(7, p);
       decode(vino.ino, p);
       decode(vino.snapid, p);
       decode(rdev, p);
@@ -215,7 +215,11 @@ struct InodeStat {
       if (struct_v >= 6) {
         bool fscrypt_flag;
 
-        decode(fscrypt_flag, p);
+        decode(fscrypt_flag, p); // ignore this
+      }
+      if (struct_v >= 7) {
+        decode(fscrypt_auth, p);
+        decode(fscrypt_file, p);
       }
       DECODE_FINISH(p);
     }

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -67,7 +67,7 @@ WRITE_CLASS_ENCODER(SnapPayload)
 
 class MClientRequest final : public MMDSOp {
 private:
-  static constexpr int HEAD_VERSION = 5;
+  static constexpr int HEAD_VERSION = 6;
   static constexpr int COMPAT_VERSION = 1;
 
 public:
@@ -100,6 +100,9 @@ public:
   filepath path, path2;
   std::string alternate_name;
   std::vector<uint64_t> gid_list;
+
+  std::vector<uint8_t> fscrypt_auth;
+  std::vector<uint8_t> fscrypt_file;
 
   /* XXX HACK */
   mutable bool queued_for_replay = false;
@@ -240,6 +243,10 @@ public:
       decode(gid_list, p);
     if (header.version >= 5)
       decode(alternate_name, p);
+    if (header.version >= 6) {
+      decode(fscrypt_auth, p);
+      decode(fscrypt_file, p);
+    }
   }
 
   void encode_payload(uint64_t features) override {
@@ -262,6 +269,8 @@ public:
     encode(stamp, payload);
     encode(gid_list, payload);
     encode(alternate_name, payload);
+    encode(fscrypt_auth, payload);
+    encode(fscrypt_file, payload);
   }
 
   std::string_view get_type_name() const override { return "creq"; }

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -3573,6 +3573,38 @@ TEST(LibCephFS, SetMountTimeout) {
   ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
   ASSERT_EQ(0, ceph_set_mount_timeout(cmount, 5));
   ASSERT_EQ(ceph_mount(cmount, NULL), 0);
+  ceph_shutdown(cmount);
+}
 
+TEST(LibCephFS, FsCrypt) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_mount(cmount, NULL), 0);
+
+  char test_xattr_file[NAME_MAX];
+  sprintf(test_xattr_file, "test_fscrypt_%d", getpid());
+  int fd = ceph_open(cmount, test_xattr_file, O_RDWR|O_CREAT, 0666);
+  ASSERT_GT(fd, 0);
+
+  ASSERT_EQ(0, ceph_fsetxattr(cmount, fd, "ceph.fscrypt.auth", "foo", 3, CEPH_XATTR_CREATE));
+  ASSERT_EQ(0, ceph_fsetxattr(cmount, fd, "ceph.fscrypt.file", "foo", 3, CEPH_XATTR_CREATE));
+
+  char buf[64];
+  ASSERT_EQ(3, ceph_fgetxattr(cmount, fd, "ceph.fscrypt.auth", buf, sizeof(buf)));
+  ASSERT_EQ(3, ceph_fgetxattr(cmount, fd, "ceph.fscrypt.file", buf, sizeof(buf)));
+  ASSERT_EQ(0, ceph_close(cmount, fd));
+
+  ASSERT_EQ(0, ceph_unmount(cmount));
+  ASSERT_EQ(0, ceph_mount(cmount, NULL));
+
+  fd = ceph_open(cmount, test_xattr_file, O_RDWR, 0666);
+  ASSERT_GT(fd, 0);
+  ASSERT_EQ(3, ceph_fgetxattr(cmount, fd, "ceph.fscrypt.auth", buf, sizeof(buf)));
+  ASSERT_EQ(3, ceph_fgetxattr(cmount, fd, "ceph.fscrypt.file", buf, sizeof(buf)));
+
+  ASSERT_EQ(0, ceph_close(cmount, fd));
+  ASSERT_EQ(0, ceph_unmount(cmount));
   ceph_shutdown(cmount);
 }


### PR DESCRIPTION
This PR is to support the size handling(truncate size) feature for file cryption, and this is based on Jeff's https://github.com/ceph/ceph/pull/41284 PR.

In the kclient side, only when truncating smaller size and the new size is not aligned to `CEPH_FSCRYPT_BLOCK_SIZE` will the truncate request pass the encrypted last block contents to MDS. And the MDS will help update the last block when truncating the file size.

More detail please see the commit comments.



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
