### PR TITLE
qa: test that new mounts of same fs function after old mount is evicted

### DIFF
--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -66,7 +66,6 @@ class CephFSTestCase(CephTestCase):
     # their special needs.  If not met, tests will be skipped.
     CLIENTS_REQUIRED = 1
     MDSS_REQUIRED = 1
-    REQUIRE_KCLIENT_REMOTE = False
     REQUIRE_ONE_CLIENT_REMOTE = False
 
     # Whether to create the default filesystem during setUp

--- a/qa/tasks/cephfs/test_client_limits.py
+++ b/qa/tasks/cephfs/test_client_limits.py
@@ -25,7 +25,6 @@ CAP_RECALL_MIN = 100
 
 
 class TestClientLimits(CephFSTestCase):
-    REQUIRE_KCLIENT_REMOTE = True
     CLIENTS_REQUIRED = 2
 
     def _test_client_pin(self, use_subdir, open_files):

--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -25,7 +25,6 @@ MDS_RESTART_GRACE = 60
 
 
 class TestClientNetworkRecovery(CephFSTestCase):
-    REQUIRE_KCLIENT_REMOTE = True
     REQUIRE_ONE_CLIENT_REMOTE = True
     CLIENTS_REQUIRED = 2
 
@@ -85,7 +84,6 @@ class TestClientNetworkRecovery(CephFSTestCase):
 
 
 class TestClientRecovery(CephFSTestCase):
-    REQUIRE_KCLIENT_REMOTE = True
     CLIENTS_REQUIRED = 2
 
     LOAD_SETTINGS = ["mds_reconnect_timeout", "ms_max_backoff"]


### PR DESCRIPTION
This is mostly intended for the kclient, which just got a patch to fail matching existing superblocks at mount time if the client is evicted (or is in the process of being forcibly unmounted):

https://lore.kernel.org/ceph-devel/CAOi1vP-jyg1E1eBB7NrtcmQB=2wYFXht669kgFqTsmgVeX-h4w@mail.gmail.com/T/#t