### PR TITLE
rgw: have "bucket check --fix" fix pool ids correctly

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -360,7 +360,7 @@ static bool obj_has_expired(const DoutPrefixProvider *dpp, CephContext *cct, cep
     *expire_time = mtime + make_timespan(cmp);
   }
 
-  ldpp_dout(dpp, 20) << __func__ << __func__
+  ldpp_dout(dpp, 20) << __func__
 		 << "(): mtime=" << mtime << " days=" << days
 		 << " base_time=" << base_time << " timediff=" << timediff
 		 << " cmp=" << cmp
@@ -855,13 +855,13 @@ int RGWLC::handle_multipart_expiration(rgw::sal::Bucket* target,
 	if (ret == -ERR_NO_SUCH_UPLOAD) {
 	  ldpp_dout(wk->get_lc(), 5)
 	    << "ERROR: abort_multipart_upload failed, ret=" << ret
-	    << wq->thr_name()
+	    << ", thread:" << wq->thr_name()
 	    << ", meta:" << obj.key
 	    << dendl;
 	} else {
 	  ldpp_dout(wk->get_lc(), 0)
 	    << "ERROR: abort_multipart_upload failed, ret=" << ret
-	    << wq->thr_name()
+	    << ", thread:" << wq->thr_name()
 	    << ", meta:" << obj.key
 	    << dendl;
 	}
@@ -1407,7 +1407,7 @@ int LCOpRule::process(rgw_bucket_dir_entry& o,
     if (!cont) {
       ldpp_dout(dpp, 20) << __func__ << "(): key=" << o.key
 			 << ": no rule match, skipping "
-			 << " " << wq->thr_name() << dendl;
+			 << wq->thr_name() << dendl;
       return 0;
     }
 
@@ -1493,7 +1493,7 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
     if (ret < 0) {
       ldpp_dout(wk->get_lc(), 20)
 	<< "ERROR: orule.process() returned ret=" << ret
-	<< wq->thr_name() 
+	<< "thread:" << wq->thr_name()
 	<< dendl;
     }
   };

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9005,6 +9005,7 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
        * non-bad ways this could happen (there probably are, but annoying
        * to handle!) */
     }
+
     // encode a suggested removal of that key
     list_state.ver.epoch = io_ctx.get_last_version();
     list_state.ver.pool = io_ctx.get_id();
@@ -9060,14 +9061,25 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
   object.meta.owner_display_name = owner.get_display_name();
 
   // encode suggested updates
-  list_state.ver.pool = io_ctx.get_id();
-  list_state.ver.epoch = astate->epoch;
+
   list_state.meta.size = object.meta.size;
   list_state.meta.accounted_size = object.meta.accounted_size;
   list_state.meta.mtime = object.meta.mtime;
   list_state.meta.category = main_category;
   list_state.meta.etag = etag;
   list_state.meta.content_type = content_type;
+
+  librados::IoCtx head_obj_ctx; // initialize to data pool so we can get pool id
+  const bool head_pool_found =
+    get_obj_head_ioctx(dpp, bucket_info, obj, &head_obj_ctx);
+  if (head_pool_found) {
+    list_state.ver.pool = head_obj_ctx.get_id();
+    list_state.ver.epoch = astate->epoch;
+  } else {
+    ldpp_dout(dpp, 0) << __PRETTY_FUNCTION__ <<
+      " WARNING: unable to find head object data pool for \"" <<
+      obj << "\", not updating version pool/epoch" << dendl;
+  }
 
   if (astate->obj_tag.length() > 0) {
     list_state.tag = astate->obj_tag.c_str();


### PR DESCRIPTION
A long-standing bug where "radosgw-admin bucket check --fix" updates the bucket index records with the wrong pool id (the index pool rather than the data pool).

Additionally cleans up some LC logging.

Fixes: https://tracker.ceph.com/issues/52941
Signed-off-by: J. Eric Ivancich ivancich@redhat.com