### PR TITLE
mgr/dashboard: fetch host facts only if get_facts orch feature available

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -287,9 +287,18 @@ class Host(RESTController):
         hosts = get_hosts(sources)
         orch = OrchClient.instance()
         if str_to_bool(facts):
-            if orch.available():
-                hosts_facts = orch.hosts.get_facts()
-                return merge_list_of_dicts_by_key(hosts, hosts_facts, 'hostname')
+            if orch.available(['get_facts']):
+                try:
+                    hosts_facts = orch.hosts.get_facts()
+                    return merge_list_of_dicts_by_key(hosts, hosts_facts, 'hostname')
+
+                except Exception:
+                    raise DashboardException(
+                        code='invalid_orchestrator_backend',  # pragma: no cover
+                        msg="Please enable the cephadm orchestrator backend "
+                        "(try `ceph orch set backend cephadm`)",
+                        component='orchestrator',
+                        http_status_code=400)
 
             raise DashboardException(code='orchestrator_status_unavailable',  # pragma: no cover
                                      msg="Please configure and enable the orchestrator if you "

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -104,7 +104,7 @@ describe('HostsComponent', () => {
       }
     ];
 
-    OrchestratorHelper.mockStatus(true);
+    OrchestratorHelper.mockStatus(false);
     hostListSpy.and.callFake(() => of(payload));
     fixture.detectChanges();
 
@@ -118,6 +118,7 @@ describe('HostsComponent', () => {
   });
 
   it('should test if host facts are tranformed correctly if orch available', () => {
+    const features = [OrchestratorFeature.HOST_FACTS];
     const payload = [
       {
         hostname: 'host_test',
@@ -137,7 +138,7 @@ describe('HostsComponent', () => {
         nic_count: 1
       }
     ];
-    OrchestratorHelper.mockStatus(true);
+    OrchestratorHelper.mockStatus(true, features);
     hostListSpy.and.callFake(() => of(payload));
     fixture.detectChanges();
 
@@ -165,6 +166,31 @@ describe('HostsComponent', () => {
       }
     ];
     OrchestratorHelper.mockStatus(false);
+    hostListSpy.and.callFake(() => of(payload));
+    fixture.detectChanges();
+
+    component.getHosts(new CdTableFetchDataContext(() => undefined));
+    fixture.detectChanges();
+
+    const spans = fixture.debugElement.nativeElement.querySelectorAll(
+      '.datatable-body-cell-label span'
+    );
+    expect(spans[7].textContent).toBe('Unavailable');
+  });
+
+  it('should test if host facts are unavailable if get_fatcs orch feature is not available', () => {
+    const payload = [
+      {
+        hostname: 'host_test',
+        services: [
+          {
+            type: 'osd',
+            id: '0'
+          }
+        ]
+      }
+    ];
+    OrchestratorHelper.mockStatus(true);
     hostListSpy.and.callFake(() => of(payload));
     fixture.detectChanges();
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -389,8 +389,19 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
     });
   }
 
+  checkHostsFactsAvailable() {
+    const orchFeatures = this.orchStatus.features;
+    if (!_.isEmpty(orchFeatures)) {
+      if (orchFeatures.get_facts.available) {
+        return true;
+      }
+      return false;
+    }
+    return false;
+  }
+
   transformHostsData() {
-    if (this.orchStatus?.available) {
+    if (this.checkHostsFactsAvailable()) {
       _.forEach(this.hosts, (hostKey) => {
         hostKey['memory_total_bytes'] = hostKey['memory_total_kb'] * 1024;
         hostKey['raw_capacity'] = hostKey['hdd_capacity_bytes'] + hostKey['flash_capacity_bytes'];
@@ -423,8 +434,8 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
       .pipe(
         mergeMap((orchStatus) => {
           this.orchStatus = orchStatus;
-
-          return this.hostService.list(`${this.orchStatus?.available}`);
+          const factsAvailable = this.checkHostsFactsAvailable();
+          return this.hostService.list(`${factsAvailable}`);
         }),
         map((hostList: object[]) =>
           hostList.map((host) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/orchestrator.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/orchestrator.enum.ts
@@ -6,6 +6,7 @@ export enum OrchestratorFeature {
   HOST_LABEL_REMOVE = 'remove_host_label',
   HOST_MAINTENANCE_ENTER = 'enter_host_maintenance',
   HOST_MAINTENANCE_EXIT = 'exit_host_maintenance',
+  HOST_FACTS = 'get_facts',
 
   SERVICE_LIST = 'describe_service',
   SERVICE_CREATE = 'apply',


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/52981
Signed-off-by: Avan Thakkar <athakkar@redhat.com>

with test_orchestrator backend:
![Screenshot from 2021-10-20 19-11-40](https://user-images.githubusercontent.com/23611106/138112075-a2adc687-780e-468e-a3d2-e23755185801.png)

Gather facts in UI should only be fetched if there is orch available and
get_facts feature is available for that orch backend.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
