### PR TITLE
mgr/cephadm: suppress TLSV1_ALERT_DECRYPT_ERROR from cherrypy

### DIFF
--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -1,6 +1,7 @@
 import cherrypy
 import ipaddress
 import json
+import logging
 import socket
 import ssl
 import tempfile
@@ -25,6 +26,18 @@ from typing import Any, Dict, List, Set, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from cephadm.module import CephadmOrchestrator
+
+
+def cherrypy_filter(record: logging.LogRecord) -> int:
+    blocked = [
+        'TLSV1_ALERT_DECRYPT_ERROR'
+    ]
+    msg = record.getMessage()
+    return not any([m for m in blocked if m in msg])
+
+
+logging.getLogger('cherrypy.access').addFilter(cherrypy_filter)
+logging.getLogger('cherrypy.error').addFilter(cherrypy_filter)
 
 
 class CherryPyThread(threading.Thread):


### PR DESCRIPTION
These errors can pop up transiently when the mgr restarts
as the agents have not yet been redeployed with the new certs.
If there's actually a persistant issue with the ssl handshake
we'll find out because the agent will stay down (and a health
warning will be raised). So, these tls alert errors end up not
being necessary to see and tend confuse people into thinking something
is actually wrong because a traceback is getting logged.

Signed-off-by: Adam King <adking@redhat.com>

Example of the traceback I'm talking about here:

```
Traceback (most recent call last):
   File "/lib/python3.6/site-packages/cheroot/server.py", line 1810, in serve
     self._connections.run(self.expiration_interval)
   File "/lib/python3.6/site-packages/cheroot/connections.py", line 201, in run
     self._run(expiration_interval)
   File "/lib/python3.6/site-packages/cheroot/connections.py", line 218, in _run
     new_conn = self._from_server_socket(self.server.socket)
   File "/lib/python3.6/site-packages/cheroot/connections.py", line 272, in _from_server_socket
     s, ssl_env = self.server.ssl_adapter.wrap(s)
   File "/lib/python3.6/site-packages/cheroot/ssl/builtin.py", line 278, in wrap
     sock, do_handshake_on_connect=True, server_side=True,
   File "/lib64/python3.6/ssl.py", line 365, in wrap_socket
    _context=self, _session=session)
  File "/lib64/python3.6/ssl.py", line 776, in __init__
     self.do_handshake()
  File "/lib64/python3.6/ssl.py", line 1036, in do_handshake
    self._sslobj.do_handshake()
   File "/lib64/python3.6/ssl.py", line 648, in do_handshake
     self._sslobj.do_handshake()
 ssl.SSLError: [SSL: TLSV1_ALERT_DECRYPT_ERROR] tlsv1 alert decrypt error (_ssl.c:897)
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
