### PR TITLE
nautilus: mgr/dashboard/api: set a UTF-8 locale when running pip

### DIFF
--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -153,6 +153,8 @@ cleanup_teuthology() {
     unset cleanup_teuthology
 }
 
+export LC_ALL=en_US.UTF-8
+
 get_build_py_version
 setup_teuthology
 setup_coverage


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52987

---

backport of https://github.com/ceph/ceph/pull/42811
parent tracker: https://tracker.ceph.com/issues/52985

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh