### PR TITLE
mgr/nfs: adjust export creation CLI args, and allow rgw user exports

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -91,6 +91,15 @@
   deprecated and will be removed in a future release.  Please use
   ``nfs cluster rm`` and ``nfs export rm`` instead.
 
+* The ``nfs export create`` CLI arguments have changed, with the
+  *fsname* or *bucket-name* argument position moving to the right of
+  *the *cluster-id* and *pseudo-path*.  Consider transitioning to
+  *using named arguments instead of positional arguments (e.g., ``ceph
+  *nfs export create cephfs --cluster-id mycluster --pseudo-path /foo
+  *--fsname myfs`` instead of ``ceph nfs export create cephfs
+  *mycluster /foo myfs`` to ensure correct behavior with any
+  *version.
+
 * mgr-pg_autoscaler: Autoscaler will now start out by scaling each
   pool to have a full complements of pgs from the start and will only
   decrease it when other pools need more pgs due to increased usage.

--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -275,23 +275,23 @@ To export a bucket
 
 .. code::
 
-   $ ceph nfs export create rgw <bucket_name> <cluster_id> <pseudo_path> [--readonly] [--client_addr <value>...] [--squash <value>]
+   $ ceph nfs export create rgw --cluster-id <cluster_id> --pseudo-path <pseudo_path> --bucket <bucket_name> [--readonly] [--client_addr <value>...] [--squash <value>]
 
 For example, to export *mybucket* via NFS cluster *mynfs* at the pseudo-path */bucketdata* to any host in the ``192.168.10.0/24`` network
 
 .. code::
 
-   $ ceph nfs export create rgw mybucket mynfs /bucketdata --client_addr 192.168.10.0/24
+   $ ceph nfs export create rgw --cluster-id mynfs --pseudo-path /bucketdata --bucket mybucket --client_addr 192.168.10.0/24
 
 .. note:: Export creation is supported only for NFS Ganesha clusters deployed using nfs interface.
-
-``<bucket_name>`` is the name of the bucket that will be exported.
-
-.. note:: Currently, if multi-site RGW is enabled, Ceph can only export RGW buckets in the default realm.
 
 ``<cluster_id>`` is the NFS Ganesha cluster ID.
 
 ``<pseudo_path>`` is the export position within the NFS v4 Pseudo Filesystem where the export will be available on the server. It must be an absolute path and unique.
+
+``<bucket_name>`` is the name of the bucket that will be exported.
+
+.. note:: Currently, if multi-site RGW is enabled, Ceph can only export RGW buckets in the default realm.
 
 ``<client_addr>`` is the list of client address for which these export
 permissions will be applicable. By default all clients can access the export

--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -239,16 +239,16 @@ Create CephFS Export
 
 .. code:: bash
 
-    $ ceph nfs export create cephfs <fsname> <cluster_id> <pseudo_path> [--readonly] [--path=/path/in/cephfs] [--client_addr <value>...] [--squash <value>]
+    $ ceph nfs export create cephfs --cluster-id <cluster_id> --pseudo-path <pseudo_path> --fsname <fsname> [--readonly] [--path=/path/in/cephfs] [--client_addr <value>...] [--squash <value>]
 
 This creates export RADOS objects containing the export block, where
-
-``<fsname>`` is the name of the FS volume used by the NFS Ganesha cluster
-that will serve this export.
 
 ``<cluster_id>`` is the NFS Ganesha cluster ID.
 
 ``<pseudo_path>`` is the export position within the NFS v4 Pseudo Filesystem where the export will be available on the server. It must be an absolute path and unique.
+
+``<fsname>`` is the name of the FS volume used by the NFS Ganesha cluster
+that will serve this export.
 
 ``<path>`` is the path within cephfs. Valid path should be given and default
 path is '/'. It need not be unique. Subvolume path can be fetched using:

--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -271,11 +271,21 @@ permissible values.
 Create RGW Export
 -----------------
 
-To export a bucket
+There are two kinds of RGW exports:
+
+- a *user* export will export all buckets owned by an
+  RGW user, where the top-level directory of the export is a list of buckets.
+- a *bucket* export will export a single bucket, where the top-level directory contains
+  the objects in the bucket.
+
+RGW bucket export
+^^^^^^^^^^^^^^^^^
+  
+To export a *bucket*:
 
 .. code::
 
-   $ ceph nfs export create rgw --cluster-id <cluster_id> --pseudo-path <pseudo_path> --bucket <bucket_name> [--readonly] [--client_addr <value>...] [--squash <value>]
+   $ ceph nfs export create rgw --cluster-id <cluster_id> --pseudo-path <pseudo_path> --bucket <bucket_name> [--user-id <user-id>] [--readonly] [--client_addr <value>...] [--squash <value>]
 
 For example, to export *mybucket* via NFS cluster *mynfs* at the pseudo-path */bucketdata* to any host in the ``192.168.10.0/24`` network
 
@@ -291,6 +301,10 @@ For example, to export *mybucket* via NFS cluster *mynfs* at the pseudo-path */b
 
 ``<bucket_name>`` is the name of the bucket that will be exported.
 
+``<user_id>`` is optional, and specifies which RGW user will be used for read and write
+operations to the bucket.  If it is not specified, the user who owns the bucket will be
+used.
+
 .. note:: Currently, if multi-site RGW is enabled, Ceph can only export RGW buckets in the default realm.
 
 ``<client_addr>`` is the list of client address for which these export
@@ -301,6 +315,22 @@ for permissible values.
 ``<squash>`` defines the kind of user id squashing to be performed. The default
 value is `no_root_squash`. See the `NFS-Ganesha Export Sample`_ for
 permissible values.
+
+RGW user export
+^^^^^^^^^^^^^^^
+
+To export an RGW *user*:
+
+.. code::
+
+   $ ceph nfs export create rgw --cluster-id <cluster_id> --pseudo-path <pseudo_path> --user-id <user-id> [--readonly] [--client_addr <value>...] [--squash <value>]
+
+For example, to export *myuser* via NFS cluster *mynfs* at the pseudo-path */myuser* to any host in the ``192.168.10.0/24`` network
+
+.. code::
+
+   $ ceph nfs export create rgw --cluster-id mynfs --pseudo-path /bucketdata --user-id myuser --client_addr 192.168.10.0/24
+
 
 Delete Export
 -------------

--- a/qa/suites/orch/cephadm/mgr-nfs-upgrade/2-nfs.yaml
+++ b/qa/suites/orch/cephadm/mgr-nfs-upgrade/2-nfs.yaml
@@ -15,7 +15,7 @@ tasks:
 - cephadm.shell:
     host.a:
       - ceph nfs cluster create foo --placement=2 || ceph nfs cluster create cephfs foo --placement=2
-      - ceph nfs export create cephfs foofs foo --binding /fake || ceph nfs export create cephfs foofs foo --pseudo-path /fake 
+      - ceph nfs export create cephfs --fsname foofs --clusterid foo --binding /fake || ceph nfs export create cephfs --fsname foofs --cluster-id foo --pseudo-path /fake 
 
       # we can't do wait_for_service here because with octopus it's nfs.ganesha-foo not nfs.foo
       - while ! ceph orch ls | grep nfs | grep 2/2 ; do sleep 1 ; done

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress-rgw-bucket.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress-rgw-bucket.yaml
@@ -40,7 +40,7 @@ tasks:
 
 - cephadm.shell:
     host.a:
-      - ceph nfs export create rgw foobucket foo --pseudo-path /foobucket
+      - ceph nfs export create rgw --bucket foobucket --cluster-id foo --pseudo-path /foobucket 
 
 - cephadm.wait_for_service:
     service: nfs.foo

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress-rgw-user.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress-rgw-user.yaml
@@ -1,0 +1,90 @@
+tasks:
+- vip:
+
+# make sure cephadm notices the new IP
+- cephadm.shell:
+    host.a:
+      - ceph orch device ls --refresh
+
+# stop kernel nfs server, if running
+- vip.exec:
+    all-hosts:
+      - systemctl stop nfs-server
+
+- cephadm.shell:
+    host.a:
+      - ceph orch apply rgw foorgw --port 8800
+      - ceph nfs cluster create foo --ingress --virtual-ip {{VIP0}}/{{VIPPREFIXLEN}}
+
+- vip.exec:
+    host.a:
+      - dnf install -y python3-boto3 || apt install -y python3-boto3
+      - /home/ubuntu/cephtest/cephadm shell radosgw-admin user create --uid foouser --display-name foo > /tmp/user.json
+
+- python:
+    host.a: |
+      import boto3
+      import json
+
+      with open('/tmp/user.json', 'rt') as f:
+          info = json.loads(f.read())
+      s3 = boto3.resource(
+          's3',
+          aws_access_key_id=info['keys'][0]['access_key'],
+          aws_secret_access_key=info['keys'][0]['secret_key'],
+          endpoint_url='http://localhost:8800',
+      )
+      bucket = s3.Bucket('foobucket')
+      bucket.create()
+      bucket.put_object(Key='myobject', Body='thebody')
+
+- cephadm.shell:
+    host.a:
+      - ceph nfs export create rgw --cluster-id foo --pseudo-path /foouser --user-id foouser
+
+- cephadm.wait_for_service:
+    service: nfs.foo
+- cephadm.wait_for_service:
+    service: ingress.nfs.foo
+
+## export and mount
+
+- vip.exec:
+    host.a:
+      - mkdir /mnt/foo
+      - sleep 5
+      - mount -t nfs {{VIP0}}:/foouser /mnt/foo
+      - test -d /mnt/foo/foobucket
+      - find /mnt/foo -ls
+      - grep thebody /mnt/foo/foobucket/myobject
+      - echo test > /mnt/foo/foobucket/newobject
+      - sync
+
+- python:
+    host.a: |
+      import boto3
+      import json
+      from io import BytesIO
+
+      with open('/tmp/user.json', 'rt') as f:
+          info = json.loads(f.read())
+      s3 = boto3.resource(
+          's3',
+          aws_access_key_id=info['keys'][0]['access_key'],
+          aws_secret_access_key=info['keys'][0]['secret_key'],
+          endpoint_url='http://localhost:8800',
+      )
+      bucket = s3.Bucket('foobucket')
+      data = BytesIO()
+      bucket.download_fileobj(Fileobj=data, Key='newobject')
+      print(data.getvalue())
+      assert data.getvalue().decode() == 'test\n'
+
+- vip.exec:
+    host.a:
+      - umount /mnt/foo
+
+- cephadm.shell:
+    host.a:
+      - ceph nfs export rm foo /foouser
+      - ceph nfs cluster rm foo

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress.yaml
@@ -40,7 +40,7 @@ tasks:
 
 - cephadm.shell:
     host.a:
-      - ceph nfs export create cephfs foofs foo --pseudo-path /fake
+      - ceph nfs export create cephfs --fsname foofs --cluster-id foo --pseudo-path /fake
 
 - vip.exec:
     host.a:

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress2.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress2.yaml
@@ -15,7 +15,7 @@ tasks:
     host.a:
       - ceph fs volume create foofs
       - ceph nfs cluster create foo --ingress --virtual-ip {{VIP0}}/{{VIPPREFIXLEN}} --port 2999
-      - ceph nfs export create cephfs foofs foo --pseudo-path /fake
+      - ceph nfs export create cephfs --fsname foofs --cluster-id foo --pseudo-path /fake
 
 - cephadm.wait_for_service:
     service: nfs.foo

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -163,11 +163,12 @@ class TestNFS(MgrTestCase):
                     j = json.loads(output)
                     if j[0]['status']['running']:
                         break
-        export_cmd = ['nfs', 'export', 'create', 'cephfs', self.fs_name, self.cluster_id]
+        export_cmd = ['nfs', 'export', 'create', 'cephfs',
+                      '--fsname', self.fs_name, '--cluster-id', self.cluster_id]
         if isinstance(extra_cmd, list):
             export_cmd.extend(extra_cmd)
         else:
-            export_cmd.append(self.pseudo_path)
+            export_cmd.extend(['--pseudo-path', self.pseudo_path])
         # Runs the nfs export create command
         self._cmd(*export_cmd)
         # Check if user id for export is created
@@ -350,9 +351,10 @@ class TestNFS(MgrTestCase):
         '''
         Test idempotency of export create and delete commands.
         '''
-        self._test_idempotency(self._create_default_export, ['nfs', 'export', 'create', 'cephfs',
-                                                             self.fs_name, self.cluster_id,
-                                                             self.pseudo_path])
+        self._test_idempotency(self._create_default_export, [
+            'nfs', 'export', 'create', 'cephfs',
+            '--fsname', self.fs_name, '--cluster-id', self.cluster_id,
+            '--pseudo-path', self.pseudo_path])
         self._test_idempotency(self._delete_export, ['nfs', 'export', 'rm', self.cluster_id,
                                                      self.pseudo_path])
         self._test_delete_cluster()
@@ -364,14 +366,18 @@ class TestNFS(MgrTestCase):
         # Export-1 with default values (access type = rw and path = '\')
         self._create_default_export()
         # Export-2 with r only
-        self._create_export(export_id='2', extra_cmd=[self.pseudo_path+'1', '--readonly'])
+        self._create_export(export_id='2',
+                            extra_cmd=['--pseudo-path', self.pseudo_path+'1', '--readonly'])
         # Export-3 for subvolume with r only
         self._cmd('fs', 'subvolume', 'create', self.fs_name, 'sub_vol')
         fs_path = self._cmd('fs', 'subvolume', 'getpath', self.fs_name, 'sub_vol').strip()
-        self._create_export(export_id='3', extra_cmd=[self.pseudo_path+'2', '--readonly',
-                                                      '--path', fs_path])
+        self._create_export(export_id='3',
+                            extra_cmd=['--pseudo-path', self.pseudo_path+'2', '--readonly',
+                                       '--path', fs_path])
         # Export-4 for subvolume
-        self._create_export(export_id='4', extra_cmd=[self.pseudo_path+'3', fs_path])
+        self._create_export(export_id='4',
+                            extra_cmd=['--pseudo-path', self.pseudo_path+'3',
+                                       '--path', fs_path])
         # Check if exports gets listed
         self._test_list_detailed(fs_path)
         self._test_delete_cluster()
@@ -404,7 +410,9 @@ class TestNFS(MgrTestCase):
         try:
             fs_name = 'nfs-test'
             self._test_create_cluster()
-            self._nfs_cmd('export', 'create', 'cephfs', fs_name, self.cluster_id, self.pseudo_path)
+            self._nfs_cmd('export', 'create', 'cephfs',
+                          '--fsname', fs_name, '--cluster-id', self.cluster_id,
+                          '--pseudo-path', self.pseudo_path)
             self.fail(f"Export created with non-existing filesystem {fs_name}")
         except CommandFailedError as e:
             # Command should fail for test to pass
@@ -419,7 +427,8 @@ class TestNFS(MgrTestCase):
         '''
         try:
             cluster_id = 'invalidtest'
-            self._nfs_cmd('export', 'create', 'cephfs', self.fs_name, cluster_id, self.pseudo_path)
+            self._nfs_cmd('export', 'create', 'cephfs', '--fsname', self.fs_name,
+                          '--cluster-id', cluster_id, '--pseudo-path', self.pseudo_path)
             self.fail(f"Export created with non-existing cluster id {cluster_id}")
         except CommandFailedError as e:
             # Command should fail for test to pass
@@ -432,8 +441,9 @@ class TestNFS(MgrTestCase):
         '''
         def check_pseudo_path(pseudo_path):
             try:
-                self._nfs_cmd('export', 'create', 'cephfs', self.fs_name, self.cluster_id,
-                              pseudo_path)
+                self._nfs_cmd('export', 'create', 'cephfs', '--fsname', self.fs_name,
+                              '--cluster-id', self.cluster_id,
+                              '--pseudo-path', pseudo_path)
                 self.fail(f"Export created for {pseudo_path}")
             except CommandFailedError as e:
                 # Command should fail for test to pass
@@ -453,7 +463,8 @@ class TestNFS(MgrTestCase):
         Test write to readonly export.
         '''
         self._test_create_cluster()
-        self._create_export(export_id='1', create_fs=True, extra_cmd=[self.pseudo_path, '--readonly'])
+        self._create_export(export_id='1', create_fs=True,
+                            extra_cmd=['--pseudo-path', self.pseudo_path, '--readonly'])
         port, ip = self._get_port_ip_info()
         self._check_nfs_cluster_status('running', 'NFS Ganesha cluster restart failed')
         self._write_to_read_only_export(self.pseudo_path, port, ip)
@@ -658,8 +669,8 @@ class TestNFS(MgrTestCase):
         exec_cmd_invalid('cluster', 'config', 'set')
         exec_cmd_invalid('cluster', 'config', 'reset')
         exec_cmd_invalid('export', 'create', 'cephfs')
-        exec_cmd_invalid('export', 'create', 'cephfs', 'a_fs')
-        exec_cmd_invalid('export', 'create', 'cephfs', 'a_fs', 'clusterid')
+        exec_cmd_invalid('export', 'create', 'cephfs', 'clusterid')
+        exec_cmd_invalid('export', 'create', 'cephfs', 'clusterid', 'a_fs')
         exec_cmd_invalid('export', 'ls')
         exec_cmd_invalid('export', 'delete')
         exec_cmd_invalid('export', 'delete', 'clusterid')

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1159,8 +1159,12 @@ def validate(args: List[str],
 
             # no arg, but not required?  Continue consuming mysig
             # in case there are later required args
-            if myarg in (None, []) and not desc.req:
-                break
+            if myarg in (None, []):
+                if not desc.req:
+                    break
+                # did we already get this argument (as a named arg, earlier?)
+                if desc.name in d:
+                    break
 
             # A keyword argument?
             if myarg:

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -205,20 +205,23 @@ class ExportMgr:
 
         elif isinstance(export.fsal, RGWFSAL):
             rgwfsal = cast(RGWFSAL, export.fsal)
-            ret, out, err = self.mgr.tool_exec(
-                ['radosgw-admin', 'bucket', 'stats', '--bucket', export.path]
-            )
-            if ret:
-                raise NFSException(f'Failed to fetch owner for bucket {export.path}')
-            j = json.loads(out)
-            owner = j.get('owner', '')
-            rgwfsal.user_id = owner
+            if not rgwfsal.user_id:
+                assert export.path
+                ret, out, err = self.mgr.tool_exec(
+                    ['radosgw-admin', 'bucket', 'stats', '--bucket', export.path]
+                )
+                if ret:
+                    raise NFSException(f'Failed to fetch owner for bucket {export.path}')
+                j = json.loads(out)
+                owner = j.get('owner', '')
+                rgwfsal.user_id = owner
+            assert rgwfsal.user_id
             ret, out, err = self.mgr.tool_exec([
-                'radosgw-admin', 'user', 'info', '--uid', owner
+                'radosgw-admin', 'user', 'info', '--uid', rgwfsal.user_id
             ])
             if ret:
                 raise NFSException(
-                    f'Failed to fetch key for bucket {export.path} owner {owner}'
+                    f'Failed to fetch key for bucket {export.path} owner {rgwfsal.user_id}'
                 )
             j = json.loads(out)
 
@@ -535,18 +538,15 @@ class ExportMgr:
             raise NFSInvalidOperation("export must specify pseudo path")
 
         path = ex_dict.get("path")
-        if not path:
+        if path is None:
             raise NFSInvalidOperation("export must specify path")
         path = self.format_path(path)
 
         fsal = ex_dict.get("fsal", {})
         fsal_type = fsal.get("name")
         if fsal_type == NFS_GANESHA_SUPPORTED_FSALS[1]:
-            if '/' in path:
-                raise NFSInvalidOperation('"/" is not allowed in path (bucket name)')
-            uid = f'nfs.{cluster_id}.{path}'
-            if "user_id" in fsal and fsal["user_id"] != uid:
-                raise NFSInvalidOperation(f"export FSAL user_id must be '{uid}'")
+            if '/' in path and path != '/':
+                raise NFSInvalidOperation('"/" is not allowed in path with bucket name')
         elif fsal_type == NFS_GANESHA_SUPPORTED_FSALS[0]:
             fs_name = fsal.get("fs_name")
             if not fs_name:
@@ -610,14 +610,18 @@ class ExportMgr:
         return 0, "", "Export already exists"
 
     def create_rgw_export(self,
-                          bucket: str,
                           cluster_id: str,
                           pseudo_path: str,
                           access_type: str,
                           read_only: bool,
                           squash: str,
+                          bucket: Optional[str] = None,
+                          user_id: Optional[str] = None,
                           clients: list = []) -> Tuple[int, str, str]:
         pseudo_path = self.format_path(pseudo_path)
+
+        if not bucket and not user_id:
+            return -errno.EINVAL, "", "Must specify either bucket or user_id"
 
         if not self._fetch_export(cluster_id, pseudo_path):
             export = self.create_export_from_dict(
@@ -625,10 +629,13 @@ class ExportMgr:
                 self._gen_export_id(cluster_id),
                 {
                     "pseudo": pseudo_path,
-                    "path": bucket,
+                    "path": bucket or '/',
                     "access_type": access_type,
                     "squash": squash,
-                    "fsal": {"name": NFS_GANESHA_SUPPORTED_FSALS[1]},
+                    "fsal": {
+                        "name": NFS_GANESHA_SUPPORTED_FSALS[1],
+                        "user_id": user_id,
+                    },
                     "clients": clients,
                 }
             )

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -27,9 +27,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     @CLICommand('nfs export create cephfs', perm='rw')
     def _cmd_nfs_export_create_cephfs(
             self,
-            fsname: str,
             cluster_id: str,
             pseudo_path: str,
+            fsname: str,
             path: Optional[str] = '/',
             readonly: Optional[bool] = False,
             client_addr: Optional[List[str]] = None,

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -46,13 +46,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             self,
             cluster_id: str,
             pseudo_path: str,
-            bucket: str,
+            bucket: Optional[str] = None,
+            user_id: Optional[str] = None,
             readonly: Optional[bool] = False,
             client_addr: Optional[List[str]] = None,
             squash: str = 'none',
     ) -> Tuple[int, str, str]:
         """Create an RGW export"""
         return self.export_mgr.create_export(fsal_type='rgw', bucket=bucket,
+                                             user_id=user_id,
                                              cluster_id=cluster_id, pseudo_path=pseudo_path,
                                              read_only=readonly, squash=squash,
                                              addr=client_addr)

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -44,9 +44,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     @CLICommand('nfs export create rgw', perm='rw')
     def _cmd_nfs_export_create_rgw(
             self,
-            bucket: str,
             cluster_id: str,
             pseudo_path: str,
+            bucket: str,
             readonly: Optional[bool] = False,
             client_addr: Optional[List[str]] = None,
             squash: str = 'none',

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1670,7 +1670,7 @@ if [ $GANESHA_DAEMON_NUM -gt 0 ]; then
 	if [ "$CEPH_NUM_RGW" -gt 0 ]; then
             pseudo_path="/rgw"
             do_rgw_create_bucket
-	    prun ceph_adm nfs export create rgw "nfs-bucket" $cluster_id $pseudo_path
+	    prun ceph_adm nfs export create rgw --cluster-id $cluster_id --pseudo-path $pseudo_path --bucket "nfs-bucket"
             echo "Mount using: mount -t nfs -o port=$port $IP:$pseudo_path mountpoint"
 	fi
     else

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1224,7 +1224,7 @@ start_ganesha() {
     ceph_adm orch set backend test_orchestrator
     ceph_adm test_orchestrator load_data -i $CEPH_ROOT/src/pybind/mgr/test_orchestrator/dummy_data.json
     prun ceph_adm nfs cluster create $cluster_id
-    prun ceph_adm nfs export create cephfs "a" $cluster_id "/cephfs"
+    prun ceph_adm nfs export create cephfs --fsname "a" --cluster-id $cluster_id --pseudo-path "/cephfs"
 
     for name in a b c d e f g h i j k l m n o p
     do
@@ -1664,7 +1664,7 @@ if [ $GANESHA_DAEMON_NUM -gt 0 ]; then
 	port="2049"
         prun ceph_adm nfs cluster create $cluster_id
 	if [ $CEPH_NUM_MDS -gt 0 ]; then
-            prun ceph_adm nfs export create cephfs "a" $cluster_id $pseudo_path
+            prun ceph_adm nfs export create cephfs --fsname "a" --cluster-id $cluster_id --pseudo-path $pseudo_path
 	    echo "Mount using: mount -t nfs -o port=$port $IP:$pseudo_path mountpoint"
 	fi
 	if [ "$CEPH_NUM_RGW" -gt 0 ]; then


### PR DESCRIPTION
- for ``nfs export create rgw``, take either bucket or user or both.  If we get only the user, do an export for the user that shows buckets at the top level.  If bucket+user, then use that user instead of the bucket owner.  If bucket only, behavior is as before (use bucket owner as the user).
- adjust hte CLI arg position for ``nfs export create cephfs`` to put the fsname as the last positional argument.  This aligns the 2 export create commands so that cluster_id and pseudo_path both come first (which FWIW is more intutive anyway)
- adjust tests so that all callers use named arguments for all of these commands, so that they work both before and after the CLI positional argument order change.

Note that the change for the ``nfs export create cephfs`` could be dropped, but I think it si worth the potential user breakage to end up with a better CLI.

TODO
- [x] add release note, and encourage users to use named arguments whenever using these interfaces
- [x] add test for rgw user-level export (including bucket creation with mkdir)




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>