### PR TITLE
pacific: mds/FSMap: do not assert allow_standby_replay on old FSMaps

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -840,8 +840,12 @@ const MDSMap::mds_info_t* FSMap::find_replacement_for(mds_role_t role) const
   return get_available_standby(*fs);
 }
 
-void FSMap::sanity() const
+void FSMap::sanity(bool pending) const
 {
+  /* Only do some sanity checks on **new** FSMaps. Older versions may not be
+   * compliant.
+   */
+
   if (legacy_client_fscid != FS_CLUSTER_ID_NONE) {
     ceph_assert(filesystems.count(legacy_client_fscid) == 1);
   }
@@ -858,7 +862,7 @@ void FSMap::sanity() const
         ceph_assert(fs->mds_map.failed.count(info.rank) == 0);
         ceph_assert(fs->mds_map.damaged.count(info.rank) == 0);
       } else {
-        ceph_assert(fs->mds_map.allows_standby_replay());
+        ceph_assert(!pending || fs->mds_map.allows_standby_replay());
       }
       ceph_assert(info.compat.writeable(fs->mds_map.compat));
     }

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -568,7 +568,7 @@ public:
    * Assert that the FSMap, Filesystem, MDSMap, mds_info_t relations are
    * all self-consistent.
    */
-  void sanity() const;
+  void sanity(bool pending=false) const;
 
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& p);

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -190,7 +190,7 @@ void MDSMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   // print map iff 'debug mon = 30' or higher
   print_map<30>(pending);
   if (!g_conf()->mon_mds_skip_sanity) {
-    pending.sanity();
+    pending.sanity(true);
   }
 
   // Set 'modified' on maps modified this epoch


### PR DESCRIPTION
https://tracker.ceph.com/issues/52998