### PR TITLE
pacific: mon/MDSMonitor: avoid crash when decoding old FSMap epochs

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -641,6 +641,7 @@ void FSMap::encode(bufferlist& bl, uint64_t features) const
 
 void FSMap::decode(bufferlist::const_iterator& p)
 {
+  struct_version = 0;
   DECODE_START(STRUCT_VERSION, p);
   DECODE_OLDEST(7);
   struct_version = struct_v;

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2306,7 +2306,12 @@ void MDSMonitor::tick()
         derr << "could not get version " << v << dendl;
         ceph_abort();
       }
-      fsmap.decode(bl);
+      try {
+        fsmap.decode(bl);
+      } catch (const ceph::buffer::malformed_input& e) {
+        dout(5) << "flushing old fsmap struct because unable to decode FSMap: " << e.what() << dendl;
+      }
+      /* N.B. FSMap::is_struct_old is also true for undecoded (failed to decode) FSMap */
       if (fsmap.is_struct_old()) {
         dout(5) << "fsmap struct is too old; proposing to flush out old versions" << dendl;
         do_propose = true;


### PR DESCRIPTION
https://tracker.ceph.com/issues/52999