### PR TITLE
crimson/os/seastore/journal: support both batching and concurrent writes

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -45,3 +45,18 @@ options:
   level: dev
   desc: Initial number of segments for rewriting extents per device
   default: 6
+- name: seastore_journal_batch_capacity
+  type: uint
+  level: dev
+  desc: The number limit of records in a journal batch
+  default: 16
+- name: seastore_journal_batch_flush_size
+  type: size
+  level: dev
+  desc: The size threshold to force flush a journal batch
+  default: 16_M
+- name: seastore_journal_iodepth_limit
+  type: uint
+  level: dev
+  desc: The io depth limit to submit journal records
+  default: 2

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -222,7 +222,7 @@ SegmentedAllocator::Writer::init_segment(Segment& segment) {
       segment_manager.get_block_size()));
   bp.zero();
   auto header =segment_header_t{
-    journal.next_journal_segment_seq - 1, // current seg seq = next seg seq - 1
+    journal.get_segment_seq(),
     segment.get_segment_id(),
     NO_DELTAS, 0, true};
   logger().debug("SegmentedAllocator::Writer::init_segment: initting {}, {}",

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include "crimson/common/log.h"
-
 #include <boost/intrusive_ptr.hpp>
 
 #include <seastar/core/future.hh>
@@ -31,6 +29,13 @@ class SegmentedAllocator;
 class Journal {
 public:
   Journal(SegmentManager &segment_manager, ExtentReader& scanner);
+
+  /**
+   * Gets the current journal segment sequence.
+   */
+  segment_seq_t get_segment_seq() const {
+    return next_journal_segment_seq - 1;
+  }
 
   /**
    * Sets the SegmentProvider.
@@ -207,7 +212,6 @@ private:
     const bufferlist &bl);
 
 private:
-
   /// replays records starting at start through end of segment
   replay_ertr::future<>
   replay_segment(
@@ -217,7 +221,6 @@ private:
   );
 
   extent_len_t max_record_length() const;
-  friend class crimson::os::seastore::SegmentedAllocator;
 };
 using JournalRef = std::unique_ptr<Journal>;
 


### PR DESCRIPTION
Both batching and concurrent writes may be benefitial, but more batching leads to less write concurrency, and vise versa. This PR introduces a `RecordSubmitter` to strike a balance.

The current strategy is to set a preferred-io-depth (currently 2). `RecordSubmitter` will try to fill the desired concurrency first before adding further records as batch, while keeping the physical write order correct with the existing `WritePipeline` and `OrderingHandle` mechanisms.

The current local tests don't see strong evidences about whether batched (preferred-io-depth = 1) or concurrent (preferred-io-depth = 10) writes is better. The only result is that this change with any preferred-io-depth doesn't seem to impact both throughput and latency under release build.

Next steps:
- [x] Add metrics to meaure batching and concurrency as graph;
- [ ] Implement the merge-journal-header feature so that batching can become benefitial;
- [ ] Adjust RecordSubmitter for a smarter decision;

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
