### PR TITLE
mds: Store symlink target in first data object

### DIFF
--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -61,3 +61,4 @@
 .. confval:: mds_wipe_ino_prealloc
 .. confval:: mds_skip_ino
 .. confval:: mds_min_caps_per_client
+.. confval:: mds_symlink_recovery

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -1285,6 +1285,9 @@ class Filesystem(MDSCluster):
         args = ["setxattr", obj_name, xattr_name, data]
         self.rados(args, pool=pool)
 
+    def read_symlink(self, ino_no, pool=None):
+        return self._read_data_xattr(ino_no, "symlink", "string_wrapper", pool)
+
     def read_backtrace(self, ino_no, pool=None):
         """
         Read the backtrace from the data pool, return a dict in the format

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -1156,6 +1156,20 @@ class CephFSMount(object):
     def get_op_read_count(self):
         raise NotImplementedError()
 
+    def readlink(self, fs_path):
+        abs_path = os.path.join(self.hostfs_mntpt, fs_path)
+
+        pyscript = dedent("""
+            import os
+
+            print(os.readlink("{path}"))
+            """).format(path=abs_path)
+
+        proc = self._run_python(pyscript)
+        proc.wait()
+        return str(proc.stdout.getvalue().strip())
+
+
     def lstat(self, fs_path, follow_symlinks=False, wait=True):
         return self.stat(fs_path, follow_symlinks=False, wait=True)
 

--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -8,6 +8,7 @@ import logging
 import os
 import time
 import traceback
+import stat
 
 from io import BytesIO, StringIO
 from collections import namedtuple, defaultdict
@@ -38,6 +39,15 @@ class Workload(object):
         try:
             if a != b:
                 raise AssertionError("{0} != {1}".format(a, b))
+        except AssertionError as e:
+            self._errors.append(
+                ValidationError(e, traceback.format_exc(3))
+            )
+
+    def assert_true(self, a):
+        try:
+            if not a:
+                raise AssertionError("{0} is not true".format(a))
         except AssertionError as e:
             self._errors.append(
                 ValidationError(e, traceback.format_exc(3))
@@ -85,6 +95,30 @@ class SimpleWorkload(Workload):
         self._mount.run_shell(["ls", "subdir"], sudo=True)
         st = self._mount.stat("subdir/sixmegs", sudo=True)
         self.assert_equal(st['st_size'], self._initial_state['st_size'])
+        return self._errors
+
+
+class SymlinkWorkload(Workload):
+    """
+    Symlink file, check that it gets recovered as symlink
+    """
+    def write(self):
+        self._mount.run_shell(["mkdir", "symdir"])
+        self._mount.write_n_mb("symdir/onemegs", 1)
+        self._mount.run_shell(["ln", "-s", "onemegs", "symdir/symlink_onemegs"])
+        self._mount.run_shell(["ln", "-s", "symdir/onemegs", "symlink1_onemegs"])
+
+    def validate(self):
+        self._mount.run_shell(["ls", "symdir"], sudo=True)
+        st = self._mount.lstat("symdir/symlink_onemegs")
+        self.assert_true(stat.S_ISLNK(st['st_mode']))
+        target = self._mount.readlink("symdir/symlink_onemegs")
+        self.assert_equal(target, "onemegs")
+
+        st = self._mount.lstat("symlink1_onemegs")
+        self.assert_true(stat.S_ISLNK(st['st_mode']))
+        target = self._mount.readlink("symlink1_onemegs")
+        self.assert_equal(target, "symdir/onemegs")
         return self._errors
 
 
@@ -393,6 +427,9 @@ class TestDataScan(CephFSTestCase):
 
     def test_rebuild_simple(self):
         self._rebuild_metadata(SimpleWorkload(self.fs, self.mount_a))
+
+    def test_rebuild_symlink(self):
+        self._rebuild_metadata(SymlinkWorkload(self.fs, self.mount_a))
 
     def test_rebuild_moved_file(self):
         self._rebuild_metadata(MovedFile(self.fs, self.mount_a))

--- a/src/cls/cephfs/cls_cephfs_client.h
+++ b/src/cls/cephfs/cls_cephfs_client.h
@@ -22,6 +22,7 @@ class ClsCephFSClient
       const std::string &oid,
       inode_backtrace_t *backtrace,
       file_layout_t *layout,
+      std::string *symlink,
       AccumulateResult *result);
 
   static int delete_inode_accumulate_result(

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1421,3 +1421,13 @@ options:
   default: false
   flags:
   - runtime
+- name: mds_symlink_recovery
+  type: bool
+  level: advanced
+  desc: Stores symlink target on the first data object of symlink file.
+    Allows recover of symlink using recovery tools.
+  default: true
+  services:
+  - mds
+  flags:
+  - runtime

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -66,9 +66,9 @@ public:
   CInodeCommitOperation(int prio, int64_t po)
     : pool(po), priority(prio) {
   }
-  CInodeCommitOperation(int prio, int64_t po, file_layout_t l, uint64_t f)
-    : pool(po), priority(prio), _layout(l), _features(f) {
-      update_layout = true;
+  CInodeCommitOperation(int prio, int64_t po, file_layout_t l, uint64_t f, std::string_view s)
+    : pool(po), priority(prio), _layout(l), _features(f), _symlink(s) {
+      update_layout_symlink = true;
   }
 
   void update(ObjectOperation &op, inode_backtrace_t &bt);
@@ -77,9 +77,10 @@ public:
 private:
   int64_t pool;     ///< pool id
   int priority;
-  bool update_layout = false;
+  bool update_layout_symlink = false;
   file_layout_t _layout;
   uint64_t _features;
+  std::string_view _symlink;
 };
 
 struct CInodeCommitOperations {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -157,6 +157,8 @@ MDCache::MDCache(MDSRank *m, PurgeQueue &purge_queue_) :
   export_ephemeral_random_config =  g_conf().get_val<bool>("mds_export_ephemeral_random");
   export_ephemeral_random_max = g_conf().get_val<double>("mds_export_ephemeral_random_max");
 
+  symlink_recovery = g_conf().get_val<bool>("mds_symlink_recovery");
+
   lru.lru_set_midpoint(g_conf().get_val<double>("mds_cache_mid"));
 
   bottom_lru.lru_set_midpoint(0);
@@ -212,6 +214,10 @@ void MDCache::handle_conf_change(const std::set<std::string>& changed, const MDS
     lru.lru_set_midpoint(g_conf().get_val<double>("mds_cache_mid"));
   if (changed.count("mds_cache_trim_decay_rate")) {
     trim_counter = DecayCounter(g_conf().get_val<double>("mds_cache_trim_decay_rate"));
+  }
+  if (changed.count("mds_symlink_recovery")) {
+    symlink_recovery = g_conf().get_val<bool>("mds_symlink_recovery");
+    dout(10) << "Storing symlink targets on file object's head " << symlink_recovery << dendl;
   }
 
   migrator->handle_conf_change(changed, mdsmap);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -223,6 +223,10 @@ class MDCache {
     return export_ephemeral_random_config;
   }
 
+  bool get_symlink_recovery(void) const {
+    return symlink_recovery;
+  }
+
   /**
    * Call this when you know that a CDentry is ready to be passed
    * on to StrayManager (i.e. this is a stray you've just created)
@@ -1314,6 +1318,9 @@ class MDCache {
   bool export_ephemeral_distributed_config;
   bool export_ephemeral_random_config;
   unsigned export_ephemeral_dist_frag_bits;
+
+  // Stores the symlink target on the file object's head
+  bool symlink_recovery;
 
   // File size recovery
   RecoveryQueue recovery_queue;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3748,6 +3748,7 @@ const char** MDSRankDispatcher::get_tracked_conf_keys() const
     "mds_cap_acquisition_throttle_retry_request_time",
     "mds_alternate_name_max",
     "mds_dir_max_entries",
+    "mds_symlink_recovery",
     NULL
   };
   return KEYS;

--- a/src/tools/ceph-dencoder/common_types.h
+++ b/src/tools/ceph-dencoder/common_types.h
@@ -12,6 +12,9 @@ TYPE(uuid_d)
 #include "sstring.h"
 TYPE(sstring_wrapper)
 
+#include "str.h"
+TYPE(string_wrapper)
+
 #include "include/CompatSet.h"
 TYPE(CompatSet)
 

--- a/src/tools/ceph-dencoder/str.h
+++ b/src/tools/ceph-dencoder/str.h
@@ -1,0 +1,38 @@
+#ifndef TEST_STRING_H
+#define TEST_STRING_H
+
+#include "common/Formatter.h"
+
+// wrapper for std::string that implements the dencoder interface
+class string_wrapper {
+  std::string s;
+  public:
+   string_wrapper() = default;
+   string_wrapper(string s1)
+    : s(s1)
+   {}
+
+  void encode(ceph::buffer::list& bl) const {
+    using ceph::encode;
+    encode(s, bl);
+  }
+
+  void decode(ceph::buffer::list::const_iterator &bl) {
+    using ceph::decode;
+    decode(s, bl);
+  }
+
+  void dump(Formatter* f) {
+    f->dump_string("s", s);
+  }
+
+  static void generate_test_instances(std::list<string_wrapper*>& ls) {
+    ls.push_back(new string_wrapper());
+    // initialize strings that fit in internal storage
+    std::string s1 = "abcdef";
+    ls.push_back(new string_wrapper(s1));
+  }
+};
+WRITE_CLASS_ENCODER(string_wrapper)
+
+#endif

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -681,8 +681,9 @@ int DataScan::scan_inodes()
     AccumulateResult accum_res;
     inode_backtrace_t backtrace;
     file_layout_t loaded_layout = file_layout_t::get_default();
+    std::string symlink;
     r = ClsCephFSClient::fetch_inode_accumulate_result(
-        data_io, oid, &backtrace, &loaded_layout, &accum_res);
+        data_io, oid, &backtrace, &loaded_layout, &symlink, &accum_res);
 
     if (r == -EINVAL) {
       dout(4) << "Accumulated metadata missing from '"
@@ -828,7 +829,7 @@ int DataScan::scan_inodes()
     }
 
     InodeStore dentry;
-    build_file_dentry(obj_name_ino, file_size, file_mtime, guessed_layout, &dentry);
+    build_file_dentry(obj_name_ino, file_size, file_mtime, guessed_layout, &dentry, symlink);
 
     // Inject inode to the metadata pool
     if (have_backtrace) {
@@ -2156,12 +2157,19 @@ int LocalFileDriver::check_roots(bool *result)
 
 void MetadataTool::build_file_dentry(
     inodeno_t ino, uint64_t file_size, time_t file_mtime,
-    const file_layout_t &layout, InodeStore *out)
+    const file_layout_t &layout, InodeStore *out, std::string symlink)
 {
   ceph_assert(out != NULL);
 
   auto inode = out->get_inode();
-  inode->mode = 0500 | S_IFREG;
+  if(!symlink.empty()) {
+    inode->mode = 0777 | S_IFLNK;
+    out->symlink = symlink;
+  }
+  else {
+    inode->mode = 0500 | S_IFREG;
+  }
+
   inode->size = file_size;
   inode->max_size_ever = file_size;
   inode->mtime.tv.tv_sec = file_mtime;

--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -153,7 +153,8 @@ class MetadataTool
   void build_file_dentry(
     inodeno_t ino, uint64_t file_size, time_t file_mtime,
     const file_layout_t &layout,
-    InodeStore *out);
+    InodeStore *out,
+    std::string symlink);
 
   /**
    * Construct a synthetic InodeStore for a directory


### PR DESCRIPTION
Problem:
The MDS only stores the symlink inode's backtrace
information in the data pool. During disaster
recovery of the metadata pool by scanning data
pool, the symlinks are recreated as regular files.

Solution:
Store the symlink target in the first
data object for recovery and add ability to cephfs-data-scan
tool recover from the same.

MDS option:
The mds option 'mds_recover_symlink' is introduced
which is enabled by default. Enabling the option
stores the symlink target.

Signed-off-by: Kotresh HR <khiremat@redhat.com>
Fixes: https://tracker.ceph.com/issues/46166


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
