### PR TITLE
[WIP] doc/mgr: update incorrect nfs module commands in docs

### DIFF
--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -341,18 +341,18 @@ An existing export can be dumped in JSON format with:
 
 .. prompt:: bash #
 
-    ceph nfs export info *<cluster_id>* *<pseudo_path>*
+    ceph nfs export get *<cluster_id>* *<pseudo_path>*
 
 An export can be created or modified by importing a JSON description in the
 same format:
 
 .. prompt:: bash #
 
-    ceph nfs export apply *<cluster_id>* -i <json_file>
+    ceph nfs export update *<cluster_id>* -i <json_file>
 
 For example,::
 
-   $ ceph nfs export info mynfs /cephfs > update_cephfs_export.json
+   $ ceph nfs export get mynfs /cephfs > update_cephfs_export.json
    $ cat update_cephfs_export.json
    {
      "export_id": 1,
@@ -389,7 +389,7 @@ previous state of the export where possible.
 
 ::
 
-   $ ceph nfs export apply mynfs -i update_cephfs_export.json
+   $ ceph nfs export update mynfs -i update_cephfs_export.json
    $ cat update_cephfs_export.json
    {
      "export_id": 1,
@@ -417,7 +417,7 @@ previous state of the export where possible.
 An export can also be created or updated by injecting a Ganesha NFS EXPORT config
 fragment.  For example,::
 
-   $ ceph nfs export apply mynfs -i update_cephfs_export.conf
+   $ ceph nfs export update mynfs -i update_cephfs_export.conf
    $ cat update_cephfs_export.conf
    EXPORT {
        FSAL {


### PR DESCRIPTION
The NFS mgr module does not have an `ceph nfs info` command. Rather, it is `ceph nfs get`. 

Similarly, `ceph nfs apply -i <file>` does not exist. Rather, it is `ceph nfs update -i <file>`.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>

ping @jmolmo 