### PR TITLE
rgw/lua: Example read/write of StorageClass field

### DIFF
--- a/examples/lua/storage_class.lua
+++ b/examples/lua/storage_class.lua
@@ -1,0 +1,19 @@
+local function isempty(input)
+  return input == nil or input == ''
+end
+
+if Request.RGWOp == 'put_obj' then
+  RGWDebugLog("Put_Obj with StorageClass: " .. Request.HTTP.StorageClass )
+  if (isempty(Request.HTTP.StorageClass)) then
+    if (Request.ContentLength >= 65536) then
+      RGWDebugLog("No StorageClass for Object and size >= threshold: " .. Request.Object.Name .. " adding QLC StorageClass")
+      Request.HTTP.StorageClass = "QLC_CLASS"
+    else
+      RGWDebugLog("No StorageClass for Object and size < threshold: " .. Request.Object.Name .. " adding STANDARD StorageClass")
+      Request.HTTP.StorageClass = "STANDARD"
+    end
+  else
+    RGWDebugLog("Storage Class Header Present on Object: " .. Request.Object.Name .. " with StorageClass: " .. Request.HTTP.StorageClass)
+  end
+end
+

--- a/examples/lua/storage_class.md
+++ b/examples/lua/storage_class.md
@@ -1,0 +1,49 @@
+# Introduction
+
+This directory contains an example `storage_class.lua` on how to
+use [Lua Scripting](https://docs.ceph.com/en/latest/radosgw/lua-scripting/)
+to read and write the Storage Class field of a put request.
+
+## Usage - following examples based on vstart environment built in ceph/build and commands invoked from ceph/build
+
+* Create Zonegroup placement info for a Storage Class (QLC_CLASS in this example) and point class to a data pool (qlc_pool in this example)
+NOTE: RGW will need restarted due to the Zonegroup placement info change.
+See: https://docs.ceph.com/en/latest/radosgw/placement/#zonegroup-zone-configuration for more information.
+
+```bash
+# Create Storage Class
+./bin/radosgw-admin zonegroup placement add --rgw-zonegroup default --placement-id default-placement --storage-class QLC_CLASS
+# Steer objects in QLC_CLASS to the qlc_pool data pool
+./bin/radosgw-admin zone placement add --rgw-zone default --placement-id default-placement --storage-class QLC_CLASS --data-pool qlc_pool
+```
+* Restart radosgw for Zone/ZoneGroup placement changes to take effect.
+
+* Upload the script:
+
+```bash
+./bin/radosgw-admin script put --infile=storage_class.lua --context=preRequest
+```
+
+* Create a bucket and put and object with a Storage Class header (no modification will occur):
+```bash
+aws --profile=ceph --endpoint=http://localhost:8000 s3api create-bucket --bucket test-bucket
+aws --profile=ceph --endpoint=http://localhost:8000 s3api put-object --bucket test-bucket --key truv-0 --body ./64KiB_object.bin --storage-class STANDARD
+```
+
+* Send a request without a Storage Class header (Storage Class will be changed to QLC_CLASS by Lua script):
+```bash
+aws --profile=ceph --endpoint=http://localhost:8000 s3api put-object --bucket test-bucket --key truv-0 --body ./64KiB_object.bin
+```
+NOTE: If you use s3cmd instead of aws command-line, s3cmd adds "STANDARD" StorageClass to any put request so the example Lua script will not modify it.
+
+* Verify S3 object had its StorageClass header added
+```bash
+grep Lua ceph/build/out/radosgw.8000.log
+
+2021-11-01T17:10:14.048-0400 7f9c7f697640 20 Lua INFO: Put_Obj with StorageClass:
+2021-11-01T17:10:14.048-0400 7f9c7f697640 20 Lua INFO: No StorageClass for Object and size >= threshold: truv-0 adding QLC StorageClass
+```
+
+## Requirements
+* Lua 5.3
+


### PR DESCRIPTION
Admins may setup different pools for RGW objects and
having the StorageClass field mutable allows the steering
of RGW objects to the proper pools.  This Lua example shows
how a user can modify the StorageClass header when
it is empty on an PUT request.

Signed-off-by: Curt Bruns <curt.e.bruns@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
