### PR TITLE
Revert "Merge pull request #42099 from aclamk/wip-bluefs-fine-grain-locking-2"

### DIFF
--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -121,11 +121,6 @@ public:
     std::atomic_int num_reading;
 
     void* vselector_hint = nullptr;
-    /* lock protects fnode and other the parts that can be modified during read & write operations.
-       Does not protect values that are fixed
-       Does not need to be taken when doing one-time operations:
-       _replay, device_migrate_to_existing, device_migrate_to_new */
-    ceph::mutex lock = ceph::make_mutex("BlueFS::File::lock");
 
   private:
     FRIEND_MAKE_REF(File);
@@ -309,6 +304,8 @@ public:
   };
 
 private:
+  ceph::mutex lock = ceph::make_mutex("BlueFS::lock");
+
   PerfCounters *logger = nullptr;
 
   uint64_t max_bytes[MAX_BDEV] = {0};
@@ -319,35 +316,26 @@ private:
   };
 
   // cache
-  struct {
-    ceph::mutex lock = ceph::make_mutex("BlueFS::nodes.lock");
-    mempool::bluefs::map<std::string, DirRef, std::less<>> dir_map; ///< dirname -> Dir
-    mempool::bluefs::unordered_map<uint64_t, FileRef> file_map;     ///< ino -> File
-  } nodes;
+  mempool::bluefs::map<std::string, DirRef, std::less<>> dir_map;          ///< dirname -> Dir
+  mempool::bluefs::unordered_map<uint64_t, FileRef> file_map; ///< ino -> File
+
+  // map of dirty files, files of same dirty_seq are grouped into list.
+  std::map<uint64_t, dirty_file_list_t> dirty_files;
 
   bluefs_super_t super;        ///< latest superblock (as last written)
   uint64_t ino_last = 0;       ///< last assigned ino (this one is in use)
+  uint64_t log_seq = 0;        ///< last used log seq (by current pending log_t)
+  uint64_t log_seq_stable = 0; ///< last stable/synced log seq
+  FileWriter *log_writer = 0;  ///< writer for the log
+  bluefs_transaction_t log_t;  ///< pending, unwritten log transaction
+  bool log_flushing = false;   ///< true while flushing the log
+  ceph::condition_variable log_cond;
 
-  struct {
-    ceph::mutex lock = ceph::make_mutex("BlueFS::log.lock");
-    //uint64_t seq_stable = 0; //seq that is now stable on disk    AK - consider also mirroring this
-    uint64_t seq_live = 1;   //seq that log is currently writing to; mirrors dirty.seq_live
-    FileWriter *writer = 0;
-    bluefs_transaction_t t;
-  } log;
+  uint64_t new_log_jump_to = 0;
+  uint64_t old_log_jump_to = 0;
+  FileRef new_log = nullptr;
+  FileWriter *new_log_writer = nullptr;
 
-  struct {
-    ceph::mutex lock = ceph::make_mutex("BlueFS::dirty.lock");
-    uint64_t seq_stable = 0; //seq that is now stable on disk
-    uint64_t seq_live = 1;   //seq that is ongoing and dirty files will be written to
-    // map of dirty files, files of same dirty_seq are grouped into list.
-    std::map<uint64_t, dirty_file_list_t> files;
-  } dirty;
-
-  ceph::condition_variable log_cond;                             ///< used for state control between log flush / log compaction
-  std::atomic<bool> log_is_compacting{false};                    ///< signals that bluefs log is already ongoing compaction
-  std::atomic<bool> log_forbidden_to_expand{false};              ///< used to signal that async compaction is in state
-                                                                 ///  that prohibits expansion of bluefs log
   /*
    * There are up to 3 block devices:
    *
@@ -361,11 +349,6 @@ private:
   std::vector<Allocator*> alloc;                   ///< allocators for bdevs
   std::vector<uint64_t> alloc_size;                ///< alloc size for each device
   std::vector<interval_set<uint64_t>> pending_release; ///< extents to release
-  // TODO: it should be examined what makes pending_release immune to
-  // eras in a way similar to dirty_files. Hints:
-  // 1) we have actually only 2 eras: log_seq and log_seq+1
-  // 2) we usually not remove extents from files. And when we do, we force log-syncing.
-
   //std::vector<interval_set<uint64_t>> block_unused_too_granular;
 
   BlockDevice::aio_callback_t discard_cb[3]; //discard callbacks for each dev
@@ -397,7 +380,7 @@ private:
 
 
   FileRef _get_file(uint64_t ino);
-  void _drop_link_D(FileRef f);
+  void _drop_link(FileRef f);
 
   unsigned _get_slow_device_id() {
     return bdev[BDEV_SLOW] ? BDEV_SLOW : BDEV_DB;
@@ -409,32 +392,22 @@ private:
 				 PExtentVector* extents);
 
   /* signal replay log to include h->file in nearest log flush */
-  int _signal_dirty_to_log_D(FileWriter *h);
-  int _flush_range_F(FileWriter *h, uint64_t offset, uint64_t length);
-  int _flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered);
-  int _flush_F(FileWriter *h, bool force, bool *flushed = nullptr);
-  int _flush_special(FileWriter *h);
-  int _fsync(FileWriter *h);
+  int _signal_dirty_to_log(FileWriter *h);
+  int _flush_range(FileWriter *h, uint64_t offset, uint64_t length);
+  int _flush(FileWriter *h, bool force, std::unique_lock<ceph::mutex>& l);
+  int _flush(FileWriter *h, bool force, bool *flushed = nullptr);
+  int _fsync(FileWriter *h, std::unique_lock<ceph::mutex>& l);
 
 #ifdef HAVE_LIBAIO
   void _claim_completed_aios(FileWriter *h, std::list<aio_t> *ls);
-  void _wait_for_aio(FileWriter *h);  // safe to call without a lock
+  void wait_for_aio(FileWriter *h);  // safe to call without a lock
 #endif
 
-  int64_t _maybe_extend_log();
-  void _extend_log();
-  uint64_t _log_advance_seq();
-  void _consume_dirty(uint64_t seq);
-  void _clear_dirty_set_stable_D(uint64_t seq_stable);
-  void _release_pending_allocations(std::vector<interval_set<uint64_t>>& to_release);
-
-  void _flush_and_sync_log_core(int64_t available_runway);
-  int _flush_and_sync_log_jump_D(uint64_t jump_to,
-			       int64_t available_runway);
-  int _flush_and_sync_log_LD(uint64_t want_seq = 0);
-
-  uint64_t _estimate_log_size_N();
-  bool _should_start_compact_log_L_N();
+  int _flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
+			  uint64_t want_seq = 0,
+			  uint64_t jump_to = 0);
+  uint64_t _estimate_log_size();
+  bool _should_compact_log();
 
   enum {
     REMOVE_DB = 1,
@@ -442,15 +415,12 @@ private:
     RENAME_SLOW2DB = 4,
     RENAME_DB2SLOW = 8,
   };
-  void _compact_log_dump_metadata_N(bluefs_transaction_t *t,
-				 int flags);
-  void compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
-					  uint64_t capture_before_seq);
+  void _compact_log_dump_metadata(bluefs_transaction_t *t,
+				  int flags);
+  void _compact_log_sync();
+  void _compact_log_async(std::unique_lock<ceph::mutex>& l);
 
-  void _compact_log_sync_LN_LD();
-  void _compact_log_async_LD_NF_D();
-
-  void _rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
+  void _rewrite_log_and_layout_sync(bool allocate_with_fallback,
 				    int super_dev,
 				    int log_dev,
 				    int new_log_dev,
@@ -459,9 +429,9 @@ private:
 
   //void _aio_finish(void *priv);
 
-  void _flush_bdev(FileWriter *h);
-  void _flush_bdev();  // this is safe to call without a lock
-  void _flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs);  // this is safe to call without a lock
+  void _flush_bdev_safely(FileWriter *h);
+  void flush_bdev();  // this is safe to call without a lock
+  void flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs);  // this is safe to call without a lock
 
   int _preallocate(FileRef f, uint64_t off, uint64_t len);
   int _truncate(FileWriter *h, uint64_t off);
@@ -478,6 +448,8 @@ private:
     uint64_t len,    ///< [in] this many bytes
     char *out);      ///< [out] optional: or copy it here
 
+  void _invalidate_cache(FileRef f, uint64_t offset, uint64_t length);
+
   int _open_super();
   int _write_super(int dev);
   int _check_allocations(const bluefs_fnode_t& fnode,
@@ -490,7 +462,6 @@ private:
   int _replay(bool noop, bool to_stdout = false); ///< replay journal
 
   FileWriter *_create_writer(FileRef f);
-  void _drain_writer(FileWriter *h);
   void _close_writer(FileWriter *h);
 
   // always put the super in the second 4k block.  FIXME should this be
@@ -556,8 +527,10 @@ public:
     FileReader **h,
     bool random = false);
 
-  // data added after last fsync() is lost
-  void close_writer(FileWriter *h);
+  void close_writer(FileWriter *h) {
+    std::lock_guard l(lock);
+    _close_writer(h);
+  }
 
   int rename(std::string_view old_dir, std::string_view old_file,
 	     std::string_view new_dir, std::string_view new_file);
@@ -581,7 +554,7 @@ public:
   /// sync any uncommitted state to disk
   void sync_metadata(bool avoid_compact);
   /// test and compact log, if necessary
-  void _maybe_compact_log_LN_NF_LD_D();
+  void _maybe_compact_log(std::unique_lock<ceph::mutex>& l);
 
   void set_volume_selector(BlueFSVolumeSelector* s) {
     vselector.reset(s);
@@ -603,11 +576,42 @@ public:
   // handler for discard event
   void handle_discard(unsigned dev, interval_set<uint64_t>& to_release);
 
-  void flush(FileWriter *h, bool force = false);
+  void flush(FileWriter *h, bool force = false) {
+    std::unique_lock l(lock);
+    int r = _flush(h, force, l);
+    ceph_assert(r == 0);
+  }
 
-  void append_try_flush(FileWriter *h, const char* buf, size_t len);
-  void flush_range(FileWriter *h, uint64_t offset, uint64_t length);
-  int fsync(FileWriter *h);
+  void append_try_flush(FileWriter *h, const char* buf, size_t len) {
+    size_t max_size = 1ull << 30; // cap to 1GB
+    while (len > 0) {
+      bool need_flush = true;
+      auto l0 = h->get_buffer_length();
+      if (l0 < max_size) {
+	size_t l = std::min(len, max_size - l0);
+	h->append(buf, l);
+	buf += l;
+	len -= l;
+	need_flush = h->get_buffer_length() >= cct->_conf->bluefs_min_flush_size;
+      }
+      if (need_flush) {
+	flush(h, true);
+	// make sure we've made any progress with flush hence the
+	// loop doesn't iterate forever
+	ceph_assert(h->get_buffer_length() < max_size);
+      }
+    }
+  }
+  void flush_range(FileWriter *h, uint64_t offset, uint64_t length) {
+    std::lock_guard l(lock);
+    _flush_range(h, offset, length);
+  }
+  int fsync(FileWriter *h) {
+    std::unique_lock l(lock);
+    int r = _fsync(h, l);
+    _maybe_compact_log(l);
+    return r;
+  }
   int64_t read(FileReader *h, uint64_t offset, size_t len,
 	   ceph::buffer::list *outbl, char *out) {
     // no need to hold the global lock here; we only touch h and
@@ -622,14 +626,23 @@ public:
     // atomics and asserts).
     return _read_random(h, offset, len, out);
   }
-  void invalidate_cache(FileRef f, uint64_t offset, uint64_t len);
-  int preallocate(FileRef f, uint64_t offset, uint64_t len);
-  int truncate(FileWriter *h, uint64_t offset);
-  int _do_replay_recovery_read(FileReader *log,
-			       size_t log_pos,
-			       size_t read_offset,
-			       size_t read_len,
-			       bufferlist* bl);
+  void invalidate_cache(FileRef f, uint64_t offset, uint64_t len) {
+    std::lock_guard l(lock);
+    _invalidate_cache(f, offset, len);
+  }
+  int preallocate(FileRef f, uint64_t offset, uint64_t len) {
+    std::lock_guard l(lock);
+    return _preallocate(f, offset, len);
+  }
+  int truncate(FileWriter *h, uint64_t offset) {
+    std::lock_guard l(lock);
+    return _truncate(h, offset);
+  }
+  int do_replay_recovery_read(FileReader *log,
+			      size_t log_pos,
+			      size_t read_offset,
+			      size_t read_len,
+			      bufferlist* bl);
 
   size_t probe_alloc_avail(int dev, uint64_t alloc_size);
 
@@ -695,22 +708,5 @@ public:
 
   void get_paths(const std::string& base, paths& res) const override;
 };
-/**
- * Directional graph of locks.
- * Vertices - Locks. Edges (directed) - locking progression.
- * Edge A->B exist if last taken lock was A and next taken lock is B.
- * 
- * Column represents last lock taken.
- * Row represents next lock taken.
- *
- *     <        | L | D | N | F | W
- * -------------|---|---|---|---|---
- * log        L |     <   <         
- * dirty      D |                   
- * nodes      N |             <     
- * File       F |                  
- * FileWriter W | <   <       <      
- * 
- * Claim: Deadlock is possible IFF graph contains cycles.
- */
+
 #endif


### PR DESCRIPTION
This reverts commit 44e89c613c6b882f3436714fdaa6c9c04b94b62d, reversing
changes made to 552ac6657753f00f039f267e20e5a4c399c2bb10.

This is causing failures in
ObjectStore/StoreTestSpecificAUSize.SyntheticMatrixCsumVsCompression/2
and ObjectStore/StoreTestSpecificAUSize.SpilloverFixedTest/2




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>