### PR TITLE
cephadm: exclude zram and cdrom from device list

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6743,6 +6743,7 @@ class HostFacts():
     _disk_vendor_workarounds = {
         '0x1af4': 'Virtio Block Device'
     }
+    _excluded_block_devices = ('sr', 'zram', 'dm-')
 
     def __init__(self, ctx: CephadmContext):
         self.ctx: CephadmContext = ctx
@@ -6782,7 +6783,7 @@ class HostFacts():
         # type: () -> List[str]
         """Determine the list of block devices by looking at /sys/block"""
         return [dev for dev in os.listdir('/sys/block')
-                if not dev.startswith('dm')]
+                if not dev.startswith(HostFacts._excluded_block_devices)]
 
     def _get_devs_by_type(self, rota='0'):
         # type: (str) -> List[str]


### PR DESCRIPTION
When compiling eligible block devices, we need to exclude zram* and cdrom (srX) devices.

Fixes: https://tracker.ceph.com/issues/52905

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>

## Checklist
- [X] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
