### PR TITLE
crimson/tools/store_nbd/fs_driver: fix mount and mkfs to handle new mkfs signature

### DIFF
--- a/src/crimson/tools/store_nbd/fs_driver.cc
+++ b/src/crimson/tools/store_nbd/fs_driver.cc
@@ -199,7 +199,18 @@ seastar::future<> FSDriver::mkfs()
     init();
     return fs->start();
   }).then([this] {
-    return fs->mount();
+    return fs->mount(
+    ).handle_error(
+      crimson::stateful_ec::handle([] (const auto& ec) {
+        crimson::get_logger(
+	  ceph_subsys_test
+	).error(
+	  "error mounting object store in {}: ({}) {}",
+	  crimson::common::local_conf().get_val<std::string>("osd_data"),
+	  ec.value(),
+	  ec.message());
+	std::exit(EXIT_FAILURE);
+      }));
   }).then([this] {
     return seastar::do_for_each(
       boost::counting_iterator<unsigned>(0),
@@ -231,7 +242,18 @@ seastar::future<> FSDriver::mount()
     init();
     return fs->start();
   }).then([this] {
-    return fs->mount();
+    return fs->mount(
+    ).handle_error(
+      crimson::stateful_ec::handle([] (const auto& ec) {
+        crimson::get_logger(
+	  ceph_subsys_test
+	).error(
+	  "error mounting object store in {}: ({}) {}",
+	  crimson::common::local_conf().get_val<std::string>("osd_data"),
+	  ec.value(),
+	  ec.message());
+        std::exit(EXIT_FAILURE);
+      }));
   }).then([this] {
     return seastar::do_for_each(
       boost::counting_iterator<unsigned>(0),


### PR DESCRIPTION
Introduced: e5f7ff
Fixes: https://tracker.ceph.com/issues/53012
Signed-off-by: Samuel Just <sjust@redhat.com>