### PR TITLE
pacific: mgr/dashboard,prometheus: fix handling of server_addr

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -109,8 +109,6 @@ class CherryPyConfig(object):
         else:
             server_port = self.get_localized_module_option('ssl_server_port', 8443)  # type: ignore
 
-        if server_addr == '::':
-            server_addr = self.get_mgr_ip()  # type: ignore
         if server_addr is None:
             raise ServerConfigException(
                 'no server_addr configured; '
@@ -193,6 +191,8 @@ class CherryPyConfig(object):
         self._url_prefix = prepare_url_prefix(self.get_module_option(  # type: ignore
             'url_prefix', default=''))
 
+        if server_addr in ['::', '0.0.0.0']:
+            server_addr = self.get_mgr_ip()  # type: ignore
         base_url = build_url(
             scheme='https' if use_ssl else 'http',
             host=server_addr,

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1374,17 +1374,17 @@ class Module(MgrModule):
 
         self.metrics_thread.start()
 
+        cherrypy.config.update({
+            'server.socket_host': server_addr,
+            'server.socket_port': server_port,
+            'engine.autoreload.on': False
+        })
         # Publish the URI that others may use to access the service we're
         # about to start serving
         if server_addr in ['::', '0.0.0.0']:
             server_addr = self.get_mgr_ip()
         self.set_uri(build_url(scheme='http', host=server_addr, port=server_port, path='/'))
 
-        cherrypy.config.update({
-            'server.socket_host': server_addr,
-            'server.socket_port': server_port,
-            'engine.autoreload.on': False
-        })
         cherrypy.tree.mount(Root(), "/")
         self.log.info('Starting engine...')
         cherrypy.engine.start()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52803

---

backport of https://github.com/ceph/ceph/pull/42716
parent tracker: https://tracker.ceph.com/issues/52002

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh