### PR TITLE
mgr/cephadm: improve agent responsiveness

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3484,7 +3484,8 @@ class MgrListener(Thread):
                         logger.error(err_str)
                     else:
                         conn.send(b'ACK')
-                        self.agent.wakeup()
+                        self.agent.ls_gatherer.wakeup()
+                        self.agent.volume_gatherer.wakeup()
                         logger.debug(f'Got mgr message {data}')
             except Exception as e:
                 logger.error(f'Mgr Listener encountered exception: {e}')
@@ -3522,10 +3523,18 @@ class CephadmAgent():
         self.ack = 1
         self.event = Event()
         self.mgr_listener = MgrListener(self)
+        self.ls_gatherer = LsGatherer(self)
+        self.ls_event = Event()
+        self.volume_gatherer = VolumeGatherer(self)
+        self.volume_event = Event()
         self.device_enhanced_scan = False
         self.recent_iteration_run_times: List[float] = [0.0, 0.0, 0.0]
         self.recent_iteration_index: int = 0
         self.cached_ls_values: Dict[str, Dict[str, str]] = {}
+        self.ls: Optional[List[Dict[str, str]]] = None
+        self.ls_ack = 0
+        self.volume: str = ''
+        self.volume_ack = 0
 
     def deploy_daemon_unit(self, config: Dict[str, str] = {}) -> None:
         if not config:
@@ -3630,6 +3639,12 @@ WantedBy=ceph-{fsid}.target
         if not self.mgr_listener.is_alive():
             self.mgr_listener.start()
 
+        if not self.ls_gatherer.is_alive():
+            self.ls_gatherer.start()
+
+        if not self.volume_gatherer.is_alive():
+            self.volume_gatherer.start()
+
         ssl_ctx = ssl.create_default_context()
         ssl_ctx.check_hostname = True
         ssl_ctx.verify_mode = ssl.CERT_REQUIRED
@@ -3638,11 +3653,6 @@ WantedBy=ceph-{fsid}.target
         while not self.stop:
             start_time = time.monotonic()
             ack = self.ack
-            try:
-                volume = self._ceph_volume(self.device_enhanced_scan)
-            except Exception as e:
-                logger.error(f'Failed to get ceph-volume metadata: {e}')
-                volume = ''
 
             # part of the networks info is returned as a set which is not JSON
             # serializable. The set must be converted to a list
@@ -3653,10 +3663,10 @@ WantedBy=ceph-{fsid}.target
                     networks_list[key] = {k: list(v)}
 
             data = json.dumps({'host': self.host,
-                              'ls': self._get_ls(),
+                               'ls': self.ls if self.ack == self.ls_ack else [],
                                'networks': networks_list,
                                'facts': HostFacts(self.ctx).dump(),
-                               'volume': volume,
+                               'volume': self.volume if self.ack == self.volume_ack else '',
                                'ack': str(ack),
                                'keyring': self.keyring,
                                'port': self.listener_port})
@@ -3809,6 +3819,84 @@ WantedBy=ceph-{fsid}.target
             else:
                 ls = [info for daemon, info in self.cached_ls_values.items()]
         return ls
+
+
+class LsGatherer(Thread):
+    def __init__(self, agent: 'CephadmAgent') -> None:
+        self.agent = agent
+        self.stop = False
+        self.recent_iteration_run_times: List[float] = [0.0, 0.0, 0.0]
+        self.recent_iteration_index: int = 0
+        super(LsGatherer, self).__init__(target=self.run)
+
+    def run(self) -> None:
+        while not self.stop:
+            try:
+                start_time = time.monotonic()
+
+                ack = self.agent.ack
+                self.agent.ls = self.agent._get_ls()
+                if ack != self.agent.ls_ack:
+                    self.agent.ls_ack = ack
+                    self.agent.wakeup()
+
+                end_time = time.monotonic()
+                run_time = datetime.timedelta(seconds=(end_time - start_time))
+                self.recent_iteration_run_times[self.recent_iteration_index] = run_time.total_seconds()
+                self.recent_iteration_index = (self.recent_iteration_index + 1) % 3
+                run_time_average = sum(self.recent_iteration_run_times, 0.0) / len([t for t in self.recent_iteration_run_times if t])
+
+                self.agent.ls_event.wait(max(self.agent.loop_interval - int(run_time_average), 0))
+                self.agent.ls_event.clear()
+            except Exception as e:
+                logger.error(f'Ls Gatherer encountered exception: {e}')
+
+    def shutdown(self) -> None:
+        self.stop = True
+
+    def wakeup(self) -> None:
+        self.agent.ls_event.set()
+
+
+class VolumeGatherer(Thread):
+    def __init__(self, agent: 'CephadmAgent') -> None:
+        self.agent = agent
+        self.stop = False
+        self.recent_iteration_run_times: List[float] = [0.0, 0.0, 0.0]
+        self.recent_iteration_index: int = 0
+        super(VolumeGatherer, self).__init__(target=self.run)
+
+    def run(self) -> None:
+        while not self.stop:
+            try:
+                start_time = time.monotonic()
+
+                ack = self.agent.ack
+                try:
+                    self.agent.volume = self.agent._ceph_volume(self.agent.device_enhanced_scan)
+                except Exception as e:
+                    logger.error(f'Failed to get ceph-volume metadata: {e}')
+                    self.agent.volume = ''
+                if ack != self.agent.volume_ack:
+                    self.agent.volume_ack = ack
+                    self.agent.wakeup()
+
+                end_time = time.monotonic()
+                run_time = datetime.timedelta(seconds=(end_time - start_time))
+                self.recent_iteration_run_times[self.recent_iteration_index] = run_time.total_seconds()
+                self.recent_iteration_index = (self.recent_iteration_index + 1) % 3
+                run_time_average = sum(self.recent_iteration_run_times, 0.0) / len([t for t in self.recent_iteration_run_times if t])
+
+                self.agent.volume_event.wait(max(self.agent.loop_interval - int(run_time_average), 0))
+                self.agent.volume_event.clear()
+            except Exception as e:
+                logger.error(f'Ls Gatherer encountered exception: {e}')
+
+    def shutdown(self) -> None:
+        self.stop = True
+
+    def wakeup(self) -> None:
+        self.agent.volume_event.set()
 
 
 def command_agent(ctx: CephadmContext) -> None:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3525,6 +3525,7 @@ class CephadmAgent():
         self.device_enhanced_scan = False
         self.recent_iteration_run_times: List[float] = [0.0, 0.0, 0.0]
         self.recent_iteration_index: int = 0
+        self.cached_ls_values: Dict[str, Dict[str, str]] = {}
 
     def deploy_daemon_unit(self, config: Dict[str, str] = {}) -> None:
         if not config:
@@ -3652,7 +3653,7 @@ WantedBy=ceph-{fsid}.target
                     networks_list[key] = {k: list(v)}
 
             data = json.dumps({'host': self.host,
-                              'ls': list_daemons(self.ctx),
+                              'ls': self._get_ls(),
                                'networks': networks_list,
                                'facts': HostFacts(self.ctx).dump(),
                                'volume': volume,
@@ -3693,6 +3694,121 @@ WantedBy=ceph-{fsid}.target
             return stdout
         else:
             raise Exception('ceph-volume returned empty value')
+
+    def _daemon_ls_subset(self) -> Dict[str, Dict[str, Any]]:
+        # gets a subset of ls info quickly. The results of this will tell us if our
+        # cached info is still good or if we need to run the full ls again.
+        # for legacy containers, we just grab the full info. For cephadmv1 containers,
+        # we only grab enabled, state, mem_usage and container id. If container id has
+        # not changed for any daemon, we assume our cached info is good.
+        daemons: Dict[str, Dict[str, Any]] = {}
+        data_dir = self.ctx.data_dir
+        seen_memusage = {}  # type: Dict[str, int]
+        out, err, code = call(
+            self.ctx,
+            [self.ctx.container_engine.path, 'stats', '--format', '{{.ID}},{{.MemUsage}}', '--no-stream'],
+            verbosity=CallVerbosity.DEBUG
+        )
+        seen_memusage_cid_len, seen_memusage = _parse_mem_usage(code, out)
+        # we need a mapping from container names to ids. Later we will convert daemon
+        # names to container names to get daemons container id to see if it has changed
+        out, err, code = call(
+            self.ctx,
+            [self.ctx.container_engine.path, 'ps', '--format', '{{.ID}},{{.Names}}', '--no-trunc'],
+            verbosity=CallVerbosity.DEBUG
+        )
+        name_id_mapping: Dict[str, str] = self._parse_container_id_name(code, out)
+        for i in os.listdir(data_dir):
+            if i in ['mon', 'osd', 'mds', 'mgr']:
+                daemon_type = i
+                for j in os.listdir(os.path.join(data_dir, i)):
+                    if '-' not in j:
+                        continue
+                    (cluster, daemon_id) = j.split('-', 1)
+                    legacy_unit_name = 'ceph-%s@%s' % (daemon_type, daemon_id)
+                    (enabled, state, _) = check_unit(self.ctx, legacy_unit_name)
+                    daemons[f'{daemon_type}.{daemon_id}'] = {
+                        'style': 'legacy',
+                        'name': '%s.%s' % (daemon_type, daemon_id),
+                        'fsid': self.ctx.fsid if self.ctx.fsid is not None else 'unknown',
+                        'systemd_unit': legacy_unit_name,
+                        'enabled': 'true' if enabled else 'false',
+                        'state': state,
+                    }
+            elif is_fsid(i):
+                fsid = str(i)  # convince mypy that fsid is a str here
+                for j in os.listdir(os.path.join(data_dir, i)):
+                    if '.' in j and os.path.isdir(os.path.join(data_dir, fsid, j)):
+                        (daemon_type, daemon_id) = j.split('.', 1)
+                        unit_name = get_unit_name(fsid, daemon_type, daemon_id)
+                        (enabled, state, _) = check_unit(self.ctx, unit_name)
+                        daemons[j] = {
+                            'style': 'cephadm:v1',
+                            'systemd_unit': unit_name,
+                            'enabled': 'true' if enabled else 'false',
+                            'state': state,
+                        }
+                        c = CephContainer.for_daemon(self.ctx, self.ctx.fsid, daemon_type, daemon_id, 'bash')
+                        container_id: Optional[str] = None
+                        for name in (c.cname, c.old_cname):
+                            if name in name_id_mapping:
+                                container_id = name_id_mapping[name]
+                                break
+                        daemons[j]['container_id'] = container_id
+                        if container_id:
+                            daemons[j]['memory_usage'] = seen_memusage.get(container_id[0:seen_memusage_cid_len])
+        return daemons
+
+    def _parse_container_id_name(self, code: int, out: str) -> Dict[str, str]:
+        # map container names to ids from ps output
+        name_id_mapping = {}  # type: Dict[str, str]
+        if not code:
+            for line in out.splitlines():
+                id, name = line.split(',')
+                name_id_mapping[name] = id
+        return name_id_mapping
+
+    def _get_ls(self) -> List[Dict[str, str]]:
+        if not self.cached_ls_values:
+            logger.info('No cached ls output. Running full daemon ls')
+            ls = list_daemons(self.ctx)
+            for d in ls:
+                self.cached_ls_values[d['name']] = d
+        else:
+            ls_subset = self._daemon_ls_subset()
+            need_full_ls = False
+            if set(self.cached_ls_values.keys()) != set(ls_subset.keys()):
+                # case for a new daemon in ls or an old daemon no longer appearing.
+                # If that happens we need a full ls
+                logger.info('Change detected in state of daemons. Running full daemon ls')
+                ls = list_daemons(self.ctx)
+                for d in ls:
+                    self.cached_ls_values[d['name']] = d
+                return ls
+            for daemon, info in self.cached_ls_values.items():
+                if info['style'] == 'legacy':
+                    # for legacy containers, ls_subset just grabs all the info
+                    self.cached_ls_values[daemon] = ls_subset[daemon]
+                else:
+                    if info['container_id'] != ls_subset[daemon]['container_id']:
+                        # case for container id having changed. We need full ls as
+                        # info we didn't grab like version and start time could have changed
+                        need_full_ls = True
+                        break
+                    # if we reach here, container id matched. Update the few values we do track
+                    # from ls subset: state, enabled, memory_usage.
+                    self.cached_ls_values[daemon]['enabled'] = ls_subset[daemon]['enabled']
+                    self.cached_ls_values[daemon]['state'] = ls_subset[daemon]['state']
+                    if 'memory_usage' in ls_subset[daemon]:
+                        self.cached_ls_values[daemon]['memory_usage'] = ls_subset[daemon]['memory_usage']
+            if need_full_ls:
+                logger.info('Change detected in state of daemons. Running full daemon ls')
+                ls = list_daemons(self.ctx)
+                for d in ls:
+                    self.cached_ls_values[d['name']] = d
+            else:
+                ls = [info for daemon, info in self.cached_ls_values.items()]
+        return ls
 
 
 def command_agent(ctx: CephadmContext) -> None:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3684,7 +3684,7 @@ WantedBy=ceph-{fsid}.target
             self.event.wait(max(self.loop_interval - int(run_time_average), 0))
             self.event.clear()
 
-    def _ceph_volume(self, enhanced: bool = False) -> str:
+    def _ceph_volume(self, enhanced: bool = False) -> Tuple[str, bool]:
         self.ctx.command = 'inventory --format=json'.split()
         if enhanced:
             self.ctx.command.append('--with-lsm')
@@ -3697,7 +3697,7 @@ WantedBy=ceph-{fsid}.target
         stdout = stream.getvalue()
 
         if stdout:
-            return stdout
+            return (stdout, False)
         else:
             raise Exception('ceph-volume returned empty value')
 
@@ -3774,15 +3774,17 @@ WantedBy=ceph-{fsid}.target
                 name_id_mapping[name] = id
         return name_id_mapping
 
-    def _get_ls(self) -> List[Dict[str, str]]:
+    def _get_ls(self) -> Tuple[List[Dict[str, str]], bool]:
         if not self.cached_ls_values:
             logger.info('No cached ls output. Running full daemon ls')
             ls = list_daemons(self.ctx)
             for d in ls:
                 self.cached_ls_values[d['name']] = d
+            return (ls, True)
         else:
             ls_subset = self._daemon_ls_subset()
             need_full_ls = False
+            state_change = False
             if set(self.cached_ls_values.keys()) != set(ls_subset.keys()):
                 # case for a new daemon in ls or an old daemon no longer appearing.
                 # If that happens we need a full ls
@@ -3790,7 +3792,7 @@ WantedBy=ceph-{fsid}.target
                 ls = list_daemons(self.ctx)
                 for d in ls:
                     self.cached_ls_values[d['name']] = d
-                return ls
+                return (ls, True)
             for daemon, info in self.cached_ls_values.items():
                 if info['style'] == 'legacy':
                     # for legacy containers, ls_subset just grabs all the info
@@ -3801,6 +3803,14 @@ WantedBy=ceph-{fsid}.target
                         # info we didn't grab like version and start time could have changed
                         need_full_ls = True
                         break
+
+                    # want to know if a daemons state change because in those cases we want
+                    # to report back quicker
+                    if (
+                        self.cached_ls_values[daemon]['enabled'] != ls_subset[daemon]['enabled']
+                        or self.cached_ls_values[daemon]['state'] != ls_subset[daemon]['state']
+                    ):
+                        state_change = True
                     # if we reach here, container id matched. Update the few values we do track
                     # from ls subset: state, enabled, memory_usage.
                     self.cached_ls_values[daemon]['enabled'] = ls_subset[daemon]['enabled']
@@ -3812,9 +3822,10 @@ WantedBy=ceph-{fsid}.target
                 ls = list_daemons(self.ctx)
                 for d in ls:
                     self.cached_ls_values[d['name']] = d
+                return (ls, True)
             else:
                 ls = [info for daemon, info in self.cached_ls_values.items()]
-        return ls
+                return (ls, state_change)
 
 
 class AgentGatherer(Thread):
@@ -3836,12 +3847,13 @@ class AgentGatherer(Thread):
                 start_time = time.monotonic()
 
                 ack = self.agent.ack
+                change = False
                 try:
-                    self.data = self.func()
+                    self.data, change = self.func()
                 except Exception as e:
                     logger.error(f'{self.gatherer_type} Gatherer encountered exception gathering data: {e}')
                     self.data = None
-                if ack != self.ack:
+                if ack != self.ack or change:
                     self.ack = ack
                     self.agent.wakeup()
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3519,7 +3519,7 @@ class CephadmAgent():
         self.listener_cert_path = os.path.join(self.daemon_dir, 'listener.crt')
         self.listener_key_path = os.path.join(self.daemon_dir, 'listener.key')
         self.listener_port = ''
-        self.ack = -1
+        self.ack = 1
         self.event = Event()
         self.mgr_listener = MgrListener(self)
         self.device_enhanced_scan = False

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3523,18 +3523,12 @@ class CephadmAgent():
         self.ack = 1
         self.event = Event()
         self.mgr_listener = MgrListener(self)
-        self.ls_gatherer = LsGatherer(self)
-        self.ls_event = Event()
-        self.volume_gatherer = VolumeGatherer(self)
-        self.volume_event = Event()
+        self.ls_gatherer = AgentGatherer(self, self._get_ls, 'Ls')
+        self.volume_gatherer = AgentGatherer(self, self._ceph_volume, 'Volume')
         self.device_enhanced_scan = False
         self.recent_iteration_run_times: List[float] = [0.0, 0.0, 0.0]
         self.recent_iteration_index: int = 0
         self.cached_ls_values: Dict[str, Dict[str, str]] = {}
-        self.ls: Optional[List[Dict[str, str]]] = None
-        self.ls_ack = 0
-        self.volume: str = ''
-        self.volume_ack = 0
 
     def deploy_daemon_unit(self, config: Dict[str, str] = {}) -> None:
         if not config:
@@ -3663,10 +3657,12 @@ WantedBy=ceph-{fsid}.target
                     networks_list[key] = {k: list(v)}
 
             data = json.dumps({'host': self.host,
-                               'ls': self.ls if self.ack == self.ls_ack else [],
+                               'ls': (self.ls_gatherer.data if self.ack == self.ls_gatherer.ack
+                                      and self.ls_gatherer.data is not None else []),
                                'networks': networks_list,
                                'facts': HostFacts(self.ctx).dump(),
-                               'volume': self.volume if self.ack == self.volume_ack else '',
+                               'volume': (self.volume_gatherer.data if self.ack == self.volume_gatherer.ack
+                                          and self.volume_gatherer.data is not None else ''),
                                'ack': str(ack),
                                'keyring': self.keyring,
                                'port': self.listener_port})
@@ -3821,50 +3817,18 @@ WantedBy=ceph-{fsid}.target
         return ls
 
 
-class LsGatherer(Thread):
-    def __init__(self, agent: 'CephadmAgent') -> None:
+class AgentGatherer(Thread):
+    def __init__(self, agent: 'CephadmAgent', func: Callable, gatherer_type: str = 'Unnamed', initial_ack: int = 0) -> None:
         self.agent = agent
+        self.func = func
+        self.gatherer_type = gatherer_type
+        self.ack = initial_ack
+        self.event = Event()
+        self.data: Any = None
         self.stop = False
         self.recent_iteration_run_times: List[float] = [0.0, 0.0, 0.0]
         self.recent_iteration_index: int = 0
-        super(LsGatherer, self).__init__(target=self.run)
-
-    def run(self) -> None:
-        while not self.stop:
-            try:
-                start_time = time.monotonic()
-
-                ack = self.agent.ack
-                self.agent.ls = self.agent._get_ls()
-                if ack != self.agent.ls_ack:
-                    self.agent.ls_ack = ack
-                    self.agent.wakeup()
-
-                end_time = time.monotonic()
-                run_time = datetime.timedelta(seconds=(end_time - start_time))
-                self.recent_iteration_run_times[self.recent_iteration_index] = run_time.total_seconds()
-                self.recent_iteration_index = (self.recent_iteration_index + 1) % 3
-                run_time_average = sum(self.recent_iteration_run_times, 0.0) / len([t for t in self.recent_iteration_run_times if t])
-
-                self.agent.ls_event.wait(max(self.agent.loop_interval - int(run_time_average), 0))
-                self.agent.ls_event.clear()
-            except Exception as e:
-                logger.error(f'Ls Gatherer encountered exception: {e}')
-
-    def shutdown(self) -> None:
-        self.stop = True
-
-    def wakeup(self) -> None:
-        self.agent.ls_event.set()
-
-
-class VolumeGatherer(Thread):
-    def __init__(self, agent: 'CephadmAgent') -> None:
-        self.agent = agent
-        self.stop = False
-        self.recent_iteration_run_times: List[float] = [0.0, 0.0, 0.0]
-        self.recent_iteration_index: int = 0
-        super(VolumeGatherer, self).__init__(target=self.run)
+        super(AgentGatherer, self).__init__(target=self.run)
 
     def run(self) -> None:
         while not self.stop:
@@ -3873,12 +3837,12 @@ class VolumeGatherer(Thread):
 
                 ack = self.agent.ack
                 try:
-                    self.agent.volume = self.agent._ceph_volume(self.agent.device_enhanced_scan)
+                    self.data = self.func()
                 except Exception as e:
-                    logger.error(f'Failed to get ceph-volume metadata: {e}')
-                    self.agent.volume = ''
-                if ack != self.agent.volume_ack:
-                    self.agent.volume_ack = ack
+                    logger.error(f'{self.gatherer_type} Gatherer encountered exception gathering data: {e}')
+                    self.data = None
+                if ack != self.ack:
+                    self.ack = ack
                     self.agent.wakeup()
 
                 end_time = time.monotonic()
@@ -3887,16 +3851,16 @@ class VolumeGatherer(Thread):
                 self.recent_iteration_index = (self.recent_iteration_index + 1) % 3
                 run_time_average = sum(self.recent_iteration_run_times, 0.0) / len([t for t in self.recent_iteration_run_times if t])
 
-                self.agent.volume_event.wait(max(self.agent.loop_interval - int(run_time_average), 0))
-                self.agent.volume_event.clear()
+                self.event.wait(max(self.agent.loop_interval - int(run_time_average), 0))
+                self.event.clear()
             except Exception as e:
-                logger.error(f'Ls Gatherer encountered exception: {e}')
+                logger.error(f'{self.gatherer_type} Gatherer encountered exception: {e}')
 
     def shutdown(self) -> None:
         self.stop = True
 
     def wakeup(self) -> None:
-        self.agent.volume_event.set()
+        self.event.set()
 
 
 def command_agent(ctx: CephadmContext) -> None:

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -321,22 +321,20 @@ class CephadmAgentHelpers:
         return False
 
     def _update_agent_down_healthcheck(self, down_agent_hosts: List[str]) -> None:
-        if 'CEPHADM_AGENT_DOWN' in self.mgr.health_checks:
-            del self.mgr.health_checks['CEPHADM_AGENT_DOWN']
+        self.mgr.remove_health_warning('CEPHADM_AGENT_DOWN')
         if down_agent_hosts:
             detail: List[str] = []
             for agent in down_agent_hosts:
                 detail.append((f'Cephadm agent on host {agent} has not reported in '
                               f'{2.5 * self.mgr.agent_refresh_rate} seconds. Agent is assumed '
                                'down and host may be offline.'))
-            self.mgr.health_checks['CEPHADM_AGENT_DOWN'] = {
-                'severity': 'warning',
-                'summary': '%d Cephadm Agent(s) are not reporting. '
-                'Hosts may be offline' % (len(down_agent_hosts)),
-                'count': len(down_agent_hosts),
-                'detail': detail,
-            }
-            self.mgr.set_health_checks(self.mgr.health_checks)
+            self.mgr.set_health_warning(
+                'CEPHADM_AGENT_DOWN',
+                summary='%d Cephadm Agent(s) are not reporting. Hosts may be offline' % (
+                    len(down_agent_hosts)),
+                count=len(down_agent_hosts),
+                detail=detail,
+            )
 
     # this function probably seems very unnecessary, but it makes it considerably easier
     # to get the unit tests working. All unit tests that check which daemons were deployed

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -204,7 +204,7 @@ class HostData:
                     f'Change detected in daemons in error state from {host} agent metadata. Kicking serve loop')
                 self.mgr._kick_serve_loop()
 
-            if up_to_date:
+            if up_to_date and ('ls' in data and data['ls']):
                 was_out_of_date = not self.mgr.cache.all_host_metadata_up_to_date()
                 self.mgr.cache.metadata_up_to_date[host] = True
                 if was_out_of_date and self.mgr.cache.all_host_metadata_up_to_date():

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -325,7 +325,7 @@ class CephadmAgentHelpers:
         if host not in [h.hostname for h in self.mgr.cache.get_non_draining_hosts()]:
             return False
         # if we haven't deployed an agent on the host yet, don't say an agent is down
-        if not [a for a in self.mgr.cache.get_daemons_by_type('agent') if a.hostname == host]:
+        if not self.mgr.cache.get_daemons_by_type('agent', host=host):
             return False
         # if we don't have a timestamp, it's likely because of a mgr fail over.
         # just set the timestamp to now. However, if host was offline before, we
@@ -421,8 +421,7 @@ class CephadmAgentHelpers:
 
                 try:
                     # try to schedule redeploy of agent in case it is individually down
-                    agent = [a for a in self.mgr.cache.get_daemons_by_type(
-                        'agent') if a.hostname == host][0]
+                    agent = self.mgr.cache.get_daemons_by_type('agent', host=host)[0]
                     with self.mgr.agent_helpers.agent_lock(host):
                         daemon_spec = CephadmDaemonDeploySpec.from_daemon_description(agent)
                         self.mgr._daemon_action(daemon_spec, action='redeploy')
@@ -432,8 +431,7 @@ class CephadmAgentHelpers:
             return True
         else:
             try:
-                agent = [a for a in self.mgr.cache.get_daemons_by_type(
-                    'agent') if a.hostname == host][0]
+                agent = self.mgr.cache.get_daemons_by_type('agent', host=host)[0]
                 assert agent.daemon_id is not None
                 assert agent.hostname is not None
             except Exception as e:

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -174,6 +174,7 @@ class HostData:
             self.mgr.cache.agent_timestamp[host] = datetime_now()
 
             error_daemons_old = set([dd.name() for dd in self.mgr.cache.get_error_daemons()])
+            daemon_count_old = len(self.mgr.cache.get_daemons_by_host(host))
 
             agents_down = []
             for h in self.mgr.cache.get_hosts():
@@ -204,9 +205,12 @@ class HostData:
                 ret = Devices.from_json(json.loads(data['volume']))
                 self.mgr.cache.update_host_devices(host, ret.devices)
 
-            if error_daemons_old != set([dd.name() for dd in self.mgr.cache.get_error_daemons()]):
+            if (
+                error_daemons_old != set([dd.name() for dd in self.mgr.cache.get_error_daemons()])
+                or daemon_count_old != len(self.mgr.cache.get_daemons_by_host(host))
+            ):
                 self.mgr.log.info(
-                    f'Change detected in daemons in error state from {host} agent metadata. Kicking serve loop')
+                    f'Change detected in state of daemons from {host} agent metadata. Kicking serve loop')
                 self.mgr._kick_serve_loop()
 
             if up_to_date and ('ls' in data and data['ls']):

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -817,8 +817,7 @@ class HostCache():
                 r.append(dd)
         return r
 
-    def get_error_daemons(self):
-        # type: () -> List[orchestrator.DaemonDescription]
+    def get_error_daemons(self) -> List[orchestrator.DaemonDescription]:
         r = []
         for host, dm in self.daemons.items():
             for name, dd in dm.items():
@@ -866,12 +865,13 @@ class HostCache():
                     result.append(d)
         return result
 
-    def get_daemons_by_type(self, service_type):
-        # type: (str) -> List[orchestrator.DaemonDescription]
+    def get_daemons_by_type(self, service_type: str, host: str = '') -> List[orchestrator.DaemonDescription]:
         assert service_type not in ['keepalived', 'haproxy']
 
         result = []   # type: List[orchestrator.DaemonDescription]
-        for host, dm in self.daemons.items():
+        for h, dm in self.daemons.items():
+            if host and h != host:
+                continue
             for name, d in dm.items():
                 if d.daemon_type in service_to_daemon_types(service_type):
                     result.append(d)
@@ -915,6 +915,8 @@ class HostCache():
             seconds=self.mgr.daemon_cache_timeout)
         if host not in self.last_daemon_update or self.last_daemon_update[host] < cutoff:
             return True
+        if not self.mgr.cache.host_metadata_up_to_date(host):
+            return True
         return False
 
     def host_needs_facts_refresh(self, host):
@@ -925,6 +927,8 @@ class HostCache():
         cutoff = datetime_now() - datetime.timedelta(
             seconds=self.mgr.facts_cache_timeout)
         if host not in self.last_facts_update or self.last_facts_update[host] < cutoff:
+            return True
+        if not self.mgr.cache.host_metadata_up_to_date(host):
             return True
         return False
 
@@ -961,6 +965,8 @@ class HostCache():
             seconds=self.mgr.device_cache_timeout)
         if host not in self.last_device_update or self.last_device_update[host] < cutoff:
             return True
+        if not self.mgr.cache.host_metadata_up_to_date(host):
+            return True
         return False
 
     def host_needs_network_refresh(self, host):
@@ -974,6 +980,8 @@ class HostCache():
         cutoff = datetime_now() - datetime.timedelta(
             seconds=self.mgr.device_cache_timeout)
         if host not in self.last_network_update or self.last_network_update[host] < cutoff:
+            return True
+        if not self.mgr.cache.host_metadata_up_to_date(host):
             return True
         return False
 

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -817,6 +817,15 @@ class HostCache():
                 r.append(dd)
         return r
 
+    def get_error_daemons(self):
+        # type: () -> List[orchestrator.DaemonDescription]
+        r = []
+        for host, dm in self.daemons.items():
+            for name, dd in dm.items():
+                if dd.status is not None and dd.status == orchestrator.DaemonDescriptionStatus.error:
+                    r.append(dd)
+        return r
+
     def get_daemons_by_host(self, host: str) -> List[orchestrator.DaemonDescription]:
         return list(self.daemons.get(host, {}).values())
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -732,11 +732,10 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def update_failed_daemon_health_check(self) -> None:
         self.remove_health_warning('CEPHADM_FAILED_DAEMON')
         failed_daemons = []
-        for dd in self.cache.get_daemons():
-            if dd.status is not None and dd.status == DaemonDescriptionStatus.error:
-                failed_daemons.append('daemon %s on %s is in %s state' % (
-                    dd.name(), dd.hostname, dd.status_desc
-                ))
+        for dd in self.cache.get_error_daemons():
+            failed_daemons.append('daemon %s on %s is in %s state' % (
+                dd.name(), dd.hostname, dd.status_desc
+            ))
         if failed_daemons:
             self.set_health_warning('CEPHADM_FAILED_DAEMON', f'{len(failed_daemons)} failed cephadm daemon(s)', len(
                 failed_daemons), failed_daemons)

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -909,12 +909,11 @@ class CephadmServe:
 
             if dd.daemon_type == 'agent':
                 try:
-                    assert self.mgr.cherrypy_thread
-                    assert self.mgr.cherrypy_thread.ssl_certs.get_root_cert()
+                    self.mgr.agent_helpers._check_agent(dd.hostname)
                 except Exception:
-                    self.log.info(
-                        f'Delaying checking {dd.name()} until cephadm endpoint finished creating root cert')
-                    continue
+                    self.log.debug(
+                        f'Agent {dd.name()} could not be checked in _check_daemons')
+                continue
 
             # These daemon types require additional configs after creation
             if dd.daemon_type in REQUIRES_POST_ACTIONS:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -261,47 +261,32 @@ class CephadmServe:
                 or host not in [h.hostname for h in self.mgr.cache.get_non_draining_hosts()]
                 or host in agents_down
             ):
-                if (
-                    self.mgr.cache.host_needs_daemon_refresh(host)
-                    or not self.mgr.cache.host_metadata_up_to_date(host)
-                ):
+                if self.mgr.cache.host_needs_daemon_refresh(host):
                     self.log.debug('refreshing %s daemons' % host)
                     r = self._refresh_host_daemons(host)
                     if r:
                         failures.append(r)
 
-                if (
-                    self.mgr.cache.host_needs_facts_refresh(host)
-                    or not self.mgr.cache.host_metadata_up_to_date(host)
-                ):
+                if self.mgr.cache.host_needs_facts_refresh(host):
                     self.log.debug(('Refreshing %s facts' % host))
                     r = self._refresh_facts(host)
                     if r:
                         failures.append(r)
 
-                if (
-                    self.mgr.cache.host_needs_network_refresh(host)
-                    or not self.mgr.cache.host_metadata_up_to_date(host)
-                ):
+                if self.mgr.cache.host_needs_network_refresh(host):
                     self.log.debug(('Refreshing %s networks' % host))
                     r = self._refresh_host_networks(host)
                     if r:
                         failures.append(r)
 
-                if (
-                    self.mgr.cache.host_needs_device_refresh(host)
-                    or not self.mgr.cache.host_metadata_up_to_date(host)
-                ):
+                if self.mgr.cache.host_needs_device_refresh(host):
                     self.log.debug('refreshing %s devices' % host)
                     r = self._refresh_host_devices(host)
                     if r:
                         failures.append(r)
                 self.mgr.cache.metadata_up_to_date[host] = True
-            elif not [a for a in self.mgr.cache.get_daemons_by_type('agent') if a.hostname == host]:
-                if (
-                    self.mgr.cache.host_needs_daemon_refresh(host)
-                    or not self.mgr.cache.host_metadata_up_to_date(host)
-                ):
+            elif not self.mgr.cache.get_daemons_by_type('agent', host=host):
+                if self.mgr.cache.host_needs_daemon_refresh(host):
                     self.log.debug('refreshing %s daemons' % host)
                     r = self._refresh_host_daemons(host)
                     if r:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1083,6 +1083,7 @@ class CephadmServe:
 
                 if daemon_spec.daemon_type == 'agent':
                     self.mgr.cache.agent_timestamp[daemon_spec.host] = datetime_now()
+                    self.mgr.cache.agent_counter[daemon_spec.host] = 1
 
                 # refresh daemon state?  (ceph daemon reconfig does not need it)
                 if not reconfig or daemon_spec.daemon_type not in CEPH_TYPES:


### PR DESCRIPTION
This includes a mix of changes to improve how fast we can respond to certain changes when using the agent.
It includes quicker reaction to new daemons entering/leaving an error state (by kicking the serve loop when
that is detected), faster reaction to agents being down or having new deps by checking for this more often,
more consistent response time from the agent by moving gathering of ls and volume data out of the agent's
main loop and finally using ssh as a fallback to quickly pick up metadata on hosts where an agent has gone down
to decrease time where we are without info on that host.

Signed-off-by: Adam King <adking@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
