### PR TITLE
mgr/dashboard: Proper error handling in module status guard

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
@@ -61,9 +61,15 @@ export class ModuleStatusGuardService implements CanActivate, CanActivateChild {
     const config = route.data['moduleStatusGuardConfig'];
     let backendCheck = false;
     if (config.backend) {
-      this.mgrModuleService.getConfig('orchestrator').subscribe((resp) => {
-        backendCheck = config.backend === resp['orchestrator'];
-      });
+      this.mgrModuleService.getConfig('orchestrator').subscribe(
+        (resp) => {
+          backendCheck = config.backend === resp['orchestrator'];
+        },
+        () => {
+          this.router.navigate([config.redirectTo]);
+          return observableOf(false);
+        }
+      );
     }
     return this.http.get(`api/${config.apiPath}/status`).pipe(
       map((resp: any) => {


### PR DESCRIPTION
I've recently introduced a check that verifies if the orch_backend we need for a feature matches the orch_backend of the cluster. But to verify this I need to call configOpt API and some user's don't have the permission to access it. So it'll show this Access Denied page. 

In the below examples I am logging in as a **read-only** user which doesn't have the configOpt permissions

**BEFORE**

https://user-images.githubusercontent.com/71764184/138654905-9f7a6f7e-2973-40bc-b545-dca0276ea94c.mov



**AFTER**

https://user-images.githubusercontent.com/71764184/138654947-a424dfb2-3e8f-4c51-8c46-03148a718216.mov




Fixes: https://tracker.ceph.com/issues/53021
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
