### PR TITLE
pacific: mgr/dashboard: pin a version for autopep8 and pyfakefs

### DIFF
--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -5,7 +5,7 @@ flake8-colors==0.1.6
 #flake8-docstrings
 #pep8-naming
 rstcheck==3.3.1
-autopep8
-pyfakefs
+autopep8==1.5.7
+pyfakefs==4.5.0
 isort==5.5.3
-pytest
+pytest==6.2.4


### PR DESCRIPTION
Pinned the version for `pytest` too which was not in master.

backport tracker: https://tracker.ceph.com/issues/53026

---

backport of https://github.com/ceph/ceph/pull/43642
parent tracker: https://tracker.ceph.com/issues/53024

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh