### PR TITLE
rgw/dbstore: add config to set sqlite performance tuning options

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3248,3 +3248,13 @@ options:
   - rgw
   flags:
   - startup
+- name: rgw_dbstore_pragma
+  type: str
+  level: advanced
+  desc: PRAGMA statements passed to the dbstore sqlite database
+  long_desc: defaults to buffered io performance optimized settings
+  default: PRAGMA journal_mode=OFF; PRAGMA synchronous=0; PRAGMA cache_size=32768; PRAGMA locking_mode=EXCLUSIVE; PRAGMA temp_store=MEMORY;
+  services:
+  - rgw
+  flags:
+  - startup

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.cc
@@ -507,6 +507,7 @@ void *SQLiteDB::openDB(const DoutPrefixProvider *dpp)
 {
   string dbname;
   int rc = 0;
+  const auto& rgw_dbstore_pragma = g_conf().get_val<std::string>("rgw_dbstore_pragma");
 
   dbname = getDBfile();
   if (dbname.empty()) {
@@ -517,7 +518,7 @@ void *SQLiteDB::openDB(const DoutPrefixProvider *dpp)
   rc = sqlite3_open_v2(dbname.c_str(), (sqlite3**)&db,
       SQLITE_OPEN_READWRITE |
       SQLITE_OPEN_CREATE |
-      SQLITE_OPEN_FULLMUTEX,
+      SQLITE_OPEN_NOMUTEX,
       NULL);
 
   if (rc) {
@@ -528,6 +529,10 @@ void *SQLiteDB::openDB(const DoutPrefixProvider *dpp)
   }
 
   exec(dpp, "PRAGMA foreign_keys=ON", NULL);
+
+  ldpp_dout(dpp, 10) << "Setting database PRAGMAs: " << std::quoted(rgw_dbstore_pragma) << dendl;
+  ldpp_dout(dpp, 10) << "sqlite3 threadsafe: " << sqlite3_threadsafe() << dendl;
+  exec(dpp, rgw_dbstore_pragma.c_str(), NULL);
 
 out:
   return db;


### PR DESCRIPTION
fixes: https://tracker.ceph.com/issues/53035

in benchmarks, changing to the sqlite tuning in the PR:
`PRAGMA journal_mode=OFF; PRAGMA synchronous=0; PRAGMA cache_size=32768; PRAGMA locking_mode=EXCLUSIVE; PRAGMA temp_store=MEMORY;`

increases performance of hsbench PUT load:
from 901 IO/s to 3089 IO/s


Signed-off-by: Mark Kogan <mkogan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
