### PR TITLE
mgr/cephadm: inform users if limit set for data devices is not met

### DIFF
--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -204,12 +204,14 @@ class OSDService(CephService):
         [
           {'data': {<metadata>},
            'osdspec': <name of osdspec>,
-           'host': <name of host>
+           'host': <name of host>,
+           'notes': <notes>
            },
 
            {'data': ...,
             'osdspec': ..,
-            'host': ..
+            'host': ...,
+            'notes': ...
            }
         ]
 
@@ -246,10 +248,16 @@ class OSDService(CephService):
                     except ValueError:
                         logger.exception('Cannot decode JSON: \'%s\'' % ' '.join(out))
                         concat_out = {}
-
+                    notes = []
+                    if osdspec.data_devices is not None and osdspec.data_devices.limit and len(concat_out) < osdspec.data_devices.limit:
+                        found = len(concat_out)
+                        limit = osdspec.data_devices.limit
+                        notes.append(
+                            f'NOTE: Did not find enough disks matching filter on host {host} to reach data device limit (Found: {found} | Limit: {limit})')
                     ret_all.append({'data': concat_out,
                                     'osdspec': osdspec.service_id,
-                                    'host': host})
+                                    'host': host,
+                                    'notes': notes})
         return ret_all
 
     def resolve_hosts_for_osdspecs(self,

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -700,6 +700,28 @@ spec:
             assert out == "Created no osd(s) on host test; already created?"
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch('cephadm.services.osd.OSDService._run_ceph_volume_command')
+    @mock.patch('cephadm.services.osd.OSDService.driveselection_to_ceph_volume')
+    @mock.patch('cephadm.services.osd.OsdIdClaims.refresh', lambda _: None)
+    @mock.patch('cephadm.services.osd.OsdIdClaims.get', lambda _: {})
+    def test_limit_not_reached(self, d_to_cv, _run_cv_cmd, cephadm_module):
+        with with_host(cephadm_module, 'test'):
+            dg = DriveGroupSpec(placement=PlacementSpec(host_pattern='test'),
+                                data_devices=DeviceSelection(limit=5, rotational=1),
+                                service_id='not_enough')
+
+            disks_found = [
+                '[{"data": "/dev/vdb", "data_size": "50.00 GB", "encryption": "None"}, {"data": "/dev/vdc", "data_size": "50.00 GB", "encryption": "None"}]']
+            d_to_cv.return_value = 'foo'
+            _run_cv_cmd.return_value = (disks_found, '', 0)
+            preview = cephadm_module.osd_service.generate_previews([dg], 'test')
+
+            for osd in preview:
+                assert 'notes' in osd
+                assert osd['notes'] == [
+                    'NOTE: Did not find enough disks matching filter on host test to reach data device limit (Found: 2 | Limit: 5)']
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_prepare_drivegroup(self, cephadm_module):
         with with_host(cephadm_module, 'test'):
             dg = DriveGroupSpec(placement=PlacementSpec(host_pattern='test'),

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -158,6 +158,7 @@ def preview_table_osd(data: List) -> str:
     table.align = 'l'
     table.left_padding_width = 0
     table.right_padding_width = 2
+    notes = ''
     for osd_data in data:
         if osd_data.get('service_type') != 'osd':
             continue
@@ -166,6 +167,8 @@ def preview_table_osd(data: List) -> str:
                 if spec.get('error'):
                     return spec.get('message')
                 dg_name = spec.get('osdspec')
+                if spec.get('notes', []):
+                    notes += '\n'.join(spec.get('notes')) + '\n'
                 for osd in spec.get('data', []):
                     db_path = osd.get('block_db', '-')
                     wal_path = osd.get('block_wal', '-')
@@ -173,7 +176,7 @@ def preview_table_osd(data: List) -> str:
                     if not block_data:
                         continue
                     table.add_row(('osd', dg_name, host, block_data, db_path, wal_path))
-    return table.get_string()
+    return notes + table.get_string()
 
 
 def preview_table_services(data: List) -> str:


### PR DESCRIPTION
Signed-off-by: Adam King <adking@redhat.com>

```
################
OSDSPEC PREVIEWS
################
NOTE: Did not find enough disks matching filter on host vm-00 to reach data device limit (Found: 4 | Limit: 7)
NOTE: Did not find enough disks matching filter on host vm-01 to reach data device limit (Found: 4 | Limit: 7)
NOTE: Did not find enough disks matching filter on host vm-02 to reach data device limit (Found: 4 | Limit: 7)
+---------+--------------+-------+----------+----+-----+
|SERVICE  |NAME          |HOST   |DATA      |DB  |WAL  |
+---------+--------------+-------+----------+----+-----+
|osd      |osd_spec_hdd  |vm-00  |/dev/vdb  |-   |-    |
|osd      |osd_spec_hdd  |vm-00  |/dev/vdc  |-   |-    |
|osd      |osd_spec_hdd  |vm-00  |/dev/vdd  |-   |-    |
|osd      |osd_spec_hdd  |vm-00  |/dev/vde  |-   |-    |
|osd      |osd_spec_hdd  |vm-01  |/dev/vdb  |-   |-    |
|osd      |osd_spec_hdd  |vm-01  |/dev/vdc  |-   |-    |
|osd      |osd_spec_hdd  |vm-01  |/dev/vdd  |-   |-    |
|osd      |osd_spec_hdd  |vm-01  |/dev/vde  |-   |-    |
|osd      |osd_spec_hdd  |vm-02  |/dev/vdb  |-   |-    |
|osd      |osd_spec_hdd  |vm-02  |/dev/vdc  |-   |-    |
|osd      |osd_spec_hdd  |vm-02  |/dev/vdd  |-   |-    |
|osd      |osd_spec_hdd  |vm-02  |/dev/vde  |-   |-    |
+---------+--------------+-------+----------+----+-----+
[ceph: root@vm-00 /]# cat osd-spec.yaml 
service_id: osd_spec_hdd
placement:
  host_pattern: '*'
data_devices:
  rotational: 1
  limit: 7
  
[ceph: root@vm-00 /]# ceph orch device ls
HOST   PATH      TYPE  DEVICE ID   SIZE  AVAILABLE  REJECT REASONS  
vm-00  /dev/vdb  hdd              53.6G  Yes                        
vm-00  /dev/vdc  hdd              53.6G  Yes                        
vm-00  /dev/vdd  hdd              53.6G  Yes                        
vm-00  /dev/vde  hdd              53.6G  Yes                        
vm-01  /dev/vdb  hdd              53.6G  Yes                        
vm-01  /dev/vdc  hdd              53.6G  Yes                        
vm-01  /dev/vdd  hdd              53.6G  Yes                        
vm-01  /dev/vde  hdd              53.6G  Yes                        
vm-02  /dev/vdb  hdd              53.6G  Yes                        
vm-02  /dev/vdc  hdd              53.6G  Yes                        
vm-02  /dev/vdd  hdd              53.6G  Yes                        
vm-02  /dev/vde  hdd              53.6G  Yes        
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
