### PR TITLE
mon,auth,cephadm: support auth key rotation

### DIFF
--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -87,6 +87,21 @@ file but will not trigger a restart of the daemon.
    ceph orch daemon reconfig <name>
 
 
+Rotating a daemon's authenticate key
+------------------------------------
+
+All Ceph and gateway daemons in the cluster have a secret key that is used to connect
+to and authenticate with the cluster.  This key can be rotated (i.e., replaced with a
+new key) with the following command:
+
+.. prompt:: bash #
+
+   ceph orch daemon rotate-key <name>
+
+For MDS, OSD, and MGR daemons, this does not require a daemon restart.  For other
+daemons, however (e.g., RGW), the daemon may be restarted to switch to the new key.
+
+
 Ceph daemon logs
 ================
 

--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -40,6 +40,53 @@ monitor hosts as well as to the monitor daemons' stderr.
 
 .. _cephadm-logs:
 
+
+Ceph daemon control
+===================
+
+Starting and stopping daemons
+-----------------------------
+
+You can stop, start, or restart a daemon with:
+
+.. prompt:: bash #
+
+   ceph orch daemon stop <name>
+   ceph orch daemon start <name>
+   ceph orch daemon restart <name>
+
+You can also do the same for all daemons for a service with:   
+
+.. prompt:: bash #
+
+   ceph orch stop <name>
+   ceph orch start <name>
+   ceph orch restart <name>
+
+
+Redeploying or reconfiguring a daemon
+-------------------------------------
+
+The container for a daemon can be stopped, recreated, and restarted with
+the ``redeploy`` command:
+
+.. prompt:: bash #
+
+   ceph orch daemon redeploy <name> [--image <image>]
+
+A container image name can optionally be provided to force a
+particular image to be used (instead of the image specified by the
+``container_image`` config value).
+
+If only the ceph configuration needs to be regenerated, you can also
+issue a ``reconfig`` command, which will rewrite the ``ceph.conf``
+file but will not trigger a restart of the daemon.
+
+.. prompt:: bash #
+
+   ceph orch daemon reconfig <name>
+
+
 Ceph daemon logs
 ================
 

--- a/qa/suites/orch/cephadm/with-work/tasks/rotate-keys.yaml
+++ b/qa/suites/orch/cephadm/with-work/tasks/rotate-keys.yaml
@@ -1,0 +1,16 @@
+tasks:
+- cephadm.shell:
+    mon.a:
+    - |
+      set -ex
+      for f in osd.0 osd.1 osd.2 osd.3 osd.4 osd.5 osd.6 osd.7 mgr.y mgr.x
+      do
+          echo "rotating key for $f"
+          K=$(ceph auth get-key $f)
+          NK="$K"
+          ceph orch daemon rotate-key $f
+          while [ "$K" == "$NK" ]; do
+              sleep 5
+              NK=$(ceph auth get-key $f)
+          done
+      done

--- a/qa/suites/rados/singleton/all/mon-auth-caps.yaml
+++ b/qa/suites/rados/singleton/all/mon-auth-caps.yaml
@@ -17,3 +17,4 @@ tasks:
     clients:
       all:
         - mon/auth_caps.sh
+        - mon/auth_key_rotation.sh

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -601,8 +601,7 @@ function test_auth()
   ceph auth caps client.xx mon 'allow command "osd tree"'
   ceph auth export | grep client.xx
   ceph auth export -o authfile
-  ceph auth import -i authfile 2>$TMPFILE
-  check_response "imported keyring"
+  ceph auth import -i authfile
 
   ceph auth export -o authfile2
   diff authfile authfile2

--- a/qa/workunits/mon/auth_key_rotation.sh
+++ b/qa/workunits/mon/auth_key_rotation.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/bash -ex
+
+function expect_false()
+{
+	set -x
+	if "$@"; then return 1; else return 0; fi
+}
+
+
+ceph auth export
+ceph auth rm client.rot
+
+ceph auth get-or-create client.rot mon 'allow rwx'
+ceph auth export client.rot | grep key
+ceph auth export client.rot | expect_false grep pending.key
+
+ceph auth get-or-create-pending client.rot
+ceph auth export client.rot | grep key
+ceph auth export client.rot | grep pending.key
+
+ceph auth clear-pending client.rot
+ceph auth export client.rot | expect_false grep pending.key
+
+ceph auth get-or-create-pending client.rot
+ceph auth export client.rot | grep key
+ceph auth export client.rot | grep pending.key
+K=$(ceph auth export client.rot | grep 'key = ' | head -n 1 | awk '{print $3}')
+PK=$(ceph auth export client.rot | grep pending.key | awk '{print $4}')
+echo "K is $K"
+echo "PK is $PK"
+ceph -n client.rot --key $K -s
+
+ceph auth commit-pending client.rot
+ceph auth export client.rot | expect_false grep pending.key
+ceph auth export client.rot | grep key | grep $PK
+
+ceph auth get-or-create-pending client.rot
+ceph auth export client.rot | grep key
+ceph auth export client.rot | grep pending.key
+K=$(ceph auth export client.rot | grep 'key = ' | head -n 1 | awk '{print $3}')
+PK=$(ceph auth export client.rot | grep pending.key | awk '{print $4}')
+echo "2, K is $K"
+echo "2, PK is $PK"
+
+ceph auth export client.rot
+
+while ceph -n client.rot --key $K -s ; do
+    ceph auth export client.rot
+    ceph -n client.rot --key $PK -s
+    sleep 1
+done
+
+ceph auth export client.rot | expect_false grep pending.key
+ceph auth export client.rot | grep key | grep $PK
+
+ceph -n client.rot --key $PK -s
+
+echo ok

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -112,6 +112,10 @@ public:
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
 
+  void clear() {
+    *this = CryptoKey();
+  }
+
   int get_type() const { return type; }
   utime_t get_created() const { return created; }
   void print(std::ostream& out) const;

--- a/src/auth/KeyRing.h
+++ b/src/auth/KeyRing.h
@@ -72,12 +72,18 @@ public:
   }
 
   // modifiers
-  void add(const EntityName& name, EntityAuth &a) {
+  void add(const EntityName& name, const EntityAuth &a) {
     keys[name] = a;
   }
-  void add(const EntityName& name, CryptoKey &k) {
+  void add(const EntityName& name, const CryptoKey &k) {
     EntityAuth a;
     a.key = k;
+    keys[name] = a;
+  }
+  void add(const EntityName& name, const CryptoKey &k, const CryptoKey &pk) {
+    EntityAuth a;
+    a.key = k;
+    a.pending_key = pk;
     keys[name] = a;
   }
   void remove(const EntityName& name) {

--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -122,7 +122,7 @@ bool KeyServerData::get_caps(CephContext *cct, const EntityName& name,
   ldout(cct, 10) << "get_caps: name=" << name.to_str() << dendl;
   auto iter = secrets.find(name);
   if (iter != secrets.end()) {
-    ldout(cct, 10) << "get_secret: num of caps=" << iter->second.caps.size() << dendl;
+    ldout(cct, 10) << "get_caps: num of caps=" << iter->second.caps.size() << dendl;
     auto capsiter = iter->second.caps.find(type);
     if (capsiter != iter->second.caps.end()) {
       caps_info.caps = capsiter->second;

--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -148,7 +148,6 @@ KeyServer::KeyServer(CephContext *cct_, KeyRing *extra_secrets)
 int KeyServer::start_server()
 {
   std::scoped_lock l{lock};
-
   _dump_rotating_secrets();
   return 0;
 }
@@ -236,6 +235,24 @@ bool KeyServer::get_service_secret(uint32_t service_id,
   std::scoped_lock l{lock};
 
   return data.get_service_secret(cct, service_id, secret_id, secret);
+}
+
+void KeyServer::note_used_pending_key(const EntityName& name, const CryptoKey& key)
+{
+  std::scoped_lock l(lock);
+  used_pending_keys[name] = key;
+}
+
+void KeyServer::clear_used_pending_keys()
+{
+  std::scoped_lock l(lock);
+  used_pending_keys.clear();
+}
+
+void KeyServer::get_used_pending_keys(std::map<EntityName,CryptoKey> *used)
+{
+  std::scoped_lock l(lock);
+  used->swap(used_pending_keys);
 }
 
 bool KeyServer::generate_secret(CryptoKey& secret)

--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -249,10 +249,12 @@ void KeyServer::clear_used_pending_keys()
   used_pending_keys.clear();
 }
 
-void KeyServer::get_used_pending_keys(std::map<EntityName,CryptoKey> *used)
+std::map<EntityName,CryptoKey> KeyServer::get_used_pending_keys()
 {
+  std::map<EntityName,CryptoKey> ret;
   std::scoped_lock l(lock);
-  used->swap(used_pending_keys);
+  ret.swap(used_pending_keys);
+  return ret;
 }
 
 bool KeyServer::generate_secret(CryptoKey& secret)

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -215,8 +215,8 @@ public:
 
   void note_used_pending_key(const EntityName& name, const CryptoKey& key);
   void clear_used_pending_keys();
-  void get_used_pending_keys(std::map<EntityName,CryptoKey> *used);
-  
+  std::map<EntityName,CryptoKey> get_used_pending_keys();
+
   int start_server();
   void rotate_timeout(double timeout);
 

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -193,6 +193,7 @@ WRITE_CLASS_ENCODER(KeyServerData::Incremental)
 class KeyServer : public KeyStore {
   CephContext *cct;
   KeyServerData data;
+  std::map<EntityName, CryptoKey> used_pending_keys;
   mutable ceph::mutex lock;
 
   int _rotate_secret(uint32_t service_id, KeyServerData &pending_data);
@@ -211,6 +212,11 @@ public:
   bool get_auth(const EntityName& name, EntityAuth& auth) const;
   bool get_caps(const EntityName& name, const std::string& type, AuthCapsInfo& caps) const;
   bool get_active_rotating_secret(const EntityName& name, CryptoKey& secret) const;
+
+  void note_used_pending_key(const EntityName& name, const CryptoKey& key);
+  void clear_used_pending_keys();
+  void get_used_pending_keys(std::map<EntityName,CryptoKey> *used);
+  
   int start_server();
   void rotate_timeout(double timeout);
 

--- a/src/auth/cephx/CephxServiceHandler.cc
+++ b/src/auth/cephx/CephxServiceHandler.cc
@@ -199,6 +199,7 @@ int CephxServiceHandler::handle_request(
 					   error);
 	if (error.empty()) {
 	  used_key = &eauth.pending_key;
+	  key_server->note_used_pending_key(entity_name, eauth.pending_key);
 	}
       }
       if (!error.empty()) {

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -101,6 +101,10 @@ def main():
         log.error("directory %s does not exist; please create" % postdir)
         time.sleep(30)
 
+    log.info("pinging cluster to exercise our key")
+    pr = subprocess.Popen(args=['timeout', '30', 'ceph', '-s'])
+    pr.wait()
+
     log.info("monitoring path %s, delay %ds" % (args.path, args.delay * 60.0))
     while True:
         scrape_path(args.path)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -211,6 +211,7 @@ Client::CommandHook::CommandHook(Client *client) :
 int Client::CommandHook::call(
   std::string_view command,
   const cmdmap_t& cmdmap,
+  const bufferlist&,
   Formatter *f,
   std::ostream& errss,
   bufferlist& out)

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -269,6 +269,7 @@ public:
   public:
     explicit CommandHook(Client *client);
     int call(std::string_view command, const cmdmap_t& cmdmap,
+	     const bufferlist&,
 	     Formatter *f,
 	     std::ostream& errss,
 	     bufferlist& out) override;

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -623,6 +623,7 @@ void AdminSocket::unregister_commands(const AdminSocketHook *hook)
 class VersionHook : public AdminSocketHook {
 public:
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& errss,
 	   bufferlist& out) override {
@@ -649,6 +650,7 @@ class HelpHook : public AdminSocketHook {
 public:
   explicit HelpHook(AdminSocket *as) : m_as(as) {}
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& errss,
 	   bufferlist& out) override {
@@ -667,6 +669,7 @@ class GetdescsHook : public AdminSocketHook {
 public:
   explicit GetdescsHook(AdminSocket *as) : m_as(as) {}
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& errss,
 	   bufferlist& out) override {

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -60,6 +60,7 @@ public:
   virtual int call(
     std::string_view command,
     const cmdmap_t& cmdmap,
+    const ceph::buffer::list& inbl,
     ceph::Formatter *f,
     std::ostream& errss,
     ceph::buffer::list& out) = 0;
@@ -96,7 +97,7 @@ public:
     // by default, call the synchronous handler and then finish
     ceph::buffer::list out;
     std::ostringstream errss;
-    int r = call(command, cmdmap, f, errss, out);
+    int r = call(command, cmdmap, inbl, f, errss, out);
     on_finish(r, errss.str(), out);
   }
   virtual ~AdminSocketHook() {}

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -182,6 +182,7 @@ public:
 
   // AdminSocketHook
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist& inbl,
 	   ceph::Formatter *f,
 	   std::ostream& errss,
 	   bufferlist& out) override {
@@ -442,6 +443,7 @@ public:
   explicit CephContextHook(CephContext *cct) : m_cct(cct) {}
 
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist& inbl,
 	   Formatter *f,
 	   std::ostream& errss,
 	   bufferlist& out) override {

--- a/src/librbd/LibrbdAdminSocketHook.cc
+++ b/src/librbd/LibrbdAdminSocketHook.cc
@@ -80,6 +80,7 @@ LibrbdAdminSocketHook::~LibrbdAdminSocketHook() {
 
 int LibrbdAdminSocketHook::call(std::string_view command,
 				const cmdmap_t& cmdmap,
+				const bufferlist&,
 				Formatter *f,
 				std::ostream& errss,
 				bufferlist& out) {

--- a/src/librbd/LibrbdAdminSocketHook.h
+++ b/src/librbd/LibrbdAdminSocketHook.h
@@ -18,6 +18,7 @@ namespace librbd {
     ~LibrbdAdminSocketHook() override;
 
     int call(std::string_view command, const cmdmap_t& cmdmap,
+	     const bufferlist&,
 	     Formatter *f,
 	     std::ostream& errss,
 	     bufferlist& out) override;

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -116,6 +116,7 @@ public:
   int call(
     std::string_view command,
     const cmdmap_t& cmdmap,
+    const bufferlist&,
     Formatter *f,
     std::ostream& errss,
     ceph::buffer::list& out) override {

--- a/src/messages/MMonUsedPendingKeys.h
+++ b/src/messages/MMonUsedPendingKeys.h
@@ -1,0 +1,48 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#pragma once
+
+#include "messages/PaxosServiceMessage.h"
+
+class MMonUsedPendingKeys final : public PaxosServiceMessage {
+public:
+  std::map<EntityName,CryptoKey> used_pending_keys;
+  
+  MMonUsedPendingKeys() : PaxosServiceMessage{MSG_MON_USED_PENDING_KEYS, 0}
+  {}
+private:
+  ~MMonUsedPendingKeys() final {}
+
+public:
+  std::string_view get_type_name() const override { return "used_pending_keys"; }
+  void print(std::ostream& out) const override {
+    out << "used_pending_keys(" << used_pending_keys.size() << " keys)";
+  }
+
+  void decode_payload() override {
+    using ceph::decode;
+    auto p = payload.cbegin();
+    paxos_decode(p);
+    decode(used_pending_keys, p);
+  }
+  void encode_payload(uint64_t features) override {
+    using ceph::encode;
+    paxos_encode();
+    encode(used_pending_keys, payload);
+  }
+private:
+  template<class T, typename... Args>
+  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+};

--- a/src/mgr/ClusterState.cc
+++ b/src/mgr/ClusterState.cc
@@ -198,6 +198,7 @@ class ClusterSocketHook : public AdminSocketHook {
 public:
   explicit ClusterSocketHook(ClusterState *o) : cluster_state(o) {}
   int call(std::string_view admin_command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& errss,
 	   bufferlist& out) override {
@@ -239,6 +240,7 @@ bool ClusterState::asok_command(
   ostream& ss)
 {
   std::lock_guard l(lock);
+
   if (admin_command == "dump_osd_network") {
     int64_t value = 0;
     // Default to health warning level if nothing specified

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -806,6 +806,7 @@ std::map<std::string, std::string> Mgr::get_services() const
 int Mgr::call(
   std::string_view admin_command,
   const cmdmap_t& cmdmap,
+  const bufferlist&,
   Formatter *f,
   std::ostream& errss,
   bufferlist& out)

--- a/src/mgr/Mgr.h
+++ b/src/mgr/Mgr.h
@@ -103,6 +103,7 @@ public:
   int call(
     std::string_view command,
     const cmdmap_t& cmdmap,
+    const bufferlist& inbl,
     Formatter *f,
     std::ostream& errss,
     ceph::buffer::list& out) override;

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -154,8 +154,7 @@ void AuthMonitor::tick()
   }
 
   if (mon.monmap->min_mon_release >= ceph_release_t::quincy) {
-    std::map<EntityName,CryptoKey> used_pending_keys;
-    mon.key_server.get_used_pending_keys(&used_pending_keys);
+    auto used_pending_keys = mon.key_server.get_used_pending_keys();
     if (!used_pending_keys.empty()) {
       dout(10) << __func__ << " " << used_pending_keys.size() << " used pending_keys"
 	       << dendl;

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -932,7 +932,7 @@ bool AuthMonitor::preprocess_command(MonOpRequestRef op)
       ss << "failed to find " << entity_name << " in keyring";
       r = -ENOENT;
     } else {
-      keyring.add(entity, entity_auth.key, entity_auth.pending_key);
+      keyring.add(entity, entity_auth);
       if (f)
 	keyring.encode_formatted("auth", f.get(), rdata);
       else

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -914,7 +914,6 @@ bool AuthMonitor::preprocess_command(MonOpRequestRef op)
 	  kr.encode_formatted("auth", f.get(), rdata);
 	else
 	  kr.encode_plaintext(rdata);
-	ss << "export " << eauth;
 	r = 0;
       } else {
 	ss << "no key for " << eauth;
@@ -925,8 +924,6 @@ bool AuthMonitor::preprocess_command(MonOpRequestRef op)
 	keyring.encode_formatted("auth", f.get(), rdata);
       else
 	keyring.encode_plaintext(rdata);
-
-      ss << "exported master keyring";
       r = 0;
     }
   } else if (prefix == "auth get" && !entity_name.empty()) {
@@ -941,7 +938,6 @@ bool AuthMonitor::preprocess_command(MonOpRequestRef op)
 	keyring.encode_formatted("auth", f.get(), rdata);
       else
 	keyring.encode_plaintext(rdata);
-      ss << "exported keyring for " << entity_name;
       r = 0;
     }
   } else if (prefix == "auth print-key" ||
@@ -965,10 +961,6 @@ bool AuthMonitor::preprocess_command(MonOpRequestRef op)
       mon.key_server.encode_formatted("auth", f.get(), rdata);
     } else {
       mon.key_server.encode_plaintext(rdata);
-      if (rdata.length() > 0)
-        ss << "installed auth entries:" << std::endl;
-      else
-        ss << "no installed auth entries!" << std::endl;
     }
     r = 0;
     goto done;
@@ -1462,8 +1454,6 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       mon.reply_command(op, -EINVAL, rs, get_last_committed());
       return true;
     }
-    ss << "imported keyring";
-    getline(ss, rs);
     err = 0;
     wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,
 					      get_last_committed() + 1));
@@ -1923,15 +1913,12 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
     KeyServerData::Incremental auth_inc;
     auth_inc.name = entity;
     if (!mon.key_server.contains(auth_inc.name)) {
-      ss << "entity " << entity << " does not exist";
       err = 0;
       goto done;
     }
     auth_inc.op = KeyServerData::AUTH_INC_DEL;
     push_cephx_inc(auth_inc);
 
-    ss << "updated";
-    getline(ss, rs);
     wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,
 					      get_last_committed() + 1));
     return true;

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -932,11 +932,11 @@ bool AuthMonitor::preprocess_command(MonOpRequestRef op)
   } else if (prefix == "auth get" && !entity_name.empty()) {
     KeyRing keyring;
     EntityAuth entity_auth;
-    if(!mon.key_server.get_auth(entity, entity_auth)) {
+    if (!mon.key_server.get_auth(entity, entity_auth)) {
       ss << "failed to find " << entity_name << " in keyring";
       r = -ENOENT;
     } else {
-      keyring.add(entity, entity_auth);
+      keyring.add(entity, entity_auth.key, entity_auth.pending_key);
       if (f)
 	keyring.encode_formatted("auth", f.get(), rdata);
       else
@@ -1690,7 +1690,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
         }
       } else {
 	KeyRing kr;
-	kr.add(entity, entity_auth.key);
+	kr.add(entity, entity_auth.key, entity_auth.pending_key);
         if (f) {
           kr.set_caps(entity, entity_auth.caps);
           kr.encode_formatted("auth", f.get(), rdata);

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -151,6 +151,8 @@ public:
   void _set_mon_num_rank(int num, int rank); ///< called under mon->auth_lock
 
 private:
+  bool prepare_used_pending_keys(MonOpRequestRef op);
+
   // propose pending update to peers
   void encode_pending(MonitorDBStore::TransactionRef t) override;
   void encode_full(MonitorDBStore::TransactionRef t) override;
@@ -165,6 +167,7 @@ private:
   bool prepare_command(MonOpRequestRef op);
 
   bool check_rotate();
+  void process_used_pending_keys(const std::map<EntityName,CryptoKey>& keys);
 
   bool entity_is_pending(EntityName& entity);
   int exists_and_matches_entity(

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -27,6 +27,7 @@
 #include "MonMap.h"
 #include "MonSub.h"
 
+#include "common/admin_socket.h"
 #include "common/async/completion.h"
 #include "common/Timer.h"
 #include "common/config.h"
@@ -269,7 +270,8 @@ const boost::system::error_category& monc_category() noexcept;
 
 class MonClient : public Dispatcher,
 		  public AuthClient,
-		  public AuthServer /* for mgr, osd, mds */ {
+		  public AuthServer, /* for mgr, osd, mds */
+		  public AdminSocketHook {
   static constexpr auto dout_subsys = ceph_subsys_monc;
 public:
   // Error, Newest, Oldest
@@ -315,6 +317,14 @@ private:
 
   void handle_auth(MAuthReply *m);
 
+  int call(
+    std::string_view command,
+    const cmdmap_t& cmdmap,
+    const ceph::buffer::list &inbl,
+    ceph::Formatter *f,
+    std::ostream& errss,
+    ceph::buffer::list& out) override;
+  
   // monitor session
   utime_t last_keepalive;
   utime_t last_send_log;

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -173,6 +173,18 @@ COMMAND("auth get-or-create "
 	"name=caps,type=CephString,n=N,req=false",
 	"add auth info for <entity> from input file, or random key if no input given, and/or any caps specified in the command",
 	"auth", "rwx")
+COMMAND("auth get-or-create-pending "
+	"name=entity,type=CephString",
+	"generate and/or retrieve existing pending key (rotated into place on first use)",
+	"auth", "rwx")
+COMMAND("auth clear-pending "
+	"name=entity,type=CephString",
+	"clear pending key",
+	"auth", "rwx")
+COMMAND("auth commit-pending "
+	"name=entity,type=CephString",
+	"rotate pending key into active position",
+	"auth", "rwx")
 COMMAND("fs authorize "
    "name=filesystem,type=CephString "
    "name=entity,type=CephString "

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4510,6 +4510,7 @@ void Monitor::dispatch_op(MonOpRequestRef op)
   switch (op->get_req()->get_type()) {
     // auth
     case MSG_MON_GLOBAL_ID:
+    case MSG_MON_USED_PENDING_KEYS:
     case CEPH_MSG_AUTH:
       op->set_type_service();
       /* no need to check caps here */

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -291,6 +291,7 @@ class AdminHook : public AdminSocketHook {
 public:
   explicit AdminHook(Monitor *m) : mon(m) {}
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& errss,
 	   bufferlist& out) override {

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -115,6 +115,7 @@
 #include "messages/MMonSubscribe.h"
 #include "messages/MMonSubscribeAck.h"
 #include "messages/MMonGlobalID.h"
+#include "messages/MMonUsedPendingKeys.h"
 #include "messages/MClientSession.h"
 #include "messages/MClientReconnect.h"
 #include "messages/MClientRequest.h"
@@ -643,6 +644,9 @@ Message *decode_message(CephContext *cct,
 
   case MSG_MON_GLOBAL_ID:
     m = make_message<MMonGlobalID>();
+    break; 
+  case MSG_MON_USED_PENDING_KEYS:
+    m = make_message<MMonUsedPendingKeys>();
     break; 
 
     // clients

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -58,6 +58,7 @@
 #define MSG_GETPOOLSTATSREPLY      59
 
 #define MSG_MON_GLOBAL_ID          60
+#define MSG_MON_USED_PENDING_KEYS  141
 
 #define MSG_ROUTE                  47
 #define MSG_FORWARD                46

--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -65,6 +65,7 @@ public:
 
   int call(std::string_view command,
 	   const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& ss,
 	   bufferlist& out) override {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -107,6 +107,7 @@ private:
   SocketHook(BlueFS* bluefs) :
     bluefs(bluefs) {}
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& errss,
 	   bufferlist& out) override {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2420,6 +2420,7 @@ class OSDSocketHook : public AdminSocketHook {
 public:
   explicit OSDSocketHook(OSD *o) : osd(o) {}
   int call(std::string_view prefix, const cmdmap_t& cmdmap,
+	   const bufferlist& inbl,
 	   Formatter *f,
 	   std::ostream& ss,
 	   bufferlist& out) override {
@@ -3319,6 +3320,7 @@ class TestOpsSocketHook : public AdminSocketHook {
 public:
   TestOpsSocketHook(OSDService *s, ObjectStore *st) : service(s), store(st) {}
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& errss,
 	   bufferlist& out) override {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2794,6 +2794,8 @@ will start to track new ops received afterwards.";
     store->generate_db_histogram(f);
   } else if (prefix == "flush_store_cache") {
     store->flush_cache(&ss);
+  } else if (prefix == "rotate-stored-key") {
+    store->write_meta("osd_key", inbl.to_str());
   } else if (prefix == "dump_pgstate_history") {
     f->open_object_section("pgstate_history");
     f->open_array_section("pgs");
@@ -3986,6 +3988,10 @@ void OSD::final_init()
   r = admin_socket->register_command("flush_store_cache",
                                      asok_hook,
                                      "Flush bluestore internal cache");
+  ceph_assert(r == 0);
+  r = admin_socket->register_command("rotate-stored-key",
+                                     asok_hook,
+                                     "Update the stored osd_key");
   ceph_assert(r == 0);
   r = admin_socket->register_command("dump_pgstate_history",
 				     asok_hook,

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -195,6 +195,7 @@ class Objecter::RequestStateHook : public AdminSocketHook {
 public:
   explicit RequestStateHook(Objecter *objecter);
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& ss,
 	   cb::list& out) override;
@@ -4713,6 +4714,7 @@ Objecter::RequestStateHook::RequestStateHook(Objecter *objecter) :
 
 int Objecter::RequestStateHook::call(std::string_view command,
 				     const cmdmap_t& cmdmap,
+				     const bufferlist&,
 				     Formatter *f,
 				     std::ostream& ss,
 				     cb::list& out)

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1236,6 +1236,7 @@ class HostCache():
             'reconfig': 3,
             'redeploy': 4,
             'stop': 5,
+            'rotate-key': 6,
         }
         existing_action = self.scheduled_daemon_actions.get(host, {}).get(daemon_name, None)
         if existing_action and priorities[existing_action] > priorities[action]:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2003,7 +2003,7 @@ Then run the following:
         if daemon_spec.daemon_type != 'osd':
             daemon_spec = self.cephadm_services[daemon_type_to_service(
                 daemon_spec.daemon_type)].prepare_create(daemon_spec)
-        CephadmServe(self)._create_daemon(daemon_spec, reconfig=True)
+        self.wait_async(CephadmServe(self)._create_daemon(daemon_spec, reconfig=True))
 
         # try to be clever, or fall back to restarting the daemon
         rc = -1

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1989,6 +1989,52 @@ Then run the following:
             for dd in dds
         ]
 
+    def _rotate_daemon_key(self, daemon_spec: CephadmDaemonDeploySpec) -> str:
+        self.log.info(f'Rotating authentication key for {daemon_spec.name()}')
+        rc, out, err = self.mon_command({
+            'prefix': 'auth get-or-create-pending',
+            'entity': daemon_spec.name(),
+            'format': 'json',
+        })
+        j = json.loads(out)
+        pending_key = j[0]['pending_key']
+
+        # deploy a new keyring file
+        if daemon_spec.daemon_type != 'osd':
+            daemon_spec = self.cephadm_services[daemon_type_to_service(
+                daemon_spec.daemon_type)].prepare_create(daemon_spec)
+        CephadmServe(self)._create_daemon(daemon_spec, reconfig=True)
+
+        # try to be clever, or fall back to restarting the daemon
+        rc = -1
+        if daemon_spec.daemon_type == 'osd':
+            rc, out, err = self.tool_exec(
+                args=['ceph', 'tell', daemon_spec.name(), 'rotate-stored-key', '-i', '-'],
+                stdin=pending_key.encode()
+            )
+            if not rc:
+                rc, out, err = self.tool_exec(
+                    args=['ceph', 'tell', daemon_spec.name(), 'rotate-key', '-i', '-'],
+                    stdin=pending_key.encode()
+                )
+        elif daemon_spec.daemon_type == 'mds':
+            rc, out, err = self.tool_exec(
+                args=['ceph', 'tell', daemon_spec.name(), 'rotate-key', '-i', '-'],
+                stdin=pending_key.encode()
+            )
+        elif (
+                daemon_spec.daemon_type == 'mgr'
+                and daemon_spec.daemon_id == self.get_mgr_id()
+        ):
+            rc, out, err = self.tool_exec(
+                args=['ceph', 'tell', daemon_spec.name(), 'rotate-key', '-i', '-'],
+                stdin=pending_key.encode()
+            )
+        if rc:
+            self._daemon_action(daemon_spec, 'restart')
+
+        return f'Rotated key for {daemon_spec.name()}'
+
     def _daemon_action(self,
                        daemon_spec: CephadmDaemonDeploySpec,
                        action: str,
@@ -2000,6 +2046,9 @@ Then run the following:
                                                                                  daemon_spec.daemon_id):
             self.mgr_service.fail_over()
             return ''  # unreachable
+
+        if action == 'rotate-key':
+            return self._rotate_daemon_key(daemon_spec)
 
         if action == 'redeploy' or action == 'reconfig':
             if daemon_spec.daemon_type != 'osd':
@@ -2056,6 +2105,12 @@ Then run the following:
                 and not self.mgr_service.mgr_map_has_standby():
             raise OrchestratorError(
                 f'Unable to schedule redeploy for {daemon_name}: No standby MGRs')
+
+        if action == 'rotate-key':
+            if d.daemon_type not in ['mgr', 'osd', 'mds']:
+                raise OrchestratorError(
+                    f'key rotation not supported for {d.daemon_type}'
+                )
 
         self._daemon_action_set_image(action, image, d.daemon_type, d.daemon_id)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1993,7 +1993,7 @@ Then run the following:
         self.log.info(f'Rotating authentication key for {daemon_spec.name()}')
         rc, out, err = self.mon_command({
             'prefix': 'auth get-or-create-pending',
-            'entity': daemon_spec.name(),
+            'entity': daemon_spec.entity_name(),
             'format': 'json',
         })
         j = json.loads(out)
@@ -2107,7 +2107,8 @@ Then run the following:
                 f'Unable to schedule redeploy for {daemon_name}: No standby MGRs')
 
         if action == 'rotate-key':
-            if d.daemon_type not in ['mgr', 'osd', 'mds']:
+            if d.daemon_type not in ['mgr', 'osd', 'mds',
+                                     'rgw', 'crash', 'nfs', 'rbd-mirror', 'iscsi']:
                 raise OrchestratorError(
                     f'key rotation not supported for {d.daemon_type}'
                 )

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -938,11 +938,13 @@ class CephadmServe:
                     if self.mgr.cache.rm_scheduled_daemon_action(dd.hostname, dd.name()):
                         self.mgr.cache.save_host(dd.hostname)
                 except OrchestratorError as e:
+                    self.log.exception(e)
                     self.mgr.events.from_orch_error(e)
                     if dd.daemon_type in daemons_post:
                         del daemons_post[dd.daemon_type]
                     # continue...
                 except Exception as e:
+                    self.log.exception(e)
                     self.mgr.events.for_daemon_from_exception(dd.name(), e)
                     if dd.daemon_type in daemons_post:
                         del daemons_post[dd.daemon_type]

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -237,6 +237,14 @@ class CephadmService(metaclass=ABCMeta):
             })
             if err:
                 self.mgr.log.warning(f"Unable to update caps for {entity}")
+
+            # get keyring anyway
+            ret, keyring, err = self.mgr.mon_command({
+                'prefix': 'auth get',
+                'entity': entity,
+            })
+            if err:
+                self.mgr.log.warning(f"Unable to fetch keyring for {entity}")
         return keyring
 
     def _inventory_get_fqdn(self, hostname: str) -> str:

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -26,6 +26,27 @@ ServiceSpecs = TypeVar('ServiceSpecs', bound=ServiceSpec)
 AuthEntity = NewType('AuthEntity', str)
 
 
+def get_auth_entity(daemon_type: str, daemon_id: str, host: str = "") -> AuthEntity:
+    """
+    Map the daemon id to a cephx keyring entity name
+    """
+    # despite this mapping entity names to daemons, self.TYPE within
+    # the CephService class refers to service types, not daemon types
+    if daemon_type in ['rgw', 'rbd-mirror', 'cephfs-mirror', 'nfs', "iscsi", 'ingress']:
+        return AuthEntity(f'client.{daemon_type}.{daemon_id}')
+    elif daemon_type in ['crash', 'agent']:
+        if host == "":
+            raise OrchestratorError(
+                f'Host not provided to generate <{daemon_type}> auth entity name')
+        return AuthEntity(f'client.{daemon_type}.{host}')
+    elif daemon_type == 'mon':
+        return AuthEntity('mon.')
+    elif daemon_type in ['mgr', 'osd', 'mds']:
+        return AuthEntity(f'{daemon_type}.{daemon_id}')
+    else:
+        raise OrchestratorError(f"unknown daemon type {daemon_type}")
+
+
 class CephadmDaemonDeploySpec:
     # typing.NamedTuple + Generic is broken in py36
     def __init__(self, host: str, daemon_id: str,
@@ -80,6 +101,9 @@ class CephadmDaemonDeploySpec:
 
     def name(self) -> str:
         return '%s.%s' % (self.daemon_type, self.daemon_id)
+
+    def entity_name(self) -> str:
+        return get_auth_entity(self.daemon_type, self.daemon_id, host=self.host)
 
     def config_get_files(self) -> Dict[str, Any]:
         files = self.extra_files
@@ -473,24 +497,7 @@ class CephService(CephadmService):
         self.remove_keyring(daemon)
 
     def get_auth_entity(self, daemon_id: str, host: str = "") -> AuthEntity:
-        """
-        Map the daemon id to a cephx keyring entity name
-        """
-        # despite this mapping entity names to daemons, self.TYPE within
-        # the CephService class refers to service types, not daemon types
-        if self.TYPE in ['rgw', 'rbd-mirror', 'cephfs-mirror', 'nfs', "iscsi", 'ingress']:
-            return AuthEntity(f'client.{self.TYPE}.{daemon_id}')
-        elif self.TYPE in ['crash', 'agent']:
-            if host == "":
-                raise OrchestratorError(
-                    f'Host not provided to generate <{self.TYPE}> auth entity name')
-            return AuthEntity(f'client.{self.TYPE}.{host}')
-        elif self.TYPE == 'mon':
-            return AuthEntity('mon.')
-        elif self.TYPE in ['mgr', 'osd', 'mds']:
-            return AuthEntity(f'{self.TYPE}.{daemon_id}')
-        else:
-            raise OrchestratorError("unknown daemon type")
+        return get_auth_entity(self.TYPE, daemon_id, host=host)
 
     def get_config_and_keyring(self,
                                daemon_type: str,
@@ -547,7 +554,7 @@ class MonService(CephService):
         # get mon. key
         ret, keyring, err = self.mgr.check_mon_command({
             'prefix': 'auth get',
-            'entity': self.get_auth_entity(name),
+            'entity': daemon_spec.entity_name(),
         })
 
         extra_config = '[mon.%s]\n' % name
@@ -1053,7 +1060,7 @@ class CephfsMirrorService(CephService):
 
         ret, keyring, err = self.mgr.check_mon_command({
             'prefix': 'auth get-or-create',
-            'entity': self.get_auth_entity(daemon_spec.daemon_id),
+            'entity': daemon_spec.entity_name(),
             'caps': ['mon', 'profile cephfs-mirror',
                      'mds', 'allow r',
                      'osd', 'allow rw tag cephfs metadata=*, allow r tag cephfs data=*',

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -472,7 +472,7 @@ class TestCephadm(object):
                         '--extra-container-args=--cpus=2',
                         '--extra-container-args=--quiet'
                     ],
-                    stdin='{"config": "", "keyring": ""}',
+                    stdin='{"config": "", "keyring": "[client.crash.test]\\nkey = None\\n"}',
                     image='',
                 )
 

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -494,7 +494,7 @@ class TestCephadm(object):
         ]
         conf_outs = [json.dumps(c.to_json()) for c in configs]
         stdin_str = '{' + \
-            f'"config": "", "keyring": "", "custom_config_files": [{conf_outs[0]}, {conf_outs[1]}]' + '}'
+            f'"config": "", "keyring": "[client.crash.test]\\nkey = None\\n", "custom_config_files": [{conf_outs[0]}, {conf_outs[1]}]' + '}'
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, ServiceSpec(service_type='crash', custom_configs=configs), CephadmOrchestrator.apply_crash):
                 _run_cephadm.assert_called_with(

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -45,6 +45,8 @@ class FakeMgr:
         if prefix == 'set-cmd':
             self.config = cmd_dict.get('value')
             return 0, 'value set', ''
+        if prefix in ['auth get']:
+            return 0, '[foo]\nkeyring = asdf\n', ''
         return -1, '', 'error'
 
     def get_minimal_ceph_conf(self) -> str:
@@ -185,9 +187,12 @@ class TestISCSIService:
         expected_call2 = call({'prefix': 'auth caps',
                                'entity': 'client.iscsi.a',
                                'caps': expected_caps})
+        expected_call3 = call({'prefix': 'auth get',
+                               'entity': 'client.iscsi.a'})
 
         assert expected_call in self.mgr.mon_command.mock_calls
         assert expected_call2 in self.mgr.mon_command.mock_calls
+        assert expected_call3 in self.mgr.mon_command.mock_calls
 
     @patch('cephadm.utils.resolve_ip')
     def test_iscsi_dashboard_config(self, mock_resolve_ip):

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -74,6 +74,7 @@ class ServiceAction(enum.Enum):
     restart = 'restart'
     redeploy = 'redeploy'
     reconfig = 'reconfig'
+    rotate_key = 'rotate-key'
 
 
 class DaemonAction(enum.Enum):
@@ -81,6 +82,7 @@ class DaemonAction(enum.Enum):
     stop = 'stop'
     restart = 'restart'
     reconfig = 'reconfig'
+    rotate_key = 'rotate-key'
 
 
 def to_format(what: Any, format: Format, many: bool, cls: Any) -> Any:
@@ -1008,7 +1010,7 @@ Usage:
 
     @_cli_write_command('orch daemon')
     def _daemon_action(self, action: DaemonAction, name: str) -> HandleCommandResult:
-        """Start, stop, restart, (redeploy,) or reconfig a specific daemon"""
+        """Start, stop, restart, redeploy, reconfig, or rotate-key for a specific daemon"""
         if '.' not in name:
             raise OrchestratorError('%s is not a valid daemon name' % name)
         completion = self.daemon_action(action.value, name)
@@ -1019,7 +1021,7 @@ Usage:
     def _daemon_action_redeploy(self,
                                 name: str,
                                 image: Optional[str] = None) -> HandleCommandResult:
-        """Redeploy a daemon (with a specifc image)"""
+        """Redeploy a daemon (with a specific image)"""
         if '.' not in name:
             raise OrchestratorError('%s is not a valid daemon name' % name)
         completion = self.daemon_action("redeploy", name, image=image)

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -880,6 +880,7 @@ int RGWCoroutinesManagerRegistry::hook_to_admin_command(const string& command)
 
 int RGWCoroutinesManagerRegistry::call(std::string_view command,
 				       const cmdmap_t& cmdmap,
+				       const bufferlist&,
 				       Formatter *f,
 				       std::ostream& ss,
 				       bufferlist& out) {

--- a/src/rgw/rgw_coroutine.h
+++ b/src/rgw/rgw_coroutine.h
@@ -606,6 +606,7 @@ public:
 
   int hook_to_admin_command(const std::string& command);
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& ss,
 	   bufferlist& out) override;

--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -199,6 +199,7 @@ string RGWSyncTraceManager::get_active_names()
 }
 
 int RGWSyncTraceManager::call(std::string_view command, const cmdmap_t& cmdmap,
+			      const bufferlist&,
 			      Formatter *f,
 			      std::ostream& ss,
 			      bufferlist& out) {

--- a/src/rgw/rgw_sync_trace.h
+++ b/src/rgw/rgw_sync_trace.h
@@ -134,6 +134,7 @@ public:
 
   int hook_to_admin_command();
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& ss,
 	   bufferlist& out) override;

--- a/src/rgw/services/svc_sys_obj_cache.cc
+++ b/src/rgw/services/svc_sys_obj_cache.cc
@@ -521,6 +521,7 @@ public:
     void shutdown();
 
     int call(std::string_view command, const cmdmap_t& cmdmap,
+	     const bufferlist&,
 	     Formatter *f,
 	     std::ostream& ss,
 	     bufferlist& out) override;
@@ -548,6 +549,7 @@ void RGWSI_SysObj_Cache_ASocketHook::shutdown()
 
 int RGWSI_SysObj_Cache_ASocketHook::call(
   std::string_view command, const cmdmap_t& cmdmap,
+  const bufferlist&,
   Formatter *f,
   std::ostream& ss,
   bufferlist& out)

--- a/src/test/admin_socket.cc
+++ b/src/test/admin_socket.cc
@@ -118,6 +118,7 @@ TEST(AdminSocket, SendTooLongRequest) {
 
 class MyTest : public AdminSocketHook {
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& ss,
 	   bufferlist& result) override {
@@ -153,6 +154,7 @@ TEST(AdminSocket, RegisterCommand) {
 
 class MyTest2 : public AdminSocketHook {
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& ss,
 	   bufferlist& result) override {
@@ -210,6 +212,7 @@ public:
   BlockingHook() = default;
 
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& ss,
 	   bufferlist& result) override {

--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -81,6 +81,7 @@ public:
   }
 
   int call(std::string_view command, const cmdmap_t& cmdmap,
+           const bufferlist&,
            Formatter *f, std::ostream &errss, bufferlist &out) override {
     auto p = commands.at(std::string(command));
     return p->call(f);

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -129,6 +129,7 @@ public:
   }
 
   int call(std::string_view command, const cmdmap_t& cmdmap,
+           const bufferlist&,
            Formatter *f, std::ostream &errss, bufferlist &out) override {
     auto p = commands.at(std::string(command));
     return p->call(f);

--- a/src/tools/rbd_mirror/ImageDeleter.cc
+++ b/src/tools/rbd_mirror/ImageDeleter.cc
@@ -105,6 +105,7 @@ public:
   }
 
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& errss,
 	   bufferlist& out) override {

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -166,6 +166,7 @@ public:
   }
 
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& errss,
 	   bufferlist& out) override {

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -338,6 +338,7 @@ public:
   }
 
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& errss,
 	   bufferlist& out) override {

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -188,6 +188,7 @@ public:
   }
 
   int call(std::string_view command, const cmdmap_t& cmdmap,
+	   const bufferlist&,
 	   Formatter *f,
 	   std::ostream& ss,
 	   bufferlist& out) override {

--- a/src/tools/rbd_wnbd/wnbd_handler.cc
+++ b/src/tools/rbd_wnbd/wnbd_handler.cc
@@ -62,15 +62,18 @@ int WnbdHandler::wait()
   return err;
 }
 
-int WnbdAdminHook::call (std::string_view command, const cmdmap_t& cmdmap,
-     Formatter *f,
-     std::ostream& errss,
-     bufferlist& out) {
-    if (command == "wnbd stats") {
-      return m_handler->dump_stats(f);
-    }
-    return -ENOSYS;
+int WnbdAdminHook::call (
+  std::string_view command, const cmdmap_t& cmdmap,
+  const bufferlist&,
+  Formatter *f,
+  std::ostream& errss,
+  bufferlist& out)
+{
+  if (command == "wnbd stats") {
+    return m_handler->dump_stats(f);
   }
+  return -ENOSYS;
+}
 
 int WnbdHandler::dump_stats(Formatter *f)
 {

--- a/src/tools/rbd_wnbd/wnbd_handler.h
+++ b/src/tools/rbd_wnbd/wnbd_handler.h
@@ -56,7 +56,8 @@ public:
   }
 
   int call(std::string_view command, const cmdmap_t& cmdmap,
-     Formatter *f, std::ostream& errss, bufferlist& out) override;
+	   const bufferlist&,
+	   Formatter *f, std::ostream& errss, bufferlist& out) override;
 };
 
 


### PR DESCRIPTION
This adds a low-level orchestrator command ``ceph orch daemon rotate-key <name>``.  Presumably we'll eventually build some automatic rotation on top of this, but this PR implements just the low-level infrastructure.

TODO
- [x] handle case when daemon is down
- [x] add support for other daemon types

## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug
