### PR TITLE
pacific: rbd-mirror: fix mirror image removal

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -549,6 +549,8 @@ status()
 
                 echo "${cluster} ${image_pool} ${image_ns} rbd_mirroring omap vals"
                 rados --cluster ${cluster} -p ${image_pool} --namespace "${image_ns}" listomapvals rbd_mirroring
+                echo "${cluster} ${image_pool} ${image_ns} rbd_mirror_leader omap vals"
+                rados --cluster ${cluster} -p ${image_pool} --namespace "${image_ns}" listomapvals rbd_mirror_leader
                 echo
             done
         done
@@ -1096,6 +1098,20 @@ unprotect_snapshot()
     rbd --cluster ${cluster} snap unprotect ${pool}/${image}@${snap}
 }
 
+unprotect_snapshot_retry()
+{
+    local cluster=$1
+    local pool=$2
+    local image=$3
+    local snap=$4
+
+    for s in 0 1 2 4 8 16 32; do
+        sleep ${s}
+        unprotect_snapshot ${cluster} ${pool} ${image} ${snap} && return 0
+    done
+    return 1
+}
+
 wait_for_snap_present()
 {
     local cluster=$1
@@ -1292,6 +1308,8 @@ enable_mirror()
     local mode=${4:-${MIRROR_IMAGE_MODE}}
 
     rbd --cluster=${cluster} mirror image enable ${pool}/${image} ${mode}
+    # Display image info including the global image id for debugging purpose
+    rbd --cluster=${cluster} info ${pool}/${image}
 }
 
 test_image_present()
@@ -1387,6 +1405,58 @@ get_clone_format()
                if (!parent) exit 1
                print format
              }'
+}
+
+list_omap_keys()
+{
+    local cluster=$1
+    local pool=$2
+    local obj_name=$3
+
+    rados --cluster ${cluster} -p ${pool} listomapkeys ${obj_name}
+}
+
+count_omap_keys_with_filter()
+{
+    local cluster=$1
+    local pool=$2
+    local obj_name=$3
+    local filter=$4
+
+    list_omap_keys ${cluster} ${pool} ${obj_name} | grep -c ${filter}
+}
+
+wait_for_omap_keys()
+{
+    local cluster=$1
+    local pool=$2
+    local obj_name=$3
+    local filter=$4
+
+    for s in 0 1 2 2 4 4 8 8 8 16 16 32; do
+        sleep $s
+
+        set +e
+        test "$(count_omap_keys_with_filter ${cluster} ${pool} ${obj_name} ${filter})" = 0
+        error_code=$?
+        set -e
+
+        if [ $error_code -eq 0 ]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+wait_for_image_in_omap()
+{
+    local cluster=$1
+    local pool=$2
+
+    wait_for_omap_keys ${cluster} ${pool} rbd_mirroring status_global
+    wait_for_omap_keys ${cluster} ${pool} rbd_mirroring image_
+    wait_for_omap_keys ${cluster} ${pool} rbd_mirror_leader image_map
 }
 
 #

--- a/qa/workunits/rbd/rbd_mirror_journal.sh
+++ b/qa/workunits/rbd/rbd_mirror_journal.sh
@@ -409,11 +409,6 @@ for i in ${image2} ${image4}; do
 done
 
 testlog "TEST: disable mirror while daemon is stopped"
-# TODO: workaround for the daemon to ack the deletion, to remove when
-#       image_map cleanup is fixed
-for i in ${image2} ${image4}; do
-        wait_for_image_present ${CLUSTER1} ${POOL} ${i} 'deleted'
-done
 stop_mirrors ${CLUSTER1}
 stop_mirrors ${CLUSTER2}
 set_pool_mirror_mode ${CLUSTER2} ${POOL} 'image'
@@ -422,11 +417,6 @@ if [ -z "${RBD_MIRROR_USE_RBD_MIRROR}" ]; then
   test_image_present ${CLUSTER1} ${POOL} ${image} 'present'
 fi
 start_mirrors ${CLUSTER1}
-start_mirrors ${CLUSTER2} # TODO: remove start/stop of cluster2 deamons when
-                          #       image_map cleanup at startup is resolved
-wait_for_image_in_omap ${CLUSTER1} ${POOL}
-wait_for_image_in_omap ${CLUSTER2} ${POOL}
-stop_mirrors ${CLUSTER2}
 wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'deleted'
 set_pool_mirror_mode ${CLUSTER2} ${POOL} 'pool'
 enable_journaling ${CLUSTER2} ${POOL} ${image}

--- a/qa/workunits/rbd/rbd_mirror_snapshot.sh
+++ b/qa/workunits/rbd/rbd_mirror_snapshot.sh
@@ -384,11 +384,6 @@ for i in ${image2} ${image4}; do
 done
 
 testlog "TEST: disable mirror while daemon is stopped"
-# TODO: workaround for the daemon to ack the deletion, to remove when
-#       image_map cleanup is fixed
-for i in ${image2} ${image4}; do
-        wait_for_image_present ${CLUSTER1} ${POOL} ${i} 'deleted'
-done
 stop_mirrors ${CLUSTER1}
 stop_mirrors ${CLUSTER2}
 disable_mirror ${CLUSTER2} ${POOL} ${image}
@@ -396,11 +391,6 @@ if [ -z "${RBD_MIRROR_USE_RBD_MIRROR}" ]; then
   test_image_present ${CLUSTER1} ${POOL} ${image} 'present'
 fi
 start_mirrors ${CLUSTER1}
-start_mirrors ${CLUSTER2} # TODO: remove start/stop of cluster2 deamons when
-                          #       image_map cleanup at startup is resolved
-wait_for_image_in_omap ${CLUSTER1} ${POOL}
-wait_for_image_in_omap ${CLUSTER2} ${POOL}
-stop_mirrors ${CLUSTER2}
 wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'deleted'
 enable_mirror ${CLUSTER2} ${POOL} ${image}
 wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'present'

--- a/qa/workunits/rbd/rbd_mirror_snapshot.sh
+++ b/qa/workunits/rbd/rbd_mirror_snapshot.sh
@@ -122,6 +122,8 @@ if [ -z "${RBD_MIRROR_USE_RBD_MIRROR}" ]; then
   all_admin_daemons ${CLUSTER1} rbd mirror status
 fi
 
+remove_image_retry ${CLUSTER2} ${POOL} ${image1}
+
 testlog "TEST: test image rename"
 new_name="${image}_RENAMED"
 rename_image ${CLUSTER2} ${POOL} ${image} ${new_name}
@@ -143,6 +145,18 @@ wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'deleted'
 trash_restore ${CLUSTER2} ${POOL} ${image_id}
 enable_mirror ${CLUSTER2} ${POOL} ${image} snapshot
 wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
+
+testlog "TEST: check if removed images' OMAP are removed (with rbd-mirror on one cluster)"
+remove_image_retry ${CLUSTER2} ${POOL} ${image}
+
+wait_for_image_in_omap ${CLUSTER1} ${POOL}
+wait_for_image_in_omap ${CLUSTER2} ${POOL}
+
+create_image_and_enable_mirror ${CLUSTER2} ${POOL} ${image}
+wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
+write_image ${CLUSTER2} ${POOL} ${image} 100
+wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${POOL} ${image}
+wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+replaying'
 
 testlog "TEST: failover and failback"
 start_mirrors ${CLUSTER2}
@@ -222,6 +236,8 @@ wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${force_promote_image} 'up+stopp
 wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${force_promote_image} 'up+stopped'
 write_image ${CLUSTER1} ${POOL} ${force_promote_image} 100
 write_image ${CLUSTER2} ${POOL} ${force_promote_image} 100
+remove_image_retry ${CLUSTER1} ${POOL} ${force_promote_image}
+remove_image_retry ${CLUSTER2} ${POOL} ${force_promote_image}
 
 testlog "TEST: cloned images"
 testlog " - default"
@@ -246,6 +262,7 @@ wait_for_image_replay_started ${CLUSTER1} ${POOL} ${clone_image}
 wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${POOL} ${clone_image}
 wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${clone_image} 'up+replaying'
 compare_images ${POOL} ${clone_image}
+remove_image_retry ${CLUSTER2} ${POOL} ${clone_image}
 
 testlog " - clone v1"
 clone_image_and_enable_mirror ${CLUSTER1} ${PARENT_POOL} ${parent_image} \
@@ -256,6 +273,10 @@ clone_image_and_enable_mirror ${CLUSTER2} ${PARENT_POOL} ${parent_image} \
 test $(get_clone_format ${CLUSTER2} ${POOL} ${clone_image}_v1) = 1
 wait_for_image_replay_started ${CLUSTER1} ${POOL} ${clone_image}_v1
 test $(get_clone_format ${CLUSTER1} ${POOL} ${clone_image}_v1) = 1
+remove_image_retry ${CLUSTER2} ${POOL} ${clone_image}_v1
+remove_image_retry ${CLUSTER1} ${POOL} ${clone_image}1
+unprotect_snapshot_retry ${CLUSTER2} ${PARENT_POOL} ${parent_image} ${parent_snap}
+remove_snapshot ${CLUSTER2} ${PARENT_POOL} ${parent_image} ${parent_snap}
 
 testlog " - clone v2"
 parent_snap=snap_v2
@@ -288,6 +309,7 @@ mirror_image_snapshot ${CLUSTER2} ${PARENT_POOL} ${parent_image}
 wait_for_snap_moved_to_trash ${CLUSTER1} ${PARENT_POOL} ${parent_image} ${parent_snap}
 remove_image_retry ${CLUSTER1} ${POOL} ${clone_image}_v2
 wait_for_snap_removed_from_trash ${CLUSTER1} ${PARENT_POOL} ${parent_image} ${parent_snap}
+remove_image_retry ${CLUSTER2} ${PARENT_POOL} ${parent_image}
 
 testlog "TEST: data pool"
 dp_image=test_data_pool
@@ -306,6 +328,7 @@ wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${dp_image} 'up+replaying'
 compare_images ${POOL} ${dp_image}@snap1
 compare_images ${POOL} ${dp_image}@snap2
 compare_images ${POOL} ${dp_image}
+remove_image_retry ${CLUSTER2} ${POOL} ${dp_image}
 
 testlog "TEST: disable mirroring / delete non-primary image"
 image2=test2
@@ -354,7 +377,18 @@ done
 mirror_image_snapshot ${CLUSTER2} ${POOL} ${image2}
 wait_for_snap_present ${CLUSTER1} ${POOL} ${image2} "${snap_name}_${i}"
 
+unprotect_snapshot ${CLUSTER2} ${POOL} ${image4} 'snap1'
+unprotect_snapshot ${CLUSTER2} ${POOL} ${image4} 'snap2'
+for i in ${image2} ${image4}; do
+    remove_image_retry ${CLUSTER2} ${POOL} ${i}
+done
+
 testlog "TEST: disable mirror while daemon is stopped"
+# TODO: workaround for the daemon to ack the deletion, to remove when
+#       image_map cleanup is fixed
+for i in ${image2} ${image4}; do
+        wait_for_image_present ${CLUSTER1} ${POOL} ${i} 'deleted'
+done
 stop_mirrors ${CLUSTER1}
 stop_mirrors ${CLUSTER2}
 disable_mirror ${CLUSTER2} ${POOL} ${image}
@@ -362,6 +396,11 @@ if [ -z "${RBD_MIRROR_USE_RBD_MIRROR}" ]; then
   test_image_present ${CLUSTER1} ${POOL} ${image} 'present'
 fi
 start_mirrors ${CLUSTER1}
+start_mirrors ${CLUSTER2} # TODO: remove start/stop of cluster2 deamons when
+                          #       image_map cleanup at startup is resolved
+wait_for_image_in_omap ${CLUSTER1} ${POOL}
+wait_for_image_in_omap ${CLUSTER2} ${POOL}
+stop_mirrors ${CLUSTER2}
 wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'deleted'
 enable_mirror ${CLUSTER2} ${POOL} ${image}
 wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'present'
@@ -387,6 +426,7 @@ remove_image_retry ${CLUSTER2} ${POOL}/${NS1} ${image}
 disable_mirror ${CLUSTER2} ${POOL}/${NS2} ${image}
 wait_for_image_present ${CLUSTER1} ${POOL}/${NS1} ${image} 'deleted'
 wait_for_image_present ${CLUSTER1} ${POOL}/${NS2} ${image} 'deleted'
+remove_image_retry ${CLUSTER2} ${POOL}/${NS2} ${image}
 
 testlog " - data pool"
 dp_image=test_data_pool
@@ -400,6 +440,7 @@ write_image ${CLUSTER2} ${POOL}/${NS1} ${dp_image} 100
 wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${POOL}/${NS1} ${dp_image}
 wait_for_status_in_pool_dir ${CLUSTER1} ${POOL}/${NS1} ${dp_image} 'up+replaying'
 compare_images ${POOL}/${NS1} ${dp_image}
+remove_image_retry ${CLUSTER2} ${POOL}/${NS1} ${dp_image}
 
 testlog "TEST: simple image resync"
 request_resync_image ${CLUSTER1} ${POOL} ${image} image_id
@@ -432,6 +473,7 @@ wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'present'
 wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
 wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+replaying'
 compare_images ${POOL} ${image}
+remove_image_retry ${CLUSTER2} ${POOL} ${image}
 
 testlog "TEST: split-brain"
 image=split-brain
@@ -445,6 +487,12 @@ demote_image ${CLUSTER1} ${POOL} ${image}
 wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+error' 'split-brain'
 request_resync_image ${CLUSTER1} ${POOL} ${image} image_id
 wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+replaying'
+remove_image_retry ${CLUSTER2} ${POOL} ${image}
+
+testlog "TEST: check if removed images' OMAP are removed"
+start_mirrors ${CLUSTER2}
+wait_for_image_in_omap ${CLUSTER1} ${POOL}
+wait_for_image_in_omap ${CLUSTER2} ${POOL}
 
 if [ -z "${RBD_MIRROR_USE_RBD_MIRROR}" ]; then
   # teuthology will trash the daemon

--- a/qa/workunits/rbd/rbd_mirror_stress.sh
+++ b/qa/workunits/rbd/rbd_mirror_stress.sh
@@ -214,3 +214,8 @@ do
   purge_snapshots ${CLUSTER2} ${POOL} ${image}
   remove_image_retry ${CLUSTER2} ${POOL} ${image}
 done
+
+testlog "TEST: check if removed images' OMAP are removed"
+
+wait_for_image_in_omap ${CLUSTER1} ${POOL}
+wait_for_image_in_omap ${CLUSTER2} ${POOL}

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -6366,7 +6366,6 @@ int mirror_image_status_set(cls_method_context_t hctx, bufferlist *in,
  * Output:
  * @returns 0 on success, negative error code on failure
  *
- * NOTE: deprecated - remove this method after Octopus is unsupported
  */
 int mirror_image_status_remove(cls_method_context_t hctx, bufferlist *in,
 			       bufferlist *out) {

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -2310,6 +2310,20 @@ int mirror_image_status_get_summary_finish(
   return 0;
 }
 
+int mirror_image_status_remove(librados::IoCtx *ioctx,
+                               const std::string &global_image_id) {
+  librados::ObjectWriteOperation op;
+  mirror_image_status_remove(&op, global_image_id);
+  return ioctx->operate(RBD_MIRRORING, &op);
+}
+
+void mirror_image_status_remove(librados::ObjectWriteOperation *op,
+                                const std::string &global_image_id) {
+  bufferlist bl;
+  encode(global_image_id, bl);
+  op->exec("rbd", "mirror_image_status_remove", bl);
+}
+
 int mirror_image_status_remove_down(librados::IoCtx *ioctx) {
   librados::ObjectWriteOperation op;
   mirror_image_status_remove_down(&op);

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -478,6 +478,10 @@ void mirror_image_status_get_summary_start(
 int mirror_image_status_get_summary_finish(
     ceph::buffer::list::const_iterator *iter,
     std::map<cls::rbd::MirrorImageStatusState, int32_t> *states);
+int mirror_image_status_remove(librados::IoCtx *ioctx,
+                               const std::string &global_image_id);
+void mirror_image_status_remove(librados::ObjectWriteOperation *op,
+                                const std::string &global_image_id);
 int mirror_image_status_remove_down(librados::IoCtx *ioctx);
 void mirror_image_status_remove_down(librados::ObjectWriteOperation *op);
 

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -1889,6 +1889,11 @@ TEST_F(TestClsRbd, mirror_image_status) {
   ASSERT_EQ(1U, states.size());
   ASSERT_EQ(3, states[cls::rbd::MIRROR_IMAGE_STATUS_STATE_UNKNOWN]);
 
+  // Test remove of status
+  ASSERT_EQ(0, mirror_image_status_set(&ioctx, "uuid1", status1));
+  ASSERT_EQ(0, mirror_image_status_remove(&ioctx, "uuid1"));
+  ASSERT_EQ(-ENOENT, mirror_image_instance_get(&ioctx, "uuid1", &read_instance));
+
   // Test statuses are not down after watcher is started
 
   ASSERT_EQ(0, mirror_image_status_set(&ioctx, "uuid1", status1));

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -664,7 +664,7 @@ TYPED_TEST(TestImageReplayer, BootstrapMirrorDisabling)
   this->create_replayer();
   C_SaferCond cond;
   this->m_replayer->start(&cond);
-  ASSERT_EQ(-EREMOTEIO, cond.wait());
+  ASSERT_EQ(-ENOENT, cond.wait());
   ASSERT_TRUE(this->m_replayer->is_stopped());
 }
 

--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -63,7 +63,10 @@ struct MirrorStatusUpdater<librbd::MockTestImageCtx> {
   MOCK_METHOD3(set_mirror_image_status,
                void(const std::string&, const cls::rbd::MirrorImageSiteStatus&,
                     bool));
-  MOCK_METHOD2(remove_mirror_image_status, void(const std::string&, Context*));
+  MOCK_METHOD2(remove_refresh_mirror_image_status, void(const std::string&,
+                                                        Context*));
+  MOCK_METHOD3(remove_mirror_image_status, void(const std::string&, bool,
+                                                Context*));
 };
 
 template <>

--- a/src/test/rbd_mirror/test_mock_MirrorStatusUpdater.cc
+++ b/src/test/rbd_mirror/test_mock_MirrorStatusUpdater.cc
@@ -186,6 +186,38 @@ public:
     }
   }
 
+  void expect_mirror_status_remove(const std::string& global_image_id, int r) {
+    EXPECT_CALL(*m_mock_local_io_ctx,
+                exec(RBD_MIRRORING, _, StrEq("rbd"),
+                     StrEq("mirror_image_status_remove"), _, _, _, _))
+      .WillOnce(WithArg<4>(Invoke(
+        [r, global_image_id](bufferlist& in_bl) {
+          auto bl_it = in_bl.cbegin();
+          std::string decode_global_image_id;
+          decode(decode_global_image_id, bl_it);
+          EXPECT_EQ(global_image_id, decode_global_image_id);
+
+          return r;
+        })));
+  }
+
+  void expect_mirror_status_removes(const std::set<std::string>& mirror_images,
+                                    int r) {
+    EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+      .WillOnce(Invoke([this](auto&&... args) {
+          int r = m_mock_local_io_ctx->do_aio_operate(decltype(args)(args)...);
+          m_mock_local_io_ctx->aio_flush();
+          return r;
+        }));
+
+    for (auto global_image_id : mirror_images) {
+      expect_mirror_status_remove(global_image_id, r);
+      if (r < 0) {
+        break;
+      }
+    }
+  }
+
   void fire_timer_event(Context** timer_event,
                         Context** update_task) {
     expect_timer_add_event(timer_event);
@@ -385,6 +417,78 @@ TEST_F(TestMockMirrorStatusUpdater, OverwriteStatus) {
                                   *mock_mirror_status_watcher);
 }
 
+TEST_F(TestMockMirrorStatusUpdater, RemoveStatus) {
+  MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
+                                                     m_mock_threads, "");
+  MockMirrorStatusWatcher* mock_mirror_status_watcher =
+    new MockMirrorStatusWatcher();
+
+  InSequence seq;
+
+  Context* timer_event = nullptr;
+  init_mirror_status_updater(mock_mirror_status_updater,
+                             *mock_mirror_status_watcher, &timer_event);
+
+  C_SaferCond ctx;
+  mock_mirror_status_updater.set_mirror_image_status("1", {}, false);
+  expect_work_queue(false);
+  mock_mirror_status_updater.remove_mirror_image_status("1", false, &ctx);
+  ASSERT_EQ(0, ctx.wait());
+
+  Context* update_task = nullptr;
+  fire_timer_event(&timer_event, &update_task);
+
+  C_SaferCond remove_flush_ctx;
+  EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
+    .WillOnce(Invoke([this, &remove_flush_ctx](auto&&... args) {
+        int r = m_mock_local_io_ctx->do_aio_operate(decltype(args)(args)...);
+        m_mock_local_io_ctx->aio_flush();
+        remove_flush_ctx.complete(r);
+        return r;
+      }));
+  expect_mirror_status_remove("1", 0);
+  update_task->complete(0);
+  ASSERT_EQ(0, remove_flush_ctx.wait());
+
+  shut_down_mirror_status_updater(mock_mirror_status_updater,
+                                  *mock_mirror_status_watcher);
+}
+
+TEST_F(TestMockMirrorStatusUpdater, OverwriteRemoveStatus) {
+  MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
+                                                     m_mock_threads, "");
+  MockMirrorStatusWatcher* mock_mirror_status_watcher =
+    new MockMirrorStatusWatcher();
+
+  InSequence seq;
+
+  Context* timer_event = nullptr;
+  init_mirror_status_updater(mock_mirror_status_updater,
+                             *mock_mirror_status_watcher, &timer_event);
+
+  C_SaferCond ctx;
+  mock_mirror_status_updater.set_mirror_image_status("1", {}, false);
+  expect_work_queue(false);
+  mock_mirror_status_updater.remove_mirror_image_status("1", false, &ctx);
+  ASSERT_EQ(0, ctx.wait());
+  mock_mirror_status_updater.set_mirror_image_status(
+    "1", {"", cls::rbd::MIRROR_IMAGE_STATUS_STATE_REPLAYING, "description"},
+    false);
+
+
+  Context* update_task = nullptr;
+  fire_timer_event(&timer_event, &update_task);
+
+  expect_mirror_status_update(
+    {{"1", cls::rbd::MirrorImageSiteStatus{
+        "", cls::rbd::MIRROR_IMAGE_STATUS_STATE_REPLAYING, "description"}}},
+    "", 0);
+  update_task->complete(0);
+
+  shut_down_mirror_status_updater(mock_mirror_status_updater,
+                                  *mock_mirror_status_watcher);
+}
+
 TEST_F(TestMockMirrorStatusUpdater, OverwriteStatusInFlight) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
                                                      m_mock_threads, "");
@@ -447,7 +551,7 @@ TEST_F(TestMockMirrorStatusUpdater, ImmediateUpdate) {
                                   *mock_mirror_status_watcher);
 }
 
-TEST_F(TestMockMirrorStatusUpdater, RemoveIdleStatus) {
+TEST_F(TestMockMirrorStatusUpdater, RemoveImmediateUpdate) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
                                                      m_mock_threads, "");
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
@@ -463,14 +567,39 @@ TEST_F(TestMockMirrorStatusUpdater, RemoveIdleStatus) {
 
   C_SaferCond ctx;
   expect_work_queue(true);
-  mock_mirror_status_updater.remove_mirror_image_status("1", &ctx);
+  expect_work_queue(true);
+  expect_mirror_status_removes({"1"}, 0);
+  mock_mirror_status_updater.remove_mirror_image_status("1", true, &ctx);
   ASSERT_EQ(0, ctx.wait());
 
   shut_down_mirror_status_updater(mock_mirror_status_updater,
                                   *mock_mirror_status_watcher);
 }
 
-TEST_F(TestMockMirrorStatusUpdater, RemoveInFlightStatus) {
+TEST_F(TestMockMirrorStatusUpdater, RemoveRefreshIdleStatus) {
+  MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
+                                                     m_mock_threads, "");
+  MockMirrorStatusWatcher* mock_mirror_status_watcher =
+    new MockMirrorStatusWatcher();
+
+  InSequence seq;
+
+  Context* timer_event = nullptr;
+  init_mirror_status_updater(mock_mirror_status_updater,
+                             *mock_mirror_status_watcher, &timer_event);
+
+  mock_mirror_status_updater.set_mirror_image_status("1", {}, false);
+
+  C_SaferCond ctx;
+  expect_work_queue(true);
+  mock_mirror_status_updater.remove_refresh_mirror_image_status("1", &ctx);
+  ASSERT_EQ(0, ctx.wait());
+
+  shut_down_mirror_status_updater(mock_mirror_status_updater,
+                                  *mock_mirror_status_watcher);
+}
+
+TEST_F(TestMockMirrorStatusUpdater, RemoveRefreshInFlightStatus) {
   MockMirrorStatusUpdater mock_mirror_status_updater(m_local_io_ctx,
                                                      m_mock_threads, "");
   MockMirrorStatusWatcher* mock_mirror_status_watcher =
@@ -491,7 +620,8 @@ TEST_F(TestMockMirrorStatusUpdater, RemoveInFlightStatus) {
   EXPECT_CALL(*m_mock_local_io_ctx, aio_operate(_, _, _, _, _))
     .WillOnce(Invoke(
       [this, &mock_mirror_status_updater, &on_removed](auto&&... args) {
-        mock_mirror_status_updater.remove_mirror_image_status("1", &on_removed);
+        mock_mirror_status_updater.remove_refresh_mirror_image_status(
+            "1", &on_removed);
 
         int r = m_mock_local_io_ctx->do_aio_operate(decltype(args)(args)...);
         m_mock_local_io_ctx->aio_flush();

--- a/src/tools/rbd_mirror/ImageMap.cc
+++ b/src/tools/rbd_mirror/ImageMap.cc
@@ -416,7 +416,7 @@ void ImageMap<I>::update_images_removed(
       to_remove.emplace_back(global_image_id, info.instance_id);
     }
 
-    if (image_mapped && image_removed) {
+    if (image_removed) {
       // local and peer images have been deleted
       if (m_policy->remove_image(global_image_id)) {
         schedule_action(global_image_id);

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -395,6 +395,9 @@ void ImageReplayer<I>::handle_bootstrap(int r) {
     m_delete_requested = true;
     on_start_fail(0, "remote image no longer exists");
     return;
+  } else if (r == -ERESTART) {
+    on_start_fail(r, "image in transient state, try again");
+    return;
   } else if (r < 0) {
     on_start_fail(r, "error bootstrapping replay");
     return;

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -310,6 +310,7 @@ void ImageReplayer<I>::start(Context *on_finish, bool manual, bool restart)
       m_manual_stop = false;
       m_delete_requested = false;
       m_restart_requested = false;
+      m_status_removed = false;
 
       if (on_finish != nullptr) {
         ceph_assert(m_on_start_finish == nullptr);
@@ -928,6 +929,7 @@ void ImageReplayer<I>::handle_shut_down(int r) {
       dout(0) << "remote image no longer exists: scheduling deletion" << dendl;
       unregister_asok_hook = true;
       std::swap(delete_requested, m_delete_requested);
+      m_delete_in_progress = true;
     }
 
     std::swap(resync_requested, m_resync_requested);
@@ -963,23 +965,12 @@ void ImageReplayer<I>::handle_shut_down(int r) {
     return;
   }
 
-  if (m_local_status_updater->exists(m_global_image_id)) {
-    dout(15) << "removing local mirror image status" << dendl;
+  if (!m_status_removed) {
     auto ctx = new LambdaContext([this, r](int) {
-        handle_shut_down(r);
-      });
-    m_local_status_updater->remove_mirror_image_status(m_global_image_id, ctx);
-    return;
-  }
-
-  if (m_remote_image_peer.mirror_status_updater != nullptr &&
-      m_remote_image_peer.mirror_status_updater->exists(m_global_image_id)) {
-    dout(15) << "removing remote mirror image status" << dendl;
-    auto ctx = new LambdaContext([this, r](int) {
-        handle_shut_down(r);
-      });
-    m_remote_image_peer.mirror_status_updater->remove_mirror_image_status(
-      m_global_image_id, ctx);
+      m_status_removed = true;
+      handle_shut_down(r);
+    });
+    remove_image_status(m_delete_in_progress, ctx);
     return;
   }
 
@@ -1133,6 +1124,48 @@ void ImageReplayer<I>::reregister_admin_socket_hook() {
 
   unregister_admin_socket_hook();
   register_admin_socket_hook();
+}
+
+template <typename I>
+void ImageReplayer<I>::remove_image_status(bool force, Context *on_finish)
+{
+  auto ctx = new LambdaContext([this, force, on_finish](int) {
+    remove_image_status_remote(force, on_finish);
+  });
+
+  if (m_local_status_updater->exists(m_global_image_id)) {
+    dout(15) << "removing local mirror image status" << dendl;
+    if (force) {
+      m_local_status_updater->remove_mirror_image_status(
+        m_global_image_id, true, ctx);
+    } else {
+      m_local_status_updater->remove_refresh_mirror_image_status(
+        m_global_image_id, ctx);
+    }
+    return;
+  }
+
+  ctx->complete(0);
+}
+
+template <typename I>
+void ImageReplayer<I>::remove_image_status_remote(bool force, Context *on_finish)
+{
+  if (m_remote_image_peer.mirror_status_updater != nullptr &&
+      m_remote_image_peer.mirror_status_updater->exists(m_global_image_id)) {
+    dout(15) << "removing remote mirror image status" << dendl;
+    if (force) {
+      m_remote_image_peer.mirror_status_updater->remove_mirror_image_status(
+        m_global_image_id, true, on_finish);
+    } else {
+      m_remote_image_peer.mirror_status_updater->remove_refresh_mirror_image_status(
+        m_global_image_id, on_finish);
+    }
+    return;
+  }
+  if (on_finish) {
+    on_finish->complete(0);
+  }
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -204,9 +204,12 @@ private:
   BootstrapProgressContext m_progress_cxt;
 
   bool m_finished = false;
+  bool m_delete_in_progress = false;
   bool m_delete_requested = false;
   bool m_resync_requested = false;
   bool m_restart_requested = false;
+
+  bool m_status_removed = false;
 
   image_replayer::StateBuilder<ImageCtxT>* m_state_builder = nullptr;
   image_replayer::Replayer* m_replayer = nullptr;
@@ -258,6 +261,8 @@ private:
   void register_admin_socket_hook();
   void unregister_admin_socket_hook();
   void reregister_admin_socket_hook();
+  void remove_image_status(bool force, Context *on_finish);
+  void remove_image_status_remote(bool force, Context *on_finish);
 
 };
 

--- a/src/tools/rbd_mirror/MirrorStatusUpdater.h
+++ b/src/tools/rbd_mirror/MirrorStatusUpdater.h
@@ -44,7 +44,9 @@ public:
       const cls::rbd::MirrorImageSiteStatus& mirror_image_site_status,
       bool immediate_update);
   void remove_mirror_image_status(const std::string& global_image_id,
-                                  Context* on_finish);
+                                  bool immediate_update, Context* on_finish);
+  void remove_refresh_mirror_image_status(const std::string& global_image_id,
+                                          Context* on_finish);
 
 private:
   /**
@@ -90,6 +92,7 @@ private:
   GlobalImageIds m_updating_global_image_ids;
 
   bool try_remove_mirror_image_status(const std::string& global_image_id,
+                                      bool queue_update, bool immediate_update,
                                       Context* on_finish);
 
   void init_mirror_status_watcher(Context* on_finish);

--- a/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.cc
+++ b/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.cc
@@ -15,6 +15,7 @@
 #include "librbd/Utils.h"
 #include "librbd/asio/ContextWQ.h"
 #include "librbd/journal/ResetRequest.h"
+#include "librbd/mirror/ImageRemoveRequest.h"
 #include "librbd/mirror/GetInfoRequest.h"
 #include "librbd/trash/MoveRequest.h"
 #include "tools/rbd_mirror/image_deleter/Types.h"
@@ -315,15 +316,12 @@ template <typename I>
 void TrashMoveRequest<I>::remove_mirror_image() {
   dout(10) << dendl;
 
-  librados::ObjectWriteOperation op;
-  librbd::cls_client::mirror_image_remove(&op, m_image_id);
-
-  auto aio_comp = create_rados_callback<
+  auto ctx = create_context_callback<
     TrashMoveRequest<I>,
     &TrashMoveRequest<I>::handle_remove_mirror_image>(this);
-  int r = m_io_ctx.aio_operate(RBD_MIRRORING, aio_comp, &op);
-  ceph_assert(r == 0);
-  aio_comp->release();
+  auto req = librbd::mirror::ImageRemoveRequest<I>::create(
+    m_io_ctx, m_global_image_id, m_image_id, ctx);
+  req->send();
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_map/LoadRequest.h
+++ b/src/tools/rbd_mirror/image_map/LoadRequest.h
@@ -36,6 +36,12 @@ private:
    *  IMAGE_MAP_LIST. . . . . . .
    *        |
    *        v
+   *  MIRROR_IMAGE_LIST
+   *        |
+   *        v
+   *  CLEANUP_IMAGE_MAP
+   *        |
+   *        v
    *    <finish>
    *
    * @endverbatim
@@ -48,11 +54,18 @@ private:
   std::map<std::string, cls::rbd::MirrorImageMap> *m_image_mapping;
   Context *m_on_finish;
 
+  std::set<std::string> m_global_image_ids;
+
   bufferlist m_out_bl;
   std::string m_start_after;
 
   void image_map_list();
   void handle_image_map_list(int r);
+
+  void mirror_image_list();
+  void handle_mirror_image_list(int r);
+
+  void cleanup_image_map();
 
   void finish(int r);
 };

--- a/src/tools/rbd_mirror/image_map/Policy.cc
+++ b/src/tools/rbd_mirror/image_map/Policy.cc
@@ -380,6 +380,7 @@ bool Policy::can_shuffle_image(const std::string &global_image_id) {
 bool Policy::set_state(ImageState* image_state, StateTransition::State state,
                        bool ignore_current_state) {
   if (!ignore_current_state && image_state->state == state) {
+    image_state->next_state = boost::none;
     return false;
   } else if (StateTransition::is_idle(image_state->state)) {
     image_state->state = state;

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
@@ -194,10 +194,10 @@ void BootstrapRequest<I>::handle_prepare_remote_image(int r) {
     // TODO need to support multiple remote images
     if (state_builder != nullptr &&
         state_builder->remote_image_id.empty() &&
-        !state_builder->local_image_id.empty() &&
-        state_builder->is_linked()) {
-      // local image exists and is non-primary and linked to the missing
-      // remote image
+        (state_builder->local_image_id.empty() ||
+         state_builder->is_linked())) {
+      // both images doesn't exist or local image exists and is non-primary
+      // and linked to the missing remote image
       finish(-ENOLINK);
     } else {
       finish(-ENOENT);

--- a/src/tools/rbd_mirror/image_replayer/PrepareLocalImageRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/PrepareLocalImageRequest.h
@@ -67,6 +67,10 @@ private:
    *    v
    * GET_MIRROR_INFO
    *    |
+   *    | (if the image mirror state is CREATING)
+   *    v
+   * TRASH_MOVE
+   *    |
    *    v
    * <finish>
    *
@@ -94,6 +98,9 @@ private:
 
   void get_mirror_info();
   void handle_get_mirror_info(int r);
+
+  void move_to_trash();
+  void handle_move_to_trash(int r);
 
   void finish(int r);
 

--- a/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.cc
@@ -112,7 +112,7 @@ void PrepareRemoteImageRequest<I>::handle_get_mirror_info(int r) {
     return;
   } else if (m_mirror_image.state == cls::rbd::MIRROR_IMAGE_STATE_DISABLING) {
     dout(5) << "remote image mirroring is being disabled" << dendl;
-    finish(-EREMOTEIO);
+    finish(-ENOENT);
     return;
   } else if (m_promotion_state != librbd::mirror::PROMOTION_STATE_PRIMARY &&
              (state_builder == nullptr ||

--- a/src/tools/rbd_mirror/image_replayer/StateBuilder.h
+++ b/src/tools/rbd_mirror/image_replayer/StateBuilder.h
@@ -81,13 +81,13 @@ public:
 
   std::string global_image_id;
 
-  std::string local_image_id;
+  std::string local_image_id{};
   librbd::mirror::PromotionState local_promotion_state =
     librbd::mirror::PROMOTION_STATE_PRIMARY;
   ImageCtxT* local_image_ctx = nullptr;
 
   std::string remote_mirror_uuid;
-  std::string remote_image_id;
+  std::string remote_image_id{};
   librbd::mirror::PromotionState remote_promotion_state =
     librbd::mirror::PROMOTION_STATE_NON_PRIMARY;
   ImageCtxT* remote_image_ctx = nullptr;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53032

---

backport of https://github.com/ceph/ceph/pull/41696
parent tracker: https://tracker.ceph.com/issues/51031

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh