### PR TITLE
mgr/k8sevents: pin the kubernetes version to 11.0.0 

### DIFF
--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -1,3 +1,3 @@
 -rrequirements-required.txt
 asyncssh
-kubernetes
+kubernetes==11.0.0


### PR DESCRIPTION
There's an API change (https://github.com/kubernetes-client/python/commit/c04e2f6ed02acbef186d50969931ab3cf9ab209d#diff-64d3d8da58fddca2ed360257976a6ab3e28fdc4805e3480d99af857ce914dc20R27-R32) happened during last night (morning depending on your timezone) which updated the `V1Events` to `CoreV1Events`. That causes a
make check failure and this commit intends to fix it.

kubernetes-client API Change PR: https://github.com/kubernetes-client/python/pull/1597

Fixes: https://tracker.ceph.com/issues/53044
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
