### PR TITLE
client: flesh out doc comments for struct ceph_client_callback_args

### DIFF
--- a/src/include/cephfs/ceph_ll_client.h
+++ b/src/include/cephfs/ceph_ll_client.h
@@ -110,28 +110,78 @@ struct ceph_statx {
 #define FALLOC_FL_PUNCH_HOLE 0x02
 #endif
 
-/* delegation recalls */
+/** ceph_deleg_cb_t: Delegation recalls
+ *
+ * Called when there is an outstanding Delegation and there is conflicting
+ * access, either locally or via cap activity.
+ * @fh: open filehandle
+ * @priv: private info registered when delegation was acquired
+ */
 typedef void (*ceph_deleg_cb_t)(Fh *fh, void *priv);
 
-/* inode data/metadata invalidation */
+/**
+ * client_ino_callback_t: Inode data/metadata invalidation
+ *
+ * Called when the client wants to invalidate the cached data for a range
+ * in the file.
+ * @handle: client callback handle
+ * @ino: vino of inode to be invalidated
+ * @off: starting offset of content to be invalidated
+ * @len: length of region to invalidate
+ */
 typedef void (*client_ino_callback_t)(void *handle, vinodeno_t ino,
 	      int64_t off, int64_t len);
 
-/* dentry invalidation */
+/**
+ * client_dentry_callback_t: Dentry invalidation
+ *
+ * Called when the client wants to purge a dentry from its cache.
+ * @handle: client callback handle
+ * @dirino: vino of directory that contains dentry to be invalidate
+ * @ino: vino of inode attached to dentry to be invalidated
+ * @name: name of dentry to be invalidated
+ * @len: length of @name
+ */
 typedef void (*client_dentry_callback_t)(void *handle, vinodeno_t dirino,
 					 vinodeno_t ino, const char *name,
 					 size_t len);
 
-/* remount entire fs */
+/**
+ * client_remount_callback_t: Remount entire fs
+ *
+ * Called when the client needs to purge the dentry cache and the application
+ * doesn't have a way to purge an individual dentry. Mostly used for ceph-fuse
+ * on older kernels.
+ * @handle: client callback handle
+ */
+
 typedef int (*client_remount_callback_t)(void *handle);
 
-/* lock request interrupted */
+/**
+ * client_switch_interrupt_callback_t: Lock request interrupted
+ *
+ * Called before file lock request to set the interrupt handler while waiting
+ * After the wait, called with "data" set to NULL pointer.
+ * @handle: client callback handle
+ * @data: opaque data passed to interrupt before call, NULL pointer after.
+ */
 typedef void (*client_switch_interrupt_callback_t)(void *handle, void *data);
 
-/* fetch umask of actor */
+/**
+ * client_umask_callback_t: Fetch umask of actor
+ *
+ * Called when the client needs the umask of the requestor.
+ * @handle: client callback handle
+ */
 typedef mode_t (*client_umask_callback_t)(void *handle);
 
-/* request that application release Inode references */
+/**
+ * client_ino_release_t: Request that application release Inode references
+ *
+ * Called when the MDS wants to trim caps and Inode records.
+ * @handle: client callback handle
+ * @ino: vino of Inode being released
+ */
 typedef void (*client_ino_release_t)(void *handle, vinodeno_t ino);
 
 /*


### PR DESCRIPTION
Add more documentation comments around the ceph_client_callback_args
functions, to give application writers a better sense of how they are
used and when they should be set. This was requested by @phlogistonjohn.

This is still pretty skeletal, so let me know if you think it needs more exposition. 


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
