### PR TITLE
doc/rbd: correct sample code to use byte string for data

### DIFF
--- a/doc/rbd/api/librbdpy.rst
+++ b/doc/rbd/api/librbdpy.rst
@@ -29,7 +29,7 @@ image::
 To perform I/O on the image, you instantiate an :class:rbd.Image object::
 
     image = rbd.Image(ioctx, 'myimage')
-    data = 'foo' * 200
+    data = b'foo' * 200
     image.write(data, 0)
 
 This writes 'foo' to the first 600 bytes of the image. Note that data
@@ -55,7 +55,7 @@ block::
             rbd_inst.create(ioctx, 'myimage', size)
             image = rbd.Image(ioctx, 'myimage')
             try:
-                data = 'foo' * 200
+                data = b'foo' * 200
                 image.write(data, 0)
             finally:
                 image.close()
@@ -75,7 +75,7 @@ above example becomes::
             size = 4 * 1024**3  # 4 GiB
             rbd_inst.create(ioctx, 'myimage', size)
             with rbd.Image(ioctx, 'myimage') as image:
-                data = 'foo' * 200
+                data = b'foo' * 200
                 image.write(data, 0)
 
 API Reference


### PR DESCRIPTION
Data must be a byte string in python 3.

Signed-off-by: Javier Cacheiro <javier.cacheiro.lopez@cesga.es>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
