### PR TITLE
doc/cephadm: isolated environment and other deployment scenarios

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -229,6 +229,8 @@ available options.
   and then store the login info in its config database. Other hosts added to
   the cluster will then also be able to make use of the authenticated registry.
 
+* See :ref:`cephadm-deployment-scenarios` for additional examples for using ``cephadm bootstrap``.
+
 .. _cephadm-enable-cli:
 
 Enable Ceph CLI
@@ -328,6 +330,47 @@ To use the *Ceph Object Gateway*, follow :ref:`cephadm-deploy-rgw`.
 To use *NFS*, follow :ref:`deploy-cephadm-nfs-ganesha`
 
 To use *iSCSI*, follow :ref:`cephadm-iscsi`
+
+.. _cephadm-deployment-scenarios:
+
+Different deployment scenarios
+==============================
+
+Single host
+-----------
+
+To configure a Ceph cluster to run on a single host, use the ``--single-host-defaults`` flag when bootstrapping. For use cases of this, see :ref:`one-node-cluster`.
+
+The ``--single-host-defaults`` flag sets the following configuration options::
+
+  global/osd_crush_choose_leaf_type = 0
+  global/osd_pool_default_size = 2
+  mgr/mgr_standby_modules = False
+   
+For more information on these options, see :ref:`one-node-cluster` and ``mgr_standby_modules`` in :ref:`mgr-administrator-guide`.
+
+Deployment in an isolated environment
+-------------------------------------
+
+You can install Cephadm in an isolated environment by using a custom container registry. You can either configure Podman or Docker to use an insecure registry, or make the registry secure. Ensure your container image is inside the registry and that you have access to all hosts you wish to add to the cluster.
+
+Run a local container registry:
+
+.. prompt:: bash #
+
+   podman run --privileged -d --name registry -p 5000:5000 -v /var/lib/registry:/var/lib/registry --restart=always registry:2
+
+If you are using an insecure registry, configure Podman or Docker with the hostname and port where the registry is running.
+
+.. note:: For every host which accesses the local insecure registry, you will need to repeat this step on the host.
+
+Next, push your container image to your local registry.
+
+Then run bootstrap using the ``--image`` flag with your container image. For example:
+
+.. prompt:: bash #
+
+   cephadm --image *<hostname>*:5000/ceph/ceph bootstrap --mon-ip *<mon-ip>*
 
 
 .. _cluster network: ../rados/configuration/network-config-ref#cluster-network

--- a/doc/rados/troubleshooting/troubleshooting-pg.rst
+++ b/doc/rados/troubleshooting/troubleshooting-pg.rst
@@ -15,6 +15,8 @@ and make appropriate adjustments.
 As a general rule, you should run your cluster with more than one OSD and a
 pool size greater than 1 object replica.
 
+.. _one-node-cluster:
+
 One Node Cluster
 ----------------
 


### PR DESCRIPTION
This PR adds a section to the cephadm docs to describe how to install cephadm in different deployment scenarios (set cluster on single host, and deployment in an isolated environment or private network).

Signed-off-by: Melissa Li <melissali@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
