### PR TITLE
crimson/net: FixedCPUServerSocket::accept() respects the listening addr's type.

### DIFF
--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -226,7 +226,7 @@ public:
             auto [socket, paddr] = std::move(accept_result);
             entity_addr_t peer_addr;
             peer_addr.set_sockaddr(&paddr.as_posix_sockaddr());
-            peer_addr.set_type(entity_addr_t::TYPE_ANY);
+            peer_addr.set_type(ss.addr.get_type());
             SocketRef _socket = std::make_unique<Socket>(
                 std::move(socket), Socket::side_t::acceptor,
                 peer_addr.get_port(), Socket::construct_tag{});


### PR DESCRIPTION
For the sake of compliance with the classical OSD where the type of the listening address is being reflected in the address type of an accepted connection:

```
int PosixServerSocketImpl::accept(ConnectedSocket *sock, const SocketOptions &opt, entity_addr_t *out, Worker *w) {
  // ...
  sockaddr_storage ss;
  // ...
  int sd = accept_cloexec(_fd, (sockaddr*)&ss, &slen);
  if (sd < 0) {
    return -ceph_sock_errno();
  }

  // ...

  out->set_type(addr_type);
  out->set_sockaddr((sockaddr*)&ss);
  handler.set_priority(sd, opt.priority, out->get_family());
}
```

In Rook crimson binds explicitly to v2 address:

```
INFO  2021-10-26 17:55:08,116 [shard 0] osd - picked address v2:0.0.0.0:0/0
ERROR 2021-10-26 17:55:08,116 [shard 0] none - Falling back to public interface
INFO  2021-10-26 17:55:08,116 [shard 0] osd - picked address v2:0.0.0.0:0/0
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
