### PR TITLE
doc/rados: storage-devices.rst rewrite

### DIFF
--- a/doc/rados/configuration/storage-devices.rst
+++ b/doc/rados/configuration/storage-devices.rst
@@ -27,24 +27,23 @@ There are several Ceph daemons in a storage cluster:
 OSD Backends
 ============
 
-There are two ways that OSDs can manage the data they store.  Starting
-with the Luminous 12.2.z release, the new default (and recommended) backend is
-*BlueStore*.  Prior to Luminous, the default (and only option) was
+There are two ways that OSDs manage the data they store. 
+As of the Luminous 12.2.z release, the default (and recommended) backend is
+*BlueStore*.  Prior to the Luminous release, the default (and only option) was
 *Filestore*.
 
 BlueStore
 ---------
 
 BlueStore is a special-purpose storage backend designed specifically for
-managing data on disk for Ceph OSD workloads.  BlueStore is based on over a
-decade of experience supporting and managing OSDs using FileStore.
+managing data on disk for Ceph OSD workloads.  BlueStore's design is based on
+a decade of experience of supporting and managing Filestore OSDs. 
 
 Key BlueStore features include:
 
-* Direct management of storage devices. BlueStore consumes raw block
-  devices or partitions.  This avoids intervening layers of
-  abstraction (such as local file systems like XFS) that can limit
-  performance or add complexity.
+* Direct management of storage devices. BlueStore consumes raw block devices or
+  partitions. This avoids intervening layers of abstraction (such as local file
+  systems like XFS) that can limit performance or add complexity.
 * Metadata management with RocksDB. RocksDB's key/value database is embedded
   in order to manage internal metadata, including the mapping of object
   names to block locations on disk.
@@ -77,7 +76,7 @@ metadata.
 
 FileStore is well-tested and widely used in production. However, it
 suffers from many performance deficiencies due to its overall design
-and its reliance on a traditional file system for storing object data.
+and its reliance on a traditional file system for object data storage.
 
 Although FileStore is capable of functioning on most POSIX-compatible
 file systems (including btrfs and ext4), we recommend that only the


### PR DESCRIPTION
This commit is a minor improvement to the
English syntax of storage-devices.rst.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
