### PR TITLE
mgr/cephadm: redeploy nfs daemons in error state w/ backoff

### DIFF
--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -25,6 +25,9 @@ CEPH_TYPES = ['mgr', 'mon', 'crash', 'osd', 'mds', 'rgw', 'rbd-mirror', 'cephfs-
 GATEWAY_TYPES = ['iscsi', 'nfs']
 MONITORING_STACK_TYPES = ['node-exporter', 'prometheus', 'alertmanager', 'grafana']
 
+# daemon types we want to try to redeploy ourselves if we find they are in an error state
+REDEPLOY_ON_ERROR = ['nfs']
+
 CEPH_UPGRADE_ORDER = CEPH_TYPES + GATEWAY_TYPES + MONITORING_STACK_TYPES
 
 # these daemon types use the ceph container image
@@ -133,3 +136,10 @@ def file_mode_to_str(mode: int) -> str:
             f'{"x" if (mode >> shift) & 1 else "-"}'
         ) + r
     return r
+
+
+def exponential_backoff(t: int) -> int:
+    if t < 1:  # default non-positive ints to result for t=1
+        return 90
+    # 90s, 6m, 24m, 1h|36m, 6h|24m, 1d|1h|36m, etc.
+    return (4 ** t) * 90


### PR DESCRIPTION
In order to keep up the availability of nfs daemons we want to try to keep them in a running state. Right now, we are  already able to fix nfs daemons that get removed somehow because the daemon will get put back when applying service specs. However, an nfs daemon that still exists but is in an error state is left in that state. The idea of this change is to try to "fix" these daemons by redeploying them.

The backoff portion is to try to stop us from repeatedly trying to redeploy a daemon that for whatever reason cannot be repaired. After a repair attempt, we wait a certain amount of time before we are allowed another attempt for that daemon. This amount of time increases with each subsequent attempt until we hit a point where we just give up.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
