### PR TITLE
doc: The description of "Host" on the page is inconsistent

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -790,7 +790,7 @@ Syntax
 ::
 
 	PUT /{admin}/user?subuser&format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 
 Request Parameters
@@ -899,7 +899,7 @@ Syntax
 ::
 
 	POST /{admin}/user?subuser&format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 
 Request Parameters
@@ -1004,7 +1004,7 @@ Syntax
 ::
 
 	DELETE /{admin}/user?subuser&format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 
 Request Parameters
@@ -1064,7 +1064,7 @@ Syntax
 ::
 
 	PUT /{admin}/user?key&format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 
 Request Parameters
@@ -1181,7 +1181,7 @@ Syntax
 ::
 
 	DELETE /{admin}/user?key&format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 
 Request Parameters
@@ -1242,7 +1242,7 @@ Syntax
 ::
 
 	GET /{admin}/bucket?format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 
 Request Parameters
@@ -1355,7 +1355,7 @@ Syntax
 ::
 
 	GET /{admin}/bucket?index&format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 
 Request Parameters
@@ -1411,7 +1411,7 @@ Syntax
 ::
 
 	DELETE /{admin}/bucket?format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 
 
@@ -1464,7 +1464,7 @@ Syntax
 ::
 
 	POST /{admin}/bucket?format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 
 Request Parameters
@@ -1511,7 +1511,7 @@ Syntax
 ::
 
 	PUT /{admin}/bucket?format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 
 Request Parameters
@@ -1614,7 +1614,7 @@ Syntax
 ::
 
 	DELETE /{admin}/bucket?object&format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 Request Parameters
 ~~~~~~~~~~~~~~~~~~
@@ -1666,7 +1666,7 @@ Syntax
 ::
 
 	GET /{admin}/bucket?policy&format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 
 Request Parameters
@@ -1718,7 +1718,7 @@ Syntax
 ::
 
 	PUT /{admin}/user?caps&format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 Request Parameters
 ~~~~~~~~~~~~~~~~~~
@@ -1794,7 +1794,7 @@ Syntax
 ::
 
 	DELETE /{admin}/user?caps&format=json HTTP/1.1
-	Host {fqdn}
+	Host: {fqdn}
 
 Request Parameters
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
In the "https://docs.ceph.com/en/latest/radosgw/adminops/#radosgw-admin-ops" page, the description of "Host" is not uniform, so I changed it.

Signed-off-by: wangyingbin <ybwang0211@163.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
