### PR TITLE
OSD: fixing multiple pg unstable_stats additions

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -829,6 +829,7 @@ void PG::publish_stats_to_osd()
   std::lock_guard l{pg_stats_publish_lock};
   auto stats =
     recovery_state.prepare_stats_for_publish(pg_stats_publish, unstable_stats);
+  unstable_stats.clear();
   if (stats) {
     pg_stats_publish = std::move(stats);
   }

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3832,8 +3832,8 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
   }
   update_blocked_by();
 
+  info.stats.stats.add(unstable_stats);
   pg_stat_t pre_publish = info.stats;
-  pre_publish.stats.add(unstable_stats);
   utime_t cutoff = now;
   cutoff -= cct->_conf->osd_pg_stat_report_interval_max;
 


### PR DESCRIPTION
avoid adding the same unstable_stats few times without clearing them.

Signed-off-by: Matan Breizman <mbreizma@redhat.com>