### PR TITLE
os/bluestore: Set min_alloc_size to optimal io size

### DIFF
--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -166,6 +166,7 @@ private:
 protected:
   uint64_t size = 0;
   uint64_t block_size = 0;
+  uint64_t optimal_io_size = 0;
   bool support_discard = false;
   bool rotational = true;
   bool lock_exclusive = true;
@@ -224,6 +225,7 @@ public:
   
   uint64_t get_size() const { return size; }
   uint64_t get_block_size() const { return block_size; }
+  uint64_t get_optimal_io_size() const { return optimal_io_size; }
 
   /// hook to provide utilization of thinly-provisioned device
   virtual bool get_thin_utilization(uint64_t *total, uint64_t *avail) const {

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -233,6 +233,7 @@ int KernelDevice::open(const string& p)
       dout(20) << __func__ << " devname " << devname << dendl;
       rotational = blkdev_buffered.is_rotational();
       support_discard = blkdev_buffered.support_discard();
+      optimal_io_size = blkdev_buffered.get_optimal_io_size();
       this->devname = devname;
       _detect_vdo();
     }
@@ -320,6 +321,7 @@ int KernelDevice::collect_metadata(const string& prefix, map<string,string> *pm)
   (*pm)[prefix + "rotational"] = stringify((int)(bool)rotational);
   (*pm)[prefix + "size"] = stringify(get_size());
   (*pm)[prefix + "block_size"] = stringify(get_block_size());
+  (*pm)[prefix + "optimal_io_size"] = stringify(get_optimal_io_size());
   (*pm)[prefix + "driver"] = "KernelDevice";
   if (rotational) {
     (*pm)[prefix + "type"] = "hdd";

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -217,6 +217,11 @@ int BlkDev::discard(int64_t offset, int64_t len) const
   return ioctl(fd, BLKDISCARD, range);
 }
 
+int BlkDev::get_optimal_io_size() const
+{
+	return get_int_property("queue/optimal_io_size");
+}
+
 bool BlkDev::is_rotational() const
 {
   return get_int_property("queue/rotational") > 0;

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -56,6 +56,7 @@ public:
   int partition(char* partition, size_t max) const;
   // from a device (e.g., "sdb")
   bool support_discard() const;
+  int get_optimal_io_size() const;
   bool is_rotational() const;
   int get_numa_node(int *node) const;
   int dev(char *dev, size_t max) const;

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4287,6 +4287,16 @@ options:
   flags:
   - create
   with_legacy: true
+- name: bluestore_use_optimal_io_size_for_min_alloc_size 
+  type: bool
+  level: advanced
+  desc: Discover media optimal IO Size and use for min_alloc_size
+  default: false
+  see_also:
+  - bluestore_min_alloc_size
+  flags:
+  - create
+  with_legacy: true
 - name: bluestore_max_alloc_size
   type: size
   level: advanced

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5376,6 +5376,8 @@ int BlueStore::_open_bdev(bool create)
   if (r < 0) {
     goto fail_close;
   }
+  // get block dev optimal io size
+  optimal_io_size = bdev->get_optimal_io_size();
 
   return 0;
 
@@ -6859,7 +6861,14 @@ int BlueStore::mkfs()
   dout(10) << " freelist_type " << freelist_type << dendl;
 
   // choose min_alloc_size
-  if (cct->_conf->bluestore_min_alloc_size) {
+  dout(5) << __func__ << " optimal_io_size 0x" << std::hex << optimal_io_size
+	  << " block_size: 0x" << block_size << std::dec << dendl;
+  if ((cct->_conf->bluestore_use_optimal_io_size_for_min_alloc_size) && (optimal_io_size != 0)) {
+    dout(5) << __func__ << " optimal_io_size 0x" << std::hex << optimal_io_size
+		<< " for min_alloc_size 0x" << min_alloc_size << std::dec << dendl;
+    min_alloc_size = optimal_io_size;
+  }
+  else if (cct->_conf->bluestore_min_alloc_size) {
     min_alloc_size = cct->_conf->bluestore_min_alloc_size;
   } else {
     ceph_assert(bdev);
@@ -6877,6 +6886,16 @@ int BlueStore::mkfs()
 	 << std::hex << min_alloc_size << std::dec
 	 << " is not power of 2 aligned!"
 	 << dendl;
+    r = -EINVAL;
+    goto out_close_bdev;
+  }
+
+  // make sure min_alloc_size is >= and aligned with block size
+  if (min_alloc_size % block_size != 0) {
+    derr << __func__ << " min_alloc_size 0x"
+	 << std::hex << min_alloc_size
+	 << " is less or not aligned with block_size: 0x"
+	 << block_size << std::dec <<  dendl;
     r = -EINVAL;
     goto out_close_bdev;
   }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2124,6 +2124,7 @@ private:
   uint64_t block_size = 0;     ///< block size of block device (power of 2)
   uint64_t block_mask = 0;     ///< mask to get just the block offset
   size_t block_size_order = 0; ///< bits to shift to get block size
+  uint64_t optimal_io_size = 0;///< best performance io size for block device
 
   uint64_t min_alloc_size; ///< minimum allocation unit (power of 2)
   ///< bits for min_alloc_size


### PR DESCRIPTION
Block devices may report an "optimal_io_size" that is different than the
typical 4KiB. To optimize BlueStore for this io size, the allocator
needs to set its min_alloc_size to this optimal_io_size. This PR adds
the discovery of the optimal_io_size for a block device and an option
to use the optimal_io_size as the min_alloc_size for the bluestore allocator.

Older devices may report an optimal_io_size of 0 and if that is the
case, the default config min_alloc_size is used.

Signed-off-by: Curt Bruns <curt.e.bruns@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
