### PR TITLE
mgr/orchestrator: log exception from wrapper

### DIFF
--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -124,6 +124,7 @@ def handle_orch_error(f: Callable[..., T]) -> Callable[..., 'OrchResult[T]']:
         try:
             return OrchResult(f(*args, **kwargs))
         except Exception as e:
+            logger.exception(e)
             return OrchResult(None, exception=e)
 
     return cast(Callable[..., OrchResult[T]], wrapper)


### PR DESCRIPTION
This lets us see a proper traceback when we are calling across
modules.

Signed-off-by: Sage Weil <sage@newdream.net>