### PR TITLE
octopus: rgw/rgw_rados: make RGW request IDs non-deterministic

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -9,6 +9,7 @@
 
 #include "include/rados/librados.hpp"
 #include "include/Context.h"
+#include "include/random.h"
 #include "common/RefCountedObj.h"
 #include "common/RWLock.h"
 #include "common/ceph_time.h"
@@ -422,7 +423,7 @@ class RGWRados
   int open_pool_ctx(const rgw_pool& pool, librados::IoCtx&  io_ctx,
 		    bool mostly_omap);
 
-  std::atomic<int64_t> max_req_id = { 0 };
+
   ceph::mutex lock = ceph::make_mutex("rados_timer_lock");
   SafeTimer *timer;
 
@@ -555,7 +556,7 @@ public:
   }
 
   uint64_t get_new_req_id() {
-    return ++max_req_id;
+    return ceph::util::generate_random_number<uint64_t>();
   }
 
   librados::IoCtx* get_lc_pool_ctx() {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52959

---

backport of https://github.com/ceph/ceph/pull/43428
parent tracker: https://tracker.ceph.com/issues/52818

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh