### PR TITLE
pacific: mon: do not quickly mark mds laggy when MON_DOWN

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2107,6 +2107,11 @@ std::vector<Option> get_global_options() {
     .add_service("mon")
     .set_description("force mons to trim mdsmaps/fsmaps through this epoch"),
 
+    Option("mds_beacon_mon_down_grace", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
+    .set_default(1_min)
+    .set_description("tolerance in seconds for missed MDS beacons to monitors")
+    .set_long_description("The interval without beacons before Ceph declares an MDS laggy when a monitor is down."),
+
     Option("mon_mds_skip_sanity", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .add_service("mon")

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3037,8 +3037,9 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f,
       string spacing(maxlen - 3, ' ');
       const auto quorum_names = get_quorum_names();
       const auto mon_count = monmap->mon_info.size();
+      auto mnow = ceph::mono_clock::now();
       ss << "    mon: " << spacing << mon_count << " daemons, quorum "
-	 << quorum_names << " (age " << quorum_age() << ")";
+	 << quorum_names << " (age " << timespan_str(mnow - quorum_since) << ")";
       if (quorum_names.size() != mon_count) {
 	std::list<std::string> out_of_q;
 	for (size_t i = 0; i < monmap->ranks.size(); ++i) {

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2595,8 +2595,7 @@ void Monitor::_quorum_status(Formatter *f, ostream& ss)
   if (!quorum.empty()) {
     f->dump_int(
       "quorum_age",
-      std::chrono::duration_cast<std::chrono::seconds>(
-	mono_clock::now() - quorum_since).count());
+      quorum_age());
   }
 
   f->open_object_section("features");
@@ -2631,8 +2630,7 @@ void Monitor::get_mon_status(Formatter *f)
   if (!quorum.empty()) {
     f->dump_int(
       "quorum_age",
-      std::chrono::duration_cast<std::chrono::seconds>(
-	mono_clock::now() - quorum_since).count());
+      quorum_age());
   }
 
   f->open_object_section("features");
@@ -2971,7 +2969,6 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f,
 
   const auto&& fs_names = session->get_allowed_fs_names();
 
-  mono_clock::time_point now = mono_clock::now();
   if (f) {
     f->dump_stream("fsid") << monmap->get_fsid();
     healthmon()->get_health_status(false, f, nullptr);
@@ -2987,8 +2984,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f,
       f->close_section();
       f->dump_int(
 	"quorum_age",
-	std::chrono::duration_cast<std::chrono::seconds>(
-	  mono_clock::now() - quorum_since).count());
+        quorum_age());
     }
     f->open_object_section("monmap");
     monmap->dump_summary(f);
@@ -3042,7 +3038,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f,
       const auto quorum_names = get_quorum_names();
       const auto mon_count = monmap->mon_info.size();
       ss << "    mon: " << spacing << mon_count << " daemons, quorum "
-	 << quorum_names << " (age " << timespan_str(now - quorum_since) << ")";
+	 << quorum_names << " (age " << quorum_age() << ")";
       if (quorum_names.size() != mon_count) {
 	std::list<std::string> out_of_q;
 	for (size_t i = 0; i < monmap->ranks.size(); ++i) {

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -217,7 +217,8 @@ public:
   std::vector<DaemonHealthMetric> get_health_metrics();
 
   int quorum_age() const {
-    auto age = ceph::mono_clock::now() - quorum_since;
+    auto age = std::chrono::duration_cast<std::chrono::seconds>(
+      ceph::mono_clock::now() - quorum_since);
     return age.count();
   }
 

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -216,6 +216,11 @@ public:
 
   std::vector<DaemonHealthMetric> get_health_metrics();
 
+  int quorum_age() const {
+    auto age = ceph::mono_clock::now() - quorum_since;
+    return age.count();
+  }
+
   // -- elector --
 private:
   std::unique_ptr<Paxos> paxos;

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -221,6 +221,13 @@ public:
     return age.count();
   }
 
+  bool is_mon_down() const {
+    int max = monmap->size();
+    int actual = get_quorum().size();
+    auto now = ceph::real_clock::now();
+    return actual < max && now > monmap->created.to_real_time();
+  }
+
   // -- elector --
 private:
   std::unique_ptr<Paxos> paxos;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52636

---

backport of https://github.com/ceph/ceph/pull/42943
parent tracker: https://tracker.ceph.com/issues/43216

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh