### PR TITLE
osd: Use __func__ macro instead of hardcoded names

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -336,7 +336,7 @@ void OSDService::remove_pgid(spg_t pgid, PG *pg)
 void OSDService::dump_live_pgids()
 {
   std::lock_guard l(pgid_lock);
-  derr << "live pgids:" << dendl;
+  derr << __func__ << " live pgids:" << dendl;
   for (map<spg_t, int>::const_iterator i = pgid_tracker.cbegin();
        i != pgid_tracker.cend();
        ++i) {
@@ -2013,7 +2013,7 @@ int OSD::mkfs(CephContext *cct,
 
   ret = store->mkfs();
   if (ret) {
-    derr << "OSD::mkfs: ObjectStore::mkfs failed with error "
+    derr << __func__ << ": ObjectStore::mkfs failed with error "
          << cpp_strerror(ret) << dendl;
     return ret;
   }
@@ -2022,7 +2022,7 @@ int OSD::mkfs(CephContext *cct,
 
   ret = store->mount();
   if (ret) {
-    derr << "OSD::mkfs: couldn't mount ObjectStore: error "
+    derr << __func__ << ": couldn't mount ObjectStore: error "
          << cpp_strerror(ret) << dendl;
     return ret;
   }
@@ -2036,7 +2036,7 @@ int OSD::mkfs(CephContext *cct,
   if (ch) {
     ret = store->read(ch, OSD_SUPERBLOCK_GOBJECT, 0, 0, sbbl);
     if (ret < 0) {
-      derr << "OSD::mkfs: have meta collection but no superblock" << dendl;
+      derr << __func__ << ": have meta collection but no superblock" << dendl;
       return ret;
     }
     /* if we already have superblock, check content of superblock */
@@ -2070,7 +2070,7 @@ int OSD::mkfs(CephContext *cct,
     t.write(coll_t::meta(), OSD_SUPERBLOCK_GOBJECT, 0, bl.length(), bl);
     ret = store->queue_transaction(ch, std::move(t));
     if (ret) {
-      derr << "OSD::mkfs: error while writing OSD_SUPERBLOCK_GOBJECT: "
+      derr << __func__ << ": error while writing OSD_SUPERBLOCK_GOBJECT: "
 	   << "queue_transaction returned " << cpp_strerror(ret) << dendl;
       return ret;
     }
@@ -2079,7 +2079,7 @@ int OSD::mkfs(CephContext *cct,
 
   ret = write_meta(cct, store.get(), sb.cluster_fsid, sb.osd_fsid, whoami, osdspec_affinity);
   if (ret) {
-    derr << "OSD::mkfs: failed to write fsid file: error "
+    derr << __func__ << ": failed to write fsid file: error "
          << cpp_strerror(ret) << dendl;
   }
   return ret;
@@ -2325,7 +2325,7 @@ int OSD::pre_init()
     return 0;
 
   if (store->test_mount_in_use()) {
-    derr << "OSD::pre_init: object store '" << dev_path << "' is "
+    derr << __func__ << ": object store '" << dev_path << "' is "
          << "currently in use. (Is ceph-osd already running?)" << dendl;
     return -EBUSY;
   }
@@ -3470,7 +3470,7 @@ int OSD::init()
   }
 
   // mount.
-  dout(2) << "init " << dev_path
+  dout(2) << __func__ << " " << dev_path
 	  << " (looks like " << (store_is_rotational ? "hdd" : "ssd") << ")"
 	  << dendl;
   dout(2) << "journal " << journal_path << dendl;
@@ -3480,7 +3480,7 @@ int OSD::init()
 
   int r = store->mount();
   if (r < 0) {
-    derr << "OSD:init: unable to mount object store" << dendl;
+    derr << __func__ << ": unable to mount object store" << dendl;
     return r;
   }
   journal_is_rotational = store->is_journal_rotational();
@@ -3498,7 +3498,7 @@ int OSD::init()
   if (getloadavg(loadavgs, 3) == 3) {
     daily_loadavg = loadavgs[2];
   } else {
-    derr << "OSD::init() : couldn't read loadavgs\n" << dendl;
+    derr << __func__ << " : couldn't read loadavgs\n" << dendl;
     daily_loadavg = 1.0;
   }
 
@@ -3534,25 +3534,28 @@ int OSD::init()
   // read superblock
   r = read_superblock();
   if (r < 0) {
-    derr << "OSD::init() : unable to read osd superblock" << dendl;
+    derr << __func__ << " : unable to read osd superblock" << dendl;
     r = -EINVAL;
     goto out;
   }
 
   if (osd_compat.compare(superblock.compat_features) < 0) {
-    derr << "The disk uses features unsupported by the executable." << dendl;
+    derr << __func__ << " The disk uses features unsupported by the executable."
+         << dendl;
     derr << " ondisk features " << superblock.compat_features << dendl;
     derr << " daemon features " << osd_compat << dendl;
 
     if (osd_compat.writeable(superblock.compat_features)) {
       CompatSet diff = osd_compat.unsupported(superblock.compat_features);
-      derr << "it is still writeable, though. Missing features: " << diff << dendl;
+      derr << __func__ << " it is still writeable, though. Missing features: "
+           << diff << dendl;
       r = -EOPNOTSUPP;
       goto out;
     }
     else {
       CompatSet diff = osd_compat.unsupported(superblock.compat_features);
-      derr << "Cannot write to disk! Missing features: " << diff << dendl;
+      derr << __func__ << " Cannot write to disk! Missing features: "
+           << diff << dendl;
       r = -EOPNOTSUPP;
       goto out;
     }
@@ -3560,7 +3563,7 @@ int OSD::init()
 
   assert_warn(whoami == superblock.whoami);
   if (whoami != superblock.whoami) {
-    derr << "OSD::init: superblock says osd"
+    derr << __func__ << ": superblock says osd"
 	 << superblock.whoami << " but I am osd." << whoami << dendl;
     r = -EINVAL;
     goto out;
@@ -3571,7 +3574,7 @@ int OSD::init()
   // load up "current" osdmap
   assert_warn(!get_osdmap());
   if (get_osdmap()) {
-    derr << "OSD::init: unable to read current osdmap" << dendl;
+    derr << __func__ << ": unable to read current osdmap" << dendl;
     r = -EINVAL;
     goto out;
   }
@@ -4352,7 +4355,7 @@ int OSD::shutdown()
   write_superblock(t);
   int r = store->queue_transaction(service.meta_ch, std::move(t));
   if (r) {
-    derr << "OSD::shutdown: error writing superblock: "
+    derr << __func__ << ": error writing superblock: "
 	 << cpp_strerror(r) << dendl;
   }
 
@@ -4852,7 +4855,7 @@ void OSD::load_pgs()
   vector<coll_t> ls;
   int r = store->list_collections(ls);
   if (r < 0) {
-    derr << "failed to list pgs: " << cpp_strerror(-r) << dendl;
+    derr << __func__ << " failed to list pgs: " << cpp_strerror(-r) << dendl;
   }
 
   int num = 0;
@@ -5796,12 +5799,12 @@ void OSD::heartbeat_check()
        ++p) {
 
     if (p->second.first_tx == utime_t()) {
-      dout(25) << "heartbeat_check we haven't sent ping to osd." << p->first
+      dout(25) << __func__ << " we haven't sent ping to osd." << p->first
                << " yet, skipping" << dendl;
       continue;
     }
 
-    dout(25) << "heartbeat_check osd." << p->first
+    dout(25) << __func__ << " osd." << p->first
 	     << " first_tx " << p->second.first_tx
 	     << " last_tx " << p->second.last_tx
 	     << " last_rx_back " << p->second.last_rx_back
@@ -5811,7 +5814,7 @@ void OSD::heartbeat_check()
       utime_t oldest_deadline = p->second.ping_history.begin()->second.first;
       if (p->second.last_rx_back == utime_t() ||
 	  p->second.last_rx_front == utime_t()) {
-        derr << "heartbeat_check: no reply from "
+        derr << __func__ << ": no reply from "
              << p->second.con_front->get_peer_addr().get_sockaddr()
              << " osd." << p->first
              << " ever on either front or back, first ping sent "
@@ -5821,7 +5824,7 @@ void OSD::heartbeat_check()
 	// fail
 	failure_queue[p->first] = p->second.first_tx;
       } else {
-	derr << "heartbeat_check: no reply from "
+	derr << __func__ << ": no reply from "
              << p->second.con_front->get_peer_addr().get_sockaddr()
 	     << " osd." << p->first << " since back " << p->second.last_rx_back
 	     << " front " << p->second.last_rx_front
@@ -7084,7 +7087,7 @@ bool OSD::heartbeat_dispatch(Message *m)
 
 bool OSD::ms_dispatch(Message *m)
 {
-  dout(20) << "OSD::ms_dispatch: " << *m << dendl;
+  dout(20) << __func__ << " " << *m << dendl;
   if (m->get_type() == MSG_OSD_MARK_ME_DOWN) {
     service.got_stop_ack();
     m->put();


### PR DESCRIPTION
Replace a number of hardcoded function names with `__func__` macro in derr/dout calls.

Signed-off-by: Ponnuvel Palaniyappan <pponnuvel@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
