### PR TITLE
mgr/cephadm: fix port handling for cephadm endpoint

### DIFF
--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -45,13 +45,12 @@ class CherryPyThread(threading.Thread):
         self.mgr = mgr
         self.cherrypy_shutdown_event = threading.Event()
         self.ssl_certs = SSLCerts(self.mgr)
+        self.server_port = 7150
+        self.server_addr = self.mgr.get_mgr_ip()
         super(CherryPyThread, self).__init__(target=self.run)
 
     def run(self) -> None:
         try:
-            server_addr = self.mgr.get_mgr_ip()
-            server_port = self.mgr.endpoint_port
-
             self.ssl_certs.generate_root_cert()
             cert, key = self.ssl_certs.generate_cert()
 
@@ -67,11 +66,9 @@ class CherryPyThread(threading.Thread):
 
             verify_tls_files(cert_fname, key_fname)
 
-            self.mgr.set_uri('https://{0}:{1}/'.format(server_addr, server_port))
-
             cherrypy.config.update({
-                'server.socket_host': server_addr,
-                'server.socket_port': server_port,
+                'server.socket_host': self.server_addr,
+                'server.socket_port': self.server_port,
                 'engine.autoreload.on': False,
                 'server.ssl_module': 'builtin',
                 'server.ssl_certificate': cert_fname,
@@ -81,7 +78,7 @@ class CherryPyThread(threading.Thread):
                                'tools.response_headers.on': True}}
             cherrypy.tree.mount(Root(self.mgr), '/', root_conf)
             self.mgr.log.info('Starting cherrypy engine...')
-            cherrypy.engine.start()
+            self.start_engine()
             self.mgr.log.info('Cherrypy engine started.')
             # wait for the shutdown event
             self.cherrypy_shutdown_event.wait()
@@ -90,6 +87,25 @@ class CherryPyThread(threading.Thread):
             self.mgr.log.info('Cherrypy engine stopped.')
         except Exception as e:
             self.mgr.log.error(f'Failed to run cephadm cherrypy endpoint: {e}')
+
+    def start_engine(self) -> None:
+        port_connect_attempts = 0
+        while port_connect_attempts < 150:
+            try:
+                cherrypy.engine.start()
+                self.mgr.log.info(f'Cephadm endpoint connected to port {self.server_port}')
+                return
+            except cherrypy.process.wspbus.ChannelFailures as e:
+                self.mgr.log.info(
+                    f'{e}. Trying next port.')
+                self.server_port += 1
+                cherrypy.server.httpserver = None
+                cherrypy.config.update({
+                    'server.socket_port': self.server_port
+                })
+                port_connect_attempts += 1
+        self.mgr.log.error(
+            'Cephadm Endpoint could not find free port in range 7150-7300 and failed to start')
 
     def shutdown(self) -> None:
         self.mgr.log.info('Stopping cherrypy engine...')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -350,12 +350,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='How often agent on each host will try to gather and send metadata'
         ),
         Option(
-            'endpoint_port',
-            type='int',
-            default=8499,
-            desc='Which port cephadm http endpoint will listen on'
-        ),
-        Option(
             'agent_starting_port',
             type='int',
             default=4721,
@@ -429,7 +423,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.ssh_pub: Optional[str] = None
             self.use_agent = False
             self.agent_refresh_rate = 0
-            self.endpoint_port = 0
             self.agent_starting_port = 0
             self.apply_spec_fails: List[Tuple[str, str]] = []
             self.max_osd_draining_count = 10
@@ -2219,11 +2212,13 @@ Then run the following:
             deps = [d.name() for d in daemons if d.daemon_type == 'haproxy']
         elif daemon_type == 'agent':
             root_cert = ''
+            server_port = ''
             try:
+                server_port = str(self.cherrypy_thread.server_port)
                 root_cert = self.cherrypy_thread.ssl_certs.get_root_cert()
             except Exception:
                 pass
-            deps = sorted([self.get_mgr_ip(), str(self.endpoint_port), root_cert,
+            deps = sorted([self.get_mgr_ip(), server_port, root_cert,
                            str(self.get_module_option('device_enhanced_scan'))])
         elif daemon_type == 'iscsi':
             deps = [self.get_mgr_ip()]


### PR DESCRIPTION
check range of ports if port is taken
reject ports < 1024 or > 65535
redeploy server with new port is endpoint_port config option changed
fix agent dep to use actual port in use rather than config option

Signed-off-by: Adam King <adking@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
