### PR TITLE
mgr/dashboard: fix nfs export creation with same pseudo value

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nfsganesha.py
+++ b/src/pybind/mgr/dashboard/controllers/nfsganesha.py
@@ -22,8 +22,8 @@ logger = logging.getLogger('controllers.nfs')
 
 
 class NFSException(DashboardException):
-    def __init__(self, msg):
-        super(NFSException, self).__init__(component="nfs", msg=msg)
+    def __init__(self, msg, code=None):
+        super(NFSException, self).__init__(component="nfs", msg=msg, code=code)
 
 
 # documentation helpers
@@ -165,6 +165,9 @@ class NFSGaneshaExports(RESTController):
             'clients': clients
         }
         export_mgr = mgr.remote('nfs', 'fetch_nfs_export_obj')
+
+        if export_mgr._get_export_dict(cluster_id, pseudo):  # pylint: disable=W0212
+            raise NFSException("Export already exists", 400)
         ret, _, err = export_mgr.apply_export(cluster_id, json.dumps(raw_ex))
         if ret == 0:
             return self._get_schema_export(


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
