### PR TITLE
cephadm: --config-json overrides --config or --keyring args

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2336,6 +2336,8 @@ def get_config_and_keyring(ctx):
         d = get_parm(ctx.config_json)
         config = d.get('config')
         keyring = d.get('keyring')
+        if config and keyring:
+            return config, keyring
 
     if 'config' in ctx and ctx.config:
         try:


### PR DESCRIPTION
These args aren't normally combined, but if --fsid and --name are
provided, they may be inferred.

Signed-off-by: Sage Weil <sage@newdream.net>