### PR TITLE
mgr/nfs: handle subprocess exceptions

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1557,6 +1557,34 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         """
         self._ceph_send_command(result, svc_type, svc_id, command, tag, inbuf)
 
+    def tool_exec(
+        self,
+        args: List[str],
+        timeout: int = 10,
+        stdin: Optional[bytes] = None
+    ) -> Tuple[int, str, str]:
+        try:
+            tool = args.pop(0)
+            cmd = [
+                tool,
+                '-k', str(self.get_ceph_option('keyring')),
+                '-n', f'mgr.{self.get_mgr_id()}',
+            ] + args
+            self.log.debug('exec: ' + ' '.join(cmd))
+            p = subprocess.run(
+                cmd,
+                input=stdin,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as ex:
+            self.log.error(ex)
+            return -errno.ETIMEDOUT, '', str(ex)
+        if p.returncode:
+            self.log.error(f'Non-zero return from {cmd}: {p.stderr.decode()}')
+        return p.returncode, p.stdout.decode(), p.stderr.decode()
+
     def set_health_checks(self, checks: HealthChecksT) -> None:
         """
         Set the module's current map of health checks.  Argument is a

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple, Iterator, List, Any
 from contextlib import contextmanager
 from unittest import mock
 from unittest.mock import MagicMock
-from mgr_module import NFS_POOL_NAME
+from mgr_module import MgrModule, NFS_POOL_NAME
 
 from rados import ObjectNotFound
 
@@ -222,7 +222,7 @@ EXPORT {
                            return_value=[self.cluster_id]), \
                 mock.patch('nfs.export.restart_nfs_service'), \
                 mock.patch('nfs.cluster.restart_nfs_service'), \
-                mock.patch('nfs.export.ExportMgr._exec', mock_exec), \
+                mock.patch.object(MgrModule, 'tool_exec', mock_exec), \
                 mock.patch('nfs.export.check_fs', return_value=True), \
                 mock.patch('nfs.export_utils.check_fs', return_value=True), \
                 mock.patch('nfs.export.ExportMgr._create_user_key',


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/53096
Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
