### PR TITLE
doc: Additional step in the manual monitor adding procedure 

### DIFF
--- a/doc/rados/operations/add-or-rm-mons.rst
+++ b/doc/rados/operations/add-or-rm-mons.rst
@@ -126,7 +126,11 @@ on ``mon.a``).
 
 	sudo ceph-mon -i {mon-id} --mkfs --monmap {tmp}/{map-filename} --keyring {tmp}/{key-filename}
 	
-
+#. Add the new monitor to the list of monitors of the cluster. 
+   This enables other nodes to use this monitor during their initial startup.
+   
+        ceph-mon add {mon-id} {ip:port}
+    
 #. Start the new monitor and it will automatically join the cluster.
    The daemon needs to know which address to bind to, via either the
    ``--public-addr {ip}`` or ``--public-network {network}`` argument.


### PR DESCRIPTION
doc: Additional step in the manual "Adding a monitor" procedure 

One step is missing from the procedure to manual add a monitor into the cluster.
Following the procedure, in fact, the monitor is not join the cluster.

Log from new monitor after starting the mon service:
> 2021-10-29T19:17:53.075+0200 7f20e7249700  0 mon.ceph-mon02-tb does not exist in monmap, will attempt to join an existing cluster
> 2021-10-29T19:17:53.075+0200 7f20e7249700  0 using public_addr v2:10.10.96.187:0/0 -> [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0]
> 2021-10-29T19:17:53.075+0200 7f20e7249700  0 starting mon.ceph-mon02-tb rank -1 at public addrs [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0] at bind addrs [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0] mon_data /var/lib/ceph/mon/ceph-ceph-mon02-tb fsid 
> 2021-10-29T19:17:53.076+0200 7f20e7249700  1 mon.ceph-mon02-tb@-1(???) e0 preinit fsid 
> 2021-10-29T19:17:53.076+0200 7f20e7249700  1 mon.ceph-mon02-tb@-1(???) e0  initial_members ceph-mon01-tb,ceph-mon02-tb,ceph-mon03-tb, filtering seed monmap
> 2021-10-29T19:17:53.077+0200 7f20e7249700  0 -- [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0] send_to message mon_probe(probe  name ceph-mon02-tb new mon_release octopus) v7 with empty dest
>2021-10-29T19:17:55.078+0200 7f20d215d700  0 -- [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0] send_to message mon_probe(probe  name ceph-mon02-tb new mon_release octopus) v7 with empty dest
> 2021-10-29T19:17:57.078+0200 7f20d215d700  0 -- [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0] send_to message mon_probe(probe name ceph-mon02-tb new mon_release octopus) v7 with empty dest
> 2021-10-29T19:17:59.078+0200 7f20d215d700  0 -- [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0] send_to message mon_probe(probe  name ceph-mon02-tb new mon_release octopus) v7 with empty dest
> 2021-10-29T19:18:01.078+0200 7f20d215d700  0 -- [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0] send_to message mon_probe(probe  name ceph-mon02-tb new mon_release octopus) v7 with empty dest
> 2021-10-29T19:18:03.078+0200 7f20d215d700  0 -- [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0] send_to message mon_probe(probe  name ceph-mon02-tb new mon_release octopus) v7 with empty dest
> 2021-10-29T19:18:05.078+0200 7f20d215d700  0 -- [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0] send_to message mon_probe(probe  name ceph-mon02-tb new mon_release octopus) v7 with empty dest
> ...

Step added: new monitor has to be added to the list of monitors of the cluster before starting the service
`
ceph mon add {mon-id} {ip:port}
`

Log from new monitor with the added step, after starting the mon service:
> 2021-10-29T19:21:39.581+0200 7fc453739700  0 mon.ceph-mon02-tb does not exist in monmap, will attempt to join an existing cluster
> 2021-10-29T19:21:39.581+0200 7fc453739700  0 using public_addr v2:10.10.96.187:0/0 -> [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0]
> 2021-10-29T19:21:39.581+0200 7fc453739700  0 starting mon.ceph-mon02-tb rank -1 at public addrs [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0] at bind addrs [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0] mon_data /var/lib/ceph/mon/ceph-ceph-mon02-tb fsid 
> 2021-10-29T19:21:39.583+0200 7fc453739700  1 mon.ceph-mon02-tb@-1(???) e0 preinit fsid 
> 2021-10-29T19:21:39.583+0200 7fc453739700  1 mon.ceph-mon02-tb@-1(???) e0  initial_members ceph-mon01-tb,ceph-mon02-tb,ceph-mon03-tb, filtering seed monmap
> 2021-10-29T19:21:39.584+0200 7fc453739700  0 -- [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0] send_to message mon_probe(probe  name ceph-mon02-tb new mon_release octopus) v7 with empty dest
> 2021-10-29T19:21:41.585+0200 7fc43e64d700  0 -- [v2:10.10.96.187:3300/0,v1:10.10.96.187:6789/0] send_to message mon_probe(probe  name ceph-mon02-tb new mon_release octopus) v7 with empty dest
> 2021-10-29T19:21:41.846+0200 7fc43be48700  0 mon.ceph-mon02-tb@-1(probing) e10  my rank is now 2 (was -1)
> 2021-10-29T19:21:41.847+0200 7fc43be48700  1 mon.ceph-mon02-tb@2(synchronizing) e10 sync_obtain_latest_monmap
> 2021-10-29T19:21:41.848+0200 7fc43be48700  1 mon.ceph-mon02-tb@2(synchronizing) e10 sync_obtain_latest_monmap obtained monmap e10
> 2021-10-29T19:21:42.120+0200 7fc43be48700  4 rocksdb: [db/db_impl_write.cc:1470] [default] New memtable created with log file: #30. Immutable memtables: 0.

 With the addictional step, the monitor joined the cluster.




## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
