### PR TITLE
pybind/mgr/pg_autoscaler: typo default option scale-up to scale-down

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -128,14 +128,14 @@ class PgAutoscaler(MgrModule):
             default=60),
         Option(
             'autoscale_profile',
-            default='scale-up',
+            default='scale-down',
             type='str',
             desc='pg_autoscale profiler',
-            long_desc=('Determines the behavior of the autoscaler algorithm '
+            long_desc=('Determines the behavior of the autoscaler algorithm, '
+                       '`scale-down means start out with full pgs and scales'
+                       'down when there is pressure'
                        '`scale-up` means that it starts out with minmum pgs '
-                       'and scales up when there is pressure, `scale-down` '
-                       'means starts out with full pgs and scales down when '
-                       'there is pressure '),
+                       'and scales up when there is pressure'),
             runtime=True),
         Option(
             name='threshold',
@@ -156,7 +156,7 @@ class PgAutoscaler(MgrModule):
         # to just keep a copy of the pythonized version.
         self._osd_map = None
         if TYPE_CHECKING:
-            self.autoscale_profile: 'ScaleModeT' = 'scale-up'
+            self.autoscale_profile: 'ScaleModeT' = 'scale-down'
             self.sleep_interval = 60
             self.mon_target_pg_per_osd = 0
             self.threshold = 3.0


### PR DESCRIPTION
Typo: `scale-up` should be `scale-down` in Module
Option.

This typo doesn't trigger a bug because we create
a key-value of `scale-down` profile in
the function `create_initial()` in `src/mon/KVMonitor.cc`.
This will override whatever is the default option
in pg_autoscaler/module.py when we start the cluster and
the monitor gets created.

The command: `ceph osd pool set autoscale-profile <option>`
is still the primary command to change the autoscale-profiler
after the pool is created.

Fixes: https://tracker.ceph.com/issues/53203

Signed-off-by: Kamoltat <ksirivad@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
