### PR TITLE
octopus: os/bluestore/AvlAllocator: introduce bluestore_avl_alloc_ff_max_* options

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4716,6 +4716,10 @@ std::vector<Option> get_global_options() {
     .set_description("Enforces specific hw profile settings")
     .set_long_description("'hdd' enforces settings intended for BlueStore above a rotational drive. 'ssd' enforces settings intended for BlueStore above a solid drive. 'default' - using settings for the actual hardware."),
 
+    Option("bluestore_avl_alloc_ff_max_search_count", Option::TYPE_UINT, Option::LEVEL_DEV)
+    .set_default(100)
+    .set_description("Search for this many ranges in first-fit mode before switching over to to best-fit mode. 0 to iterate through all ranges for required chunk."),
+
     Option("bluestore_avl_alloc_bf_threshold", Option::TYPE_UINT, Option::LEVEL_DEV)
     .set_default(131072)
     .set_description(""),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4720,6 +4720,10 @@ std::vector<Option> get_global_options() {
     .set_default(100)
     .set_description("Search for this many ranges in first-fit mode before switching over to to best-fit mode. 0 to iterate through all ranges for required chunk."),
 
+    Option("bluestore_avl_alloc_ff_max_search_bytes", Option::TYPE_SIZE, Option::LEVEL_DEV)
+    .set_default(16_M)
+    .set_description("Maximum distance to search in first-fit mode before switching over to to best-fit mode. 0 to iterate through all ranges for required chunk."),
+
     Option("bluestore_avl_alloc_bf_threshold", Option::TYPE_UINT, Option::LEVEL_DEV)
     .set_default(131072)
     .set_description(""),

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -340,14 +340,7 @@ AvlAllocator::AvlAllocator(CephContext* cct,
 			   int64_t device_size,
 			   int64_t block_size,
 			   const std::string& name) :
-  Allocator(name),
-  num_total(device_size),
-  block_size(block_size),
-  range_size_alloc_threshold(
-    cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_threshold")),
-  range_size_alloc_free_pct(
-    cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_free_pct")),
-  cct(cct)
+  AvlAllocator(cct, device_size, block_size, 0 /* max_mem */, name)
 {}
 
 AvlAllocator::~AvlAllocator()

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -36,8 +36,8 @@ uint64_t AvlAllocator::_block_picker(const Tree& t,
 				     uint64_t align)
 {
   const auto compare = t.key_comp();
-  for (auto rs = t.lower_bound(range_t{*cursor, size}, compare);
-       rs != t.end(); ++rs) {
+  auto rs_start = t.lower_bound(range_t{*cursor, size}, compare);
+  for (auto rs = rs_start; rs != t.end(); ++rs) {
     uint64_t offset = p2roundup(rs->start, align);
     if (offset + size <= rs->end) {
       *cursor = offset + size;
@@ -48,7 +48,7 @@ uint64_t AvlAllocator::_block_picker(const Tree& t,
    * If we know we've searched the whole tree (*cursor == 0), give up.
    * Otherwise, reset the cursor to the beginning and try again.
    */
-   if (*cursor == 0) {
+   if (*cursor == 0 || rs_start == t.begin()) {
      return -1ULL;
    }
    *cursor = 0;

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -35,6 +35,7 @@ uint64_t AvlAllocator::_pick_block_after(uint64_t *cursor,
 {
   const auto compare = range_tree.key_comp();
   uint32_t search_count = 0;
+  uint64_t search_bytes = 0;
   auto rs_start = range_tree.lower_bound(range_t{*cursor, size}, compare);
   for (auto rs = rs_start; rs != range_tree.end(); ++rs) {
     uint64_t offset = p2roundup(rs->start, align);
@@ -43,6 +44,10 @@ uint64_t AvlAllocator::_pick_block_after(uint64_t *cursor,
       return offset;
     }
     if (max_search_count > 0 && ++search_count > max_search_count) {
+      return -1ULL;
+    }
+    if (search_bytes = rs->start - rs_start->start;
+	max_search_bytes > 0 && search_bytes > max_search_bytes) {
       return -1ULL;
     }
   }
@@ -58,6 +63,9 @@ uint64_t AvlAllocator::_pick_block_after(uint64_t *cursor,
       return offset;
     }
     if (max_search_count > 0 && ++search_count > max_search_count) {
+      return -1ULL;
+    }
+    if (max_search_bytes > 0 && search_bytes + rs->start > max_search_bytes) {
       return -1ULL;
     }
   }
@@ -333,6 +341,8 @@ AvlAllocator::AvlAllocator(CephContext* cct,
     cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_free_pct")),
   max_search_count(
     cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_ff_max_search_count")),
+  max_search_bytes(
+    cct->_conf.get_val<Option::size_t>("bluestore_avl_alloc_ff_max_search_bytes")),
   range_count_cap(max_mem / sizeof(range_seg_t)),
   cct(cct)
 {}

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -266,10 +266,7 @@ int AvlAllocator::_allocate(
        * not guarantee that other allocations sizes may exist in the same
        * region.
        */
-      uint64_t align = size & -size;
-      ceph_assert(align != 0);
-      uint64_t* cursor = &lbas[cbits(align) - 1];
-
+      uint64_t* cursor = &lbas[cbits(size) - 1];
       start = _pick_block_after(cursor, size, unit);
       dout(20) << __func__ << " first fit=" << start << " size=" << size << dendl;
       if (start != uint64_t(-1ULL)) {

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -34,12 +34,16 @@ uint64_t AvlAllocator::_pick_block_after(uint64_t *cursor,
 					 uint64_t align)
 {
   const auto compare = range_tree.key_comp();
+  uint32_t search_count = 0;
   auto rs_start = range_tree.lower_bound(range_t{*cursor, size}, compare);
   for (auto rs = rs_start; rs != range_tree.end(); ++rs) {
     uint64_t offset = p2roundup(rs->start, align);
     if (offset + size <= rs->end) {
       *cursor = offset + size;
       return offset;
+    }
+    if (max_search_count > 0 && ++search_count > max_search_count) {
+      return -1ULL;
     }
   }
   if (*cursor == 0) {
@@ -52,6 +56,9 @@ uint64_t AvlAllocator::_pick_block_after(uint64_t *cursor,
     if (offset + size <= rs->end) {
       *cursor = offset + size;
       return offset;
+    }
+    if (max_search_count > 0 && ++search_count > max_search_count) {
+      return -1ULL;
     }
   }
   return -1ULL;
@@ -240,35 +247,30 @@ int AvlAllocator::_allocate(
 
   const int free_pct = num_free * 100 / num_total;
   uint64_t start = 0;
-  /*
-   * If we're running low on space switch to using the size
-   * sorted AVL tree (best-fit).
-   */
+  // If we're running low on space, find a range by size by looking up in the size
+  // sorted tree (best-fit), instead of searching in the area pointed by cursor
   if (force_range_size_alloc ||
       max_size < range_size_alloc_threshold ||
       free_pct < range_size_alloc_free_pct) {
+    start = -1ULL;
+  } else {
+    /*
+     * Find the largest power of 2 block size that evenly divides the
+     * requested size. This is used to try to allocate blocks with similar
+     * alignment from the same area (i.e. same cursor bucket) but it does
+     * not guarantee that other allocations sizes may exist in the same
+     * region.
+     */
+    uint64_t align = size & -size;
+    ceph_assert(align != 0);
+    uint64_t* cursor = &lbas[cbits(align) - 1];
+    start = _pick_block_after(cursor, size, unit);
+    dout(20) << __func__ << " first fit=" << start << " size=" << size << dendl;
+  }
+  if (start == -1ULL) {
     do {
       start = _pick_block_fits(size, unit);
       dout(20) << __func__ << " best fit=" << start << " size=" << size << dendl;
-      if (start != uint64_t(-1ULL)) {
-        break;
-      }
-      // try to collect smaller extents as we could fail to retrieve
-      // that large block due to misaligned extents
-      size = p2align(size >> 1, unit);
-    } while (size >= unit);
-  } else {
-    do {
-      /*
-       * Find the largest power of 2 block size that evenly divides the
-       * requested size. This is used to try to allocate blocks with similar
-       * alignment from the same area (i.e. same cursor bucket) but it does
-       * not guarantee that other allocations sizes may exist in the same
-       * region.
-       */
-      uint64_t* cursor = &lbas[cbits(size) - 1];
-      start = _pick_block_after(cursor, size, unit);
-      dout(20) << __func__ << " first fit=" << start << " size=" << size << dendl;
       if (start != uint64_t(-1ULL)) {
         break;
       }
@@ -329,6 +331,8 @@ AvlAllocator::AvlAllocator(CephContext* cct,
     cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_threshold")),
   range_size_alloc_free_pct(
     cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_free_pct")),
+  max_search_count(
+    cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_ff_max_search_count")),
   range_count_cap(max_mem / sizeof(range_seg_t)),
   cct(cct)
 {}

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -163,7 +163,12 @@ private:
    * switch to using best-fit allocations.
    */
   int range_size_alloc_free_pct = 0;
-
+  /*
+   * Maximum number of segments to check in the first-fit mode, without this
+   * limit, fragmented device can see lots of iterations and _block_picker()
+   * becomes the performance limiting factor on high-performance storage.
+   */
+  const uint32_t max_search_count;
   /*
   * Max amount of range entries allowed. 0 - unlimited
   */

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -170,6 +170,12 @@ private:
    */
   const uint32_t max_search_count;
   /*
+   * Maximum distance to search forward from the last offset, without this
+   * limit, fragmented device can see lots of iterations and _block_picker()
+   * becomes the performance limiting factor on high-performance storage.
+   */
+  const uint32_t max_search_bytes;
+  /*
   * Max amount of range entries allowed. 0 - unlimited
   */
   uint64_t range_count_cap = 0;

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -95,8 +95,14 @@ public:
   void shutdown() override;
 
 private:
-  template<class Tree>
-  uint64_t _block_picker(const Tree& t, uint64_t *cursor, uint64_t size,
+  // pick a range by search from cursor forward
+  uint64_t _pick_block_after(
+    uint64_t *cursor,
+    uint64_t size,
+    uint64_t align);
+  // pick a range with exactly the same size or larger
+  uint64_t _pick_block_fits(
+    uint64_t size,
     uint64_t align);
   int _allocate(
     uint64_t size,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48477
backport of #38148
parent tracker: https://tracker.ceph.com/issues/48272

backport tracker: https://tracker.ceph.com/issues/53104
backport of #41398
parent tracker: https://tracker.ceph.com/issues/53085

backport tracker: https://tracker.ceph.com/issues/53102
backport of #41825
parent tracker: https://tracker.ceph.com/issues/53086

backport tracker: https://tracker.ceph.com/issues/53100
backport of #41615
parent tracker: https://tracker.ceph.com/issues/53087

These backport PRs are for tracker https://tracker.ceph.com/issues/52804

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh