### PR TITLE
crimson/os/seastore: minor cleanups

### DIFF
--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -38,17 +38,13 @@ namespace crimson::os::seastore {
 class FileMDStore final : public SeaStore::MDStore {
   std::string root;
 public:
-  FileMDStore(std::string root) : root(root) {}
+  FileMDStore(const std::string& root) : root(root) {}
 
   write_meta_ret write_meta(
     const std::string& key, const std::string& value) final {
     std::string path = fmt::format("{}/{}", root, key);
-    std::string fvalue = value;
-    fvalue += "\n";
-    ceph::bufferptr bp(fvalue.length());
     ceph::bufferlist bl;
-    bp.copy_in(0, fvalue.length(), fvalue.c_str());
-    bl.push_back(bp);
+    bl.append(value + "\n");
     return crimson::write_file(std::move(bl), path);
   }
 
@@ -73,7 +69,7 @@ public:
 };
 
 SeaStore::SeaStore(
-  std::string root,
+  const std::string& root,
   MDStoreRef mdstore,
   SegmentManagerRef sm,
   TransactionManagerRef tm,
@@ -90,7 +86,7 @@ SeaStore::SeaStore(
 }
 
 SeaStore::SeaStore(
-  std::string root,
+  const std::string& root,
   SegmentManagerRef sm,
   TransactionManagerRef tm,
   CollectionManagerRef cm,

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -62,14 +62,14 @@ public:
   using MDStoreRef = std::unique_ptr<MDStore>;
 
   SeaStore(
-    std::string root,
+    const std::string& root,
     MDStoreRef mdstore,
     SegmentManagerRef sm,
     TransactionManagerRef tm,
     CollectionManagerRef cm,
     OnodeManagerRef om);
   SeaStore(
-    std::string root,
+    const std::string& root,
     SegmentManagerRef sm,
     TransactionManagerRef tm,
     CollectionManagerRef cm,


### PR DESCRIPTION
* pass string by reference. more consistent this way.
* set a bl using list::append(), simpler this way.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
