### PR TITLE
doc: add admonition for tracker 53062

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -2,6 +2,29 @@
 Upgrading Ceph
 ==============
 
+.. DANGER:: DATE: 01 NOV 2021. 
+
+   DO NOT UPGRADE TO CEPH PACIFIC FROM AN OLDER VERSION.  
+
+   A recently-discovered bug (https://tracker.ceph.com/issues/53062) can cause
+   data corruption. This bug occurs during OMAP format conversion for
+   clusters that are updated to Pacific. New clusters are not affected by this
+   bug.
+
+   The trigger for this bug is BlueStore's repair/quick-fix functionality. This
+   bug can be triggered in two known ways: 
+
+    (1) manually via the ceph-bluestore-tool, or 
+    (2) automatically, by OSD if ``bluestore_fsck_quick_fix_on_mount`` is set 
+        to true.
+
+   The fix for this bug is expected to be available in Ceph v16.2.7.
+
+   DO NOT set ``bluestore_quick_fix_on_mount`` to true. If it is currently
+   set to true in your configuration, immediately set it to false.
+
+   DO NOT run ``ceph-bluestore-tool``'s repair/quick-fix commands.
+
 Cephadm can safely upgrade Ceph from one bugfix release to the next.  For
 example, you can upgrade from v15.2.0 (the first Octopus release) to the next
 point release, v15.2.1.

--- a/doc/releases/pacific.rst
+++ b/doc/releases/pacific.rst
@@ -5,11 +5,59 @@ Pacific
 Pacific is the 16th stable release of Ceph.  It is named after the
 giant pacific octopus (Enteroctopus dofleini).
 
+.. DANGER:: DATE: 01 NOV 2021. 
+
+   DO NOT UPGRADE TO CEPH PACIFIC FROM AN OLDER VERSION.  
+
+   A recently-discovered bug (https://tracker.ceph.com/issues/53062) can cause
+   data corruption. This bug occurs during OMAP format conversion for
+   clusters that are updated to Pacific. New clusters are not affected by this
+   bug.
+
+   The trigger for this bug is BlueStore's repair/quick-fix functionality. This
+   bug can be triggered in two known ways: 
+
+    (1) manually via the ceph-bluestore-tool, or 
+    (2) automatically, by OSD if ``bluestore_fsck_quick_fix_on_mount`` is set 
+        to true.
+
+   The fix for this bug is expected to be available in Ceph v16.2.7.
+
+   DO NOT set ``bluestore_quick_fix_on_mount`` to true. If it is currently
+   set to true in your configuration, immediately set it to false.
+
+   DO NOT run ``ceph-bluestore-tool``'s repair/quick-fix commands.
+
+
 v16.2.6 Pacific
 ===============
 
-This is the sixth backport release in the Pacific series. We recommend all
-users update to this release.
+.. DANGER:: DATE: 01 NOV 2021. 
+
+   DO NOT UPGRADE TO CEPH PACIFIC FROM AN OLDER VERSION.  
+
+   A recently-discovered bug (https://tracker.ceph.com/issues/53062) can cause
+   data corruption. This bug occurs during OMAP format conversion for
+   clusters that are updated to Pacific. New clusters are not affected by this
+   bug.
+
+   The trigger for this bug is BlueStore's repair/quick-fix functionality. This
+   bug can be triggered in two known ways: 
+
+    (1) manually via the ceph-bluestore-tool, or 
+    (2) automatically, by OSD if ``bluestore_fsck_quick_fix_on_mount`` is set 
+        to true.
+
+   The fix for this bug is expected to be available in Ceph v16.2.7.
+
+   DO NOT set ``bluestore_quick_fix_on_mount`` to true. If it is currently
+   set to true in your configuration, immediately set it to false.
+
+   DO NOT run ``ceph-bluestore-tool``'s repair/quick-fix commands.
+
+
+This is the sixth backport release in the Pacific series. 
+
 
 Notable Changes
 ---------------


### PR DESCRIPTION
NOTE: This commit also adds an admonition to the pacific.rst
      page, in the /releases directory.

This commit warns users not to upgrade to Ceph v16 (Pacific). Upgrading
to v16 (Pacific) can cause data corruption.

This commit has been made in response to https://tracker.ceph.com/issues/53062
and in response to Stefan Kooman's urgent request that we update the
documentation, adding a warning to the documentation to prevent users
from upgrading to v16 (Pacific).

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
