### PR TITLE
rgw: fix debug build of OpsLogFile

### DIFF
--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -169,7 +169,7 @@ class OpsLogFile : public JsonOpsLogSink, public Thread, public DoutPrefixProvid
   ceph::mutex flush_mutex = ceph::make_mutex("OpsLogFile_flush");
   std::vector<bufferlist> log_buffer;
   std::vector<bufferlist> flush_buffer;
-  std::condition_variable cond_flush;
+  ceph::condition_variable cond_flush;
   std::ofstream file;
   bool stopped;
   uint64_t data_size;


### PR DESCRIPTION
can't use ceph::mutex locks with std::condition_variable::wait() in debug builds. use the ceph::condition_variable wrapper instead

```
... -DCEPH_DEBUG_MUTEX ... ../src/rgw/rgw_log.cc
../src/rgw/rgw_log.cc: In member function ‘virtual void* OpsLogFile::entry()’:
../src/rgw/rgw_log.cc:391:20: error: no matching function for call to ‘std::condition_variable::wait(std::unique_lock<ceph::mutex_debug_detail::mutex_debug_impl<false> >&)’
  391 |     cond_flush.wait(lock);
      |     ~~~~~~~~~~~~~~~^~~~~~
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
