### PR TITLE
rgw/dbstore: No need for explicit LOCK in DBStore

### DIFF
--- a/src/rgw/store/dbstore/common/dbstore.cc
+++ b/src/rgw/store/dbstore/common/dbstore.cc
@@ -250,17 +250,14 @@ int DB::ProcessOp(const DoutPrefixProvider *dpp, string Op, struct DBOpParams *p
   int ret = -1;
   class DBOp *db_op;
 
-  Lock(dpp);
   db_op = getDBOp(dpp, Op, params);
 
   if (!db_op) {
     ldpp_dout(dpp, 0)<<"No db_op found for Op("<<Op<<")" << dendl;
-    Unlock(dpp);
     return ret;
   }
   ret = db_op->Execute(dpp, params);
 
-  Unlock(dpp);
   if (ret) {
     ldpp_dout(dpp, 0)<<"In Process op Execute failed for fop(" \
       <<Op.c_str()<<") " << dendl;


### PR DESCRIPTION
The current form of DBStore is not suited for multiple writers scenario (which will be addressed by using SQLite transactions) 

Thanks to Mark Kogan. `rgw::store::DB::Lock(DoutPrefixProvider const*)` seems to be bottleneck for GET ops in DBStore. This explicit lock is not useful even for I/O concurrency. Hence removing it to rely on just sqlite locking mechanisms for now.

Signed-off-by: Soumya Koduri <skoduri@redhat.com>

