### PR TITLE
crimson/os/seastore: fix ordered updates to JournalSegmentManager::committed_to

### DIFF
--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -69,7 +69,7 @@ public:
       extent_offset += extent.get_bptr().length();
     }
     assert(extent_offset == (segment_off_t)(base + rsize.mdlength + rsize.dlength));
-    return encode_record(rsize, std::move(record), block_size, base, nonce);
+    return encode_record(rsize, std::move(record), block_size, journal_seq_t(), nonce);
   }
   void add_extent(LogicalCachedExtentRef& extent) {
     extents.emplace_back(extent);
@@ -87,7 +87,7 @@ public:
   void set_base(segment_off_t b) {
     base = b;
   }
-  segment_off_t get_base() {
+  segment_off_t get_base() const {
     return base;
   }
   void clear() {

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -140,10 +140,8 @@ private:
       return current_segment_nonce;
     }
 
-    segment_off_t get_committed_to() const {
-      assert(committed_to.segment_seq ==
-             get_segment_seq());
-      return committed_to.offset.offset;
+    journal_seq_t get_committed_to() const {
+      return committed_to;
     }
 
     segment_seq_t get_segment_seq() const {
@@ -287,7 +285,7 @@ private:
     // Encode the batched records for write.
     ceph::bufferlist encode_records(
         size_t block_size,
-        segment_off_t committed_to,
+        const journal_seq_t& committed_to,
         segment_nonce_t segment_nonce);
 
     // Set the write result and reset for reuse
@@ -304,7 +302,7 @@ private:
         record_t&&,
         const record_size_t&,
         size_t block_size,
-        segment_off_t committed_to,
+        const journal_seq_t& committed_to,
         segment_nonce_t segment_nonce);
 
   private:

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -150,7 +150,7 @@ ceph::bufferlist encode_record(
   record_size_t rsize,
   record_t &&record,
   size_t block_size,
-  segment_off_t committed_to,
+  const journal_seq_t& committed_to,
   segment_nonce_t current_segment_nonce)
 {
   bufferlist data_bl;


### PR DESCRIPTION
Journal segment should not update committed_to during rolling as there
might be still pending writes from the previous segment.

A side-effect here is that committed_to now needs to include
segment_seq_t to point to a previous segment.

Signed-off-by: Yingxin Cheng <yingxin.cheng@intel.com>

---

See discussions in https://github.com/ceph/ceph/pull/43617#discussion_r738135557

This PR depends on the refactoring work in https://github.com/ceph/ceph/pull/43617 and starts from the last commit.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
