### PR TITLE
src/rgw/rgw_opa.cc: Set rgw_opa_token as Bearer token

### DIFF
--- a/src/rgw/rgw_opa.cc
+++ b/src/rgw/rgw_opa.cc
@@ -23,15 +23,16 @@ int rgw_opa_authorize(RGWOp *& op,
   }
   ldpp_dout(op, 2) << "OPA URL= " << opa_url.c_str() << dendl;
 
-  /* get authentication token for OPA */
-  const string& opa_token = s->cct->_conf->rgw_opa_token;
-
   int ret;
   bufferlist bl;
   RGWHTTPTransceiver req(s->cct, "POST", opa_url.c_str(), &bl);
 
+  /* get authentication token for OPA */
+  if (!s->cct->_conf->rgw_opa_token.empty()) {
+    req.append_header("Authorization", "Bearer " + s->cct->_conf->rgw_opa_token);
+  }
+
   /* set required headers for OPA request */
-  req.append_header("X-Auth-Token", opa_token);
   req.append_header("Content-Type", "application/json");
   req.append_header("Expect", "100-continue");
 


### PR DESCRIPTION
The token defined in `rgw_opa_token` was being passed to Open Policy Agent in
the `X-Auth-Token` header, but it expects a bearer token in the `Authorization`
header [1].

This commit replaces

```
X-Auth-Token: <rgw_opa_token>
```

with

```
Authorization: Bearer <rgw_opa_token>
```

and only set the header if `rgw_opa_token` is defined.

[1]: https://www.openpolicyagent.org/docs/latest/rest-api/#bearer-tokens

Fixes: https://tracker.ceph.com/issues/53119
Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
