### PR TITLE
octopus: admin/doc-requirements.txt: pin Sphinx at 3.5.4

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,6 +1,6 @@
 Sphinx == 2.4.3
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
-breathe == 4.14.0
+breathe >= 4.20.0
 pyyaml >= 5.1.2
 Cython
 prettytable

--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,4 +1,4 @@
-Sphinx == 2.4.3
+Sphinx == 3.5.4
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
 breathe >= 4.20.0
 pyyaml >= 5.1.2

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -99,6 +99,11 @@ breathe_projects_source = {
              ["rados_types.h", "librados.h"])
 }
 breathe_domain_by_extension = {'py': 'py', 'c': 'c', 'h': 'c', 'cc': 'cxx', 'hpp': 'cxx'}
+breathe_doxygen_config_options = {
+    'EXPAND_ONLY_PREDEF': 'YES',
+    'MACRO_EXPANSION': 'YES',
+    'PREDEFINED': 'CEPH_RADOS_API= '
+}
 
 # the docs are rendered with github links pointing to master. the javascript
 # snippet in _static/ceph.js rewrites the edit links when a page is loaded, to

--- a/doc/scripts/gen_state_diagram.py
+++ b/doc/scripts/gen_state_diagram.py
@@ -23,7 +23,7 @@ def acc_lines(generator):
 def to_char(generator):
     for line in generator:
         for char in line:
-            if char is not '\n':
+            if char != '\n':
                 yield char
             else:
                 yield ' '
@@ -41,22 +41,22 @@ def remove_multiline_comments(generator):
     in_comment = False
     for char in generator:
         if in_comment:
-            if saw is "*":
-                if char is "/":
+            if saw == "*":
+                if char == "/":
                     in_comment = False
                 saw = ""
-            if char is "*":
+            if char == "*":
                 saw = "*"
             continue
-        if saw is "/":
-            if char is '*':
+        if saw == "/":
+            if char == '*':
                 in_comment = True
                 saw = ""
                 continue
             else:
                 yield saw
                 saw = ""
-        if char is '/':
+        if char == '/':
             saw = "/"
             continue
         yield char
@@ -129,7 +129,7 @@ class StateMachineRenderer(object):
             if tokens.group(2) not in self.state_contents.keys():
                 self.state_contents[tokens.group(2)] = []
             self.state_contents[tokens.group(2)].append(tokens.group(1))
-            if tokens.group(3) is not "":
+            if tokens.group(3):
                 self.machines[tokens.group(1)] = tokens.group(3)
             self.context.append((tokens.group(1), self.context_depth, ""))
             return
@@ -140,14 +140,14 @@ class StateMachineRenderer(object):
                                  line):
                 if i.group(1) not in self.edges.keys():
                     self.edges[i.group(1)] = []
-                if len(self.context) is 0:
+                if not self.context:
                     raise Exception("no context at line: " + line)
                 self.edges[i.group(1)].append((self.context[-1][0], i.group(2)))
         i = re.search("return\s+transit<\s*(\w*)\s*>()", line)
         if i is not None:
-            if len(self.context) is 0:
+            if not self.context:
                 raise Exception("no context at line: " + line)
-            if self.context[-1][2] is "":
+            if not self.context[-1][2]:
                 raise Exception("no event in context at line: " + line)
             if self.context[-1][2] not in self.edges.keys():
                 self.edges[self.context[-1][2]] = []

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -241,7 +241,7 @@ typedef void * rados_object_list_cursor;
  * The item populated by rados_object_list in
  * the results array.
  */
-typedef struct rados_object_list_item {
+typedef struct {
 
   /// oid length
   size_t oid_length;

--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -7,5 +7,5 @@ flake8-colors==0.1.6; python_version >= '3'
 #flake8-typing-imports; python_version >= '3'
 #pep8-naming
 rstcheck==3.3.1; python_version >= '3'
-autopep8; python_version >= '3'
-pyfakefs; python_version >= '3'
+autopep8==1.5.7; python_version >= '3'
+pyfakefs==4.5.0; python_version >= '3'

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -157,10 +157,6 @@ add_executable(unittest_rgw_dmclock_scheduler test_rgw_dmclock_scheduler.cc $<TA
 add_ceph_unittest(unittest_rgw_dmclock_scheduler)
 
 target_link_libraries(unittest_rgw_dmclock_scheduler rgw_schedulers global ${UNITTEST_LIBS})
-if(WITH_BOOST_CONTEXT)
-  target_compile_definitions(unittest_rgw_dmclock_scheduler PRIVATE BOOST_COROUTINES_NO_DEPRECATION_WARNING)
-  target_link_libraries(unittest_rgw_dmclock_scheduler Boost::coroutine Boost::context)
-endif()
 
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   add_executable(unittest_rgw_amqp test_rgw_amqp.cc)

--- a/src/test/rgw/test_rgw_dmclock_scheduler.cc
+++ b/src/test/rgw/test_rgw_dmclock_scheduler.cc
@@ -18,9 +18,7 @@
 #include "rgw/rgw_dmclock_async_scheduler.h"
 
 #include <optional>
-#ifdef HAVE_BOOST_CONTEXT
-#include <boost/asio/spawn.hpp>
-#endif
+#include <spawn/spawn.hpp>
 #include <gtest/gtest.h>
 #include "acconfig.h"
 #include "global/global_context.h"
@@ -403,7 +401,7 @@ TEST(Queue, SpawnAsyncRequest)
 {
   boost::asio::io_context context;
 
-  boost::asio::spawn(context, [&] (boost::asio::yield_context yield) {
+  spawn::spawn(context, [&] (spawn::yield_context yield) {
     ClientCounters counters(g_ceph_context);
     AsyncScheduler queue(g_ceph_context, context, std::ref(counters), nullptr,
                     [] (client_id client) -> ClientInfo* {

--- a/src/test/rgw/test_rgw_dmclock_scheduler.cc
+++ b/src/test/rgw/test_rgw_dmclock_scheduler.cc
@@ -108,7 +108,7 @@ TEST(Queue, RateLimit)
   EXPECT_EQ(1u, counters(client_id::admin)->get(queue_counters::l_qlen));
   EXPECT_EQ(1u, counters(client_id::auth)->get(queue_counters::l_qlen));
 
-  context.poll();
+  context.run_for(std::chrono::milliseconds(1));
   EXPECT_TRUE(context.stopped());
 
   ASSERT_TRUE(ec1);
@@ -166,7 +166,7 @@ TEST(Queue, AsyncRequest)
   EXPECT_EQ(1u, counters(client_id::admin)->get(queue_counters::l_qlen));
   EXPECT_EQ(1u, counters(client_id::auth)->get(queue_counters::l_qlen));
 
-  context.poll();
+  context.run_for(std::chrono::milliseconds(1));
   EXPECT_TRUE(context.stopped());
 
   ASSERT_TRUE(ec1);
@@ -220,7 +220,7 @@ TEST(Queue, Cancel)
   EXPECT_FALSE(ec1);
   EXPECT_FALSE(ec2);
 
-  context.poll();
+  context.run_for(std::chrono::milliseconds(1));
   EXPECT_TRUE(context.stopped());
 
   ASSERT_TRUE(ec1);
@@ -268,7 +268,7 @@ TEST(Queue, CancelClient)
   EXPECT_FALSE(ec1);
   EXPECT_FALSE(ec2);
 
-  context.poll();
+  context.run_for(std::chrono::milliseconds(1));
   EXPECT_TRUE(context.stopped());
 
   ASSERT_TRUE(ec1);
@@ -318,7 +318,7 @@ TEST(Queue, CancelOnDestructor)
   EXPECT_FALSE(ec1);
   EXPECT_FALSE(ec2);
 
-  context.poll();
+  context.run_for(std::chrono::milliseconds(1));
   EXPECT_TRUE(context.stopped());
 
   ASSERT_TRUE(ec1);
@@ -372,20 +372,20 @@ TEST(Queue, CrossExecutorRequest)
   EXPECT_EQ(1u, counters(client_id::admin)->get(queue_counters::l_qlen));
   EXPECT_EQ(1u, counters(client_id::auth)->get(queue_counters::l_qlen));
 
-  callback_context.poll();
+  callback_context.run_for(std::chrono::milliseconds(1));
   // maintains work on callback executor while in queue
   EXPECT_FALSE(callback_context.stopped());
 
   EXPECT_FALSE(ec1);
   EXPECT_FALSE(ec2);
 
-  queue_context.poll();
+  queue_context.run_for(std::chrono::milliseconds(1));
   EXPECT_TRUE(queue_context.stopped());
 
   EXPECT_FALSE(ec1); // no callbacks until callback executor runs
   EXPECT_FALSE(ec2);
 
-  callback_context.poll();
+  callback_context.run_for(std::chrono::milliseconds(1));
   EXPECT_TRUE(callback_context.stopped());
 
   ASSERT_TRUE(ec1);
@@ -424,7 +424,7 @@ TEST(Queue, SpawnAsyncRequest)
     EXPECT_EQ(PhaseType::priority, p2);
   });
 
-  context.poll();
+  context.run_for(std::chrono::milliseconds(1));
   EXPECT_TRUE(context.stopped());
 }
 


### PR DESCRIPTION
* pin Sphinx at 3.5.4
* pin docutils at 0.18

at least the combination of these two versions
is known to compile.

to address the bug reported at
https://sourceforge.net/p/docutils/bugs/431/

the backtrace looks like:

/home/jenkins-build/build/workspace/ceph-pr-docs/build-doc/virtualenv/lib/python3.8/site-packages/sphinx/util/docutils.py:285:
RemovedInSphinx30Warning: function based directive support is now
deprecated. Use class based directive instead.
  warnings.warn('function based directive support is now deprecated. '

Exception occurred:
  File
"/home/jenkins-build/build/workspace/ceph-pr-docs/build-doc/virtualenv/lib/python3.8/site-packages/docutils/writers/html5_polyglot/__init__.py",
line 445, in section_title_tags
    if (ids and self.settings.section_self_link
AttributeError: 'Values' object has no attribute 'section_self_link'

please note this change is not cherry-picked from
master, because master already bumped Sphinx to 3.5.4
in 4968baa2523bd2a5ca6be147b26bc28906a864c9.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>
(cherry picked from commit 6362b554e2e57227c9fda51c7703f14674da8358)

Conflicts:
	admin/doc-requirements.txt: trivial resolution


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
