### PR TITLE
qa: increase the timeout value to wait a litte longer

### DIFF
--- a/qa/tasks/cephfs/test_openfiletable.py
+++ b/qa/tasks/cephfs/test_openfiletable.py
@@ -62,7 +62,7 @@ class OpenFileTable(CephFSTestCase):
         
         # Open the file
         p = self.mount_a.open_background("omap_counter_test_file")
-        self.wait_until_true(lambda: self._check_oft_counter('omap_total_updates', 2), timeout=30)
+        self.wait_until_true(lambda: self._check_oft_counter('omap_total_updates', 2), timeout=120)
         
         perf_dump = self.fs.mds_asok(['perf', 'dump'])
         omap_total_updates_1 = perf_dump['oft']['omap_total_updates']
@@ -73,8 +73,8 @@ class OpenFileTable(CephFSTestCase):
         # Now close the file
         self.mount_a.kill_background(p)
         # Ensure that the file does not exist any more
-        self.wait_until_true(lambda: self._check_oft_counter('omap_total_removes', 1), timeout=30)
-        self.wait_until_true(lambda: self._check_oft_counter('omap_total_kv_pairs', 1), timeout=30)
+        self.wait_until_true(lambda: self._check_oft_counter('omap_total_removes', 1), timeout=120)
+        self.wait_until_true(lambda: self._check_oft_counter('omap_total_kv_pairs', 1), timeout=120)
 
         perf_dump = self.fs.mds_asok(['perf', 'dump'])
         omap_total_removes = perf_dump['oft']['omap_total_removes']


### PR DESCRIPTION
Sometimes the OpenFileTable::commit() will just come after the 30
seconds' waiting.

Fixes: https://tracker.ceph.com/issues/52887
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
