### PR TITLE
rgw: Ensure buckets too old to decode a layout have layout logs

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2278,6 +2278,11 @@ void RGWBucketInfo::decode(bufferlist::const_iterator& bl) {
   if (struct_v >= 23) {
     decode(owner.ns, bl);
   }
+
+  if (layout.logs.empty() &&
+      layout.current_index.layout.type == rgw::BucketIndexType::Normal) {
+    layout.logs.push_back(log_layout_from_index(0, layout.current_index));
+  }
   DECODE_FINISH(bl);
 }
 


### PR DESCRIPTION
Fix a potential problem where pre-pacific buckets get a synthesized layout, but not a synthesized layout log.