### PR TITLE
rgw: Ensure buckets too old to decode a layout have layout logs

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2278,6 +2278,11 @@ void RGWBucketInfo::decode(bufferlist::const_iterator& bl) {
   if (struct_v >= 23) {
     decode(owner.ns, bl);
   }
+
+  if (layout.logs.empty() &&
+      layout.current_index.layout.type == rgw::BucketIndexType::Normal) {
+    layout.logs.push_back(rgw::log_layout_from_index(0, layout.current_index.layout.normal));
+  }
   DECODE_FINISH(bl);
 }
 

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -285,12 +285,29 @@ void rgw_bucket::generate_test_instances(list<rgw_bucket*>& o)
 
 void RGWBucketInfo::generate_test_instances(list<RGWBucketInfo*>& o)
 {
+  // Since things without a log will have one synthesized on decode,
+  // ensure the things we attempt to encode will have one added so we
+  // round-trip properly.
+  auto gen_layout = [](rgw::BucketLayout& l) {
+    l.current_index.gen = 0;
+    l.current_index.layout.normal.hash_type = rgw::BucketHashType::Mod;
+    l.current_index.layout.type = rgw::BucketIndexType::Normal;
+    l.current_index.layout.normal.num_shards = 11;
+    l.logs.push_back(log_layout_from_index(
+		       l.current_index.gen,
+		       l.current_index.layout.normal));
+  };
+
+
   RGWBucketInfo *i = new RGWBucketInfo;
   init_bucket(&i->bucket, "tenant", "bucket", "pool", ".index_pool", "marker", "10");
   i->owner = "owner";
   i->flags = BUCKET_SUSPENDED;
+  gen_layout(i->layout);
   o.push_back(i);
-  o.push_back(new RGWBucketInfo);
+  i = new RGWBucketInfo;
+  gen_layout(i->layout);
+  o.push_back(i);
 }
 
 void RGWZoneGroup::generate_test_instances(list<RGWZoneGroup*>& o)


### PR DESCRIPTION
When decoding `RGWBucketInfo` data from before Pacific, we won't call
`rgw::BucketLayout::decode`, but will instead synthesize the layout
information. This leaves the `rgw::BucketLayout::logs` empty, as the
fallback to populate it only applies to old versions of
`rgw::BucketLayout`.

Add a check at the end of `RGWBUcketInfo::decode` to populate it if
empty.

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
