### PR TITLE
os/bluestore: BlueFS fine grain locking

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3624,7 +3624,7 @@ int BlueFS::open_for_write(
   FileWriter **h,
   bool overwrite)
 {
-  std::lock_guard nl(nodes.lock);
+  std::unique_lock nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   DirRef dir;
@@ -3686,6 +3686,7 @@ int BlueFS::open_for_write(
   dout(20) << __func__ << " mapping " << dirname << "/" << filename
 	   << " vsel_hint " << file->vselector_hint
 	   << dendl;
+  nl.unlock();
   {
     std::lock_guard ll(log.lock);
     log.t.op_file_update(file->fnode);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2638,40 +2638,53 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
   new_log->lock.unlock();
   new_log_writer->lock.unlock();
   // 5. update our log fnode
-  // discard first old_log_jump_to extents
-
-  dout(10) << __func__ << " remove 0x" << std::hex << old_log_jump_to << std::dec
-	   << " of " << log_file->fnode.extents << dendl;
-  uint64_t discarded = 0;
+  // we need to append to new_log the extents that were allocated in step 1.1
+  // we do it by inverse logic - we drop 'old_log_jump_to' bytes and keep rest
+  // todo - maybe improve _allocate so we will give clear set of new allocations
+  uint64_t processed = 0;
   mempool::bluefs::vector<bluefs_extent_t> old_extents;
-  while (discarded < old_log_jump_to) {
-    ceph_assert(!log_file->fnode.extents.empty());
-    bluefs_extent_t& e = log_file->fnode.extents.front();
-    bluefs_extent_t temp = e;
-    if (discarded + e.length <= old_log_jump_to) {
+  for (auto& e : log_file->fnode.extents) {
+    if (processed + e.length <= old_log_jump_to) {
+      // drop whole extent
       dout(10) << __func__ << " remove old log extent " << e << dendl;
-      discarded += e.length;
-      log_file->fnode.pop_front_extent();
+      old_extents.push_back(e);
     } else {
-      dout(10) << __func__ << " remove front of old log extent " << e << dendl;
-      uint64_t drop = old_log_jump_to - discarded;
-      temp.length = drop;
-      e.offset += drop;
-      e.length -= drop;
-      discarded += drop;
-      dout(10) << __func__ << "   kept " << e << " removed " << temp << dendl;
+      // keep, but how much?
+      if (processed < old_log_jump_to) {
+	ceph_assert(processed + e.length > old_log_jump_to);
+	ceph_assert(old_log_jump_to - processed <= std::numeric_limits<uint32_t>::max());
+	uint32_t cut_at = uint32_t(old_log_jump_to - processed);
+	// need to cut, first half gets dropped
+	bluefs_extent_t retire(e.bdev, e.offset, cut_at);
+	old_extents.push_back(retire);
+	// second half goes to new log
+	bluefs_extent_t keep(e.bdev, e.offset + cut_at, e.length - cut_at);
+	new_log->fnode.append_extent(keep);
+	dout(10) << __func__ << " kept " << keep << " removed " << retire << dendl;
+      } else {
+	// take entire extent
+	ceph_assert(processed >= old_log_jump_to);
+	new_log->fnode.append_extent(e);
+	dout(10) << __func__ << " kept " << e << dendl;
+      }
     }
-    old_extents.push_back(temp);
-  }
-  auto from = log_file->fnode.extents.begin();
-  auto to = log_file->fnode.extents.end();
-  while (from != to) {
-    new_log->fnode.append_extent(*from);
-    ++from;
+    processed += e.length;
   }
   // we will write it to super
   new_log->fnode.reset_delta();
 
+  // 6. write the super block to reflect the changes
+  dout(10) << __func__ << " writing super" << dendl;
+  new_log->fnode.ino = log_file->fnode.ino;
+  new_log->fnode.size = 0;
+  new_log->fnode.mtime = ceph_clock_now();
+  super.log_fnode = new_log->fnode;
+  ++super.version;
+  _write_super(BDEV_DB);
+  _flush_bdev();
+
+  log.lock.lock();
+  // swapping log_file and new_log
   vselector->sub_usage(log_file->vselector_hint, log_file->fnode);
 
   // clear the extents from old log file, they are added to new log
@@ -2684,13 +2697,7 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
 
   vselector->add_usage(log_file->vselector_hint, log_file->fnode);
 
-  // 6. write the super block to reflect the changes
-  dout(10) << __func__ << " writing super" << dendl;
-  super.log_fnode = log_file->fnode;
-  ++super.version;
-  _write_super(BDEV_DB);
-
-  _flush_bdev();
+  log.lock.unlock();
 
   old_forbidden = atomic_exchange(&log_forbidden_to_expand, false);
   ceph_assert(old_forbidden == true);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2011,13 +2011,12 @@ void BlueFS::_drop_link_D(FileRef file)
     nodes.file_map.erase(file->fnode.ino);
     file->deleted = true;
 
-    if (file->dirty_seq) {
+    if (file->dirty_seq > dirty.seq_stable) {
       // retract request to serialize changes
-      ceph_assert(file->dirty_seq > dirty.seq_stable);
       ceph_assert(dirty.files.count(file->dirty_seq));
       auto it = dirty.files[file->dirty_seq].iterator_to(*file);
       dirty.files[file->dirty_seq].erase(it);
-      file->dirty_seq = 0;
+      file->dirty_seq = dirty.seq_stable;
     }
   }
 }
@@ -2359,6 +2358,40 @@ void BlueFS::_compact_log_dump_metadata_N(bluefs_transaction_t *t,
     }
   }
 }
+/* Streams to t files modified before *capture_before_seq* and all dirs */
+void BlueFS::compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
+					     uint64_t capture_before_seq)
+{
+  std::lock_guard nl(nodes.lock);
+
+  t->seq = 1;
+  t->uuid = super.uuid;
+  dout(20) << __func__ << " op_init" << dendl;
+
+  t->op_init();
+  for (auto& [ino, file_ref] : nodes.file_map) {
+    if (ino == 1)
+      continue;
+    ceph_assert(ino > 1);
+    std::lock_guard fl(file_ref->lock);
+    if (file_ref->dirty_seq < capture_before_seq) {
+      dout(20) << __func__ << " op_file_update " << file_ref->fnode << dendl;
+      t->op_file_update(file_ref->fnode);
+    } else {
+      dout(20) << __func__ << " skipping just modified, dirty_seq="
+	       << file_ref->dirty_seq << " " << file_ref->fnode << dendl;
+    }
+  }
+  for (auto& [path, dir_ref] : nodes.dir_map) {
+    dout(20) << __func__ << " op_dir_create " << path << dendl;
+    t->op_dir_create(path);
+    for (auto& [fname, file_ref] : dir_ref->file_map) {
+      dout(20) << __func__ << " op_dir_link " << path << "/" << fname
+	       << " to " << file_ref->fnode.ino << dendl;
+      t->op_dir_link(path, fname, file_ref->fnode.ino);
+    }
+  }
+}
 
 void BlueFS::_compact_log_sync_LN_LD()
 {
@@ -2564,7 +2597,7 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
   //this needs files lock
   //what will happen, if a file is modified *twice* before we stream it to log?
   //the later state that we capture will be seen earlier and replay will see a temporary retraction (!)
-  _compact_log_dump_metadata_N(&t, 0);
+  compact_log_async_dump_metadata_NF(&t, seq_now);
 
   uint64_t max_alloc_size = std::max(alloc_size[BDEV_WAL],
 				     std::max(alloc_size[BDEV_DB],
@@ -2851,10 +2884,9 @@ void BlueFS::_clear_dirty_set_stable_D(uint64_t seq)
       auto l = p->second.begin();
       while (l != p->second.end()) {
         File *file = &*l;
-        ceph_assert(file->dirty_seq > 0);
         ceph_assert(file->dirty_seq <= dirty.seq_stable);
         dout(20) << __func__ << " cleaned file " << file->fnode << dendl;
-        file->dirty_seq = 0;
+        file->dirty_seq = dirty.seq_stable;
         p->second.erase(l++);
       }
 
@@ -3020,7 +3052,7 @@ int BlueFS::_signal_dirty_to_log_D(FileWriter *h)
   std::lock_guard dl(dirty.lock);
   h->file->fnode.mtime = ceph_clock_now();
   ceph_assert(h->file->fnode.ino >= 1);
-  if (h->file->dirty_seq == 0) {
+  if (h->file->dirty_seq <= dirty.seq_stable) {
     h->file->dirty_seq = dirty.seq_live;
     dirty.files[h->file->dirty_seq].push_back(*h->file);
     dout(20) << __func__ << " dirty_seq = " << dirty.seq_live
@@ -3372,13 +3404,7 @@ int BlueFS::fsync(FileWriter *h)
     }
   }
   if (old_dirty_seq) {
-    uint64_t s = log.seq_live; // AKAK !!! locks!
-    dout(20) << __func__ << " file metadata was dirty (" << old_dirty_seq
-	     << ") on " << h->file->fnode << ", flushing log" << dendl;
     _flush_and_sync_log_LD(old_dirty_seq);
-    // AK - TODO - think - how can dirty_seq change if we are under h lock?
-    ceph_assert(h->file->dirty_seq == 0 ||  // cleaned
-		h->file->dirty_seq >= s);    // or redirtied by someone else
   }
   _maybe_compact_log_LN_NF_LD_D();
   return 0;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -588,6 +588,8 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
   log.writer = _create_writer(log_file);
 
   // initial txn
+  ceph_assert(log.seq_live == 1);
+  log.t.seq = 1;
   log.t.op_init();
   flush_and_sync_log();
 
@@ -1338,7 +1340,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
                       << std::endl;
           }
 
-	  ceph_assert(next_seq >= log_seq);
+	  ceph_assert(next_seq > log_seq);
 	  log_seq = next_seq - 1; // we will increment it below
 	  uint64_t skip = offset - read_pos;
 	  if (skip) {
@@ -1366,7 +1368,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
                       << ":  op_jump_seq " << next_seq << std::endl;
           }
 
-	  ceph_assert(next_seq >= log_seq);
+	  ceph_assert(next_seq > log_seq);
 	  log_seq = next_seq - 1; // we will increment it below
 	}
 	break;
@@ -1644,8 +1646,10 @@ int BlueFS::_replay(bool noop, bool to_stdout)
   }
   if (!noop) {
     vselector->add_usage(log_file->vselector_hint, log_file->fnode);
-    log.seq_live = log_seq;
-    dirty.seq_next = log_seq + 1;
+    log.seq_live = log_seq + 1;
+    dirty.seq_live = log_seq + 1;
+    log.t.seq = log.seq_live;
+    //log.seq_stable = log_seq;
     dirty.seq_stable = log_seq;
   }
 
@@ -2382,8 +2386,13 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
 
   File *log_file = log.writer->file.get();
 
-  // clear out log (be careful who calls us!!!)
+  // log.t.seq is always set to current live seq
+  ceph_assert(log.t.seq == log.seq_live);
+  // Capturing entire state. Dump anything that has been stored there.
   log.t.clear();
+  log.t.seq = log.seq_live;
+  // From now on, no changes to log.t are permitted until we finish rewriting log.
+  // Can allow dirty to remain dirty - log.seq_live will not change.
 
   dout(20) << __func__ << " super_dev:" << super_dev
                        << " log_dev:" << log_dev
@@ -2537,9 +2546,10 @@ void BlueFS::compact_log_async()
 
   // update the log file change and log a jump to the offset where we want to
   // write the new entries
-  log.t.op_file_update(log_file->fnode); // 1.2
-  log.t.op_jump(log.seq_live, old_log_jump_to); // 1.3
-
+  log.t.op_file_update(log_file->fnode);
+  // jump to new position should mean next seq
+  log.t.op_jump(log.seq_live + 1, old_log_jump_to);
+  uint64_t seq_now = log.seq_live;
   // we need to flush all bdev because we will be streaming all dirty files to log
   // TODO - think - if _flush_and_sync_log_jump will not add dirty files nor release pending allocations
   // then flush_bdev() will not be necessary
@@ -2563,7 +2573,8 @@ void BlueFS::compact_log_async()
   // conservative estimate for final encoded size
   new_log_jump_to = round_up_to(t.op_bl.length() + super.block_size * 2,
                                 max_alloc_size);
-  t.op_jump(log.seq_live, new_log_jump_to);
+  //newly constructed log head will jump to what we had before
+  t.op_jump(seq_now, new_log_jump_to);
 
   // allocate
   //FIXME: check if we want DB here?
@@ -2707,19 +2718,31 @@ void BlueFS::_pad_bl(bufferlist& bl)
  * pending_release and log.t go with same lock
  */
 
-// Adds to log.t file modifications mentioned in `dirty.files`.
-// Note: some bluefs ops may have already been stored in log.t transaction.
-uint64_t BlueFS::_consume_dirty()
+// Returns log seq that was live before advance.
+uint64_t BlueFS::_log_advance_seq()
 {
   ceph_assert(ceph_mutex_is_locked(dirty.lock));
   ceph_assert(ceph_mutex_is_locked(log.lock));
   //acquire new seq
   // this will became seq_stable once we write
-  ++dirty.seq_next;
-  ++log.seq_live;
-  ceph_assert(dirty.seq_next == log.seq_live + 1);
-  uint64_t seq = log.t.seq = log.seq_live;
+  ceph_assert(dirty.seq_stable < dirty.seq_live);
+  ceph_assert(log.t.seq == log.seq_live);
+  uint64_t seq = log.seq_live;
   log.t.uuid = super.uuid;
+
+  ++dirty.seq_live;
+  ++log.seq_live;
+  ceph_assert(dirty.seq_live == log.seq_live);
+  return seq;
+}
+
+
+// Adds to log.t file modifications mentioned in `dirty.files`.
+// Note: some bluefs ops may have already been stored in log.t transaction.
+void BlueFS::_consume_dirty(uint64_t seq)
+{
+  ceph_assert(ceph_mutex_is_locked(dirty.lock));
+  ceph_assert(ceph_mutex_is_locked(log.lock));
 
   // log dirty files
   // we just incremented log_seq. It is now illegal to add to dirty.files[log_seq]
@@ -2731,7 +2754,6 @@ uint64_t BlueFS::_consume_dirty()
       log.t.op_file_update_inc(f.fnode);
     }
   }
-  return seq;
 }
 
 // Extends log if its free space is smaller then bluefs_min_log_runway.
@@ -2798,8 +2820,9 @@ void BlueFS::_flush_and_sync_log_core(int64_t runway)
 
   log.writer->append(bl);
 
+  // prepare log for new transactions
   log.t.clear();
-  log.t.seq = 0;  // just so debug output is less confusing
+  log.t.seq = log.seq_live;
 
   int r = _flush_special(log.writer);
   ceph_assert(r == 0);
@@ -2894,10 +2917,10 @@ int BlueFS::flush_and_sync_log(uint64_t want_seq)
       ceph_assert(available_runway >= 0);
     }
   } while (available_runway < 0);
-
-  ceph_assert(want_seq == 0 || want_seq <= log.seq_live); // illegal to request seq that was not created yet
-
-  uint64_t seq = _consume_dirty();
+  
+  ceph_assert(want_seq == 0 || want_seq <= dirty.seq_live); // illegal to request seq that was not created yet
+  uint64_t seq =_log_advance_seq();
+  _consume_dirty(seq);
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
   dirty.lock.unlock();
@@ -2924,7 +2947,8 @@ int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
   // we synchronize writing to log, by lock to log_lock
 
   dirty.lock.lock();
-  uint64_t seq = _consume_dirty();
+  uint64_t seq =_log_advance_seq();
+  _consume_dirty(seq);
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
   dirty.lock.unlock();
@@ -2996,22 +3020,22 @@ int BlueFS::_signal_dirty_to_log(FileWriter *h)
   h->file->fnode.mtime = ceph_clock_now();
   ceph_assert(h->file->fnode.ino >= 1);
   if (h->file->dirty_seq == 0) {
-    h->file->dirty_seq = dirty.seq_next;
+    h->file->dirty_seq = dirty.seq_live;
     dirty.files[h->file->dirty_seq].push_back(*h->file);
-    dout(20) << __func__ << " dirty_seq = " << dirty.seq_next
+    dout(20) << __func__ << " dirty_seq = " << dirty.seq_live
 	     << " (was clean)" << dendl;
   } else {
-    if (h->file->dirty_seq != dirty.seq_next) {
+    if (h->file->dirty_seq != dirty.seq_live) {
       // need re-dirty, erase from list first
       ceph_assert(dirty.files.count(h->file->dirty_seq));
       auto it = dirty.files[h->file->dirty_seq].iterator_to(*h->file);
       dirty.files[h->file->dirty_seq].erase(it);
-      h->file->dirty_seq = dirty.seq_next;
+      h->file->dirty_seq = dirty.seq_live;
       dirty.files[h->file->dirty_seq].push_back(*h->file);
-      dout(20) << __func__ << " dirty_seq = " << dirty.seq_next
+      dout(20) << __func__ << " dirty_seq = " << dirty.seq_live
 	       << " (was " << h->file->dirty_seq << ")" << dendl;
     } else {
-      dout(20) << __func__ << " dirty_seq = " << dirty.seq_next
+      dout(20) << __func__ << " dirty_seq = " << dirty.seq_live
 	       << " (unchanged, do nothing) " << dendl;
     }
   }
@@ -3344,7 +3368,7 @@ int BlueFS::fsync(FileWriter *h)
     flush_and_sync_log(old_dirty_seq);
     // AK - TODO - think - how can dirty_seq change if we are under h lock?
     ceph_assert(h->file->dirty_seq == 0 ||  // cleaned
-		h->file->dirty_seq > s);    // or redirtied by someone else
+		h->file->dirty_seq >= s);    // or redirtied by someone else
   }
   maybe_compact_log();
   return 0;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2376,11 +2376,11 @@ void BlueFS::compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
     std::lock_guard fl(file_ref->lock);
     if (file_ref->dirty_seq < capture_before_seq) {
       dout(20) << __func__ << " op_file_update " << file_ref->fnode << dendl;
-      t->op_file_update(file_ref->fnode);
     } else {
-      dout(20) << __func__ << " skipping just modified, dirty_seq="
+      dout(20) << __func__ << " op_file_update just modified, dirty_seq="
 	       << file_ref->dirty_seq << " " << file_ref->fnode << dendl;
     }
+    t->op_file_update(file_ref->fnode);
   }
   for (auto& [path, dir_ref] : nodes.dir_map) {
     dout(20) << __func__ << " op_dir_create " << path << dendl;
@@ -2588,12 +2588,16 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
   _flush_bdev();
   _flush_and_sync_log_jump_D(old_log_jump_to, runway);
 
-  log.lock.unlock();
-  // out of jump section - now log can be used to write to
+  // out of jump section
 
   // 2. prepare compacted log
   bluefs_transaction_t t;
   compact_log_async_dump_metadata_NF(&t, seq_now);
+
+  // now state is captured to bufferlist
+  // log can be used to write to, ops in log will be continuation of captured state
+  log.lock.unlock();
+
   uint64_t max_alloc_size = std::max(alloc_size[BDEV_WAL],
 				     std::max(alloc_size[BDEV_DB],
 					      alloc_size[BDEV_SLOW]));

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3120,7 +3120,9 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
   }
 
   dout(20) << __func__ << " file now, unflushed " << h->file->fnode << dendl;
-  return _flush_data(h, offset, length, buffered);
+  int res = _flush_data(h, offset, length, buffered);
+  vselector->add_usage(h->file->vselector_hint, h->file->fnode);
+  return res;
 }
 
 int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered)
@@ -3199,7 +3201,6 @@ int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool bu
       }
     }
   }
-  vselector->add_usage(h->file->vselector_hint, h->file->fnode);
   dout(20) << __func__ << " h " << h << " pos now 0x"
            << std::hex << h->pos << std::dec << dendl;
   return 0;
@@ -3325,7 +3326,9 @@ int BlueFS::_flush_special(FileWriter *h)
   uint64_t offset = h->pos;
   ceph_assert(length + offset <= h->file->fnode.get_allocated());
   if (h->file->fnode.size < offset + length) {
+    vselector->sub_usage(h->file->vselector_hint, h->file->fnode.size);
     h->file->fnode.size = offset + length;
+    vselector->add_usage(h->file->vselector_hint, h->file->fnode.size);
   }
   return _flush_data(h, offset, length, false);
 }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2414,7 +2414,6 @@ void BlueFS::_rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
 					 int flags,
 					 std::optional<bluefs_layout_t> layout)
 {
-  //ceph_assert(ceph_mutex_is_notlocked(log.lock));
   std::lock_guard ll(log.lock);
 
   File *log_file = log.writer->file.get();
@@ -2594,11 +2593,7 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
 
   // 2. prepare compacted log
   bluefs_transaction_t t;
-  //this needs files lock
-  //what will happen, if a file is modified *twice* before we stream it to log?
-  //the later state that we capture will be seen earlier and replay will see a temporary retraction (!)
   compact_log_async_dump_metadata_NF(&t, seq_now);
-
   uint64_t max_alloc_size = std::max(alloc_size[BDEV_WAL],
 				     std::max(alloc_size[BDEV_DB],
 					      alloc_size[BDEV_SLOW]));
@@ -2709,15 +2704,6 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
 
   // delete the new log, remove from the dirty files list
   _close_writer(new_log_writer);
-  // flush_special does not dirty files
-  /*
-  if (new_log->dirty_seq) {
-    std::lock_guard dl(dirty.lock);
-    ceph_assert(dirty.files.count(new_log->dirty_seq));
-    auto it = dirty.files[new_log->dirty_seq].iterator_to(*new_log);
-    dirty.files[new_log->dirty_seq].erase(it);
-  }
-  */
   new_log_writer = nullptr;
   new_log = nullptr;
   log_cond.notify_all();
@@ -2977,7 +2963,7 @@ int BlueFS::_flush_and_sync_log_jump_D(uint64_t jump_to,
   ceph_assert(ceph_mutex_is_locked(log.lock));
 
   ceph_assert(jump_to);
-  // we synchronize writing to log, by lock to log_lock
+  // we synchronize writing to log, by lock to log.lock
 
   dirty.lock.lock();
   uint64_t seq =_log_advance_seq();
@@ -3249,41 +3235,47 @@ void BlueFS::_wait_for_aio(FileWriter *h)
 }
 #endif
 
-
-void BlueFS::append_try_flush/*_WFL_WFN*/(FileWriter *h, const char* buf, size_t len)
+void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
 {
-  std::unique_lock hl(h->lock);
-  size_t max_size = 1ull << 30; // cap to 1GB
-  while (len > 0) {
-    bool need_flush = true;
-    auto l0 = h->get_buffer_length();
-    if (l0 < max_size) {
-      size_t l = std::min(len, max_size - l0);
-      h->append(buf, l);
-      buf += l;
-      len -= l;
-      need_flush = h->get_buffer_length() >= cct->_conf->bluefs_min_flush_size;
-    }
-    if (need_flush) {
-      bool flushed = false;
-      int r = _flush_F(h, true, &flushed);
-      ceph_assert(r == 0);
-      if (r == 0 && flushed) {
-	_maybe_compact_log_LN_NF_LD_D();
+  bool flushed_sum = false;
+  {
+    std::unique_lock hl(h->lock);
+    size_t max_size = 1ull << 30; // cap to 1GB
+    while (len > 0) {
+      bool need_flush = true;
+      auto l0 = h->get_buffer_length();
+      if (l0 < max_size) {
+	size_t l = std::min(len, max_size - l0);
+	h->append(buf, l);
+	buf += l;
+	len -= l;
+	need_flush = h->get_buffer_length() >= cct->_conf->bluefs_min_flush_size;
       }
-      // make sure we've made any progress with flush hence the
-      // loop doesn't iterate forever
-      ceph_assert(h->get_buffer_length() < max_size);
+      if (need_flush) {
+	bool flushed = false;
+	int r = _flush_F(h, true, &flushed);
+	ceph_assert(r == 0);
+	flushed_sum |= flushed;
+	// make sure we've made any progress with flush hence the
+	// loop doesn't iterate forever
+	ceph_assert(h->get_buffer_length() < max_size);
+      }
     }
+  }
+  if (flushed_sum) {
+    _maybe_compact_log_LN_NF_LD_D();
   }
 }
 
 void BlueFS::flush(FileWriter *h, bool force)
 {
-  std::unique_lock hl(h->lock);
   bool flushed = false;
-  int r = _flush_F(h, force, &flushed);
-  ceph_assert(r == 0);
+  int r;
+  {
+    std::unique_lock hl(h->lock);
+    r = _flush_F(h, force, &flushed);
+    ceph_assert(r == 0);
+  }
   if (r == 0 && flushed) {
     _maybe_compact_log_LN_NF_LD_D();
   }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2627,16 +2627,12 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
   new_log_writer = _create_writer(new_log);
 
   new_log_writer->append(bl);
-  new_log_writer->lock.lock();
-  new_log->lock.lock();
   // 3. flush
   r = _flush_special(new_log_writer);
   ceph_assert(r == 0);
 
   // 4. wait
   _flush_bdev(new_log_writer);
-  new_log->lock.unlock();
-  new_log_writer->lock.unlock();
   // 5. update our log fnode
   // we need to append to new_log the extents that were allocated in step 1.1
   // we do it by inverse logic - we drop 'old_log_jump_to' bytes and keep rest
@@ -2782,6 +2778,10 @@ void BlueFS::_consume_dirty(uint64_t seq)
   if (lsi != dirty.files.end()) {
     dout(20) << __func__ << " " << lsi->second.size() << " dirty.files" << dendl;
     for (auto &f : lsi->second) {
+      // fnode here is protected indirectly
+      // the only path that adds to dirty.files goes from _fsync()
+      // _fsync() is executed under writer lock,
+      // and does not exit until syncing log is done
       dout(20) << __func__ << "   op_file_update_inc " << f.fnode << dendl;
       log.t.op_file_update_inc(f.fnode);
     }
@@ -3006,7 +3006,7 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
   const unsigned length,
   const bluefs_super_t& super)
 {
-  ceph_assert(ceph_mutex_is_locked(this->lock) || file->fnode.ino == 1);
+  ceph_assert(ceph_mutex_is_locked(this->lock) || file->fnode.ino <= 1);
   ceph::bufferlist bl;
   if (partial) {
     tail_block.splice(0, tail_block.length(), &bl);
@@ -3138,7 +3138,7 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
 
 int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered)
 {
-  if (h->file->fnode.ino != 1) {
+  if (h->file->fnode.ino > 1) {
     ceph_assert(ceph_mutex_is_locked(h->lock));
     ceph_assert(ceph_mutex_is_locked(h->file->lock));
   }
@@ -3388,9 +3388,9 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)
 
 int BlueFS::fsync(FileWriter *h)
 {
+  std::unique_lock hl(h->lock);
   uint64_t old_dirty_seq = 0;
   {
-    std::unique_lock hl(h->lock);
     dout(10) << __func__ << " " << h << " " << h->file->fnode << dendl;
     int r = _flush_F(h, true);
     if (r < 0)
@@ -3419,9 +3419,9 @@ int BlueFS::fsync(FileWriter *h)
 // be careful - either h->file->lock or log.lock must be taken
 void BlueFS::_flush_bdev(FileWriter *h)
 {
-  if (h->file->fnode.ino != 1) {
+  if (h->file->fnode.ino > 1) {
     ceph_assert(ceph_mutex_is_locked(h->lock));
-  } else {
+  } else if (h->file->fnode.ino == 1) {
     ceph_assert(ceph_mutex_is_locked(log.lock));
   }
   std::array<bool, MAX_BDEV> flush_devs = h->dirty_devs;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -148,9 +148,9 @@ private:
       out.append(ss);
     } else if (command == "bluefs files list") {
       const char* devnames[3] = {"wal","db","slow"};
-      std::lock_guard l(bluefs->dirs_lock);
+      std::lock_guard l(bluefs->nodes.lock);
       f->open_array_section("files");
-      for (auto &d : bluefs->dir_map) {
+      for (auto &d : bluefs->nodes.dir_map) {
         std::string dir = d.first;
         for (auto &r : d.second->file_map) {
           f->open_object_section("file");
@@ -388,8 +388,8 @@ void BlueFS::_shutdown_logger()
 void BlueFS::_update_logger_stats()
 {
   // we must be holding the lock
-  logger->set(l_bluefs_num_files, file_map.size());
-  logger->set(l_bluefs_log_bytes, log_writer->file->fnode.size);
+  logger->set(l_bluefs_num_files, nodes.file_map.size());
+  logger->set(l_bluefs_log_bytes, log.writer->file->fnode.size);
 
   if (alloc[BDEV_WAL]) {
     logger->set(l_bluefs_wal_total_bytes, _get_total(BDEV_WAL));
@@ -538,10 +538,10 @@ void BlueFS::dump_block_extents(ostream& out)
 
 int BlueFS::get_block_extents(unsigned id, interval_set<uint64_t> *extents)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " bdev " << id << dendl;
   ceph_assert(id < alloc.size());
-  for (auto& p : file_map) {
+  for (auto& p : nodes.file_map) {
     for (auto& q : p.second->fnode.extents) {
       if (q.bdev == id) {
         extents->insert(q.offset, q.length);
@@ -585,10 +585,10 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
     &log_file->fnode);
   vselector->add_usage(log_file->vselector_hint, log_file->fnode);
   ceph_assert(r == 0);
-  log_writer = _create_writer(log_file);
+  log.writer = _create_writer(log_file);
 
   // initial txn
-  log_t.op_init();
+  log.t.op_init();
   flush_and_sync_log();
 
   // write supers
@@ -599,8 +599,8 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
 
   // clean up
   super = bluefs_super_t();
-  _close_writer(log_writer);
-  log_writer = NULL;
+  _close_writer(log.writer);
+  log.writer = NULL;
   vselector.reset(nullptr);
   _stop_alloc();
   _shutdown_logger();
@@ -897,7 +897,7 @@ int BlueFS::mount()
   }
 
   // init freelist
-  for (auto& p : file_map) {
+  for (auto& p : nodes.file_map) {
     dout(30) << __func__ << " noting alloc for " << p.second->fnode << dendl;
     for (auto& q : p.second->fnode.extents) {
       bool is_shared = is_shared_alloc(q.bdev);
@@ -920,12 +920,12 @@ int BlueFS::mount()
   }
 
   // set up the log for future writes
-  log_writer = _create_writer(_get_file(1));
-  ceph_assert(log_writer->file->fnode.ino == 1);
-  log_writer->pos = log_writer->file->fnode.size;
-  log_writer->file->fnode.reset_delta();
+  log.writer = _create_writer(_get_file(1));
+  ceph_assert(log.writer->file->fnode.ino == 1);
+  log.writer->pos = log.writer->file->fnode.size;
+  log.writer->file->fnode.reset_delta();
   dout(10) << __func__ << " log write pos set to 0x"
-           << std::hex << log_writer->pos << std::dec
+           << std::hex << log.writer->pos << std::dec
            << dendl;
 
   return 0;
@@ -958,15 +958,15 @@ void BlueFS::umount(bool avoid_compact)
 
   sync_metadata(avoid_compact);
 
-  _close_writer(log_writer);
-  log_writer = NULL;
+  _close_writer(log.writer);
+  log.writer = NULL;
 
   vselector.reset(nullptr);
   _stop_alloc();
-  file_map.clear();
-  dir_map.clear();
+  nodes.file_map.clear();
+  nodes.dir_map.clear();
   super = bluefs_super_t();
-  log_t.clear();
+  log.t.clear();
   _shutdown_logger();
 }
 
@@ -1150,7 +1150,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 {
   dout(10) << __func__ << (noop ? " NO-OP" : "") << dendl;
   ino_last = 1;  // by the log
-  log_seq = 0;
+  uint64_t log_seq = 0;
 
   FileRef log_file;
   log_file = _get_file(1);
@@ -1414,8 +1414,8 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 	  if (!noop) {
 	    FileRef file = _get_file(ino);
 	    ceph_assert(file->fnode.ino);
-	    map<string,DirRef>::iterator q = dir_map.find(dirname);
-	    ceph_assert(q != dir_map.end());
+	    map<string,DirRef>::iterator q = nodes.dir_map.find(dirname);
+	    ceph_assert(q != nodes.dir_map.end());
 	    map<string,FileRef>::iterator r = q->second->file_map.find(filename);
 	    ceph_assert(r == q->second->file_map.end());
 
@@ -1445,8 +1445,8 @@ int BlueFS::_replay(bool noop, bool to_stdout)
           }
  
 	  if (!noop) {
-	    map<string,DirRef>::iterator q = dir_map.find(dirname);
-	    ceph_assert(q != dir_map.end());
+	    map<string,DirRef>::iterator q = nodes.dir_map.find(dirname);
+	    ceph_assert(q != nodes.dir_map.end());
 	    map<string,FileRef>::iterator r = q->second->file_map.find(filename);
 	    ceph_assert(r != q->second->file_map.end());
             ceph_assert(r->second->refs > 0); 
@@ -1468,9 +1468,9 @@ int BlueFS::_replay(bool noop, bool to_stdout)
           }
 
 	  if (!noop) {
-	    map<string,DirRef>::iterator q = dir_map.find(dirname);
-	    ceph_assert(q == dir_map.end());
-	    dir_map[dirname] = ceph::make_ref<Dir>();
+	    map<string,DirRef>::iterator q = nodes.dir_map.find(dirname);
+	    ceph_assert(q == nodes.dir_map.end());
+	    nodes.dir_map[dirname] = ceph::make_ref<Dir>();
 	  }
 	}
 	break;
@@ -1487,10 +1487,10 @@ int BlueFS::_replay(bool noop, bool to_stdout)
           }
 
 	  if (!noop) {
-	    map<string,DirRef>::iterator q = dir_map.find(dirname);
-	    ceph_assert(q != dir_map.end());
+	    map<string,DirRef>::iterator q = nodes.dir_map.find(dirname);
+	    ceph_assert(q != nodes.dir_map.end());
 	    ceph_assert(q->second->file_map.empty());
-	    dir_map.erase(q);
+	    nodes.dir_map.erase(q);
 	  }
 	}
 	break;
@@ -1614,8 +1614,8 @@ int BlueFS::_replay(bool noop, bool to_stdout)
           }
 
           if (!noop) {
-            auto p = file_map.find(ino);
-            ceph_assert(p != file_map.end());
+            auto p = nodes.file_map.find(ino);
+            ceph_assert(p != nodes.file_map.end());
             vselector->sub_usage(p->second->vselector_hint, p->second->fnode);
             if (cct->_conf->bluefs_log_replay_check_allocations) {
 	      int r = _check_allocations(p->second->fnode,
@@ -1624,7 +1624,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 		return r;
               }
             }
-            file_map.erase(p);
+            nodes.file_map.erase(p);
           }
         }
 	break;
@@ -1644,6 +1644,9 @@ int BlueFS::_replay(bool noop, bool to_stdout)
   }
   if (!noop) {
     vselector->add_usage(log_file->vselector_hint, log_file->fnode);
+    log.seq_live = log_seq;
+    dirty.seq_next = log_seq + 1;
+    dirty.seq_stable = log_seq;
   }
 
   dout(10) << __func__ << " log file size was 0x"
@@ -1657,7 +1660,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 
   if (!noop) {
     // verify file link counts are all >0
-    for (auto& p : file_map) {
+    for (auto& p : nodes.file_map) {
       if (p.second->refs == 0 &&
 	  p.second->fnode.ino > 1) {
 	derr << __func__ << " file with link count 0: " << p.second->fnode
@@ -1674,7 +1677,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 int BlueFS::log_dump()
 {
   // only dump log file's content
-  ceph_assert(log_writer == nullptr && "cannot log_dump on mounted BlueFS");
+  ceph_assert(log.writer == nullptr && "cannot log_dump on mounted BlueFS");
   _init_logger();
   int r = _open_super();
   if (r < 0) {
@@ -1716,7 +1719,7 @@ int BlueFS::device_migrate_to_existing(
     dout(0) << __func__ << " super to be written to " << dev_target << dendl;
   }
 
-  for (auto& [ino, file_ref] : file_map) {
+  for (auto& [ino, file_ref] : nodes.file_map) {
     //do not copy log
     if (file_ref->fnode.ino == 1) {
       continue;
@@ -1854,7 +1857,7 @@ int BlueFS::device_migrate_to_new(
   flags |= devs_source.count(BDEV_WAL) ? REMOVE_WAL : 0;
   int dev_target_new = dev_target; //FIXME: remove, makes no sense
 
-  for (auto& p : file_map) {
+  for (auto& p : nodes.file_map) {
     //do not copy log
     if (p.second->fnode.ino == 1) {
       continue;
@@ -1970,10 +1973,10 @@ int BlueFS::device_migrate_to_new(
 
 BlueFS::FileRef BlueFS::_get_file(uint64_t ino)
 {
-  auto p = file_map.find(ino);
-  if (p == file_map.end()) {
+  auto p = nodes.file_map.find(ino);
+  if (p == nodes.file_map.end()) {
     FileRef f = ceph::make_ref<File>();
-    file_map[ino] = f;
+    nodes.file_map[ino] = f;
     dout(30) << __func__ << " ino " << ino << " = " << f
 	     << " (new)" << dendl;
     return f;
@@ -1988,28 +1991,28 @@ void BlueFS::_drop_link(FileRef file)
   dout(20) << __func__ << " had refs " << file->refs
 	   << " on " << file->fnode << dendl;
   ceph_assert(file->refs > 0);
-  ceph_assert(ceph_mutex_is_locked(log_lock));
+  ceph_assert(ceph_mutex_is_locked(log.lock));
 
   --file->refs;
   if (file->refs == 0) {
     dout(20) << __func__ << " destroying " << file->fnode << dendl;
     ceph_assert(file->num_reading.load() == 0);
     vselector->sub_usage(file->vselector_hint, file->fnode);
-    log_t.op_file_remove(file->fnode.ino);
+    log.t.op_file_remove(file->fnode.ino);
 
-    std::lock_guard dl(dirty_lock);
+    std::lock_guard dl(dirty.lock);
     for (auto& r : file->fnode.extents) {
       pending_release[r.bdev].insert(r.offset, r.length);
     }
-    file_map.erase(file->fnode.ino);
+    nodes.file_map.erase(file->fnode.ino);
     file->deleted = true;
 
     if (file->dirty_seq) {
       // retract request to serialize changes
-      ceph_assert(file->dirty_seq > log_seq_stable);
-      ceph_assert(dirty_files.count(file->dirty_seq));
-      auto it = dirty_files[file->dirty_seq].iterator_to(*file);
-      dirty_files[file->dirty_seq].erase(it);
+      ceph_assert(file->dirty_seq > dirty.seq_stable);
+      ceph_assert(dirty.files.count(file->dirty_seq));
+      auto it = dirty.files[file->dirty_seq].iterator_to(*file);
+      dirty.files[file->dirty_seq].erase(it);
       file->dirty_seq = 0;
     }
   }
@@ -2257,13 +2260,13 @@ void BlueFS::invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
 
 uint64_t BlueFS::estimate_log_size()
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   int avg_dir_size = 40;  // fixme
   int avg_file_size = 12;
   uint64_t size = 4096 * 2;
-  size += file_map.size() * (1 + sizeof(bluefs_fnode_t));
-  size += dir_map.size() + (1 + avg_dir_size);
-  size += file_map.size() * (1 + avg_dir_size + avg_file_size);
+  size += nodes.file_map.size() * (1 + sizeof(bluefs_fnode_t));
+  size += nodes.dir_map.size() + (1 + avg_dir_size);
+  size += nodes.file_map.size() * (1 + avg_dir_size + avg_file_size);
   return round_up_to(size, super.block_size);
 }
 
@@ -2286,8 +2289,8 @@ bool BlueFS::should_start_compact_log()
   }
   uint64_t current;
   {
-    std::lock_guard dirl(log_lock);
-    current = log_writer->file->fnode.size;
+    std::lock_guard dirl(log.lock);
+    current = log.writer->file->fnode.size;
   }
   uint64_t expected = estimate_log_size();
   float ratio = (float)current / (float)expected;
@@ -2305,14 +2308,14 @@ bool BlueFS::should_start_compact_log()
 void BlueFS::compact_log_dump_metadata(bluefs_transaction_t *t,
 					int flags)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
 
   t->seq = 1;
   t->uuid = super.uuid;
   dout(20) << __func__ << " op_init" << dendl;
 
   t->op_init();
-  for (auto& [ino, file_ref] : file_map) {
+  for (auto& [ino, file_ref] : nodes.file_map) {
     if (ino == 1)
       continue;
     ceph_assert(ino > 1);
@@ -2342,7 +2345,7 @@ void BlueFS::compact_log_dump_metadata(bluefs_transaction_t *t,
     dout(20) << __func__ << " op_file_update " << file_ref->fnode << dendl;
     t->op_file_update(file_ref->fnode);
   }
-  for (auto& [path, dir_ref] : dir_map) {
+  for (auto& [path, dir_ref] : nodes.dir_map) {
     dout(20) << __func__ << " op_dir_create " << path << dendl;
     t->op_dir_create(path);
     for (auto& [fname, file_ref] : dir_ref->file_map) {
@@ -2357,7 +2360,7 @@ void BlueFS::compact_log_sync()
 {
   dout(10) << __func__ << dendl;
   auto prefer_bdev =
-    vselector->select_prefer_bdev(log_writer->file->vselector_hint);
+    vselector->select_prefer_bdev(log.writer->file->vselector_hint);
   rewrite_log_and_layout_sync(true,
     BDEV_DB,
     prefer_bdev,
@@ -2374,13 +2377,13 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
 					 int flags,
 					 std::optional<bluefs_layout_t> layout)
 {
-  //ceph_assert(ceph_mutex_is_notlocked(log_lock));
-  std::lock_guard ll(log_lock);
+  //ceph_assert(ceph_mutex_is_notlocked(log.lock));
+  std::lock_guard ll(log.lock);
 
-  File *log_file = log_writer->file.get();
+  File *log_file = log.writer->file.get();
 
   // clear out log (be careful who calls us!!!)
-  log_t.clear();
+  log.t.clear();
 
   dout(20) << __func__ << " super_dev:" << super_dev
                        << " log_dev:" << log_dev
@@ -2390,8 +2393,8 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
   bluefs_transaction_t t;
   compact_log_dump_metadata(&t, flags);
 
-  dout(20) << __func__ << " op_jump_seq " << log_seq << dendl;
-  t.op_jump_seq(log_seq);
+  dout(20) << __func__ << " op_jump_seq " << log.seq_live << dendl;
+  t.op_jump_seq(log.seq_live);
 
   bufferlist bl;
   encode(t, bl);
@@ -2418,7 +2421,7 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
     }
   }
 
-  _close_writer(log_writer);
+  _close_writer(log.writer);
 
   // we will write it to super
   log_file->fnode.reset_delta();
@@ -2426,15 +2429,15 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
   vselector->sub_usage(log_file->vselector_hint, old_fnode);
   vselector->add_usage(log_file->vselector_hint, log_file->fnode);
 
-  log_writer = _create_writer(log_file);
-  log_writer->append(bl);
-  r = _flush_special(log_writer);
+  log.writer = _create_writer(log_file);
+  log.writer->append(bl);
+  r = _flush_special(log.writer);
   ceph_assert(r == 0);
 #ifdef HAVE_LIBAIO
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
-    _claim_completed_aios(log_writer, &completed_ios);
-    wait_for_aio(log_writer);
+    _claim_completed_aios(log.writer, &completed_ios);
+    wait_for_aio(log.writer);
     completed_ios.clear();
   }
 #endif
@@ -2456,7 +2459,7 @@ void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
   flush_bdev();
 
   dout(10) << __func__ << " release old log extents " << old_fnode.extents << dendl;
-  std::lock_guard dl(dirty_lock);
+  std::lock_guard dl(dirty.lock);
   for (auto& r : old_fnode.extents) {
     pending_release[r.bdev].insert(r.offset, r.length);
   }
@@ -2495,8 +2498,8 @@ void BlueFS::compact_log_async()
     return;
   }
 
-  log_lock.lock();
-  File *log_file = log_writer->file.get();
+  log.lock.lock();
+  File *log_file = log.writer->file.get();
   FileWriter *new_log_writer = nullptr;
   FileRef new_log = nullptr;
   uint64_t new_log_jump_to = 0;
@@ -2521,7 +2524,7 @@ void BlueFS::compact_log_async()
 
   // 1.1 allocate new log space and jump to it.
   old_log_jump_to = log_file->fnode.get_allocated();
-  uint64_t runway = log_file->fnode.get_allocated() - log_writer->get_effective_write_pos();
+  uint64_t runway = log_file->fnode.get_allocated() - log.writer->get_effective_write_pos();
   dout(10) << __func__ << " old_log_jump_to 0x" << std::hex << old_log_jump_to
            << " need 0x" << (old_log_jump_to + cct->_conf->bluefs_max_log_runway) << std::dec << dendl;
   int r = _allocate(vselector->select_prefer_bdev(log_file->vselector_hint),
@@ -2534,8 +2537,8 @@ void BlueFS::compact_log_async()
 
   // update the log file change and log a jump to the offset where we want to
   // write the new entries
-  log_t.op_file_update(log_file->fnode); // 1.2
-  log_t.op_jump(log_seq, old_log_jump_to); // 1.3
+  log.t.op_file_update(log_file->fnode); // 1.2
+  log.t.op_jump(log.seq_live, old_log_jump_to); // 1.3
 
   // we need to flush all bdev because we will be streaming all dirty files to log
   // TODO - think - if _flush_and_sync_log_jump will not add dirty files nor release pending allocations
@@ -2543,7 +2546,7 @@ void BlueFS::compact_log_async()
   flush_bdev();
   _flush_and_sync_log_jump(old_log_jump_to, runway);
 
-  log_lock.unlock();
+  log.lock.unlock();
   // out of jump section - now log can be used to write to
 
   // 2. prepare compacted log
@@ -2560,7 +2563,7 @@ void BlueFS::compact_log_async()
   // conservative estimate for final encoded size
   new_log_jump_to = round_up_to(t.op_bl.length() + super.block_size * 2,
                                 max_alloc_size);
-  t.op_jump(log_seq, new_log_jump_to);
+  t.op_jump(log.seq_live, new_log_jump_to);
 
   // allocate
   //FIXME: check if we want DB here?
@@ -2631,8 +2634,8 @@ void BlueFS::compact_log_async()
   // swap the log files. New log file is the log file now.
   new_log->fnode.swap_extents(log_file->fnode);
 
-  log_writer->pos = log_writer->file->fnode.size =
-    log_writer->pos - old_log_jump_to + new_log_jump_to;
+  log.writer->pos = log.writer->file->fnode.size =
+    log.writer->pos - old_log_jump_to + new_log_jump_to;
 
   vselector->add_usage(log_file->vselector_hint, log_file->fnode);
 
@@ -2652,7 +2655,7 @@ void BlueFS::compact_log_async()
   // 7. release old space
   dout(10) << __func__ << " release old log extents " << old_extents << dendl;
   {
-    std::lock_guard dl(dirty_lock);
+    std::lock_guard dl(dirty.lock);
     for (auto& r : old_extents) {
       pending_release[r.bdev].insert(r.offset, r.length);
     }
@@ -2663,10 +2666,10 @@ void BlueFS::compact_log_async()
   // flush_special does not dirty files
   /*
   if (new_log->dirty_seq) {
-    std::lock_guard dl(dirty_lock);
-    ceph_assert(dirty_files.count(new_log->dirty_seq));
-    auto it = dirty_files[new_log->dirty_seq].iterator_to(*new_log);
-    dirty_files[new_log->dirty_seq].erase(it);
+    std::lock_guard dl(dirty.lock);
+    ceph_assert(dirty.files.count(new_log->dirty_seq));
+    auto it = dirty.files[new_log->dirty_seq].iterator_to(*new_log);
+    dirty.files[new_log->dirty_seq].erase(it);
   }
   */
   new_log_writer = nullptr;
@@ -2691,38 +2694,41 @@ void BlueFS::_pad_bl(bufferlist& bl)
 }
 
 /**
- * Adds file modifications from `dirty_files` to bluefs transactions
- * already stored in `log_t`. Writes them to disk and waits until are stable.
+ * Adds file modifications from `dirty.files` to bluefs transactions
+ * already stored in `log.t`. Writes them to disk and waits until are stable.
  * Guarantees that file modifications with `want_seq` are already stable on disk.
  * In addition may insert jump forward transaction to log write position `jump_to`.
  *
  * it should lock ability to:
- * 1) add to log_t
- * 2) modify dirty_files
+ * 1) add to log.t
+ * 2) modify dirty.files
  * 3) add to pending_release
  *
- * pending_release and log_t go with same lock
+ * pending_release and log.t go with same lock
  */
 
-// Adds to log_t file modifications mentioned in `dirty_files`.
-// Note: some bluefs ops may have already been stored in log_t transaction.
+// Adds to log.t file modifications mentioned in `dirty.files`.
+// Note: some bluefs ops may have already been stored in log.t transaction.
 uint64_t BlueFS::_consume_dirty()
 {
-  ceph_assert(ceph_mutex_is_locked(dirty_lock));
-  ceph_assert(ceph_mutex_is_locked(log_lock));
+  ceph_assert(ceph_mutex_is_locked(dirty.lock));
+  ceph_assert(ceph_mutex_is_locked(log.lock));
   //acquire new seq
-  // this will became log_seq_stable once we write
-  uint64_t seq = log_t.seq = ++log_seq;
-  log_t.uuid = super.uuid;
+  // this will became seq_stable once we write
+  ++dirty.seq_next;
+  ++log.seq_live;
+  ceph_assert(dirty.seq_next == log.seq_live + 1);
+  uint64_t seq = log.t.seq = log.seq_live;
+  log.t.uuid = super.uuid;
 
   // log dirty files
-  // we just incremented log_seq. It is now illegal to add to dirty_files[log_seq]
-  auto lsi = dirty_files.find(seq);
-  if (lsi != dirty_files.end()) {
-    dout(20) << __func__ << " " << lsi->second.size() << " dirty_files" << dendl;
+  // we just incremented log_seq. It is now illegal to add to dirty.files[log_seq]
+  auto lsi = dirty.files.find(seq);
+  if (lsi != dirty.files.end()) {
+    dout(20) << __func__ << " " << lsi->second.size() << " dirty.files" << dendl;
     for (auto &f : lsi->second) {
       dout(20) << __func__ << "   op_file_update_inc " << f.fnode << dendl;
-      log_t.op_file_update_inc(f.fnode);
+      log.t.op_file_update_inc(f.fnode);
     }
   }
   return seq;
@@ -2732,11 +2738,11 @@ uint64_t BlueFS::_consume_dirty()
 // Returns space available *BEFORE* adding new space. Signed for additional <0 detection.
 int64_t BlueFS::_maybe_extend_log()
 {
-  ceph_assert(ceph_mutex_is_locked(log_lock));
+  ceph_assert(ceph_mutex_is_locked(log.lock));
   // allocate some more space (before we run out)?
-  // BTW: this triggers `flush()` in the `page_aligned_appender` of `log_writer`.
-  int64_t runway = log_writer->file->fnode.get_allocated() -
-    log_writer->get_effective_write_pos();
+  // BTW: this triggers `flush()` in the `page_aligned_appender` of `log.writer`.
+  int64_t runway = log.writer->file->fnode.get_allocated() -
+    log.writer->get_effective_write_pos();
   if (runway < (int64_t)cct->_conf->bluefs_min_log_runway) {
     dout(10) << __func__ << " allocating more log runway (0x"
 	     << std::hex << runway << std::dec  << " remaining)" << dendl;
@@ -2758,26 +2764,26 @@ int64_t BlueFS::_maybe_extend_log()
     if (log_forbidden_to_expand.load() == true) {
       return -EWOULDBLOCK;
     }
-    vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
+    vselector->sub_usage(log.writer->file->vselector_hint, log.writer->file->fnode);
     int r = _allocate(
-      vselector->select_prefer_bdev(log_writer->file->vselector_hint),
+      vselector->select_prefer_bdev(log.writer->file->vselector_hint),
       cct->_conf->bluefs_max_log_runway,
-      &log_writer->file->fnode);
+      &log.writer->file->fnode);
     ceph_assert(r == 0);
-    vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
-    log_t.op_file_update_inc(log_writer->file->fnode);
+    vselector->add_usage(log.writer->file->vselector_hint, log.writer->file->fnode);
+    log.t.op_file_update_inc(log.writer->file->fnode);
   }
   return runway;
 }
 
 void BlueFS::_flush_and_sync_log_core(int64_t runway)
 {
-  ceph_assert(ceph_mutex_is_locked(log_lock));
-  dout(10) << __func__ << " " << log_t << dendl;
+  ceph_assert(ceph_mutex_is_locked(log.lock));
+  dout(10) << __func__ << " " << log.t << dendl;
 
   bufferlist bl;
   bl.reserve(super.block_size);
-  encode(log_t, bl);
+  encode(log.t, bl);
   // pad to block boundary
   size_t realign = super.block_size - (bl.length() % super.block_size);
   if (realign && realign != super.block_size)
@@ -2790,29 +2796,29 @@ void BlueFS::_flush_and_sync_log_core(int64_t runway)
                                         // transaction will not fit extents before growth -> data loss on _replay
   }
 
-  log_writer->append(bl);
+  log.writer->append(bl);
 
-  log_t.clear();
-  log_t.seq = 0;  // just so debug output is less confusing
+  log.t.clear();
+  log.t.seq = 0;  // just so debug output is less confusing
 
-  int r = _flush_special(log_writer);
+  int r = _flush_special(log.writer);
   ceph_assert(r == 0);
 }
 
-// Clears dirty_files up to (including) seq_stable.
+// Clears dirty.files up to (including) seq_stable.
 void BlueFS::_clear_dirty_set_stable(uint64_t seq)
 {
-  std::lock_guard lg(dirty_lock);
+  std::lock_guard lg(dirty.lock);
 
   // clean dirty files
-  if (seq > log_seq_stable) {
-    log_seq_stable = seq;
-    dout(20) << __func__ << " log_seq_stable " << log_seq_stable << dendl;
+  if (seq > dirty.seq_stable) {
+    dirty.seq_stable = seq;
+    dout(20) << __func__ << " seq_stable " << dirty.seq_stable << dendl;
 
     // undirty all files that were already streamed to log
-    auto p = dirty_files.begin();
-    while (p != dirty_files.end()) {
-      if (p->first > log_seq_stable) {
+    auto p = dirty.files.begin();
+    while (p != dirty.files.end()) {
+      if (p->first > dirty.seq_stable) {
         dout(20) << __func__ << " done cleaning up dirty files" << dendl;
         break;
       }
@@ -2821,17 +2827,17 @@ void BlueFS::_clear_dirty_set_stable(uint64_t seq)
       while (l != p->second.end()) {
         File *file = &*l;
         ceph_assert(file->dirty_seq > 0);
-        ceph_assert(file->dirty_seq <= log_seq_stable);
+        ceph_assert(file->dirty_seq <= dirty.seq_stable);
         dout(20) << __func__ << " cleaned file " << file->fnode << dendl;
         file->dirty_seq = 0;
         p->second.erase(l++);
       }
 
       ceph_assert(p->second.empty());
-      dirty_files.erase(p++);
+      dirty.files.erase(p++);
     }
   } else {
-    dout(20) << __func__ << " log_seq_stable " << log_seq_stable
+    dout(20) << __func__ << " seq_stable " << dirty.seq_stable
              << " already >= out seq " << seq
              << ", we lost a race against another log flush, done" << dendl;
   }
@@ -2865,22 +2871,22 @@ int BlueFS::flush_and_sync_log(uint64_t want_seq)
   // we synchronize writing to log, by lock to log_lock
   int64_t available_runway;
   do {
-    log_lock.lock();
-    dirty_lock.lock();
-    if (want_seq && want_seq <= log_seq_stable) {
-      dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
-	       << log_seq_stable << ", done" << dendl;
-      dirty_lock.unlock();
-      log_lock.unlock();
+    log.lock.lock();
+    dirty.lock.lock();
+    if (want_seq && want_seq <= dirty.seq_stable) {
+      dout(10) << __func__ << " want_seq " << want_seq << " <= seq_stable "
+	       << dirty.seq_stable << ", done" << dendl;
+      dirty.lock.unlock();
+      log.lock.unlock();
       return 0;
     }
 
     available_runway = _maybe_extend_log();
     if (available_runway == -EWOULDBLOCK) {
       // we are in need of adding runway, but we are during log-switch from compaction
-      dirty_lock.unlock();
-      //instead log_lock_unlock() do move ownership
-      std::unique_lock<ceph::mutex> ll(log_lock, std::adopt_lock);
+      dirty.lock.unlock();
+      //instead log.lock_unlock() do move ownership
+      std::unique_lock<ceph::mutex> ll(log.lock, std::adopt_lock);
       while (log_forbidden_to_expand.load()) {
 	log_cond.wait(ll);
       }
@@ -2889,17 +2895,17 @@ int BlueFS::flush_and_sync_log(uint64_t want_seq)
     }
   } while (available_runway < 0);
 
-  ceph_assert(want_seq == 0 || want_seq <= log_seq + 1); // illegal to request seq that was not created yet
+  ceph_assert(want_seq == 0 || want_seq <= log.seq_live); // illegal to request seq that was not created yet
 
   uint64_t seq = _consume_dirty();
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
-  dirty_lock.unlock();
+  dirty.lock.unlock();
 
   _flush_and_sync_log_core(available_runway);
-  _flush_bdev(log_writer);
-  //now log_lock is no longer needed
-  log_lock.unlock();
+  _flush_bdev(log.writer);
+  //now log.lock is no longer needed
+  log.lock.unlock();
 
   _clear_dirty_set_stable(seq);
   _release_pending_allocations(to_release);
@@ -2912,26 +2918,26 @@ int BlueFS::flush_and_sync_log(uint64_t want_seq)
 int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
 				     int64_t available_runway)
 {
-  ceph_assert(ceph_mutex_is_locked(log_lock));
+  ceph_assert(ceph_mutex_is_locked(log.lock));
 
   ceph_assert(jump_to);
   // we synchronize writing to log, by lock to log_lock
 
-  dirty_lock.lock();
+  dirty.lock.lock();
   uint64_t seq = _consume_dirty();
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
-  dirty_lock.unlock();
+  dirty.lock.unlock();
   _flush_and_sync_log_core(available_runway);
 
   dout(10) << __func__ << " jumping log offset from 0x" << std::hex
-	   << log_writer->pos << " -> 0x" << jump_to << std::dec << dendl;
-  log_writer->pos = jump_to;
-  vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
-  log_writer->file->fnode.size = jump_to;
-  vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
+	   << log.writer->pos << " -> 0x" << jump_to << std::dec << dendl;
+  log.writer->pos = jump_to;
+  vselector->sub_usage(log.writer->file->vselector_hint, log.writer->file->fnode.size);
+  log.writer->file->fnode.size = jump_to;
+  vselector->add_usage(log.writer->file->vselector_hint, log.writer->file->fnode.size);
 
-  _flush_bdev(log_writer);
+  _flush_bdev(log.writer);
 
   _clear_dirty_set_stable(seq);
   _release_pending_allocations(to_release);
@@ -2986,26 +2992,26 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
 int BlueFS::_signal_dirty_to_log(FileWriter *h)
 {
   ceph_assert(ceph_mutex_is_locked(h->lock));
-  std::lock_guard dl(dirty_lock);
+  std::lock_guard dl(dirty.lock);
   h->file->fnode.mtime = ceph_clock_now();
   ceph_assert(h->file->fnode.ino >= 1);
   if (h->file->dirty_seq == 0) {
-    h->file->dirty_seq = log_seq + 1;
-    dirty_files[h->file->dirty_seq].push_back(*h->file);
-    dout(20) << __func__ << " dirty_seq = " << log_seq + 1
+    h->file->dirty_seq = dirty.seq_next;
+    dirty.files[h->file->dirty_seq].push_back(*h->file);
+    dout(20) << __func__ << " dirty_seq = " << dirty.seq_next
 	     << " (was clean)" << dendl;
   } else {
-    if (h->file->dirty_seq != log_seq + 1) {
+    if (h->file->dirty_seq != dirty.seq_next) {
       // need re-dirty, erase from list first
-      ceph_assert(dirty_files.count(h->file->dirty_seq));
-      auto it = dirty_files[h->file->dirty_seq].iterator_to(*h->file);
-      dirty_files[h->file->dirty_seq].erase(it);
-      h->file->dirty_seq = log_seq + 1;
-      dirty_files[h->file->dirty_seq].push_back(*h->file);
-      dout(20) << __func__ << " dirty_seq = " << log_seq + 1
+      ceph_assert(dirty.files.count(h->file->dirty_seq));
+      auto it = dirty.files[h->file->dirty_seq].iterator_to(*h->file);
+      dirty.files[h->file->dirty_seq].erase(it);
+      h->file->dirty_seq = dirty.seq_next;
+      dirty.files[h->file->dirty_seq].push_back(*h->file);
+      dout(20) << __func__ << " dirty_seq = " << dirty.seq_next
 	       << " (was " << h->file->dirty_seq << ")" << dendl;
     } else {
-      dout(20) << __func__ << " dirty_seq = " << log_seq + 1
+      dout(20) << __func__ << " dirty_seq = " << dirty.seq_next
 	       << " (unchanged, do nothing) " << dendl;
     }
   }
@@ -3311,8 +3317,8 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)
   h->file->fnode.size = offset;
   vselector->add_usage(h->file->vselector_hint, h->file->fnode.size);
 
-  std::lock_guard ll(log_lock);
-  log_t.op_file_update_inc(h->file->fnode);
+  std::lock_guard ll(log.lock);
+  log.t.op_file_update_inc(h->file->fnode);
   return 0;
 }
 
@@ -3332,7 +3338,7 @@ int BlueFS::fsync(FileWriter *h)
   _flush_bdev(h);
 
   if (old_dirty_seq) {
-    uint64_t s = log_seq;
+    uint64_t s = log.seq_live; // AKAK !!! locks!
     dout(20) << __func__ << " file metadata was dirty (" << old_dirty_seq
 	     << ") on " << h->file->fnode << ", flushing log" << dendl;
     flush_and_sync_log(old_dirty_seq);
@@ -3344,13 +3350,13 @@ int BlueFS::fsync(FileWriter *h)
   return 0;
 }
 
-// be careful - either h->file->lock or log_lock must be taken
+// be careful - either h->file->lock or log.lock must be taken
 void BlueFS::_flush_bdev(FileWriter *h)
 {
   if (h->file->fnode.ino != 1) {
     ceph_assert(ceph_mutex_is_locked(h->lock));
   } else {
-    ceph_assert(ceph_mutex_is_locked(log_lock));
+    ceph_assert(ceph_mutex_is_locked(log.lock));
   }
   std::array<bool, MAX_BDEV> flush_devs = h->dirty_devs;
   h->dirty_devs.fill(false);
@@ -3517,8 +3523,8 @@ int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
     vselector->add_usage(f->vselector_hint, f->fnode);
     if (r < 0)
       return r;
-    std::lock_guard ll(log_lock);
-    log_t.op_file_update_inc(f->fnode);
+    std::lock_guard ll(log.lock);
+    log.t.op_file_update_inc(f->fnode);
   }
   return 0;
 }
@@ -3527,9 +3533,9 @@ void BlueFS::sync_metadata(bool avoid_compact)
 {
   bool can_skip_flush;
   {
-    std::lock_guard ll(log_lock);
-    std::lock_guard dl(dirty_lock);
-    can_skip_flush = log_t.empty() && dirty_files.empty();
+    std::lock_guard ll(log.lock);
+    std::lock_guard dl(dirty.lock);
+    can_skip_flush = log.t.empty() && dirty.files.empty();
   }
   if (can_skip_flush) {
     dout(10) << __func__ << " - no pending log events" << dendl;
@@ -3566,11 +3572,11 @@ int BlueFS::open_for_write(
   FileWriter **h,
   bool overwrite)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
   DirRef dir;
-  if (p == dir_map.end()) {
+  if (p == nodes.dir_map.end()) {
     // implicitly create the dir
     dout(20) << __func__ << "  dir " << dirname
 	     << " does not exist" << dendl;
@@ -3592,7 +3598,7 @@ int BlueFS::open_for_write(
     }
     file = ceph::make_ref<File>();
     file->fnode.ino = ++ino_last;
-    file_map[ino_last] = file;
+    nodes.file_map[ino_last] = file;
     dir->file_map[string{filename}] = file;
     ++file->refs;
     create = true;
@@ -3629,10 +3635,10 @@ int BlueFS::open_for_write(
 	   << " vsel_hint " << file->vselector_hint
 	   << dendl;
   {
-    std::lock_guard ll(log_lock);
-    log_t.op_file_update(file->fnode);
+    std::lock_guard ll(log.lock);
+    log.t.op_file_update(file->fnode);
     if (create)
-      log_t.op_dir_link(dirname, filename, file->fnode.ino);
+      log.t.op_dir_link(dirname, filename, file->fnode.ino);
   }
   *h = _create_writer(file);
 
@@ -3713,11 +3719,11 @@ int BlueFS::open_for_read(
   FileReader **h,
   bool random)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename
 	   << (random ? " (random)":" (sequential)") << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
-  if (p == dir_map.end()) {
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << dirname << " not found" << dendl;
     return -ENOENT;
   }
@@ -3742,12 +3748,12 @@ int BlueFS::rename(
   std::string_view old_dirname, std::string_view old_filename,
   std::string_view new_dirname, std::string_view new_filename)
 {
-  std::lock_guard dirl(dirs_lock);
-  std::lock_guard ll(log_lock);
+  std::lock_guard dirl(nodes.lock);
+  std::lock_guard ll(log.lock);
   dout(10) << __func__ << " " << old_dirname << "/" << old_filename
 	   << " -> " << new_dirname << "/" << new_filename << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(old_dirname);
-  if (p == dir_map.end()) {
+  map<string,DirRef>::iterator p = nodes.dir_map.find(old_dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << old_dirname << " not found" << dendl;
     return -ENOENT;
   }
@@ -3761,8 +3767,8 @@ int BlueFS::rename(
   }
   FileRef file = q->second;
 
-  p = dir_map.find(new_dirname);
-  if (p == dir_map.end()) {
+  p = nodes.dir_map.find(new_dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << new_dirname << " not found" << dendl;
     return -ENOENT;
   }
@@ -3773,7 +3779,7 @@ int BlueFS::rename(
 	     << ") file " << new_filename
 	     << " already exists, unlinking" << dendl;
     ceph_assert(q->second != file);
-    log_t.op_dir_unlink(new_dirname, new_filename);
+    log.t.op_dir_unlink(new_dirname, new_filename);
     _drop_link(q->second);
   }
 
@@ -3783,33 +3789,33 @@ int BlueFS::rename(
   new_dir->file_map[string{new_filename}] = file;
   old_dir->file_map.erase(string{old_filename});
 
-  log_t.op_dir_link(new_dirname, new_filename, file->fnode.ino);
-  log_t.op_dir_unlink(old_dirname, old_filename);
+  log.t.op_dir_link(new_dirname, new_filename, file->fnode.ino);
+  log.t.op_dir_unlink(old_dirname, old_filename);
   return 0;
 }
 
 int BlueFS::mkdir(std::string_view dirname)
 {
-  std::lock_guard dirl(dirs_lock);
-  std::lock_guard ll(log_lock);
+  std::lock_guard dirl(nodes.lock);
+  std::lock_guard ll(log.lock);
   dout(10) << __func__ << " " << dirname << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
-  if (p != dir_map.end()) {
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+  if (p != nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << dirname << " exists" << dendl;
     return -EEXIST;
   }
-  dir_map[string{dirname}] = ceph::make_ref<Dir>();
-  log_t.op_dir_create(dirname);
+  nodes.dir_map[string{dirname}] = ceph::make_ref<Dir>();
+  log.t.op_dir_create(dirname);
   return 0;
 }
 
 int BlueFS::rmdir(std::string_view dirname)
 {
-  std::lock_guard dirl(dirs_lock);
-  std::lock_guard ll(log_lock);
+  std::lock_guard dirl(nodes.lock);
+  std::lock_guard ll(log.lock);
   dout(10) << __func__ << " " << dirname << dendl;
-  auto p = dir_map.find(dirname);
-  if (p == dir_map.end()) {
+  auto p = nodes.dir_map.find(dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << dirname << " does not exist" << dendl;
     return -ENOENT;
   }
@@ -3818,16 +3824,16 @@ int BlueFS::rmdir(std::string_view dirname)
     dout(20) << __func__ << " dir " << dirname << " not empty" << dendl;
     return -ENOTEMPTY;
   }
-  dir_map.erase(string{dirname});
-  log_t.op_dir_remove(dirname);
+  nodes.dir_map.erase(string{dirname});
+  log.t.op_dir_remove(dirname);
   return 0;
 }
 
 bool BlueFS::dir_exists(std::string_view dirname)
 {
-  std::lock_guard dirl(dirs_lock);
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
-  bool exists = p != dir_map.end();
+  std::lock_guard dirl(nodes.lock);
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+  bool exists = p != nodes.dir_map.end();
   dout(10) << __func__ << " " << dirname << " = " << (int)exists << dendl;
   return exists;
 }
@@ -3835,10 +3841,10 @@ bool BlueFS::dir_exists(std::string_view dirname)
 int BlueFS::stat(std::string_view dirname, std::string_view filename,
 		 uint64_t *size, utime_t *mtime)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
-  if (p == dir_map.end()) {
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << dirname << " not found" << dendl;
     return -ENOENT;
   }
@@ -3863,10 +3869,10 @@ int BlueFS::stat(std::string_view dirname, std::string_view filename,
 int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 		      FileLock **plock)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
-  if (p == dir_map.end()) {
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << dirname << " not found" << dendl;
     return -ENOENT;
   }
@@ -3880,12 +3886,12 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
     file = ceph::make_ref<File>();
     file->fnode.ino = ++ino_last;
     file->fnode.mtime = ceph_clock_now();
-    file_map[ino_last] = file;
+    nodes.file_map[ino_last] = file;
     dir->file_map[string{filename}] = file;
     ++file->refs;
-    std::lock_guard ll(log_lock);
-    log_t.op_file_update(file->fnode);
-    log_t.op_dir_link(dirname, filename, file->fnode.ino);
+    std::lock_guard ll(log.lock);
+    log.t.op_file_update(file->fnode);
+    log.t.op_dir_link(dirname, filename, file->fnode.ino);
   } else {
     file = q->second;
     if (file->locked) {
@@ -3902,7 +3908,7 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 
 int BlueFS::unlock_file(FileLock *fl)
 {
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " " << fl << " on " << fl->file->fnode << dendl;
   ceph_assert(fl->file->locked);
   fl->file->locked = false;
@@ -3916,18 +3922,18 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
   if (!dirname.empty() && dirname.back() == '/') {
     dirname.remove_suffix(1);
   }
-  std::lock_guard dirl(dirs_lock);
+  std::lock_guard dirl(nodes.lock);
   dout(10) << __func__ << " " << dirname << dendl;
   if (dirname.empty()) {
     // list dirs
-    ls->reserve(dir_map.size() + 2);
-    for (auto& q : dir_map) {
+    ls->reserve(nodes.dir_map.size() + 2);
+    for (auto& q : nodes.dir_map) {
       ls->push_back(q.first);
     }
   } else {
     // list files in dir
-    map<string,DirRef>::iterator p = dir_map.find(dirname);
-    if (p == dir_map.end()) {
+    map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+    if (p == nodes.dir_map.end()) {
       dout(20) << __func__ << " dir " << dirname << " not found" << dendl;
       return -ENOENT;
     }
@@ -3944,11 +3950,11 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
 
 int BlueFS::unlink(std::string_view dirname, std::string_view filename)
 {
-  std::lock_guard dirl(dirs_lock);
-  std::lock_guard ll(log_lock);
+  std::lock_guard dirl(nodes.lock);
+  std::lock_guard ll(log.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
-  map<string,DirRef>::iterator p = dir_map.find(dirname);
-  if (p == dir_map.end()) {
+  map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
+  if (p == nodes.dir_map.end()) {
     dout(20) << __func__ << " dir " << dirname << " not found" << dendl;
     return -ENOENT;
   }
@@ -3966,7 +3972,7 @@ int BlueFS::unlink(std::string_view dirname, std::string_view filename)
     return -EBUSY;
   }
   dir->file_map.erase(string{filename});
-  log_t.op_dir_unlink(dirname, filename);
+  log.t.op_dir_unlink(dirname, filename);
   _drop_link(file);
   return 0;
 }
@@ -4045,7 +4051,7 @@ int BlueFS::do_replay_recovery_read(FileReader *log_reader,
     dout(2) << __func__ << " processing " << get_device_name(dev) << dendl;
     interval_set<uint64_t> disk_regions;
     disk_regions.insert(0, bdev[dev]->get_size());
-    for (auto f : file_map) {
+    for (auto f : nodes.file_map) {
       auto& e = f.second->fnode.extents;
       for (auto& p : e) {
 	if (p.bdev == dev) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2495,6 +2495,7 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
 
   // 1. allocate new log space and jump to it.
   old_log_jump_to = log_file->fnode.get_allocated();
+  uint64_t runway = log_file->fnode.get_allocated() - log_writer->get_effective_write_pos();
   dout(10) << __func__ << " old_log_jump_to 0x" << std::hex << old_log_jump_to
            << " need 0x" << (old_log_jump_to + cct->_conf->bluefs_max_log_runway) << std::dec << dendl;
   int r = _allocate(vselector->select_prefer_bdev(log_file->vselector_hint),
@@ -2510,9 +2511,12 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
   log_t.op_file_update(log_file->fnode);
   log_t.op_jump(log_seq, old_log_jump_to);
 
-  flush_bdev();  // FIXME?
+  // we need to flush all bdev because we will be streaming all dirty files to log
+  // TODO - think - if _flush_and_sync_log_jump will not add dirty files nor release pending allocations
+  // then flush_bdev() will not be necessary
+  flush_bdev();
 
-  _flush_and_sync_log(l, 0, old_log_jump_to);
+  _flush_and_sync_log_jump(old_log_jump_to, runway);
 
   // 2. prepare compacted log
   bluefs_transaction_t t;
@@ -2643,38 +2647,17 @@ void BlueFS::_pad_bl(bufferlist& bl)
   }
 }
 
-
-int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
-				uint64_t want_seq,
-				uint64_t jump_to)
+// Adds to log_t file modifications mentioned in `dirty_files`.
+// Note: some bluefs ops may have already been stored in log_t transaction.
+uint64_t BlueFS::_consume_dirty()
 {
-  while (log_flushing) {
-    dout(10) << __func__ << " want_seq " << want_seq
-	     << " log is currently flushing, waiting" << dendl;
-    ceph_assert(!jump_to);
-    log_cond.wait(l);
-  }
-  if (want_seq && want_seq <= log_seq_stable) {
-    dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
-	     << log_seq_stable << ", done" << dendl;
-    ceph_assert(!jump_to);
-    return 0;
-  }
-  if (log_t.empty() && dirty_files.empty()) {
-    dout(10) << __func__ << " want_seq " << want_seq
-	     << " " << log_t << " not dirty, dirty_files empty, no-op" << dendl;
-    ceph_assert(!jump_to);
-    return 0;
-  }
-
-  vector<interval_set<uint64_t>> to_release(pending_release.size());
-  to_release.swap(pending_release);
-
+  //acquire new seq
+  // this will became log_seq_stable once we write
   uint64_t seq = log_t.seq = ++log_seq;
-  ceph_assert(want_seq == 0 || want_seq <= seq);
   log_t.uuid = super.uuid;
 
   // log dirty files
+  // we just incremented log_seq. It is now illegal to add to dirty_files[log_seq]
   auto lsi = dirty_files.find(seq);
   if (lsi != dirty_files.end()) {
     dout(20) << __func__ << " " << lsi->second.size() << " dirty_files" << dendl;
@@ -2683,21 +2666,37 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
       log_t.op_file_update_inc(f.fnode);
     }
   }
+  return seq;
+}
 
-  dout(10) << __func__ << " " << log_t << dendl;
-  ceph_assert(!log_t.empty());
-
+// Extends log if its free space is smaller then bluefs_min_log_runway.
+// Returns space available *BEFORE* adding new space. Signed for additional <0 detection.
+int64_t BlueFS::_maybe_extend_log()
+{
   // allocate some more space (before we run out)?
   // BTW: this triggers `flush()` in the `page_aligned_appender` of `log_writer`.
   int64_t runway = log_writer->file->fnode.get_allocated() -
     log_writer->get_effective_write_pos();
-  bool just_expanded_log = false;
   if (runway < (int64_t)cct->_conf->bluefs_min_log_runway) {
     dout(10) << __func__ << " allocating more log runway (0x"
 	     << std::hex << runway << std::dec  << " remaining)" << dendl;
-    while (new_log_writer) {
-      dout(10) << __func__ << " waiting for async compaction" << dendl;
-      log_cond.wait(l);
+    /*
+     * Usually, when we are low on space in log, we just allocate new extent,
+     * put update op(log) to log and we are fine.
+     * Problem - it interferes with log compaction:
+     * New log produced in compaction will include - as last op - jump into some offset (anchor) of current log.
+     * It is assumed that log region (anchor - end) will contain all changes made by bluefs since
+     * full state capture into new log.
+     * Putting log update into (anchor - end) region is illegal, because any update there must be compatible with
+     * both logs, but old log is different then new log.
+     *
+     * Possible solutions:
+     * - stall extending log until we finish compacting and switch log (CURRENT)
+     * - re-run compaction with more runway for old log
+     * - add OP_FILE_ADDEXT that adds extent; will be compatible with both logs
+     */
+    if (new_log_writer) {
+      return -EWOULDBLOCK;
     }
     vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
     int r = _allocate(
@@ -2707,8 +2706,13 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
     ceph_assert(r == 0);
     vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
     log_t.op_file_update_inc(log_writer->file->fnode);
-    just_expanded_log = true;
   }
+  return runway;
+}
+
+void BlueFS::_flush_and_sync_log_core(int64_t runway)
+{
+  dout(10) << __func__ << " " << log_t << dendl;
 
   bufferlist bl;
   bl.reserve(super.block_size);
@@ -2720,38 +2724,29 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
 
   logger->inc(l_bluefs_logged_bytes, bl.length());
 
-  if (just_expanded_log) {
+  if (true) {
     ceph_assert(bl.length() <= runway); // if we write this, we will have an unrecoverable data loss
+                                        // transaction will not fit extents before growth -> data loss on _replay
   }
 
   log_writer->append(bl);
 
   log_t.clear();
   log_t.seq = 0;  // just so debug output is less confusing
-  log_flushing = true;
 
   int r = _flush(log_writer, true);
   ceph_assert(r == 0);
+}
 
-  if (jump_to) {
-    dout(10) << __func__ << " jumping log offset from 0x" << std::hex
-	     << log_writer->pos << " -> 0x" << jump_to << std::dec << dendl;
-    log_writer->pos = jump_to;
-    vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
-    log_writer->file->fnode.size = jump_to;
-    vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
-  }
-
-  _flush_bdev_safely(log_writer);
-
-  log_flushing = false;
-  log_cond.notify_all();
-
+// Clears dirty_files up to (including) seq_stable.
+void BlueFS::_clear_dirty_set_stable(uint64_t seq)
+{
   // clean dirty files
   if (seq > log_seq_stable) {
     log_seq_stable = seq;
     dout(20) << __func__ << " log_seq_stable " << log_seq_stable << dendl;
 
+    // undirty all files that were already streamed to log
     auto p = dirty_files.begin();
     while (p != dirty_files.end()) {
       if (p->first > log_seq_stable) {
@@ -2777,7 +2772,10 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
              << " already >= out seq " << seq
              << ", we lost a race against another log flush, done" << dendl;
   }
+}
 
+void BlueFS::_release_pending_allocations(vector<interval_set<uint64_t>>& to_release)
+{
   for (unsigned i = 0; i < to_release.size(); ++i) {
     if (!to_release[i].empty()) {
       /* OK, now we have the guarantee alloc[i] won't be null. */
@@ -2797,9 +2795,67 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
       }
     }
   }
+}
+
+int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
+			       uint64_t want_seq)
+{
+  if (want_seq && want_seq <= log_seq_stable) {
+    dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
+	     << log_seq_stable << ", done" << dendl;
+    return 0;
+  }
+  int64_t available_runway;
+  do {
+    available_runway = _maybe_extend_log();
+    if (available_runway == -EWOULDBLOCK) {
+      while (new_log_writer) {
+	dout(10) << __func__ << " waiting for async compaction" << dendl;
+	log_cond.wait(l);
+      }
+    }
+  } while (available_runway == -EWOULDBLOCK);
+
+  ceph_assert(want_seq == 0 || want_seq <= log_seq + 1); // illegal to request seq that was not created yet
+
+  uint64_t seq = _consume_dirty();
+  vector<interval_set<uint64_t>> to_release(pending_release.size());
+  to_release.swap(pending_release);
+
+  _flush_and_sync_log_core(available_runway);
+  _flush_bdev_safely(log_writer);
+
+  _clear_dirty_set_stable(seq);
+  _release_pending_allocations(to_release);
 
   _update_logger_stats();
+  return 0;
+}
 
+// Flushes log and immediately adjusts log_writer pos.
+int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
+				     int64_t available_runway)
+{
+  ceph_assert(jump_to);
+  uint64_t seq = _consume_dirty();
+  vector<interval_set<uint64_t>> to_release(pending_release.size());
+  to_release.swap(pending_release);
+
+  _flush_and_sync_log_core(available_runway);
+
+  dout(10) << __func__ << " jumping log offset from 0x" << std::hex
+	   << log_writer->pos << " -> 0x" << jump_to << std::dec << dendl;
+  log_writer->pos = jump_to;
+  vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
+  log_writer->file->fnode.size = jump_to;
+  vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
+
+  _flush_bdev_safely(log_writer);
+
+  _clear_dirty_set_stable(seq);
+  _release_pending_allocations(to_release);
+
+  _update_logger_stats();
   return 0;
 }
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1649,7 +1649,6 @@ int BlueFS::_replay(bool noop, bool to_stdout)
     log.seq_live = log_seq + 1;
     dirty.seq_live = log_seq + 1;
     log.t.seq = log.seq_live;
-    //log.seq_stable = log_seq;
     dirty.seq_stable = log_seq;
   }
 
@@ -1990,10 +1989,20 @@ BlueFS::FileRef BlueFS::_get_file(uint64_t ino)
   }
 }
 
+struct lock_fnode_print {
+  BlueFS::FileRef file;
+  lock_fnode_print(BlueFS::FileRef file) : file(file) {};
+};
+std::ostream& operator<<(std::ostream& out, const lock_fnode_print& to_lock) {
+  std::lock_guard l(to_lock.file->lock);
+  out << to_lock.file->fnode;
+  return out;
+}
+
 void BlueFS::_drop_link_D(FileRef file)
 {
   dout(20) << __func__ << " had refs " << file->refs
-	   << " on " << file->fnode << dendl;
+	   << " on " << lock_fnode_print(file) << dendl;
   ceph_assert(file->refs > 0);
   ceph_assert(ceph_mutex_is_locked(log.lock));
 
@@ -2003,14 +2012,13 @@ void BlueFS::_drop_link_D(FileRef file)
     ceph_assert(file->num_reading.load() == 0);
     vselector->sub_usage(file->vselector_hint, file->fnode);
     log.t.op_file_remove(file->fnode.ino);
+    nodes.file_map.erase(file->fnode.ino);
+    file->deleted = true;
 
     std::lock_guard dl(dirty.lock);
     for (auto& r : file->fnode.extents) {
       pending_release[r.bdev].insert(r.offset, r.length);
     }
-    nodes.file_map.erase(file->fnode.ino);
-    file->deleted = true;
-
     if (file->dirty_seq > dirty.seq_stable) {
       // retract request to serialize changes
       ceph_assert(dirty.files.count(file->dirty_seq));
@@ -2032,7 +2040,7 @@ int64_t BlueFS::_read_random(
   int64_t ret = 0;
   dout(10) << __func__ << " h " << h
            << " 0x" << std::hex << off << "~" << len << std::dec
-	   << " from " << h->file->fnode << dendl;
+	   << " from " << lock_fnode_print(h->file) << dendl;
 
   ++h->file->num_reading;
 
@@ -2125,7 +2133,7 @@ int64_t BlueFS::_read(
   bool prefetch = !outbl && !out;
   dout(10) << __func__ << " h " << h
            << " 0x" << std::hex << off << "~" << len << std::dec
-	   << " from " << h->file->fnode
+	   << " from " << lock_fnode_print(h->file)
 	   << (prefetch ? " prefetch" : "")
 	   << dendl;
 
@@ -2242,7 +2250,7 @@ int64_t BlueFS::_read(
 void BlueFS::invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
 {
   std::lock_guard l(f->lock);
-  dout(10) << __func__ << " file " << f->fnode
+  dout(10) << __func__ << " file " << lock_fnode_print(f)
 	   << " 0x" << std::hex << offset << "~" << length << std::dec
            << dendl;
   if (offset & ~super.block_mask()) {
@@ -2322,7 +2330,7 @@ void BlueFS::_compact_log_dump_metadata_N(bluefs_transaction_t *t,
     if (ino == 1)
       continue;
     ceph_assert(ino > 1);
-    //AK - TODO - touching fnode - need to lock
+    std::lock_guard fl(file_ref->lock);
     for(auto& e : file_ref->fnode.extents) {
       auto bdev = e.bdev;
       auto bdev_new = bdev;
@@ -2359,8 +2367,8 @@ void BlueFS::_compact_log_dump_metadata_N(bluefs_transaction_t *t,
   }
 }
 /* Streams to t files modified before *capture_before_seq* and all dirs */
-void BlueFS::compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
-					     uint64_t capture_before_seq)
+void BlueFS::_compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
+						 uint64_t capture_before_seq)
 {
   std::lock_guard nl(nodes.lock);
 
@@ -2592,7 +2600,7 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
 
   // 2. prepare compacted log
   bluefs_transaction_t t;
-  compact_log_async_dump_metadata_NF(&t, seq_now);
+  _compact_log_async_dump_metadata_NF(&t, seq_now);
 
   // now state is captured to bufferlist
   // log can be used to write to, ops in log will be continuation of captured state
@@ -2882,7 +2890,7 @@ void BlueFS::_clear_dirty_set_stable_D(uint64_t seq)
       while (l != p->second.end()) {
         File *file = &*l;
         ceph_assert(file->dirty_seq <= dirty.seq_stable);
-        dout(20) << __func__ << " cleaned file " << file->fnode << dendl;
+        dout(20) << __func__ << " cleaned file " << file->fnode.ino << dendl;
         file->dirty_seq = dirty.seq_stable;
         p->second.erase(l++);
       }
@@ -2938,7 +2946,7 @@ int BlueFS::_flush_and_sync_log_LD(uint64_t want_seq)
     if (available_runway == -EWOULDBLOCK) {
       // we are in need of adding runway, but we are during log-switch from compaction
       dirty.lock.unlock();
-      //instead log.lock_unlock() do move ownership
+      //instead log.lock.unlock() do move ownership
       std::unique_lock<ceph::mutex> ll(log.lock, std::adopt_lock);
       while (log_forbidden_to_expand.load()) {
 	log_cond.wait(ll);
@@ -3080,6 +3088,9 @@ void BlueFS::flush_range/*WF*/(FileWriter *h, uint64_t offset, uint64_t length) 
 int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
 {
   ceph_assert(ceph_mutex_is_locked(h->lock));
+  ceph_assert(h->file->num_readers.load() == 0);
+  ceph_assert(h->file->fnode.ino > 1);
+
   dout(10) << __func__ << " " << h << " pos 0x" << std::hex << h->pos
 	   << " 0x" << offset << "~" << length << std::dec
 	   << " to " << h->file->fnode << dendl;
@@ -3088,10 +3099,7 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
     return 0;
   }
 
-  ceph_assert(h->file->num_readers.load() == 0);
-
   bool buffered = cct->_conf->bluefs_buffered_io;
-  ceph_assert(h->file->fnode.ino > 1);
 
   if (offset + length <= h->pos)
     return 0;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -148,7 +148,7 @@ private:
       out.append(ss);
     } else if (command == "bluefs files list") {
       const char* devnames[3] = {"wal","db","slow"};
-      std::lock_guard l(bluefs->lock);
+      std::lock_guard l(bluefs->dirs_lock);
       f->open_array_section("files");
       for (auto &d : bluefs->dir_map) {
         std::string dir = d.first;
@@ -384,6 +384,7 @@ void BlueFS::_shutdown_logger()
   delete logger;
 }
 
+//AK - TODO - locking needed but not certain
 void BlueFS::_update_logger_stats()
 {
   // we must be holding the lock
@@ -466,7 +467,6 @@ void BlueFS::handle_discard(unsigned id, interval_set<uint64_t>& to_release)
 
 uint64_t BlueFS::get_used()
 {
-  std::lock_guard l(lock);
   uint64_t used = 0;
   for (unsigned id = 0; id < MAX_BDEV; ++id) {
     used += _get_used(id);
@@ -492,7 +492,6 @@ uint64_t BlueFS::get_used(unsigned id)
 {
   ceph_assert(id < alloc.size());
   ceph_assert(alloc[id]);
-  std::lock_guard l(lock);
   return _get_used(id);
 }
 
@@ -505,13 +504,11 @@ uint64_t BlueFS::_get_total(unsigned id) const
 
 uint64_t BlueFS::get_total(unsigned id)
 {
-  std::lock_guard l(lock);
   return _get_total(id);
 }
 
 uint64_t BlueFS::get_free(unsigned id)
 {
-  std::lock_guard l(lock);
   ceph_assert(id < alloc.size());
   return alloc[id]->get_free();
 }
@@ -541,7 +538,7 @@ void BlueFS::dump_block_extents(ostream& out)
 
 int BlueFS::get_block_extents(unsigned id, interval_set<uint64_t> *extents)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " bdev " << id << dendl;
   ceph_assert(id < alloc.size());
   for (auto& p : file_map) {
@@ -556,7 +553,6 @@ int BlueFS::get_block_extents(unsigned id, interval_set<uint64_t> *extents)
 
 int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
 {
-  std::unique_lock l(lock);
   dout(1) << __func__
 	  << " osd_uuid " << osd_uuid
 	  << dendl;
@@ -593,7 +589,7 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
 
   // initial txn
   log_t.op_init();
-  _flush_and_sync_log(l);
+  flush_and_sync_log();
 
   // write supers
   super.log_fnode = log_file->fnode;
@@ -985,7 +981,7 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
       new_log_dev_cur = BDEV_NEWDB;
       new_log_dev_next = BDEV_DB;
     }
-    _rewrite_log_and_layout_sync(false,
+    rewrite_log_and_layout_sync(false,
       BDEV_NEWDB,
       new_log_dev_cur,
       new_log_dev_next,
@@ -993,7 +989,7 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
       layout);
     //}
   } else if(id == BDEV_NEWWAL) {
-    _rewrite_log_and_layout_sync(false,
+    rewrite_log_and_layout_sync(false,
       BDEV_DB,
       BDEV_NEWWAL,
       BDEV_WAL,
@@ -1024,7 +1020,6 @@ void BlueFS::get_devices(set<string> *ls)
 
 int BlueFS::fsck()
 {
-  std::lock_guard l(lock);
   dout(1) << __func__ << dendl;
   // hrm, i think we check everything on mount...
   return 0;
@@ -1828,7 +1823,7 @@ int BlueFS::device_migrate_to_existing(
         new_log_dev_next;
   }
 
-  _rewrite_log_and_layout_sync(
+  rewrite_log_and_layout_sync(
     false,
     (flags & REMOVE_DB) ? BDEV_SLOW : BDEV_DB,
     new_log_dev_cur,
@@ -1963,7 +1958,7 @@ int BlueFS::device_migrate_to_new(
         BDEV_DB :
 	BDEV_SLOW;
 
-  _rewrite_log_and_layout_sync(
+  rewrite_log_and_layout_sync(
     false,
     super_dev,
     new_log_dev_cur,
@@ -1993,12 +1988,16 @@ void BlueFS::_drop_link(FileRef file)
   dout(20) << __func__ << " had refs " << file->refs
 	   << " on " << file->fnode << dendl;
   ceph_assert(file->refs > 0);
+  ceph_assert(ceph_mutex_is_locked(log_lock));
+
   --file->refs;
   if (file->refs == 0) {
     dout(20) << __func__ << " destroying " << file->fnode << dendl;
     ceph_assert(file->num_reading.load() == 0);
     vselector->sub_usage(file->vselector_hint, file->fnode);
     log_t.op_file_remove(file->fnode.ino);
+
+    std::lock_guard dl(dirty_lock);
     for (auto& r : file->fnode.extents) {
       pending_release[r.bdev].insert(r.offset, r.length);
     }
@@ -2006,6 +2005,7 @@ void BlueFS::_drop_link(FileRef file)
     file->deleted = true;
 
     if (file->dirty_seq) {
+      // retract request to serialize changes
       ceph_assert(file->dirty_seq > log_seq_stable);
       ceph_assert(dirty_files.count(file->dirty_seq));
       auto it = dirty_files[file->dirty_seq].iterator_to(*file);
@@ -2233,8 +2233,9 @@ int64_t BlueFS::_read(
   return ret;
 }
 
-void BlueFS::_invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
+void BlueFS::invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
 {
+  std::lock_guard l(f->lock);
   dout(10) << __func__ << " file " << f->fnode
 	   << " 0x" << std::hex << offset << "~" << length << std::dec
            << dendl;
@@ -2254,8 +2255,9 @@ void BlueFS::_invalidate_cache(FileRef f, uint64_t offset, uint64_t length)
   }
 }
 
-uint64_t BlueFS::_estimate_log_size()
+uint64_t BlueFS::estimate_log_size()
 {
+  std::lock_guard dirl(dirs_lock);
   int avg_dir_size = 40;  // fixme
   int avg_file_size = 12;
   uint64_t size = 4096 * 2;
@@ -2267,37 +2269,44 @@ uint64_t BlueFS::_estimate_log_size()
 
 void BlueFS::compact_log()
 {
-  std::unique_lock<ceph::mutex> l(lock);
   if (!cct->_conf->bluefs_replay_recovery_disable_compact) {
     if (cct->_conf->bluefs_compact_log_sync) {
-      _compact_log_sync();
+      compact_log_sync();
     } else {
-      _compact_log_async(l);
+      compact_log_async();
     }
   }
 }
 
-bool BlueFS::_should_compact_log()
+bool BlueFS::should_start_compact_log()
 {
-  uint64_t current = log_writer->file->fnode.size;
-  uint64_t expected = _estimate_log_size();
+  if (log_is_compacting.load() == true) {
+    // compaction is already running
+    return false;
+  }
+  uint64_t current;
+  {
+    std::lock_guard dirl(log_lock);
+    current = log_writer->file->fnode.size;
+  }
+  uint64_t expected = estimate_log_size();
   float ratio = (float)current / (float)expected;
   dout(10) << __func__ << " current 0x" << std::hex << current
 	   << " expected " << expected << std::dec
 	   << " ratio " << ratio
-	   << (new_log ? " (async compaction in progress)" : "")
 	   << dendl;
-  if (new_log ||
-      current < cct->_conf->bluefs_log_compact_min_size ||
+  if (current < cct->_conf->bluefs_log_compact_min_size ||
       ratio < cct->_conf->bluefs_log_compact_min_ratio) {
     return false;
   }
   return true;
 }
 
-void BlueFS::_compact_log_dump_metadata(bluefs_transaction_t *t,
+void BlueFS::compact_log_dump_metadata(bluefs_transaction_t *t,
 					int flags)
 {
+  std::lock_guard dirl(dirs_lock);
+
   t->seq = 1;
   t->uuid = super.uuid;
   dout(20) << __func__ << " op_init" << dendl;
@@ -2307,7 +2316,7 @@ void BlueFS::_compact_log_dump_metadata(bluefs_transaction_t *t,
     if (ino == 1)
       continue;
     ceph_assert(ino > 1);
-
+    //AK - TODO - touching fnode - need to lock
     for(auto& e : file_ref->fnode.extents) {
       auto bdev = e.bdev;
       auto bdev_new = bdev;
@@ -2344,12 +2353,12 @@ void BlueFS::_compact_log_dump_metadata(bluefs_transaction_t *t,
   }
 }
 
-void BlueFS::_compact_log_sync()
+void BlueFS::compact_log_sync()
 {
   dout(10) << __func__ << dendl;
   auto prefer_bdev =
     vselector->select_prefer_bdev(log_writer->file->vselector_hint);
-  _rewrite_log_and_layout_sync(true,
+  rewrite_log_and_layout_sync(true,
     BDEV_DB,
     prefer_bdev,
     prefer_bdev,
@@ -2358,13 +2367,16 @@ void BlueFS::_compact_log_sync()
   logger->inc(l_bluefs_log_compactions);
 }
 
-void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
-					  int super_dev,
-					  int log_dev,
-					  int log_dev_new,
-					  int flags,
-					  std::optional<bluefs_layout_t> layout)
+void BlueFS::rewrite_log_and_layout_sync(bool allocate_with_fallback,
+					 int super_dev,
+					 int log_dev,
+					 int log_dev_new,
+					 int flags,
+					 std::optional<bluefs_layout_t> layout)
 {
+  //ceph_assert(ceph_mutex_is_notlocked(log_lock));
+  std::lock_guard ll(log_lock);
+
   File *log_file = log_writer->file.get();
 
   // clear out log (be careful who calls us!!!)
@@ -2376,7 +2388,7 @@ void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
 		       << " flags:" << flags
 		       << dendl;
   bluefs_transaction_t t;
-  _compact_log_dump_metadata(&t, flags);
+  compact_log_dump_metadata(&t, flags);
 
   dout(20) << __func__ << " op_jump_seq " << log_seq << dendl;
   t.op_jump_seq(log_seq);
@@ -2444,6 +2456,7 @@ void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
   flush_bdev();
 
   dout(10) << __func__ << " release old log extents " << old_fnode.extents << dendl;
+  std::lock_guard dl(dirty_lock);
   for (auto& r : old_fnode.extents) {
     pending_release[r.bdev].insert(r.offset, r.length);
   }
@@ -2471,29 +2484,42 @@ void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
  *
  * 8. Release the old log space.  Clean up.
  */
-void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
+
+void BlueFS::compact_log_async()
 {
   dout(10) << __func__ << dendl;
-  File *log_file = log_writer->file.get();
-  ceph_assert(!new_log);
-  ceph_assert(!new_log_writer);
-
-  // create a new log [writer] so that we know compaction is in progress
-  // (see _should_compact_log)
-  new_log = ceph::make_ref<File>();
-  new_log->fnode.ino = 0;   // so that _flush_range won't try to log the fnode
-
-  // 0. wait for any racing flushes to complete.  (We do not want to block
-  // in _flush_sync_log with jump_to set or else a racing thread might flush
-  // our entries and our jump_to update won't be correct.)
-  while (log_flushing) {
-    dout(10) << __func__ << " log is currently flushing, waiting" << dendl;
-    log_cond.wait(l);
+  // only one compaction allowed at one time
+  bool old_is_comp = std::atomic_exchange(&log_is_compacting, true);
+  if (old_is_comp) {
+    dout(10) << __func__ << " ongoing" <<dendl;
+    return;
   }
+
+  log_lock.lock();
+  File *log_file = log_writer->file.get();
+  FileWriter *new_log_writer = nullptr;
+  FileRef new_log = nullptr;
+  uint64_t new_log_jump_to = 0;
+  uint64_t old_log_jump_to = 0;
+
+  new_log = ceph::make_ref<File>();
+  new_log->fnode.ino = 0;   // we use _flush_special to avoid log of the fnode
+
+  // Part 1.
+  // Prepare current log for jumping into it.
+  // 1. Allocate extent
+  // 2. Update op to log
+  // 3. Jump op to log
+  // During that, no one else can write to log, otherwise we risk jumping backwards.
+  // We need to sync log, because we are injecting discontinuity, and writer is not prepared for that.
+
+  //signal _maybe_extend_log that expansion of log is temporary inacceptable
+  bool old_forbidden = atomic_exchange(&log_forbidden_to_expand, true);
+  ceph_assert(old_forbidden == false);
 
   vselector->sub_usage(log_file->vselector_hint, log_file->fnode);
 
-  // 1. allocate new log space and jump to it.
+  // 1.1 allocate new log space and jump to it.
   old_log_jump_to = log_file->fnode.get_allocated();
   uint64_t runway = log_file->fnode.get_allocated() - log_writer->get_effective_write_pos();
   dout(10) << __func__ << " old_log_jump_to 0x" << std::hex << old_log_jump_to
@@ -2508,21 +2534,24 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
 
   // update the log file change and log a jump to the offset where we want to
   // write the new entries
-  log_t.op_file_update(log_file->fnode);
-  log_t.op_jump(log_seq, old_log_jump_to);
+  log_t.op_file_update(log_file->fnode); // 1.2
+  log_t.op_jump(log_seq, old_log_jump_to); // 1.3
 
   // we need to flush all bdev because we will be streaming all dirty files to log
   // TODO - think - if _flush_and_sync_log_jump will not add dirty files nor release pending allocations
   // then flush_bdev() will not be necessary
   flush_bdev();
-
   _flush_and_sync_log_jump(old_log_jump_to, runway);
+
+  log_lock.unlock();
+  // out of jump section - now log can be used to write to
 
   // 2. prepare compacted log
   bluefs_transaction_t t;
-  //avoid record two times in log_t and _compact_log_dump_metadata.
-  log_t.clear();
-  _compact_log_dump_metadata(&t, 0);
+  //this needs files lock
+  //what will happen, if a file is modified *twice* before we stream it to log?
+  //the later state that we capture will be seen earlier and replay will see a temporary retraction (!)
+  compact_log_dump_metadata(&t, 0);
 
   uint64_t max_alloc_size = std::max(alloc_size[BDEV_WAL],
 				     std::max(alloc_size[BDEV_DB],
@@ -2540,7 +2569,7 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
   ceph_assert(r == 0);
 
   // we might have some more ops in log_t due to _allocate call
-  t.claim_ops(log_t);
+  // t.claim_ops(log_t); no we no longer track allocations in log
 
   bufferlist bl;
   encode(t, bl);
@@ -2550,15 +2579,16 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
 	   << std::dec << dendl;
 
   new_log_writer = _create_writer(new_log);
-  new_log_writer->append(bl);
 
+  new_log_writer->append(bl);
+  new_log_writer->lock.lock();
   // 3. flush
   r = _flush_special(new_log_writer);
   ceph_assert(r == 0);
 
   // 4. wait
-  _flush_bdev_safely(new_log_writer);
-
+  _flush_bdev(new_log_writer);
+  new_log_writer->lock.unlock();
   // 5. update our log fnode
   // discard first old_log_jump_to extents
 
@@ -2612,29 +2642,42 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
   ++super.version;
   _write_super(BDEV_DB);
 
-  lock.unlock();
   flush_bdev();
-  lock.lock();
+
+  old_forbidden = atomic_exchange(&log_forbidden_to_expand, false);
+  ceph_assert(old_forbidden == true);
+  //to wake up if someone was in need of expanding log
+  log_cond.notify_all();
 
   // 7. release old space
   dout(10) << __func__ << " release old log extents " << old_extents << dendl;
-  for (auto& r : old_extents) {
-    pending_release[r.bdev].insert(r.offset, r.length);
+  {
+    std::lock_guard dl(dirty_lock);
+    for (auto& r : old_extents) {
+      pending_release[r.bdev].insert(r.offset, r.length);
+    }
   }
 
   // delete the new log, remove from the dirty files list
   _close_writer(new_log_writer);
+  // flush_special does not dirty files
+  /*
   if (new_log->dirty_seq) {
+    std::lock_guard dl(dirty_lock);
     ceph_assert(dirty_files.count(new_log->dirty_seq));
     auto it = dirty_files[new_log->dirty_seq].iterator_to(*new_log);
     dirty_files[new_log->dirty_seq].erase(it);
   }
+  */
   new_log_writer = nullptr;
   new_log = nullptr;
   log_cond.notify_all();
 
   dout(10) << __func__ << " log extents " << log_file->fnode.extents << dendl;
   logger->inc(l_bluefs_log_compactions);
+
+  old_is_comp = atomic_exchange(&log_is_compacting, false);
+  ceph_assert(old_is_comp);
 }
 
 void BlueFS::_pad_bl(bufferlist& bl)
@@ -2647,10 +2690,26 @@ void BlueFS::_pad_bl(bufferlist& bl)
   }
 }
 
+/**
+ * Adds file modifications from `dirty_files` to bluefs transactions
+ * already stored in `log_t`. Writes them to disk and waits until are stable.
+ * Guarantees that file modifications with `want_seq` are already stable on disk.
+ * In addition may insert jump forward transaction to log write position `jump_to`.
+ *
+ * it should lock ability to:
+ * 1) add to log_t
+ * 2) modify dirty_files
+ * 3) add to pending_release
+ *
+ * pending_release and log_t go with same lock
+ */
+
 // Adds to log_t file modifications mentioned in `dirty_files`.
 // Note: some bluefs ops may have already been stored in log_t transaction.
 uint64_t BlueFS::_consume_dirty()
 {
+  ceph_assert(ceph_mutex_is_locked(dirty_lock));
+  ceph_assert(ceph_mutex_is_locked(log_lock));
   //acquire new seq
   // this will became log_seq_stable once we write
   uint64_t seq = log_t.seq = ++log_seq;
@@ -2673,6 +2732,7 @@ uint64_t BlueFS::_consume_dirty()
 // Returns space available *BEFORE* adding new space. Signed for additional <0 detection.
 int64_t BlueFS::_maybe_extend_log()
 {
+  ceph_assert(ceph_mutex_is_locked(log_lock));
   // allocate some more space (before we run out)?
   // BTW: this triggers `flush()` in the `page_aligned_appender` of `log_writer`.
   int64_t runway = log_writer->file->fnode.get_allocated() -
@@ -2695,7 +2755,7 @@ int64_t BlueFS::_maybe_extend_log()
      * - re-run compaction with more runway for old log
      * - add OP_FILE_ADDEXT that adds extent; will be compatible with both logs
      */
-    if (new_log_writer) {
+    if (log_forbidden_to_expand.load() == true) {
       return -EWOULDBLOCK;
     }
     vselector->sub_usage(log_writer->file->vselector_hint, log_writer->file->fnode);
@@ -2712,6 +2772,7 @@ int64_t BlueFS::_maybe_extend_log()
 
 void BlueFS::_flush_and_sync_log_core(int64_t runway)
 {
+  ceph_assert(ceph_mutex_is_locked(log_lock));
   dout(10) << __func__ << " " << log_t << dendl;
 
   bufferlist bl;
@@ -2741,6 +2802,8 @@ void BlueFS::_flush_and_sync_log_core(int64_t runway)
 // Clears dirty_files up to (including) seq_stable.
 void BlueFS::_clear_dirty_set_stable(uint64_t seq)
 {
+  std::lock_guard lg(dirty_lock);
+
   // clean dirty files
   if (seq > log_seq_stable) {
     log_seq_stable = seq;
@@ -2797,33 +2860,46 @@ void BlueFS::_release_pending_allocations(vector<interval_set<uint64_t>>& to_rel
   }
 }
 
-int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
-			       uint64_t want_seq)
+int BlueFS::flush_and_sync_log(uint64_t want_seq)
 {
-  if (want_seq && want_seq <= log_seq_stable) {
-    dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
-	     << log_seq_stable << ", done" << dendl;
-    return 0;
-  }
+  // we synchronize writing to log, by lock to log_lock
   int64_t available_runway;
   do {
+    log_lock.lock();
+    dirty_lock.lock();
+    if (want_seq && want_seq <= log_seq_stable) {
+      dout(10) << __func__ << " want_seq " << want_seq << " <= log_seq_stable "
+	       << log_seq_stable << ", done" << dendl;
+      dirty_lock.unlock();
+      log_lock.unlock();
+      return 0;
+    }
+
     available_runway = _maybe_extend_log();
     if (available_runway == -EWOULDBLOCK) {
-      while (new_log_writer) {
-	dout(10) << __func__ << " waiting for async compaction" << dendl;
-	log_cond.wait(l);
+      // we are in need of adding runway, but we are during log-switch from compaction
+      dirty_lock.unlock();
+      //instead log_lock_unlock() do move ownership
+      std::unique_lock<ceph::mutex> ll(log_lock, std::adopt_lock);
+      while (log_forbidden_to_expand.load()) {
+	log_cond.wait(ll);
       }
+    } else {
+      ceph_assert(available_runway >= 0);
     }
-  } while (available_runway == -EWOULDBLOCK);
+  } while (available_runway < 0);
 
   ceph_assert(want_seq == 0 || want_seq <= log_seq + 1); // illegal to request seq that was not created yet
 
   uint64_t seq = _consume_dirty();
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
+  dirty_lock.unlock();
 
   _flush_and_sync_log_core(available_runway);
-  _flush_bdev_safely(log_writer);
+  _flush_bdev(log_writer);
+  //now log_lock is no longer needed
+  log_lock.unlock();
 
   _clear_dirty_set_stable(seq);
   _release_pending_allocations(to_release);
@@ -2836,11 +2912,16 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
 int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
 				     int64_t available_runway)
 {
+  ceph_assert(ceph_mutex_is_locked(log_lock));
+
   ceph_assert(jump_to);
+  // we synchronize writing to log, by lock to log_lock
+
+  dirty_lock.lock();
   uint64_t seq = _consume_dirty();
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
-
+  dirty_lock.unlock();
   _flush_and_sync_log_core(available_runway);
 
   dout(10) << __func__ << " jumping log offset from 0x" << std::hex
@@ -2850,7 +2931,7 @@ int BlueFS::_flush_and_sync_log_jump(uint64_t jump_to,
   log_writer->file->fnode.size = jump_to;
   vselector->add_usage(log_writer->file->vselector_hint, log_writer->file->fnode.size);
 
-  _flush_bdev_safely(log_writer);
+  _flush_bdev(log_writer);
 
   _clear_dirty_set_stable(seq);
   _release_pending_allocations(to_release);
@@ -2865,6 +2946,7 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
   const unsigned length,
   const bluefs_super_t& super)
 {
+  ceph_assert(ceph_mutex_is_locked(this->lock) || file->fnode.ino == 1);
   ceph::bufferlist bl;
   if (partial) {
     tail_block.splice(0, tail_block.length(), &bl);
@@ -2903,6 +2985,8 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
 
 int BlueFS::_signal_dirty_to_log(FileWriter *h)
 {
+  ceph_assert(ceph_mutex_is_locked(h->lock));
+  std::lock_guard dl(dirty_lock);
   h->file->fnode.mtime = ceph_clock_now();
   ceph_assert(h->file->fnode.ino >= 1);
   if (h->file->dirty_seq == 0) {
@@ -2928,8 +3012,14 @@ int BlueFS::_signal_dirty_to_log(FileWriter *h)
   return 0;
 }
 
+void BlueFS::flush_range(FileWriter *h, uint64_t offset, uint64_t length) {
+  std::unique_lock hl(h->lock);
+  _flush_range(h, offset, length);
+}
+
 int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
 {
+  ceph_assert(ceph_mutex_is_locked(h->lock));
   dout(10) << __func__ << " " << h << " pos 0x" << std::hex << h->pos
 	   << " 0x" << offset << "~" << length << std::dec
 	   << " to " << h->file->fnode << dendl;
@@ -2952,13 +3042,13 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
              << std::hex << offset << "~" << length << std::dec
              << dendl;
   }
+  std::lock_guard file_lock(h->file->lock);
   ceph_assert(offset <= h->file->fnode.size);
 
   uint64_t allocated = h->file->fnode.get_allocated();
   vselector->sub_usage(h->file->vselector_hint, h->file->fnode);
   // do not bother to dirty the file if we are overwriting
   // previously allocated extents.
-
   if (allocated < offset + length) {
     // we should never run out of log space here; see the min runway check
     // in _flush_and_sync_log.
@@ -2979,12 +3069,15 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
     h->file->fnode.size = offset + length;
     h->file->is_dirty = true;
   }
+
   dout(20) << __func__ << " file now, unflushed " << h->file->fnode << dendl;
   return _flush_data(h, offset, length, buffered);
 }
 
 int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered)
 {
+  //ceph_assert(ceph_mutex_is_locked(h->lock));
+  //ceph_assert(ceph_mutex_is_locked(h->file->lock));
   uint64_t x_off = 0;
   auto p = h->file->fnode.seek(offset, &x_off);
   ceph_assert(p != h->file->fnode.extents.end());
@@ -3091,18 +3184,49 @@ void BlueFS::wait_for_aio(FileWriter *h)
 }
 #endif
 
-int BlueFS::_flush(FileWriter *h, bool force, std::unique_lock<ceph::mutex>& l)
+
+void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
 {
+  std::unique_lock hl(h->lock);
+  size_t max_size = 1ull << 30; // cap to 1GB
+  while (len > 0) {
+    bool need_flush = true;
+    auto l0 = h->get_buffer_length();
+    if (l0 < max_size) {
+      size_t l = std::min(len, max_size - l0);
+      h->append(buf, l);
+      buf += l;
+      len -= l;
+      need_flush = h->get_buffer_length() >= cct->_conf->bluefs_min_flush_size;
+    }
+    if (need_flush) {
+      bool flushed = false;
+      int r = _flush(h, true, &flushed);
+      ceph_assert(r == 0);
+      if (r == 0 && flushed) {
+	maybe_compact_log();
+      }
+      // make sure we've made any progress with flush hence the
+      // loop doesn't iterate forever
+      ceph_assert(h->get_buffer_length() < max_size);
+    }
+  }
+}
+
+void BlueFS::flush(FileWriter *h, bool force)
+{
+  std::unique_lock hl(h->lock);
   bool flushed = false;
   int r = _flush(h, force, &flushed);
+  ceph_assert(r == 0);
   if (r == 0 && flushed) {
-    _maybe_compact_log(l);
+    maybe_compact_log();
   }
-  return r;
 }
 
 int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
 {
+  ceph_assert(ceph_mutex_is_locked(h->lock));
   uint64_t length = h->get_buffer_length();
   uint64_t offset = h->pos;
   if (flushed) {
@@ -3139,6 +3263,8 @@ int BlueFS::_flush(FileWriter *h, bool force, bool *flushed)
 // smart enough to discover it on its own.
 int BlueFS::_flush_special(FileWriter *h)
 {
+  //ceph_assert(ceph_mutex_is_locked(h->lock));
+  //ceph_assert(ceph_mutex_is_locked(h->file->lock));
   uint64_t length = h->get_buffer_length();
   uint64_t offset = h->pos;
   ceph_assert(length + offset <= h->file->fnode.get_allocated());
@@ -3148,8 +3274,9 @@ int BlueFS::_flush_special(FileWriter *h)
   return _flush_data(h, offset, length, false);
 }
 
-int BlueFS::_truncate(FileWriter *h, uint64_t offset)
+int BlueFS::truncate(FileWriter *h, uint64_t offset)
 {
+  std::lock_guard hl(h->lock);
   dout(10) << __func__ << " 0x" << std::hex << offset << std::dec
            << " file " << h->file->fnode << dendl;
   if (h->file->deleted) {
@@ -3179,17 +3306,19 @@ int BlueFS::_truncate(FileWriter *h, uint64_t offset)
     ceph_abort_msg("truncate up not supported");
   }
   ceph_assert(h->file->fnode.size >= offset);
-  _flush_bdev_safely(h);
+  _flush_bdev(h);
   vselector->sub_usage(h->file->vselector_hint, h->file->fnode.size);
   h->file->fnode.size = offset;
   vselector->add_usage(h->file->vselector_hint, h->file->fnode.size);
 
+  std::lock_guard ll(log_lock);
   log_t.op_file_update_inc(h->file->fnode);
   return 0;
 }
 
-int BlueFS::_fsync(FileWriter *h, std::unique_lock<ceph::mutex>& l)
+int BlueFS::fsync(FileWriter *h)
 {
+  std::unique_lock hl(h->lock);
   dout(10) << __func__ << " " << h << " " << h->file->fnode << dendl;
   int r = _flush(h, true);
   if (r < 0)
@@ -3200,39 +3329,40 @@ int BlueFS::_fsync(FileWriter *h, std::unique_lock<ceph::mutex>& l)
   }
   uint64_t old_dirty_seq = h->file->dirty_seq;
 
-  _flush_bdev_safely(h);
+  _flush_bdev(h);
 
   if (old_dirty_seq) {
     uint64_t s = log_seq;
     dout(20) << __func__ << " file metadata was dirty (" << old_dirty_seq
 	     << ") on " << h->file->fnode << ", flushing log" << dendl;
-    _flush_and_sync_log(l, old_dirty_seq);
+    flush_and_sync_log(old_dirty_seq);
+    // AK - TODO - think - how can dirty_seq change if we are under h lock?
     ceph_assert(h->file->dirty_seq == 0 ||  // cleaned
-	   h->file->dirty_seq > s);    // or redirtied by someone else
+		h->file->dirty_seq > s);    // or redirtied by someone else
   }
+  maybe_compact_log();
   return 0;
 }
 
-void BlueFS::_flush_bdev_safely(FileWriter *h)
+// be careful - either h->file->lock or log_lock must be taken
+void BlueFS::_flush_bdev(FileWriter *h)
 {
+  if (h->file->fnode.ino != 1) {
+    ceph_assert(ceph_mutex_is_locked(h->lock));
+  } else {
+    ceph_assert(ceph_mutex_is_locked(log_lock));
+  }
   std::array<bool, MAX_BDEV> flush_devs = h->dirty_devs;
   h->dirty_devs.fill(false);
 #ifdef HAVE_LIBAIO
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
     _claim_completed_aios(h, &completed_ios);
-    lock.unlock();
     wait_for_aio(h);
     completed_ios.clear();
-    flush_bdev(flush_devs);
-    lock.lock();
-  } else
-#endif
-  {
-    lock.unlock();
-    flush_bdev(flush_devs);
-    lock.lock();
   }
+#endif
+  flush_bdev(flush_devs);
 }
 
 void BlueFS::flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs)
@@ -3366,8 +3496,9 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
   return 0;
 }
 
-int BlueFS::_preallocate(FileRef f, uint64_t off, uint64_t len)
+int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
 {
+  std::lock_guard fl(f->lock);
   dout(10) << __func__ << " file " << f->fnode << " 0x"
 	   << std::hex << off << "~" << len << std::dec << dendl;
   if (f->deleted) {
@@ -3386,6 +3517,7 @@ int BlueFS::_preallocate(FileRef f, uint64_t off, uint64_t len)
     vselector->add_usage(f->vselector_hint, f->fnode);
     if (r < 0)
       return r;
+    std::lock_guard ll(log_lock);
     log_t.op_file_update_inc(f->fnode);
   }
   return 0;
@@ -3393,8 +3525,13 @@ int BlueFS::_preallocate(FileRef f, uint64_t off, uint64_t len)
 
 void BlueFS::sync_metadata(bool avoid_compact)
 {
-  std::unique_lock l(lock);
-  if (log_t.empty() && dirty_files.empty()) {
+  bool can_skip_flush;
+  {
+    std::lock_guard ll(log_lock);
+    std::lock_guard dl(dirty_lock);
+    can_skip_flush = log_t.empty() && dirty_files.empty();
+  }
+  if (can_skip_flush) {
     dout(10) << __func__ << " - no pending log events" << dendl;
   } else {
     utime_t start;
@@ -3402,23 +3539,23 @@ void BlueFS::sync_metadata(bool avoid_compact)
     start = ceph_clock_now();
     *_dout <<  dendl;
     flush_bdev(); // FIXME?
-    _flush_and_sync_log(l);
+    flush_and_sync_log();
     dout(10) << __func__ << " done in " << (ceph_clock_now() - start) << dendl;
   }
 
   if (!avoid_compact) {
-    _maybe_compact_log(l);
+    maybe_compact_log();
   }
 }
 
-void BlueFS::_maybe_compact_log(std::unique_lock<ceph::mutex>& l)
+void BlueFS::maybe_compact_log()
 {
   if (!cct->_conf->bluefs_replay_recovery_disable_compact &&
-      _should_compact_log()) {
+      should_start_compact_log()) {
     if (cct->_conf->bluefs_compact_log_sync) {
-      _compact_log_sync();
+      compact_log_sync();
     } else {
-      _compact_log_async(l);
+      compact_log_async();
     }
   }
 }
@@ -3429,7 +3566,7 @@ int BlueFS::open_for_write(
   FileWriter **h,
   bool overwrite)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   DirRef dir;
@@ -3491,11 +3628,12 @@ int BlueFS::open_for_write(
   dout(20) << __func__ << " mapping " << dirname << "/" << filename
 	   << " vsel_hint " << file->vselector_hint
 	   << dendl;
-
-  log_t.op_file_update(file->fnode);
-  if (create)
-    log_t.op_dir_link(dirname, filename, file->fnode.ino);
-
+  {
+    std::lock_guard ll(log_lock);
+    log_t.op_file_update(file->fnode);
+    if (create)
+      log_t.op_dir_link(dirname, filename, file->fnode.ino);
+  }
   *h = _create_writer(file);
 
   if (boost::algorithm::ends_with(filename, ".log")) {
@@ -3525,7 +3663,7 @@ BlueFS::FileWriter *BlueFS::_create_writer(FileRef f)
   return w;
 }
 
-void BlueFS::_close_writer(FileWriter *h)
+void BlueFS::_drain_writer(FileWriter *h)
 {
   dout(10) << __func__ << " " << h << " type " << h->writer_type << dendl;
   //h->buffer.reassign_to_mempool(mempool::mempool_bluefs_file_writer);
@@ -3541,18 +3679,31 @@ void BlueFS::_close_writer(FileWriter *h)
   if (h->file->fnode.size >= (1ull << 30)) {
     dout(10) << __func__ << " file is unexpectedly large:" << h->file->fnode << dendl;
   }
+}
+
+void BlueFS::_close_writer(FileWriter *h)
+{
+  _drain_writer(h);
+  delete h;
+}
+void BlueFS::close_writer(FileWriter *h)
+{
+  {
+    std::lock_guard l(h->lock);
+    _drain_writer(h);
+  }
   delete h;
 }
 
 uint64_t BlueFS::debug_get_dirty_seq(FileWriter *h)
 {
-  std::lock_guard l(lock);
+  std::lock_guard l(h->lock);
   return h->file->dirty_seq;
 }
 
 bool BlueFS::debug_get_is_dev_dirty(FileWriter *h, uint8_t dev)
 {
-  std::lock_guard l(lock);
+  std::lock_guard l(h->lock);
   return h->dirty_devs[dev];
 }
 
@@ -3562,7 +3713,7 @@ int BlueFS::open_for_read(
   FileReader **h,
   bool random)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename
 	   << (random ? " (random)":" (sequential)") << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
@@ -3591,7 +3742,8 @@ int BlueFS::rename(
   std::string_view old_dirname, std::string_view old_filename,
   std::string_view new_dirname, std::string_view new_filename)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
+  std::lock_guard ll(log_lock);
   dout(10) << __func__ << " " << old_dirname << "/" << old_filename
 	   << " -> " << new_dirname << "/" << new_filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(old_dirname);
@@ -3638,7 +3790,8 @@ int BlueFS::rename(
 
 int BlueFS::mkdir(std::string_view dirname)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
+  std::lock_guard ll(log_lock);
   dout(10) << __func__ << " " << dirname << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   if (p != dir_map.end()) {
@@ -3652,7 +3805,8 @@ int BlueFS::mkdir(std::string_view dirname)
 
 int BlueFS::rmdir(std::string_view dirname)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
+  std::lock_guard ll(log_lock);
   dout(10) << __func__ << " " << dirname << dendl;
   auto p = dir_map.find(dirname);
   if (p == dir_map.end()) {
@@ -3671,7 +3825,7 @@ int BlueFS::rmdir(std::string_view dirname)
 
 bool BlueFS::dir_exists(std::string_view dirname)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   bool exists = p != dir_map.end();
   dout(10) << __func__ << " " << dirname << " = " << (int)exists << dendl;
@@ -3681,7 +3835,7 @@ bool BlueFS::dir_exists(std::string_view dirname)
 int BlueFS::stat(std::string_view dirname, std::string_view filename,
 		 uint64_t *size, utime_t *mtime)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   if (p == dir_map.end()) {
@@ -3709,7 +3863,7 @@ int BlueFS::stat(std::string_view dirname, std::string_view filename,
 int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 		      FileLock **plock)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   if (p == dir_map.end()) {
@@ -3729,6 +3883,7 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
     file_map[ino_last] = file;
     dir->file_map[string{filename}] = file;
     ++file->refs;
+    std::lock_guard ll(log_lock);
     log_t.op_file_update(file->fnode);
     log_t.op_dir_link(dirname, filename, file->fnode.ino);
   } else {
@@ -3747,7 +3902,7 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
 
 int BlueFS::unlock_file(FileLock *fl)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << fl << " on " << fl->file->fnode << dendl;
   ceph_assert(fl->file->locked);
   fl->file->locked = false;
@@ -3761,7 +3916,7 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
   if (!dirname.empty() && dirname.back() == '/') {
     dirname.remove_suffix(1);
   }
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
   dout(10) << __func__ << " " << dirname << dendl;
   if (dirname.empty()) {
     // list dirs
@@ -3789,7 +3944,8 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
 
 int BlueFS::unlink(std::string_view dirname, std::string_view filename)
 {
-  std::lock_guard l(lock);
+  std::lock_guard dirl(dirs_lock);
+  std::lock_guard ll(log_lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
   map<string,DirRef>::iterator p = dir_map.find(dirname);
   if (p == dir_map.end()) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3556,6 +3556,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
 
 int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
 {
+  std::lock_guard ll(log.lock);
   std::lock_guard fl(f->lock);
   dout(10) << __func__ << " file " << f->fnode << " 0x"
 	   << std::hex << off << "~" << len << std::dec << dendl;
@@ -3575,7 +3576,7 @@ int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
     vselector->add_usage(f->vselector_hint, f->fnode);
     if (r < 0)
       return r;
-    std::lock_guard ll(log.lock);
+
     log.t.op_file_update_inc(f->fnode);
   }
   return 0;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2623,16 +2623,16 @@ void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
   new_log_writer = _create_writer(new_log);
 
   new_log_writer->append(bl);
-  new_log->lock.lock();
   new_log_writer->lock.lock();
+  new_log->lock.lock();
   // 3. flush
   r = _flush_special(new_log_writer);
   ceph_assert(r == 0);
 
   // 4. wait
   _flush_bdev(new_log_writer);
-  new_log_writer->lock.unlock();
   new_log->lock.unlock();
+  new_log_writer->lock.unlock();
   // 5. update our log fnode
   // discard first old_log_jump_to extents
 
@@ -3374,9 +3374,9 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)
 
 int BlueFS::fsync(FileWriter *h)
 {
-  std::unique_lock hl(h->lock);
   uint64_t old_dirty_seq = 0;
   {
+    std::unique_lock hl(h->lock);
     dout(10) << __func__ << " " << h << " " << h->file->fnode << dendl;
     int r = _flush_F(h, true);
     if (r < 0)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2291,13 +2291,13 @@ uint64_t BlueFS::_estimate_log_size_N()
   return round_up_to(size, super.block_size);
 }
 
-void BlueFS::compact_log()
+void BlueFS::compact_log()/*_LNF_LD_NF_D*/
 {
   if (!cct->_conf->bluefs_replay_recovery_disable_compact) {
     if (cct->_conf->bluefs_compact_log_sync) {
       _compact_log_sync_LNF_LD();
     } else {
-      _compact_log_async_LD_NF_D();
+      _compact_log_async_LD_LNF_D();
     }
   }
 }
@@ -2551,7 +2551,7 @@ void BlueFS::_rewrite_log_and_layout_sync_LNF_LD(bool allocate_with_fallback,
  * 8. Release the old log space.  Clean up.
  */
 
-void BlueFS::_compact_log_async_LD_NF_D() //also locks FW for new_writer
+void BlueFS::_compact_log_async_LD_LNF_D() //also locks FW for new_writer
 {
   dout(10) << __func__ << dendl;
   // only one compaction allowed at one time
@@ -3080,7 +3080,8 @@ int BlueFS::_signal_dirty_to_log_D(FileWriter *h)
   return 0;
 }
 
-void BlueFS::flush_range(FileWriter *h, uint64_t offset, uint64_t length) {
+void BlueFS::flush_range(FileWriter *h, uint64_t offset, uint64_t length)/*_WF*/
+{
   std::unique_lock hl(h->lock);
   _flush_range_F(h, offset, length);
 }
@@ -3255,7 +3256,7 @@ void BlueFS::_wait_for_aio(FileWriter *h)
 }
 #endif
 
-void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
+void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)/*_WF_LNF_NF_LD_D*/
 {
   bool flushed_sum = false;
   {
@@ -3287,7 +3288,7 @@ void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)
   }
 }
 
-void BlueFS::flush(FileWriter *h, bool force)
+void BlueFS::flush(FileWriter *h, bool force)/*_WF_LNF_NF_LD_D*/
 {
   bool flushed = false;
   int r;
@@ -3352,7 +3353,7 @@ int BlueFS::_flush_special(FileWriter *h)
   return _flush_data(h, offset, length, false);
 }
 
-int BlueFS::truncate(FileWriter *h, uint64_t offset)
+int BlueFS::truncate(FileWriter *h, uint64_t offset)/*_WF_L*/
 {
   std::lock_guard hl(h->lock);
   dout(10) << __func__ << " 0x" << std::hex << offset << std::dec
@@ -3394,7 +3395,7 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)
   return 0;
 }
 
-int BlueFS::fsync(FileWriter *h)
+int BlueFS::fsync(FileWriter *h)/*_WF_WD_WLD_WLNF_WNF*/
 {
   std::unique_lock hl(h->lock);
   uint64_t old_dirty_seq = 0;
@@ -3576,7 +3577,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
   return 0;
 }
 
-int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
+int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)/*_LF*/
 {
   std::lock_guard ll(log.lock);
   std::lock_guard fl(f->lock);
@@ -3604,7 +3605,7 @@ int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)
   return 0;
 }
 
-void BlueFS::sync_metadata(bool avoid_compact)
+void BlueFS::sync_metadata(bool avoid_compact)/*_LNF_NF_LD_D*/
 {
   bool can_skip_flush;
   {
@@ -3636,7 +3637,7 @@ void BlueFS::_maybe_compact_log_LNF_NF_LD_D()
     if (cct->_conf->bluefs_compact_log_sync) {
       _compact_log_sync_LNF_LD();
     } else {
-      _compact_log_async_LD_NF_D();
+      _compact_log_async_LD_LNF_D();
     }
   }
 }
@@ -3645,7 +3646,7 @@ int BlueFS::open_for_write(
   std::string_view dirname,
   std::string_view filename,
   FileWriter **h,
-  bool overwrite)
+  bool overwrite)/*_N_LD*/
 {
   FileRef file;
   bool create = false;
@@ -3799,7 +3800,7 @@ int BlueFS::open_for_read(
   std::string_view dirname,
   std::string_view filename,
   FileReader **h,
-  bool random)
+  bool random)/*_N*/
 {
   std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename
@@ -3828,7 +3829,7 @@ int BlueFS::open_for_read(
 
 int BlueFS::rename(
   std::string_view old_dirname, std::string_view old_filename,
-  std::string_view new_dirname, std::string_view new_filename)
+  std::string_view new_dirname, std::string_view new_filename)/*_LND*/
 {
   std::lock_guard ll(log.lock);
   std::lock_guard nl(nodes.lock);
@@ -3876,7 +3877,7 @@ int BlueFS::rename(
   return 0;
 }
 
-int BlueFS::mkdir(std::string_view dirname)
+int BlueFS::mkdir(std::string_view dirname)/*_LN*/
 {
   std::lock_guard ll(log.lock);
   std::lock_guard nl(nodes.lock);
@@ -3891,7 +3892,7 @@ int BlueFS::mkdir(std::string_view dirname)
   return 0;
 }
 
-int BlueFS::rmdir(std::string_view dirname)
+int BlueFS::rmdir(std::string_view dirname)/*_LN*/
 {
   std::lock_guard ll(log.lock);
   std::lock_guard nl(nodes.lock);
@@ -3911,7 +3912,7 @@ int BlueFS::rmdir(std::string_view dirname)
   return 0;
 }
 
-bool BlueFS::dir_exists(std::string_view dirname)
+bool BlueFS::dir_exists(std::string_view dirname)/*_N*/
 {
   std::lock_guard nl(nodes.lock);
   map<string,DirRef>::iterator p = nodes.dir_map.find(dirname);
@@ -3921,7 +3922,7 @@ bool BlueFS::dir_exists(std::string_view dirname)
 }
 
 int BlueFS::stat(std::string_view dirname, std::string_view filename,
-		 uint64_t *size, utime_t *mtime)
+		 uint64_t *size, utime_t *mtime)/*_N*/
 {
   std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << dirname << "/" << filename << dendl;
@@ -3949,7 +3950,7 @@ int BlueFS::stat(std::string_view dirname, std::string_view filename,
 }
 
 int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
-		      FileLock **plock)
+		      FileLock **plock)/*_LN*/
 {
   std::lock_guard ll(log.lock);
   std::lock_guard nl(nodes.lock);
@@ -3989,7 +3990,7 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
   return 0;
 }
 
-int BlueFS::unlock_file(FileLock *fl)
+int BlueFS::unlock_file(FileLock *fl)/*_N*/
 {
   std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " " << fl << " on " << fl->file->fnode << dendl;
@@ -3999,7 +4000,7 @@ int BlueFS::unlock_file(FileLock *fl)
   return 0;
 }
 
-int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
+int BlueFS::readdir(std::string_view dirname, vector<string> *ls)/*_N*/
 {
   // dirname may contain a trailing /
   if (!dirname.empty() && dirname.back() == '/') {
@@ -4031,7 +4032,7 @@ int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
   return 0;
 }
 
-int BlueFS::unlink(std::string_view dirname, std::string_view filename)
+int BlueFS::unlink(std::string_view dirname, std::string_view filename)/*_LND*/
 {
   std::lock_guard ll(log.lock);
   std::lock_guard nl(nodes.lock);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -384,13 +384,8 @@ void BlueFS::_shutdown_logger()
   delete logger;
 }
 
-//AK - TODO - locking needed but not certain
 void BlueFS::_update_logger_stats()
 {
-  // we must be holding the lock
-  logger->set(l_bluefs_num_files, nodes.file_map.size());
-  logger->set(l_bluefs_log_bytes, log.writer->file->fnode.size);
-
   if (alloc[BDEV_WAL]) {
     logger->set(l_bluefs_wal_total_bytes, _get_total(BDEV_WAL));
     logger->set(l_bluefs_wal_used_bytes, _get_used(BDEV_WAL));
@@ -929,7 +924,8 @@ int BlueFS::mount()
   dout(10) << __func__ << " log write pos set to 0x"
            << std::hex << log.writer->pos << std::dec
            << dendl;
-
+  // update log size
+  logger->set(l_bluefs_log_bytes, log.writer->file->fnode.size);
   return 0;
 
  out:
@@ -1672,6 +1668,8 @@ int BlueFS::_replay(bool noop, bool to_stdout)
       }
     }
   }
+  // reflect file count in logger
+  logger->set(l_bluefs_num_files, nodes.file_map.size());
 
   dout(10) << __func__ << " done" << dendl;
   return 0;
@@ -1980,6 +1978,8 @@ BlueFS::FileRef BlueFS::_get_file(uint64_t ino)
   if (p == nodes.file_map.end()) {
     FileRef f = ceph::make_ref<File>();
     nodes.file_map[ino] = f;
+    // track files count in logger
+    logger->set(l_bluefs_num_files, nodes.file_map.size());
     dout(30) << __func__ << " ino " << ino << " = " << f
 	     << " (new)" << dendl;
     return f;
@@ -2013,6 +2013,7 @@ void BlueFS::_drop_link_D(FileRef file)
     vselector->sub_usage(file->vselector_hint, file->fnode);
     log.t.op_file_remove(file->fnode.ino);
     nodes.file_map.erase(file->fnode.ino);
+    logger->set(l_bluefs_num_files, nodes.file_map.size());
     file->deleted = true;
 
     std::lock_guard dl(dirty.lock);
@@ -2965,6 +2966,7 @@ int BlueFS::_flush_and_sync_log_LD(uint64_t want_seq)
 
   _flush_and_sync_log_core(available_runway);
   _flush_bdev(log.writer);
+  logger->set(l_bluefs_log_bytes, log.writer->file->fnode.size);
   //now log.lock is no longer needed
   log.lock.unlock();
 
@@ -3004,6 +3006,7 @@ int BlueFS::_flush_and_sync_log_jump_D(uint64_t jump_to,
   _clear_dirty_set_stable_D(seq);
   _release_pending_allocations(to_release);
 
+  logger->set(l_bluefs_log_bytes, log.writer->file->fnode.size);
   _update_logger_stats();
   return 0;
 }
@@ -3677,6 +3680,7 @@ int BlueFS::open_for_write(
     dir->file_map[string{filename}] = file;
     ++file->refs;
     create = true;
+    logger->set(l_bluefs_num_files, nodes.file_map.size());
   } else {
     // overwrite existing file?
     file = q->second;
@@ -3965,6 +3969,7 @@ int BlueFS::lock_file(std::string_view dirname, std::string_view filename,
     file->fnode.mtime = ceph_clock_now();
     nodes.file_map[ino_last] = file;
     dir->file_map[string{filename}] = file;
+    logger->set(l_bluefs_num_files, nodes.file_map.size());
     ++file->refs;
     log.t.op_file_update(file->fnode);
     log.t.op_dir_link(dirname, filename, file->fnode.ino);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -344,7 +344,8 @@ private:
 
   struct {
     ceph::mutex lock = ceph::make_mutex("BlueFS::log.lock");
-    uint64_t seq_live = 0; //seq that log is currently writing to
+    //uint64_t seq_stable = 0; //seq that is now stable on disk    AK - consider also mirroring this
+    uint64_t seq_live = 1;   //seq that log is currently writing to; mirrors dirty.seq_live
     FileWriter *writer = 0;
     bluefs_transaction_t t;
   } log;
@@ -352,7 +353,7 @@ private:
   struct {
     ceph::mutex lock = ceph::make_mutex("BlueFS::dirty.lock");
     uint64_t seq_stable = 0; //seq that is now stable on disk
-    uint64_t seq_next = 1;   //seq that is ongoing and not yet stable
+    uint64_t seq_live = 1;   //seq that is ongoing and dirty files will be written to
     // map of dirty files, files of same dirty_seq are grouped into list.
     std::map<uint64_t, dirty_file_list_t> files;
   } dirty;
@@ -436,9 +437,10 @@ private:
 
   int64_t _maybe_extend_log();
   void _extend_log();
-  uint64_t _consume_dirty();
-  void _clear_dirty_set_stable(uint64_t seq_stable);
-  void _release_pending_allocations(std::vector<interval_set<uint64_t>>& to_release);
+  uint64_t _log_advance_seq();
+  void _consume_dirty(uint64_t seq);
+  void clear_dirty_set_stable(uint64_t seq_stable);
+  void release_pending_allocations(std::vector<interval_set<uint64_t>>& to_release);
 
   void _flush_and_sync_log_core(int64_t available_runway);
   int _flush_and_sync_log_jump(uint64_t jump_to,

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -411,7 +411,7 @@ private:
 
 
   FileRef _get_file(uint64_t ino);
-  void _drop_link(FileRef f);
+  void _drop_link_D(FileRef f);
 
   unsigned _get_slow_device_id() {
     return bdev[BDEV_SLOW] ? BDEV_SLOW : BDEV_DB;
@@ -423,32 +423,32 @@ private:
 				 PExtentVector* extents);
 
   /* signal replay log to include h->file in nearest log flush */
-  int _signal_dirty_to_log(FileWriter *h);
-  int _flush_range(FileWriter *h, uint64_t offset, uint64_t length);
+  int _signal_dirty_to_log_D(FileWriter *h);
+  int _flush_range_F(FileWriter *h, uint64_t offset, uint64_t length);
   int _flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered);
-  int _flush(FileWriter *h, bool force, bool *flushed = nullptr);
+  int _flush_F(FileWriter *h, bool force, bool *flushed = nullptr);
   int _flush_special(FileWriter *h);
   int _fsync(FileWriter *h);
 
 #ifdef HAVE_LIBAIO
   void _claim_completed_aios(FileWriter *h, std::list<aio_t> *ls);
-  void wait_for_aio(FileWriter *h);  // safe to call without a lock
+  void _wait_for_aio(FileWriter *h);  // safe to call without a lock
 #endif
 
   int64_t _maybe_extend_log();
   void _extend_log();
   uint64_t _log_advance_seq();
   void _consume_dirty(uint64_t seq);
-  void clear_dirty_set_stable(uint64_t seq_stable);
-  void release_pending_allocations(std::vector<interval_set<uint64_t>>& to_release);
+  void _clear_dirty_set_stable_D(uint64_t seq_stable);
+  void _release_pending_allocations(std::vector<interval_set<uint64_t>>& to_release);
 
   void _flush_and_sync_log_core(int64_t available_runway);
-  int _flush_and_sync_log_jump(uint64_t jump_to,
+  int _flush_and_sync_log_jump_D(uint64_t jump_to,
 			       int64_t available_runway);
-  int flush_and_sync_log(uint64_t want_seq = 0);
+  int _flush_and_sync_log_LD(uint64_t want_seq = 0);
 
-  uint64_t estimate_log_size();
-  bool should_start_compact_log();
+  uint64_t _estimate_log_size_N();
+  bool _should_start_compact_log_L_N();
 
   enum {
     REMOVE_DB = 1,
@@ -456,12 +456,12 @@ private:
     RENAME_SLOW2DB = 4,
     RENAME_DB2SLOW = 8,
   };
-  void compact_log_dump_metadata(bluefs_transaction_t *t,
+  void _compact_log_dump_metadata_N(bluefs_transaction_t *t,
 				 int flags);
-  void compact_log_sync();
-  void compact_log_async();
+  void _compact_log_sync_LN_LD();
+  void _compact_log_async_LD_NF_D();
 
-  void rewrite_log_and_layout_sync(bool allocate_with_fallback,
+  void _rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
 				    int super_dev,
 				    int log_dev,
 				    int new_log_dev,
@@ -471,8 +471,8 @@ private:
   //void _aio_finish(void *priv);
 
   void _flush_bdev(FileWriter *h);
-  void flush_bdev();  // this is safe to call without a lock
-  void flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs);  // this is safe to call without a lock
+  void _flush_bdev();  // this is safe to call without a lock
+  void _flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs);  // this is safe to call without a lock
 
   int _preallocate(FileRef f, uint64_t off, uint64_t len);
   int _truncate(FileWriter *h, uint64_t off);
@@ -592,7 +592,7 @@ public:
   /// sync any uncommitted state to disk
   void sync_metadata(bool avoid_compact);
   /// test and compact log, if necessary
-  void maybe_compact_log();
+  void _maybe_compact_log_LN_NF_LD_D();
 
   void set_volume_selector(BlueFSVolumeSelector* s) {
     vselector.reset(s);
@@ -636,11 +636,11 @@ public:
   void invalidate_cache(FileRef f, uint64_t offset, uint64_t len);
   int preallocate(FileRef f, uint64_t offset, uint64_t len);
   int truncate(FileWriter *h, uint64_t offset);
-  int do_replay_recovery_read(FileReader *log,
-			      size_t log_pos,
-			      size_t read_offset,
-			      size_t read_len,
-			      bufferlist* bl);
+  int _do_replay_recovery_read(FileReader *log,
+			       size_t log_pos,
+			       size_t read_offset,
+			       size_t read_len,
+			       bufferlist* bl);
 
   size_t probe_alloc_avail(int dev, uint64_t alloc_size);
 
@@ -710,5 +710,22 @@ public:
 
   void get_paths(const std::string& base, paths& res) const override;
 };
-
+/**
+ * Directional graph of locks.
+ * Vertices - Locks. Edges (directed) - locking progression.
+ * Edge A->B exist if last taken lock was A and next taken lock is B.
+ * 
+ * Column represents last lock taken.
+ * Row represents next lock taken.
+ *
+ *     <        | L | D | N | F | W
+ * -------------|---|---|---|---|---
+ * log        L |     <   <         
+ * dirty      D |                   
+ * nodes      N |             <     
+ * File       F | <                 
+ * FileWriter W | <  <        <      
+ * 
+ * Claim: Deadlock is possible IFF graph contains cycles.
+ */
 #endif

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -414,9 +414,18 @@ private:
   void wait_for_aio(FileWriter *h);  // safe to call without a lock
 #endif
 
+  int64_t _maybe_extend_log();
+  void _extend_log();
+  uint64_t _consume_dirty();
+  void _clear_dirty_set_stable(uint64_t seq_stable);
+  void _release_pending_allocations(std::vector<interval_set<uint64_t>>& to_release);
+
+  void _flush_and_sync_log_core(int64_t available_runway);
+  int _flush_and_sync_log_jump(uint64_t jump_to,
+			       int64_t available_runway);
   int _flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
-			  uint64_t want_seq = 0,
-			  uint64_t jump_to = 0);
+			  uint64_t want_seq = 0);
+
   uint64_t _estimate_log_size();
   bool _should_compact_log();
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -718,13 +718,13 @@ public:
  * Column represents last lock taken.
  * Row represents next lock taken.
  *
- *     <        | L | D | N | F | W
+ *     >        | W | L | D | N | F
  * -------------|---|---|---|---|---
- * log        L |     <   <         
- * dirty      D |                   
- * nodes      N |             <     
- * File       F |                  
- * FileWriter W | <   <       <      
+ * FileWriter W |   | > | > |   | >
+ * log        L |       | > | > | >
+ * dirty      D |           |   | >
+ * nodes      N |               | >
+ * File       F |
  * 
  * Claim: Deadlock is possible IFF graph contains cycles.
  */

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -458,6 +458,9 @@ private:
   };
   void _compact_log_dump_metadata_N(bluefs_transaction_t *t,
 				 int flags);
+  void compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
+					  uint64_t capture_before_seq);
+
   void _compact_log_sync_LN_LD();
   void _compact_log_async_LD_NF_D();
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -405,8 +405,10 @@ private:
   /* signal replay log to include h->file in nearest log flush */
   int _signal_dirty_to_log(FileWriter *h);
   int _flush_range(FileWriter *h, uint64_t offset, uint64_t length);
+  int _flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered);
   int _flush(FileWriter *h, bool force, std::unique_lock<ceph::mutex>& l);
   int _flush(FileWriter *h, bool force, bool *flushed = nullptr);
+  int _flush_special(FileWriter *h);
   int _fsync(FileWriter *h, std::unique_lock<ceph::mutex>& l);
 
 #ifdef HAVE_LIBAIO

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -333,22 +333,31 @@ private:
   };
 
   // cache
-  mempool::bluefs::map<std::string, DirRef, std::less<>> dir_map;          ///< dirname -> Dir
-  mempool::bluefs::unordered_map<uint64_t, FileRef> file_map; ///< ino -> File
-
-  // map of dirty files, files of same dirty_seq are grouped into list.
-  std::map<uint64_t, dirty_file_list_t> dirty_files;
+  struct {
+    ceph::mutex lock = ceph::make_mutex("BlueFS::nodes.lock");
+    mempool::bluefs::map<std::string, DirRef, std::less<>> dir_map; ///< dirname -> Dir
+    mempool::bluefs::unordered_map<uint64_t, FileRef> file_map;     ///< ino -> File
+  } nodes;
 
   bluefs_super_t super;        ///< latest superblock (as last written)
   uint64_t ino_last = 0;       ///< last assigned ino (this one is in use)
-  uint64_t log_seq = 0;        ///< last used log seq (by current pending log_t)
-  uint64_t log_seq_stable = 0; ///< last stable/synced log seq
-  FileWriter *log_writer = 0;  ///< writer for the log
-  bluefs_transaction_t log_t;  ///< pending, unwritten log transaction
-  bool log_flushing = false;   ///< true while flushing the log
+
+  struct {
+    ceph::mutex lock = ceph::make_mutex("BlueFS::log.lock");
+    uint64_t seq_live = 0; //seq that log is currently writing to
+    FileWriter *writer = 0;
+    bluefs_transaction_t t;
+  } log;
+
+  struct {
+    ceph::mutex lock = ceph::make_mutex("BlueFS::dirty.lock");
+    uint64_t seq_stable = 0; //seq that is now stable on disk
+    uint64_t seq_next = 1;   //seq that is ongoing and not yet stable
+    // map of dirty files, files of same dirty_seq are grouped into list.
+    std::map<uint64_t, dirty_file_list_t> files;
+  } dirty;
 
   ceph::condition_variable log_cond;                             ///< used for state control between log flush / log compaction
-  ceph::mutex cond_lock = ceph::make_mutex("BlueFS::cond_lock"); ///< ....
   std::atomic<bool> log_is_compacting{false};                    ///< signals that bluefs log is already ongoing compaction
   std::atomic<bool> log_forbidden_to_expand{false};              ///< used to signal that async compaction is in state
                                                                  ///  that prohibits expansion of bluefs log

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -726,8 +726,8 @@ public:
  * log        L |     <   <         
  * dirty      D |                   
  * nodes      N |             <     
- * File       F | <                 
- * FileWriter W | <  <        <      
+ * File       F |                  
+ * FileWriter W | <   <       <      
  * 
  * Claim: Deadlock is possible IFF graph contains cycles.
  */

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -320,9 +320,6 @@ public:
   };
 
 private:
-  ceph::mutex log_lock = ceph::make_mutex("BlueFS::log_lock");
-  ceph::mutex dirs_lock = ceph::make_mutex("BlueFS::dirs_lock");
-  ceph::mutex dirty_lock = ceph::make_mutex("BlueFS::dirty_lock");
   PerfCounters *logger = nullptr;
 
   uint64_t max_bytes[MAX_BDEV] = {0};

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -132,6 +132,11 @@ public:
     std::atomic_int num_reading;
 
     void* vselector_hint = nullptr;
+    /* lock protects fnode and other the parts that can be modified during read & write operations.
+       Does not protect values that are fixed
+       Does not need to be taken when doing one-time operations:
+       _replay, device_migrate_to_existing, device_migrate_to_new */
+    ceph::mutex lock = ceph::make_mutex("BlueFS::File::lock");
 
   private:
     FRIEND_MAKE_REF(File);
@@ -315,8 +320,9 @@ public:
   };
 
 private:
-  ceph::mutex lock = ceph::make_mutex("BlueFS::lock");
-
+  ceph::mutex log_lock = ceph::make_mutex("BlueFS::log_lock");
+  ceph::mutex dirs_lock = ceph::make_mutex("BlueFS::dirs_lock");
+  ceph::mutex dirty_lock = ceph::make_mutex("BlueFS::dirty_lock");
   PerfCounters *logger = nullptr;
 
   uint64_t max_bytes[MAX_BDEV] = {0};
@@ -340,13 +346,12 @@ private:
   FileWriter *log_writer = 0;  ///< writer for the log
   bluefs_transaction_t log_t;  ///< pending, unwritten log transaction
   bool log_flushing = false;   ///< true while flushing the log
-  ceph::condition_variable log_cond;
 
-  uint64_t new_log_jump_to = 0;
-  uint64_t old_log_jump_to = 0;
-  FileRef new_log = nullptr;
-  FileWriter *new_log_writer = nullptr;
-
+  ceph::condition_variable log_cond;                             ///< used for state control between log flush / log compaction
+  ceph::mutex cond_lock = ceph::make_mutex("BlueFS::cond_lock"); ///< ....
+  std::atomic<bool> log_is_compacting{false};                    ///< signals that bluefs log is already ongoing compaction
+  std::atomic<bool> log_forbidden_to_expand{false};              ///< used to signal that async compaction is in state
+                                                                 ///  that prohibits expansion of bluefs log
   /*
    * There are up to 3 block devices:
    *
@@ -360,6 +365,11 @@ private:
   std::vector<Allocator*> alloc;                   ///< allocators for bdevs
   std::vector<uint64_t> alloc_size;                ///< alloc size for each device
   std::vector<interval_set<uint64_t>> pending_release; ///< extents to release
+  // TODO: it should be examined what makes pending_release immune to
+  // eras in a way similar to dirty_files. Hints:
+  // 1) we have actually only 2 eras: log_seq and log_seq+1
+  // 2) we usually not remove extents from files. And when we do, we force log-syncing.
+
   //std::vector<interval_set<uint64_t>> block_unused_too_granular;
 
   BlockDevice::aio_callback_t discard_cb[3]; //discard callbacks for each dev
@@ -406,10 +416,9 @@ private:
   int _signal_dirty_to_log(FileWriter *h);
   int _flush_range(FileWriter *h, uint64_t offset, uint64_t length);
   int _flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered);
-  int _flush(FileWriter *h, bool force, std::unique_lock<ceph::mutex>& l);
   int _flush(FileWriter *h, bool force, bool *flushed = nullptr);
   int _flush_special(FileWriter *h);
-  int _fsync(FileWriter *h, std::unique_lock<ceph::mutex>& l);
+  int _fsync(FileWriter *h);
 
 #ifdef HAVE_LIBAIO
   void _claim_completed_aios(FileWriter *h, std::list<aio_t> *ls);
@@ -425,11 +434,10 @@ private:
   void _flush_and_sync_log_core(int64_t available_runway);
   int _flush_and_sync_log_jump(uint64_t jump_to,
 			       int64_t available_runway);
-  int _flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
-			  uint64_t want_seq = 0);
+  int flush_and_sync_log(uint64_t want_seq = 0);
 
-  uint64_t _estimate_log_size();
-  bool _should_compact_log();
+  uint64_t estimate_log_size();
+  bool should_start_compact_log();
 
   enum {
     REMOVE_DB = 1,
@@ -437,12 +445,12 @@ private:
     RENAME_SLOW2DB = 4,
     RENAME_DB2SLOW = 8,
   };
-  void _compact_log_dump_metadata(bluefs_transaction_t *t,
-				  int flags);
-  void _compact_log_sync();
-  void _compact_log_async(std::unique_lock<ceph::mutex>& l);
+  void compact_log_dump_metadata(bluefs_transaction_t *t,
+				 int flags);
+  void compact_log_sync();
+  void compact_log_async();
 
-  void _rewrite_log_and_layout_sync(bool allocate_with_fallback,
+  void rewrite_log_and_layout_sync(bool allocate_with_fallback,
 				    int super_dev,
 				    int log_dev,
 				    int new_log_dev,
@@ -451,7 +459,7 @@ private:
 
   //void _aio_finish(void *priv);
 
-  void _flush_bdev_safely(FileWriter *h);
+  void _flush_bdev(FileWriter *h);
   void flush_bdev();  // this is safe to call without a lock
   void flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs);  // this is safe to call without a lock
 
@@ -470,8 +478,6 @@ private:
     uint64_t len,    ///< [in] this many bytes
     char *out);      ///< [out] optional: or copy it here
 
-  void _invalidate_cache(FileRef f, uint64_t offset, uint64_t length);
-
   int _open_super();
   int _write_super(int dev);
   int _check_allocations(const bluefs_fnode_t& fnode,
@@ -484,6 +490,7 @@ private:
   int _replay(bool noop, bool to_stdout = false); ///< replay journal
 
   FileWriter *_create_writer(FileRef f);
+  void _drain_writer(FileWriter *h);
   void _close_writer(FileWriter *h);
 
   // always put the super in the second 4k block.  FIXME should this be
@@ -549,10 +556,8 @@ public:
     FileReader **h,
     bool random = false);
 
-  void close_writer(FileWriter *h) {
-    std::lock_guard l(lock);
-    _close_writer(h);
-  }
+  // data added after last fsync() is lost
+  void close_writer(FileWriter *h);
 
   int rename(std::string_view old_dir, std::string_view old_file,
 	     std::string_view new_dir, std::string_view new_file);
@@ -576,7 +581,7 @@ public:
   /// sync any uncommitted state to disk
   void sync_metadata(bool avoid_compact);
   /// test and compact log, if necessary
-  void _maybe_compact_log(std::unique_lock<ceph::mutex>& l);
+  void maybe_compact_log();
 
   void set_volume_selector(BlueFSVolumeSelector* s) {
     vselector.reset(s);
@@ -598,42 +603,11 @@ public:
   // handler for discard event
   void handle_discard(unsigned dev, interval_set<uint64_t>& to_release);
 
-  void flush(FileWriter *h, bool force = false) {
-    std::unique_lock l(lock);
-    int r = _flush(h, force, l);
-    ceph_assert(r == 0);
-  }
+  void flush(FileWriter *h, bool force = false);
 
-  void append_try_flush(FileWriter *h, const char* buf, size_t len) {
-    size_t max_size = 1ull << 30; // cap to 1GB
-    while (len > 0) {
-      bool need_flush = true;
-      auto l0 = h->get_buffer_length();
-      if (l0 < max_size) {
-	size_t l = std::min(len, max_size - l0);
-	h->append(buf, l);
-	buf += l;
-	len -= l;
-	need_flush = h->get_buffer_length() >= cct->_conf->bluefs_min_flush_size;
-      }
-      if (need_flush) {
-	flush(h, true);
-	// make sure we've made any progress with flush hence the
-	// loop doesn't iterate forever
-	ceph_assert(h->get_buffer_length() < max_size);
-      }
-    }
-  }
-  void flush_range(FileWriter *h, uint64_t offset, uint64_t length) {
-    std::lock_guard l(lock);
-    _flush_range(h, offset, length);
-  }
-  int fsync(FileWriter *h) {
-    std::unique_lock l(lock);
-    int r = _fsync(h, l);
-    _maybe_compact_log(l);
-    return r;
-  }
+  void append_try_flush(FileWriter *h, const char* buf, size_t len);
+  void flush_range(FileWriter *h, uint64_t offset, uint64_t length);
+  int fsync(FileWriter *h);
   int64_t read(FileReader *h, uint64_t offset, size_t len,
 	   ceph::buffer::list *outbl, char *out) {
     // no need to hold the global lock here; we only touch h and
@@ -648,18 +622,9 @@ public:
     // atomics and asserts).
     return _read_random(h, offset, len, out);
   }
-  void invalidate_cache(FileRef f, uint64_t offset, uint64_t len) {
-    std::lock_guard l(lock);
-    _invalidate_cache(f, offset, len);
-  }
-  int preallocate(FileRef f, uint64_t offset, uint64_t len) {
-    std::lock_guard l(lock);
-    return _preallocate(f, offset, len);
-  }
-  int truncate(FileWriter *h, uint64_t offset) {
-    std::lock_guard l(lock);
-    return _truncate(h, offset);
-  }
+  void invalidate_cache(FileRef f, uint64_t offset, uint64_t len);
+  int preallocate(FileRef f, uint64_t offset, uint64_t len);
+  int truncate(FileWriter *h, uint64_t offset);
   int do_replay_recovery_read(FileReader *log,
 			      size_t log_pos,
 			      size_t read_offset,

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -341,7 +341,6 @@ private:
 
   struct {
     ceph::mutex lock = ceph::make_mutex("BlueFS::log.lock");
-    //uint64_t seq_stable = 0; //seq that is now stable on disk    AK - consider also mirroring this
     uint64_t seq_live = 1;   //seq that log is currently writing to; mirrors dirty.seq_live
     FileWriter *writer = 0;
     bluefs_transaction_t t;
@@ -455,8 +454,8 @@ private:
   };
   void _compact_log_dump_metadata_N(bluefs_transaction_t *t,
 				 int flags);
-  void compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
-					  uint64_t capture_before_seq);
+  void _compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
+					   uint64_t capture_before_seq);
 
   void _compact_log_sync_LN_LD();
   void _compact_log_async_LD_NF_D();

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -458,7 +458,7 @@ private:
 					   uint64_t capture_before_seq);
 
   void _compact_log_sync_LNF_LD();
-  void _compact_log_async_LD_NF_D();
+  void _compact_log_async_LD_LNF_D();
 
   void _rewrite_log_and_layout_sync_LNF_LD(bool allocate_with_fallback,
 				    int super_dev,
@@ -590,8 +590,6 @@ public:
 
   /// sync any uncommitted state to disk
   void sync_metadata(bool avoid_compact);
-  /// test and compact log, if necessary
-  void _maybe_compact_log_LNF_NF_LD_D();
 
   void set_volume_selector(BlueFSVolumeSelector* s) {
     vselector.reset(s);
@@ -635,11 +633,6 @@ public:
   void invalidate_cache(FileRef f, uint64_t offset, uint64_t len);
   int preallocate(FileRef f, uint64_t offset, uint64_t len);
   int truncate(FileWriter *h, uint64_t offset);
-  int _do_replay_recovery_read(FileReader *log,
-			       size_t log_pos,
-			       size_t read_offset,
-			       size_t read_len,
-			       bufferlist* bl);
 
   size_t probe_alloc_avail(int dev, uint64_t alloc_size);
 
@@ -660,6 +653,14 @@ private:
   int _bdev_read(uint8_t ndev, uint64_t off, uint64_t len,
     ceph::buffer::list* pbl, IOContext* ioc, bool buffered);
   int _bdev_read_random(uint8_t ndev, uint64_t off, uint64_t len, char* buf, bool buffered);
+
+  /// test and compact log, if necessary
+  void _maybe_compact_log_LNF_NF_LD_D();
+  int _do_replay_recovery_read(FileReader *log,
+			       size_t log_pos,
+			       size_t read_offset,
+			       size_t read_len,
+			       bufferlist* bl);
 };
 
 class OriginalVolumeSelector : public BlueFSVolumeSelector {
@@ -714,15 +715,15 @@ public:
  * Vertices - Locks. Edges (directed) - locking progression.
  * Edge A->B exist if last taken lock was A and next taken lock is B.
  * 
- * Column represents last lock taken.
- * Row represents next lock taken.
+ * Row represents last lock taken.
+ * Column represents next lock taken.
  *
- *     >        | W | L | D | N | F
+ *     >        | W | L | N | D | F
  * -------------|---|---|---|---|---
- * FileWriter W |   | > | > |   | >
+ * FileWriter W |   | > | > | > | >
  * log        L |       | > | > | >
+ * nodes      N |           | > | >
  * dirty      D |           |   | >
- * nodes      N |               | >
  * File       F |
  * 
  * Claim: Deadlock is possible IFF graph contains cycles.

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -452,15 +452,15 @@ private:
     RENAME_SLOW2DB = 4,
     RENAME_DB2SLOW = 8,
   };
-  void _compact_log_dump_metadata_N(bluefs_transaction_t *t,
+  void _compact_log_dump_metadata_NF(bluefs_transaction_t *t,
 				 int flags);
   void _compact_log_async_dump_metadata_NF(bluefs_transaction_t *t,
 					   uint64_t capture_before_seq);
 
-  void _compact_log_sync_LN_LD();
+  void _compact_log_sync_LNF_LD();
   void _compact_log_async_LD_NF_D();
 
-  void _rewrite_log_and_layout_sync_LN_LD(bool allocate_with_fallback,
+  void _rewrite_log_and_layout_sync_LNF_LD(bool allocate_with_fallback,
 				    int super_dev,
 				    int log_dev,
 				    int new_log_dev,
@@ -591,7 +591,7 @@ public:
   /// sync any uncommitted state to disk
   void sync_metadata(bool avoid_compact);
   /// test and compact log, if necessary
-  void _maybe_compact_log_LN_NF_LD_D();
+  void _maybe_compact_log_LNF_NF_LD_D();
 
   void set_volume_selector(BlueFSVolumeSelector* s) {
     vselector.reset(s);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -352,6 +352,11 @@ private:
     uint64_t seq_live = 1;   //seq that is ongoing and dirty files will be written to
     // map of dirty files, files of same dirty_seq are grouped into list.
     std::map<uint64_t, dirty_file_list_t> files;
+    std::vector<interval_set<uint64_t>> pending_release; ///< extents to release
+    // TODO: it should be examined what makes pending_release immune to
+    // eras in a way similar to dirty_files. Hints:
+    // 1) we have actually only 2 eras: log_seq and log_seq+1
+    // 2) we usually not remove extents from files. And when we do, we force log-syncing.
   } dirty;
 
   ceph::condition_variable log_cond;                             ///< used for state control between log flush / log compaction
@@ -370,11 +375,6 @@ private:
   std::vector<uint64_t> block_reserved;            ///< starting reserve extent per device
   std::vector<Allocator*> alloc;                   ///< allocators for bdevs
   std::vector<uint64_t> alloc_size;                ///< alloc size for each device
-  std::vector<interval_set<uint64_t>> pending_release; ///< extents to release
-  // TODO: it should be examined what makes pending_release immune to
-  // eras in a way similar to dirty_files. Hints:
-  // 1) we have actually only 2 eras: log_seq and log_seq+1
-  // 2) we usually not remove extents from files. And when we do, we force log-syncing.
 
   //std::vector<interval_set<uint64_t>> block_unused_too_granular;
 


### PR DESCRIPTION
This is continuation of merged and then reverted https://github.com/ceph/ceph/pull/42099.
This PR includes:
https://github.com/ceph/ceph/pull/43634
https://github.com/ceph/ceph/pull/43589
and
- fixes missing locks in compact_log_async.
- fixes broken logic that caused discrepancy between captured state of file and 1st update to a file

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
