### PR TITLE
WIP: pacific: qa/suites/upgrade: upgrade test autoscale profile

### DIFF
--- a/qa/suites/upgrade/pacific-p2p-autoscale-profile/test-autoscale-profile-upgrade.yaml
+++ b/qa/suites/upgrade/pacific-p2p-autoscale-profile/test-autoscale-profile-upgrade.yaml
@@ -1,0 +1,43 @@
+roles:
+- - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+- - client.0
+
+tasks:
+- install:
+  tag: v16.2.5
+- print: "**** done v16.2.5 install"
+- ceph:
+    create_rbd_pool: false
+    log-ignorelist:
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(OBJECT_
+      - \(SLOW_OPS\)
+      - \(REQUEST_SLOW\)
+      - \(TOO_FEW_PGS\)
+      - slow request
+
+#  upgrade to v16.2.6
+- install.upgrade:
+    mon.a:
+    client.0:
+- ceph.restart:
+    daemons: [mon.a, mgr.x, osd.0, osd.1, osd.2, osd.3]
+    wait-for-healthy: true
+    wait-for-osds-up: true
+- print: "**** done upgrade to v16.2.6 ceph.restart all mon/mgr/osd "
+
+- workunit:
+    clients:
+      client.0:
+        - mgr/test_autoscale_profile_create_pool.sh
+- print: "*** done mgr/test_autoscale_profile_create_pool.sh"

--- a/qa/workunits/mgr/test_autoscale_profile_create_pool.sh
+++ b/qa/workunits/mgr/test_autoscale_profile_create_pool.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -ex
+
+DHM_POOL=$(ceph osd pool autoscale-status | grep -o -m 1 'device_health_metrics' || true)
+
+if [[ -z $DHM_POOL ]]
+then
+  echo "Error: device_health_metrics pool doesn't exist "
+  exit 1
+fi
+
+PROFILE1=$(ceph osd pool autoscale-status | grep 'device_health_metrics' | grep -o -m 1 'scale-up\|scale-down' || true)
+
+if [[ -z $PROFILE1 ]]
+then
+  echo "Error: device_health_metrics PROFILE is empty!"
+  exit 1
+fi
+
+if [[ $PROFILE1 = "scale-up" ]]
+then
+  echo "Success: device_health_metrics PROFILE is scale-up"
+else
+  echo "Error: device_health_metrics PROFILE is scale-down"
+  exit 1
+fi
+
+
+ceph osd pool create test_pool
+
+sleep 5
+
+PROFILE2=$(ceph osd pool autoscale-status | grep 'test_pool' | grep -o -m 1 'scale-up\|scale-down' || true)
+
+if [[ -z $PROFILE2 ]]
+then
+  echo "Error: test_pool PROFILE is empty!"
+  exit 1
+fi
+
+if [[ $PROFILE2 = "scale-up" ]]
+then
+  echo "Success, test_pool PROFILE is scale-up"
+else
+  echo "Error: test_pool PROFILE is scale-down"
+  exit 1
+fi
+
+echo OK


### PR DESCRIPTION
Introduce an upgrade test for the autoscale profile
v16.2.5 - v16.2.6

We test to see after the upgrade to v16.2.6 if the newly created
pool will have a `scale-up` profile and that
the existing pool that was created in v16.2.5 also
has a `scale-up` profile.

Pending for https://github.com/ceph/ceph/pull/43999 to be merged and backported to Pacific

Signed-off-by: Kamoltat <ksirivad@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
