### PR TITLE
mds/FSMap: assign v16.2.4 compat to pre-v16.2.5 standby daemons

### DIFF
--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -83,6 +83,23 @@ CompatSet MDSMap::get_compat_set_base() {
   return CompatSet(feature_compat_base, feature_ro_compat_base, feature_incompat_base);
 }
 
+// pre-v16.2.5 CompatSet in MDS beacon
+CompatSet MDSMap::get_compat_set_v16_2_4() {
+  CompatSet::FeatureSet feature_compat;
+  CompatSet::FeatureSet feature_ro_compat;
+  CompatSet::FeatureSet feature_incompat;
+  feature_incompat.insert(MDS_FEATURE_INCOMPAT_BASE);
+  feature_incompat.insert(MDS_FEATURE_INCOMPAT_CLIENTRANGES);
+  feature_incompat.insert(MDS_FEATURE_INCOMPAT_FILELAYOUT);
+  feature_incompat.insert(MDS_FEATURE_INCOMPAT_DIRINODE);
+  feature_incompat.insert(MDS_FEATURE_INCOMPAT_ENCODING);
+  feature_incompat.insert(MDS_FEATURE_INCOMPAT_OMAPDIRFRAG);
+  feature_incompat.insert(MDS_FEATURE_INCOMPAT_NOANCHOR);
+  feature_incompat.insert(MDS_FEATURE_INCOMPAT_FILE_LAYOUT_V2);
+  feature_incompat.insert(MDS_FEATURE_INCOMPAT_SNAPREALM_V2);
+  return CompatSet(feature_compat, feature_ro_compat, feature_incompat);
+}
+
 void MDSMap::mds_info_t::dump(Formatter *f) const
 {
   f->dump_unsigned("gid", global_id);
@@ -638,6 +655,8 @@ void MDSMap::mds_info_t::decode(bufferlist::const_iterator& bl)
   }
   if (struct_v >= 10) {
     decode(compat, bl);
+  } else {
+    compat = MDSMap::get_compat_set_v16_2_4();
   }
   DECODE_FINISH(bl);
 }

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -168,6 +168,7 @@ public:
   static CompatSet get_compat_set_all();
   static CompatSet get_compat_set_default();
   static CompatSet get_compat_set_base(); // pre v0.20
+  static CompatSet get_compat_set_v16_2_4(); // pre-v16.2.5 CompatSet in MDS beacon
 
   static MDSMap create_null_mdsmap() {
     MDSMap null_map;

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -584,6 +584,18 @@ class CephadmUpgrade:
 
         image_settings = self.get_distinct_container_image_settings()
 
+        # Older monitors (pre-v16.2.5) asserted that FSMap::compat ==
+        # MDSMap::compat for all fs. This is no longer the case beginning in
+        # v16.2.5. We must disable the sanity checks during upgrade.
+        # N.B.: we don't bother confirming the operator has not already
+        # disabled this or saving the config value.
+        self.mgr.check_mon_command({
+            'prefix': 'config set',
+            'name': 'mon_mds_skip_sanity',
+            'value': '1',
+            'who': 'mon',
+        })
+
         daemons = [d for d in self.mgr.cache.get_daemons() if d.daemon_type in CEPH_UPGRADE_ORDER]
         done = 0
         for daemon_type in CEPH_UPGRADE_ORDER:
@@ -876,6 +888,12 @@ class CephadmUpgrade:
                 'name': 'container_image',
                 'who': name_to_config_section(daemon_type),
             })
+
+        self.mgr.check_mon_command({
+            'prefix': 'config rm',
+            'name': 'mon_mds_skip_sanity',
+            'who': 'mon',
+        })
 
         logger.info('Upgrade: Complete!')
         if self.upgrade_state.progress_id:


### PR DESCRIPTION
I'm testing this to see it fixes https://tracker.ceph.com/issues/53150