### PR TITLE
octopus: librbd/object_map: rbd diff between two snapshots lists entire image content

### DIFF
--- a/src/librbd/object_map/DiffRequest.cc
+++ b/src/librbd/object_map/DiffRequest.cc
@@ -222,7 +222,9 @@ void DiffRequest<I>::handle_load_object_map(int r) {
       uint8_t object_map_state = *it;
       if (object_map_state == OBJECT_NONEXISTENT) {
         *diff_it = DIFF_STATE_HOLE;
-      } else if (diff_from_start || object_map_state != OBJECT_EXISTS_CLEAN) {
+      } else if (diff_from_start ||
+                 (m_object_diff_state_valid &&
+                  object_map_state != OBJECT_EXISTS_CLEAN)) {
         *diff_it = DIFF_STATE_DATA_UPDATED;
       } else {
         *diff_it = DIFF_STATE_DATA;

--- a/src/test/librbd/object_map/test_mock_DiffRequest.cc
+++ b/src/test/librbd/object_map/test_mock_DiffRequest.cc
@@ -212,7 +212,7 @@ TEST_F(TestMockObjectMapDiffRequest, IntermediateDelta) {
 
   BitVector<2> object_map_1;
   object_map_1.resize(object_count);
-  object_map_1[1] = OBJECT_EXISTS_CLEAN;
+  object_map_1[1] = OBJECT_EXISTS;
   object_map_1[2] = OBJECT_EXISTS_CLEAN;
   expect_load_map(mock_image_ctx, 1U, object_map_1, 0);
 
@@ -281,7 +281,7 @@ TEST_F(TestMockObjectMapDiffRequest, EndDelta) {
   BitVector<2> expected_diff_state;
   expected_diff_state.resize(object_count);
   expected_diff_state[1] = DIFF_STATE_DATA;
-  expected_diff_state[2] = DIFF_STATE_DATA_UPDATED;
+  expected_diff_state[2] = DIFF_STATE_DATA;
   expected_diff_state[3] = DIFF_STATE_HOLE_UPDATED;
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53027

---

backport of https://github.com/ceph/ceph/pull/41657
parent tracker: https://tracker.ceph.com/issues/50787

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh