### PR TITLE
doc/cephadm: Recommend osd_memory_target_autotune

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -316,7 +316,16 @@ available and unused device:
 
     ceph orch apply osd --all-available-devices
 
-Or See :ref:`cephadm-deploy-osds` for more detailed instructions.
+See :ref:`cephadm-deploy-osds` for more detailed instructions.
+
+In case the cluster runs on hardware that is used exclusively for
+Ceph, it is recommended to enable ``osd_memory_target_autotune``.
+See :ref:`osd_autotune`.
+
+  .. prompt:: bash #
+
+    ceph config set osd osd_memory_target_autotune true
+
 
 Using Ceph
 ==========


### PR DESCRIPTION
In case the cluster runs on hardware that is used exclusively for
Ceph, let's recommend `osd_memory_target_autotune`

Signed-off-by: Sebastian Wagner <sewagner@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
