### PR TITLE
pacific: mgr/dashboard: fix missing alert rule details

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.html
@@ -9,9 +9,10 @@
 <cd-table *ngIf="isPrometheusConfigured"
           [data]="prometheusAlertService.rules"
           [columns]="columns"
+          [selectionType]="'single'"
           [hasDetails]="true"
-          (updateSelection)="setExpandedRow($event)"
-          [selectionType]="'single'">
+          (setExpandedRow)="setExpandedRow($event)"
+          (updateSelection)="updateSelection($event)">
   <cd-table-key-value cdTableDetail
                       *ngIf="expandedRow"
                       [data]="expandedRow"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53153

---

backport of https://github.com/ceph/ceph/pull/43797
parent tracker: https://tracker.ceph.com/issues/53144

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh