### PR TITLE
rgw: fix UploadPartCopy error code when src object not exist and src bucket not exist

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -367,10 +367,10 @@ static int read_obj_policy(const DoutPrefixProvider *dpp,
                            map<string, bufferlist>& bucket_attrs,
                            RGWAccessControlPolicy* acl,
                            string *storage_class,
-			   boost::optional<Policy>& policy,
+                           boost::optional<Policy>& policy,
                            rgw::sal::Bucket* bucket,
                            rgw::sal::Object* object,
-			   optional_yield y,
+                           optional_yield y,
                            bool copy_src=false)
 {
   string upload_id;
@@ -3489,6 +3489,9 @@ int RGWPutObj::init_processing(optional_yield y) {
 			      &bucket, y);
     if (ret < 0) {
       ldpp_dout(this, 5) << __func__ << "(): get_bucket() returned ret=" << ret << dendl;
+      if (ret == -ENOENT) {
+        ret = -ERR_NO_SUCH_BUCKET;
+      }
       return ret;
     }
 
@@ -3556,9 +3559,9 @@ int RGWPutObj::verify_permission(optional_yield y)
     cs_object->set_prefetch_data(s->obj_ctx);
 
     /* check source object permissions */
-    if (read_obj_policy(this, store, s, copy_source_bucket_info, cs_attrs, &cs_acl, nullptr,
-			policy, cs_bucket.get(), cs_object.get(), y, true) < 0) {
-      return -EACCES;
+    if (ret = read_obj_policy(this, store, s, copy_source_bucket_info, cs_attrs, &cs_acl, nullptr,
+			policy, cs_bucket.get(), cs_object.get(), y, true); ret < 0) {
+      return ret;
     }
 
     /* admin request overrides permission checks */


### PR DESCRIPTION
fix https://tracker.ceph.com/issues/53181

```
# -*- coding: utf-8 -*-
from boto3.session import Session
import boto3
import logging
boto3.set_stream_logger('', logging.DEBUG)
access_key = ''
secret_key = ''
host = "s3.amazonaws.com"
url = "http://s3.amazonaws.com"
session = Session(access_key, secret_key)
config = boto3.session.Config(connect_timeout=30000, read_timeout=30000, retries={'max_attempts': 0}, signature_version="s3")
s3_client = session.client('s3', endpoint_url=url, config=config)
dst_bucket = "destbucket"
dst_obj = 'destobject'
src_bucket = "srcbucketnotexist"
src_obj = 'srcobjectnotexist'
mpu = s3_client.create_multipart_upload(Bucket=dst_bucket, Key=dst_obj)
res = s3_client.upload_part_copy(Bucket=dst_bucket, CopySource=src_bucket+"/"+src_obj,
                                 Key=dst_obj,
                                 PartNumber=1, UploadId=mpu["UploadId"])
```
when src bucket not exist, it should return -ERR_NO_SUCH_BUCKET rather than -ENOENT
when src object not exist, it should return -ENOENT rather than -ACCESS
