### PR TITLE
pacific: tool/bluestore-tool: introduce repair_omap_upgrade command

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8264,21 +8264,29 @@ out_db:
 int BlueStore::what_omap_upgrade_recovery(const std::string& key,
 					  std::string& new_key)
 {
-  auto p1 = key.find_first_of('.');
-  if (p1 == string::npos || p1 <= 8) {
+  size_t p1 = 8 + 4 + 8;
+  size_t p2 = p1 + 1 + 8;
+  string s1 = "<"; // assign something just to have s1 != s2D
+  string s2 = ">";
+  if (key.length() < 8 + 4 + 8 + 1 + 8 + 1 ||
+      key[p1] != '.') {
     return 0;
   }
-  auto p2 = key.find_first_of('-', p1 + 1);
-  if (p2 == string::npos) {
-    p2 = key.find_first_of('.', p1 + 1);
+
+  if (key[p2] == '-' || key[p2] == '.') {
+    s1 = key.substr(p1 - 8, 8);
+    s2 = key.substr(p2 - 8, 8);
   }
-  if (p2 == string::npos || p1 + 8 > p2) {
-    return 0;
-  }
-  string s1 = key.substr(p1 - 8, 8);
-  string s2 = key.substr(p2 - 8, 8);
   if (s1 != s2) {
-    return 0;
+    p2 += 8;
+    if (key.length() >= 8 + 4 + 8 + 1 + 8 + 8 + 1 &&
+        (key[p2] == '-' || key[p2] == '.')) {
+      s1 = key.substr(p1 - 8, 8);
+      s2 = key.substr(p2 - 8, 8);
+    }
+    if (s1 != s2) {
+      return 0;
+    }
   }
   if (key[p2] == '.') {
     new_key = key;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2665,6 +2665,8 @@ public:
   int quick_fix() override {
     return _fsck(FSCK_SHALLOW, true);
   }
+  static int what_omap_upgrade_recovery(const std::string& key,
+                                        std::string& new_key);
   int repair_omap_upgrade();
 
   void set_cache_shards(unsigned num) override;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2665,6 +2665,7 @@ public:
   int quick_fix() override {
     return _fsck(FSCK_SHALLOW, true);
   }
+  int repair_omap_upgrade();
 
   void set_cache_shards(unsigned num) override;
   void dump_cache_stats(ceph::Formatter *f) override {

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -276,7 +276,8 @@ int main(int argc, char **argv)
         "free-score, "
         "bluefs-stats, "
         "reshard, "
-        "show-sharding")
+        "show-sharding, "
+        "repair_omap_upgrade")
     ;
   po::options_description po_all("All options");
   po_all.add(po_options).add(po_positional);
@@ -309,7 +310,8 @@ int main(int argc, char **argv)
     exit(EXIT_FAILURE);
   }
 
-  if (action == "fsck" || action == "repair" || action == "quick-fix") {
+  if (action == "fsck" || action == "repair" || action == "quick-fix" ||
+      action == "repair_omap_upgrade") {
     if (path.empty()) {
       cerr << "must specify bluestore path" << std::endl;
       exit(EXIT_FAILURE);
@@ -446,7 +448,8 @@ int main(int argc, char **argv)
 
   if (action == "fsck" ||
       action == "repair" ||
-      action == "quick-fix") {
+      action == "quick-fix" ||
+      action == "repair_omap_upgrade") {
     validate_path(cct.get(), path, false);
     BlueStore bluestore(cct.get(), path);
     int r;
@@ -454,6 +457,8 @@ int main(int argc, char **argv)
       r = bluestore.fsck(fsck_deep);
     } else if (action == "repair") {
       r = bluestore.repair(fsck_deep);
+    } else if (action == "repair_omap_upgrade") {
+      r = bluestore.repair_omap_upgrade();
     } else {
       r = bluestore.quick_fix();
     }


### PR DESCRIPTION
This allows to recover OMAPs broken due to
https://tracker.ceph.com/issues/53062

This command applied to OSD would fix OMAP keys and hopefully brings OSD
and other daemons back to working state.

I'm still uncertain whether we need this in the mainstream code base but it looks like some users might need that urgently to recover their clusters. Hence sharing this patch to permit custom build creation if needed. For the same reason provided as a Pacific patch only.
Definitely this should be used with with an extreme care in custom builds as  it bypasses all the regular QA procedures...

Signed-off-by: Igor Fedotov <igor.fedotov@croit.io>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
