### PR TITLE
octopus: cephadm: Fix iscsi client caps (allow mgr <service status> calls)

### DIFF
--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -37,6 +37,7 @@ class IscsiService(CephService):
             'caps': ['mon', 'profile rbd, '
                             'allow command "osd blacklist", '
                             'allow command "config-key get" with "key" prefix "iscsi/"',
+                     'mgr', 'allow command "service status"',
                      'osd', 'allow rwx'],
         })
 

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -1,6 +1,6 @@
 import pytest
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from cephadm.services.cephadmservice import MonService, MgrService, MdsService, RgwService, \
     RbdMirrorService, CrashService, CephadmService, AuthEntity
@@ -9,6 +9,7 @@ from cephadm.services.nfs import NFSService
 from cephadm.services.osd import RemoveUtil, OSDRemovalQueue, OSDService, OSD, NotFoundError
 from cephadm.services.monitoring import GrafanaService, AlertmanagerService, PrometheusService, \
     NodeExporterService
+from ceph.deployment.service_spec import IscsiServiceSpec
 
 from orchestrator import OrchestratorError
 
@@ -17,6 +18,7 @@ class FakeMgr:
     def __init__(self):
         self.config = ''
         self.check_mon_command = MagicMock(side_effect=self._check_mon_command)
+        self.template = MagicMock()
 
     def _check_mon_command(self, cmd_dict, inbuf=None):
         prefix = cmd_dict.get('prefix')
@@ -73,6 +75,30 @@ class TestCephadmService:
             'iscsi': iscsi_service,
         }
         return cephadm_services
+
+    def test_iscsi_client_caps(self):
+        mgr = FakeMgr()
+        iscsi_service = self._get_services(mgr)['iscsi']
+
+        iscsi_spec = IscsiServiceSpec(service_type='iscsi', service_id="a")
+        iscsi_spec.daemon_type = "iscsi"
+        iscsi_spec.daemon_id = "a"
+        iscsi_spec.spec = MagicMock()
+        iscsi_spec.spec.daemon_type = "iscsi"
+        iscsi_spec.spec.ssl_cert = ''
+
+        iscsi_service.prepare_create(iscsi_spec)
+
+        expected_caps = ['mon',
+                         'profile rbd, allow command "osd blacklist", allow command "config-key get" with "key" prefix "iscsi/"',
+                         'mgr', 'allow command "service status"',
+                         'osd', 'allow rwx']
+
+        expected_call = call({'prefix': 'auth get-or-create',
+                              'entity': 'client.iscsi.a',
+                              'caps': expected_caps})
+
+        assert expected_call in mgr.check_mon_command.mock_calls
 
     def test_get_auth_entity(self):
         mgr = FakeMgr()


### PR DESCRIPTION
iSCSI daemons need to execute <ceph service status> command

Fixes: https://tracker.ceph.com/issues/48925

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>
(cherry picked from commit 9b9934f75b648a9ee01848710a6f7150a371e26e)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
