### PR TITLE
cephadm: fix upgrade name already in use

### DIFF
--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -104,9 +104,9 @@ class DaemonPlacement(NamedTuple):
         if self.name and self.name != dd.daemon_id:
             return False
         if self.ports:
-            if self.ports != dd.ports:
+            if self.ports != dd.ports and dd.ports:
                 return False
-            if self.ip != dd.ip:
+            if self.ip != dd.ip and dd.ip:
                 return False
         return True
 


### PR DESCRIPTION
during an upgrade once the active mgr is running pacific/master it will start applying specs. 
in _apply_service a new host assignment is calculated using the list of current daemons from the cache, and place() determines new candidates and compares the existing daemons. if the daemon in the cache is old and doesn't have ports or ip it will fail the comparison because the new candidates have ports and ip info. it will then schedule the removal of the daemon and create a new one. the check for a unique name later fails because the daemon being removed is the same as the new one.


Fixes: https://tracker.ceph.com/issues/53097
Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>


