### PR TITLE
mgr/cephadm: allow zapping devices from other clusters

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2030,15 +2030,6 @@ Then run the following:
 
         for dev in host_devices:
             if dev.path == path:
-                # match, so look a little deeper
-                if dev.lvs:
-                    for lv in cast(List[Dict[str, str]], dev.lvs):
-                        if lv.get('osd_id', ''):
-                            lv_fsid = lv.get('cluster_fsid')
-                            if lv_fsid != self._cluster_fsid:
-                                raise OrchestratorError(
-                                    f"device {path} has lv's from a different Ceph cluster ({lv_fsid})")
-                            osd_id_list.append(lv.get('osd_id', ''))
                 path_found = True
                 break
         if not path_found:


### PR DESCRIPTION
This is the 99% of the devices that ever get zapped.

Fixes: b7782084ac9657be9b2da6ebd56b5029cf859225

Partially reverts #43560


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>