### PR TITLE
librbd/cache/pwl: fix reorder issue between func process_writeback_di…

### DIFF
--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -1639,6 +1639,7 @@ Context* AbstractWriteLog<I>::construct_flush_entry(std::shared_ptr<GenericLogEn
     m_lowest_flushing_sync_gen = log_entry->ram_entry.sync_gen_number;
   }
   m_flush_ops_in_flight += 1;
+  m_flush_ops_will_send += 1;
   /* For write same this is the bytes affected by the flush op, not the bytes transferred */
   m_flush_bytes_in_flight += log_entry->ram_entry.write_bytes;
 
@@ -1709,6 +1710,11 @@ void AbstractWriteLog<I>::process_writeback_dirty_entries() {
         /* Do flush complete only when all flush ops are finished */
         all_clean = !m_flush_ops_in_flight;
         break;
+      }
+
+      if (m_flush_ops_will_send) {
+	ldout(cct, 20) << "Previous flush-ops is still not sent" << dendl;
+	break;
       }
       auto candidate = m_dirty_log_entries.front();
       bool flushable = can_flush_entry(candidate);

--- a/src/librbd/cache/pwl/AbstractWriteLog.h
+++ b/src/librbd/cache/pwl/AbstractWriteLog.h
@@ -294,6 +294,7 @@ protected:
   std::atomic<int> m_async_flush_ops = {0};
   std::atomic<int> m_async_append_ops = {0};
 
+  std::atomic<int> m_flush_ops_will_send = {0};
   /* Acquire locks in order declared here */
 
   mutable ceph::mutex m_log_retire_lock;

--- a/src/librbd/cache/pwl/rwl/WriteLog.cc
+++ b/src/librbd/cache/pwl/rwl/WriteLog.cc
@@ -592,6 +592,7 @@ void WriteLog<I>::construct_flush_entries(pwl::GenericLogEntries entries_to_flus
 	      ldout(m_image_ctx.cct, 15) << "flushing:" << log_entry
 					 << " " << *log_entry << dendl;
 	      log_entry->writeback(this->m_image_writeback, ctx);
+	      this->m_flush_ops_will_send -= 1;
 	    }), 0);
         });
    }

--- a/src/librbd/cache/pwl/ssd/WriteLog.cc
+++ b/src/librbd/cache/pwl/ssd/WriteLog.cc
@@ -539,6 +539,7 @@ void WriteLog<I>::construct_flush_entries(pwl::GenericLogEntries entries_to_flus
 	      ldout(m_image_ctx.cct, 15) << "flushing:" << log_entry
                                          << " " << *log_entry << dendl;
 	      log_entry->writeback(this->m_image_writeback, ctx);
+	      this->m_flush_ops_will_send -= 1;
 	    }), 0);
 	});
       }
@@ -589,6 +590,7 @@ void WriteLog<I>::construct_flush_entries(pwl::GenericLogEntries entries_to_flus
 				           << " " << *log_entry << dendl;
 		log_entry->writeback_bl(this->m_image_writeback, ctx,
 					std::move(captured_entry_bl));
+		this->m_flush_ops_will_send -= 1;
 	      }), 0);
 	  } else {
 	      m_image_ctx.op_work_queue->queue(new LambdaContext(
@@ -596,6 +598,7 @@ void WriteLog<I>::construct_flush_entries(pwl::GenericLogEntries entries_to_flus
 		  ldout(m_image_ctx.cct, 15) << "flushing:" << log_entry
                                              << " " << *log_entry << dendl;
 		  log_entry->writeback(this->m_image_writeback, ctx);
+		  this->m_flush_ops_will_send -= 1;
 		}), 0);
 	  }
 	}


### PR DESCRIPTION
…rty_entries

In fact, we not only make sure ops in order in func process_writeback_dirty_entries,
but also make sure ops in order between func process_writeback_dirty_entries.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
