### PR TITLE
[RFC]librbd/cache/pwl: add id to distinguish openrequest

### DIFF
--- a/src/librbd/cache/pwl/ImageCacheState.cc
+++ b/src/librbd/cache/pwl/ImageCacheState.cc
@@ -59,6 +59,7 @@ ImageCacheState<I>::ImageCacheState(
   cache_type = f["cache_type"];
   host = f["pwl_host"];
   path = f["pwl_path"];
+  id = f["pwl_id"];
   uint64_t pwl_size;
   std::istringstream iss(f["pwl_size"]);
   iss >> pwl_size;
@@ -101,6 +102,7 @@ void ImageCacheState<I>::dump(ceph::Formatter *f) const {
   ::encode_json("pwl_host", host, f);
   ::encode_json("pwl_path", path, f);
   ::encode_json("pwl_size", size, f);
+  ::encode_json("pwl_id", id, f);
 }
 
 template <typename I>

--- a/src/librbd/cache/pwl/ImageCacheState.h
+++ b/src/librbd/cache/pwl/ImageCacheState.h
@@ -32,6 +32,7 @@ public:
   std::string host;
   std::string path;
   std::string cache_type;
+  std::string id;
   uint64_t size = 0;
   bool log_periodic_stats;
 

--- a/src/librbd/cache/pwl/Types.h
+++ b/src/librbd/cache/pwl/Types.h
@@ -299,6 +299,9 @@ struct WriteLogPoolRoot {
   uint32_t num_log_entries;
   uint32_t first_free_entry;     /* Entry following the newest valid entry */
   uint32_t first_valid_entry;    /* Index of the oldest valid entry in the log */
+  /* TODO: It's better to change memory-copy mode to encode/decode for RWL
+   *       Then char [] could be changed to string */
+  char id[37];                   /* id for this open request */
 
   #ifdef WITH_RBD_SSD_CACHE
   DENC(WriteLogPoolRoot, v, p) {


### PR DESCRIPTION
If multiple clients successively write to the same image and go down
halfway, and then the client that went down earlier starts to write
back the cache data, the data may have expired and may overwrite the
new data. For example, client A write cache and down, then client B
write cache and down. Client A up and write back the exist dirty cache
file to osd, may cause old data overwrite new data. Add instance id
to guarantee last open request is on this client.

https://tracker.ceph.com/issues/53373

Signed-off-by: Yin Congmin <congmin.yin@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
