### PR TITLE
test/cls/rgw: add index transaction simulator to model bucket stats

### DIFF
--- a/qa/suites/rgw/verify/tasks/cls.yaml
+++ b/qa/suites/rgw/verify/tasks/cls.yaml
@@ -6,6 +6,7 @@ tasks:
         - cls/test_cls_log.sh
         - cls/test_cls_refcount.sh
         - cls/test_cls_rgw.sh
+        - cls/test_cls_rgw_stats.sh
         - cls/test_cls_cmpomap.sh
         - cls/test_cls_2pc_queue.sh
         - rgw/test_rgw_gc_log.sh

--- a/qa/workunits/cls/test_cls_rgw_stats.sh
+++ b/qa/workunits/cls/test_cls_rgw_stats.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+ceph_test_cls_rgw_stats
+
+exit 0

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -263,9 +263,9 @@ void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
   o.exec(RGW_CLASS, RGW_BUCKET_UPDATE_STATS, in);
 }
 
-void cls_rgw_bucket_prepare_op(ObjectWriteOperation& o, RGWModifyOp op, string& tag,
+void cls_rgw_bucket_prepare_op(ObjectWriteOperation& o, RGWModifyOp op, const string& tag,
                                const cls_rgw_obj_key& key, const string& locator, bool log_op,
-                               uint16_t bilog_flags, rgw_zone_set& zones_trace)
+                               uint16_t bilog_flags, const rgw_zone_set& zones_trace)
 {
   rgw_cls_obj_prepare_op call;
   call.op = op;
@@ -280,13 +280,13 @@ void cls_rgw_bucket_prepare_op(ObjectWriteOperation& o, RGWModifyOp op, string& 
   o.exec(RGW_CLASS, RGW_BUCKET_PREPARE_OP, in);
 }
 
-void cls_rgw_bucket_complete_op(ObjectWriteOperation& o, RGWModifyOp op, string& tag,
-                                rgw_bucket_entry_ver& ver,
+void cls_rgw_bucket_complete_op(ObjectWriteOperation& o, RGWModifyOp op, const string& tag,
+                                const rgw_bucket_entry_ver& ver,
                                 const cls_rgw_obj_key& key,
-                                rgw_bucket_dir_entry_meta& dir_meta,
-				list<cls_rgw_obj_key> *remove_objs, bool log_op,
+                                const rgw_bucket_dir_entry_meta& dir_meta,
+				const list<cls_rgw_obj_key> *remove_objs, bool log_op,
                                 uint16_t bilog_flags,
-                                rgw_zone_set *zones_trace)
+                                const rgw_zone_set *zones_trace)
 {
 
   bufferlist in;
@@ -416,7 +416,7 @@ void cls_rgw_obj_check_mtime(librados::ObjectOperation& o, const real_time& mtim
 }
 
 int cls_rgw_bi_get(librados::IoCtx& io_ctx, const string oid,
-                   BIIndexType index_type, cls_rgw_obj_key& key,
+                   BIIndexType index_type, const cls_rgw_obj_key& key,
                    rgw_cls_bi_entry *entry)
 {
   bufferlist in, out;
@@ -441,7 +441,7 @@ int cls_rgw_bi_get(librados::IoCtx& io_ctx, const string oid,
   return 0;
 }
 
-int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string oid, rgw_cls_bi_entry& entry)
+int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string oid, const rgw_cls_bi_entry& entry)
 {
   bufferlist in, out;
   rgw_cls_bi_put_op call;
@@ -454,7 +454,7 @@ int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string oid, rgw_cls_bi_entry& 
   return 0;
 }
 
-void cls_rgw_bi_put(ObjectWriteOperation& op, const string oid, rgw_cls_bi_entry& entry)
+void cls_rgw_bi_put(ObjectWriteOperation& op, const string oid, const rgw_cls_bi_entry& entry)
 {
   bufferlist in, out;
   rgw_cls_bi_put_op call;
@@ -495,9 +495,9 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const std::string& oid,
 }
 
 int cls_rgw_bucket_link_olh(librados::IoCtx& io_ctx, const string& oid,
-                            const cls_rgw_obj_key& key, bufferlist& olh_tag,
-                            bool delete_marker, const string& op_tag, rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, rgw_zone_set& zones_trace)
+                            const cls_rgw_obj_key& key, const bufferlist& olh_tag,
+                            bool delete_marker, const string& op_tag, const rgw_bucket_dir_entry_meta *meta,
+                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace)
 {
   librados::ObjectWriteOperation op;
   cls_rgw_bucket_link_olh(op, key, olh_tag, delete_marker, op_tag, meta,
@@ -509,14 +509,14 @@ int cls_rgw_bucket_link_olh(librados::IoCtx& io_ctx, const string& oid,
 
 
 void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& key,
-                            bufferlist& olh_tag, bool delete_marker,
-                            const string& op_tag, rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, rgw_zone_set& zones_trace)
+                            const bufferlist& olh_tag, bool delete_marker,
+                            const string& op_tag, const rgw_bucket_dir_entry_meta *meta,
+                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace)
 {
   bufferlist in, out;
   rgw_cls_link_olh_op call;
   call.key = key;
-  call.olh_tag = string(olh_tag.c_str(), olh_tag.length());
+  call.olh_tag = olh_tag.to_str();
   call.op_tag = op_tag;
   call.delete_marker = delete_marker;
   if (meta) {
@@ -533,7 +533,7 @@ void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op, const cls_rgw_o
 
 int cls_rgw_bucket_unlink_instance(librados::IoCtx& io_ctx, const string& oid,
                                    const cls_rgw_obj_key& key, const string& op_tag,
-                                   const string& olh_tag, uint64_t olh_epoch, bool log_op, rgw_zone_set& zones_trace)
+                                   const string& olh_tag, uint64_t olh_epoch, bool log_op, const rgw_zone_set& zones_trace)
 {
   librados::ObjectWriteOperation op;
   cls_rgw_bucket_unlink_instance(op, key, op_tag, olh_tag, olh_epoch, log_op, zones_trace);
@@ -546,7 +546,7 @@ int cls_rgw_bucket_unlink_instance(librados::IoCtx& io_ctx, const string& oid,
 
 void cls_rgw_bucket_unlink_instance(librados::ObjectWriteOperation& op,
                                    const cls_rgw_obj_key& key, const string& op_tag,
-                                   const string& olh_tag, uint64_t olh_epoch, bool log_op, rgw_zone_set& zones_trace)
+                                   const string& olh_tag, uint64_t olh_epoch, bool log_op, const rgw_zone_set& zones_trace)
 {
   bufferlist in, out;
   rgw_cls_unlink_instance_op call;

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -344,16 +344,16 @@ void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
                                  bool absolute,
                                  const std::map<RGWObjCategory, rgw_bucket_category_stats>& stats);
 
-void cls_rgw_bucket_prepare_op(librados::ObjectWriteOperation& o, RGWModifyOp op, std::string& tag,
+void cls_rgw_bucket_prepare_op(librados::ObjectWriteOperation& o, RGWModifyOp op, const std::string& tag,
                                const cls_rgw_obj_key& key, const std::string& locator, bool log_op,
-                               uint16_t bilog_op, rgw_zone_set& zones_trace);
+                               uint16_t bilog_op, const rgw_zone_set& zones_trace);
 
-void cls_rgw_bucket_complete_op(librados::ObjectWriteOperation& o, RGWModifyOp op, std::string& tag,
-                                rgw_bucket_entry_ver& ver,
+void cls_rgw_bucket_complete_op(librados::ObjectWriteOperation& o, RGWModifyOp op, const std::string& tag,
+                                const rgw_bucket_entry_ver& ver,
                                 const cls_rgw_obj_key& key,
-                                rgw_bucket_dir_entry_meta& dir_meta,
-				std::list<cls_rgw_obj_key> *remove_objs, bool log_op,
-                                uint16_t bilog_op, rgw_zone_set *zones_trace);
+                                const rgw_bucket_dir_entry_meta& dir_meta,
+				const std::list<cls_rgw_obj_key> *remove_objs, bool log_op,
+                                uint16_t bilog_op, const rgw_zone_set *zones_trace);
 
 void cls_rgw_remove_obj(librados::ObjectWriteOperation& o, std::list<std::string>& keep_attr_prefixes);
 void cls_rgw_obj_store_pg_ver(librados::ObjectWriteOperation& o, const std::string& attr);
@@ -361,22 +361,22 @@ void cls_rgw_obj_check_attrs_prefix(librados::ObjectOperation& o, const std::str
 void cls_rgw_obj_check_mtime(librados::ObjectOperation& o, const ceph::real_time& mtime, bool high_precision_time, RGWCheckMTimeType type);
 
 int cls_rgw_bi_get(librados::IoCtx& io_ctx, const std::string oid,
-                   BIIndexType index_type, cls_rgw_obj_key& key,
+                   BIIndexType index_type, const cls_rgw_obj_key& key,
                    rgw_cls_bi_entry *entry);
-int cls_rgw_bi_put(librados::IoCtx& io_ctx, const std::string oid, rgw_cls_bi_entry& entry);
-void cls_rgw_bi_put(librados::ObjectWriteOperation& op, const std::string oid, rgw_cls_bi_entry& entry);
+int cls_rgw_bi_put(librados::IoCtx& io_ctx, const std::string oid, const rgw_cls_bi_entry& entry);
+void cls_rgw_bi_put(librados::ObjectWriteOperation& op, const std::string oid, const rgw_cls_bi_entry& entry);
 int cls_rgw_bi_list(librados::IoCtx& io_ctx, const std::string& oid,
                    const std::string& name, const std::string& marker, uint32_t max,
                    std::list<rgw_cls_bi_entry> *entries, bool *is_truncated);
 
 
 void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op,
-                            const cls_rgw_obj_key& key, ceph::buffer::list& olh_tag,
-                            bool delete_marker, const std::string& op_tag, rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, rgw_zone_set& zones_trace);
+                            const cls_rgw_obj_key& key, const ceph::buffer::list& olh_tag,
+                            bool delete_marker, const std::string& op_tag, const rgw_bucket_dir_entry_meta *meta,
+                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace);
 void cls_rgw_bucket_unlink_instance(librados::ObjectWriteOperation& op,
                                    const cls_rgw_obj_key& key, const std::string& op_tag,
-                                   const std::string& olh_tag, uint64_t olh_epoch, bool log_op, rgw_zone_set& zones_trace);
+                                   const std::string& olh_tag, uint64_t olh_epoch, bool log_op, const rgw_zone_set& zones_trace);
 void cls_rgw_get_olh_log(librados::ObjectReadOperation& op, const cls_rgw_obj_key& olh, uint64_t ver_marker, const std::string& olh_tag, rgw_cls_read_olh_log_ret& log_ret, int& op_ret);
 void cls_rgw_trim_olh_log(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, uint64_t ver, const std::string& olh_tag);
 void cls_rgw_clear_olh(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, const std::string& olh_tag);
@@ -385,12 +385,12 @@ void cls_rgw_clear_olh(librados::ObjectWriteOperation& op, const cls_rgw_obj_key
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
 #ifndef CLS_CLIENT_HIDE_IOCTX
 int cls_rgw_bucket_link_olh(librados::IoCtx& io_ctx, const std::string& oid,
-                            const cls_rgw_obj_key& key, ceph::buffer::list& olh_tag,
-                            bool delete_marker, const std::string& op_tag, rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, rgw_zone_set& zones_trace);
+                            const cls_rgw_obj_key& key, const ceph::buffer::list& olh_tag,
+                            bool delete_marker, const std::string& op_tag, const rgw_bucket_dir_entry_meta *meta,
+                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace);
 int cls_rgw_bucket_unlink_instance(librados::IoCtx& io_ctx, const std::string& oid,
                                    const cls_rgw_obj_key& key, const std::string& op_tag,
-                                   const std::string& olh_tag, uint64_t olh_epoch, bool log_op, rgw_zone_set& zones_trace);
+                                   const std::string& olh_tag, uint64_t olh_epoch, bool log_op, const rgw_zone_set& zones_trace);
 int cls_rgw_get_olh_log(librados::IoCtx& io_ctx, std::string& oid, const cls_rgw_obj_key& olh, uint64_t ver_marker,
                         const std::string& olh_tag, rgw_cls_read_olh_log_ret& log_ret);
 int cls_rgw_clear_olh(librados::IoCtx& io_ctx, std::string& oid, const cls_rgw_obj_key& olh, const std::string& olh_tag);

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -77,6 +77,45 @@ void decode_json_obj(rgw_zone_set& zs, JSONObj *obj)
   decode_json_obj(zs.entries, obj);
 }
 
+std::string_view to_string(RGWModifyOp op)
+{
+  switch (op) {
+    case CLS_RGW_OP_ADD: return "write";
+    case CLS_RGW_OP_DEL: return "del";
+    case CLS_RGW_OP_CANCEL: return "cancel";
+    case CLS_RGW_OP_LINK_OLH: return "link_olh";
+    case CLS_RGW_OP_LINK_OLH_DM: return "link_olh_del";
+    case CLS_RGW_OP_UNLINK_INSTANCE: return "unlink_instance";
+    case CLS_RGW_OP_SYNCSTOP: return "syncstop";
+    case CLS_RGW_OP_RESYNC: return "resync";
+    default:
+    case CLS_RGW_OP_UNKNOWN: return "unknown";
+  }
+}
+
+RGWModifyOp parse_modify_op(std::string_view name)
+{
+  if (name == "write") {
+    return CLS_RGW_OP_ADD;
+  } else if (name == "del") {
+    return CLS_RGW_OP_DEL;
+  } else if (name == "cancel") {
+    return CLS_RGW_OP_CANCEL;
+  } else if (name == "link_olh") {
+    return CLS_RGW_OP_LINK_OLH;
+  } else if (name == "link_olh_del") {
+    return CLS_RGW_OP_LINK_OLH_DM;
+  } else if (name == "unlink_instance") {
+    return CLS_RGW_OP_UNLINK_INSTANCE;
+  } else if (name == "syncstop") {
+    return CLS_RGW_OP_SYNCSTOP;
+  } else if (name == "resync") {
+    return CLS_RGW_OP_RESYNC;
+  } else {
+    return CLS_RGW_OP_UNKNOWN;
+  }
+}
+
 void rgw_bucket_pending_info::generate_test_instances(list<rgw_bucket_pending_info*>& o)
 {
   rgw_bucket_pending_info *i = new rgw_bucket_pending_info;
@@ -436,27 +475,7 @@ void rgw_bi_log_entry::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("op_tag", tag, obj);
   string op_str;
   JSONDecoder::decode_json("op", op_str, obj);
-  if (op_str == "write") {
-    op = CLS_RGW_OP_ADD;
-  } else if (op_str == "del") {
-    op = CLS_RGW_OP_DEL;
-  } else if (op_str == "cancel") {
-    op = CLS_RGW_OP_CANCEL;
-  } else if (op_str == "unknown") {
-    op = CLS_RGW_OP_UNKNOWN;
-  } else if (op_str == "link_olh") {
-    op = CLS_RGW_OP_LINK_OLH;
-  } else if (op_str == "link_olh_del") {
-    op = CLS_RGW_OP_LINK_OLH_DM;
-  } else if (op_str == "unlink_instance") {
-    op = CLS_RGW_OP_UNLINK_INSTANCE;
-  } else if (op_str == "syncstop") {
-    op = CLS_RGW_OP_SYNCSTOP;
-  } else if (op_str == "resync") {
-    op = CLS_RGW_OP_RESYNC;
-  } else {
-    op = CLS_RGW_OP_UNKNOWN;
-  }
+  op = parse_modify_op(op_str);
   JSONDecoder::decode_json("object", object, obj);
   JSONDecoder::decode_json("instance", instance, obj);
   string state_str;
@@ -485,39 +504,7 @@ void rgw_bi_log_entry::dump(Formatter *f) const
 {
   f->dump_string("op_id", id);
   f->dump_string("op_tag", tag);
-  switch (op) {
-    case CLS_RGW_OP_ADD:
-      f->dump_string("op", "write");
-      break;
-    case CLS_RGW_OP_DEL:
-      f->dump_string("op", "del");
-      break;
-    case CLS_RGW_OP_CANCEL:
-      f->dump_string("op", "cancel");
-      break;
-    case CLS_RGW_OP_UNKNOWN:
-      f->dump_string("op", "unknown");
-      break;
-    case CLS_RGW_OP_LINK_OLH:
-      f->dump_string("op", "link_olh");
-      break;
-    case CLS_RGW_OP_LINK_OLH_DM:
-      f->dump_string("op", "link_olh_del");
-      break;
-    case CLS_RGW_OP_UNLINK_INSTANCE:
-      f->dump_string("op", "unlink_instance");
-      break;
-    case CLS_RGW_OP_SYNCSTOP:
-      f->dump_string("op", "syncstop");
-      break;
-    case CLS_RGW_OP_RESYNC:
-      f->dump_string("op", "resync");
-      break;
-    default:
-      f->dump_string("op", "invalid");
-      break;
-  }
-
+  f->dump_string("op", to_string(op));
   f->dump_string("object", object);
   f->dump_string("instance", instance);
 

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -116,6 +116,18 @@ RGWModifyOp parse_modify_op(std::string_view name)
   }
 }
 
+std::string_view to_string(RGWObjCategory c)
+{
+  switch (c) {
+    case RGWObjCategory::None: return "rgw.none";
+    case RGWObjCategory::Main: return "rgw.main";
+    case RGWObjCategory::Shadow: return "rgw.shadow";
+    case RGWObjCategory::MultiMeta: return "rgw.multimeta";
+    case RGWObjCategory::CloudTiered: return "rgw.cloudtiered";
+    default: return "unknown";
+  }
+}
+
 void rgw_bucket_pending_info::generate_test_instances(list<rgw_bucket_pending_info*>& o)
 {
   rgw_bucket_pending_info *i = new rgw_bucket_pending_info;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -184,6 +184,11 @@ enum class RGWObjCategory : uint8_t {
   CloudTiered = 4, // b-i entries which are tiered to external cloud
 };
 
+std::string_view to_string(RGWObjCategory c);
+
+inline std::ostream& operator<<(std::ostream& out, RGWObjCategory c) {
+  return out << to_string(c);
+}
 
 struct rgw_bucket_dir_entry_meta {
   RGWObjCategory category;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <string>
 #include <boost/container/flat_map.hpp>
 #include "common/ceph_time.h"
 #include "common/Formatter.h"
@@ -95,6 +96,13 @@ enum RGWModifyOp {
   CLS_RGW_OP_SYNCSTOP        = 7,
   CLS_RGW_OP_RESYNC          = 8,
 };
+
+std::string_view to_string(RGWModifyOp op);
+RGWModifyOp parse_modify_op(std::string_view name);
+
+inline std::ostream& operator<<(std::ostream& out, RGWModifyOp op) {
+  return out << to_string(op);
+}
 
 enum RGWBILogFlags {
   RGW_BILOG_FLAG_VERSIONED_OP = 0x1,

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -807,8 +807,10 @@ struct cls_rgw_bucket_instance_entry {
 };
 WRITE_CLASS_ENCODER(cls_rgw_bucket_instance_entry)
 
+using rgw_bucket_dir_stats = std::map<RGWObjCategory, rgw_bucket_category_stats>;
+
 struct rgw_bucket_dir_header {
-  std::map<RGWObjCategory, rgw_bucket_category_stats> stats;
+  rgw_bucket_dir_stats stats;
   uint64_t tag_timeout;
   uint64_t ver;
   uint64_t master_ver;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -376,11 +376,6 @@ struct cls_rgw_obj_key {
     return !(k < *this);
   }
 
-  std::ostream& operator<<(std::ostream& out) const {
-    out << to_string();
-    return out;
-  }
-
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(name, bl);
@@ -407,6 +402,13 @@ struct cls_rgw_obj_key {
 };
 WRITE_CLASS_ENCODER(cls_rgw_obj_key)
 
+inline std::ostream& operator<<(std::ostream& out, const cls_rgw_obj_key& o) {
+  out << o.name;
+  if (!o.instance.empty()) {
+    out << '[' << o.instance << ']';
+  }
+  return out;
+}
 
 struct rgw_bucket_dir_entry {
   /* a versioned object instance */

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -377,6 +377,11 @@ struct cls_rgw_obj_key {
            (instance.compare(k.instance) == 0);
   }
 
+  bool operator!=(const cls_rgw_obj_key& k) const {
+    return (name.compare(k.name) != 0) ||
+           (instance.compare(k.instance) != 0);
+  }
+
   bool operator<(const cls_rgw_obj_key& k) const {
     int r = name.compare(k.name);
     if (r == 0) {
@@ -752,6 +757,18 @@ struct rgw_bucket_category_stats {
   static void generate_test_instances(std::list<rgw_bucket_category_stats*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_bucket_category_stats)
+
+inline bool operator==(const rgw_bucket_category_stats& lhs,
+                       const rgw_bucket_category_stats& rhs) {
+  return lhs.total_size == rhs.total_size
+      && lhs.total_size_rounded == rhs.total_size_rounded
+      && lhs.num_entries == rhs.num_entries
+      && lhs.actual_size == rhs.actual_size;
+}
+inline bool operator!=(const rgw_bucket_category_stats& lhs,
+                       const rgw_bucket_category_stats& rhs) {
+  return !(lhs == rhs);
+}
 
 enum class cls_rgw_reshard_status : uint8_t {
   NOT_RESHARDING  = 0,

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -462,8 +462,7 @@ static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, Forma
   formatter->open_object_section("usage");
   for (iter = stats.begin(); iter != stats.end(); ++iter) {
     RGWStorageStats& s = iter->second;
-    const char *cat_name = rgw_obj_category_name(iter->first);
-    formatter->open_object_section(cat_name);
+    formatter->open_object_section(to_string(iter->first));
     s.dump(formatter);
     formatter->close_section();
   }

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1492,14 +1492,6 @@ inline std::ostream& operator<<(std::ostream& out, const rgw_obj_key &o) {
   return out << o.to_str();
 }
 
-inline std::ostream& operator<<(std::ostream& out, const rgw_obj_index_key &o) {
-  if (o.instance.empty()) {
-    return out << o.name;
-  } else {
-    return out << o.name << "[" << o.instance << "]";
-  }
-}
-
 struct req_init_state {
   /* Keeps [[tenant]:]bucket until we parse the token. */
   std::string url_bucket;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1965,24 +1965,6 @@ static inline void append_rand_alpha(CephContext *cct, const std::string& src, s
   dest.append(buf);
 }
 
-static inline const char *rgw_obj_category_name(RGWObjCategory category)
-{
-  switch (category) {
-  case RGWObjCategory::None:
-    return "rgw.none";
-  case RGWObjCategory::Main:
-    return "rgw.main";
-  case RGWObjCategory::Shadow:
-    return "rgw.shadow";
-  case RGWObjCategory::MultiMeta:
-    return "rgw.multimeta";
-  case RGWObjCategory::CloudTiered:
-    return "rgw.cloudtiered";
-  }
-
-  return "unknown";
-}
-
 static inline uint64_t rgw_rounded_kb(uint64_t bytes)
 {
   return (bytes + 1023) / 1024;

--- a/src/test/cls_rgw/CMakeLists.txt
+++ b/src/test/cls_rgw/CMakeLists.txt
@@ -14,5 +14,11 @@ if(${WITH_RADOSGW})
   install(TARGETS
     ceph_test_cls_rgw
     DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+  add_executable(ceph_test_cls_rgw_stats test_cls_rgw_stats.cc
+	  $<TARGET_OBJECTS:unit-main>)
+  target_link_libraries(ceph_test_cls_rgw_stats cls_rgw_client global
+	  librados ${UNITTEST_LIBS} radostest-cxx)
+  install(TARGETS ceph_test_cls_rgw_stats DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif(${WITH_RADOSGW})
 

--- a/src/test/cls_rgw/test_cls_rgw_stats.cc
+++ b/src/test/cls_rgw/test_cls_rgw_stats.cc
@@ -1,0 +1,452 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <vector>
+#include <boost/circular_buffer.hpp>
+#include <boost/intrusive/set.hpp>
+#include <gtest/gtest.h>
+#include "cls/rgw/cls_rgw_client.h"
+#include "common/debug.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "common/random_string.h"
+#include "global/global_context.h"
+#include "test/librados/test_cxx.h"
+
+#define dout_subsys ceph_subsys_rgw
+#define dout_context g_ceph_context
+
+// create/destroy a pool that's shared by all tests in the process
+struct RadosEnv : public ::testing::Environment {
+  static std::optional<std::string> pool_name;
+ public:
+  static librados::Rados rados;
+  static librados::IoCtx ioctx;
+
+  void SetUp() override {
+    // create pool
+    std::string name = get_temp_pool_name();
+    ASSERT_EQ("", create_one_pool_pp(name, rados));
+    pool_name = name;
+    ASSERT_EQ(rados.ioctx_create(name.c_str(), ioctx), 0);
+  }
+  void TearDown() override {
+    ioctx.close();
+    if (pool_name) {
+      ASSERT_EQ(destroy_one_pool_pp(*pool_name, rados), 0);
+    }
+  }
+};
+std::optional<std::string> RadosEnv::pool_name;
+librados::Rados RadosEnv::rados;
+librados::IoCtx RadosEnv::ioctx;
+
+auto *const rados_env = ::testing::AddGlobalTestEnvironment(new RadosEnv);
+
+
+std::ostream& operator<<(std::ostream& out, const rgw_bucket_category_stats& c) {
+  return out << "{count=" << c.num_entries << " size=" << c.total_size << '}';
+}
+
+rgw_bucket_entry_ver last_version(librados::IoCtx& ioctx)
+{
+  rgw_bucket_entry_ver ver;
+  ver.pool = ioctx.get_id();
+  ver.epoch = ioctx.get_last_version();
+  return ver;
+}
+
+int index_init(librados::IoCtx& ioctx, const std::string& oid)
+{
+  librados::ObjectWriteOperation op;
+  cls_rgw_bucket_init_index(op);
+  return ioctx.operate(oid, &op);
+}
+
+int index_prepare(librados::IoCtx& ioctx, const std::string& oid,
+                  const cls_rgw_obj_key& key, const std::string& tag,
+                  RGWModifyOp type)
+{
+  librados::ObjectWriteOperation op;
+  const std::string loc; // empty
+  constexpr bool log_op = false;
+  constexpr int flags = 0;
+  rgw_zone_set zones;
+  cls_rgw_bucket_prepare_op(op, type, tag, key, loc, log_op, flags, zones);
+  return ioctx.operate(oid, &op);
+}
+
+int index_complete(librados::IoCtx& ioctx, const std::string& oid,
+                   const cls_rgw_obj_key& key, const std::string& tag,
+                   RGWModifyOp type, const rgw_bucket_entry_ver& ver,
+                   const rgw_bucket_dir_entry_meta& meta)
+{
+  librados::ObjectWriteOperation op;
+  constexpr std::list<cls_rgw_obj_key>* remove_objs = nullptr;
+  constexpr bool log_op = false;
+  constexpr int flags = 0;
+  constexpr rgw_zone_set* zones = nullptr;
+  cls_rgw_bucket_complete_op(op, type, tag, ver, key, meta,
+                             remove_objs, log_op, flags, zones);
+  return ioctx.operate(oid, &op);
+}
+
+void read_stats(librados::IoCtx& ioctx, const std::string& oid,
+                rgw_bucket_dir_stats& stats)
+{
+  auto oids = std::map<int, std::string>{{0, oid}};
+  std::map<int, rgw_cls_list_ret> results;
+  ASSERT_EQ(0, CLSRGWIssueGetDirHeader(ioctx, oids, results, 8)());
+  ASSERT_EQ(1, results.size());
+  stats = std::move(results.begin()->second.dir.header.stats);
+}
+
+static void account_entry(rgw_bucket_dir_stats& stats,
+                          const rgw_bucket_dir_entry_meta& meta)
+{
+  rgw_bucket_category_stats& c = stats[meta.category];
+  c.num_entries++;
+  c.total_size += meta.accounted_size;
+  c.total_size_rounded += cls_rgw_get_rounded_size(meta.accounted_size);
+  c.actual_size += meta.size;
+}
+
+static void unaccount_entry(rgw_bucket_dir_stats& stats,
+                            const rgw_bucket_dir_entry_meta& meta)
+{
+  rgw_bucket_category_stats& c = stats[meta.category];
+  c.num_entries--;
+  c.total_size -= meta.accounted_size;
+  c.total_size_rounded -= cls_rgw_get_rounded_size(meta.accounted_size);
+  c.actual_size -= meta.size;
+}
+
+
+struct object : rgw_bucket_dir_entry, boost::intrusive::set_base_hook<> {
+  explicit object(const cls_rgw_obj_key& key) {
+    this->key = key;
+  }
+};
+
+struct object_key {
+  using type = cls_rgw_obj_key;
+  const type& operator()(const object& o) const { return o.key; }
+};
+
+using object_map_base = boost::intrusive::set<object,
+      boost::intrusive::key_of_value<object_key>>;
+
+struct object_map : object_map_base {
+  ~object_map() {
+    clear_and_dispose(std::default_delete<object>{});
+  }
+};
+
+struct operation {
+  RGWModifyOp type;
+  cls_rgw_obj_key key;
+  std::string tag;
+  rgw_bucket_entry_ver ver;
+  rgw_bucket_dir_entry_meta meta;
+};
+
+struct config {
+  size_t max_operations = 0;
+  size_t max_entries = 0;
+  size_t max_pending = 0;
+  size_t max_object_size = 0;
+};
+
+class simulator {
+ public:
+  simulator(librados::IoCtx& ioctx,
+            std::string oid,
+            const config& cfg)
+      : ioctx(ioctx),
+        oid(std::move(oid)),
+        cfg(cfg),
+        pending(cfg.max_pending)
+  {
+    // generate a set of object keys. each operation chooses one at random
+    keys.reserve(cfg.max_entries);
+    for (size_t i = 0; i < cfg.max_entries; i++) {
+      keys.emplace_back(gen_rand_alphanumeric(g_ceph_context, 12));
+    }
+  }
+
+  void run();
+
+ private:
+  void step();
+  void start();
+  int try_start(const cls_rgw_obj_key& key,
+                const std::string& tag);
+  void finish(const operation& op);
+  void complete(const operation& op, RGWModifyOp type);
+  void suggest(const operation& op, char suggestion);
+
+  object_map::iterator find_or_create(const cls_rgw_obj_key& key);
+  void check_stats();
+
+  librados::IoCtx& ioctx;
+  std::string oid;
+  const config& cfg;
+
+  std::vector<cls_rgw_obj_key> keys;
+  object_map objects;
+  boost::circular_buffer<operation> pending;
+  rgw_bucket_dir_stats stats;
+};
+
+
+void simulator::run()
+{
+  // init the bucket index object
+  ASSERT_EQ(0, index_init(ioctx, oid));
+  // for the simulation for N steps
+  for (size_t i = 0; i < cfg.max_operations; i++) {
+    step();
+  }
+
+  // TODO: recalc stats and compare
+}
+
+void simulator::step()
+{
+  if (pending.full()) {
+    auto& op = pending.front();
+    finish(op);
+    pending.pop_front();
+    check_stats();
+  }
+  start();
+  check_stats();
+}
+
+object_map::iterator simulator::find_or_create(const cls_rgw_obj_key& key)
+{
+  object_map::insert_commit_data commit;
+  auto result = objects.insert_check(key, std::less<cls_rgw_obj_key>{}, commit);
+  if (result.second) { // inserting new entry
+    auto p = new object(key);
+    result.first = objects.insert_commit(*p, commit);
+  }
+  return result.first;
+}
+
+int simulator::try_start(const cls_rgw_obj_key& key, const std::string& tag)
+{
+  // choose randomly betwen create and delete
+  const auto type = static_cast<RGWModifyOp>(
+      ceph::util::generate_random_number<size_t, size_t>(CLS_RGW_OP_ADD,
+                                                         CLS_RGW_OP_DEL));
+  // prepare operation
+  int r = index_prepare(ioctx, oid, key, tag, type);
+  if (r != 0) {
+    derr << "> failed to prepare operation key=" << key
+        << " tag=" << tag << " type=" << type
+        << ": " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  // on success, initialize the pending operation
+  auto op = operation{type, key, tag, last_version(ioctx)};
+
+  op.meta.category = static_cast<RGWObjCategory>(
+      ceph::util::generate_random_number(0, 1));
+  op.meta.size = op.meta.accounted_size =
+      ceph::util::generate_random_number(1, cfg.max_object_size);
+
+  dout(1) << "> prepared operation key=" << key
+      << " tag=" << tag << " type=" << type
+      << " cat=" << op.meta.category
+      << " size=" << op.meta.size << dendl;
+  ceph_assert(!pending.full());
+  pending.push_back(std::move(op));
+
+  find_or_create(key);
+  return 0;
+}
+
+void simulator::start()
+{
+  // choose a random object key
+  const size_t index = ceph::util::generate_random_number(0, keys.size() - 1);
+  const auto& key = keys[index];
+  // generate a random tag
+  const auto tag = gen_rand_alphanumeric(g_ceph_context, 12);
+
+  // retry until success
+  while (try_start(key, tag) != 0)
+    ;
+}
+
+void simulator::finish(const operation& op)
+{
+  // complete most operations, but finish some with cancel or dir suggest
+  constexpr int cancel_percent = 10;
+  constexpr int suggest_update_percent = 10;
+  constexpr int suggest_remove_percent = 10;
+
+  int result = ceph::util::generate_random_number(0, 99);
+  if (result < cancel_percent) {
+    complete(op, CLS_RGW_OP_CANCEL);
+    return;
+  }
+  result -= cancel_percent;
+  if (result < suggest_update_percent) {
+    suggest(op, CEPH_RGW_UPDATE);
+    return;
+  }
+  result -= suggest_update_percent;
+  if (result < suggest_remove_percent) {
+    suggest(op, CEPH_RGW_REMOVE);
+    return;
+  }
+  complete(op, op.type);
+}
+
+void simulator::complete(const operation& op, RGWModifyOp type)
+{
+  int r = index_complete(ioctx, oid, op.key, op.tag, type, op.ver, op.meta);
+  if (r != 0) {
+    derr << "< failed to complete operation key=" << op.key
+        << " tag=" << op.tag << " type=" << op.type
+        << " cat=" << op.meta.category
+        << " size=" << op.meta.size
+        << ": " << cpp_strerror(r) << dendl;
+    return;
+  }
+
+  if (type == CLS_RGW_OP_CANCEL) {
+    dout(1) << "< canceled operation key=" << op.key
+        << " tag=" << op.tag << " type=" << op.type
+        << " cat=" << op.meta.category
+        << " size=" << op.meta.size << dendl;
+  } else if (type == CLS_RGW_OP_ADD) {
+    auto obj = find_or_create(op.key);
+    if (obj->exists) {
+      unaccount_entry(stats, obj->meta);
+    }
+    obj->exists = true;
+    obj->meta = op.meta;
+    account_entry(stats, obj->meta);
+    dout(1) << "< completed write operation key=" << op.key
+        << " tag=" << op.tag << " type=" << type
+        << " cat=" << op.meta.category
+        << " size=" << op.meta.size << dendl;
+  } else {
+    ceph_assert(type == CLS_RGW_OP_DEL);
+    auto obj = objects.find(op.key, std::less<cls_rgw_obj_key>{});
+    if (obj != objects.end()) {
+      if (obj->exists) {
+        unaccount_entry(stats, obj->meta);
+      }
+      objects.erase_and_dispose(obj, std::default_delete<object>{});
+    }
+    dout(1) << "< completed delete operation key=" << op.key
+        << " tag=" << op.tag << " type=" << type
+        << " cat=" << op.meta.category << dendl;
+  }
+}
+
+void simulator::suggest(const operation& op, char suggestion)
+{
+  // read and decode the current dir entry
+  rgw_cls_bi_entry bi_entry;
+  int r = cls_rgw_bi_get(ioctx, oid, BIIndexType::Plain, op.key, &bi_entry);
+  if (r != 0) {
+    derr << "< no bi entry to suggest for operation key=" << op.key
+        << " tag=" << op.tag << " type=" << op.type
+        << " cat=" << op.meta.category
+        << " size=" << op.meta.size
+        << ": " << cpp_strerror(r) << dendl;
+    return;
+  }
+  ASSERT_EQ(bi_entry.type, BIIndexType::Plain);
+
+  rgw_bucket_dir_entry entry;
+  auto p = bi_entry.data.cbegin();
+  ASSERT_NO_THROW(decode(entry, p));
+
+  ASSERT_EQ(entry.key, op.key);
+
+  // clear pending info and write it back; this cancels those pending
+  // operations (we'll see EINVAL when we try to complete them), but dir
+  // suggest is ignored unless the pending_map is empty
+  entry.pending_map.clear();
+
+  bi_entry.data.clear();
+  encode(entry, bi_entry.data);
+
+  r = cls_rgw_bi_put(ioctx, oid, bi_entry);
+  ASSERT_EQ(0, r);
+
+  // now suggest changes for this entry
+  entry.ver = last_version(ioctx);
+  entry.exists = (suggestion == CEPH_RGW_UPDATE);
+  entry.meta = op.meta;
+
+  bufferlist update;
+  cls_rgw_encode_suggestion(suggestion, entry, update);
+
+  librados::ObjectWriteOperation write_op;
+  cls_rgw_suggest_changes(write_op, update);
+  r = ioctx.operate(oid, &write_op);
+  if (r != 0) {
+    derr << "< failed to suggest operation key=" << op.key
+        << " tag=" << op.tag << " type=" << op.type
+        << " cat=" << op.meta.category
+        << " size=" << op.meta.size
+        << ": " << cpp_strerror(r) << dendl;
+    return;
+  }
+
+  // update our cache accordingly
+  if (suggestion == CEPH_RGW_UPDATE) {
+    auto obj = find_or_create(op.key);
+    if (obj->exists) {
+      unaccount_entry(stats, obj->meta);
+    }
+    obj->exists = true;
+    obj->meta = op.meta;
+    account_entry(stats, obj->meta);
+    dout(1) << "< suggested update operation key=" << op.key
+        << " tag=" << op.tag << " type=" << op.type
+        << " cat=" << op.meta.category
+        << " size=" << op.meta.size << dendl;
+  } else {
+    ceph_assert(suggestion == CEPH_RGW_REMOVE);
+    auto obj = objects.find(op.key, std::less<cls_rgw_obj_key>{});
+    if (obj != objects.end()) {
+      if (obj->exists) {
+        unaccount_entry(stats, obj->meta);
+      }
+      objects.erase_and_dispose(obj, std::default_delete<object>{});
+    }
+    dout(1) << "< suggested remove operation key=" << op.key
+        << " tag=" << op.tag << " type=" << op.type
+        << " cat=" << op.meta.category << dendl;
+  }
+}
+
+void simulator::check_stats()
+{
+  rgw_bucket_dir_stats stored_stats;
+  read_stats(ioctx, oid, stored_stats);
+
+  const rgw_bucket_dir_stats& expected_stats = stats;
+  ASSERT_EQ(expected_stats, stored_stats);
+}
+
+TEST(cls_rgw_stats, simulate)
+{
+  const char* bucket_oid = __func__;
+  config cfg;
+  cfg.max_operations = 2048;
+  cfg.max_entries = 64;
+  cfg.max_pending = 16;
+  cfg.max_object_size = 4*1024*1024; // 4M
+  auto sim = simulator{RadosEnv::ioctx, bucket_oid, cfg};
+  sim.run();
+}

--- a/src/test/cls_rgw/test_cls_rgw_stats.cc
+++ b/src/test/cls_rgw/test_cls_rgw_stats.cc
@@ -16,6 +16,22 @@
 #define dout_subsys ceph_subsys_rgw
 #define dout_context g_ceph_context
 
+
+// simulation parameters:
+
+// total number of index operations to prepare
+constexpr size_t max_operations = 2048;
+// total number of object names. each operation chooses one at random
+constexpr size_t max_entries = 32;
+// maximum number of pending operations. once the limit is reached, the oldest
+// pending operation is finished before another can start
+constexpr size_t max_pending = 16;
+// object size is randomly distributed between 0 and 4M
+constexpr size_t max_object_size = 4*1024*1024;
+// multipart upload threshold
+constexpr size_t max_part_size = 1024*1024;
+
+
 // create/destroy a pool that's shared by all tests in the process
 struct RadosEnv : public ::testing::Environment {
   static std::optional<std::string> pool_name;
@@ -48,6 +64,8 @@ std::ostream& operator<<(std::ostream& out, const rgw_bucket_category_stats& c) 
   return out << "{count=" << c.num_entries << " size=" << c.total_size << '}';
 }
 
+
+// librados helpers
 rgw_bucket_entry_ver last_version(librados::IoCtx& ioctx)
 {
   rgw_bucket_entry_ver ver;
@@ -79,10 +97,10 @@ int index_prepare(librados::IoCtx& ioctx, const std::string& oid,
 int index_complete(librados::IoCtx& ioctx, const std::string& oid,
                    const cls_rgw_obj_key& key, const std::string& tag,
                    RGWModifyOp type, const rgw_bucket_entry_ver& ver,
-                   const rgw_bucket_dir_entry_meta& meta)
+                   const rgw_bucket_dir_entry_meta& meta,
+                   std::list<cls_rgw_obj_key>* remove_objs)
 {
   librados::ObjectWriteOperation op;
-  constexpr std::list<cls_rgw_obj_key>* remove_objs = nullptr;
   constexpr bool log_op = false;
   constexpr int flags = 0;
   constexpr rgw_zone_set* zones = nullptr;
@@ -122,6 +140,7 @@ static void unaccount_entry(rgw_bucket_dir_stats& stats,
 }
 
 
+// a map of cached dir entries representing the expected state of cls_rgw
 struct object : rgw_bucket_dir_entry, boost::intrusive::set_base_hook<> {
   explicit object(const cls_rgw_obj_key& key) {
     this->key = key;
@@ -142,55 +161,51 @@ struct object_map : object_map_base {
   }
 };
 
+
+// models a bucket index operation, starting with cls_rgw_bucket_prepare_op().
+// stores all of the state necessary to complete the operation, either with
+// cls_rgw_bucket_complete_op() or cls_rgw_suggest_changes(). uploads larger
+// than max_part_size are modeled as multipart uploads
 struct operation {
   RGWModifyOp type;
   cls_rgw_obj_key key;
   std::string tag;
   rgw_bucket_entry_ver ver;
+  std::string upload_id; // empty unless multipart
   rgw_bucket_dir_entry_meta meta;
 };
 
-struct config {
-  size_t max_operations = 0;
-  size_t max_entries = 0;
-  size_t max_pending = 0;
-  size_t max_object_size = 0;
-};
 
 class simulator {
  public:
-  simulator(librados::IoCtx& ioctx,
-            std::string oid,
-            const config& cfg)
-      : ioctx(ioctx),
-        oid(std::move(oid)),
-        cfg(cfg),
-        pending(cfg.max_pending)
+  simulator(librados::IoCtx& ioctx, std::string oid)
+      : ioctx(ioctx), oid(std::move(oid)), pending(max_pending)
   {
     // generate a set of object keys. each operation chooses one at random
-    keys.reserve(cfg.max_entries);
-    for (size_t i = 0; i < cfg.max_entries; i++) {
-      keys.emplace_back(gen_rand_alphanumeric(g_ceph_context, 12));
+    keys.reserve(max_entries);
+    for (size_t i = 0; i < max_entries; i++) {
+      keys.emplace_back(gen_rand_alphanumeric_upper(g_ceph_context, 12));
     }
   }
 
   void run();
 
  private:
-  void step();
   void start();
   int try_start(const cls_rgw_obj_key& key,
                 const std::string& tag);
+
   void finish(const operation& op);
   void complete(const operation& op, RGWModifyOp type);
   void suggest(const operation& op, char suggestion);
 
+  int init_multipart(const operation& op);
+  void complete_multipart(const operation& op);
+
   object_map::iterator find_or_create(const cls_rgw_obj_key& key);
-  void check_stats();
 
   librados::IoCtx& ioctx;
   std::string oid;
-  const config& cfg;
 
   std::vector<cls_rgw_obj_key> keys;
   object_map objects;
@@ -203,24 +218,32 @@ void simulator::run()
 {
   // init the bucket index object
   ASSERT_EQ(0, index_init(ioctx, oid));
-  // for the simulation for N steps
-  for (size_t i = 0; i < cfg.max_operations; i++) {
-    step();
-  }
+  // run the simulation for N steps
+  for (size_t i = 0; i < max_operations; i++) {
+    if (pending.full()) {
+      // if we're at max_pending, finish the oldest operation
+      auto& op = pending.front();
+      finish(op);
+      pending.pop_front();
 
-  // TODO: recalc stats and compare
-}
+      // verify bucket stats
+      rgw_bucket_dir_stats stored_stats;
+      read_stats(ioctx, oid, stored_stats);
 
-void simulator::step()
-{
-  if (pending.full()) {
-    auto& op = pending.front();
-    finish(op);
-    pending.pop_front();
-    check_stats();
+      const rgw_bucket_dir_stats& expected_stats = stats;
+      ASSERT_EQ(expected_stats, stored_stats);
+    }
+
+    // initiate the next operation
+    start();
+
+    // verify bucket stats
+    rgw_bucket_dir_stats stored_stats;
+    read_stats(ioctx, oid, stored_stats);
+
+    const rgw_bucket_dir_stats& expected_stats = stats;
+    ASSERT_EQ(expected_stats, stored_stats);
   }
-  start();
-  check_stats();
 }
 
 object_map::iterator simulator::find_or_create(const cls_rgw_obj_key& key)
@@ -240,31 +263,45 @@ int simulator::try_start(const cls_rgw_obj_key& key, const std::string& tag)
   const auto type = static_cast<RGWModifyOp>(
       ceph::util::generate_random_number<size_t, size_t>(CLS_RGW_OP_ADD,
                                                          CLS_RGW_OP_DEL));
-  // prepare operation
-  int r = index_prepare(ioctx, oid, key, tag, type);
-  if (r != 0) {
-    derr << "> failed to prepare operation key=" << key
-        << " tag=" << tag << " type=" << type
-        << ": " << cpp_strerror(r) << dendl;
-    return r;
-  }
+  auto op = operation{type, key, tag};
 
-  // on success, initialize the pending operation
-  auto op = operation{type, key, tag, last_version(ioctx)};
-
-  op.meta.category = static_cast<RGWObjCategory>(
-      ceph::util::generate_random_number(0, 1));
+  op.meta.category = RGWObjCategory::Main;
   op.meta.size = op.meta.accounted_size =
-      ceph::util::generate_random_number(1, cfg.max_object_size);
+      ceph::util::generate_random_number(1, max_object_size);
 
-  dout(1) << "> prepared operation key=" << key
-      << " tag=" << tag << " type=" << type
-      << " cat=" << op.meta.category
-      << " size=" << op.meta.size << dendl;
+  if (type == CLS_RGW_OP_ADD && op.meta.size > max_part_size) {
+    // simulate multipart for uploads over the max_part_size threshold
+    op.upload_id = gen_rand_alphanumeric_upper(g_ceph_context, 12);
+
+    int r = init_multipart(op);
+    if (r != 0) {
+      derr << "> failed to prepare multipart upload key=" << key
+          << " upload=" << op.upload_id << " tag=" << tag
+          << " type=" << type << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+
+    dout(1) << "> prepared multipart upload key=" << key
+        << " upload=" << op.upload_id << " tag=" << tag
+        << " type=" << type << " size=" << op.meta.size << dendl;
+  } else {
+    // prepare operation
+    int r = index_prepare(ioctx, oid, op.key, op.tag, op.type);
+    if (r != 0) {
+      derr << "> failed to prepare operation key=" << key
+          << " tag=" << tag << " type=" << type
+          << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+
+    dout(1) << "> prepared operation key=" << key
+        << " tag=" << tag << " type=" << type
+        << " size=" << op.meta.size << dendl;
+  }
+  op.ver = last_version(ioctx);
+
   ceph_assert(!pending.full());
   pending.push_back(std::move(op));
-
-  find_or_create(key);
   return 0;
 }
 
@@ -274,15 +311,21 @@ void simulator::start()
   const size_t index = ceph::util::generate_random_number(0, keys.size() - 1);
   const auto& key = keys[index];
   // generate a random tag
-  const auto tag = gen_rand_alphanumeric(g_ceph_context, 12);
+  const auto tag = gen_rand_alphanumeric_upper(g_ceph_context, 12);
 
-  // retry until success
+  // retry until success. failures don't count towards max_operations
   while (try_start(key, tag) != 0)
     ;
 }
 
 void simulator::finish(const operation& op)
 {
+  if (op.type == CLS_RGW_OP_ADD && !op.upload_id.empty()) {
+    // multipart uploads either complete or abort based on part uploads
+    complete_multipart(op);
+    return;
+  }
+
   // complete most operations, but finish some with cancel or dir suggest
   constexpr int cancel_percent = 10;
   constexpr int suggest_update_percent = 10;
@@ -308,11 +351,11 @@ void simulator::finish(const operation& op)
 
 void simulator::complete(const operation& op, RGWModifyOp type)
 {
-  int r = index_complete(ioctx, oid, op.key, op.tag, type, op.ver, op.meta);
+  int r = index_complete(ioctx, oid, op.key, op.tag, type,
+                         op.ver, op.meta, nullptr);
   if (r != 0) {
     derr << "< failed to complete operation key=" << op.key
         << " tag=" << op.tag << " type=" << op.type
-        << " cat=" << op.meta.category
         << " size=" << op.meta.size
         << ": " << cpp_strerror(r) << dendl;
     return;
@@ -321,7 +364,6 @@ void simulator::complete(const operation& op, RGWModifyOp type)
   if (type == CLS_RGW_OP_CANCEL) {
     dout(1) << "< canceled operation key=" << op.key
         << " tag=" << op.tag << " type=" << op.type
-        << " cat=" << op.meta.category
         << " size=" << op.meta.size << dendl;
   } else if (type == CLS_RGW_OP_ADD) {
     auto obj = find_or_create(op.key);
@@ -333,7 +375,6 @@ void simulator::complete(const operation& op, RGWModifyOp type)
     account_entry(stats, obj->meta);
     dout(1) << "< completed write operation key=" << op.key
         << " tag=" << op.tag << " type=" << type
-        << " cat=" << op.meta.category
         << " size=" << op.meta.size << dendl;
   } else {
     ceph_assert(type == CLS_RGW_OP_DEL);
@@ -345,8 +386,7 @@ void simulator::complete(const operation& op, RGWModifyOp type)
       objects.erase_and_dispose(obj, std::default_delete<object>{});
     }
     dout(1) << "< completed delete operation key=" << op.key
-        << " tag=" << op.tag << " type=" << type
-        << " cat=" << op.meta.category << dendl;
+        << " tag=" << op.tag << " type=" << type << dendl;
   }
 }
 
@@ -358,7 +398,6 @@ void simulator::suggest(const operation& op, char suggestion)
   if (r != 0) {
     derr << "< no bi entry to suggest for operation key=" << op.key
         << " tag=" << op.tag << " type=" << op.type
-        << " cat=" << op.meta.category
         << " size=" << op.meta.size
         << ": " << cpp_strerror(r) << dendl;
     return;
@@ -396,7 +435,6 @@ void simulator::suggest(const operation& op, char suggestion)
   if (r != 0) {
     derr << "< failed to suggest operation key=" << op.key
         << " tag=" << op.tag << " type=" << op.type
-        << " cat=" << op.meta.category
         << " size=" << op.meta.size
         << ": " << cpp_strerror(r) << dendl;
     return;
@@ -413,7 +451,6 @@ void simulator::suggest(const operation& op, char suggestion)
     account_entry(stats, obj->meta);
     dout(1) << "< suggested update operation key=" << op.key
         << " tag=" << op.tag << " type=" << op.type
-        << " cat=" << op.meta.category
         << " size=" << op.meta.size << dendl;
   } else {
     ceph_assert(suggestion == CEPH_RGW_REMOVE);
@@ -425,28 +462,185 @@ void simulator::suggest(const operation& op, char suggestion)
       objects.erase_and_dispose(obj, std::default_delete<object>{});
     }
     dout(1) << "< suggested remove operation key=" << op.key
-        << " tag=" << op.tag << " type=" << op.type
-        << " cat=" << op.meta.category << dendl;
+        << " tag=" << op.tag << " type=" << op.type << dendl;
   }
 }
 
-void simulator::check_stats()
+int simulator::init_multipart(const operation& op)
 {
-  rgw_bucket_dir_stats stored_stats;
-  read_stats(ioctx, oid, stored_stats);
+  // create (not just prepare) the meta object
+  const auto meta_key = cls_rgw_obj_key{
+    fmt::format("_multipart_{}.2~{}.meta", op.key.name, op.upload_id)};
+  const std::string empty_tag; // empty tag enables complete without prepare
+  const rgw_bucket_entry_ver empty_ver;
+  rgw_bucket_dir_entry_meta meta_meta;
+  meta_meta.category = RGWObjCategory::MultiMeta;
+  int r = index_complete(ioctx, oid, meta_key, empty_tag, CLS_RGW_OP_ADD,
+                         empty_ver, meta_meta, nullptr);
+  if (r != 0) {
+    derr << "  < failed to create multipart meta key=" << meta_key
+        << ": " << cpp_strerror(r) << dendl;
+    return r;
+  } else {
+    // account for meta object
+    auto obj = find_or_create(meta_key);
+    if (obj->exists) {
+      unaccount_entry(stats, obj->meta);
+    }
+    obj->exists = true;
+    obj->meta = meta_meta;
+    account_entry(stats, obj->meta);
+  }
 
-  const rgw_bucket_dir_stats& expected_stats = stats;
-  ASSERT_EQ(expected_stats, stored_stats);
+  // prepare part uploads
+  std::list<cls_rgw_obj_key> remove_objs;
+  size_t part_id = 0;
+
+  size_t remaining = op.meta.size;
+  while (remaining > max_part_size) {
+    remaining -= max_part_size;
+    const auto part_size = std::min(remaining, max_part_size);
+    const auto part_key = cls_rgw_obj_key{
+      fmt::format("_multipart_{}.2~{}.{}", op.key.name, op.upload_id, part_id)};
+    part_id++;
+
+    r = index_prepare(ioctx, oid, part_key, op.tag, op.type);
+    if (r != 0) {
+      // if part prepare fails, remove the meta object and remove_objs
+      [[maybe_unused]] int ignored =
+          index_complete(ioctx, oid, meta_key, empty_tag, CLS_RGW_OP_DEL,
+                         empty_ver, meta_meta, &remove_objs);
+      derr << "  > failed to prepare part key=" << part_key
+          << " size=" << part_size << dendl;
+      return r; // return the error from prepare
+    }
+    dout(1) << "  > prepared part key=" << part_key
+        << " size=" << part_size << dendl;
+    remove_objs.push_back(part_key);
+  }
+  return 0;
+}
+
+void simulator::complete_multipart(const operation& op)
+{
+  const std::string empty_tag; // empty tag enables complete without prepare
+  const rgw_bucket_entry_ver empty_ver;
+
+  // try to finish part uploads
+  size_t part_id = 0;
+  std::list<cls_rgw_obj_key> remove_objs;
+
+  RGWModifyOp type = op.type; // OP_ADD, or OP_CANCEL for abort
+
+  size_t remaining = op.meta.size;
+  while (remaining > max_part_size) {
+    remaining -= max_part_size;
+    const auto part_size = std::min(remaining, max_part_size);
+    const auto part_key = cls_rgw_obj_key{
+      fmt::format("_multipart_{}.2~{}.{}", op.key.name, op.upload_id, part_id)};
+    part_id++;
+
+    // cancel 10% of part uploads (and abort the multipart upload)
+    constexpr int cancel_percent = 10;
+    const int result = ceph::util::generate_random_number(0, 99);
+    if (result < cancel_percent) {
+      type = CLS_RGW_OP_CANCEL; // abort multipart
+      dout(1) << "  < canceled part key=" << part_key
+          << " size=" << part_size << dendl;
+    } else {
+      rgw_bucket_dir_entry_meta meta;
+      meta.category = op.meta.category;
+      meta.size = meta.accounted_size = part_size;
+
+      int r = index_complete(ioctx, oid, part_key, op.tag, op.type,
+                             empty_ver, meta, nullptr);
+      if (r != 0) {
+        derr << "  < failed to complete part key=" << part_key
+            << " size=" << meta.size << ": " << cpp_strerror(r) << dendl;
+        type = CLS_RGW_OP_CANCEL; // abort multipart
+      } else {
+        dout(1) << "  < completed part key=" << part_key
+            << " size=" << meta.size << dendl;
+        // account for successful part upload
+        auto obj = find_or_create(part_key);
+        if (obj->exists) {
+          unaccount_entry(stats, obj->meta);
+        }
+        obj->exists = true;
+        obj->meta = meta;
+        account_entry(stats, obj->meta);
+      }
+    }
+    remove_objs.push_back(part_key);
+  }
+
+  // delete the multipart meta object
+  const auto meta_key = cls_rgw_obj_key{
+    fmt::format("_multipart_{}.2~{}.meta", op.key.name, op.upload_id)};
+  rgw_bucket_dir_entry_meta meta_meta;
+  meta_meta.category = RGWObjCategory::MultiMeta;
+
+  int r = index_complete(ioctx, oid, meta_key, empty_tag, CLS_RGW_OP_DEL,
+                         empty_ver, meta_meta, nullptr);
+  if (r != 0) {
+    derr << "  < failed to remove multipart meta key=" << meta_key
+        << ": " << cpp_strerror(r) << dendl;
+  } else {
+    // unaccount for meta object
+    auto obj = objects.find(meta_key, std::less<cls_rgw_obj_key>{});
+    if (obj != objects.end()) {
+      if (obj->exists) {
+        unaccount_entry(stats, obj->meta);
+      }
+      objects.erase_and_dispose(obj, std::default_delete<object>{});
+    }
+  }
+
+  // create or cancel the head object
+  r = index_complete(ioctx, oid, op.key, empty_tag, type,
+                     empty_ver, op.meta, &remove_objs);
+  if (r != 0) {
+    derr << "< failed to complete multipart upload key=" << op.key
+        << " upload=" << op.upload_id << " tag=" << op.tag
+        << " type=" << type << " size=" << op.meta.size
+        << ": " << cpp_strerror(r) << dendl;
+    return;
+  }
+
+  if (type == CLS_RGW_OP_ADD) {
+    dout(1) << "< completed multipart upload key=" << op.key
+        << " upload=" << op.upload_id << " tag=" << op.tag
+        << " type=" << op.type << " size=" << op.meta.size << dendl;
+
+    // account for head stats
+    auto obj = find_or_create(op.key);
+    if (obj->exists) {
+      unaccount_entry(stats, obj->meta);
+    }
+    obj->exists = true;
+    obj->meta = op.meta;
+    account_entry(stats, obj->meta);
+  } else {
+    dout(1) << "< canceled multipart upload key=" << op.key
+        << " upload=" << op.upload_id << " tag=" << op.tag
+        << " type=" << op.type << " size=" << op.meta.size << dendl;
+  }
+
+  // unaccount for remove_objs
+  for (const auto& part_key : remove_objs) {
+    auto obj = objects.find(part_key, std::less<cls_rgw_obj_key>{});
+    if (obj != objects.end()) {
+      if (obj->exists) {
+        unaccount_entry(stats, obj->meta);
+      }
+      objects.erase_and_dispose(obj, std::default_delete<object>{});
+    }
+  }
 }
 
 TEST(cls_rgw_stats, simulate)
 {
   const char* bucket_oid = __func__;
-  config cfg;
-  cfg.max_operations = 2048;
-  cfg.max_entries = 64;
-  cfg.max_pending = 16;
-  cfg.max_object_size = 4*1024*1024; // 4M
-  auto sim = simulator{RadosEnv::ioctx, bucket_oid, cfg};
+  auto sim = simulator{RadosEnv::ioctx, bucket_oid};
   sim.run();
 }


### PR DESCRIPTION
# ceph_test_cls_rgw_stats

a simulator that generates lots of create/delete operations against a set of object names, and tracks the expected bucket stats for comparison

each operation has a 70% chance to complete successfully, a 10% chance to cancel, 10% chance to suggest update, and 10% chance to suggest removal

TODO:
- [x] simulate multipart uploads (covers the `remove_objs` case of `cls_rgw_bucket_complete_op`)

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
