### PR TITLE
mgr/dashboard: include mfa_ids in rgw user-details section

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.html
@@ -68,6 +68,11 @@
                   </div>
                 </td>
               </tr>
+              <tr *ngIf="user.mfa_ids?.length">
+                <td i18n
+                    class="bold">MFAs(Id)</td>
+                <td>{{ user.mfa_ids | join}}</td>
+              </tr>
             </tbody>
           </table>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.spec.ts
@@ -71,4 +71,24 @@ describe('RgwUserDetailsComponent', () => {
 
     expect(detailsTab[11].textContent).toEqual('No');
   });
+
+  it('should show mfa ids only if length > 0', () => {
+    component.selection = {
+      uid: 'dashboard',
+      email: '',
+      system: 'true',
+      keys: [],
+      swift_keys: [],
+      mfa_ids: ['testMFA1', 'testMFA2']
+    };
+
+    component.ngOnChanges();
+    fixture.detectChanges();
+
+    const detailsTab = fixture.debugElement.nativeElement.querySelectorAll(
+      '.table.table-striped.table-bordered tr td'
+    );
+    expect(detailsTab[14].textContent).toEqual('MFAs(Id)');
+    expect(detailsTab[15].textContent).toEqual('testMFA1, testMFA2');
+  });
 });


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/53193
Signed-off-by: Avan Thakkar <athakkar@redhat.com>

Introducing mfa_ids in user details section.
![Screenshot from 2021-11-09 21-53-59](https://user-images.githubusercontent.com/23611106/140963645-8ca2dc73-2fa8-40a2-81b2-b56e8642c200.png)



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
