### PR TITLE
blk, os/bluestore: introduce huge page-based read buffers

### DIFF
--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -73,6 +73,10 @@ std::ostream& operator<<(std::ostream& os, const blk_access_mode_t buffered);
 
 /// track in-flight io
 struct IOContext {
+  enum {
+    FLAG_DONT_CACHE = 1
+  };
+
 private:
   ceph::mutex lock = ceph::make_mutex("IOContext::lock");
   ceph::condition_variable cond;
@@ -94,6 +98,7 @@ public:
   std::atomic_int num_pending = {0};
   std::atomic_int num_running = {0};
   bool allow_eio;
+  uint32_t flags = 0;               // FLAG_*
 
   explicit IOContext(CephContext* cct, void *p, bool allow_eio = false)
     : cct(cct), priv(p), allow_eio(allow_eio)
@@ -130,6 +135,10 @@ public:
 
   int get_return_value() const {
     return r;
+  }
+
+  bool skip_cache() const {
+    return flags & FLAG_DONT_CACHE;
   }
 };
 

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -295,6 +295,8 @@ public:
   virtual int open(const std::string& path) = 0;
   virtual void close() = 0;
 
+  struct hugepaged_raw_marker_t {};
+
 protected:
   bool is_valid_io(uint64_t off, uint64_t len) const;
 };

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -20,7 +20,10 @@
 #include <fcntl.h>
 #include <sys/file.h>
 
+#include <boost/lockfree/queue.hpp>
+
 #include "KernelDevice.h"
+#include "include/buffer_raw.h"
 #include "include/intarith.h"
 #include "include/types.h"
 #include "include/compat.h"
@@ -1041,20 +1044,111 @@ int KernelDevice::discard(uint64_t offset, uint64_t len)
   return r;
 }
 
+template <std::size_t BufferSizeV>
+struct ExplicitHugePagePool {
+  using region_queue_t = boost::lockfree::queue<void*>;
+
+  struct mmaped_buffer_raw : public buffer::raw {
+    region_queue_t& region_q; // for recycling
+
+    mmaped_buffer_raw(void* mmaped_region, region_queue_t& region_q)
+      : raw(static_cast<char*>(mmaped_region), BufferSizeV),
+	region_q(region_q) {
+      // the `mmaped_region` has been passed to `raw` as the buffer's `data`
+    }
+    ~mmaped_buffer_raw() override {
+      // don't delete nor unmmap; recycle the region instead
+      region_q.push(data);
+    }
+    raw* clone_empty() override {
+      // the entire cloning facility is used solely by the dev-only MemDB.
+      // see: https://github.com/ceph/ceph/pull/36282
+      ceph_abort_msg("this should be never called on this path!");
+    }
+  };
+
+  ExplicitHugePagePool(size_t pool_size)
+    : region_q(pool_size) {
+    while (pool_size--) {
+      void* const mmaped_region = ::mmap(
+        nullptr,
+        BufferSizeV,
+        PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE | MAP_HUGETLB,
+        -1,
+        0);
+      if (mmaped_region == MAP_FAILED) {
+        ceph_abort("can't allocate huge buffer;"
+                   " /proc/sys/vm/nr_hugepages misconfigured?");
+      } else {
+        region_q.push(mmaped_region);
+      }
+    }
+  }
+  ~ExplicitHugePagePool() {
+    void* mmaped_region;
+    while (region_q.pop(mmaped_region)) {
+      ::munmap(mmaped_region, BufferSizeV);
+    }
+  }
+
+  ceph::unique_leakable_ptr<buffer::raw> try_create() {
+    if (void* mmaped_region; region_q.pop(mmaped_region)) {
+      return ceph::unique_leakable_ptr<buffer::raw> {
+	new mmaped_buffer_raw(mmaped_region, region_q)
+      };
+    } else {
+      // oops, empty queue.
+      return nullptr;
+    }
+  }
+
+  bool empty_estimation() const {
+    return region_q.empty();
+  }
+
+private:
+  region_queue_t region_q;
+};
+
+
+#define LUCKY_BUFFER_SIZE 4 * 1024 * 1024
 
 // create a buffer basing on user-configurable. it's intended to make
 // our buffers THP-able.
-static ceph::unique_leakable_ptr<buffer::raw> create_custom_aligned(
-  CephContext* const cct,
-  const size_t len)
+ceph::unique_leakable_ptr<buffer::raw> KernelDevice::create_custom_aligned(
+  const size_t len) const
 {
   // just to preserve the logic of create_small_page_aligned().
   if (len < CEPH_PAGE_SIZE) {
     return ceph::buffer::create_small_page_aligned(len);
-  } else {
-    const size_t custom_alignment = cct->_conf->bdev_read_buffer_alignment;
-    return ceph::buffer::create_aligned(len, custom_alignment);
+  } else if (len == LUCKY_BUFFER_SIZE) {
+    static ExplicitHugePagePool<LUCKY_BUFFER_SIZE> hp_pool{
+      cct->_conf->bdev_read_preallocated_huge_buffer_num
+    };
+    if (auto lucky_raw = hp_pool.try_create(); lucky_raw) {
+      dout(20) << __func__ << " allocated from huge pool"
+	       << " lucky_raw.data=" << (void*)lucky_raw->get_data()
+	       << " bdev_read_preallocated_huge_buffer_num="
+	       << cct->_conf->bdev_read_preallocated_huge_buffer_num
+	       << dendl;
+      return lucky_raw;
+    } else {
+      // fallthrough due to empty buffer pool. this can happen also
+      // when the configurable was explicitly set to 0.
+      dout(20) << __func__ << " cannot allocate from huge pool"
+	       << " hp_pool.empty_estimation=" << hp_pool.empty_estimation()
+	       << " bdev_read_preallocated_huge_buffer_num="
+	       << cct->_conf->bdev_read_preallocated_huge_buffer_num
+	       << dendl;
+    }
   }
+  const size_t custom_alignment = cct->_conf->bdev_read_buffer_alignment;
+  dout(20) << __func__ << " with the custom alignment;"
+           << " len=" << len
+           << " custom_alignment=" << custom_alignment
+           << dendl;
+  return ceph::buffer::create_aligned(len, custom_alignment);
 }
 
 int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
@@ -1070,7 +1164,7 @@ int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
 
   auto start1 = mono_clock::now();
 
-  auto p = ceph::buffer::ptr_node::create(create_custom_aligned(cct, len));
+  auto p = ceph::buffer::ptr_node::create(create_custom_aligned(len));
   int r = ::pread(choose_fd(buffered,  WRITE_LIFE_NOT_SET),
 		  p->c_str(), len, off);
   auto age = cct->_conf->bdev_debug_aio_log_age;
@@ -1122,7 +1216,7 @@ int KernelDevice::aio_read(
     ++ioc->num_pending;
     aio_t& aio = ioc->pending_aios.back();
     aio.bl.push_back(
-      ceph::buffer::ptr_node::create(create_custom_aligned(cct, len)));
+      ceph::buffer::ptr_node::create(create_custom_aligned(len)));
     aio.bl.prepare_iov(&aio.iov);
     aio.preadv(off, len);
     dout(30) << aio << dendl;

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -112,7 +112,7 @@ private:
   void _detect_vdo();
   int choose_fd(bool buffered, int write_hint) const;
 
-  ceph::unique_leakable_ptr<buffer::raw> create_custom_aligned(size_t len) const;
+  ceph::unique_leakable_ptr<buffer::raw> create_custom_aligned(size_t len, IOContext* ioc) const;
 
 public:
   KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, aio_callback_t d_cb, void *d_cbpriv);

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -112,6 +112,8 @@ private:
   void _detect_vdo();
   int choose_fd(bool buffered, int write_hint) const;
 
+  ceph::unique_leakable_ptr<buffer::raw> create_custom_aligned(size_t len) const;
+
 public:
   KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, aio_callback_t d_cb, void *d_cbpriv);
 

--- a/src/common/buffer_instrumentation.h
+++ b/src/common/buffer_instrumentation.h
@@ -1,0 +1,14 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "include/buffer.h"
+
+namespace ceph::buffer_instrumentation {
+
+struct instrumented_bptr : public ceph::buffer::ptr {
+  const ceph::buffer::raw* get_raw() const {
+    return _raw;
+  }
+};
+
+} // namespace ceph::buffer_instrumentation

--- a/src/common/buffer_instrumentation.h
+++ b/src/common/buffer_instrumentation.h
@@ -2,12 +2,30 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "include/buffer.h"
+#include "include/buffer_raw.h"
 
 namespace ceph::buffer_instrumentation {
+
+// this is nothing more than an intermediary for a class hierarchy which
+// can placed between a user's custom raw and the `ceph::buffer::raw` to
+// detect whether a given `ceph::buffer::ptr` instance wraps a particular
+// raw's implementation (via `dynamic_cast` or `typeid`).
+//
+// users are supposed to define marker type (e.g. `class my_marker{}`).
+// this marker. i
+template <class MarkerT>
+struct instrumented_raw : public ceph::buffer::raw {
+  using raw::raw;
+};
 
 struct instrumented_bptr : public ceph::buffer::ptr {
   const ceph::buffer::raw* get_raw() const {
     return _raw;
+  }
+
+  template <class MarkerT>
+  bool is_raw_marked() const {
+    return dynamic_cast<const instrumented_raw<MarkerT>*>(get_raw()) != nullptr;
   }
 };
 

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3920,11 +3920,26 @@ options:
   level: advanced
   default: 4_K
   with_legacy: true
-- name: bdev_read_preallocated_huge_buffer_num
-  type: size
+- name: bdev_read_preallocated_huge_buffers
+  type: str
   level: advanced
-  default: 128
-  with_legacy: true
+  desc: description of pools arrangement for huge page-based read buffers
+  long_desc: Arrangement of preallocated, huge pages-based pools for reading
+    from a KernelDevice. Applied to minimize size of scatter-gather lists
+    sent to NICs. Targets really  big buffers (>= 2 or 4 MBs).
+    Keep in mind the system must be configured accordingly (see /proc/sys/vm/nr_hugepages).
+    Otherwise the OSD wil fail early.
+    Beware BlueStore, by default, stores large chunks across many smaller blobs.
+    Increasing bluestore_max_blob_size changes that, and thus allows the data to
+    be read back into small number of huge page-backed buffers.
+  fmt_desc: List of key=value pairs delimited by comma, semicolon or tab.
+    key specifies the targeted read size and must be expressed in bytes.
+    value specifies the number of preallocated buffers.
+    For instance, to preallocate 64 buffers that will be used to serve
+    2 MB-sized read requests and 128 for 4 MB, someone needs to set
+    "2097152=64,4194304=128".
+  see_also:
+  - bluestore_max_blob_size
 - name: bdev_debug_aio
   type: bool
   level: dev

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3920,6 +3920,11 @@ options:
   level: advanced
   default: 4_K
   with_legacy: true
+- name: bdev_read_preallocated_huge_buffer_num
+  type: size
+  level: advanced
+  default: 128
+  with_legacy: true
 - name: bdev_debug_aio
   type: bool
   level: dev

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3915,6 +3915,11 @@ options:
   level: advanced
   default: 4_K
   with_legacy: true
+- name: bdev_read_buffer_alignment
+  type: size
+  level: advanced
+  default: 4_K
+  with_legacy: true
 - name: bdev_debug_aio
   type: bool
   level: dev

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10812,7 +10812,8 @@ int BlueStore::_do_read(
   bool csum_error = false;
   r = _generate_read_result_bl(o, offset, length, ready_regions,
                               compressed_blob_bls, blobs2read,
-                              buffered, &csum_error, bl);
+                              buffered && !ioc.skip_cache(),
+                              &csum_error, bl);
   if (csum_error) {
     // Handles spurious read errors caused by a kernel bug.
     // We sometimes get all-zero pages as a result of the read under

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -29,6 +29,7 @@
 #include "include/utime.h"
 #include "include/coredumpctl.h"
 #include "include/encoding.h"
+#include "common/buffer_instrumentation.h"
 #include "common/environment.h"
 #include "common/Clock.h"
 #include "common/safe_io.h"
@@ -47,11 +48,7 @@ using namespace std;
 
 static char cmd[128];
 
-struct instrumented_bptr : public ceph::buffer::ptr {
-  const ceph::buffer::raw* get_raw() const {
-    return _raw;
-  }
-};
+using ceph::buffer_instrumentation::instrumented_bptr;
 
 TEST(Buffer, constructors) {
   unsigned len = 17;


### PR DESCRIPTION
Summary
=======

This PR brings two facilities that enable efficient utilization of some NICs during large reads in BlueStore:

  1. configurable alignment for allocating read buffers in `KernelDevice`,
  2. allocation from a configurable pools of reusable buffers placed on huge pages.

These features allow to minimize the size of scatter-gather list a network hardware is provided with. For instance, on a system offering 2 MB pages, reading an entire RBD segment may require up to 2 different, non-contiguous regions of physical memory.

By default all these facilities are disabled and there shouldn't be flow difference in comparison to the current `master`.

The provided unit test requires a machine with HP available. I'm not sure we can assume this is always the case; if not, we can disable it by default.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
