### PR TITLE
msg/async: remove the misleading error description on read failures

### DIFF
--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1083,7 +1083,7 @@ CtPtr ProtocolV2::handle_read_frame_preamble_main(rx_buffer_t &&buffer, int r) {
 
   if (r < 0) {
     ldout(cct, 1) << __func__ << " read frame preamble failed r=" << r
-                  << " (" << cpp_strerror(r) << ")" << dendl;
+                  << dendl;
     return _fault();
   }
 


### PR DESCRIPTION
Before this patch we were calling `cpp_strerror` on the error code returned by messenger's low-level methods for reading from socket. Unfortunately, it leaded to misleading debugs like:

  ```
  (...).read_bulk peer close file descriptor 28
  (...).read_until read failed
  (...).handle_read_frame_preamble_main read frame preamble failed r=-1 ((1) Operation not permitted)
  ```

The problem is that these lower layers simply don't adhere to the POSIX-like, ernno convention for reporting problems. Therefore, `-1` doesn't really mean _Operation not permitted_. The snippets bellow show the actual convention.

  ```cpp
  /* return -1 means `fd` occurs error or closed, it should be closed
   * return 0 means EAGAIN or EINTR */
  ssize_t AsyncConnection::read_bulk(char *buf, unsigned len)
  {
    ssize_t nread;
   again:
    nread = cs.read(buf, len);
    if (nread < 0) {
      if (nread == -EAGAIN) {
        nread = 0;
      } else if (nread == -EINTR) {
        goto again;
      } else {
        ldout(async_msgr->cct, 1) << __func__ << " reading from fd=" << cs.fd()
                            << " : "<< nread << " " << strerror(nread) << dendl;
        return -1;
      }
    } else if (nread == 0) {
      ldout(async_msgr->cct, 1) << __func__ << " peer close file descriptor "
                                << cs.fd() << dendl;
      return -1;
    }
    return nread;
  }

  size_t AsyncConnection::read_until(unsigned len, char *p)
  {
    // ...
    recv_end = recv_start = 0;
    /* nothing left in the prefetch buffer */
    if (left > (uint64_t)recv_max_prefetch) {
      /* this was a large read, we don't prefetch for these */
      do {
        r = read_bulk(p+state_offset, left);
        ldout(async_msgr->cct, 25) << __func__ << " read_bulk left is " << left << " got " << r << dendl;
        if (r < 0) {
          ldout(async_msgr->cct, 1) << __func__ << " read failed" << dendl;
          return -1;
        } else if (r == static_cast<int>(left)) {
          state_offset = 0;
          return 0;
        }
        state_offset += r;
        left -= r;
      } while (r > 0);
    } else {
    // ...
  }
  CtPtr ProtocolV2::read_frame() {
    if (state == CLOSED) {
      return nullptr;
    }

    ldout(cct, 20) << __func__ << dendl;
    rx_preamble.clear();
    rx_epilogue.clear();
    rx_segments_data.clear();

    return READ(rx_frame_asm.get_preamble_onwire_len(),
                handle_read_frame_preamble_main);
  }

  CtPtr ProtocolV2::handle_read_frame_preamble_main(rx_buffer_t &&buffer, int r) {
    ldout(cct, 20) << __func__ << " r=" << r << dendl;

    if (r < 0) {
      ldout(cct, 1) << __func__ << " read frame preamble failed r=" << r
                    << " (" << cpp_strerror(r) << ")" << dendl;
      return _fault();
    }
    // ...
  }
  ```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
