### PR TITLE
librbd/crypto: don't decrypt image uninitialized data

### DIFF
--- a/src/librbd/crypto/BlockCrypto.cc
+++ b/src/librbd/crypto/BlockCrypto.cc
@@ -58,29 +58,13 @@ int BlockCrypto<T>::crypt(ceph::bufferlist* data, uint64_t image_offset,
   auto sg = make_scope_guard([&] {
       m_data_cryptor->return_context(ctx, mode); });
 
-  auto sector_number = image_offset / 512;
   auto appender = data->get_contiguous_appender(src.length());
-  unsigned char* out_buf_ptr = nullptr;
   unsigned char* leftover_block = (unsigned char*)alloca(m_block_size);
   uint32_t leftover_size = 0;
   for (auto buf = src.buffers().begin(); buf != src.buffers().end(); ++buf) {
     auto in_buf_ptr = reinterpret_cast<const unsigned char*>(buf->c_str());
     auto remaining_buf_bytes = buf->length();
     while (remaining_buf_bytes > 0) {
-      if (leftover_size == 0) {
-        auto block_offset_le = ceph_le64(sector_number);
-        memcpy(iv, &block_offset_le, sizeof(block_offset_le));
-        auto r = m_data_cryptor->init_context(ctx, iv, m_iv_size);
-        if (r != 0) {
-          lderr(m_cct) << "unable to init cipher's IV" << dendl;
-          return r;
-        }
-
-        out_buf_ptr = reinterpret_cast<unsigned char*>(
-                appender.get_pos_add(m_block_size));
-        sector_number += m_block_size / 512;
-      }
-
       if (leftover_size > 0 || remaining_buf_bytes < m_block_size) {
         auto copy_size = std::min(
                 (uint32_t)m_block_size - leftover_size, remaining_buf_bytes);
@@ -90,25 +74,47 @@ int BlockCrypto<T>::crypt(ceph::bufferlist* data, uint64_t image_offset,
         remaining_buf_bytes -= copy_size;
       }
 
-      int crypto_output_length = 0;
+      const unsigned char* crypto_in_ptr = nullptr;
       if (leftover_size == 0) {
-        crypto_output_length = m_data_cryptor->update_context(
-              ctx, in_buf_ptr, out_buf_ptr, m_block_size);
-
+        crypto_in_ptr = in_buf_ptr;
         in_buf_ptr += m_block_size;
         remaining_buf_bytes -= m_block_size;
       } else if (leftover_size == m_block_size) {
-        crypto_output_length = m_data_cryptor->update_context(
-              ctx, leftover_block, out_buf_ptr, m_block_size);
+        crypto_in_ptr = leftover_block;
         leftover_size = 0;
+      } else {
+        continue;
       }
 
-      if (crypto_output_length < 0) {
-        lderr(m_cct) << "crypt update failed" << dendl;
-        return crypto_output_length;
+      unsigned char* out_buf_ptr = reinterpret_cast<unsigned char*>(
+              appender.get_pos_add(m_block_size));
+
+      if (mode == CIPHER_MODE_DEC &&
+        mem_is_zero(reinterpret_cast<const char*>(crypto_in_ptr),
+                    m_block_size)) {
+        // input is already plaintext (zeros), so don't decrypt
+        memset(out_buf_ptr, 0, m_block_size);
+      } else {
+        uint64_t sector_number = image_offset / 512;
+        auto block_offset_le = ceph_le64(sector_number);
+        memcpy(iv, &block_offset_le, sizeof(block_offset_le));
+        auto r = m_data_cryptor->init_context(ctx, iv, m_iv_size);
+        if (r != 0) {
+          lderr(m_cct) << "unable to init cipher's IV" << dendl;
+          return r;
+        }
+
+        int crypto_output_length = m_data_cryptor->update_context(
+                ctx, crypto_in_ptr, out_buf_ptr, m_block_size);
+        if (crypto_output_length < 0) {
+          lderr(m_cct) << "crypt update failed" << dendl;
+          return crypto_output_length;
+        }
+
+        ceph_assert(crypto_output_length == static_cast<int>(m_block_size));
       }
 
-      out_buf_ptr += crypto_output_length;
+      image_offset += m_block_size;
     }
   }
 


### PR DESCRIPTION
By convention, librbd returns zeros when reading uninitialized image data.
When using encryption, this convention is not guaranteed.
Specifically, this can happen when non-sparse reads are issued to the OSDs,
such in the case where the reads are smaller than `rbd_sparse_read_threshold_bytes`.
To overcome this, this commit adds a check to bypass decryption in case
the data read from the OSD is all zeros.

Signed-off-by: Or Ozeri <oro@il.ibm.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
