### PR TITLE
octopus: mon/MgrStatMonitor: ignore MMgrReport from non-active mgr

### DIFF
--- a/src/messages/MMonMgrReport.h
+++ b/src/messages/MMonMgrReport.h
@@ -23,7 +23,7 @@
 
 class MMonMgrReport : public PaxosServiceMessage {
 private:
-  static constexpr int HEAD_VERSION = 2;
+  static constexpr int HEAD_VERSION = 3;
   static constexpr int COMPAT_VERSION = 1;
 
 public:
@@ -31,6 +31,7 @@ public:
   health_check_map_t health_checks;
   bufferlist service_map_bl;  // encoded ServiceMap
   std::map<std::string,ProgressEvent> progress_events;
+  uint64_t gid = 0;
 
   MMonMgrReport()
     : PaxosServiceMessage{MSG_MON_MGR_REPORT, 0, HEAD_VERSION, COMPAT_VERSION}
@@ -41,8 +42,9 @@ private:
 public:
   std::string_view get_type_name() const override { return "monmgrreport"; }
 
-  void print(ostream& out) const override {
-    out << get_type_name() << "(" << health_checks.checks.size() << " checks, "
+  void print(std::ostream& out) const override {
+    out << get_type_name() << "(gid " << gid
+	<< ", " << health_checks.checks.size() << " checks, "
 	<< progress_events.size() << " progress events)";
   }
 
@@ -52,6 +54,7 @@ public:
     encode(health_checks, payload);
     encode(service_map_bl, payload);
     encode(progress_events, payload);
+    encode(gid, payload);
 
     if (!HAVE_FEATURE(features, SERVER_NAUTILUS) ||
 	!HAVE_FEATURE(features, SERVER_MIMIC)) {
@@ -77,6 +80,9 @@ public:
     decode(service_map_bl, p);
     if (header.version >= 2) {
       decode(progress_events, p);
+    }
+    if (header.version >= 3) {
+      decode(gid, p);
     }
   }
 private:

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2405,6 +2405,7 @@ void DaemonServer::send_report()
   }
 
   auto m = ceph::make_message<MMonMgrReport>();
+  m->gid = monc->get_global_id();
   py_modules.get_health_checks(&m->health_checks);
   py_modules.get_progress_events(&m->progress_events);
 

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -515,6 +515,7 @@ void Mgr::handle_log(ref_t<MLog> m)
 void Mgr::handle_service_map(ref_t<MServiceMap> m)
 {
   dout(10) << "e" << m->service_map.epoch << dendl;
+  monc->sub_got("servicemap", m->service_map.epoch);
   cluster_state.set_service_map(m->service_map);
   server.got_service_map();
 }
@@ -589,8 +590,9 @@ void Mgr::handle_fs_map(ref_t<MFSMap> m)
   ceph_assert(ceph_mutex_is_locked_by_me(lock));
 
   std::set<std::string> names_exist;
-  
   const FSMap &new_fsmap = m->get_fsmap();
+
+  monc->sub_got("fsmap", m->epoch);
 
   fs_map_cond.notify_all();
 

--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -3,6 +3,7 @@
 
 #include "MgrStatMonitor.h"
 #include "mon/OSDMonitor.h"
+#include "mon/MgrMonitor.h"
 #include "mon/PGMap.h"
 #include "messages/MGetPoolStats.h"
 #include "messages/MGetPoolStatsReply.h"
@@ -184,7 +185,14 @@ bool MgrStatMonitor::prepare_update(MonOpRequestRef op)
 
 bool MgrStatMonitor::preprocess_report(MonOpRequestRef op)
 {
+  auto m = op->get_req<MMonMgrReport>();
   mon->no_reply(op);
+  if (m->gid &&
+      m->gid != mon->mgrmon()->get_map().get_active_gid()) {
+    dout(10) << "ignoring report from non-active mgr " << m->gid
+	     << dendl;
+    return true;
+  }
   return false;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53198

---

backport of https://github.com/ceph/ceph/pull/40219
parent tracker: https://tracker.ceph.com/issues/48022

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh