### PR TITLE
octopus: rgw: fix bucket purge incomplete multipart uploads

### DIFF
--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -285,16 +285,19 @@ int abort_multipart_upload(rgw::sal::RGWRadosStore *store, CephContext *cct,
   return (ret == -ENOENT) ? -ERR_NO_SUCH_UPLOAD : ret;
 }
 
-int list_bucket_multiparts(rgw::sal::RGWRadosStore *store, RGWBucketInfo& bucket_info,
-			   const string& prefix, const string& marker,
-			   const string& delim,
+int list_bucket_multiparts(rgw::sal::RGWRadosStore* store,
+			   RGWBucketInfo& bucket_info,
+			   const std::string& prefix,
+			   std::string& marker, // in/out
+			   const std::string& delim,
 			   const int& max_uploads,
-			   vector<rgw_bucket_dir_entry> *objs,
-			   map<string, bool> *common_prefixes, bool *is_truncated)
+			   std::vector<rgw_bucket_dir_entry> *objs,
+			   std::map<std::string, bool> *common_prefixes,
+			   bool *is_truncated)
 {
   RGWRados::Bucket target(store->getRados(), bucket_info);
   RGWRados::Bucket::List list_op(&target);
-  MultipartMetaFilter mp_filter;
+  MultipartMetaFilter mp_filter; // filter out all but ".meta" entries
 
   list_op.params.prefix = prefix;
   list_op.params.delim = delim;
@@ -302,11 +305,18 @@ int list_bucket_multiparts(rgw::sal::RGWRadosStore *store, RGWBucketInfo& bucket
   list_op.params.ns = RGW_OBJ_NS_MULTIPART;
   list_op.params.filter = &mp_filter;
 
-  return(list_op.list_objects(max_uploads, objs, common_prefixes, is_truncated, null_yield));
+  int ret = list_op.list_objects(max_uploads, objs, common_prefixes, is_truncated, null_yield);
+  if (ret >= 0) {
+    marker = list_op.params.marker.name;
+  }
+  return ret;
 }
 
-int abort_bucket_multiparts(rgw::sal::RGWRadosStore *store, CephContext *cct, RGWBucketInfo& bucket_info,
-				string& prefix, string& delim)
+int abort_bucket_multiparts(rgw::sal::RGWRadosStore* store,
+			    CephContext* cct,
+			    RGWBucketInfo& bucket_info,
+			    const std::string& prefix,
+			    const std::string& delim)
 {
   constexpr int max = 1000;
   int ret, num_deleted = 0;

--- a/src/rgw/rgw_multi.h
+++ b/src/rgw/rgw_multi.h
@@ -126,14 +126,19 @@ extern int list_multipart_parts(rgw::sal::RGWRadosStore *store, struct req_state
 extern int abort_multipart_upload(rgw::sal::RGWRadosStore *store, CephContext *cct, RGWObjectCtx *obj_ctx,
                                 RGWBucketInfo& bucket_info, RGWMPObj& mp_obj);
 
-extern int list_bucket_multiparts(rgw::sal::RGWRadosStore *store, RGWBucketInfo& bucket_info,
-				  const string& prefix,
-				  const string& marker,
-				  const string& delim,
+extern int list_bucket_multiparts(rgw::sal::RGWRadosStore* store,
+				  RGWBucketInfo& bucket_info,
+				  const std::string& prefix,
+				  std::string& marker, // in/out
+				  const std::string& delim,
 				  const int& max_uploads,
-				  vector<rgw_bucket_dir_entry> *objs,
-				  map<string, bool> *common_prefixes, bool *is_truncated);
+				  std::vector<rgw_bucket_dir_entry>* objs,
+				  std::map<std::string, bool>* common_prefixes,
+				  bool* is_truncated);
 
-extern int abort_bucket_multiparts(rgw::sal::RGWRadosStore *store, CephContext *cct, RGWBucketInfo& bucket_info,
-                                string& prefix, string& delim);
+extern int abort_bucket_multiparts(rgw::sal::RGWRadosStore* store,
+				   CephContext* cct,
+				   RGWBucketInfo& bucket_info,
+				   const std::string& prefix,
+				   const std::string& delim);
 #endif


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53213

parent tracker (pacific): https://tracker.ceph.com/issues/52662

---

The marker was not working correctly as segments of the bucket index
were listed to shut down any incomplete multipart uploads. This fixes
the marker, so it's maintained properly across iterations.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>
Fixes: https://tracker.ceph.com/issues/53213

Note: this is currently a place-holder. When pacific version is merged, we'll cherry-pick from there to document the chain.