### PR TITLE
os/bluestore: allow legacy per-pool omap scheme

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5143,15 +5143,16 @@ options:
   desc: inject crc verification errors into bluestore device reads
   default: 0
   with_legacy: true
-- name: bluestore_debug_legacy_omap
-  type: bool
+- name: bluestore_omap_naming
+  type: str
   level: dev
-  desc: Allows mkfs to create OSD in legacy OMAP naming mode (neither per-pool nor per-pg).
+  desc: Allows to create omap in legacy mode
+  long_desc: Allows mkfs to create OSD in legacy OMAP naming mode.
     This is intended primarily for developers' purposes. The resulting OSD might/would
-    be transformed to the currrently default 'per-pg' format when BlueStore's quick-fix or
-    repair are applied.
-  default: false
-  with_legacy: true
+    be transformed to the currently default 'per-pg' format when BlueStore's quick-fix or
+    repair are applied. Acceptable values 'bulk', 'per-pool', 'per-pg'
+  default: per-pg
+  with_legacy: false
 - name: bluestore_fsck_error_on_no_per_pool_stats
   type: bool
   level: advanced

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5152,6 +5152,13 @@ options:
     be transformed to the currently default 'per-pg' format when BlueStore's quick-fix or
     repair are applied. Acceptable values 'bulk', 'per-pool', 'per-pg'
   default: per-pg
+  enum_values:
+  - bulk
+  - per-pool
+  - per-pg
+  flags:
+#It is not actually runtime, since it is only applied during mkfs. It is needed for unit tests.
+  - runtime
   with_legacy: false
 - name: bluestore_fsck_error_on_no_per_pool_stats
   type: bool

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7107,10 +7107,16 @@ int BlueStore::mkfs()
     }
     {
       bufferlist bl;
-      if (cct->_conf.get_val<bool>("bluestore_debug_legacy_omap")) {
+      std::string omap_naming = cct->_conf.get_val<std::string>("bluestore_omap_naming");
+      if (omap_naming == "bulk") {
 	bl.append(stringify(OMAP_BULK));
-      } else {
+      } else if (omap_naming == "per-pool") {
+	bl.append(stringify(OMAP_PER_POOL));
+      } else if (omap_naming == "per-pg") {
 	bl.append(stringify(OMAP_PER_PG));
+      } else {
+	derr << __func__ << " invalid omap naming scheme:" << omap_naming << dendl;
+	ceph_assert(false);
       }
       t->set(PREFIX_SUPER, "per_pool_omap", bl);
     }
@@ -16216,7 +16222,7 @@ int BlueStore::_omap_setkeys(TransContext *txc,
     if (o->oid.is_pgmeta()) {
       o->onode.set_omap_flags_pgmeta();
     } else {
-      o->onode.set_omap_flags(per_pool_omap == OMAP_BULK);
+      o->onode.set_omap_flags(get_current_omap_flags());
     }
     txc->write_onode(o);
 
@@ -16261,7 +16267,7 @@ int BlueStore::_omap_setheader(TransContext *txc,
     if (o->oid.is_pgmeta()) {
       o->onode.set_omap_flags_pgmeta();
     } else {
-      o->onode.set_omap_flags(per_pool_omap == OMAP_BULK);
+      o->onode.set_omap_flags(get_current_omap_flags());
     }
     txc->write_onode(o);
 
@@ -16416,7 +16422,7 @@ int BlueStore::_clone(TransContext *txc,
     if (newo->oid.is_pgmeta()) {
       newo->onode.set_omap_flags_pgmeta();
     } else {
-      newo->onode.set_omap_flags(per_pool_omap == OMAP_BULK);
+      newo->onode.set_omap_flags(get_current_omap_flags());
     }
     // check if prefix for omap key is exactly the same size for both objects
     // otherwise rewrite_omap_key will corrupt data

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2239,6 +2239,14 @@ private:
     OMAP_PER_POOL = 1,
     OMAP_PER_PG = 2,
     } per_pool_omap = OMAP_BULK;
+  uint8_t get_current_omap_flags() {
+    if (per_pool_omap == OMAP_PER_PG)
+      return bluestore_onode_t::FLAG_PERPOOL_OMAP
+	   | bluestore_onode_t::FLAG_PERPG_OMAP;
+    if (per_pool_omap == OMAP_PER_POOL)
+      return bluestore_onode_t::FLAG_PERPOOL_OMAP;
+    return 0;
+  }
 
   ///< maximum allocation unit (power of 2)
   std::atomic<uint64_t> max_alloc_size = {0};

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -1021,8 +1021,8 @@ struct bluestore_onode_t {
     return has_flag(FLAG_PERPG_OMAP);
   }
 
-  void set_omap_flags(bool legacy) {
-    set_flag(FLAG_OMAP | (legacy ? 0 : (FLAG_PERPOOL_OMAP | FLAG_PERPG_OMAP)));
+  void set_omap_flags(uint8_t omap_flags) {
+    set_flag(FLAG_OMAP | omap_flags);
   }
   void set_omap_flags_pgmeta() {
     set_flag(FLAG_OMAP | FLAG_PGMETA_OMAP);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -10170,7 +10170,7 @@ TEST_P(StoreTestOmapUpgrade, WithOmapHeader) {
   if (string(GetParam()) != "bluestore")
     return;
 
-  SetVal(g_conf(), "bluestore_debug_legacy_omap", "true");
+  SetVal(g_conf(), "bluestore_omap_naming", "bulk");
   g_conf().apply_changes(nullptr);
 
   StartDeferred();
@@ -10213,9 +10213,12 @@ TEST_P(StoreTestOmapUpgrade, WithOmapHeader) {
   }
   store->umount();
   ASSERT_EQ(store->fsck(false), 0);
-  SetVal(g_conf(), "bluestore_debug_legacy_omap", "false");
+  g_conf()._clear_safe_to_start_threads();
+  SetVal(g_conf(), "bluestore_omap_naming", "per-pg");
   SetVal(g_conf(), "bluestore_fsck_error_on_no_per_pool_omap", "true");
   g_conf().apply_changes(nullptr);
+  g_conf().set_safe_to_start_threads();
+
   ASSERT_EQ(store->fsck(false), 2);
   ASSERT_EQ(store->quick_fix(), 0);
   store->mount();
@@ -10304,7 +10307,7 @@ TEST_P(StoreTestOmapUpgrade, NoOmapHeader) {
   if (string(GetParam()) != "bluestore")
     return;
 
-  SetVal(g_conf(), "bluestore_debug_legacy_omap", "true");
+  SetVal(g_conf(), "bluestore_omap_naming", "bulk");
   g_conf().apply_changes(nullptr);
 
   StartDeferred();
@@ -10342,7 +10345,7 @@ TEST_P(StoreTestOmapUpgrade, NoOmapHeader) {
   }
   store->umount();
   ASSERT_EQ(store->fsck(false), 0);
-  SetVal(g_conf(), "bluestore_debug_legacy_omap", "false");
+  SetVal(g_conf(), "bluestore_omap_naming", "per-pg");
   SetVal(g_conf(), "bluestore_fsck_error_on_no_per_pool_omap", "true");
   g_conf().apply_changes(nullptr);
   ASSERT_EQ(store->fsck(false), 2);
@@ -10370,7 +10373,7 @@ TEST_P(StoreTestOmapUpgrade, LargeLegacyToPG) {
   if (string(GetParam()) != "bluestore")
     return;
 
-  SetVal(g_conf(), "bluestore_debug_legacy_omap", "true");
+  SetVal(g_conf(), "bluestore_omap_naming", "bulk");
   g_conf().apply_changes(nullptr);
 
   int64_t poolid;
@@ -10400,7 +10403,7 @@ TEST_P(StoreTestOmapUpgrade, LargeLegacyToPG) {
 
   store->umount();
   ASSERT_EQ(store->fsck(false), 0);
-  SetVal(g_conf(), "bluestore_debug_legacy_omap", "false");
+  SetVal(g_conf(), "bluestore_omap_naming", "per-pg");
   SetVal(g_conf(), "bluestore_fsck_error_on_no_per_pool_omap", "true");
   g_conf().apply_changes(nullptr);
   ASSERT_EQ(store->fsck(false), 1001);


### PR DESCRIPTION
Allow mkfs to create bluestore with now legacy per-pool omap scheme.
It is useful for debug and upgrade test purposes.

This is an extension, and a tribute to: https://github.com/ceph/ceph/pull/42832

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
