### PR TITLE
mgr/dashboard: Device health status is not getting listed under hosts section

### DIFF
--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -265,13 +265,15 @@ class CephService(object):
                     except SendCommandError:
                         # Try to retrieve SMART data from another daemon.
                         continue
-                else:
+                elif 'mon' in svc_type:
                     try:
                         dev_smart_data = CephService.send_command(
-                            svc_type, 'device get-health-metrics', svc_id, devid=device['devid'])
+                            svc_type, 'device query-daemon-health-metrics', who=daemon)
                     except SendCommandError:
                         # Try to retrieve SMART data from another daemon.
                         continue
+                else:
+                    dev_smart_data = {}
                 for dev_id, dev_data in dev_smart_data.items():
                     if 'error' in dev_data:
                         logger.warning(

--- a/src/pybind/mgr/dashboard/tests/test_ceph_service.py
+++ b/src/pybind/mgr/dashboard/tests/test_ceph_service.py
@@ -125,4 +125,7 @@ def test_get_smart_data_from_appropriate_ceph_command(send_command):
     ]
     CephService._get_smart_data_by_device({'devid': '1', 'daemons': ['osd.1', 'mon.1']})
     send_command.assert_has_calls([mock.call('mon', 'osd tree'),
-                                   mock.call('mon', 'device get-health-metrics', '1', devid='1')])
+                                   mock.call('osd', 'smart', '1', devid='1'),
+                                   mock.call('mon', 'osd tree'),
+                                   mock.call('mon', 'device query-daemon-health-metrics',
+                                             who='mon.1')])


### PR DESCRIPTION
Device health is shown as failed to retrieve data under Hosts > Device Health section. This PR intends to fix this issue.

Fixes: https://tracker.ceph.com/issues/53209
Signed-off-by: Aashish Sharma <aasharma@redhat.com>





<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
