### PR TITLE
pacific: tool/bluestore-tool: introduce repair_omap_upgrade command (continuation)

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8261,9 +8261,9 @@ out_db:
   return r;
 }
 
-int BlueStore::repair_omap_upgrade()
+int BlueStore::repair_omap_upgrade(bool dry_run)
 {
-  dout(1) << __func__  << dendl;
+  dout(1) << __func__  << (dry_run ? " dry run" : "real run") << dendl;
 
   int r = _open_db_and_around(false);
   if (r < 0)
@@ -8287,56 +8287,189 @@ int BlueStore::repair_omap_upgrade()
   }
   if (r < 0)
     goto out_scan;
-
   {
+    // we assume that all entries under PREFIX_PERPG_OMAP are valid, that is
+    // each starts with: u64 pool_id + u32 hash + u64 nid
     auto it = db->get_iterator(PREFIX_PERPG_OMAP);
     if (it) {
+      uint64_t prev_pool;
+      uint64_t prev_hash;
+      uint64_t prev_nid;
+      bool expect_next_object = true;
+      bool expect_header_copy = false;
       size_t cnt = 0;
+      size_t problems = 0;
       KeyValueDB::Transaction txn = db->get_transaction();
       it->lower_bound(std::string());
       while(it->valid()) {
         auto key = it->key();
         auto val = it->value();
-        it->next();
-        auto p1 = key.find_first_of('.');
-        if (p1 == string::npos || p1 <= 8) {
-          continue;
-        }
-        auto p2 = key.find_first_of('-', p1 + 1);
-        if (p2 == string::npos) {
-          p2 = key.find_first_of('.', p1 + 1);
-        }
-        if (p2 == string::npos || p1 + 8 > p2) {
-          continue;
-        }
-        string s1 = key.substr(p1 - 8, 8);
-        string s2 = key.substr(p2 - 8, 8);
-        if (s1 != s2) {
-          continue;
-        }
-        txn->rmkey(PREFIX_PERPG_OMAP, key);
-        if (key[p2] == '.') {
-          auto new_key = key;
-          new_key.erase(p1, p2 - p1);
-          dout(0) << __func__ << " " << pretty_binary_string(key)
-                  << " -> " << pretty_binary_string(new_key) << dendl;
-          txn->set(PREFIX_PERPG_OMAP, new_key, val);
-        } else {
-          dout(0) << __func__ << " " << pretty_binary_string(key)
-                  << " rm " << dendl;
-        }
-        cnt++;
-        if (cnt >= 1024) {
-          key = it->key();
-          db->submit_transaction_sync(txn);
-          it->lower_bound(key);
-          txn = db->get_transaction();
-          cnt = 0;
-        }
+	dout(20) << __func__ << " key=" << pretty_binary_string(key) << dendl;
+	it->next();
+	ceph_assert(key.length() >= 8 + 4 + 8 + 1);
+	const char* p = key.c_str();
+	uint64_t pool;
+	unsigned hash;
+	uint64_t nid;
+	p = _key_decode_u64(p, &pool);
+	p = _key_decode_u32(p, &hash);
+	p = _key_decode_u64(p, &nid);
+	if (pool == prev_pool && hash == prev_hash && nid == prev_nid) {
+	  if (expect_next_object) {
+	    dout(10) << __func__ << " next object expected, but old continued" << dendl;
+	    problems++;
+	  }
+	} else {
+	  if (!expect_next_object) {
+	    // we should continue same object
+	    dout(10) << __func__ << " next objext unexpected" << dendl;
+	    problems++;
+	    expect_header_copy = false;
+	  }
+	  prev_pool = pool;
+	  prev_hash = hash;
+	  prev_nid = nid;
+	}
+	char c = *p;
+	p++;
+
+	if (expect_header_copy) {
+	  // copy of header should look like:
+	  // pppppppphhhhnnnnnnnn.ppppppppnnnnnnnn-   (for PERPOOL->PERPG failed upgrade)
+	  // pppppppphhhhnnnnnnnn.nnnnnnnn-           (for BULK->PERPG failed upgrade)
+
+	  // we expect copy only right after valid header
+	  expect_header_copy = false;
+	  if (key.length() == 8 + 4 + 8 + 1 + 8 + 8 + 1) {
+	    uint64_t pool_copy;
+	    uint64_t nid_copy;
+	    char c1;
+	    const char* p1 = p;
+	    p1 = _key_decode_u64(p1, &pool_copy);
+	    p1 = _key_decode_u64(p1, &nid_copy);
+	    c1 = *p1;
+	    if (c == '.' && pool_copy == pool && nid_copy == nid && c1 == '-') {
+	      // bingo - delete
+	      dout(15) << __func__ << " rmkey " << pretty_binary_string(key) << dendl;
+	      txn->rmkey(PREFIX_PERPG_OMAP, key);
+	      cnt += 1000;
+	      continue;
+	    }
+	  }
+	  if (key.length() == 8 + 4 + 8 + 1 + 8 + 1) {
+	    uint64_t nid_copy;
+	    char c1;
+	    const char* p1 = _key_decode_u64(p, &nid_copy);
+	    c1 = *p1;
+	    if (c == '.' && nid_copy == nid && c1 == '-') {
+	      // bingo - delete
+	      dout(15) << __func__ << " rmkey " << pretty_binary_string(key) << dendl;
+	      txn->rmkey(PREFIX_PERPG_OMAP, key);
+	      cnt += 1000;
+	      continue;
+	    }
+	  }
+	  dout(10) << __func__ << " expected copy of header. not found" << dendl;
+	  problems++;
+	}
+
+	if (c == '~') {
+	  // Tail. Good place to submit transaction.
+	  // We need to wait for omap tail before writing to DB
+	  // to avoid iterating over keys we just processed.
+	  if (cnt > 1000000) {
+	    if (dry_run) {
+	      dout(10) << __func__ << " dropping DB transaction" << dendl;
+	    } else {
+	      dout(10) << __func__ << " submit DB" << dendl;
+	      db->submit_transaction_sync(txn);
+	    }
+	    it->lower_bound(key);
+	    txn = db->get_transaction();
+	    cnt = 0;
+	  }
+	  // Tail key should not have extra chars.
+	  if (key.length() != 8 + 4 + 8 + 1) {
+	    dout(10) << __func__ << " unexpected extra chars in omap tail key" << dendl;
+	  }
+	  expect_next_object = true;
+	  continue;
+	}
+
+	if (c == '-' && key.length() == 8 + 4 + 8 + 1) {
+	  // this is a good omap header key. it is expected to be followed by a copy of it
+	  expect_header_copy = true;
+	  if (!expect_next_object) {
+	    // omap header is expected as first entry or right after tail ("~")
+	    problems++;
+	    dout(10) << __func__ << " unexpected omap head" << dendl;
+	  }
+	  expect_next_object = false;
+	  continue;
+	}
+
+	if (c == '.') {
+	  // corrupted DB keys do look like:
+	  // pppppppphhhhnnnnnnnn.ppppppppnnnnnnnn.kkkkk   (for PERPOOL->PERPG failed upgrade)
+	  // pppppppphhhhnnnnnnnn.nnnnnnnn.kkkkk           (for BULK->PERPG failed upgrade)
+	  if (key.length() > 8 + 4 + 8 + 1 + 8 + 8 + 1) {
+	    // can check PERPOOL->PERPG
+	    uint64_t pool_copy;
+	    uint64_t nid_copy;
+	    char c1;
+	    const char* p1 = p;
+	    p1 = _key_decode_u64(p1, &pool_copy);
+	    p1 = _key_decode_u64(p1, &nid_copy);
+	    c1 = *p1;
+	    if (c == '.' && pool_copy == pool && nid_copy == nid && c1 == '.') {
+	      // this is very likely a match
+	      expect_next_object = false;
+	      // erase old
+	      txn->rmkey(PREFIX_PERPG_OMAP, key);
+	      // write new
+	      auto new_key = key;
+	      new_key.erase(8 + 4 + 8, 8 + 8 + 1);
+	      txn->set(PREFIX_PERPG_OMAP, new_key, val);
+	      dout(15) << __func__ << " rename " << pretty_binary_string(key)
+		       << " to " << pretty_binary_string(new_key) << dendl;
+	      cnt += 1000 + val.length();
+	      continue;
+	    }
+	  }
+	  if (key.length() > 8 + 4 + 8 + 1 + 8 + 1) {
+	    // can check BULK->PERPG
+	    uint64_t nid_copy;
+	    char c1;
+	    const char* p1 = _key_decode_u64(p, &nid_copy);
+	    c1 = *p1;
+	    if (c == '.' && nid_copy == nid && c1 == '.') {
+	      // this is very likely a match
+	      expect_next_object = false;
+	      // erase old
+	      txn->rmkey(PREFIX_PERPG_OMAP, key);
+	      // write new
+	      auto new_key = key;
+	      new_key.erase(8 + 4 + 8, 8 + 1);
+	      txn->set(PREFIX_PERPG_OMAP, new_key, val);
+	      dout(15) << __func__ << " rename " << pretty_binary_string(key)
+		       << " to " << pretty_binary_string(new_key) << dendl;
+	      cnt += 1000 + val.length();
+	      continue;
+	    }
+	  }
+	  problems++;
+	  dout(10) << __func__ << " key " << pretty_binary_string(key) << " not converted" << dendl;
+	}
       }
       if (cnt > 0) {
-        db->submit_transaction_sync(txn);
+	if (dry_run) {
+	  dout(10) << __func__ << " dropping DB transaction" << dendl;
+	} else {
+	  dout(10) << __func__ << " submit DB" << dendl;
+	  db->submit_transaction_sync(txn);
+	}
       }
+      r = problems;
     }
   }
 out_scan:

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2665,7 +2665,7 @@ public:
   int quick_fix() override {
     return _fsck(FSCK_SHALLOW, true);
   }
-  int repair_omap_upgrade();
+  int repair_omap_upgrade(bool dry_run);
 
   void set_cache_shards(unsigned num) override;
   void dump_cache_stats(ceph::Formatter *f) override {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2665,6 +2665,7 @@ public:
   int quick_fix() override {
     return _fsck(FSCK_SHALLOW, true);
   }
+  int repair_omap_upgrade();
 
   void set_cache_shards(unsigned num) override;
   void dump_cache_stats(ceph::Formatter *f) override {

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -276,7 +276,8 @@ int main(int argc, char **argv)
         "free-score, "
         "bluefs-stats, "
         "reshard, "
-        "show-sharding")
+        "show-sharding, "
+        "repair_omap_upgrade")
     ;
   po::options_description po_all("All options");
   po_all.add(po_options).add(po_positional);
@@ -309,7 +310,8 @@ int main(int argc, char **argv)
     exit(EXIT_FAILURE);
   }
 
-  if (action == "fsck" || action == "repair" || action == "quick-fix") {
+  if (action == "fsck" || action == "repair" || action == "quick-fix" ||
+      action == "repair_omap_upgrade") {
     if (path.empty()) {
       cerr << "must specify bluestore path" << std::endl;
       exit(EXIT_FAILURE);
@@ -446,7 +448,8 @@ int main(int argc, char **argv)
 
   if (action == "fsck" ||
       action == "repair" ||
-      action == "quick-fix") {
+      action == "quick-fix" ||
+      action == "repair_omap_upgrade") {
     validate_path(cct.get(), path, false);
     BlueStore bluestore(cct.get(), path);
     int r;
@@ -454,6 +457,8 @@ int main(int argc, char **argv)
       r = bluestore.fsck(fsck_deep);
     } else if (action == "repair") {
       r = bluestore.repair(fsck_deep);
+    } else if (action == "repair_omap_upgrade") {
+      r = bluestore.repair_omap_upgrade();
     } else {
       r = bluestore.quick_fix();
     }

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -236,6 +236,7 @@ int main(int argc, char **argv)
   string empty_sharding(1, '\0');
   string new_sharding = empty_sharding;
   string resharding_ctrl;
+  bool dry_run = false;
   int log_level = 30;
   bool fsck_deep = false;
   po::options_description po_options("Options");
@@ -254,6 +255,7 @@ int main(int argc, char **argv)
     ("allocator", po::value<vector<string>>(&allocs_name), "allocator to inspect: 'block'/'bluefs-wal'/'bluefs-db'/'bluefs-slow'")
     ("sharding", po::value<string>(&new_sharding), "new sharding to apply")
     ("resharding-ctrl", po::value<string>(&resharding_ctrl), "gives control over resharding procedure details")
+    ("dry-run", po::value<bool>(&dry_run), "make a dry run of repair_omap_upgrade")
     ;
   po::options_description po_positional("Positional options");
   po_positional.add_options()
@@ -458,7 +460,7 @@ int main(int argc, char **argv)
     } else if (action == "repair") {
       r = bluestore.repair(fsck_deep);
     } else if (action == "repair_omap_upgrade") {
-      r = bluestore.repair_omap_upgrade();
+      r = bluestore.repair_omap_upgrade(dry_run);
     } else {
       r = bluestore.quick_fix();
     }


### PR DESCRIPTION
This is the improvement / continuation of original repair command:
https://github.com/ceph/ceph/pull/43820

Major features:
- restrictive data check before key modification
- state machine to detect omap head copies
- state machine to detect object discontinuity (just report, not fixing anything)
- counts problems during repair
- --dry-run option

Missing:
- actual procedure to test in repeatable way, including a way to run broken fsck-quick-fix ?

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
