### PR TITLE
cephadm: add --shared_ceph_folder to shell cmd

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -7793,6 +7793,10 @@ def _get_parser():
         'shell', help='run an interactive shell inside a daemon container')
     parser_shell.set_defaults(func=command_shell)
     parser_shell.add_argument(
+        '--shared_ceph_folder',
+        metavar='CEPH_SOURCE_FOLDER',
+        help='Development mode. Several folders in containers are volumes mapped to different sub-folders in the ceph source folder')
+    parser_shell.add_argument(
         '--fsid',
         help='cluster FSID')
     parser_shell.add_argument(


### PR DESCRIPTION
It can be useful to share ceph src when running the `cephadm shell`
command in order to do quick tests.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>