### PR TITLE
octopus: os/bluestore: fix writing to invalid offset when repairing 

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8906,7 +8906,9 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
 	  pext_to_release.reserve(pextents.size());
 	  // rewriting all valid pextents
 	  for (auto e = pextents.begin(); e != pextents.end();
-	         b_off += e->length, e++) {
+	         e++) {
+	    auto b_off_cur = b_off;
+	    b_off += e->length;
 	    if (!e->is_valid()) {
 	      continue;
 	    }
@@ -8943,7 +8945,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
 	    e = pextents.erase(e);
     	    e = pextents.insert(e, exts.begin(), exts.end());
 	    b->get_blob().map_bl(
-	      b_off, bl,
+	      b_off_cur, bl,
 	      [&](uint64_t offset, bufferlist& t) {
 		int r = bdev->write(offset, t, false);
 		ceph_assert(r == 0);

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1689,6 +1689,55 @@ TEST(bluestore_blob_t, unused)
     ASSERT_TRUE(b.is_unused(end0_aligned, min_alloc_size * 3 - end0_aligned));
   }
 }
+// This UT is primarily intended to show how repair procedure
+// causes erroneous write to INVALID_OFFSET which is reported in
+// https://tracker.ceph.com/issues/51682
+// Basic map_any functionality is tested as well though.
+//
+TEST(bluestore_blob_t, wrong_map_bl_in_51682)
+{
+  {
+    bluestore_blob_t b;
+    uint64_t min_alloc_size = 4 << 10; // 64 kB
+
+    b.allocated_test(bluestore_pextent_t(0x17ba000, 4 * min_alloc_size));
+    b.allocated_test(bluestore_pextent_t(0x17bf000, 4 * min_alloc_size));
+    b.allocated_test(
+      bluestore_pextent_t(
+        bluestore_pextent_t::INVALID_OFFSET,
+        1 * min_alloc_size));
+    b.allocated_test(bluestore_pextent_t(0x153c44d000, 7 * min_alloc_size));
+
+    b.mark_used(0, 0x8000);
+    b.mark_used(0x9000, 0x7000);
+
+    string s(0x7000, 'a');
+    bufferlist bl;
+    bl.append(s);
+    const size_t num_expected_entries = 5;
+    uint64_t expected[num_expected_entries][2] = {
+      {0x17ba000, 0x4000},
+      {0x17bf000, 0x3000},
+      {0x17c0000, 0x3000},
+      {0xffffffffffffffff, 0x1000},
+      {0x153c44d000, 0x3000}};
+    size_t expected_pos = 0;
+    b.map_bl(0, bl,
+      [&](uint64_t o, bufferlist& bl) {
+        ASSERT_EQ(o, expected[expected_pos][0]);
+        ASSERT_EQ(bl.length(), expected[expected_pos][1]);
+        ++expected_pos;
+      });
+    // 0x5000 is an improper offset presumably provided when doing a repair
+    b.map_bl(0x5000, bl,
+      [&](uint64_t o, bufferlist& bl) {
+        ASSERT_EQ(o, expected[expected_pos][0]);
+        ASSERT_EQ(bl.length(), expected[expected_pos][1]);
+        ++expected_pos;
+      });
+    ASSERT_EQ(expected_pos, num_expected_entries);
+  }
+}
 
 int main(int argc, char **argv) {
   vector<const char*> args;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52767
backport of https://github.com/ceph/ceph/pull/42353
parent tracker: https://tracker.ceph.com/issues/51682

Signed-off-by: Igor Fedotov <igor.fedotov@croit.io>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
