### PR TITLE
pacific: mgr/dashboard: include mfa_ids in rgw user-details section

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.html
@@ -68,6 +68,11 @@
                   </div>
                 </td>
               </tr>
+              <tr *ngIf="user.mfa_ids?.length">
+                <td i18n
+                    class="bold">MFAs(Id)</td>
+                <td>{{ user.mfa_ids | join}}</td>
+              </tr>
             </tbody>
           </table>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.spec.ts
@@ -71,4 +71,24 @@ describe('RgwUserDetailsComponent', () => {
 
     expect(detailsTab[11].textContent).toEqual('No');
   });
+
+  it('should show mfa ids only if length > 0', () => {
+    component.selection = {
+      uid: 'dashboard',
+      email: '',
+      system: 'true',
+      keys: [],
+      swift_keys: [],
+      mfa_ids: ['testMFA1', 'testMFA2']
+    };
+
+    component.ngOnChanges();
+    fixture.detectChanges();
+
+    const detailsTab = fixture.debugElement.nativeElement.querySelectorAll(
+      '.table.table-striped.table-bordered tr td'
+    );
+    expect(detailsTab[14].textContent).toEqual('MFAs(Id)');
+    expect(detailsTab[15].textContent).toEqual('testMFA1, testMFA2');
+  });
 });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53221

---

backport of https://github.com/ceph/ceph/pull/43845
parent tracker: https://tracker.ceph.com/issues/53193

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh