### PR TITLE
mgr/cephadm: show unmanaged OSDs under 'osd' service

### DIFF
--- a/qa/suites/orch/cephadm/osds/1-start.yaml
+++ b/qa/suites/orch/cephadm/osds/1-start.yaml
@@ -8,6 +8,7 @@ tasks:
       - ceph orch ls
       - ceph orch host ls
       - ceph orch device ls
+      - ceph orch ls | grep '^osd.all-available-devices '
 roles:
 - - host.a
   - client.0

--- a/qa/suites/orch/cephadm/smoke-roleless/3-final.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/3-final.yaml
@@ -6,3 +6,4 @@ tasks:
       - ceph orch ls
       - ceph orch host ls
       - ceph orch device ls
+      - ceph orch ls | grep '^osd.all-available-devices '

--- a/qa/suites/orch/cephadm/smoke/start.yaml
+++ b/qa/suites/orch/cephadm/smoke/start.yaml
@@ -12,3 +12,4 @@ tasks:
       - ceph orch host ls
       - ceph orch device ls
       - ceph orch ls --format yaml
+      - ceph orch ls | grep '^osd '

--- a/qa/suites/orch/cephadm/upgrade/4-wait.yaml
+++ b/qa/suites/orch/cephadm/upgrade/4-wait.yaml
@@ -11,3 +11,4 @@ tasks:
       - ceph versions
       - ceph versions | jq -e '.overall | length == 1'
       - ceph versions | jq -e '.overall | keys' | grep $sha1
+      - ceph orch ls | grep '^osd '

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -905,7 +905,7 @@ class DaemonDescription(object):
         if self.daemon_type == 'osd':
             if self.osdspec_affinity and self.osdspec_affinity != 'None':
                 return self.osdspec_affinity
-            return 'unmanaged'
+            return ''
 
         def _match() -> str:
             assert self.daemon_id is not None
@@ -1051,6 +1051,15 @@ class DaemonDescription(object):
         status_int = c.pop('status', None)
         if 'daemon_name' in c:
             del c['daemon_name']
+        if 'service_name' in c and c['service_name'].startswith('osd.'):
+            # if the service_name is a osd.NNN (numeric osd id) then
+            # ignore it -- it is not a valid service_name and
+            # (presumably) came from an older version of cephadm.
+            try:
+                int(c['service_name'][4:])
+                del c['service_name']
+            except ValueError:
+                pass
         status = DaemonDescriptionStatus(status_int) if status_int is not None else None
         return cls(events=events, status=status, **c)
 


### PR DESCRIPTION
1- If the unit.meta file service_name = osd.NNN (which is true for lots of
OSDs deployed on older version of cephadm) then ignore the field entirely.

2- If an OSD has not service_name (see above) then show it under the 'osd'
service (instead of 'osd.unmanaged').

Sample 'ceph orch ls' output with a drivegroup + unmanaged OSD:

```
NAME      PORTS  RUNNING  REFRESHED  AGE  PLACEMENT
...
osd                    1  85s ago    -    <unmanaged>
osd.hdds               5  85s ago    2s   *
...
```






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [x] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>