### PR TITLE
pacific: mgr/prometheus: Make prometheus standby behaviour configurable

### DIFF
--- a/doc/mgr/prometheus.rst
+++ b/doc/mgr/prometheus.rst
@@ -88,6 +88,24 @@ If you are confident that you don't require the cache, you can disable it::
 
     ceph config set mgr mgr/prometheus/cache false
 
+If you are using the prometheus module behind some kind of reverse proxy or
+loadbalancer, you can simplify discovering the active instance by switching
+to ``error``-mode::
+
+    ceph config set mgr mgr/prometheus/standby_behaviour error
+
+If set, the prometheus module will repond with a HTTP error when requesting ``/``
+from the standby instance. The default error code is 500, but you can configure
+the HTTP response code with::
+
+    ceph config set mgr mgr/prometheus/standby_error_status_code 503
+
+Valid error codes are between 400-599.
+
+To switch back to the default behaviour, simply set the config key to ``default``::
+
+    ceph config set mgr mgr/prometheus/standby_behaviour default
+
 .. _prometheus-rbd-io-statistics:
 
 RBD IO statistics

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -294,6 +294,21 @@ class Module(MgrModule):
             name='rbd_stats_pools_refresh_interval',
             type='int',
             default=300
+        ),
+        Option(
+            name='standby_behaviour',
+            type='str',
+            default='default',
+            enum_allowed=['default', 'error'],
+            runtime=True
+        ),
+        Option(
+            name='standby_error_status_code',
+            type='int',
+            default=500,
+            min=400,
+            max=599,
+            runtime=True
         )
     ]
 
@@ -1436,7 +1451,8 @@ class StandbyModule(MgrStandbyModule):
         cherrypy.config.update({
             'server.socket_host': server_addr,
             'server.socket_port': server_port,
-            'engine.autoreload.on': False
+            'engine.autoreload.on': False,
+            'request.show_tracebacks': False
         })
 
         module = self
@@ -1444,8 +1460,10 @@ class StandbyModule(MgrStandbyModule):
         class Root(object):
             @cherrypy.expose
             def index(self) -> str:
-                active_uri = module.get_active_uri()
-                return '''<!DOCTYPE html>
+                standby_behaviour = module.get_module_option('standby_behaviour')
+                if standby_behaviour == 'default':
+                    active_uri = module.get_active_uri()
+                    return '''<!DOCTYPE html>
 <html>
     <head><title>Ceph Exporter</title></head>
     <body>
@@ -1453,6 +1471,9 @@ class StandbyModule(MgrStandbyModule):
         <p><a href='{}metrics'>Metrics</a></p>
     </body>
 </html>'''.format(active_uri)
+                else:
+                    status = module.get_module_option('standby_error_status_code')
+                    raise cherrypy.HTTPError(status, message="Keep on looking")
 
             @cherrypy.expose
             def metrics(self) -> str:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53234

---

backport of https://github.com/ceph/ceph/pull/43464
parent tracker: https://tracker.ceph.com/issues/53229

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh