### PR TITLE
mgr/dashboard: dashboard does not show degraded objects if they are less than 0.5% under "Dashboard->Capacity->Objects block

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
@@ -340,8 +340,9 @@ describe('HealthComponent', () => {
       expect(component['calcPercentage'](undefined, 1)).toEqual(0);
       expect(component['calcPercentage'](null, 1)).toEqual(0);
       expect(component['calcPercentage'](0, 1)).toEqual(0);
-      expect(component['calcPercentage'](2.346, 10)).toEqual(23);
-      expect(component['calcPercentage'](2.35, 10)).toEqual(24);
+      expect(component['calcPercentage'](1, 100000)).toEqual(0.01);
+      expect(component['calcPercentage'](2.346, 10)).toEqual(23.46);
+      expect(component['calcPercentage'](2.56, 10)).toEqual(25.6);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
@@ -249,6 +249,6 @@ export class HealthComponent implements OnInit, OnDestroy {
       return 0;
     }
 
-    return Math.round((dividend / divisor) * 100);
+    return Math.ceil((dividend / divisor) * 100 * 100) / 100;
   }
 }


### PR DESCRIPTION
This PR is intended to fix this issue

Fixes: https://tracker.ceph.com/issues/53242
Signed-off-by: Aashish Sharma <aasharma@redhat.com>

![Screenshot from 2021-11-12 14-20-29](https://user-images.githubusercontent.com/66050535/141449675-9f7d18cb-6147-4317-a834-8532113857d3.png)

<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
