### PR TITLE
pacific: cephadm: November batch

### DIFF
--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -518,3 +518,28 @@ For example, to distribute configs to hosts with the ``bare_config`` label, run 
   ceph config set mgr mgr/cephadm/manage_etc_ceph_ceph_conf_hosts label:bare_config
 
 (See :ref:`orchestrator-cli-placement-spec` for more information about placement specs.)
+
+Purging a cluster
+=================
+
+.. danger:: THIS OPERATION WILL DESTROY ALL DATA STORED IN THIS CLUSTER
+
+In order to destory a cluster and delete all data stored in this cluster, pause 
+cephadm to avoid deploying new daemons.
+
+.. prompt:: bash #
+
+  ceph orch pause
+
+Then verify the FSID of the cluster:
+
+.. prompt:: bash #
+
+  ceph fsid 
+
+Purge ceph daemons from all hosts in the cluster
+
+.. prompt:: bash #
+
+  # For each host:
+  cephadm rm-cluster --force --zap-osds --fsid <fsid>

--- a/doc/cephadm/troubleshooting.rst
+++ b/doc/cephadm/troubleshooting.rst
@@ -252,6 +252,28 @@ To access the admin socket, first enter the daemon container on the host::
     [root@mon1 ~]# cephadm enter --name <daemon-name>
     [ceph: root@mon1 /]# ceph --admin-daemon /var/run/ceph/ceph-<daemon-name>.asok config show
 
+Calling miscellaneous ceph tools
+--------------------------------
+
+To call miscellaneous like ``ceph-objectstore-tool`` or 
+``ceph-monstore-tool``, you can run them by calling 
+``cephadm shell --name <daemon-name>`` like so::
+
+    root@myhostname # cephadm unit --name mon.myhostname stop
+    root@myhostname # cephadm shell --name mon.myhostname
+    [ceph: root@myhostname /]# ceph-monstore-tool /var/lib/ceph/mon/ceph-myhostname get monmap > monmap         
+    [ceph: root@myhostname /]# monmaptool --print monmap
+    monmaptool: monmap file monmap
+    epoch 1
+    fsid 28596f44-3b56-11ec-9034-482ae35a5fbb
+    last_changed 2021-11-01T20:57:19.755111+0000
+    created 2021-11-01T20:57:19.755111+0000
+    min_mon_release 17 (quincy)
+    election_strategy: 1
+    0: [v2:127.0.0.1:3300/0,v1:127.0.0.1:6789/0] mon.myhostname
+
+This command sets up the environment in a way that is suitable
+for extended daemon maintenance and running the deamon interactively. 
 
 .. _cephadm-restore-quorum:
 

--- a/qa/distros/podman/centos_8.stream_container_tools.yaml
+++ b/qa/distros/podman/centos_8.stream_container_tools.yaml
@@ -1,0 +1,14 @@
+os_type: centos
+os_version: "8.stream"
+overrides:
+  selinux:
+    whitelist:
+      - scontext=system_u:system_r:logrotate_t:s0
+
+tasks:
+- pexec:
+    all:
+    - sudo cp /etc/containers/registries.conf /etc/containers/registries.conf.backup
+    - sudo dnf -y  module reset container-tools
+    - sudo dnf -y  module install container-tools
+    - sudo cp /etc/containers/registries.conf.backup /etc/containers/registries.conf

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/centos_8.3_container_tools_3.0.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/centos_8.3_container_tools_3.0.yaml
@@ -1,1 +1,0 @@
-.qa/distros/podman/centos_8.3_container_tools_3.0.yaml

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/centos_8.stream_container_tools.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/centos_8.stream_container_tools.yaml
@@ -1,0 +1,1 @@
+.qa/distros/podman/centos_8.stream_container_tools.yaml

--- a/qa/suites/orch/cephadm/dashboard/0-distro/centos_8.2_container_tools_3.0.yaml
+++ b/qa/suites/orch/cephadm/dashboard/0-distro/centos_8.2_container_tools_3.0.yaml
@@ -1,1 +1,0 @@
-.qa/distros/podman/centos_8.2_container_tools_3.0.yaml

--- a/qa/suites/orch/cephadm/dashboard/0-distro/centos_8.3_container_tools_3.0.yaml
+++ b/qa/suites/orch/cephadm/dashboard/0-distro/centos_8.3_container_tools_3.0.yaml
@@ -1,0 +1,1 @@
+.qa/distros/podman/centos_8.3_container_tools_3.0.yaml

--- a/qa/suites/orch/cephadm/mgr-nfs-upgrade/0-centos_8.stream_container_tools.yaml
+++ b/qa/suites/orch/cephadm/mgr-nfs-upgrade/0-centos_8.stream_container_tools.yaml
@@ -1,0 +1,1 @@
+.qa/distros/podman/centos_8.stream_container_tools.yaml

--- a/qa/suites/orch/cephadm/smoke/distro/centos_8.stream_container_tools.yaml
+++ b/qa/suites/orch/cephadm/smoke/distro/centos_8.stream_container_tools.yaml
@@ -1,0 +1,1 @@
+.qa/distros/podman/centos_8.stream_container_tools.yaml

--- a/qa/suites/orch/cephadm/upgrade/1-start-distro/1-start-centos_8.stream_container-tools.yaml
+++ b/qa/suites/orch/cephadm/upgrade/1-start-distro/1-start-centos_8.stream_container-tools.yaml
@@ -1,21 +1,22 @@
 os_type: centos
-os_version: "8.3"
-overrides:
-  selinux:
-    whitelist:
-      - scontext=system_u:system_r:logrotate_t:s0
+os_version: "8.stream"
 
 tasks:
+- pexec:
+    all:
+    - sudo cp /etc/containers/registries.conf /etc/containers/registries.conf.backup
+    - sudo dnf -y  module reset container-tools
+    - sudo dnf -y  module install container-tools
+    - sudo cp /etc/containers/registries.conf.backup /etc/containers/registries.conf
 - cephadm:
-    image: quay.ceph.io/ceph-ci/ceph:octopus
-    cephadm_branch: octopus
+    image: docker.io/ceph/ceph:v15.2.0
+    cephadm_branch: v15.2.0
     cephadm_git_url: https://github.com/ceph/ceph
     # avoid --cap-add=PTRACE + --privileged for older cephadm versions
     allow_ptrace: false
     # deploy additional mons the "old" (octopus) way
     add_mons_via_daemon_add: true
     avoid_pacific_features: true
-
 
 roles:
 - - mon.a
@@ -26,7 +27,7 @@ roles:
   - osd.2
   - osd.3
   - client.0
-#  - ceph.rgw.realm.zone.a  # CLI change in v16 pacific
+#   - ceph.rgw.realm.zone.a # Disabled, needs 15.2.4 as an upgrade start
   - node-exporter.a
   - alertmanager.a
 - - mon.b
@@ -39,4 +40,4 @@ roles:
   - prometheus.a
   - grafana.a
   - node-exporter.b
-  - ceph.iscsi.iscsi.a
+#  - ceph.iscsi.iscsi.a  # needs later start point

--- a/qa/suites/orch/cephadm/workunits/0-distro/centos_8.stream_container_tools.yaml
+++ b/qa/suites/orch/cephadm/workunits/0-distro/centos_8.stream_container_tools.yaml
@@ -1,0 +1,1 @@
+.qa/distros/podman/centos_8.stream_container_tools.yaml

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6564,6 +6564,7 @@ class HostFacts():
     _disk_vendor_workarounds = {
         '0x1af4': 'Virtio Block Device'
     }
+    _excluded_block_devices = ('sr', 'zram', 'dm-')
 
     def __init__(self, ctx: CephadmContext):
         self.ctx: CephadmContext = ctx
@@ -6603,7 +6604,7 @@ class HostFacts():
         # type: () -> List[str]
         """Determine the list of block devices by looking at /sys/block"""
         return [dev for dev in os.listdir('/sys/block')
-                if not dev.startswith('dm')]
+                if not dev.startswith(HostFacts._excluded_block_devices)]
 
     def _get_devs_by_type(self, rota='0'):
         # type: (str) -> List[str]

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2315,6 +2315,8 @@ def get_config_and_keyring(ctx):
         d = get_parm(ctx.config_json)
         config = d.get('config')
         keyring = d.get('keyring')
+        if config and keyring:
+            return config, keyring
 
     if 'config' in ctx and ctx.config:
         try:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -31,7 +31,7 @@ from contextlib import redirect_stdout
 import ssl
 from enum import Enum
 
-from typing import Dict, List, Tuple, Optional, Union, Any, NoReturn, Callable, IO, Sequence, TypeVar, cast, Set
+from typing import Dict, List, Tuple, Optional, Union, Any, NoReturn, Callable, IO, Sequence, TypeVar, cast, Set, Iterable
 
 import re
 import uuid
@@ -4136,6 +4136,65 @@ def finish_bootstrap_config(
     pass
 
 
+# funcs to process spec file for apply spec
+def _parse_yaml_docs(f: Iterable[str]) -> List[List[str]]:
+    docs = []
+    current_doc = []  # type: List[str]
+    for line in f:
+        if '---' in line:
+            if current_doc:
+                docs.append(current_doc)
+            current_doc = []
+        else:
+            current_doc.append(line.rstrip())
+    if current_doc:
+        docs.append(current_doc)
+    return docs
+
+
+def _parse_yaml_obj(doc: List[str]) -> Dict[str, str]:
+    # note: this only parses the first layer of yaml
+    obj = {}  # type: Dict[str, str]
+    current_key = ''
+    for line in doc:
+        if line.startswith(' '):
+            obj[current_key] += line.strip()
+        elif line.endswith(':'):
+            current_key = line.strip(':')
+            obj[current_key] = ''
+        else:
+            current_key, val = line.split(':')
+            obj[current_key] = val.strip()
+    return obj
+
+
+def parse_yaml_objs(f: Iterable[str]) -> List[Dict[str, str]]:
+    objs = []
+    for d in _parse_yaml_docs(f):
+        objs.append(_parse_yaml_obj(d))
+    return objs
+
+
+def _distribute_ssh_keys(ctx: CephadmContext, host_spec: Dict[str, str], bootstrap_hostname: str) -> int:
+    # copy ssh key to hosts in host spec (used for apply spec)
+    ssh_key = '/etc/ceph/ceph.pub'
+    if ctx.ssh_public_key:
+        ssh_key = ctx.ssh_public_key.name
+
+    if bootstrap_hostname != host_spec['hostname']:
+        if 'addr' in host_spec:
+            addr = host_spec['addr']
+        else:
+            addr = host_spec['hostname']
+        out, err, code = call(ctx, ['sudo', '-u', ctx.ssh_user, 'ssh-copy-id', '-f', '-i', ssh_key, '-o StrictHostKeyChecking=no', '%s@%s' % (ctx.ssh_user, addr)])
+        if code:
+            logger.info('\nCopying ssh key to host %s at address %s failed!\n' % (host_spec['hostname'], addr))
+            return 1
+        else:
+            logger.info('Added ssh key to host %s at address %s\n' % (host_spec['hostname'], addr))
+    return 0
+
+
 @default_image
 def command_bootstrap(ctx):
     # type: (CephadmContext) -> int
@@ -4350,25 +4409,22 @@ def command_bootstrap(ctx):
 
     if ctx.apply_spec:
         logger.info('Applying %s to cluster' % ctx.apply_spec)
-
+        # copy ssh key to hosts in spec file
         with open(ctx.apply_spec) as f:
-            for line in f:
-                if 'hostname:' in line:
-                    line = line.replace('\n', '')
-                    split = line.split(': ')
-                    if split[1] != hostname:
-                        logger.info('Adding ssh key to %s' % split[1])
-
-                        ssh_key = '/etc/ceph/ceph.pub'
-                        if ctx.ssh_public_key:
-                            ssh_key = ctx.ssh_public_key.name
-                        out, err, code = call_throws(ctx, ['sudo', '-u', ctx.ssh_user, 'ssh-copy-id', '-f', '-i', ssh_key, '-o StrictHostKeyChecking=no', '%s@%s' % (ctx.ssh_user, split[1])])
+            try:
+                for spec in parse_yaml_objs(f):
+                    if spec.get('service_type') == 'host':
+                        _distribute_ssh_keys(ctx, spec, hostname)
+            except ValueError:
+                logger.info('Unable to parse %s succesfully' % ctx.apply_spec)
 
         mounts = {}
         mounts[pathify(ctx.apply_spec)] = '/tmp/spec.yml:ro'
-
-        out = cli(['orch', 'apply', '-i', '/tmp/spec.yml'], extra_mounts=mounts)
-        logger.info(out)
+        try:
+            out = cli(['orch', 'apply', '-i', '/tmp/spec.yml'], extra_mounts=mounts)
+            logger.info(out)
+        except Exception:
+            logger.info('\nApplying %s to cluster failed!\n' % ctx.apply_spec)
 
     logger.info('You can access the Ceph CLI with:\n\n'
                 '\tsudo %s shell --fsid %s -c %s -k %s\n' % (

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1999,8 +1999,8 @@ def find_container_engine(ctx: CephadmContext) -> Optional[ContainerEngine]:
         for i in CONTAINER_PREFERENCE:
             try:
                 return i()
-            except Exception as e:
-                logger.debug('Could not locate %s: %s' % (i.EXE, e))
+            except Exception:
+                pass
     return None
 
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -1071,6 +1071,9 @@ class TestBootstrap(object):
             *args,
         ]
 
+
+###############################################3
+
     def test_config(self, cephadm_fs):
         conf_file = 'foo'
         cmd = self._get_cmd(
@@ -1652,3 +1655,62 @@ class TestPull:
         with pytest.raises(cd.Error) as e:
             cd.command_pull(ctx)
         assert err in str(e.value)
+
+
+class TestApplySpec:
+ 
+    def test_parse_yaml(self, cephadm_fs):
+        yaml = '''service_type: host
+hostname: vm-00
+addr: 192.168.122.44
+labels:
+ - example1
+ - example2
+---
+service_type: host
+hostname: vm-01
+addr: 192.168.122.247
+labels:
+ - grafana
+---
+service_type: host
+hostname: vm-02
+addr: 192.168.122.165'''
+
+        cephadm_fs.create_file('spec.yml', contents=yaml)
+
+        retdic = [{'service_type': 'host', 'hostname': 'vm-00', 'addr': '192.168.122.44', 'labels': '- example1- example2'},
+                  {'service_type': 'host', 'hostname': 'vm-01', 'addr': '192.168.122.247', 'labels': '- grafana'},
+                  {'service_type': 'host', 'hostname': 'vm-02', 'addr': '192.168.122.165'}]
+      
+        with open('spec.yml') as f:
+            dic = cd.parse_yaml_objs(f)
+            assert dic == retdic
+
+    @mock.patch('cephadm.call', return_value=('', '', 0))
+    def test_distribute_ssh_keys(self, call):
+        ctx = cd.CephadmContext()
+        ctx.ssh_public_key = None
+        ctx.ssh_user = 'root'
+
+        host_spec = {'service_type': 'host', 'hostname': 'vm-02', 'addr': '192.168.122.165'}
+
+        retval = cd._distribute_ssh_keys(ctx, host_spec, 'bootstrap_hostname')
+
+        assert retval == 0
+
+        call.return_value = ('', '', 1)
+
+        retval = cd._distribute_ssh_keys(ctx, host_spec, 'bootstrap_hostname')
+
+        assert retval == 1
+
+
+
+
+
+
+
+
+
+  

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2062,9 +2062,9 @@ Then run the following:
                 return f'Unable to remove {service_name} service.\n' \
                        f'Note, you might want to mark the {service_name} service as "unmanaged"'
 
-        # Report list of affected OSDs
-        osds_msg = {}
-        if service_name.startswith('osd.'):
+        # Report list of affected OSDs?
+        if not force and service_name.startswith('osd.'):
+            osds_msg = {}
             for h, dm in self.cache.get_daemons_with_volatile_status():
                 osds_to_remove = []
                 for name, dd in dm.items():
@@ -2072,23 +2072,17 @@ Then run the following:
                         osds_to_remove.append(str(dd.daemon_id))
                 if osds_to_remove:
                     osds_msg[h] = osds_to_remove
-
-        found = self.spec_store.rm(service_name) or osds_msg
-        if found:
-            self._kick_serve_loop()
             if osds_msg:
-                return f'The service {service_name} will be deleted once the following OSDs: {osds_msg} ' \
-                       f'will be deleted manually.'
-            else:
-                return f'Removed service {service_name}'
-        else:
-            # must be idempotent: still a success.
-            try:
-                self.cache.get_daemon(service_name)
-                return (f'Failed to remove service <{service_name}>. "{service_name}" is the name of a daemon, not a service. '
-                        + 'Running service names can be found with "ceph orch ls"')
-            except OrchestratorError:
-                return f'Failed to remove service. <{service_name}> was not found. Running service names can be found with "ceph orch ls"'
+                msg = ''
+                for h, ls in osds_msg.items():
+                    msg += f'\thost {h}: {" ".join([f"osd.{id}" for id in ls])}'
+                raise OrchestratorError(f'If {service_name} is removed then the following OSDs will remain, --force to proceed anyway\n{msg}')
+
+        found = self.spec_store.rm(service_name)
+        if found and service_name.startswith('osd.'):
+            self.spec_store.finally_rm(service_name)
+        self._kick_serve_loop()
+        return f'Removed service {service_name}'
 
     @handle_orch_error
     def get_inventory(self, host_filter: Optional[orchestrator.InventoryFilter] = None, refresh: bool = False) -> List[orchestrator.InventoryHost]:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2054,7 +2054,7 @@ Then run the following:
         return self._remove_daemons(args)
 
     @handle_orch_error
-    def remove_service(self, service_name: str) -> str:
+    def remove_service(self, service_name: str, force: bool = False) -> str:
         self.log.info('Remove service %s' % service_name)
         self._trigger_preview_refresh(service_name=service_name)
         if service_name in self.spec_store:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -407,7 +407,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.default_registry = ''
             self.autotune_memory_target_ratio = 0.0
             self.autotune_interval = 0
-
+            self.apply_spec_fails: List[Tuple[str, str]] = []
             self.max_osd_draining_count = 10
 
         self._cons: Dict[str, Tuple[remoto.backends.BaseConnection,

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -104,9 +104,9 @@ class DaemonPlacement(NamedTuple):
         if self.name and self.name != dd.daemon_id:
             return False
         if self.ports:
-            if self.ports != dd.ports:
+            if self.ports != dd.ports and dd.ports:
                 return False
-            if self.ip != dd.ip:
+            if self.ip != dd.ip and dd.ip:
                 return False
         return True
 

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -361,8 +361,8 @@ class HostAssignment(object):
     def find_ip_on_host(self, hostname: str, subnets: List[str]) -> Optional[str]:
         for subnet in subnets:
             ips: List[str] = []
-            for iface, ips in self.networks.get(hostname, {}).get(subnet, {}).items():
-                ips.extend(ips)
+            for iface, iface_ips in self.networks.get(hostname, {}).get(subnet, {}).items():
+                ips.extend(iface_ips)
             if ips:
                 return sorted(ips)[0]
         return None

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -942,8 +942,12 @@ class CephadmServe:
 
         # do daemon post actions
         for daemon_type, daemon_descs in daemons_post.items():
-            if daemon_type in self.mgr.requires_post_actions:
-                self.mgr.requires_post_actions.remove(daemon_type)
+            run_post = False
+            for d in daemon_descs:
+                if d.name() in self.mgr.requires_post_actions:
+                    self.mgr.requires_post_actions.remove(d.name())
+                    run_post = True
+            if run_post:
                 self.mgr._get_cephadm_service(daemon_type_to_service(
                     daemon_type)).daemon_check_post(daemon_descs)
 
@@ -1065,7 +1069,7 @@ class CephadmServe:
                             DaemonDescriptionStatus.running, 'starting')
                         self.mgr.cache.add_daemon(daemon_spec.host, sd)
                         if daemon_spec.daemon_type in REQUIRES_POST_ACTIONS:
-                            self.mgr.requires_post_actions.add(daemon_spec.daemon_type)
+                            self.mgr.requires_post_actions.add(daemon_spec.name())
                     self.mgr.cache.invalidate_host_daemons(daemon_spec.host)
 
                 self.mgr.cache.update_daemon_config_deps(

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -10,6 +10,7 @@ from mgr_module import HandleCommandResult, MonCommandFailed
 
 from ceph.deployment.service_spec import ServiceSpec, RGWSpec
 from ceph.deployment.utils import is_ipv6, unwrap_ipv6
+from mgr_util import build_url
 from orchestrator import OrchestratorError, DaemonDescription, DaemonDescriptionStatus
 from orchestrator._interface import daemon_type_to_service
 from cephadm import utils
@@ -821,25 +822,27 @@ class RgwService(CephService):
         if ftype == 'beast':
             if spec.ssl:
                 if daemon_spec.ip:
-                    args.append(f"ssl_endpoint={daemon_spec.ip}:{port}")
+                    args.append(
+                        f"ssl_endpoint={build_url(host=daemon_spec.ip, port=port).lstrip('/')}")
                 else:
                     args.append(f"ssl_port={port}")
                 args.append(f"ssl_certificate=config://rgw/cert/{spec.service_name()}")
             else:
                 if daemon_spec.ip:
-                    args.append(f"endpoint={daemon_spec.ip}:{port}")
+                    args.append(f"endpoint={build_url(host=daemon_spec.ip, port=port).lstrip('/')}")
                 else:
                     args.append(f"port={port}")
         elif ftype == 'civetweb':
             if spec.ssl:
                 if daemon_spec.ip:
-                    args.append(f"port={daemon_spec.ip}:{port}s")  # note the 's' suffix on port
+                    # note the 's' suffix on port
+                    args.append(f"port={build_url(host=daemon_spec.ip, port=port).lstrip('/')}s")
                 else:
                     args.append(f"port={port}s")  # note the 's' suffix on port
                 args.append(f"ssl_certificate=config://rgw/cert/{spec.service_name()}")
             else:
                 if daemon_spec.ip:
-                    args.append(f"port={daemon_spec.ip}:{port}")
+                    args.append(f"port={build_url(host=daemon_spec.ip, port=port).lstrip('/')}")
                 else:
                     args.append(f"port={port}")
         frontend = f'{ftype} {" ".join(args)}'

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -412,7 +412,7 @@ class RemoveUtil(object):
         while not self.ok_to_stop(osds):
             if len(osds) <= 1:
                 # can't even stop one OSD, aborting
-                self.mgr.log.info(
+                self.mgr.log.debug(
                     "Can't even stop one OSD. Cluster is probably busy. Retrying later..")
                 return []
 

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -432,7 +432,7 @@ class RemoveUtil(object):
             'prefix': "osd ok-to-stop",
             'ids': [str(osd.osd_id) for osd in osds]
         }
-        return self._run_mon_cmd(cmd_args)
+        return self._run_mon_cmd(cmd_args, error_ok=True)
 
     def set_osd_flag(self, osds: List["OSD"], flag: str) -> bool:
         base_cmd = f"osd {flag}"
@@ -492,7 +492,7 @@ class RemoveUtil(object):
         """ Queries the safe-to-destroy flag for OSDs """
         cmd_args = {'prefix': 'osd safe-to-destroy',
                     'ids': [str(x) for x in osd_ids]}
-        return self._run_mon_cmd(cmd_args)
+        return self._run_mon_cmd(cmd_args, error_ok=True)
 
     def destroy_osd(self, osd_id: int) -> bool:
         """ Destroys an OSD (forcefully) """
@@ -510,14 +510,15 @@ class RemoveUtil(object):
         }
         return self._run_mon_cmd(cmd_args)
 
-    def _run_mon_cmd(self, cmd_args: dict) -> bool:
+    def _run_mon_cmd(self, cmd_args: dict, error_ok: bool = False) -> bool:
         """
         Generic command to run mon_command and evaluate/log the results
         """
         ret, out, err = self.mgr.mon_command(cmd_args)
         if ret != 0:
             self.mgr.log.debug(f"ran {cmd_args} with mon_command")
-            self.mgr.log.error(f"cmd: {cmd_args.get('prefix')} failed with: {err}. (errno:{ret})")
+            if not error_ok:
+                self.mgr.log.error(f"cmd: {cmd_args.get('prefix')} failed with: {err}. (errno:{ret})")
             return False
         self.mgr.log.debug(f"cmd: {cmd_args.get('prefix')} returns: {out}")
         return True

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -204,12 +204,14 @@ class OSDService(CephService):
         [
           {'data': {<metadata>},
            'osdspec': <name of osdspec>,
-           'host': <name of host>
+           'host': <name of host>,
+           'notes': <notes>
            },
 
            {'data': ...,
             'osdspec': ..,
-            'host': ..
+            'host': ...,
+            'notes': ...
            }
         ]
 
@@ -246,10 +248,16 @@ class OSDService(CephService):
                     except ValueError:
                         logger.exception('Cannot decode JSON: \'%s\'' % ' '.join(out))
                         concat_out = {}
-
+                    notes = []
+                    if osdspec.data_devices is not None and osdspec.data_devices.limit and len(concat_out) < osdspec.data_devices.limit:
+                        found = len(concat_out)
+                        limit = osdspec.data_devices.limit
+                        notes.append(
+                            f'NOTE: Did not find enough disks matching filter on host {host} to reach data device limit (Found: {found} | Limit: {limit})')
                     ret_all.append({'data': concat_out,
                                     'osdspec': osdspec.service_id,
-                                    'host': host})
+                                    'host': host,
+                                    'notes': notes})
         return ret_all
 
     def resolve_hosts_for_osdspecs(self,

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -668,6 +668,28 @@ class TestCephadm(object):
             assert out == "Created no osd(s) on host test; already created?"
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch('cephadm.services.osd.OSDService._run_ceph_volume_command')
+    @mock.patch('cephadm.services.osd.OSDService.driveselection_to_ceph_volume')
+    @mock.patch('cephadm.services.osd.OsdIdClaims.refresh', lambda _: None)
+    @mock.patch('cephadm.services.osd.OsdIdClaims.get', lambda _: {})
+    def test_limit_not_reached(self, d_to_cv, _run_cv_cmd, cephadm_module):
+        with with_host(cephadm_module, 'test'):
+            dg = DriveGroupSpec(placement=PlacementSpec(host_pattern='test'),
+                                data_devices=DeviceSelection(limit=5, rotational=1),
+                                service_id='not_enough')
+
+            disks_found = [
+                '[{"data": "/dev/vdb", "data_size": "50.00 GB", "encryption": "None"}, {"data": "/dev/vdc", "data_size": "50.00 GB", "encryption": "None"}]']
+            d_to_cv.return_value = 'foo'
+            _run_cv_cmd.return_value = (disks_found, '', 0)
+            preview = cephadm_module.osd_service.generate_previews([dg], 'test')
+
+            for osd in preview:
+                assert 'notes' in osd
+                assert osd['notes'] == [
+                    'NOTE: Did not find enough disks matching filter on host test to reach data device limit (Found: 2 | Limit: 5)']
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     def test_prepare_drivegroup(self, cephadm_module):
         with with_host(cephadm_module, 'test'):
             dg = DriveGroupSpec(placement=PlacementSpec(host_pattern='test'),

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -391,6 +391,66 @@ class TestCephadm(object):
                         {'prefix': 'dashboard set-grafana-api-url', 'value': 'https://[1::4]:3000'},
                         None)
 
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '1.2.3.4')
+    def test_iscsi_post_actions_with_missing_daemon_in_cache(self, cephadm_module: CephadmOrchestrator):
+        # https://tracker.ceph.com/issues/52866
+        with with_host(cephadm_module, 'test1'):
+            with with_host(cephadm_module, 'test2'):
+                with with_service(cephadm_module, IscsiServiceSpec(service_id='foobar', pool='pool', placement=PlacementSpec(host_pattern='*')), CephadmOrchestrator.apply_iscsi, 'test'):
+
+                    CephadmServe(cephadm_module)._apply_all_services()
+                    assert len(cephadm_module.cache.get_daemons_by_type('iscsi')) == 2
+
+                    # get a deamons from postaction list (ARRGH sets!!)
+                    tempset = cephadm_module.requires_post_actions.copy()
+                    tempdeamon1 = tempset.pop()
+                    tempdeamon2 = tempset.pop()
+
+                    # make sure post actions has 2 daemons in it
+                    assert len(cephadm_module.requires_post_actions) == 2
+
+                    # replicate a host cache that is not in sync when check_daemons is called
+                    tempdd1 = cephadm_module.cache.get_daemon(tempdeamon1)
+                    tempdd2 = cephadm_module.cache.get_daemon(tempdeamon2)
+                    host = 'test1'
+                    if 'test1' not in tempdeamon1:
+                        host = 'test2'
+                    cephadm_module.cache.rm_daemon(host, tempdeamon1)
+
+                    # Make sure, _check_daemons does a redeploy due to monmap change:
+                    cephadm_module.mock_store_set('_ceph_get', 'mon_map', {
+                        'modified': datetime_to_str(datetime_now()),
+                        'fsid': 'foobar',
+                    })
+                    cephadm_module.notify('mon_map', None)
+                    cephadm_module.mock_store_set('_ceph_get', 'mgr_map', {
+                        'modules': ['dashboard']
+                    })
+
+                    with mock.patch("cephadm.module.IscsiService.config_dashboard") as _cfg_db:
+                        CephadmServe(cephadm_module)._check_daemons()
+                        _cfg_db.assert_called_once_with([tempdd2])
+
+                        # post actions still has the other deamon in it and will run next _check_deamons
+                        assert len(cephadm_module.requires_post_actions) == 1
+
+                        # post actions was missed for a daemon
+                        assert tempdeamon1 in cephadm_module.requires_post_actions
+
+                        # put the daemon back in the cache
+                        cephadm_module.cache.add_daemon(host, tempdd1)
+
+                        _cfg_db.reset_mock()
+                        # replicate serve loop running again
+                        CephadmServe(cephadm_module)._check_daemons()
+
+                        # post actions should have been called again
+                        _cfg_db.asset_called()
+
+                        # post actions is now empty
+                        assert len(cephadm_module.requires_post_actions) == 0
+
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
     def test_mon_add(self, cephadm_module):
         with with_host(cephadm_module, 'test'):

--- a/src/pybind/mgr/cephadm/tests/test_osd_removal.py
+++ b/src/pybind/mgr/cephadm/tests/test_osd_removal.py
@@ -84,11 +84,13 @@ class TestOSDRemoval:
 
     def test_ok_to_stop(self, rm_util):
         rm_util.ok_to_stop([MockOSD(1)])
-        rm_util._run_mon_cmd.assert_called_with({'prefix': 'osd ok-to-stop', 'ids': ['1']})
+        rm_util._run_mon_cmd.assert_called_with({'prefix': 'osd ok-to-stop', 'ids': ['1']},
+                                                error_ok=True)
 
     def test_safe_to_destroy(self, rm_util):
         rm_util.safe_to_destroy([1])
-        rm_util._run_mon_cmd.assert_called_with({'prefix': 'osd safe-to-destroy', 'ids': ['1']})
+        rm_util._run_mon_cmd.assert_called_with({'prefix': 'osd safe-to-destroy',
+                                                 'ids': ['1']}, error_ok=True)
 
     def test_destroy_osd(self, rm_util):
         rm_util.destroy_osd(1)

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -16,8 +16,9 @@ from cephadm.services.monitoring import GrafanaService, AlertmanagerService, Pro
     NodeExporterService
 from cephadm.services.exporter import CephadmExporter
 from cephadm.module import CephadmOrchestrator
-from ceph.deployment.service_spec import IscsiServiceSpec, MonitoringSpec, AlertManagerSpec, ServiceSpec
-from cephadm.tests.fixtures import with_host, with_service
+from ceph.deployment.service_spec import IscsiServiceSpec, MonitoringSpec, AlertManagerSpec, \
+    ServiceSpec, RGWSpec
+from cephadm.tests.fixtures import with_host, with_service, _run_cephadm
 
 from orchestrator import OrchestratorError
 from orchestrator._interface import DaemonDescription
@@ -422,3 +423,40 @@ spec:
                         ],
                         stdin='{}',
                         image='')
+
+
+class TestRGWService:
+
+    @pytest.mark.parametrize(
+        "frontend, ssl, expected",
+        [
+            ('beast', False, 'beast endpoint=[fd00:fd00:fd00:3000::1]:80'),
+            ('beast', True,
+             'beast ssl_endpoint=[fd00:fd00:fd00:3000::1]:443 ssl_certificate=config://rgw/cert/rgw.foo'),
+            ('civetweb', False, 'civetweb port=[fd00:fd00:fd00:3000::1]:80'),
+            ('civetweb', True,
+             'civetweb port=[fd00:fd00:fd00:3000::1]:443s ssl_certificate=config://rgw/cert/rgw.foo'),
+        ]
+    )
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_rgw_update(self, frontend, ssl, expected, cephadm_module: CephadmOrchestrator):
+        with with_host(cephadm_module, 'host1'):
+            cephadm_module.cache.update_host_devices_networks(
+                'host1',
+                dls=cephadm_module.cache.devices['host1'],
+                nets={
+                    'fd00:fd00:fd00:3000::/64': {
+                        'if0': ['fd00:fd00:fd00:3000::1']
+                    }
+                })
+            s = RGWSpec(service_id="foo",
+                        networks=['fd00:fd00:fd00:3000::/64'],
+                        ssl=ssl,
+                        rgw_frontend_type=frontend)
+            with with_service(cephadm_module, s) as dds:
+                _, f, _ = cephadm_module.check_mon_command({
+                    'prefix': 'config get',
+                    'who': f'client.{dds[0]}',
+                    'key': 'rgw_frontends',
+                })
+                assert f == expected

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -491,7 +491,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def remove_service(self, service_name: str) -> OrchResult[str]:
+    def remove_service(self, service_name: str, force: bool = False) -> OrchResult[str]:
         """
         Remove a service (a collection of daemons).
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -159,6 +159,7 @@ def preview_table_osd(data: List) -> str:
     table.align = 'l'
     table.left_padding_width = 0
     table.right_padding_width = 2
+    notes = ''
     for osd_data in data:
         if osd_data.get('service_type') != 'osd':
             continue
@@ -167,6 +168,8 @@ def preview_table_osd(data: List) -> str:
                 if spec.get('error'):
                     return spec.get('message')
                 dg_name = spec.get('osdspec')
+                if spec.get('notes', []):
+                    notes += '\n'.join(spec.get('notes')) + '\n'
                 for osd in spec.get('data', []):
                     db_path = osd.get('block_db', '-')
                     wal_path = osd.get('block_wal', '-')
@@ -174,7 +177,7 @@ def preview_table_osd(data: List) -> str:
                     if not block_data:
                         continue
                     table.add_row(('osd', dg_name, host, block_data, db_path, wal_path))
-    return table.get_string()
+    return notes + table.get_string()
 
 
 def preview_table_services(data: List) -> str:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -850,14 +850,17 @@ Usage:
             out = to_format(report, format, many=True, cls=None)
         else:
             table = PrettyTable(
-                ['OSD_ID', 'HOST', 'STATE', 'PG_COUNT', 'REPLACE', 'FORCE', 'DRAIN_STARTED_AT'],
+                ['OSD', 'HOST', 'STATE', 'PGS', 'REPLACE', 'FORCE', 'ZAP',
+                 'DRAIN STARTED AT'],
                 border=False)
             table.align = 'l'
+            table._align['PGS'] = 'r'
             table.left_padding_width = 0
             table.right_padding_width = 2
             for osd in sorted(report, key=lambda o: o.osd_id):
                 table.add_row([osd.osd_id, osd.hostname, osd.drain_status_human(),
-                               osd.get_pg_count(), osd.replace, osd.force, osd.drain_started_at])
+                               osd.get_pg_count(), osd.replace, osd.force, osd.zap,
+                               osd.drain_started_at or ''])
             out = table.get_string()
 
         return HandleCommandResult(stdout=out)

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1013,7 +1013,7 @@ Usage:
         """Remove a service"""
         if service_name in ['mon', 'mgr'] and not force:
             raise OrchestratorError('The mon and mgr services cannot be removed')
-        completion = self.remove_service(service_name)
+        completion = self.remove_service(service_name, force=force)
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -401,7 +401,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         return result
 
     @handle_orch_error
-    def remove_service(self, service_name: str) -> str:
+    def remove_service(self, service_name: str, force: bool = False) -> str:
         service_type, service_name = service_name.split('.', 1)
         if service_type == 'mds':
             return self.rook_cluster.rm_service('cephfilesystems', service_name)

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -227,7 +227,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         return 'done'
 
     @handle_orch_error
-    def remove_service(self, service_name):
+    def remove_service(self, service_name, force = False):
         assert isinstance(service_name, str)
         return 'done'
 


### PR DESCRIPTION
Backport of #43376, #43602, #43654, #43734, #42838, #43454, #43628, #43762, #43790, #43737, #43827, #43821, #43825, #43789, #43536, #43874

```
git log -n 23 | grep -C 10 Conflicts  
commit 240241dae589f1c6996a9011cbb42dc1792c3927
    qa/suites/orch/cephadm: add 8.stream + container_tools
    
    Conflicts:
            qa/suites/orch/cephadm/dashboard/0-distro/centos_8.2_container_tools_3.0.yaml

commit 7c8a492e5fd43a3c76e630f076ff12d31da06311
    mgr/orchestrator: pass 'force' flag down for remove_service
    
    Conflicts:
            src/pybind/mgr/rook/module.py

commit d62ac37a0e2abfddec22bf698997f87d31e130e0
    mgr/cephadm: Fix RGW ipv6 frontend configuration

    Conflicts:
    
      src/pybind/mgr/cephadm/tests/test_services.py
    
      fix tox test: AttributeError: 'HostCache' object has no
      attribute 'update_host_networks' which was introduced in
      78983ad0d0cce422da32dc4876ac186f6d32c3f5 (not yet in pacific)

commit 385b35569d7fe4c1901f491ffcb43183cccb7bbb
    mgr/cephadm: set health check warning for apply spec failures and daemon place failures in serve
    
    Conflicts:
            src/pybind/mgr/cephadm/module.py
            src/pybind/mgr/cephadm/serve.py
```

Changelog:

Dropped `05125a4533 ceph-volume: implement lvm wrapper`, `d 0dbd9bf9e4 cephadm: mount rootfs in osd containers`