### PR TITLE
rbd: correct encoding of snap protection record in exporting image

### DIFF
--- a/src/tools/rbd/action/Export.cc
+++ b/src/tools/rbd/action/Export.cc
@@ -173,7 +173,7 @@ int do_export_diff_fd(librbd::Image& image, const char *fromsnapname,
       if (r < 0) {
         return r;
       }
-      len = 8;
+      len = 1;
       encode(len, bl);
       encode(is_protected, bl);
     }


### PR DESCRIPTION
Correct the size of `protection` field. This bug is harmless since Export/Import writes/reads one byte for `protected` field regardless of `length` field. So the current wrong diff works correctly by chance.

Fixes: https://tracker.ceph.com/issues/53243
Signed-off-by: Satoru Takeuchi <satoru.takeuchi@gmail.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [x] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
