### PR TITLE
qa/standalone: fix osd-scrub-dump following changes to 'pg dump pgs' output

### DIFF
--- a/qa/standalone/scrub/osd-scrub-dump.sh
+++ b/qa/standalone/scrub/osd-scrub-dump.sh
@@ -104,7 +104,7 @@ function TEST_recover_unexpected() {
     for i in $(seq 0 300)
     do
 	ceph pg dump pgs
-	if ceph pg dump pgs | grep scrubbing; then
+	if ceph pg dump pgs | grep '+scrubbing'; then
 	    ok=true
 	    break
 	fi
@@ -144,7 +144,7 @@ function TEST_recover_unexpected() {
     # Check that there are no more scrubs
     for i in $(seq 0 5)
     do
-        if ceph pg dump pgs | grep scrubbing; then
+        if ceph pg dump pgs | grep '+scrubbing'; then
 	    echo "ERROR: Extra scrubs after test completion...not expected"
 	    return 1
         fi


### PR DESCRIPTION

Make osd-scrub-dump test ignore the 'scrubbing' that might be late to disappear
from the modified (PR #43403) 'pg dump' output.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
