### PR TITLE
osd/scrub (& qa/standalone): test for scrub behavior when no-scrub is set but no-deep-scrub is not

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4147,7 +4147,7 @@ void OSD::final_init()
   r = admin_socket->register_command(
     "scrubdebug "						\
     "name=pgid,type=CephPgid "	                                \
-    "name=cmd,type=CephChoices,strings=block|unblock "          \
+    "name=cmd,type=CephChoices,strings=block|unblock|set|unset " \
     "name=value,type=CephString,req=false",
     asok_hook,
     "debug the scrubber");

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1189,7 +1189,8 @@ void PrimaryLogPG::do_command(
     outbl.append(ss.str());
   }
 
-  else if (prefix == "block" || prefix == "unblock") {
+  else if (prefix == "block" || prefix == "unblock" || prefix == "set" ||
+           prefix == "unset") {
     string value;
     cmd_getval(cmdmap, "value", value);
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -86,7 +86,7 @@ class LocalReservation {
   bool m_holding_local_reservation{false};
 
  public:
-  LocalReservation(OSDService* osds);
+  explicit LocalReservation(OSDService* osds);
   ~LocalReservation();
   bool is_reserved() const { return m_holding_local_reservation; }
 };
@@ -612,6 +612,17 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
    *  triggered by the backend will be discarded.
    */
   Scrub::act_token_t m_current_token{1};
+
+  /**
+   *  (primary/replica) a test aid. A counter that is incremented whenever a scrub starts,
+   *  and again when it terminates. Exposed as part of the 'pg query' command, to be used
+   *  by test scripts.
+   *
+   *  @ATTN: not guaranteed to be accurate. To be only used for tests. This is why it
+   *  is initialized to a meaningless number;
+   */
+  int32_t m_sessions_counter{(int32_t)((int64_t)(this) & 0x0000'0000'00ff'fff0)};
+  bool m_publish_sessions{false}; //< will the counter be part of 'query' output?
 
   scrub_flags_t m_flags;
 


### PR DESCRIPTION
 
Due to a bug (https://tracker.ceph.com/issues/52901 - fixed in #43521),
this combination of conditions ('noscrub' but no 'nodeepscrub') left PGs in "scrubbing" state
forever.

Adding:
- a test to detect this (now fixed) mishandling of 'noscrub'.

and to support this test (and others):
- an ever-increasing scrub sessions counter that is ticked for each start or termination
 of a scrub. An ASOK command makes the obfuscated counter appear in 'pg query'
 command output.
    
Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

