### PR TITLE
src/test/librbd/test_librbd.cc: add 2 unit-tests

### DIFF
--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -3533,11 +3533,21 @@ TEST_F(TestLibRBD, TestClone2)
                                            &snap_namespace_type));
   ASSERT_EQ(RBD_SNAP_NAMESPACE_TYPE_TRASH, snap_namespace_type);
 
+  rbd_snap_group_namespace_t group_snap_type;
+  ASSERT_EQ(0, rbd_snap_get_group_namespace(parent, snaps[0].id,
+                                            &group_snap_type,
+                                            sizeof(group_snap_type)));
+
   char original_name[32];
   ASSERT_EQ(0, rbd_snap_get_trash_namespace(parent, snaps[0].id,
                                             original_name,
                                             sizeof(original_name)));
   ASSERT_EQ(0, strcmp("parent_snap", original_name));
+
+  rbd_snap_mirror_namespace_t mirror_snap_type;
+  ASSERT_EQ(0, rbd_snap_get_mirror_namespace(parent, snaps[0].id,
+                                             &mirror_snap_type,
+                                             sizeof(mirror_snap_type)));
 
   ASSERT_EQ(0, rbd_close(child));
   ASSERT_EQ(0, rbd_close(parent));


### PR DESCRIPTION
rbd_snap_get_trash_namespace(),rbd_snap_get_mirror_namespace()

Signed-off-by: Song Tongshuai





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
