### PR TITLE
crimson: futurize FuturizedStore::create()

### DIFF
--- a/src/crimson/os/futurized_store.cc
+++ b/src/crimson/os/futurized_store.cc
@@ -10,20 +10,20 @@
 
 namespace crimson::os {
 
-std::unique_ptr<FuturizedStore>
+seastar::future<std::unique_ptr<FuturizedStore>>
 FuturizedStore::create(const std::string& type,
                        const std::string& data,
                        const ConfigValues& values)
 {
   if (type == "cyanstore") {
-    return std::make_unique<crimson::os::CyanStore>(data);
+    return seastar::make_ready_future<std::unique_ptr<FuturizedStore>>(std::make_unique<crimson::os::CyanStore>(data));
   } else if (type == "seastore") {
-    return crimson::os::seastore::make_seastore(data, values);
+    return seastar::make_ready_future<std::unique_ptr<FuturizedStore>>(crimson::os::seastore::make_seastore(data, values));
   } else {
 #ifdef WITH_BLUESTORE
     // use AlienStore as a fallback. It adapts e.g. BlueStore.
-    return std::make_unique<crimson::os::AlienStore>(
-      type, data, values);
+    return seastar::make_ready_future<std::unique_ptr<FuturizedStore>>(std::make_unique<crimson::os::AlienStore>(
+      type, data, values));
 #else
     ceph_abort_msgf("unsupported objectstore type: %s", type.c_str());
     return {};

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -51,7 +51,7 @@ public:
   };
   using OmapIteratorRef = boost::intrusive_ptr<OmapIterator>;
 
-  static std::unique_ptr<FuturizedStore> create(const std::string& type,
+  static seastar::future<std::unique_ptr<FuturizedStore>> create(const std::string& type,
                                                 const std::string& data,
                                                 const ConfigValues& values);
   FuturizedStore() = default;

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -314,7 +314,7 @@ int main(int argc, char* argv[])
           auto store = crimson::os::FuturizedStore::create(
             local_conf().get_val<std::string>("osd_objectstore"),
             local_conf().get_val<std::string>("osd_data"),
-            local_conf().get_config_values());
+            local_conf().get_config_values()).get();
 
           osd.start_single(whoami, nonce,
                            std::ref(*store),

--- a/src/crimson/tools/store_nbd/fs_driver.cc
+++ b/src/crimson/tools/store_nbd/fs_driver.cc
@@ -179,10 +179,12 @@ seastar::future<bufferlist> FSDriver::read(
 
 seastar::future<> FSDriver::mkfs()
 {
-  init();
-  assert(fs);
-  return fs->start(
+  return init(    
   ).then([this] {
+    assert(fs);
+  }).then([this] {
+    return fs->start();
+  }).then([this] {
     uuid_d uuid;
     uuid.generate_random();
     return fs->mkfs(uuid).handle_error(
@@ -196,8 +198,9 @@ seastar::future<> FSDriver::mkfs()
   }).then([this] {
     return fs->stop();
   }).then([this] {
-    init();
-    return fs->start();
+    return init().then([this] {
+      return fs->start();
+    });
   }).then([this] {
     return fs->mount(
     ).handle_error(
@@ -239,8 +242,9 @@ seastar::future<> FSDriver::mount()
   return (
     config.mkfs ? mkfs() : seastar::now()
   ).then([this] {
-    init();
-    return fs->start();
+    return init().then([this] {
+      return fs->start();
+    });
   }).then([this] {
     return fs->mount(
     ).handle_error(
@@ -299,11 +303,15 @@ seastar::future<> FSDriver::close()
   });
 }
 
-void FSDriver::init()
+seastar::future<> FSDriver::init()
 {
   fs.reset();
-  fs = FuturizedStore::create(
+  return FuturizedStore::create(
     config.get_fs_type(),
     *config.path,
-    crimson::common::local_conf().get_config_values());
+    crimson::common::local_conf().get_config_values()
+  ).then([this] (auto store_ptr) {
+      fs = std::move(store_ptr);
+      return seastar::now();
+  });
 }

--- a/src/crimson/tools/store_nbd/fs_driver.h
+++ b/src/crimson/tools/store_nbd/fs_driver.h
@@ -55,7 +55,7 @@ private:
   offset_mapping_t map_offset(off_t offset);
 
   seastar::future<> mkfs();
-  void init();
+  seastar::future<> init();
 
   friend void populate_log(
     ceph::os::Transaction &,


### PR DESCRIPTION
This commit changes the FuturizedStore::create() function to return a
seastar::future containing its original return value.

This PR is setup for when we will futurize make_seastore() to be able to auto-detect whether a device is
ZNS to instantiate the correct type of segment manager.

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
