### PR TITLE
qa/suites/orch/cephadm: stop testing container-tools:3.0

### DIFF
--- a/qa/suites/orch/cephadm/smoke/distro/centos_8.2_container_tools_3.0.yaml
+++ b/qa/suites/orch/cephadm/smoke/distro/centos_8.2_container_tools_3.0.yaml
@@ -1,1 +1,0 @@
-.qa/distros/podman/centos_8.2_container_tools_3.0.yaml

--- a/qa/suites/orch/cephadm/smoke/distro/centos_8.3_container_tools_3.0.yaml
+++ b/qa/suites/orch/cephadm/smoke/distro/centos_8.3_container_tools_3.0.yaml
@@ -1,1 +1,0 @@
-.qa/distros/podman/centos_8.3_container_tools_3.0.yaml

--- a/qa/suites/orch/cephadm/smoke/distro/rhel_8.4_container_tools_3.0.yaml
+++ b/qa/suites/orch/cephadm/smoke/distro/rhel_8.4_container_tools_3.0.yaml
@@ -1,1 +1,0 @@
-.qa/distros/podman/rhel_8.4_container_tools_3.0.yaml

--- a/qa/suites/orch/cephadm/smoke/distro/rhel_8.4_container_tools_rhel8.yaml
+++ b/qa/suites/orch/cephadm/smoke/distro/rhel_8.4_container_tools_rhel8.yaml
@@ -1,1 +1,0 @@
-.qa/distros/podman/rhel_8.4_container_tools_rhel8.yaml

--- a/qa/suites/orch/cephadm/workunits/0-distro/centos_8.2_container_tools_3.0.yaml
+++ b/qa/suites/orch/cephadm/workunits/0-distro/centos_8.2_container_tools_3.0.yaml
@@ -1,1 +1,0 @@
-.qa/distros/podman/centos_8.2_container_tools_3.0.yaml


### PR DESCRIPTION
container-tools-3.0 is too buggy and generates too many test failures.

Signed-off-by: Sage Weil <sage@newdream.net>