### PR TITLE
pacific: rgw/beast: optimizations for request timeout

### DIFF
--- a/src/common/async/yield_context.h
+++ b/src/common/async/yield_context.h
@@ -22,17 +22,23 @@
 
 #include <spawn/spawn.hpp>
 
+// use explicit executor types instead of the type-erased boost::asio::executor.
+// coroutines wrap the default io_context executor with a strand executor
+using yield_context = spawn::basic_yield_context<
+    boost::asio::executor_binder<void(*)(),
+        boost::asio::strand<boost::asio::io_context::executor_type>>>;
+
 /// optional-like wrapper for a spawn::yield_context and its associated
 /// boost::asio::io_context. operations that take an optional_yield argument
 /// will, when passed a non-empty yield context, suspend this coroutine instead
 /// of the blocking the thread of execution
 class optional_yield {
   boost::asio::io_context *c = nullptr;
-  spawn::yield_context *y = nullptr;
+  yield_context *y = nullptr;
  public:
   /// construct with a valid io and yield_context
   explicit optional_yield(boost::asio::io_context& c,
-                          spawn::yield_context& y) noexcept
+                          yield_context& y) noexcept
     : c(&c), y(&y) {}
 
   /// type tag to construct an empty object
@@ -46,7 +52,7 @@ class optional_yield {
   boost::asio::io_context& get_io_context() const noexcept { return *c; }
 
   /// return a reference to the yield_context. only valid if non-empty
-  spawn::yield_context& get_yield_context() const noexcept { return *y; }
+  yield_context& get_yield_context() const noexcept { return *y; }
 };
 
 // type tag object to construct an empty optional_yield

--- a/src/rgw/rgw_aio.cc
+++ b/src/rgw/rgw_aio.cc
@@ -79,12 +79,12 @@ struct Handler {
 
 template <typename Op>
 Aio::OpFunc aio_abstract(Op&& op, boost::asio::io_context& context,
-                         spawn::yield_context yield) {
+                         yield_context yield) {
   return [op = std::move(op), &context, yield] (Aio* aio, AioResult& r) mutable {
       // arrange for the completion Handler to run on the yield_context's strand
       // executor so it can safely call back into Aio without locking
       using namespace boost::asio;
-      async_completion<spawn::yield_context, void()> init(yield);
+      async_completion<yield_context, void()> init(yield);
       auto ex = get_associated_executor(init.completion_handler);
 
       auto& ref = r.obj.get_ref();

--- a/src/rgw/rgw_aio_throttle.h
+++ b/src/rgw/rgw_aio_throttle.h
@@ -82,7 +82,7 @@ class BlockingAioThrottle final : public Aio, private Throttle {
 // functions must be called within the coroutine strand
 class YieldingAioThrottle final : public Aio, private Throttle {
   boost::asio::io_context& context;
-  spawn::yield_context yield;
+  yield_context yield;
   struct Handler;
 
   // completion callback associated with the waiter
@@ -96,7 +96,7 @@ class YieldingAioThrottle final : public Aio, private Throttle {
 
  public:
   YieldingAioThrottle(uint64_t window, boost::asio::io_context& context,
-                      spawn::yield_context yield)
+                      yield_context yield)
     : Throttle(window), context(context), yield(yield)
   {}
 

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -22,6 +22,7 @@
 #ifdef WITH_RADOSGW_BEAST_OPENSSL
 #include <boost/asio/ssl.hpp>
 #include <boost/beast/ssl/ssl_stream.hpp>
+#endif
 
 #include "common/split.h"
 
@@ -29,8 +30,6 @@
 #include "services/svc_zone.h"
 
 #include "rgw_zone.h"
-
-#endif
 
 #include "rgw_dmclock_async_scheduler.h"
 

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -54,13 +54,12 @@ template <typename Stream>
 class StreamIO : public rgw::asio::ClientIO {
   CephContext* const cct;
   Stream& stream;
-  spawn::yield_context yield;
+  yield_context yield;
   parse_buffer& buffer;
   ceph::timespan request_timeout;
  public:
   StreamIO(CephContext *cct, Stream& stream, rgw::asio::parser_type& parser,
-           spawn::yield_context yield,
-           parse_buffer& buffer, bool is_ssl,
+           yield_context yield, parse_buffer& buffer, bool is_ssl,
            const tcp::endpoint& local_endpoint,
            const tcp::endpoint& remote_endpoint,
            ceph::timespan request_timeout)
@@ -172,7 +171,7 @@ void handle_connection(boost::asio::io_context& context,
                        SharedMutex& pause_mutex,
                        rgw::dmclock::Scheduler *scheduler,
                        boost::system::error_code& ec,
-                       spawn::yield_context yield,
+                       yield_context yield,
                        ceph::timespan request_timeout)
 {
   // limit header to 4k, since we read it all into a single flat_buffer
@@ -950,7 +949,7 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
 #ifdef WITH_RADOSGW_BEAST_OPENSSL
   if (l.use_ssl) {
     spawn::spawn(context,
-      [this, s=std::move(stream)] (spawn::yield_context yield) mutable {
+      [this, s=std::move(stream)] (yield_context yield) mutable {
         Connection conn{s.socket()};
         auto c = connections.add(conn);
         // wrap the tcp_stream in an ssl stream
@@ -981,7 +980,7 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
   {
 #endif // WITH_RADOSGW_BEAST_OPENSSL
     spawn::spawn(context,
-      [this, s=std::move(stream)] (spawn::yield_context yield) mutable {
+      [this, s=std::move(stream)] (yield_context yield) mutable {
         Connection conn{s.socket()};
         auto c = connections.add(conn);
         auto buffer = std::make_unique<parse_buffer>();

--- a/src/rgw/rgw_asio_frontend_timer.h
+++ b/src/rgw/rgw_asio_frontend_timer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <boost/asio/basic_waitable_timer.hpp>
+#include <boost/intrusive_ptr.hpp>
 
 #include "common/ceph_time.h"
 
@@ -9,9 +10,12 @@ namespace rgw {
 // a WaitHandler that closes a stream if the timeout expires
 template <typename Stream>
 struct timeout_handler {
-  Stream* stream;
+  // this handler may outlive the timer/stream, so we need to hold a reference
+  // to keep the stream alive
+  boost::intrusive_ptr<Stream> stream;
 
-  explicit timeout_handler(Stream* stream) noexcept : stream(stream) {}
+  explicit timeout_handler(boost::intrusive_ptr<Stream> stream) noexcept
+      : stream(std::move(stream)) {}
 
   void operator()(boost::system::error_code ec) {
     if (!ec) { // wait was not canceled
@@ -22,22 +26,24 @@ struct timeout_handler {
 };
 
 // a timeout timer for stream operations
-template <typename Clock, typename Executor>
+template <typename Clock, typename Executor, typename Stream>
 class basic_timeout_timer {
  public:
   using clock_type = Clock;
   using duration = typename clock_type::duration;
   using executor_type = Executor;
 
-  explicit basic_timeout_timer(const executor_type& ex) : timer(ex) {}
+  explicit basic_timeout_timer(const executor_type& ex, duration dur,
+                               boost::intrusive_ptr<Stream> stream)
+      : timer(ex), dur(dur), stream(std::move(stream))
+  {}
 
   basic_timeout_timer(const basic_timeout_timer&) = delete;
   basic_timeout_timer& operator=(const basic_timeout_timer&) = delete;
 
-  template <typename Stream>
-  void expires_after(Stream& stream, duration dur) {
+  void start() {
     timer.expires_after(dur);
-    timer.async_wait(timeout_handler{&stream});
+    timer.async_wait(timeout_handler{stream});
   }
 
   void cancel() {
@@ -48,6 +54,8 @@ class basic_timeout_timer {
   using Timer = boost::asio::basic_waitable_timer<clock_type,
         boost::asio::wait_traits<clock_type>, executor_type>;
   Timer timer;
+  duration dur;
+  boost::intrusive_ptr<Stream> stream;
 };
 
 } // namespace rgw

--- a/src/rgw/rgw_asio_frontend_timer.h
+++ b/src/rgw/rgw_asio_frontend_timer.h
@@ -42,12 +42,16 @@ class basic_timeout_timer {
   basic_timeout_timer& operator=(const basic_timeout_timer&) = delete;
 
   void start() {
-    timer.expires_after(dur);
-    timer.async_wait(timeout_handler{stream});
+    if (dur.count() > 0) {
+      timer.expires_after(dur);
+      timer.async_wait(timeout_handler{stream});
+    }
   }
 
   void cancel() {
-    timer.cancel();
+    if (dur.count() > 0) {
+      timer.cancel();
+    }
   }
 
  private:

--- a/src/rgw/rgw_asio_frontend_timer.h
+++ b/src/rgw/rgw_asio_frontend_timer.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <boost/asio/basic_waitable_timer.hpp>
+
+#include "common/ceph_time.h"
+
+namespace rgw {
+
+// a WaitHandler that closes a stream if the timeout expires
+template <typename Stream>
+struct timeout_handler {
+  Stream* stream;
+
+  explicit timeout_handler(Stream* stream) noexcept : stream(stream) {}
+
+  void operator()(boost::system::error_code ec) {
+    if (!ec) { // wait was not canceled
+      boost::system::error_code ec_ignored;
+      stream->close(ec_ignored);
+    }
+  }
+};
+
+// a timeout timer for stream operations
+template <typename Clock, typename Executor>
+class basic_timeout_timer {
+ public:
+  using clock_type = Clock;
+  using duration = typename clock_type::duration;
+  using executor_type = Executor;
+
+  explicit basic_timeout_timer(const executor_type& ex) : timer(ex) {}
+
+  basic_timeout_timer(const basic_timeout_timer&) = delete;
+  basic_timeout_timer& operator=(const basic_timeout_timer&) = delete;
+
+  template <typename Stream>
+  void expires_after(Stream& stream, duration dur) {
+    timer.expires_after(dur);
+    timer.async_wait(timeout_handler{&stream});
+  }
+
+  void cancel() {
+    timer.cancel();
+  }
+
+ private:
+  using Timer = boost::asio::basic_waitable_timer<clock_type,
+        boost::asio::wait_traits<clock_type>, executor_type>;
+  Timer timer;
+};
+
+} // namespace rgw

--- a/src/rgw/rgw_sync_checkpoint.cc
+++ b/src/rgw/rgw_sync_checkpoint.cc
@@ -177,7 +177,7 @@ int rgw_bucket_sync_checkpoint(const DoutPrefixProvider* dpp,
     entry.pipe = pipe;
 
     // fetch remote markers
-    spawn::spawn(ioctx, [&] (spawn::yield_context yield) {
+    spawn::spawn(ioctx, [&] (yield_context yield) {
       auto y = optional_yield{ioctx, yield};
       int r = source_bilog_markers(dpp, store->svc()->zone, entry.pipe,
                                    entry.remote_markers, y);
@@ -188,7 +188,7 @@ int rgw_bucket_sync_checkpoint(const DoutPrefixProvider* dpp,
       }
     });
     // fetch source bucket info
-    spawn::spawn(ioctx, [&] (spawn::yield_context yield) {
+    spawn::spawn(ioctx, [&] (yield_context yield) {
       auto y = optional_yield{ioctx, yield};
       auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
       int r = store->getRados()->get_bucket_instance_info(

--- a/src/test/rgw/test_rgw_dmclock_scheduler.cc
+++ b/src/test/rgw/test_rgw_dmclock_scheduler.cc
@@ -400,7 +400,7 @@ TEST(Queue, SpawnAsyncRequest)
 {
   boost::asio::io_context context;
 
-  spawn::spawn(context, [&] (spawn::yield_context yield) {
+  spawn::spawn(context, [&] (yield_context yield) {
     ClientCounters counters(g_ceph_context);
     AsyncScheduler queue(g_ceph_context, context, std::ref(counters), nullptr,
                     [] (client_id client) -> ClientInfo* {

--- a/src/test/rgw/test_rgw_reshard_wait.cc
+++ b/src/test/rgw/test_rgw_reshard_wait.cc
@@ -64,7 +64,7 @@ TEST(ReshardWait, wait_yield)
   RGWReshardWait waiter(wait_duration);
 
   boost::asio::io_context context;
-  spawn::spawn(context, [&] (spawn::yield_context yield) {
+  spawn::spawn(context, [&] (yield_context yield) {
       EXPECT_EQ(0, waiter.wait(optional_yield{context, yield}));
     });
 
@@ -90,7 +90,7 @@ TEST(ReshardWait, stop_yield)
 
   boost::asio::io_context context;
   spawn::spawn(context,
-    [&] (spawn::yield_context yield) {
+    [&] (yield_context yield) {
       EXPECT_EQ(-ECANCELED, long_waiter.wait(optional_yield{context, yield}));
     });
 
@@ -133,7 +133,7 @@ TEST(ReshardWait, stop_multiple)
   // spawn 4 coroutines
   boost::asio::io_context context;
   {
-    auto async_waiter = [&] (spawn::yield_context yield) {
+    auto async_waiter = [&] (yield_context yield) {
         EXPECT_EQ(-ECANCELED, long_waiter.wait(optional_yield{context, yield}));
       };
     spawn::spawn(context, async_waiter);

--- a/src/test/rgw/test_rgw_throttle.cc
+++ b/src/test/rgw/test_rgw_throttle.cc
@@ -172,7 +172,7 @@ TEST_F(Aio_Throttle, YieldCostOverWindow)
 
   boost::asio::io_context context;
   spawn::spawn(context,
-    [&] (spawn::yield_context yield) {
+    [&] (yield_context yield) {
       YieldingAioThrottle throttle(4, context, yield);
       scoped_completion op;
       auto c = throttle.get(obj, wait_on(op), 8, 0);
@@ -194,7 +194,7 @@ TEST_F(Aio_Throttle, YieldingThrottleOverMax)
 
   boost::asio::io_context context;
   spawn::spawn(context,
-    [&] (spawn::yield_context yield) {
+    [&] (yield_context yield) {
       YieldingAioThrottle throttle(window, context, yield);
       for (uint64_t i = 0; i < total; i++) {
         using namespace std::chrono_literals;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53271

---

backport of https://github.com/ceph/ceph/pull/43761
parent tracker: https://tracker.ceph.com/issues/52333

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh