### PR TITLE
octopus: ceph-volume: fix bug with miscalculation of required db/wal slot size for VGs with multiple PVs

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -63,6 +63,9 @@ def mock_lv_device_generator():
 def mock_devices_available():
     dev = create_autospec(device.Device)
     dev.path = '/dev/foo'
+    dev.vg_name = 'vg_foo'
+    dev.lv_name = 'lv_foo'
+    dev.vgs = [lvm.VolumeGroup(vg_name=dev.vg_name, lv_name=dev.lv_name)]
     dev.available_lvm = True
     dev.vg_size = [21474836480]
     dev.vg_free = dev.vg_size
@@ -73,6 +76,9 @@ def mock_device_generator():
     def mock_device():
         dev = create_autospec(device.Device)
         dev.path = '/dev/foo'
+        dev.vg_name = 'vg_foo'
+        dev.lv_name = 'lv_foo'
+        dev.vgs = [lvm.VolumeGroup(vg_name=dev.vg_name, lv_name=dev.lv_name)]
         dev.available_lvm = True
         dev.vg_size = [21474836480]
         dev.vg_free = dev.vg_size

--- a/src/ceph-volume/ceph_volume/tests/functional/Vagrantfile
+++ b/src/ceph-volume/ceph_volume/tests/functional/Vagrantfile
@@ -390,7 +390,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # always make /dev/sd{a/b/c/d} so that CI can ensure that
         # virtualbox and libvirt will have the same devices to use for OSDs
         (0..3).each do |d|
-          lv.storage :file, :device => "sd#{driverletters[d]}", :size => '12G'
+          lv.storage :file, :device => "sd#{driverletters[d]}", :size => '100G'
         end
         lv.memory = MEMORY
         lv.random_hostname = true

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/setup_mixed_type.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/setup_mixed_type.yml
@@ -1,4 +1,4 @@
-
+---
 - hosts: osds
   become: yes
   tasks:
@@ -119,8 +119,8 @@
         - /opt/vdd/loop0_nvme0
         - /opt/vde/loop1_nvme1
 
-    - name: create 11GB sparse files for NVMe
-      command: "fallocate -l 11G {{ item }}"
+    - name: create 20GB sparse files for NVMe
+      command: "fallocate -l 20G {{ item }}"
       loop:
         - /opt/vdd/loop0_nvme0
         - /opt/vde/loop1_nvme1


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53277

---

backport of https://github.com/ceph/ceph/pull/43300
parent tracker: https://tracker.ceph.com/issues/52730

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh