### PR TITLE
octopus: cephadm/ceph-volume: do not use lvm binary in containers

### DIFF
--- a/src/ceph-volume/ceph_volume/process.py
+++ b/src/ceph-volume/ceph_volume/process.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 host_rootfs = '/rootfs'
 run_host_cmd = [
         'nsenter',
-        '--root={}'.format(host_rootfs),
         '--mount={}/proc/1/ns/mnt'.format(host_rootfs),
         '--ipc={}/proc/1/ns/ipc'.format(host_rootfs),
         '--net={}/proc/1/ns/net'.format(host_rootfs),

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -195,8 +195,8 @@ class TestCreateLV(object):
     def test_uses_size(self, m_get_single_lv, m_call, m_run, monkeypatch):
         m_get_single_lv.return_value = self.foo_volume
         api.create_lv('foo', 0, vg=self.foo_group, size=419430400, tags={'ceph.type': 'data'})
-        expected = ['lvcreate', '--yes', '-l', '100', '-n', 'foo-0', 'foo_group']
-        m_run.assert_called_with(expected)
+        expected = (['lvcreate', '--yes', '-l', '100', '-n', 'foo-0', 'foo_group'])
+        m_run.assert_called_with(expected, run_on_host=True)
 
     @patch('ceph_volume.api.lvm.process.run')
     @patch('ceph_volume.api.lvm.process.call')
@@ -211,7 +211,7 @@ class TestCreateLV(object):
         # 423624704 should be just under 1% off of the available size 419430400
         api.create_lv('foo', 0, vg=foo_group, size=4232052736, tags={'ceph.type': 'data'})
         expected = ['lvcreate', '--yes', '-l', '1000', '-n', 'foo-0', 'foo_group']
-        m_run.assert_called_with(expected)
+        m_run.assert_called_with(expected, run_on_host=True)
 
     @patch('ceph_volume.api.lvm.process.run')
     @patch('ceph_volume.api.lvm.process.call')
@@ -228,7 +228,7 @@ class TestCreateLV(object):
         m_get_single_lv.return_value = self.foo_volume
         api.create_lv('foo', 0, vg=self.foo_group, extents='50', tags={'ceph.type': 'data'})
         expected = ['lvcreate', '--yes', '-l', '50', '-n', 'foo-0', 'foo_group']
-        m_run.assert_called_with(expected)
+        m_run.assert_called_with(expected, run_on_host=True)
 
     @pytest.mark.parametrize("test_input,expected",
                              [(2, 50),
@@ -240,7 +240,7 @@ class TestCreateLV(object):
         m_get_single_lv.return_value = self.foo_volume
         api.create_lv('foo', 0, vg=self.foo_group, slots=test_input, tags={'ceph.type': 'data'})
         expected = ['lvcreate', '--yes', '-l', str(expected), '-n', 'foo-0', 'foo_group']
-        m_run.assert_called_with(expected)
+        m_run.assert_called_with(expected, run_on_host=True)
 
     @patch('ceph_volume.api.lvm.process.run')
     @patch('ceph_volume.api.lvm.process.call')
@@ -249,7 +249,7 @@ class TestCreateLV(object):
         m_get_single_lv.return_value = self.foo_volume
         api.create_lv('foo', 0, vg=self.foo_group, tags={'ceph.type': 'data'})
         expected = ['lvcreate', '--yes', '-l', '100%FREE', '-n', 'foo-0', 'foo_group']
-        m_run.assert_called_with(expected)
+        m_run.assert_called_with(expected, run_on_host=True)
 
     @patch('ceph_volume.api.lvm.process.run')
     @patch('ceph_volume.api.lvm.process.call')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1990,6 +1990,7 @@ def get_container_mounts(fsid, daemon_type, daemon_id,
         mounts['/sys'] = '/sys'  # for numa.cc, pick_address, cgroups, ...
         mounts['/run/lvm'] = '/run/lvm'
         mounts['/run/lock/lvm'] = '/run/lock/lvm'
+        mounts['/'] = '/rootfs'
 
     try:
         if args.shared_ceph_folder:  # make easy manager modules/ceph-volume development


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53279

---

backport of https://github.com/ceph/ceph/pull/43536
parent tracker: https://tracker.ceph.com/issues/52926

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh