### PR TITLE
pacific: rgw/sts: adding role name and role session to ops log.

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -824,6 +824,8 @@ void rgw::auth::RoleApplier::modify_request_state(const DoutPrefixProvider *dpp,
   s->env.emplace("aws:TokenIssueTime", token_issued_at);
 
   s->token_claims.emplace_back("sts");
+  s->token_claims.emplace_back("role_name:" + role.tenant + "$" + role.name);
+  s->token_claims.emplace_back("role_session:" + role_session_name);
   for (auto& it : token_claims) {
     s->token_claims.emplace_back(it);
   }

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -282,9 +282,28 @@ void rgw_format_ops_log_entry(struct rgw_log_entry& entry, Formatter *formatter)
     formatter->close_section();
   }
   formatter->dump_string("trans_id", entry.trans_id);
+  switch(entry.identity_type) {
+    case TYPE_RGW:
+      formatter->dump_string("authentication_type","Local");
+      break;
+    case TYPE_LDAP:
+      formatter->dump_string("authentication_type","LDAP");
+      break;
+    case TYPE_KEYSTONE:
+      formatter->dump_string("authentication_type","Keystone");
+      break;
+    case TYPE_WEB:
+      formatter->dump_string("authentication_type","OIDC Provider");
+      break;
+    case TYPE_ROLE:
+      formatter->dump_string("authentication_type","STS");
+      break;
+    default:
+      break;
+  }
   if (entry.token_claims.size() > 0) {
     if (entry.token_claims[0] == "sts") {
-      formatter->open_object_section("sts_token_claims");
+      formatter->open_object_section("sts_info");
       for (const auto& iter: entry.token_claims) {
         auto pos = iter.find(":");
         if (pos != string::npos) {
@@ -565,6 +584,8 @@ int rgw_log_op(RGWREST* const rest, struct req_state *s, const string& op_name, 
   entry.uri = std::move(uri);
 
   entry.op = op_name;
+
+  entry.identity_type = s->auth.identity->get_identity_type();
 
   if (! s->token_claims.empty()) {
     entry.token_claims = std::move(s->token_claims);

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -585,7 +585,11 @@ int rgw_log_op(RGWREST* const rest, struct req_state *s, const string& op_name, 
 
   entry.op = op_name;
 
-  entry.identity_type = s->auth.identity->get_identity_type();
+  if (s->auth.identity) {
+    entry.identity_type = s->auth.identity->get_identity_type();
+  } else {
+    entry.identity_type = TYPE_NONE;
+  }
 
   if (! s->token_claims.empty()) {
     entry.token_claims = std::move(s->token_claims);

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -40,9 +40,10 @@ struct rgw_log_entry {
   headers_map x_headers;
   string trans_id;
   std::vector<string> token_claims;
+  uint32_t identity_type;
 
   void encode(bufferlist &bl) const {
-    ENCODE_START(11, 5, bl);
+    ENCODE_START(12, 5, bl);
     encode(object_owner.id, bl);
     encode(bucket_owner.id, bl);
     encode(bucket, bl);
@@ -67,10 +68,11 @@ struct rgw_log_entry {
     encode(x_headers, bl);
     encode(trans_id, bl);
     encode(token_claims, bl);
+    encode(identity_type,bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &p) {
-    DECODE_START_LEGACY_COMPAT_LEN(11, 5, 5, p);
+    DECODE_START_LEGACY_COMPAT_LEN(12, 5, 5, p);
     decode(object_owner.id, p);
     if (struct_v > 3)
       decode(bucket_owner.id, p);
@@ -121,6 +123,9 @@ struct rgw_log_entry {
     }
     if (struct_v >= 11) {
       decode(token_claims, p);
+    }
+    if (struct_v >= 12) {
+      decode(identity_type, p);
     }
     DECODE_FINISH(p);
   }

--- a/src/test/rgw/test_rgw_lua.cc
+++ b/src/test/rgw/test_rgw_lua.cc
@@ -1,11 +1,15 @@
 #include <gtest/gtest.h>
 #include "common/ceph_context.h"
 #include "rgw/rgw_common.h"
+#include "rgw/rgw_auth.h"
 #include "rgw/rgw_process.h"
 #include "rgw/rgw_sal_rados.h"
 #include "rgw/rgw_lua_request.h"
 
 using namespace rgw;
+using boost::container::flat_set;
+using rgw::auth::Identity;
+using rgw::auth::Principal;
 
 class CctCleaner {
   CephContext* cct;
@@ -17,6 +21,47 @@ public:
 #else
     cct->put(); 
 #endif
+  }
+};
+
+class FakeIdentity : public Identity {
+public:
+  FakeIdentity() = default;
+
+  uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override {
+    return 0;
+  };
+
+  bool is_admin_of(const rgw_user& uid) const override {
+    return false;
+  }
+
+  bool is_owner_of(const rgw_user& uid) const override {
+    return false;
+  }
+
+  virtual uint32_t get_perm_mask() const override {
+    return 0;
+  }
+
+  uint32_t get_identity_type() const override {
+    return TYPE_RGW;
+  }
+
+  string get_acct_name() const override {
+    return "";
+  }
+
+  string get_subuser() const override {
+    return "";
+  }
+
+  void to_str(std::ostream& out) const override {
+    return;
+  }
+
+  bool is_identity(const flat_set<Principal>& ids) const override {
+    return false;
   }
 };
 
@@ -562,6 +607,9 @@ TEST(TestRGWLua, OpsLog)
   TestAccounter ac;
   s.cio = &ac; 
 	s.cct->_conf->rgw_ops_log_rados	= false;
+
+  s.auth.identity = std::unique_ptr<rgw::auth::Identity>(
+                        new FakeIdentity());
 
   auto rc = lua::request::execute(store.get(), nullptr, olog.get(), &s, "put_obj", script);
   EXPECT_EQ(rc, 0);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52782

---

backport of https://github.com/ceph/ceph/pull/41735
parent tracker: https://tracker.ceph.com/issues/51152

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh