### PR TITLE
mgr/dashboard: Daemon Events listing using bootstrap class

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
@@ -57,23 +57,26 @@
 
 <ng-template #listTpl
              let-events="value">
-  <div *ngIf="events.length == 0 || events == undefined">
-    <span>No data available</span>
-  </div>
-  <div *ngIf="events.length != 0 && events != undefined"
-       class="ul-margin">
-    <ul *ngFor="let event of events; trackBy:trackByFn">
-      <li><b>{{ event.created | relativeDate }} - </b>
+  <ul class="list-group list-group-flush"
+      *ngIf="events?.length else noEventsAvailable">
+    <li class="list-group-item"
+        *ngFor="let event of events; trackBy:trackByFn">
+      <b>{{ event.created | relativeDate }} - </b>
       <span class="badge badge-info">{{ event.subject }}</span><br>
-      <span *ngIf="event.level == 'INFO'">
+      <span *ngIf="event.level === 'INFO'">
       <i [ngClass]="[icons.infoCircle]"
          aria-hidden="true"></i>
       </span>
-      <span *ngIf="event.level == 'ERROR'">
+      <span *ngIf="event.level === 'ERROR'">
       <i [ngClass]="[icons.warning]"
          aria-hidden="true"></i>
       </span>
-      {{ event.message }}</li>
-    </ul>
-  </div>
+      {{ event.message }}
+    </li>
+  </ul>
+  <ng-template #noEventsAvailable>
+    <div *ngIf="events?.length === 0">
+      <span>No data available</span>
+    </div>
+  </ng-template>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.scss
@@ -8,6 +8,7 @@
   color: vv.$danger;
 }
 
-.ul-margin {
-  margin-left: -30px;
+.list-group-item {
+  background-color: transparent;
+  border-width: 0;
 }


### PR DESCRIPTION
**BEFORE**
![Screenshot from 2021-11-16 19-36-42](https://user-images.githubusercontent.com/71764184/142007845-9fc3d227-5deb-495f-a43a-997de866d3f1.png)

**AFTER**
![Screenshot from 2021-11-16 20-58-21](https://user-images.githubusercontent.com/71764184/142014777-873c6829-83f2-46c4-9532-d87d0f8b3a42.png)



Fixes: https://tracker.ceph.com/issues/53282
Signed-off-by: Nizamudeen A <nia@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [x] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
