### PR TITLE
octopus: ceph-volume: `get_first_lv()` refactor

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -376,8 +376,12 @@ class PVolume(object):
             self.set_tag(k, v)
         # after setting all the tags, refresh them for the current object, use the
         # pv_* identifiers to filter because those shouldn't change
-        pv_object = self.get_first_pv(filter={'pv_name': self.pv_name,
-                                              'pv_uuid': self.pv_uuid})
+        pv_object = self.get_single_pv(filter={'pv_name': self.pv_name,
+                                               'pv_uuid': self.pv_uuid})
+
+        if not pv_object:
+            raise RuntimeError('No PV was found.')
+
         self.tags = pv_object.tags
 
     def set_tag(self, key, value):
@@ -471,15 +475,21 @@ def get_pvs(fields=PV_FIELDS, filters='', tags=None):
     return [PVolume(**pv_report) for pv_report in pvs_report]
 
 
-def get_first_pv(fields=PV_FIELDS, filters=None, tags=None):
+def get_single_pv(fields=PV_FIELDS, filters=None, tags=None):
     """
-    Wrapper of get_pv meant to be a convenience method to avoid the phrase::
+    Wrapper of get_pvs() meant to be a convenience method to avoid the phrase::
         pvs = get_pvs()
         if len(pvs) >= 1:
             pv = pvs[0]
     """
     pvs = get_pvs(fields=fields, filters=filters, tags=tags)
-    return pvs[0] if len(pvs) > 0 else []
+
+    if len(pvs) == 0:
+        return None
+    if len(pvs) > 1:
+        raise RuntimeError('Filters {} matched more than 1 PV present on this host.'.format(str(filters)))
+
+    return pvs[0]
 
 
 ################################
@@ -650,7 +660,7 @@ def create_vg(devices, name=None, name_prefix=None):
         name] + devices
     )
 
-    return get_first_vg(filters={'vg_name': name})
+    return get_single_vg(filters={'vg_name': name})
 
 
 def extend_vg(vg, devices):
@@ -674,7 +684,7 @@ def extend_vg(vg, devices):
         vg.name] + devices
     )
 
-    return get_first_vg(filters={'vg_name': vg.name})
+    return get_single_vg(filters={'vg_name': vg.name})
 
 
 def reduce_vg(vg, devices):
@@ -696,7 +706,7 @@ def reduce_vg(vg, devices):
         vg.name] + devices
     )
 
-    return get_first_vg(filter={'vg_name': vg.name})
+    return get_single_vg(filter={'vg_name': vg.name})
 
 
 def remove_vg(vg_name):
@@ -742,15 +752,21 @@ def get_vgs(fields=VG_FIELDS, filters='', tags=None):
     return [VolumeGroup(**vg_report) for vg_report in vgs_report]
 
 
-def get_first_vg(fields=VG_FIELDS, filters=None, tags=None):
+def get_single_vg(fields=VG_FIELDS, filters=None, tags=None):
     """
-    Wrapper of get_vg meant to be a convenience method to avoid the phrase::
+    Wrapper of get_vgs() meant to be a convenience method to avoid the phrase::
         vgs = get_vgs()
         if len(vgs) >= 1:
             vg = vgs[0]
     """
     vgs = get_vgs(fields=fields, filters=filters, tags=tags)
-    return vgs[0] if len(vgs) > 0 else []
+
+    if len(vgs) == 0:
+        return None
+    if len(vgs) > 1:
+        raise RuntimeError('Filters {} matched more than 1 VG present on this host.'.format(str(filters)))
+
+    return vgs[0]
 
 
 def get_device_vgs(device, name_prefix=''):
@@ -970,7 +986,7 @@ def create_lv(name_prefix,
         ]
     process.run(command)
 
-    lv = get_first_lv(filters={'lv_name': name, 'vg_name': vg.vg_name})
+    lv = get_single_lv(filters={'lv_name': name, 'vg_name': vg.vg_name})
 
     if tags is None:
         tags = {
@@ -1095,15 +1111,21 @@ def get_lvs(fields=LV_FIELDS, filters='', tags=None):
     return [Volume(**lv_report) for lv_report in lvs_report]
 
 
-def get_first_lv(fields=LV_FIELDS, filters=None, tags=None):
+def get_single_lv(fields=LV_FIELDS, filters=None, tags=None):
     """
-    Wrapper of get_lv meant to be a convenience method to avoid the phrase::
+    Wrapper of get_lvs() meant to be a convenience method to avoid the phrase::
         lvs = get_lvs()
         if len(lvs) >= 1:
             lv = lvs[0]
     """
     lvs = get_lvs(fields=fields, filters=filters, tags=tags)
-    return lvs[0] if len(lvs) > 0 else []
+
+    if len(lvs) == 0:
+        return None
+    if len(lvs) > 1:
+        raise RuntimeError('Filters {} matched more than 1 LV present on this host.'.format(str(filters)))
+
+    return lvs[0]
 
 
 def get_lv_by_name(name):
@@ -1141,7 +1163,7 @@ def get_lv_by_fullname(full_name):
     """
     try:
         vg_name, lv_name = full_name.split('/')
-        res_lv = get_first_lv(filters={'lv_name': lv_name,
+        res_lv = get_single_lv(filters={'lv_name': lv_name,
                                        'vg_name': vg_name})
     except ValueError:
         res_lv = None

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -151,8 +151,8 @@ class Prepare(object):
 
         try:
             vg_name, lv_name = device_name.split('/')
-            lv = api.get_first_lv(filters={'lv_name': lv_name,
-                                           'vg_name': vg_name})
+            lv = api.get_single_lv(filters={'lv_name': lv_name,
+                                            'vg_name': vg_name})
         except ValueError:
             lv = None
 
@@ -240,8 +240,8 @@ class Prepare(object):
 
         try:
             vgname, lvname = self.args.data.split('/')
-            lv = api.get_first_lv(filters={'lv_name': lvname,
-                                           'vg_name': vgname})
+            lv = api.get_single_lv(filters={'lv_name': lvname,
+                                            'vg_name': vgname})
         except ValueError:
             lv = None
 
@@ -325,7 +325,7 @@ class Prepare(object):
 
             try:
                 vg_name, lv_name = self.args.data.split('/')
-                data_lv = api.get_first_lv(filters={'lv_name': lv_name,
+                data_lv = api.get_single_lv(filters={'lv_name': lv_name,
                                                     'vg_name': vg_name})
             except ValueError:
                 data_lv = None
@@ -340,8 +340,8 @@ class Prepare(object):
             data_lv.set_tags(tags)
             if not journal_device.startswith('/'):
                 # we got a journal lv, set rest of the tags
-                api.get_first_lv(filters={'lv_name': lv_name,
-                                          'vg_name': vg_name}).set_tags(tags)
+                api.get_single_lv(filters={'lv_name': lv_name,
+                                           'vg_name': vg_name}).set_tags(tags)
 
             prepare_filestore(
                 data_lv.lv_path,
@@ -354,8 +354,8 @@ class Prepare(object):
         elif self.args.bluestore:
             try:
                 vg_name, lv_name = self.args.data.split('/')
-                block_lv = api.get_first_lv(filters={'lv_name': lv_name,
-                                                 'vg_name': vg_name})
+                block_lv = api.get_single_lv(filters={'lv_name': lv_name,
+                                                      'vg_name': vg_name})
             except ValueError:
                 block_lv = None
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -167,8 +167,8 @@ class Zap(object):
         Device examples: vg-name/lv-name, /dev/vg-name/lv-name
         Requirements: Must be a logical volume (LV)
         """
-        lv = api.get_first_lv(filters={'lv_name': device.lv_name, 'vg_name':
-                                       device.vg_name})
+        lv = api.get_single_lv(filters={'lv_name': device.lv_name, 'vg_name':
+                                        device.vg_name})
         self.unmount_lv(lv)
 
         wipefs(device.abspath)
@@ -232,7 +232,7 @@ class Zap(object):
                 mlogger.info('Zapping lvm member {}. lv_path is {}'.format(device.abspath, lv.lv_path))
                 self.zap_lv(Device(lv.lv_path))
             else:
-                vg = api.get_first_vg(filters={'vg_name': lv.vg_name})
+                vg = api.get_single_vg(filters={'vg_name': lv.vg_name})
                 if vg:
                     mlogger.info('Found empty VG {}, removing'.format(vg.vg_name))
                     api.remove_vg(vg.vg_name)

--- a/src/ceph-volume/ceph_volume/devices/simple/scan.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/scan.py
@@ -80,7 +80,7 @@ class Scan(object):
             device = os.readlink(path)
         else:
             device = path
-        lvm_device = lvm.get_first_lv(filters={'lv_path': device})
+        lvm_device = lvm.get_single_lv(filters={'lv_path': device})
         if lvm_device:
             device_uuid = lvm_device.lv_uuid
         else:

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -287,7 +287,7 @@ def device_info(monkeypatch, patch_bluestore_label):
         monkeypatch.setattr("ceph_volume.sys_info.devices", {})
         monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda: devices)
         if not devices:
-            monkeypatch.setattr("ceph_volume.util.device.lvm.get_first_lv", lambda filters: lv)
+            monkeypatch.setattr("ceph_volume.util.device.lvm.get_single_lv", lambda filters: lv)
         else:
             monkeypatch.setattr("ceph_volume.util.device.lvm.get_device_lvs",
                                 lambda path: [lv])

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
@@ -51,7 +51,7 @@ class TestActivate(object):
         volumes = []
         volumes.append(FooVolume)
         monkeypatch.setattr(api, 'get_lvs', lambda **kwargs: [])
-        monkeypatch.setattr(api, 'get_first_lv', lambda **kwargs: [])
+        monkeypatch.setattr(api, 'get_single_lv', lambda **kwargs: [])
         monkeypatch.setattr(activate, 'activate_filestore', capture)
 
         args = Args(osd_id=None, osd_fsid='2222')

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
@@ -106,7 +106,7 @@ class TestFullReport(object):
                          lv_path='/dev/VolGroup/lv', vg_name='VolGroup')
         volumes = []
         volumes.append(osd)
-        monkeypatch.setattr(lvm.listing.api, 'get_first_pv', lambda **kwargs: pv)
+        monkeypatch.setattr(lvm.listing.api, 'get_single_pv', lambda **kwargs: pv)
         monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
                             volumes)
 
@@ -126,7 +126,7 @@ class TestFullReport(object):
         volumes = []
         volumes.append(osd)
         volumes.append(journal)
-        monkeypatch.setattr(lvm.listing.api,'get_first_pv',lambda **kwargs:pv)
+        monkeypatch.setattr(lvm.listing.api,'get_single_pv',lambda **kwargs:pv)
         monkeypatch.setattr(lvm.listing.api, 'get_lvs', lambda **kwargs:
                             volumes)
 

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_migrate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_migrate.py
@@ -47,7 +47,7 @@ class TestFindAssociatedDevices(object):
         return self.mock_volumes.pop(0)
 
     mock_single_volumes = {}
-    def mock_get_first_lv(self, *args, **kwargs):
+    def mock_get_single_lv(self, *args, **kwargs):
         p = kwargs['filters']['lv_path']
         return self.mock_single_volumes[p]
 
@@ -64,7 +64,7 @@ class TestFindAssociatedDevices(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': vol}
 
         monkeypatch.setattr(migrate.api, 'get_lvs', self.mock_get_lvs)
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
         monkeypatch.setattr(process, 'call', lambda x, **kw: ('', '', 0))
 
         result = migrate.find_associated_devices(osd_id='0', osd_fsid='1234')
@@ -89,7 +89,7 @@ class TestFindAssociatedDevices(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': vol, '/dev/VolGroup/lv2': vol2}
 
         monkeypatch.setattr(migrate.api, 'get_lvs', self.mock_get_lvs)
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
         monkeypatch.setattr(process, 'call', lambda x, **kw: ('', '', 0))
 
         result = migrate.find_associated_devices(osd_id='0', osd_fsid='1234')
@@ -126,7 +126,7 @@ class TestFindAssociatedDevices(object):
                                     '/dev/VolGroup/lv3': vol3}
 
         monkeypatch.setattr(migrate.api, 'get_lvs', self.mock_get_lvs)
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
         monkeypatch.setattr(process, 'call', lambda x, **kw: ('', '', 0))
 
         result = migrate.find_associated_devices(osd_id='0', osd_fsid='1234')
@@ -159,7 +159,7 @@ class TestFindAssociatedDevices(object):
 
 class TestVolumeTagTracker(object):
     mock_single_volumes = {}
-    def mock_get_first_lv(self, *args, **kwargs):
+    def mock_get_single_lv(self, *args, **kwargs):
         p = kwargs['filters']['lv_path']
         return self.mock_single_volumes[p]
 
@@ -185,7 +185,7 @@ class TestVolumeTagTracker(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol,
                                     '/dev/VolGroup/lv2': db_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -233,7 +233,7 @@ class TestVolumeTagTracker(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol,
                                     '/dev/VolGroup/lv2': db_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -297,7 +297,7 @@ class TestVolumeTagTracker(object):
                                     '/dev/VolGroup/lv2': db_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -355,7 +355,7 @@ class TestVolumeTagTracker(object):
                                     '/dev/VolGroup/lv2': db_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -426,7 +426,7 @@ class TestVolumeTagTracker(object):
                                     '/dev/VolGroup/lv2': db_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -512,7 +512,7 @@ class TestNew(object):
         return ('', '', 0)
 
     mock_single_volumes = {}
-    def mock_get_first_lv(self, *args, **kwargs):
+    def mock_get_single_lv(self, *args, **kwargs):
         p = kwargs['filters']['lv_path']
         return self.mock_single_volumes[p]
 
@@ -590,8 +590,8 @@ class TestNew(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -681,8 +681,8 @@ class TestNew(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -746,8 +746,8 @@ class TestNew(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -826,7 +826,7 @@ class TestNew(object):
 
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -889,7 +889,7 @@ class TestNew(object):
 
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -937,7 +937,7 @@ class TestNew(object):
 
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -1006,7 +1006,7 @@ class TestMigrate(object):
         return ('', '', 0)
 
     mock_single_volumes = {}
-    def mock_get_first_lv(self, *args, **kwargs):
+    def mock_get_single_lv(self, *args, **kwargs):
         p = kwargs['filters']['lv_path']
         return self.mock_single_volumes[p]
 
@@ -1042,8 +1042,8 @@ class TestMigrate(object):
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2', lv_uuid='y',
                                       vg_name='vg',
@@ -1168,8 +1168,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv1': data_vol,
             '/dev/VolGroup/lv2': db_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
                                       vg_name='vg',
@@ -1266,8 +1266,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv1': data_vol,
             '/dev/VolGroup/lv2': db_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
                                       vg_name='vg',
@@ -1329,8 +1329,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv1': data_vol,
             '/dev/VolGroup/lv2': db_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
                                       vg_name='vg',
@@ -1437,8 +1437,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
                                       vg_name='vg',
@@ -1561,8 +1561,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
                                       vg_name='vg',
@@ -1680,8 +1680,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv1': data_vol,
             '/dev/VolGroup/lv2': db_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
                                       vg_name='vg',
@@ -1759,8 +1759,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = wal_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',
@@ -1835,8 +1835,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = db_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',
@@ -1911,8 +1911,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = db_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',
@@ -1982,8 +1982,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = db_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',
@@ -2063,8 +2063,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = db_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',
@@ -2162,8 +2162,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = db_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',
@@ -2234,8 +2234,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = db_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -121,10 +121,10 @@ class TestPrepare(object):
         assert result == ('', '', {'ceph.type': 'data'})
 
     @patch('ceph_volume.api.lvm.Volume.set_tags')
-    @patch('ceph_volume.devices.lvm.prepare.api.get_first_lv')
-    def test_setup_device_lv_passed(self, m_get_first_lv, m_set_tags):
+    @patch('ceph_volume.devices.lvm.prepare.api.get_single_lv')
+    def test_setup_device_lv_passed(self, m_get_single_lv, m_set_tags):
         fake_volume = api.Volume(lv_name='lv_foo', lv_path='/fake-path', vg_name='vg_foo', lv_tags='', lv_uuid='fake-uuid')
-        m_get_first_lv.return_value = fake_volume
+        m_get_single_lv.return_value = fake_volume
         result = lvm.prepare.Prepare([]).setup_device(device_type='data', device_name='vg_foo/lv_foo', tags={'ceph.type': 'data'}, size=0, slots=None)
 
         assert result == ('/fake-path', 'fake-uuid', {'ceph.type': 'data',
@@ -147,9 +147,9 @@ class TestPrepare(object):
                                                     'ceph.data_device': '/fake-path'})
 
     @patch('ceph_volume.devices.lvm.prepare.Prepare.get_ptuuid')
-    @patch('ceph_volume.devices.lvm.prepare.api.get_first_lv')
-    def test_setup_device_partition_passed(self, m_get_first_lv, m_get_ptuuid):
-        m_get_first_lv.side_effect = ValueError()
+    @patch('ceph_volume.devices.lvm.prepare.api.get_single_lv')
+    def test_setup_device_partition_passed(self, m_get_single_lv, m_get_ptuuid):
+        m_get_single_lv.side_effect = ValueError()
         m_get_ptuuid.return_value = 'fake-uuid'
         result = lvm.prepare.Prepare([]).setup_device(device_type='data', device_name='/dev/sdx', tags={'ceph.type': 'data'}, size=0, slots=None)
 

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -162,11 +162,11 @@ class Device(object):
         # if the path is not absolute, we have 'vg/lv', let's use LV name
         # to get the LV.
         if self.path[0] == '/':
-            lv = lvm.get_first_lv(filters={'lv_path': self.path})
+            lv = lvm.get_single_lv(filters={'lv_path': self.path})
         else:
             vgname, lvname = self.path.split('/')
-            lv = lvm.get_first_lv(filters={'lv_name': lvname,
-                                           'vg_name': vgname})
+            lv = lvm.get_single_lv(filters={'lv_name': lvname,
+                                            'vg_name': vgname})
         if lv:
             self.lv_api = lv
             self.lvs = [lv]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53283

---

backport of https://github.com/ceph/ceph/pull/39907
parent tracker: https://tracker.ceph.com/issues/49643

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh