### PR TITLE
octopus: osd: fix 'ceph osd stop <osd.nnn>' doesn't take effect

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8287,6 +8287,9 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
 	reset_heartbeat_peers(true);
       }
     }
+  } else if (osdmap->get_epoch() > 0 && osdmap->is_stop(whoami)) {
+    derr << "map says i am stopped by admin. shutting down." << dendl;
+    do_shutdown = true;
   }
 
   map_lock.unlock();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53200

---

backport of https://github.com/ceph/ceph/pull/43664
parent tracker: https://tracker.ceph.com/issues/53039

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh