### PR TITLE
octopus: qa/rgw: Fix vault token file access.

### DIFF
--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -113,7 +113,7 @@ def start_rgw(ctx, config, clients):
         vault_role = client_config.get('use-vault-role', None)
         barbican_role = client_config.get('use-barbican-role', None)
 
-        token_path = teuthology.get_testdir(ctx) + '/vault-token'
+        token_path = '/etc/ceph/vault-root-token'
         if barbican_role is not None:
             if not hasattr(ctx, 'barbican'):
                 raise ConfigError('rgw must run after the barbican task')
@@ -131,11 +131,11 @@ def start_rgw(ctx, config, clients):
             if not ctx.vault.root_token:
                 raise ConfigError('vault: no "root_token" specified')
             # create token on file
-            ctx.cluster.only(client).run(args=['echo', '-n', ctx.vault.root_token, run.Raw('>'), token_path])
+            ctx.cluster.only(client).run(args=['sudo', 'echo', '-n', ctx.vault.root_token, run.Raw('|'), 'sudo', 'tee', token_path])
             log.info("Token file content")
             ctx.cluster.only(client).run(args=['cat', token_path])
             log.info("Restrict access to token file")
-            ctx.cluster.only(client).run(args=['chmod', '600', token_path])
+            ctx.cluster.only(client).run(args=['sudo', 'chmod', '600', token_path])
             ctx.cluster.only(client).run(args=['sudo', 'chown', 'ceph', token_path])
 
             rgw_cmd.extend([
@@ -196,7 +196,7 @@ def start_rgw(ctx, config, clients):
                                                              client=client_with_cluster),
                     ],
                 )
-            ctx.cluster.only(client).run(args=['rm', '-f', token_path])
+            ctx.cluster.only(client).run(args=['sudo', 'rm', '-f', token_path])
 
 def assign_endpoints(ctx, config, default_cert):
     role_endpoints = {}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53099

---

backport of https://github.com/ceph/ceph/pull/43625
parent tracker: https://tracker.ceph.com/issues/51539

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh