### PR TITLE
octopus: pybind/mgr/balancer: define Plan.{dump,show}() 

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -60,6 +60,13 @@ class Plan(object):
         self.inc = osdmap.new_incremental()
         self.pg_status = {}
 
+    def dump(self) -> str:
+        return json.dumps(self.inc.dump(), indent=4, sort_keys=True)
+
+    def show(self) -> str:
+        return 'upmap plan'
+
+
 class MsPlan(Plan):
     """
     Plan with a preloaded MappingState member.
@@ -76,10 +83,7 @@ class MsPlan(Plan):
                             self.initial.raw_pool_stats,
                             'plan %s final' % self.name)
 
-    def dump(self):
-        return json.dumps(self.inc.dump(), indent=4, sort_keys=True)
-
-    def show(self):
+    def show(self) -> str:
         ls = []
         ls.append('# starting osdmap epoch %d' % self.initial.osdmap.get_epoch())
         ls.append('# starting crush version %d' %


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51485

---

backport of https://github.com/ceph/ceph/pull/39295
parent tracker: https://tracker.ceph.com/issues/47514

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh