### PR TITLE
pacific: qa/rgw: bump tempest version to resolve dependency issue

### DIFF
--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -20,7 +20,7 @@ tasks:
       use-keystone-role: client.0
 - tempest:
     client.0:
-      sha1: d43223773d75d2e82fb33a1281038e611c41d0f3
+      sha1: train-last
       force-branch: master
       use-keystone-role: client.0
       auth:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53225

---

backport of https://github.com/ceph/ceph/pull/43847
parent tracker: https://tracker.ceph.com/issues/53095

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh