### PR TITLE
pacific: librgw: treat empty root path as "/" on mount

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -2061,10 +2061,21 @@ int rgw_mount2(librgw_t rgw, const char *uid, const char *acc_key,
 {
   int rc = 0;
 
-  /* stash access data for "mount" */
-  RGWLibFS* new_fs = new RGWLibFS(static_cast<CephContext*>(rgw), uid, acc_key,
-				  sec_key, root);
-  ceph_assert(new_fs);
+  /* if the config has no value for path/root, choose "/" */
+  RGWLibFS* new_fs{nullptr};
+  if(root &&
+     (!strcmp(root, ""))) {
+    /* stash access data for "mount" */
+    new_fs = new RGWLibFS(
+      static_cast<CephContext*>(rgw), uid, acc_key, sec_key, "/");
+  }
+  else {
+    /* stash access data for "mount" */
+    new_fs = new RGWLibFS(
+      static_cast<CephContext*>(rgw), uid, acc_key, sec_key, root);
+  }
+
+  ceph_assert(new_fs); /* should we be using ceph_assert? */
 
   const DoutPrefix dp(rgwlib.get_store()->ctx(), dout_subsys, "rgw mount2: ");
   rc = new_fs->authorize(&dp, rgwlib.get_store());

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -371,6 +371,10 @@ namespace rgw {
       fh.fh_private = this;
     }
 
+    const std::string& get_name() const {
+      return name;
+    }
+
     const fh_key& get_key() const {
       return fhk;
     }
@@ -1292,6 +1296,8 @@ namespace rgw {
     }
 
     struct rgw_fs* get_fs() { return &fs; }
+
+    RGWFileHandle& get_fh() { return root_fh; }
 
     uint64_t get_fsid() { return root_fh.state.dev; }
 

--- a/src/test/librgw_file_nfsns.cc
+++ b/src/test/librgw_file_nfsns.cc
@@ -187,6 +187,21 @@ TEST(LibRGW, INIT) {
   ASSERT_NE(rgw_h, nullptr);
 }
 
+TEST(LibRGW, MOUNT_NOROOT) {
+  /* do a mount at root="" and verify that it's root is "/" */
+  struct rgw_fs *fs = nullptr;
+  int ret = rgw_mount2(rgw_h, userid.c_str(), access_key.c_str(),
+                       secret_key.c_str(), "", &fs, RGW_MOUNT_FLAG_NONE);
+  ASSERT_EQ(ret, 0);
+  ASSERT_NE(fs, nullptr);
+
+  auto& root_fh = static_cast<RGWLibFS*>(fs->fs_private)->get_fh();
+  ASSERT_EQ(root_fh.get_name(), "/");
+
+  ret = rgw_umount(fs, RGW_UMOUNT_FLAG_NONE);
+  ASSERT_EQ(ret, 0);
+}
+
 TEST(LibRGW, MOUNT) {
   int ret = rgw_mount2(rgw_h, userid.c_str(), access_key.c_str(),
                        secret_key.c_str(), "/", &fs, RGW_MOUNT_FLAG_NONE);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53256

---

backport of https://github.com/ceph/ceph/pull/43773
parent tracker: https://tracker.ceph.com/issues/53030

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh