### PR TITLE
pacific: mon: MonMap: display disallowed_leaders whenever they're set

### DIFF
--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -372,6 +372,9 @@ void MonMap::print(ostream& out) const
   if (stretch_mode_enabled) {
     out << "stretch_mode_enabled " << stretch_mode_enabled << "\n";
     out << "tiebreaker_mon " << tiebreaker_mon << "\n";
+  }
+  if (stretch_mode_enabled ||
+      !disallowed_leaders.empty()) {
     out << "disallowed_leaders " << disallowed_leaders << "\n";
   }
   unsigned i = 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53259

---

backport of https://github.com/ceph/ceph/pull/43932
parent tracker: https://tracker.ceph.com/issues/53258

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh