### PR TITLE
pacific: mgr/dashboard: Spelling mistake in host-form Network address field

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
@@ -50,7 +50,7 @@
                *ngIf="!hostPattern">
             <label class="cd-col-form-label"
                    for="addr"
-                   i18n>Nework address</label>
+                   i18n>Network address</label>
             <div class="cd-col-form-input">
               <input class="form-control"
                      type="text"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53253

---

backport of https://github.com/ceph/ceph/pull/43877
parent tracker: https://tracker.ceph.com/issues/53215

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh