### PR TITLE
mgr/selftest: add test for osd_command() in the mgr module

### DIFF
--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -215,6 +215,7 @@ class Module(MgrModule):
         self._self_test_store()
         self._self_test_misc()
         self._self_test_perf_counters()
+        self._self_test_osd_command()
 
     def _self_test_getters(self) -> None:
         self.version
@@ -366,6 +367,30 @@ class Module(MgrModule):
         self.get_counter("osd", "0", "osd.op")
         # get_counter
         # get_all_perf_coutners
+
+    def _self_test_osd_command(self) -> None:
+        # The Telemetry module depends on the osd_command function,
+        # as well as the command dicts used in this test function.
+
+        # Test 1: `ceph osd.0 perf histogram dump`
+        cmd_dict = {
+            'prefix': 'perf histogram dump',
+            'id': '0',
+            'format': 'json'
+        }
+        r, outb, outs = self.osd_command(cmd_dict)
+        assert r == 0
+        json.loads(outb)
+
+        # Test 2: `ceph osd.0 dump_mempools`
+        cmd_dict = {
+            'prefix': 'dump_mempools',
+            'id': '0',
+            'format': 'json'
+        }
+        r, outb, outs = self.osd_command(cmd_dict)
+        assert r == 0
+        json.loads(outb)
 
     def _self_test_misc(self) -> None:
         self.set_uri("http://this.is.a.test.com")


### PR DESCRIPTION
This is in response to the conversation in #42436. We need to write a check for the `osd_command()` function in the mgr module to ensure that it doesn't get deleted, as the Telemetry module depends on it.

The idea is that if `osd_command()` is deleted, the `selftest` module will trigger an error like this:
```
Error EINVAL: Traceback (most recent call last):
  File "/home/lflores/ceph/src/pybind/mgr/mgr_module.py", line 1595, in _handle_command
    return CLICommand.COMMANDS[cmd['prefix']].call(self, cmd, inbuf)
  File "/home/lflores/ceph/src/pybind/mgr/mgr_module.py", line 416, in call
    return self.func(mgr, **kwargs)
  File "/home/lflores/ceph/src/pybind/mgr/selftest/module.py", line 83, in run
    self._self_test()
  File "/home/lflores/ceph/src/pybind/mgr/selftest/module.py", line 218, in _self_test
    self._self_test_osd_command()
  File "/home/lflores/ceph/src/pybind/mgr/selftest/module.py", line 381, in _self_test_osd_command
    r, outb, outs = self.osd_command(cmd_dict)
AttributeError: 'Module' object has no attribute 'osd_command'
```
Telemetry also depends on the CLI commands used in this test, `osd.* perf histogram dump` and `osd.* dump_mempools`. If there is a change to any of the commands, this test will also trigger a JSON error message, such as this:
```
Error EINVAL: Traceback (most recent call last):
  File "/home/lflores/ceph/src/pybind/mgr/mgr_module.py", line 1620, in _handle_command
    return CLICommand.COMMANDS[cmd['prefix']].call(self, cmd, inbuf)
  File "/home/lflores/ceph/src/pybind/mgr/mgr_module.py", line 416, in call
    return self.func(mgr, **kwargs)
  File "/home/lflores/ceph/src/pybind/mgr/selftest/module.py", line 83, in run
    self._self_test()
  File "/home/lflores/ceph/src/pybind/mgr/selftest/module.py", line 218, in _self_test
    self._self_test_osd_command()
  File "/home/lflores/ceph/src/pybind/mgr/selftest/module.py", line 383, in _self_test_osd_command
    dump = json.loads(outb)
  File "/usr/lib64/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
Signed-off-by: Laura Flores <lflores@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [x] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
