### PR TITLE
crimson/os/seastore/lba_manager: do full merge if the donor node is *AT* its minimum capacity

### DIFF
--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
@@ -675,7 +675,7 @@ LBABtree::handle_merge_ret merge_level(
     auto [liter, riter] = donor_is_left ?
       std::make_pair(donor_iter, iter) : std::make_pair(iter, donor_iter);
 
-    if (donor->below_min_capacity()) {
+    if (donor->at_min_capacity()) {
       auto replacement = l->make_full_merge(c, r);
 
       parent_pos.node->update(

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -322,6 +322,11 @@ struct LBAInternalNode
     return get_size() == get_capacity();
   }
 
+  bool at_min_capacity() const {
+    assert(get_size() >= (get_min_capacity() - 1));
+    return get_size() <= get_min_capacity();
+  }
+
   bool below_min_capacity() const {
     assert(get_size() >= (get_min_capacity() - 1));
     return get_size() < get_min_capacity();
@@ -543,6 +548,11 @@ struct LBALeafNode
   bool at_max_capacity() const {
     assert(get_size() <= get_capacity());
     return get_size() == get_capacity();
+  }
+
+  bool at_min_capacity() const {
+    assert(get_size() >= (get_min_capacity() - 1));
+    return get_size() <= get_min_capacity();
   }
 
   bool below_min_capacity() const {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/53273
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
