### PR TITLE
rgw: Bucket owner's bucket ACL

### DIFF
--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -110,7 +110,7 @@ uint32_t RGWAccessControlPolicy::get_perm(const DoutPrefixProvider* dpp,
   uint32_t perm = acl.get_perm(dpp, auth_identity, perm_mask);
 
   if (auth_identity.is_owner_of(owner.get_id())) {
-    perm |= perm_mask & (RGW_PERM_READ_ACP | RGW_PERM_WRITE_ACP);
+    perm |= RGW_PERM_FULL_CONTROL;
   }
 
   if (perm == perm_mask) {


### PR DESCRIPTION
The owner of the bucket has full control over the bucket it owns, so it has full control over the bucket at any time

Signed-off-by: gaoweinan <gaoweinan@inspur.com>