### PR TITLE
pacific: qa: increase the timeout value to wait a litte longer

### DIFF
--- a/qa/tasks/cephfs/test_openfiletable.py
+++ b/qa/tasks/cephfs/test_openfiletable.py
@@ -62,7 +62,7 @@ class OpenFileTable(CephFSTestCase):
         
         # Open the file
         p = self.mount_a.open_background("omap_counter_test_file")
-        self.wait_until_true(lambda: self._check_oft_counter('omap_total_updates', 2), timeout=30)
+        self.wait_until_true(lambda: self._check_oft_counter('omap_total_updates', 2), timeout=120)
         
         perf_dump = self.fs.mds_asok(['perf', 'dump'])
         omap_total_updates_1 = perf_dump['oft']['omap_total_updates']
@@ -73,8 +73,8 @@ class OpenFileTable(CephFSTestCase):
         # Now close the file
         self.mount_a.kill_background(p)
         # Ensure that the file does not exist any more
-        self.wait_until_true(lambda: self._check_oft_counter('omap_total_removes', 1), timeout=30)
-        self.wait_until_true(lambda: self._check_oft_counter('omap_total_kv_pairs', 1), timeout=30)
+        self.wait_until_true(lambda: self._check_oft_counter('omap_total_removes', 1), timeout=120)
+        self.wait_until_true(lambda: self._check_oft_counter('omap_total_kv_pairs', 1), timeout=120)
 
         perf_dump = self.fs.mds_asok(['perf', 'dump'])
         omap_total_removes = perf_dump['oft']['omap_total_removes']


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53218

---

backport of https://github.com/ceph/ceph/pull/43767
parent tracker: https://tracker.ceph.com/issues/52887


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [x] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
