### PR TITLE
qa/cephfs: correct the parameters' order 

### DIFF
--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -720,7 +720,7 @@ class Filesystem(MDSCluster):
         # avoid circular dep by importing here:
         from tasks.cephfs.fuse_mount import FuseMount
         d = misc.get_testdir(self._ctx)
-        m = FuseMount(self._ctx, {}, d, "admin", self.client_remote, cephfs_name=self.name)
+        m = FuseMount(self._ctx, d, "admin", self.client_remote, cephfs_name=self.name)
         m.mount_wait()
         m.run_shell_payload(cmd)
         m.umount_wait(require_clean=True)

--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -16,15 +16,16 @@ log = logging.getLogger(__name__)
 
 # Refer mount.py for docstrings.
 class FuseMount(CephFSMount):
-    def __init__(self, ctx, client_config, test_dir, client_id,
-                 client_remote, client_keyring_path=None, cephfs_name=None,
-                 cephfs_mntpt=None, hostfs_mntpt=None, brxnet=None):
+    def __init__(self, ctx, test_dir, client_id, client_remote,
+                 client_keyring_path=None, cephfs_name=None,
+                 cephfs_mntpt=None, hostfs_mntpt=None, brxnet=None,
+                 client_config={}):
         super(FuseMount, self).__init__(ctx=ctx, test_dir=test_dir,
             client_id=client_id, client_remote=client_remote,
             client_keyring_path=client_keyring_path, hostfs_mntpt=hostfs_mntpt,
             cephfs_name=cephfs_name, cephfs_mntpt=cephfs_mntpt, brxnet=brxnet)
 
-        self.client_config = client_config if client_config else {}
+        self.client_config = client_config
         self.fuse_daemon = None
         self._fuse_conn = None
         self.id = None

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -22,15 +22,17 @@ DEBUGFS_META_DIR = 'meta'
 class KernelMount(CephFSMount):
     def __init__(self, ctx, test_dir, client_id, client_remote,
                  client_keyring_path=None, hostfs_mntpt=None,
-                 cephfs_name=None, cephfs_mntpt=None, brxnet=None, config={}):
+                 cephfs_name=None, cephfs_mntpt=None, brxnet=None,
+                 client_config={}):
         super(KernelMount, self).__init__(ctx=ctx, test_dir=test_dir,
             client_id=client_id, client_remote=client_remote,
             client_keyring_path=client_keyring_path, hostfs_mntpt=hostfs_mntpt,
             cephfs_name=cephfs_name, cephfs_mntpt=cephfs_mntpt, brxnet=brxnet)
 
-        self.dynamic_debug = config.get('dynamic_debug', False)
-        self.rbytes = config.get('rbytes', False)
-        self.syntax_style = config.get('syntax', 'v2')
+        self.client_config = client_config
+        self.dynamic_debug = client_config.get('dynamic_debug', False)
+        self.rbytes = client_config.get('rbytes', False)
+        self.syntax_style = client_config.get('syntax', 'v2')
         self.inst = None
         self.addr = None
         self._mount_bin = ['adjust-ulimits', 'ceph-coverage', self.test_dir +\

--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -499,10 +499,16 @@ class TestClientRecovery(CephFSTestCase):
 
         # create a new instance of mount_a's class with most of the
         # same settings, but mounted on mount_b's mountpoint.
-        m = cl(self.mount_a.ctx, self.mount_a.test_dir, self.mount_a.client_id,
-               self.mount_a.client_remote, self.mount_a.client_keyring_path,
-               self.mount_b.hostfs_mntpt, self.mount_a.cephfs_name,
-               self.mount_a.cephfs_mntpt, self.mount_a.ceph_brx_net)
+        m = cl(ctx=self.mount_a.ctx,
+               client_config=self.mount_a.client_config,
+               test_dir=self.mount_a.test_dir,
+               client_id=self.mount_a.client_id,
+               client_remote=self.mount_a.client_remote,
+               client_keyring_path=self.mount_a.client_keyring_path,
+               cephfs_name=self.mount_a.cephfs_name,
+               cephfs_mntpt= self.mount_a.cephfs_mntpt,
+               hostfs_mntpt=self.mount_b.hostfs_mntpt,
+               brxnet=self.mount_a.ceph_brx_net)
 
         # evict mount_a
         mount_a_client_id = self.mount_a.get_global_id()

--- a/qa/tasks/kclient.py
+++ b/qa/tasks/kclient.py
@@ -100,7 +100,7 @@ def task(ctx, config):
             client_id=id_,
             client_remote=remote,
             brxnet=ctx.teuthology_config.get('brxnet', None),
-            config=client_config,
+            client_config=client_config,
             cephfs_name=cephfs_name)
 
         mounts[id_] = kernel_mount

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -713,9 +713,8 @@ class LocalFuseMount(LocalCephFSMount, FuseMount):
     def __init__(self, ctx, test_dir, client_id, client_keyring_path=None,
                  client_remote=None, hostfs_mntpt=None, cephfs_name=None,
                  cephfs_mntpt=None, brxnet=None):
-        super(LocalFuseMount, self).__init__(ctx=ctx, client_config=None,
-            test_dir=test_dir, client_id=client_id,
-            client_keyring_path=client_keyring_path,
+        super(LocalFuseMount, self).__init__(ctx=ctx, test_dir=test_dir,
+            client_id=client_id, client_keyring_path=client_keyring_path,
             client_remote=LocalRemote(), hostfs_mntpt=hostfs_mntpt,
             cephfs_name=cephfs_name, cephfs_mntpt=cephfs_mntpt, brxnet=brxnet)
 


### PR DESCRIPTION
The parameters' order is incorrect and missing the client_config.

Fixes: https://tracker.ceph.com/issues/53216
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
