### PR TITLE
mgr/dashboard: Predefine labels in create host form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
@@ -41,7 +41,7 @@ export class HostsPageHelper extends PageHelper {
       });
   }
 
-  add(hostname: string, exist?: boolean, maintenance?: boolean) {
+  add(hostname: string, exist?: boolean, maintenance?: boolean, labels: string[] = []) {
     cy.get(`${this.pages.add.id}`).within(() => {
       cy.get('#hostname').type(hostname);
       if (maintenance) {
@@ -50,10 +50,22 @@ export class HostsPageHelper extends PageHelper {
       if (exist) {
         cy.get('#hostname').should('have.class', 'ng-invalid');
       }
-      cy.get('cd-submit-button').click();
     });
+
+    if (labels.length) {
+      this.selectPredefinedLabels(labels);
+    }
+
+    cy.get('cd-submit-button').click();
     // back to host list
     cy.get(`${this.pages.index.id}`);
+  }
+
+  selectPredefinedLabels(labels: string[]) {
+    cy.get('a[data-testid=select-menu-edit]').click();
+    for (const label of labels) {
+      cy.get('.popover-body div.select-menu-item-content').contains(label).click();
+    }
   }
 
   checkExist(hostname: string, exist: boolean) {

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/02-create-cluster-add-host.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/02-create-cluster-add-host.e2e-spec.ts
@@ -12,9 +12,9 @@ describe('Create cluster add host page', () => {
     'ceph-node-02.cephlab.com',
     'ceph-node-[01-02].cephlab.com'
   ];
-  const addHost = (hostname: string, exist?: boolean, pattern?: boolean) => {
+  const addHost = (hostname: string, exist?: boolean, pattern?: boolean, labels: string[] = []) => {
     cy.get('.btn.btn-accent').first().click({ force: true });
-    createClusterHostPage.add(hostname, exist, false);
+    createClusterHostPage.add(hostname, exist, false, labels);
     if (!pattern) {
       createClusterHostPage.checkExist(hostname, true);
     }
@@ -43,9 +43,14 @@ describe('Create cluster add host page', () => {
     addHost(hostnames[3], false, true);
   });
 
-  it('should delete a host and add it back', () => {
+  it('should delete a host', () => {
     createClusterHostPage.delete(hostnames[1]);
-    addHost(hostnames[1], false);
+  });
+
+  it('should add a host with some predefined labels and verify it', () => {
+    const labels = ['mon', 'mgr', 'rgw', 'osd'];
+    addHost(hostnames[1], false, false, labels);
+    createClusterHostPage.checkLabelExists(hostnames[1], labels, true);
   });
 
   it('should verify "_no_schedule" label is added', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
@@ -72,6 +72,7 @@
             <div class="cd-col-form-input">
               <cd-select-badges id="labels"
                                 [data]="hostForm.controls.labels.value"
+                                [options]="labelsOption"
                                 [customBadges]="true"
                                 [messages]="messages">
               </cd-select-badges>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
@@ -7,6 +7,7 @@ import expand from 'brace-expansion';
 
 import { HostService } from '~/app/shared/api/host.service';
 import { SelectMessages } from '~/app/shared/components/select/select-messages.model';
+import { SelectOption } from '~/app/shared/components/select/select-option.model';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { CdForm } from '~/app/shared/forms/cd-form';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
@@ -30,6 +31,7 @@ export class HostFormComponent extends CdForm implements OnInit {
   allLabels: string[];
   pageURL: string;
   hostPattern = false;
+  labelsOption: Array<SelectOption> = [];
 
   messages = new SelectMessages({
     empty: $localize`There are no labels.`,
@@ -59,6 +61,13 @@ export class HostFormComponent extends CdForm implements OnInit {
         return host['hostname'];
       });
       this.loadingReady();
+    });
+
+    this.hostService.getLabels().subscribe((resp: string[]) => {
+      const uniqueLabels = new Set(resp.concat(this.hostService.predefinedLabels));
+      this.labelsOption = Array.from(uniqueLabels).map((label) => {
+        return { enabled: true, name: label, selected: false, description: null };
+      });
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -263,7 +263,8 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
   editAction() {
     this.hostService.getLabels().subscribe((resp: string[]) => {
       const host = this.selection.first();
-      const allLabels = resp.map((label) => {
+      const labels = new Set(resp.concat(this.hostService.predefinedLabels));
+      const allLabels = Array.from(labels).map((label) => {
         return { enabled: true, name: label };
       });
       this.modalService.show(FormModalComponent, {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.ts
@@ -21,6 +21,8 @@ export class HostService extends ApiClient {
   baseURL = 'api/host';
   baseUIURL = 'ui-api/host';
 
+  predefinedLabels = ['mon', 'mgr', 'osd', 'mds', 'rgw', 'nfs', 'iscsi', 'rbd', 'grafana'];
+
   constructor(private http: HttpClient, private deviceService: DeviceService) {
     super();
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/select/select.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/select/select.component.html
@@ -63,6 +63,7 @@
 <a class="select-menu-edit float-left"
    [ngClass]="elemClass"
    [ngbPopover]="popTemplate"
+   data-testid="select-menu-edit"
    *ngIf="customBadges || options.length > 0">
   <ng-content></ng-content>
 </a>


### PR DESCRIPTION
Also retains the previously created labels by user in the form

![Screenshot from 2021-11-18 16-44-05](https://user-images.githubusercontent.com/71764184/142410433-d4dfe73e-78da-4a3e-85c6-b6353d9f5f33.png)

Fixes: https://tracker.ceph.com/issues/53315
Signed-off-by: Nizamudeen A <nia@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [x] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
