### PR TITLE
pybind/mgr/pg_autoscale: revert to default profile scale-up

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -66,9 +66,9 @@
   The POST notification at the beginning of the upload, and PUT notifications that 
   were sent on each part are not sent anymore.
 
-* MGR: The pg_autoscaler has a new default 'scale-down' profile which provides more
-  performance from the start for new pools (for newly created clusters).
-  Existing clusters will retain the old behavior, now called the 'scale-up' profile.
+* MGR: The pg_autoscaler has a new 'scale-down' profile which provides more
+  performance from the start for new pools. However, the module will remain
+  using it old behavior by default, now called the 'scale-up' profile.
   For more details, see:
 
   https://docs.ceph.com/en/latest/rados/operations/placement-groups/

--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -126,24 +126,24 @@ example, a pool that maps to OSDs of class `ssd` and a pool that maps
 to OSDs of class `hdd` will each have optimal PG counts that depend on
 the number of those respective device types.
 
-The autoscaler uses the `scale-down` profile by default, 
-where each pool starts out with a full complements of PGs and only scales 
-down when the usage ratio across the pools is not even. However, it also has 
-a `scale-up` profile, where it starts out each pool with minimal PGs and scales
-up PGs when there is more usage in each pool.
+The autoscaler uses the `scale-up` profile by default,
+where it starts out each pool with minimal PGs and scales
+up PGs when there is more usage in each pool. However, it also has
+a `scale-down` profile, where each pool starts out with a full complements 
+of PGs and only scales down when the usage ratio across the pools is not even.
 
 With only the `scale-down` profile, the autoscaler identifies
 any overlapping roots and prevents the pools with such roots
 from scaling because overlapping roots can cause problems
 with the scaling process.
 
-To use the `scale-up` profile::
-
-  ceph osd pool set autoscale-profile scale-up
-
-To switch back to the default `scale-down` profile::
+To use the `scale-down` profile::
 
   ceph osd pool set autoscale-profile scale-down
+
+To switch back to the default `scale-up` profile::
+
+  ceph osd pool set autoscale-profile scale-up
 
 Existing clusters will continue to use the `scale-up` profile.
 To use the `scale-down` profile, users will need to set autoscale-profile `scale-down`,

--- a/qa/workunits/mon/pg_autoscaler.sh
+++ b/qa/workunits/mon/pg_autoscaler.sh
@@ -45,6 +45,56 @@ ceph osd pool set b pg_autoscale_mode on
 # get num pools again since we created more pools
 NUM_POOLS=$(ceph osd pool ls | wc -l)
 
+# get profiles of pool a and b
+PROFILE1=$(ceph osd pool autoscale-status | grep 'a' | grep -o -m 1 'scale-up\|scale-down' || true)
+PROFILE2=$(ceph osd pool autoscale-status | grep 'b' | grep -o -m 1 'scale-up\|scale-down' || true)
+
+# evaluate the default profile a
+if [[ $PROFILE1 = "scale-up" ]]
+then
+  echo "Success: pool a PROFILE is scale-up"
+else
+  echo "Error: a PROFILE is scale-down"
+  exit 1
+fi
+
+# evaluate the default profile of pool b
+if [[ $PROFILE2 = "scale-up" ]]
+then
+  echo "Success: pool b PROFILE is scale-up"
+else
+  echo "Error: b PROFILE is scale-down"
+  exit 1
+fi
+
+# This part of this code will now evaluate the accuracy of
+# scale-down profile
+
+# change to scale-down profile
+ceph osd pool set autoscale-profile scale-down 
+
+# get profiles of pool a and b
+PROFILE1=$(ceph osd pool autoscale-status | grep 'a' | grep -o -m 1 'scale-up\|scale-down' || true)
+PROFILE2=$(ceph osd pool autoscale-status | grep 'b' | grep -o -m 1 'scale-up\|scale-down' || true)
+
+# evaluate that profile a is now scale-down
+if [[ $PROFILE1 = "scale-down" ]]
+then
+  echo "Success: pool a PROFILE is scale-down"
+else
+  echo "Error: a PROFILE is scale-up"
+  exit 1
+fi
+
+# evaluate the profile of b is now scale-down
+if [[ $PROFILE2 = "scale-down" ]]
+then
+  echo "Success: pool b PROFILE is scale-down"
+else
+  echo "Error: b PROFILE is scale-up"
+  exit 1
+fi
+
 # get pool size
 POOL_SIZE_A=$(ceph osd pool get a size| grep -Eo '[0-9]{1,4}')
 POOL_SIZE_B=$(ceph osd pool get b size| grep -Eo '[0-9]{1,4}')

--- a/src/mon/KVMonitor.cc
+++ b/src/mon/KVMonitor.cc
@@ -54,7 +54,7 @@ void KVMonitor::create_initial()
   version = 0;
   pending.clear();
   bufferlist bl;
-  bl.append("scale-down");
+  bl.append("scale-up");
   pending["config/mgr/mgr/pg_autoscaler/autoscale_profile"] = bl;
 }
 

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -128,14 +128,14 @@ class PgAutoscaler(MgrModule):
             default=60),
         Option(
             'autoscale_profile',
-            default='scale-down',
+            default='scale-up',
             type='str',
             desc='pg_autoscale profiler',
             long_desc=('Determines the behavior of the autoscaler algorithm, '
-                       '`scale-down means start out with full pgs and scales'
-                       'down when there is pressure'
                        '`scale-up` means that it starts out with minmum pgs '
-                       'and scales up when there is pressure'),
+                       'and scales up when there is pressure'
+                       '`scale-down means start out with full pgs and scales'
+                       'down when there is pressure'),
             runtime=True),
         Option(
             name='threshold',
@@ -156,7 +156,7 @@ class PgAutoscaler(MgrModule):
         # to just keep a copy of the pythonized version.
         self._osd_map = None
         if TYPE_CHECKING:
-            self.autoscale_profile: 'ScaleModeT' = 'scale-down'
+            self.autoscale_profile: 'ScaleModeT' = 'scale-up'
             self.sleep_interval = 60
             self.mon_target_pg_per_osd = 0
             self.threshold = 3.0


### PR DESCRIPTION
pg_autoscale module will now start out all the pools
with a scale-up profile by default.

Added tests in workunits/mon/pg_autoscaler.sh
to evaluate if the default pool creation is
a scale-up profile

Updated documentation and release notes to
reflect the change in the default behavior
of the pg_autoscale profile.

Fixes: https://tracker.ceph.com/issues/53309

Signed-off-by: Kamoltat <ksirivad@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
