### PR TITLE
crimson/osd: don't interruptize PeeringEvent if there is no PG yet.

### DIFF
--- a/src/crimson/osd/osd_operations/compound_peering_request.cc
+++ b/src/crimson/osd/osd_operations/compound_peering_request.cc
@@ -42,8 +42,7 @@ public:
   PeeringSubEvent(compound_state_ref state, Args &&... args) :
     RemotePeeringEvent(std::forward<Args>(args)...), state(state) {}
 
-  PeeringEvent::interruptible_future<>
-  complete_rctx(Ref<crimson::osd::PG> pg) final {
+  seastar::future<> complete_rctx(Ref<crimson::osd::PG> pg) final {
     logger().debug("{}: submitting ctx transaction", *this);
     state->ctx.accept_buffered_messages(ctx);
     state = {};

--- a/src/crimson/osd/osd_operations/peering_event.h
+++ b/src/crimson/osd/osd_operations/peering_event.h
@@ -60,7 +60,7 @@ protected:
   }
 
   virtual void on_pg_absent();
-  virtual PeeringEvent::interruptible_future<> complete_rctx(Ref<PG>);
+  virtual seastar::future<> complete_rctx(Ref<PG>);
   virtual seastar::future<Ref<PG>> get_pg() = 0;
 
 public:
@@ -95,7 +95,7 @@ protected:
   crimson::net::ConnectionRef conn;
 
   void on_pg_absent() final;
-  PeeringEvent::interruptible_future<> complete_rctx(Ref<PG> pg) override;
+  seastar::future<> complete_rctx(Ref<PG> pg) override;
   seastar::future<Ref<PG>> get_pg() final;
 
 public:


### PR DESCRIPTION
`InterruptibleOperation::interruptor` uses `IOInterruptCondition` underneath which in turn requires a PG to operate:

```cpp
IOInterruptCondition::IOInterruptCondition(Ref<PG>& pg)
  : pg(pg), e(pg->get_osdmap_epoch()) {}
```

Providing empty smart pointer leads to crashes like the following one:

```
DEBUG 2021-11-16 13:05:13,536 [shard 0] osd - peering_event(id=3, detail=PeeringEvent(from=7 pgid=2.5 sent=15 requested=15 evt=epoch_sent: 15 epoch_requested: 15 MQuery 2.5 from 7 query_epoch 15 query: query(inf
o 0'0 epoch_sent 15))): got map 15
ceph-osd: /home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/17.0.0-8895-ga6b615de/rpm/el8/BUILD/ceph-17.0.
0-8895-ga6b615de/x86_64-redhat-linux-gnu/boost/include/boost/smart_ptr/intrusive_ptr.hpp:199: T* boost::intrusive_ptr<T>::operator->() const [with T = crimson::osd::PG]: Assertion `px != 0' failed.
Aborting on shard 0.
Backtrace:
Reactor stalled for 2493 ms on shard 0. Backtrace: 0xb14ab 0x46e4d6f8 0x46bba7dd 0x46bd668d 0x46bd6a52 0x46bd6c16 0x46bd6ec6 0x12b1f 0xc8e3b 0x3fdcdab2 0x3fdd11c8 0x3fdd44be 0x3fdd4b83 0x3fdca1fb 0x3fdca712 0x3fdcaf0a 0x12b1f 0x3737e 0x21db4 0x21c88 0x2fa75 0x3c5ca510 0x3bae05b7 0x3bae1026 0x3a752413 0x3a7764a2 0x3a777185 0x46b8c541 0x46bd47ea 0x46d5ebeb 0x46d60bc0 0x46810aa2 0x4681530b 0x39fc9922 0x23492 0x39b6f00d
 0# gsignal in /lib64/libc.so.6
 1# abort in /lib64/libc.so.6
 2# 0x00007FDD53414C89 in /lib64/libc.so.6
 3# 0x00007FDD53422A76 in /lib64/libc.so.6
 4# crimson::osd::IOInterruptCondition::IOInterruptCondition(boost::intrusive_ptr<crimson::osd::PG>&) in ceph-osd
 5# 0x0000559C7F1FB5B8 in ceph-osd
 6# 0x0000559C7F1FC027 in ceph-osd
 7# auto seastar::internal::future_invoke<seastar::noncopyable_function<seastar::future<void> (boost::intrusive_ptr<crimson::osd::PG>&&)>&, boost::intrusive_ptr<crimson::osd::PG> >(seastar::noncopyable_function<seastar::future<void> (boost::intrusive_ptr<crimson::osd::PG>&&)>&, boost::intrusive_ptr<crimson::osd::PG>&&) in ceph-osd
 8# void seastar::futurize<seastar::future<void> >::satisfy_with_result_of<seastar::future<boost::intrusive_ptr<crimson::osd::PG> >::then_impl_nrvo<seastar::noncopyable_function<seastar::future<void> (boost::intrusive_ptr<crimson::osd::PG>&&)>, seastar::future<void> >(seastar::noncopyable_function<seastar::future<void> (boost::intrusive_ptr<crimson::osd::PG>&&)>&&)::{lambda(seastar::internal::promise_base_with_type<void>&&, seastar::noncopyable_function<seastar::future<void> (boost::intrusive_ptr<crimson::osd::PG>&&)>&, seastar::future_state<boost::intrusive_ptr<crimson::osd::PG> >&&)#1}::operator()(seastar::internal::promise_base_with_type<void>&&, seastar::noncopyable_function<seastar::future<void> (boost::intrusive_ptr<crimson::osd::PG>&&)>&, seastar::future_state<boost::intrusive_ptr<crimson::osd::PG> >&&) const::{lambda()#1}>(seastar::internal::promise_base_with_type<void>&&, seastar::noncopyable_function<seastar::future<void> (boost::intrusive_ptr<crimson::osd::PG>&&)>&&) in ceph-osd
 9# seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::noncopyable_function<seastar::future<void> (boost::intrusive_ptr<crimson::osd::PG>&&)>, seastar::future<boost::intrusive_ptr<crimson::osd::PG> >::then_impl_nrvo<seastar::noncopyable_function<seastar::future<void> (boost::intrusive_ptr<crimson::osd::PG>&&)>, seastar::future<void> >(seastar::noncopyable_function<seastar::future<void> (boost::intrusive_ptr<crimson::osd::PG>&&)>&&)::{lambda(seastar::internal::promise_base_with_type<void>&&, seastar::noncopyable_function<seastar::future<void> (boost::intrusive_ptr<crimson::osd::PG>&&)>&, seastar::future_state<boost::intrusive_ptr<crimson::osd::PG> >&&)#1}, boost::intrusive_ptr<crimson::osd::PG> >::run_and_dispose() in ceph-osd
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
