### PR TITLE
qa/rgw: run ceph_test_cls_rgw_gc in rgw/verify suite

### DIFF
--- a/qa/suites/rgw/verify/tasks/cls.yaml
+++ b/qa/suites/rgw/verify/tasks/cls.yaml
@@ -6,6 +6,7 @@ tasks:
         - cls/test_cls_log.sh
         - cls/test_cls_refcount.sh
         - cls/test_cls_rgw.sh
+        - cls/test_cls_rgw_gc.sh
         - cls/test_cls_rgw_stats.sh
         - cls/test_cls_cmpomap.sh
         - cls/test_cls_2pc_queue.sh

--- a/qa/workunits/cls/test_cls_rgw_gc.sh
+++ b/qa/workunits/cls/test_cls_rgw_gc.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+ceph_test_cls_rgw_gc
+
+exit 0


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
