### PR TITLE
python-common: add string representation for Device and DeviceSelection classes

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -1,7 +1,7 @@
 import logging
 
 try:
-    from typing import List, Optional
+    from typing import List, Optional, Dict
 except ImportError:
     pass
 
@@ -149,3 +149,14 @@ class DriveSelection(object):
                 self.disks.remove(taken_device)
 
         return sorted([x for x in devices], key=lambda dev: dev.path)
+
+    def __repr__(self) -> str:
+        selection: Dict[str, List[str]] = {
+            'data devices': [d.path for d in self._data],
+            'wal_devices': [d.path for d in self._wal],
+            'db devices': [d.path for d in self._db],
+            'journal devices': [d.path for d in self._journal]
+        }
+        return "DeviceSelection({})".format(
+            ', '.join('{}={}'.format(key, selection[key]) for key in selection.keys())
+        )

--- a/src/python-common/ceph/deployment/inventory.py
+++ b/src/python-common/ceph/deployment/inventory.py
@@ -1,5 +1,5 @@
 try:
-    from typing import List, Optional, Dict, Any
+    from typing import List, Optional, Dict, Any, Union
 except ImportError:
     pass  # for type checking
 
@@ -89,3 +89,15 @@ class Device(object):
         if self.sys_api is None or 'rotational' not in self.sys_api:
             return "unknown"
         return 'hdd' if self.sys_api["rotational"] == "1" else 'ssd'
+
+    def __repr__(self) -> str:
+        device_desc: Dict[str, Union[str, List[str]]] = {
+            'path': self.path if self.path is not None else 'unknown',
+            'lvs': self.lvs if self.lvs else 'None',
+            'available': str(self.available),
+        }
+        if not self.available and self.rejected_reasons:
+            device_desc['rejection reasons'] = self.rejected_reasons
+        return "Device({})".format(
+            ', '.join('{}={}'.format(key, device_desc[key]) for key in device_desc.keys())
+        )


### PR DESCRIPTION

Signed-off-by: Adam King <adking@redhat.com>

Previously you would get log messages like 

```
Found inventory for host [<ceph.deployment.inventory.Device object at 0x7f14e8b1b8d0>, <ceph.deployment.inventory.Device object at 0x7f14e8b1b668>, <ceph.deployment.inventory.Device object at 0x7f14e8b1b0b8>, <ceph.deployment.inventory.Device object at 0x7f14e8b1b898>]

Found drive selection <ceph.deployment.drive_selection.selector.DriveSelection object at 0x7f14e3282320>
```


With this change, it comes out like

```
Found inventory for host [Device(path=/dev/vdb, lvs=None, available=True), Device(path=/dev/vde, lvs=None, available=True), Device(path=/dev/vdc, lvs=None, available=False, rejection reasons=['Has GPT headers']), Device(path=/dev/vdd, lvs=None, available=False, rejection reasons=['Has GPT headers'])]

Found drive selection DeviceSelection(data devices=['/dev/vdb', '/dev/vdc', '/dev/vdd', '/dev/vde'], wal_devices=[], db devices=[], journal devices=[])
```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
