### PR TITLE
[DNM] python-common/ceph/deployment/drive_selection: ignore unavailable disks

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -111,6 +111,12 @@ class DriveSelection(object):
         for disk in self.disks:
             logger.debug("Processing disk {}".format(disk.path))
 
+            if not disk.available:
+                logger.debug(
+                    f'Ignoring disk {disk.path}. Disk is unavailable due to {disk.rejected_reasons}'
+                )
+                continue
+
             if not self._has_mandatory_idents(disk):
                 logger.debug(
                     "Ignoring disk {}. Missing mandatory idents".format(


### PR DESCRIPTION

Since they can cause lvm batch to fail if used

Signed-off-by: Adam King <adking@redhat.com>

What logs look like when this happens:

```
2021-11-18T19:23:29.776397+0000 mgr.vm-00.jihpcj [DBG] Processing disk /dev/vdb
2021-11-18T19:23:29.776587+0000 mgr.vm-00.jihpcj [DBG] Found matching disk: /dev/vdb
2021-11-18T19:23:29.776805+0000 mgr.vm-00.jihpcj [DBG] Adding disk /dev/vdb
2021-11-18T19:23:29.777033+0000 mgr.vm-00.jihpcj [DBG] Processing disk /dev/vde
2021-11-18T19:23:29.777227+0000 mgr.vm-00.jihpcj [DBG] Found matching disk: /dev/vde
2021-11-18T19:23:29.777417+0000 mgr.vm-00.jihpcj [DBG] Adding disk /dev/vde
2021-11-18T19:23:29.777611+0000 mgr.vm-00.jihpcj [DBG] Processing disk /dev/vdc
2021-11-18T19:23:29.777809+0000 mgr.vm-00.jihpcj [DBG] Ignoring disk /dev/vdc. Disk is unavailable due to ['Has GPT headers']
2021-11-18T19:23:29.778040+0000 mgr.vm-00.jihpcj [DBG] Processing disk /dev/vdd
2021-11-18T19:23:29.778267+0000 mgr.vm-00.jihpcj [DBG] Ignoring disk /dev/vdd. Disk is unavailable due to ['Has GPT headers']
2021-11-18T19:23:29.778457+0000 mgr.vm-00.jihpcj [DBG] device_filter is None
2021-11-18T19:23:29.778652+0000 mgr.vm-00.jihpcj [DBG] device_filter is None
2021-11-18T19:23:29.778823+0000 mgr.vm-00.jihpcj [DBG] device_filter is None
2021-11-18T19:23:29.779056+0000 mgr.vm-00.jihpcj [DBG] Found drive selection <ceph.deployment.drive_selection.selector.DriveSelection object at 0x7f0698e3d8d0>
2021-11-18T19:23:29.779354+0000 mgr.vm-00.jihpcj [DBG] Translating DriveGroup <DriveGroupSpec(name=all-available-devices->placement=PlacementSpec(host_pattern='*'), service_id='all-available-devices', service_type='osd', data_devices=DeviceSelection(all=True), osd_id_claims={}, unmanaged=False, filter_logic='AND', preview_only=False)> to ceph-volume command
2021-11-18T19:23:29.779492+0000 mgr.vm-00.jihpcj [DBG] Resulting ceph-volume cmd: lvm batch --no-auto /dev/vdb /dev/vde --yes --no-systemd
```


The disks with GPT headers are ignored and not included in the lvm batch command



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
