### PR TITLE
mgr/orchestrator: add filtering and count option for orch host ls

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -8,7 +8,13 @@ To list hosts associated with the cluster:
 
 .. prompt:: bash #
 
-    ceph orch host ls [--format yaml]
+    ceph orch host ls [--format yaml] [--host-pattern <name>] [--label <label>] [--host-status <status>]
+
+where the optional arguments "host-pattern", "label" and "host-status" are used for filtering.
+"host-pattern" is a regex that will match against hostnames and will only return matching hosts
+"label" will only return hosts with the given label
+"host-status" will only return hosts with the given status (currently "offline" or "maintenance")
+Any combination of these filtering flags is valid. You may filter against name, label and/or status simultaneously
 
 .. _cephadm-adding-hosts:    
     


### PR DESCRIPTION
Filter orch host ls output for only hosts whose name
contains a certain substring or who have a certain label

Add a count flag that causes the command to return the number
of hosts found (either overall or matching the substring and/or
label) instead of a list of all the matching hosts

Signed-off-by: Adam King <adking@redhat.com>

Fixes: https://tracker.ceph.com/issues/47774

Sample output:

```
[ceph: root@vm-00 /]# ceph orch host ls
HOST   ADDR             LABELS  STATUS  
vm-00  192.168.122.199  _admin          
vm-01  192.168.122.47                   
[ceph: root@vm-00 /]# ceph orch host ls --match 00
HOST   ADDR             LABELS  STATUS  
vm-00  192.168.122.199  _admin          
[ceph: root@vm-00 /]# ceph orch host ls --match 01
HOST   ADDR            LABELS  STATUS  
vm-01  192.168.122.47                  
[ceph: root@vm-00 /]# ceph orch host ls --label _admin
HOST   ADDR             LABELS  STATUS  
vm-00  192.168.122.199  _admin          
[ceph: root@vm-00 /]# ceph orch host label add vm-01 label2
Added label label2 to host vm-01
[ceph: root@vm-00 /]# ceph orch host ls --label label2
HOST   ADDR            LABELS  STATUS  
vm-01  192.168.122.47  label2          
[ceph: root@vm-00 /]# ceph orch host ls --match vm    
HOST   ADDR             LABELS  STATUS  
vm-00  192.168.122.199  _admin          
vm-01  192.168.122.47   label2          
[ceph: root@vm-00 /]# ceph orch host label add vm-00 all
Added label all to host vm-00
[ceph: root@vm-00 /]# ceph orch host label add vm-01 all
Added label all to host vm-01
[ceph: root@vm-00 /]# ceph orch host ls --label all   
HOST   ADDR             LABELS      STATUS  
vm-00  192.168.122.199  _admin all          
vm-01  192.168.122.47   label2 all          
[ceph: root@vm-00 /]# ceph orch host ls --count
2 hosts in cluster
[ceph: root@vm-00 /]# ceph orch host ls --match 00 --count
1 hosts in cluster whose hostname contained 00
[ceph: root@vm-00 /]# ceph orch host ls --match 01 --count
1 hosts in cluster whose hostname contained 01
[ceph: root@vm-00 /]# ceph orch host ls --match vm --count
2 hosts in cluster whose hostname contained vm
[ceph: root@vm-00 /]# ceph orch host ls --match vm --label all --count
2 hosts in cluster who had label all whose hostname contained vm
[ceph: root@vm-00 /]# ceph orch host ls --match vm --label _admin --count
1 hosts in cluster who had label _admin whose hostname contained vm
[ceph: root@vm-00 /]# ceph orch host ls --match vm --label thing2 --count
0 hosts in cluster who had label thing2 whose hostname contained vm
[ceph: root@vm-00 /]# ceph orch host ls --match vm --label label2 --count
1 hosts in cluster who had label label2 whose hostname contained vm
[ceph: root@vm-00 /]# ceph orch host ls --match 00 --label label2 --count
0 hosts in cluster who had label label2 whose hostname contained 00
[ceph: root@vm-00 /]# ceph orch host ls --match nobody
[ceph: root@vm-00 /]# ceph orch host ls --label fakelabel
[ceph: root@vm-00 /]# 

```




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
