### PR TITLE
mgr/dashboard: Improve notifications for osd nearfull, full

### DIFF
--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -112,6 +112,7 @@ class HealthTest(DashboardTestCase):
                     JObj({
                         'in': int,
                         'up': int,
+                        'state': JList(str)
                     })),
             }),
             'pg_info': self.__pg_info_schema,

--- a/src/pybind/mgr/dashboard/controllers/health.py
+++ b/src/pybind/mgr/dashboard/controllers/health.py
@@ -248,7 +248,7 @@ class HealthData(object):
         if self._minimal:
             osd_map = partial_dict(osd_map, ['osds'])
             osd_map['osds'] = [
-                partial_dict(item, ['in', 'up'])
+                partial_dict(item, ['in', 'up', 'state'])
                 for item in osd_map['osds']
             ]
         else:

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -18,6 +18,7 @@ from ..tools import str_to_bool
 from . import APIDoc, APIRouter, CreatePermission, DeletePermission, Endpoint, \
     EndpointDoc, ReadPermission, RESTController, Task, UpdatePermission, \
     allow_empty_body
+from ._version import APIVersion
 from .orchestrator import raise_if_no_orchestrator
 
 logger = logging.getLogger('controllers.osd')
@@ -92,6 +93,15 @@ class Osd(RESTController):
                 osd['stats'][stat.split('.')[1]] = mgr.get_latest('osd', osd_spec, stat)
             osd['operational_status'] = self._get_operational_status(osd_id, removing_osd_ids)
         return list(osds.values())
+
+    @RESTController.Collection('GET', version=APIVersion.EXPERIMENTAL)
+    @ReadPermission
+    def settings(self):
+        result = CephService.send_command('mon', 'osd dump')
+        return {
+            'nearfull_ratio': result['nearfull_ratio'],
+            'full_ratio': result['full_ratio']
+        }
 
     def _get_operational_status(self, osd_id: int, removing_osd_ids: Optional[List[int]]):
         if removing_osd_ids is None:

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -86,7 +86,9 @@
 <ng-template #osdUsageTpl
              let-row="row">
   <cd-usage-bar [total]="row.stats.stat_bytes"
-                [used]="row.stats.stat_bytes_used">
+                [used]="row.stats.stat_bytes_used"
+                [warningThreshold]="osdSettings.nearfull_ratio"
+                [errorThreshold]="osdSettings.full_ratio">
   </cd-usage-bar>
 </ng-template>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -5,6 +5,7 @@ import { Router } from '@angular/router';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import _ from 'lodash';
 import { forkJoin as observableForkJoin, Observable } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 import { OrchestratorService } from '~/app/shared/api/orchestrator.service';
 import { OsdService } from '~/app/shared/api/osd.service';
@@ -23,6 +24,7 @@ import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import { OrchestratorFeature } from '~/app/shared/models/orchestrator.enum';
 import { OrchestratorStatus } from '~/app/shared/models/orchestrator.interface';
+import { OsdSettings } from '~/app/shared/models/osd-settings';
 import { Permissions } from '~/app/shared/models/permissions';
 import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
@@ -67,6 +69,7 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
   columns: CdTableColumn[];
   clusterWideActions: CdTableAction[];
   icons = Icons;
+  osdSettings = new OsdSettings();
 
   selection = new CdTableSelection();
   osds: any[] = [];
@@ -344,6 +347,13 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
     ];
 
     this.orchService.status().subscribe((status: OrchestratorStatus) => (this.orchStatus = status));
+
+    this.osdService
+      .getOsdSettings()
+      .pipe(take(1))
+      .subscribe((data: any) => {
+        this.osdSettings = data;
+      });
   }
 
   getDisable(action: 'create' | 'delete', selection: CdTableSelection): boolean | string {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.scss
@@ -27,7 +27,7 @@ cd-info-card {
 }
 
 .card-text-error {
-  color: vv.$danger;
+  color: vv.$chart-danger;
   display: inline;
 }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/osd-summary.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/osd-summary.pipe.spec.ts
@@ -25,9 +25,9 @@ describe('OsdSummaryPipe', () => {
   it('transforms having 3 osd with 3 up, 3 in, 0 down, 0 out', () => {
     const value = {
       osds: [
-        { up: 1, in: 1 },
-        { up: 1, in: 1 },
-        { up: 1, in: 1 }
+        { up: 1, in: 1, state: ['up', 'exists'] },
+        { up: 1, in: 1, state: ['up', 'exists'] },
+        { up: 1, in: 1, state: ['up', 'exists'] }
       ]
     };
     expect(pipe.transform(value)).toEqual([
@@ -49,9 +49,9 @@ describe('OsdSummaryPipe', () => {
   it('transforms having 3 osd with 2 up, 1 in, 1 down, 2 out', () => {
     const value = {
       osds: [
-        { up: 1, in: 1 },
-        { up: 1, in: 0 },
-        { up: 0, in: 0 }
+        { up: 1, in: 1, state: ['up', 'exists'] },
+        { up: 1, in: 0, state: ['up', 'exists'] },
+        { up: 0, in: 0, state: ['exists'] }
       ]
     };
     expect(pipe.transform(value)).toEqual([
@@ -78,12 +78,12 @@ describe('OsdSummaryPipe', () => {
     ]);
   });
 
-  it('transforms having 3 osd with 2 up, 3 in, 1 down, 0 out', () => {
+  it('transforms having 3 osd with 2 up, 3 in, 1 full, 1 nearfull, 1 down, 0 out', () => {
     const value = {
       osds: [
-        { up: 1, in: 1 },
-        { up: 1, in: 1 },
-        { up: 0, in: 1 }
+        { up: 1, in: 1, state: ['up', 'nearfull'] },
+        { up: 1, in: 1, state: ['up', 'exists'] },
+        { up: 0, in: 1, state: ['full'] }
       ]
     };
     expect(pipe.transform(value)).toEqual([
@@ -106,6 +106,22 @@ describe('OsdSummaryPipe', () => {
       {
         content: '1 down',
         class: 'card-text-error'
+      },
+      {
+        content: '',
+        class: 'card-text-line-break'
+      },
+      {
+        content: '1 near full',
+        class: 'card-text-error'
+      },
+      {
+        content: '',
+        class: 'card-text-line-break'
+      },
+      {
+        content: '1 full',
+        class: 'card-text-error'
       }
     ]);
   });
@@ -113,9 +129,9 @@ describe('OsdSummaryPipe', () => {
   it('transforms having 3 osd with 3 up, 2 in, 0 down, 1 out', () => {
     const value = {
       osds: [
-        { up: 1, in: 1 },
-        { up: 1, in: 1 },
-        { up: 1, in: 0 }
+        { up: 1, in: 1, state: ['up', 'exists'] },
+        { up: 1, in: 1, state: ['up', 'exists'] },
+        { up: 1, in: 0, state: ['up', 'exists'] }
       ]
     };
     expect(pipe.transform(value)).toEqual([
@@ -145,10 +161,10 @@ describe('OsdSummaryPipe', () => {
   it('transforms having 4 osd with 3 up, 2 in, 1 down, another 2 out', () => {
     const value = {
       osds: [
-        { up: 1, in: 1 },
-        { up: 1, in: 0 },
-        { up: 1, in: 0 },
-        { up: 0, in: 1 }
+        { up: 1, in: 1, state: ['up', 'exists'] },
+        { up: 1, in: 0, state: ['up', 'exists'] },
+        { up: 1, in: 0, state: ['up', 'exists'] },
+        { up: 0, in: 1, state: ['exists'] }
       ]
     };
     expect(pipe.transform(value)).toEqual([

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/osd-summary.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/osd-summary.pipe.ts
@@ -13,12 +13,20 @@ export class OsdSummaryPipe implements PipeTransform {
 
     let inCount = 0;
     let upCount = 0;
+    let nearFullCount = 0;
+    let fullCount = 0;
     _.each(value.osds, (osd) => {
       if (osd.in) {
         inCount++;
       }
       if (osd.up) {
         upCount++;
+      }
+      if (osd.state.includes('nearfull')) {
+        nearFullCount++;
+      }
+      if (osd.state.includes('full')) {
+        fullCount++;
       }
     });
 
@@ -50,6 +58,30 @@ export class OsdSummaryPipe implements PipeTransform {
       const outText = outCount > 0 ? `${outCount} ${$localize`out`}` : '';
       osdSummary.push({
         content: `${downText}${separator}${outText}`,
+        class: 'card-text-error'
+      });
+    }
+
+    if (nearFullCount > 0) {
+      osdSummary.push(
+        {
+          content: '',
+          class: 'card-text-line-break'
+        },
+        {
+          content: `${nearFullCount} ${$localize`near full`}`,
+          class: 'card-text-error'
+        },
+        {
+          content: '',
+          class: 'card-text-line-break'
+        }
+      );
+    }
+
+    if (fullCount > 0) {
+      osdSummary.push({
+        content: `${fullCount} ${$localize`full`}`,
         class: 'card-text-error'
       });
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
@@ -2,10 +2,12 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import _ from 'lodash';
+import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { CdDevice } from '../models/devices';
 import { InventoryDeviceType } from '../models/inventory-device-type.model';
+import { OsdSettings } from '../models/osd-settings';
 import { SmartDataResponseV1 } from '../models/smart';
 import { DeviceService } from '../services/device.service';
 
@@ -74,6 +76,12 @@ export class OsdService {
 
   getList() {
     return this.http.get(`${this.path}`);
+  }
+
+  getOsdSettings(): Observable<OsdSettings> {
+    return this.http.get<OsdSettings>(`${this.path}/settings`, {
+      headers: { Accept: 'application/vnd.ceph.api.v0.1+json' }
+    });
   }
 
   getDetails(id: number) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.html
@@ -15,6 +15,7 @@
      data-placement="left"
      [ngbTooltip]="usageTooltipTpl">
   <div class="progress-bar bg-info"
+       [ngClass]="{'bg-warning': usedPercentage/100 >= warningThreshold, 'bg-danger': usedPercentage/100 >= errorThreshold}"
        role="progressbar"
        [style.width]="usedPercentage + '%'">
     <span>{{ usedPercentage | number: '1.0-' + decimals }}%</span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.scss
@@ -4,6 +4,14 @@
   background-color: vv.$primary !important;
 }
 
+.bg-warning {
+  background-color: vv.$warning !important;
+}
+
+.bg-danger {
+  background-color: vv.$danger !important;
+}
+
 .bg-freespace {
   background-color: vv.$gray-400 !important;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input, OnChanges } from '@angular/core';
 
+import _ from 'lodash';
+
 @Component({
   selector: 'cd-usage-bar',
   templateUrl: './usage-bar.component.html',
@@ -10,6 +12,10 @@ export class UsageBarComponent implements OnChanges {
   total: number;
   @Input()
   used: number;
+  @Input()
+  warningThreshold: number;
+  @Input()
+  errorThreshold: number;
   @Input()
   isBinary = true;
   @Input()

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/osd-settings.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/osd-settings.ts
@@ -1,0 +1,4 @@
+export class OsdSettings {
+  nearfull_ratio: number;
+  full_ratio: number;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/styles/defaults/_bootstrap-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/defaults/_bootstrap-defaults.scss
@@ -68,6 +68,7 @@ $chart-color-purple: #3c3d99 !default;
 $chart-color-center-text: #151515 !default;
 $chart-color-center-text-description: #72767b !default;
 $chart-color-tooltip-background: $black !default;
+$chart-danger: #c9190b !default;
 
 // Typography
 

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -6232,6 +6232,28 @@ paths:
       summary: Check If OSD is Safe to Destroy
       tags:
       - OSD
+  /api/osd/settings:
+    get:
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v0.1+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - OSD
   /api/osd/{svc_id}:
     delete:
       parameters:


### PR DESCRIPTION
This PR adds some visual hints for osds that are near full or full

Fixes: https://tracker.ceph.com/issues/53334
Signed-off-by: Aashish Sharma <aasharma@redhat.com>

Landing Page > Capacity > Warning
![Screenshot from 2021-11-19 13-29-26](https://user-images.githubusercontent.com/66050535/142597492-93fe1024-cfe0-42ae-9ee2-5aa64b5b2e07.png)

Landing Page > Capacity > Danger
![Screenshot from 2021-11-19 13-29-14](https://user-images.githubusercontent.com/66050535/142597754-1b1324c4-e5da-425b-b321-f79bf3a0453b.png)

Landing Page > OSD card
![Screenshot from 2022-01-10 15-18-30](https://user-images.githubusercontent.com/66050535/148746386-666a71d2-3584-466a-be93-8349c85bd490.png)




OSD Page > usage bar > warning
![Screenshot from 2021-11-19 13-10-10](https://user-images.githubusercontent.com/66050535/142597926-53618ea4-7909-41d2-9022-d7b8b3d811a4.png)

OSD Page > usage bar > danger
![Screenshot from 2021-11-19 13-10-28](https://user-images.githubusercontent.com/66050535/142597983-55b1c825-e30d-432f-9318-86c072e0c396.png)



