### PR TITLE
mgr/telemetry: remove aggregated perf metrics from the perf channel

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -46,12 +46,12 @@ the per-channel setting has no effect.)
     - cluster description
     - contact email address
 
-* **perf** (default: off): Aggregated performance counter metrics of a cluster, which can be used to
+* **perf** (default: off): Various performance metrics of a cluster, which can be used to
 
     - reveal overall cluster health
     - identify workload patterns
     - troubleshoot issues with latency, throttling, memory management, etc.
-    - monitor cluster performance by daemon types
+    - monitor cluster performance by daemon
 
 The data being reported does *not* contain any sensitive
 data like pool names, object names, object contents, hostnames, or device

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -140,7 +140,7 @@
                      for="channel_perf">
                 <ng-container i18n>Perf</ng-container>
                 <cd-helper>
-                  <ng-container i18n>Includes performance counter metrics summed across the cluster.</ng-container>
+                  <ng-container i18n>Includes various performance metrics of a cluster.</ng-container>
                 </cd-helper>
               </label>
               <div class="cd-col-form-input">

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -900,19 +900,12 @@ class Module(MgrModule):
             report['crashes'] = self.gather_crashinfo()
 
         if 'perf' in channels:
-            report['perf_counters_aggregated'] = self.gather_perf_counters('aggregated')
-            report['perf_counters_separated'] = self.gather_perf_counters('separated')
-
+            report['perf_counters'] = self.gather_perf_counters('separated')
             report['stats_per_pool'] = self.get('pg_dump')['pool_stats']
             report['stats_per_pg'] = self.get('pg_dump')['pg_stats']
-
             report['io_rate'] = self.get_io_rate()
-
-            report['osd_perf_histograms_aggregated'] = self.get_osd_histograms('aggregated')
-            report['osd_perf_histograms_separated'] = self.get_osd_histograms('separated')
-
-            report['mempool_aggregated'] = self.get_mempool('aggregated')
-            report['mempool_separated'] = self.get_mempool('separated')
+            report['osd_perf_histograms'] = self.get_osd_histograms('separated')
+            report['mempool'] = self.get_mempool('separated')
 
         # NOTE: We do not include the 'device' channel in this report; it is
         # sent to a different endpoint.
@@ -1042,7 +1035,7 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
         # they are displayed horizontally instead of vertically.
         try:
             # Formatting ranges and values in osd_perf_histograms
-            modes_to_be_formatted = ['osd_perf_histograms_aggregated', 'osd_perf_histograms_separated']
+            modes_to_be_formatted = ['osd_perf_histograms']
             for mode in modes_to_be_formatted:
                 for config in report[mode]:
                     for histogram in config:


### PR DESCRIPTION
Up until this point, we included aggregated and separated data for
testing purposes. Now that we've done our testing, the aggregated
metrics are no longer relevant.

Aggregated metrics can still be achieved on the server side by
summing separated metrics.

Signed-off-by: Laura Flores <lflores@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
