### PR TITLE
mgr: Identify missing connection with monitors

### DIFF
--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -57,6 +57,7 @@ class ActivePyModules
   Finisher &finisher;
 public:
   Finisher cmd_finisher;
+  std::string mon_connection_status;
 private:
   DaemonServer &server;
   PyModuleRegistry &py_module_registry;
@@ -64,6 +65,7 @@ private:
   map<std::string,ProgressEvent> progress_events;
 
   mutable ceph::mutex lock = ceph::make_mutex("ActivePyModules::lock");
+
 
 public:
   ActivePyModules(

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -711,7 +711,7 @@ ceph_set_wear_level(BaseMgrModule *self, PyObject *args)
 static PyObject*
 ceph_have_mon_connection(BaseMgrModule *self, PyObject *args)
 {
-  if (self->py_modules->get_monc().is_connected()) {
+  if (self->py_modules->get_monc().is_connected() && self->py_modules->mon_connection_status == "up") {
     Py_RETURN_TRUE;
   } else {
     Py_RETURN_FALSE;

--- a/src/mgr/ClusterState.h
+++ b/src/mgr/ClusterState.h
@@ -14,6 +14,7 @@
 #ifndef CLUSTER_STATE_H_
 #define CLUSTER_STATE_H_
 
+#include "include/utime.h"
 #include "mds/FSMap.h"
 #include "mon/MgrMap.h"
 #include "common/ceph_mutex.h"
@@ -51,6 +52,8 @@ protected:
   bufferlist mon_status_json;
 
   class ClusterSocketHook *asok_hook;
+
+  utime_t last_message_time;
 
 public:
 
@@ -157,6 +160,15 @@ public:
 		    const cmdmap_t& cmdmap,
 		    Formatter *f,
 		    std::ostream& ss);
+
+
+  utime_t get_last_message_time() {
+    return last_message_time;
+  }
+
+  void set_last_message_time(utime_t time) {
+    last_message_time = time;
+  }
 };
 
 #endif

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -16,6 +16,7 @@
 #include "osdc/Objecter.h"
 #include "client/Client.h"
 #include "common/errno.h"
+#include "common/Clock.h"
 #include "mon/MonClient.h"
 #include "include/stringify.h"
 #include "global/global_context.h"
@@ -633,6 +634,11 @@ bool Mgr::ms_dispatch2(const ref_t<Message>& m)
       py_module_registry->notify_all("service_map", "");
       break;
     case MSG_LOG:
+      // Set the last time we received a message from the monitor.
+      // This isn't exactly the last message because the monitor keeps sending
+      // messages to the mgr even with a broken monitor, so we have to use the timestamp
+      // of the last log. This should be fixed in the monitor itself.
+      cluster_state.set_last_message_time(ref_cast<MLog>(m)->entries.back().stamp);
       handle_log(ref_cast<MLog>(m));
       break;
     case MSG_KV_DATA:

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.ts
@@ -48,6 +48,7 @@ export class ApiInterceptorService implements HttpInterceptor {
     }
     return next.handle(reqWithVersion).pipe(
       catchError((resp: CdHttpErrorResponse) => {
+          console.log(resp);
         if (resp instanceof HttpErrorResponse) {
           let timeoutId: number;
           switch (resp.status) {
@@ -78,6 +79,17 @@ export class ApiInterceptorService implements HttpInterceptor {
                   message: $localize`Sorry, you don’t have permission to view this page or resource.`,
                   header: $localize`Access Denied`,
                   icon: 'fa fa-lock',
+                  source: 'forbidden'
+                }
+              });
+              break;
+            case 503:
+              this.router.navigate(['error'], {
+                state: {
+                  // TODO: change with response error message.
+                  message: $localize`The connection with monitor's daemons was compromised.`,
+                  header: $localize`Monitor connection error`,
+                  icon: 'fa fa-warning',
                   source: 'forbidden'
                 }
               });

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -127,6 +127,7 @@ class CherryPyConfig(object):
         cherrypy.tools.request_logging = RequestLoggingTool()
         cherrypy.tools.dashboard_exception_handler = HandlerWrapperTool(dashboard_exception_handler,
                                                                         priority=31)
+        cherrypy.tools.mon_connection_checker = MonConnectionChecker()
 
         cherrypy.log.access_log.propagate = False
         cherrypy.log.error_log.propagate = False
@@ -150,6 +151,7 @@ class CherryPyConfig(object):
             'tools.json_in.on': True,
             'tools.json_in.force': True,
             'tools.plugin_hooks_filter_request.on': True,
+            'tools.mon_connection_checker.on': True,
         }
 
         if use_ssl:


### PR DESCRIPTION
If you have 3 monitors and kill two of them you'll find yourself in a place where monitors stop responding and the data will be incorrect in both prometheus and dashboard.

Even though you cannot use the mon to perform any action, the mon keeps sending messages. As it keeps seding logs from the mon to mgr, we decided to do a kick fix where we store the stamp of the last log message received from the mon and, use it to see if it has been a lot of time since the last message.

There are different ways we could approach this: 
* Heartbeats from mon to mgr
* Ping the monitors in the mgr
* Don't allow mon to send messages to mgr if it's not responding.

And if you have a suggestion please leave a comment :)

Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>
Fixes: https://tracker.ceph.com/issues/52467




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
