### PR TITLE
ceph-volume: add raw support for db/wal for list and activate

### DIFF
--- a/src/ceph-volume/ceph_volume/activate/main.py
+++ b/src/ceph-volume/ceph_volume/activate/main.py
@@ -45,7 +45,7 @@ class Activate(object):
         # first try raw
         try:
             RAWActivate([]).activate(
-                device=None,
+                devs=None,
                 start_osd_id=self.args.osd_id,
                 start_osd_uuid=self.args.osd_uuid,
                 tmpfs=not self.args.no_tmpfs,

--- a/src/ceph-volume/ceph_volume/devices/raw/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/activate.py
@@ -35,21 +35,27 @@ def activate_bluestore(meta, tmpfs, systemd, block_wal=None, block_db=None):
     system.chown(osd_path)
     prime_command = [
         'ceph-bluestore-tool',
-        'prime-osd-dir', '--dev', meta['device'],
+        'prime-osd-dir',
         '--path', osd_path,
-        '--no-mon-config']
+        '--no-mon-config',
+        '--dev', meta['device'],
+    ]
     process.run(prime_command)
 
     # always re-do the symlink regardless if it exists, so that the block,
     # block.wal, and block.db devices that may have changed can be mapped
     # correctly every time
-    prepare_utils.link_block( meta['device'], osd_id)
-
-    if block_wal:
-        prepare_utils.link_wal(block_wal, osd_id, osd_uuid)
+    prepare_utils.link_block(meta['device'], osd_id)
 
     if block_db:
         prepare_utils.link_db(block_db, osd_id, osd_uuid)
+    elif 'device_db' in meta:
+        prepare_utils.link_db(meta['device_db'], osd_id, osd_uuid)
+
+    if block_wal:
+        prepare_utils.link_wal(block_wal, osd_id, osd_uuid)
+    elif 'device_wal' in meta:
+        prepare_utils.link_wal(meta['device_wal'], osd_id, osd_uuid)
 
     system.chown(osd_path)
     terminal.success("ceph-volume raw activate successful for osd ID: %s" % osd_id)

--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -68,12 +68,6 @@ class List(object):
 
     def generate(self, devs=None):
         logger.debug('Listing block devices via lsblk...')
-        # in case where we come from `ceph-volume raw activate`
-        # `--device` will call `List.list()` with a string instead of a list
-        # which can lead the logic in this function to a bug. The following lines will basically
-        # convert it to a list with a single element to be sure we don't hit any issue.
-        if isinstance(devs, str):
-            devs = [devs]
         if devs is None or devs == []:
             devs = []
             # If no devs are given initially, we want to list ALL devices including children and

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -59,6 +59,7 @@ class CephadmServe:
         self.mgr.config_checker.load_network_config()
 
         while self.mgr.run:
+            self.log.debug("serve loop start")
 
             try:
 
@@ -104,7 +105,9 @@ class CephadmServe:
                 if e.event_subject:
                     self.mgr.events.from_orch_error(e)
 
+            self.log.debug("serve loop sleep")
             self._serve_sleep()
+            self.log.debug("serve loop wake")
         self.log.debug("serve exit")
 
     def _serve_sleep(self) -> None:
@@ -122,6 +125,7 @@ class CephadmServe:
         self.mgr.event.clear()
 
     def _update_paused_health(self) -> None:
+        self.log.debug('_update_paused_health')
         if self.mgr.paused:
             self.mgr.set_health_warning('CEPHADM_PAUSED', 'cephadm background work is paused', 1, [
                                         "'ceph orch resume' to resume"])
@@ -174,6 +178,7 @@ class CephadmServe:
         self.mgr.cache.update_autotune(host)
 
     def _refresh_hosts_and_daemons(self) -> None:
+        self.log.debug('_refresh_hosts_and_daemons')
         bad_hosts = []
         failures = []
 
@@ -517,6 +522,7 @@ class CephadmServe:
                     'CEPHADM_STRAY_DAEMON', f'{len(daemon_detail)} stray daemon(s) not managed by cephadm', len(daemon_detail), daemon_detail)
 
     def _check_for_moved_osds(self) -> None:
+        self.log.debug('_check_for_moved_osds')
         all_osds: DefaultDict[int, List[orchestrator.DaemonDescription]] = defaultdict(list)
         for dd in self.mgr.cache.get_daemons_by_type('osd'):
             assert dd.daemon_id
@@ -544,6 +550,7 @@ class CephadmServe:
                     logger.exception(f'failed to remove duplicated daemon {e}')
 
     def _apply_all_services(self) -> bool:
+        self.log.debug('_apply_all_services')
         r = False
         specs = []  # type: List[ServiceSpec]
         # if metadata is not up to date, we still need to apply spec for agent
@@ -900,6 +907,7 @@ class CephadmServe:
         return r
 
     def _check_daemons(self) -> None:
+        self.log.debug('_check_daemons')
         daemons = self.mgr.cache.get_daemons()
         daemons_post: Dict[str, List[orchestrator.DaemonDescription]] = defaultdict(list)
         for dd in daemons:
@@ -996,6 +1004,7 @@ class CephadmServe:
                     daemon_type)).daemon_check_post(daemon_descs)
 
     def _purge_deleted_services(self) -> None:
+        self.log.debug('_purge_deleted_services')
         existing_services = self.mgr.spec_store.all_specs.items()
         for service_name, spec in list(existing_services):
             if service_name not in self.mgr.spec_store.spec_deleted:


### PR DESCRIPTION
Currently 'prepare' doesn't support db/wal, but we want it in list and activate because 'ceph-volume activate ...' tries raw before lvm, and trying to activate with only the main (and not additional) device(s) will lead to an OSD that crashes when it tries to start up.

This cleans up the ``raw activate`` command to take a list of devices.

Fixes cephadm regression introduced by #42727 





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [x] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>