### PR TITLE
mgr/cephadm: use a copy of the hosts facts during config checks

### DIFF
--- a/src/pybind/mgr/cephadm/configchecks.py
+++ b/src/pybind/mgr/cephadm/configchecks.py
@@ -1,6 +1,7 @@
 import json
 import ipaddress
 import logging
+import copy
 
 from mgr_module import ServiceInfoT
 
@@ -636,9 +637,10 @@ class CephadmConfigChecks:
 
     def _process_hosts(self) -> None:
         self.log.debug(f"processing data from {len(self.mgr.cache.facts)} hosts")
-        for hostname in self.mgr.cache.facts:
+        facts = copy.deepcopy(self.mgr.cache.facts)
+        for hostname in facts:
             host = HostFacts()
-            host.load_facts(self.mgr.cache.facts[hostname])
+            host.load_facts(facts[hostname])
             if not host._valid:
                 self.log.warning(f"skipping {hostname} - incompatible host facts")
                 continue


### PR DESCRIPTION
When cephadm agent is frequently updating the mgr's host facts
the facts can change during processing, causing a runtime error.
This patch taks a copy of the facts up front, and processes the copy
to avoid the runtime issue.

Fixes: https://tracker.ceph.com/issues/53351

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>




## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [X] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [X] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
