### PR TITLE
pacific: mgr/dashboard: NFS non-existent files cleanup 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -230,10 +230,9 @@ nfs:
   - src/pybind/mgr/nfs/**
   - src/pybind/mgr/cephadm/services/nfs.py
   - src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
-  - src/pybind/mgr/dashboard/services/ganesha.py
-  - src/pybind/mgr/dashboard/tests/test_ganesha.py
+  - src/pybind/mgr/dashboard/controllers/nfs.py
+  - src/pybind/mgr/dashboard/tests/test_nfs.py
   - qa/tasks/cephfs/test_nfs.py
-  - qa/tasks/mgr/dashboard/test_ganesha.py
   - doc/mgr/nfs.rst
   - doc/cephfs/nfs.rst
   - doc/cephadm/nfs.rst

--- a/qa/suites/rados/dashboard/tasks/dashboard.yaml
+++ b/qa/suites/rados/dashboard/tasks/dashboard.yaml
@@ -33,18 +33,19 @@ tasks:
       fail_on_skip: false
       modules:
         - tasks.mgr.test_dashboard
+        - tasks.mgr.dashboard.test_api
         - tasks.mgr.dashboard.test_auth
         - tasks.mgr.dashboard.test_cephfs
-        - tasks.mgr.dashboard.test_cluster_configuration
         - tasks.mgr.dashboard.test_cluster
+        - tasks.mgr.dashboard.test_cluster_configuration
         - tasks.mgr.dashboard.test_crush_rule
         - tasks.mgr.dashboard.test_erasure_code_profile
-        - tasks.mgr.dashboard.test_ganesha
         - tasks.mgr.dashboard.test_health
         - tasks.mgr.dashboard.test_host
         - tasks.mgr.dashboard.test_logs
         - tasks.mgr.dashboard.test_mgr_module
         - tasks.mgr.dashboard.test_monitor
+        - tasks.mgr.dashboard.test_motd
         - tasks.mgr.dashboard.test_orchestrator
         - tasks.mgr.dashboard.test_osd
         - tasks.mgr.dashboard.test_perf_counters
@@ -58,4 +59,3 @@ tasks:
         - tasks.mgr.dashboard.test_summary
         - tasks.mgr.dashboard.test_telemetry
         - tasks.mgr.dashboard.test_user
-        - tasks.mgr.dashboard.test_motd


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53344

---

backport of https://github.com/ceph/ceph/pull/43987
parent tracker: https://tracker.ceph.com/issues/53123

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh