### PR TITLE
rgw/multisite: RunBucketSourcesSync no longer takes optional target

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -231,10 +231,6 @@ RGWCoroutinesStack::~RGWCoroutinesStack()
   for (auto stack : spawned.entries) {
     stack->put();
   }
-
-  if (preallocated_stack) {
-    preallocated_stack->put();
-  }
 }
 
 int RGWCoroutinesStack::operate(const DoutPrefixProvider *dpp, RGWCoroutinesEnv *_env)
@@ -306,12 +302,7 @@ RGWCoroutinesStack *RGWCoroutinesStack::spawn(RGWCoroutine *source_op, RGWCorout
 
   rgw_spawned_stacks *s = (source_op ? &source_op->spawned : &spawned);
 
-  RGWCoroutinesStack *stack = preallocated_stack;
-  if (!stack) {
-    stack = env->manager->allocate_stack();
-  }
-  preallocated_stack = nullptr;
-
+  RGWCoroutinesStack *stack = env->manager->allocate_stack();
   s->add_pending(stack);
   stack->parent = this;
 
@@ -330,14 +321,6 @@ RGWCoroutinesStack *RGWCoroutinesStack::spawn(RGWCoroutine *source_op, RGWCorout
 RGWCoroutinesStack *RGWCoroutinesStack::spawn(RGWCoroutine *op, bool wait)
 {
   return spawn(NULL, op, wait);
-}
-
-RGWCoroutinesStack *RGWCoroutinesStack::prealloc_stack()
-{
-  if (!preallocated_stack) {
-    preallocated_stack = env->manager->allocate_stack();
-  }
-  return preallocated_stack;
 }
 
 int RGWCoroutinesStack::wait(const utime_t& interval)
@@ -916,16 +899,6 @@ void RGWCoroutine::call(RGWCoroutine *op)
 RGWCoroutinesStack *RGWCoroutine::spawn(RGWCoroutine *op, bool wait)
 {
   return stack->spawn(this, op, wait);
-}
-
-RGWCoroutinesStack *RGWCoroutine::prealloc_stack()
-{
-  return stack->prealloc_stack();
-}
-
-uint64_t RGWCoroutine::prealloc_stack_id()
-{
-  return prealloc_stack()->get_id();
 }
 
 bool RGWCoroutine::collect(int *ret, RGWCoroutinesStack *skip_stack, uint64_t *stack_id) /* returns true if needs to be called again */

--- a/src/rgw/rgw_coroutine.h
+++ b/src/rgw/rgw_coroutine.h
@@ -300,9 +300,6 @@ public:
   bool collect(int *ret, RGWCoroutinesStack *skip_stack, uint64_t *stack_id = nullptr); /* returns true if needs to be called again */
   bool collect_next(int *ret, RGWCoroutinesStack **collected_stack = NULL); /* returns true if found a stack to collect */
 
-  RGWCoroutinesStack *prealloc_stack(); /* prepare a stack that will be used in the next spawn operation */
-  uint64_t prealloc_stack_id(); /* prepare a stack that will be used in the next spawn operation, return its id */
-
   int wait(const utime_t& interval);
   bool drain_children(int num_cr_left,
                       RGWCoroutinesStack *skip_stack = nullptr,
@@ -435,8 +432,6 @@ class RGWCoroutinesStack : public RefCountedObject {
 
   rgw_spawned_stacks spawned;
 
-  RGWCoroutinesStack *preallocated_stack{nullptr};
-
   std::set<RGWCoroutinesStack *> blocked_by_stack;
   std::set<RGWCoroutinesStack *> blocking_stacks;
 
@@ -534,7 +529,6 @@ public:
 
   void call(RGWCoroutine *next_op);
   RGWCoroutinesStack *spawn(RGWCoroutine *next_op, bool wait);
-  RGWCoroutinesStack *prealloc_stack();
   int unwind(int retcode);
 
   int wait(const utime_t& interval);

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1257,10 +1257,8 @@ class RGWRunBucketSourcesSyncCR : public RGWCoroutine {
 
   RGWSyncTraceNodeRef tn;
   ceph::real_time* progress;
-  std::map<uint64_t, ceph::real_time> shard_progress;
-
-  ceph::real_time *cur_progress{nullptr};
-  std::optional<ceph::real_time> min_progress;
+  std::vector<ceph::real_time> shard_progress;
+  std::vector<ceph::real_time>::iterator cur_shard_progress;
 
   RGWRESTConn *conn{nullptr};
   rgw_zone_id last_zone;
@@ -1278,25 +1276,6 @@ public:
                             ceph::real_time* progress);
 
   int operate(const DoutPrefixProvider *dpp) override;
-
-  void handle_complete_stack(uint64_t stack_id) {
-    auto iter = shard_progress.find(stack_id);
-    if (iter == shard_progress.end()) {
-      lderr(cct) << "ERROR: RGWRunBucketSourcesSyncCR::handle_complete_stack(): stack_id=" << stack_id << " not found! Likely a bug" << dendl;
-      return;
-    }
-    if (progress) {
-      if (!min_progress) {
-        min_progress = iter->second;
-      } else {
-        if (iter->second < *min_progress) {
-          min_progress = iter->second;
-        }
-      }
-    }
-
-    shard_progress.erase(stack_id);
-  }
 };
 
 class RGWDataSyncSingleEntryCR : public RGWCoroutine {
@@ -4767,13 +4746,13 @@ int RGWRunBucketSourcesSyncCR::operate(const DoutPrefixProvider *dpp)
 
       ldpp_dout(dpp, 20) << __func__ << "(): sync_pair=" << sync_pair << dendl;
 
-      cur_progress = (progress ? &shard_progress[prealloc_stack_id()] : nullptr);
+      shard_progress.resize(1);
+      cur_shard_progress = shard_progress.begin();
 
       yield_spawn_window(sync_bucket_shard_cr(sc, lease_cr, sync_pair,
-                                              gen, tn, cur_progress),
+                                              gen, tn, &*cur_shard_progress),
                          BUCKET_SYNC_SPAWN_WINDOW,
                          [&](uint64_t stack_id, int ret) {
-                           handle_complete_stack(stack_id);
                            if (ret < 0) {
                              tn->log(10, SSTR("ERROR: a sync operation returned error: " << ret));
                            }
@@ -4781,14 +4760,13 @@ int RGWRunBucketSourcesSyncCR::operate(const DoutPrefixProvider *dpp)
                          });
     }
     drain_all_cb([&](uint64_t stack_id, int ret) {
-                   handle_complete_stack(stack_id);
                    if (ret < 0) {
                      tn->log(10, SSTR("a sync operation returned error: " << ret));
                    }
                    return ret;
                  });
-    if (progress && min_progress) {
-      *progress = *min_progress;
+    if (progress) {
+      *progress = *std::min_element(shard_progress.begin(), shard_progress.end());
     }
     return set_cr_done();
   }

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1250,12 +1250,6 @@ class RGWRunBucketSourcesSyncCR : public RGWCoroutine {
   RGWDataSyncEnv *sync_env;
   boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr;
 
-  std::optional<rgw_bucket_shard> target_bs;
-  std::optional<rgw_bucket_shard> source_bs;
-
-  std::optional<rgw_bucket> target_bucket;
-  std::optional<rgw_bucket> source_bucket;
-
   rgw_sync_pipe_info_set pipes;
   rgw_sync_pipe_info_set::iterator siter;
 
@@ -1271,12 +1265,6 @@ class RGWRunBucketSourcesSyncCR : public RGWCoroutine {
   RGWRESTConn *conn{nullptr};
   rgw_zone_id last_zone;
 
-  int source_num_shards{0};
-  int target_num_shards{0};
-
-  int num_shards{0};
-  int cur_shard{0};
-  bool again = false;
   std::optional<uint64_t> gen;
   rgw_bucket_index_marker_info marker_info;
   BucketIndexShardsManager marker_mgr;
@@ -1284,8 +1272,7 @@ class RGWRunBucketSourcesSyncCR : public RGWCoroutine {
 public:
   RGWRunBucketSourcesSyncCR(RGWDataSyncCtx *_sc,
                             boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
-                            std::optional<rgw_bucket_shard> _target_bs,
-                            std::optional<rgw_bucket_shard> _source_bs,
+                            const rgw_bucket_shard& source_bs,
                             const RGWSyncTraceNodeRef& _tn_parent,
 			    std::optional<uint64_t> gen,
                             ceph::real_time* progress);
@@ -1373,7 +1360,6 @@ public:
           ldout(cct, 4) << "starting sync on " << bucket_shard_str{state->key}
               << ' ' << *state->obligation << dendl;
           yield call(new RGWRunBucketSourcesSyncCR(sc, lease_cr,
-                                                   std::nullopt, /* target_bs */
                                                    state->key, tn,
                                                    state->obligation->gen,
 						   &progress));
@@ -4741,39 +4727,32 @@ static RGWCoroutine* sync_bucket_shard_cr(RGWDataSyncCtx* sc,
 
 RGWRunBucketSourcesSyncCR::RGWRunBucketSourcesSyncCR(RGWDataSyncCtx *_sc,
                                                      boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
-                                                     std::optional<rgw_bucket_shard> _target_bs,
-                                                     std::optional<rgw_bucket_shard> _source_bs,
+                                                     const rgw_bucket_shard& source_bs,
                                                      const RGWSyncTraceNodeRef& _tn_parent,
 						     std::optional<uint64_t> gen,
                                                      ceph::real_time* progress)
   : RGWCoroutine(_sc->env->cct), sc(_sc), sync_env(_sc->env),
-    lease_cr(std::move(lease_cr)), target_bs(_target_bs), source_bs(_source_bs),
+    lease_cr(std::move(lease_cr)),
     tn(sync_env->sync_tracer->add_node(
 	 _tn_parent, "bucket_sync_sources",
-	 SSTR( "target=" << target_bucket.value_or(rgw_bucket()) <<
-	       ":source_bucket=" << source_bucket.value_or(rgw_bucket()) <<
-	       ":source_zone=" << sc->source_zone))),
+	 SSTR( "source=" << source_bs << ":source_zone=" << sc->source_zone))),
     progress(progress),
     gen(gen)
 {
-  if (target_bs) {
-    target_bucket = target_bs->bucket;
-  }
-  if (source_bs) {
-    source_bucket = source_bs->bucket;
-  }
+  sync_pair.source_bs = source_bs;
 }
 
 int RGWRunBucketSourcesSyncCR::operate(const DoutPrefixProvider *dpp)
 {
   reenter(this) {
-    yield call(new RGWGetBucketPeersCR(sync_env, target_bucket, sc->source_zone, source_bucket, &pipes, tn));
+    yield call(new RGWGetBucketPeersCR(sync_env, std::nullopt, sc->source_zone,
+                                       sync_pair.source_bs.bucket, &pipes, tn));
     if (retcode < 0 && retcode != -ENOENT) {
       tn->log(0, SSTR("ERROR: failed to read sync status for bucket. error: " << retcode));
       return set_cr_error(retcode);
     }
 
-    ldpp_dout(dpp, 20) << __func__ << "(): requested source_bs=" << source_bs << " target_bs=" << target_bs << dendl;
+    ldpp_dout(dpp, 20) << __func__ << "(): requested source_bs=" << sync_pair.source_bs << dendl;
 
     if (pipes.empty()) {
       ldpp_dout(dpp, 20) << __func__ << "(): no relevant sync pipes found" << dendl;
@@ -4781,66 +4760,25 @@ int RGWRunBucketSourcesSyncCR::operate(const DoutPrefixProvider *dpp)
     }
 
     for (siter = pipes.begin(); siter != pipes.end(); ++siter) {
-      {
-        ldpp_dout(dpp, 20) << __func__ << "(): sync pipe=" << *siter << dendl;
-	yield call(new RGWReadRemoteBucketIndexLogInfoCR(
-		     sc, siter->source.get_bucket_info().bucket, &marker_info));
-	if (retcode < 0) {
-	  tn->log(0, SSTR("ERROR: failed to fetch markers for bucket: "
-			  << siter->source.get_bucket_info().bucket));
-	  return set_cr_error(retcode);
-	}
-	retcode = marker_mgr.from_string(marker_info.max_marker, -1);
-	if (retcode < 0) {
-	  ldpp_dout(dpp, 0) << "ERROR: failed to decode markers for bucket: "
-			    << siter->source.get_bucket_info().bucket << dendl;
-	  return set_cr_error(retcode);
-	}
-	source_num_shards = marker_mgr.get().size();
+      ldpp_dout(dpp, 20) << __func__ << "(): sync pipe=" << *siter << dendl;
 
-	target_num_shards = siter->target.get_bucket_info().layout.current_index.layout.normal.num_shards;
-        if (source_bs) {
-          sync_pair.source_bs = *source_bs;
-        } else {
-          sync_pair.source_bs.bucket = siter->source.get_bucket();
-        }
-        sync_pair.dest_bucket = siter->target.get_bucket();
+      sync_pair.dest_bucket = siter->target.get_bucket();
+      sync_pair.handler = siter->handler;
 
-        sync_pair.handler = siter->handler;
+      ldpp_dout(dpp, 20) << __func__ << "(): sync_pair=" << sync_pair << dendl;
 
-        if (sync_pair.source_bs.shard_id >= 0) {
-          num_shards = 1;
-          cur_shard = sync_pair.source_bs.shard_id;
-        } else {
-          num_shards = std::max<int>(1, source_num_shards);
-          cur_shard = std::min<int>(0, source_num_shards);
-        }
-      }
+      cur_progress = (progress ? &shard_progress[prealloc_stack_id()] : nullptr);
 
-      ldpp_dout(dpp, 20) << __func__ << "(): num shards=" << num_shards << " cur_shard=" << cur_shard << dendl;
-
-      for (; num_shards > 0; --num_shards, ++cur_shard) {
-        /*
-         * use a negatvie shard_id for backward compatibility,
-         * this affects the crafted status oid
-         */
-        sync_pair.source_bs.shard_id = (source_num_shards > 0 ? cur_shard : -1);
-
-        ldpp_dout(dpp, 20) << __func__ << "(): sync_pair=" << sync_pair << dendl;
-
-        cur_progress = (progress ? &shard_progress[prealloc_stack_id()] : nullptr);
-
-        yield_spawn_window(sync_bucket_shard_cr(sc, lease_cr, sync_pair,
-                                                gen, tn, cur_progress),
-                           BUCKET_SYNC_SPAWN_WINDOW,
-                           [&](uint64_t stack_id, int ret) {
-                             handle_complete_stack(stack_id);
-                             if (ret < 0) {
-                               tn->log(10, SSTR("ERROR: a sync operation returned error: " << ret));
-                             }
-                             return ret;
-                           });
-      }
+      yield_spawn_window(sync_bucket_shard_cr(sc, lease_cr, sync_pair,
+                                              gen, tn, cur_progress),
+                         BUCKET_SYNC_SPAWN_WINDOW,
+                         [&](uint64_t stack_id, int ret) {
+                           handle_complete_stack(stack_id);
+                           if (ret < 0) {
+                             tn->log(10, SSTR("ERROR: a sync operation returned error: " << ret));
+                           }
+                           return ret;
+                         });
     }
     drain_all_cb([&](uint64_t stack_id, int ret) {
                    handle_complete_stack(stack_id);

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1225,6 +1225,10 @@ struct rgw_sync_pipe_info_set {
     return handlers.end();
   }
 
+  size_t size() const {
+    return handlers.size();
+  }
+
   bool empty() const {
     return handlers.empty();
   }
@@ -4738,16 +4742,16 @@ int RGWRunBucketSourcesSyncCR::operate(const DoutPrefixProvider *dpp)
       return set_cr_done();
     }
 
-    for (siter = pipes.begin(); siter != pipes.end(); ++siter) {
+    shard_progress.resize(pipes.size());
+    cur_shard_progress = shard_progress.begin();
+
+    for (siter = pipes.begin(); siter != pipes.end(); ++siter, ++cur_shard_progress) {
       ldpp_dout(dpp, 20) << __func__ << "(): sync pipe=" << *siter << dendl;
 
       sync_pair.dest_bucket = siter->target.get_bucket();
       sync_pair.handler = siter->handler;
 
       ldpp_dout(dpp, 20) << __func__ << "(): sync_pair=" << sync_pair << dendl;
-
-      shard_progress.resize(1);
-      cur_shard_progress = shard_progress.begin();
 
       yield_spawn_window(sync_bucket_shard_cr(sc, lease_cr, sync_pair,
                                               gen, tn, &*cur_shard_progress),


### PR DESCRIPTION
RGWDataSyncSingleEntryCR is the only caller of RGWRunBucketSourcesSyncCR

it always provides a source_bs, and never provides a target_bs. so remove all the complexity related to target_bs, and the idea that we'd need to sync several source bucket shards related to the target bucket

we now just have the single loop over the target buckets that use the given bucket as a source


the commits related to `prealloc_stack()` were added specifically for this loop, so they're reverted to simplify RGWCoroutine

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [ ] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
