### PR TITLE
osd/scrub: ignoring unsolicited DigestUpdate events

### DIFF
--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2188,6 +2188,11 @@ std::ostream& PgScrubber::gen_prefix(std::ostream& out) const
   }
 }
 
+void PgScrubber::log_cluster_warning(const std::string& warning) const
+{
+  m_osds->clog->do_log(CLOG_WARN, warning);
+}
+
 ostream& PgScrubber::show(ostream& out) const
 {
   return out << " [ " << m_pg_id << ": " << m_flags << " ] ";

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -516,6 +516,8 @@ class PgScrubber : public ScrubPgIF,
     return m_pg->snap_mapper.get_snaps(hoid, snaps_set);
   }
 
+  void log_cluster_warning(const std::string& warning) const final;
+
  protected:
   bool state_test(uint64_t m) const { return m_pg->state_test(m); }
   void state_set(uint64_t m) { m_pg->state_set(m); }

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -436,7 +436,10 @@ sc::result WaitReplicas::react(const GotReplicas&)
 
 sc::result WaitReplicas::react(const DigestUpdate&)
 {
-  dout(10) << "WaitReplicas::react(const DigestUpdate&) - too early" << dendl;
+  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  auto warn_msg = "WaitReplicas::react(const DigestUpdate&): Unexpected DigestUpdate event"s;
+  dout(10) << warn_msg << dendl;
+  scrbr->log_cluster_warning(warn_msg);
   return discard_event();
 }
 

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -190,4 +190,7 @@ struct ScrubMachineListener {
 
   /// exposed to be used by the scrub_machine logger
   virtual std::ostream& gen_prefix(std::ostream& out) const = 0;
+
+  /// sending cluster-log warnings
+  virtual void log_cluster_warning(const std::string& msg) const = 0;
 };


### PR DESCRIPTION
DigestUpdate events arriving too early, i.e. in WaitReplicas state, can
and should be ignored. The down-counter for pending digest updates is
checked upon entering state WaitDigestUpdates, and a zero counter will be
noticed then. And if the early event is a result of a bug -
handling it is a mistake.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

