### PR TITLE
pacific: mgr/dashboard: provisioned values is misleading in RBD image table 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -29,6 +29,26 @@
        [innerHtml]="'Only available for RBD images with <strong>fast-diff</strong> enabled'"></div>
 </ng-template>
 
+<ng-template #provisionedNotAvailableTooltipTpl
+             let-row="row">
+  <span *ngIf="row.disk_usage === null; else provisioned"
+        [ngbTooltip]="usageNotAvailableTooltipTpl"
+        placement="top"
+        i18n>N/A</span>
+  <ng-template #provisioned
+               i18n>{{row.disk_usage | dimlessBinary}}</ng-template>
+</ng-template>
+
+<ng-template #totalProvisionedNotAvailableTooltipTpl
+             let-row="row">
+  <span *ngIf="row.total_disk_usage === null; else totalProvisioned"
+        [ngbTooltip]="usageNotAvailableTooltipTpl"
+        placement="top"
+        i18n>N/A</span>
+  <ng-template #totalProvisioned
+               i18n>{{row.total_disk_usage | dimlessBinary}}</ng-template>
+</ng-template>
+
 <ng-template #parentTpl
              let-value="value">
   <span *ngIf="value">{{ value.pool_name }}<span

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -94,6 +94,43 @@ describe('RbdListComponent', () => {
     });
   });
 
+  describe('handling of provisioned columns', () => {
+    const images = [
+      {
+        name: 'img1',
+        pool_name: 'rbd',
+        features: ['layering', 'exclusive-lock'],
+        disk_usage: null,
+        total_disk_usage: null
+      },
+      {
+        name: 'img2',
+        pool_name: 'rbd',
+        features: ['layering', 'exclusive-lock', 'object-map', 'fast-diff'],
+        disk_usage: 1024,
+        total_disk_usage: 1024
+      }
+    ];
+
+    beforeEach(() => {
+      component.images = images;
+      refresh({ executing_tasks: [], finished_tasks: [] });
+      spyOn(rbdService, 'list').and.callFake(() =>
+        of([{ pool_name: 'rbd', status: 1, value: images }])
+      );
+      fixture.detectChanges();
+    });
+
+    it('should display N/A for Provisioned & Total Provisioned columns if disk usage is null', () => {
+      const spans = fixture.debugElement.nativeElement.querySelectorAll(
+        '.datatable-body-cell-label span'
+      );
+      // check image with disk usage = null
+      expect(spans[6].textContent).toBe('N/A');
+      expect(spans[7].textContent).toBe('N/A');
+    });
+  });
+
   describe('handling of deletion', () => {
     beforeEach(() => {
       fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -56,6 +56,10 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
   deleteTpl: TemplateRef<any>;
   @ViewChild('removingStatTpl', { static: true })
   removingStatTpl: TemplateRef<any>;
+  @ViewChild('provisionedNotAvailableTooltipTpl', { static: true })
+  provisionedNotAvailableTooltipTpl: TemplateRef<any>;
+  @ViewChild('totalProvisionedNotAvailableTooltipTpl', { static: true })
+  totalProvisionedNotAvailableTooltipTpl: TemplateRef<any>;
 
   permission: Permission;
   tableActions: CdTableAction[];
@@ -230,14 +234,16 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
         prop: 'disk_usage',
         cellClass: 'text-center',
         flexGrow: 1,
-        pipe: this.dimlessBinaryPipe
+        pipe: this.dimlessBinaryPipe,
+        cellTemplate: this.provisionedNotAvailableTooltipTpl
       },
       {
         name: $localize`Total provisioned`,
         prop: 'total_disk_usage',
         cellClass: 'text-center',
         flexGrow: 1,
-        pipe: this.dimlessBinaryPipe
+        pipe: this.dimlessBinaryPipe,
+        cellTemplate: this.totalProvisionedNotAvailableTooltipTpl
       },
       {
         name: $localize`Parent`,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53364

---

backport of https://github.com/ceph/ceph/pull/43866
parent tracker: https://tracker.ceph.com/issues/46617

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh