### PR TITLE
pacific: mgr/dashboard: fix flaky inventory e2e test

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/03-inventory.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/03-inventory.e2e-spec.ts
@@ -12,7 +12,7 @@ describe('Physical Disks page', () => {
   it('should have correct devices', () => {
     cy.fixture('orchestrator/inventory.json').then((hosts) => {
       const totalDiskCount = Cypress._.sumBy(hosts, 'devices.length');
-      inventory.getTableCount('total').should('be.eq', totalDiskCount);
+      inventory.expectTableCount('total', totalDiskCount);
       for (const host of hosts) {
         inventory.filterTable('Hostname', host['name']);
         inventory.getTableCount('found').should('be.eq', host.devices.length);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53366

---

backport of https://github.com/ceph/ceph/pull/43992
parent tracker: https://tracker.ceph.com/issues/53353

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh