### PR TITLE
ceph-volume: zap osds in rollback_osd()

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -345,7 +345,7 @@ class Batch(object):
             nargs='*',
             default=[],
             help='Reuse existing OSD ids',
-            type=common.valid_osd_id
+            type=arg_validators.valid_osd_id
         )
         self.args = parser.parse_args(argv)
         self.parser = parser

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -1,15 +1,14 @@
 from ceph_volume.util import arg_validators, disk
 from ceph_volume import process, conf
 from ceph_volume import terminal
+from ceph_volume.devices.lvm.zap import Zap
 import argparse
 
-def valid_osd_id(val):
-    return str(int(val))
 
 def rollback_osd(args, osd_id=None):
     """
     When the process of creating or preparing fails, the OSD needs to be
-    destroyed so that the ID cane be reused.  This is prevents leaving the ID
+    destroyed so that the ID can be reused.  This prevents from leaving the ID
     around as "used" on the monitor, which can cause confusion if expecting
     sequential OSD IDs.
 
@@ -34,6 +33,7 @@ def rollback_osd(args, osd_id=None):
     ]
 
     process.run(cmd)
+    Zap(['--destroy', '--osd-id', osd_id]).main()
 
 
 common_args = {
@@ -58,7 +58,7 @@ common_args = {
     '--osd-id': {
         'help': 'Reuse an existing OSD id',
         'default': None,
-        'type': valid_osd_id,
+        'type': arg_validators.valid_osd_id,
     },
     '--osd-fsid': {
         'help': 'Reuse an existing OSD fsid',

--- a/src/ceph-volume/ceph_volume/devices/lvm/migrate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/migrate.py
@@ -5,10 +5,10 @@ import os
 from textwrap import dedent
 from ceph_volume.util import system, disk, merge_dict
 from ceph_volume.util.device import Device
+from ceph_volume.util.arg_validators import valid_osd_id
 from ceph_volume import decorators, terminal, process
 from ceph_volume.api import lvm as api
 from ceph_volume.systemd import systemctl
-from ceph_volume.devices.lvm.common import valid_osd_id
 
 
 logger = logging.getLogger(__name__)

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -10,7 +10,6 @@ from ceph_volume.api import lvm as api
 from ceph_volume.util import system, encryption, disk, arg_validators, str_to_int, merge_dict
 from ceph_volume.util.device import Device
 from ceph_volume.systemd import systemctl
-from ceph_volume.devices.lvm.common import valid_osd_id
 
 logger = logging.getLogger(__name__)
 mlogger = terminal.MultiLogger(__name__)
@@ -377,7 +376,7 @@ class Zap(object):
 
         parser.add_argument(
             '--osd-id',
-            type=valid_osd_id,
+            type=arg_validators.valid_osd_id,
             help='Specify an OSD ID to detect associated devices for zapping',
         )
 

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -7,6 +7,9 @@ from ceph_volume.util import disk
 from ceph_volume.util.device import Device
 
 
+def valid_osd_id(val):
+    return str(int(val))
+
 class ValidDevice(object):
 
     def __init__(self, as_string=False, gpt_ok=False):


### PR DESCRIPTION
rollback_osd() should zap and wipe the device for the corresponding osd
that was being prepared after a failure happens.

Fixes: https://tracker.ceph.com/issues/53376

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
