### PR TITLE
mon: config profiles

### DIFF
--- a/src/common/options.h
+++ b/src/common/options.h
@@ -151,7 +151,7 @@ struct Option {
     uuid_d>;
   const std::string name;
   const type_t type;
-  const level_t level;
+  level_t level;
 
   std::string desc;
   std::string long_desc;

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -1124,13 +1124,11 @@ PyObject *ActivePyModules::get_foreign_config(
 		 << " class " << device_class << dendl;
       }
 
-      std::map<std::string,pair<std::string,const MaskedOption*>> src;
       config = config_map.generate_entity_map(
 	entity,
 	crush_location,
 	osdmap.crush.get(),
-	device_class,
-	&src);
+	device_class);
     });
 
   // get a single value

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -775,7 +775,8 @@ void ActivePyModules::update_kv_data(
       dout(20) << " rm " << i.first << dendl;
       store_cache.erase(i.first);
     }
-    if (i.first.find("config/") == 0) {
+    if (i.first.find("config/") == 0 ||
+	i.first.find("config-profile/") == 0) {
       do_config = true;
     }
   }
@@ -788,6 +789,20 @@ void ActivePyModules::_refresh_config_map()
 {
   dout(10) << dendl;
   config_map.clear();
+  for (auto p = store_cache.lower_bound("config-profile/");
+       p != store_cache.end() && p->first.find("config-profile/") == 0;
+       ++p) {
+    string name = p->first.substr(sizeof("config-profile/") - 1);
+    const string& def = p->second;
+    config_map.add_profile(
+      g_ceph_context,
+      name,
+      def,
+      [&](const std::string& name) {
+	// NOTE: for now, ignore mgr options
+	return g_conf().find_option(name);
+      });
+  }
   for (auto p = store_cache.lower_bound("config/");
        p != store_cache.end() && p->first.find("config/") == 0;
        ++p) {

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -801,42 +801,11 @@ void ActivePyModules::_refresh_config_map()
     string who;
     config_map.parse_key(key, &name, &who);
 
-    const Option *opt = g_conf().find_option(name);
-    if (!opt) {
-      config_map.stray_options.push_back(
-	std::unique_ptr<Option>(
-	  new Option(name, Option::TYPE_STR, Option::LEVEL_UNKNOWN)));
-      opt = config_map.stray_options.back().get();
-    }
-
-    string err;
-    int r = opt->pre_validate(&value, &err);
-    if (r < 0) {
-      dout(10) << __func__ << " pre-validate failed on '" << name << "' = '"
-	       << value << "' for " << name << dendl;
-    }
-
-    MaskedOption mopt(opt);
-    mopt.raw_value = value;
-    string section_name;
-    if (who.size() &&
-	!ConfigMap::parse_mask(who, &section_name, &mopt.mask)) {
-      derr << __func__ << " invalid mask for key " << key << dendl;
-    } else if (opt->has_flag(Option::FLAG_NO_MON_UPDATE)) {
-      dout(10) << __func__ << " NO_MON_UPDATE option '"
-	       << name << "' = '" << value << "' for " << name
-	       << dendl;
-    } else {
-      Section *section = &config_map.global;;
-      if (section_name.size() && section_name != "global") {
-	if (section_name.find('.') != std::string::npos) {
-	  section = &config_map.by_id[section_name];
-	} else {
-	  section = &config_map.by_type[section_name];
-	}
-      }
-      section->options.insert(make_pair(name, std::move(mopt)));
-    }
+    config_map.add_option(
+      g_ceph_context, name, who, value,
+      [&](const std::string& name) {
+	return  g_conf().find_option(name);
+      });
   }
 }
 

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -47,7 +47,7 @@ class ActivePyModules
   PyModuleConfig &module_config;
   bool have_local_config_map = false;
   std::map<std::string, std::string> store_cache;
-  ConfigMap config_map;  ///< derived from store_cache config/ keys
+  ConfigMap config_map;  ///< derived from store_cache config/ and config-profile/ keys
   DaemonStateIndex &daemon_state;
   ClusterState &cluster_state;
   MonClient &monc;

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -264,6 +264,7 @@ void Mgr::init()
   monc->sub_want("servicemap", 0, 0);
   if (mon_allows_kv_sub) {
     monc->sub_want("kv:config/", 0, 0);
+    monc->sub_want("kv:config-profile/", 0, 0);
     monc->sub_want("kv:mgr/", 0, 0);
     monc->sub_want("kv:device/", 0, 0);
   }

--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -6,6 +6,7 @@
 #include "ConfigMap.h"
 #include "crush/CrushWrapper.h"
 #include "common/entity_name.h"
+#include "json_spirit/json_spirit.h"
 
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix
@@ -119,6 +120,101 @@ std::string Section::get_minimal_conf() const
 
 // ------------
 
+Profile::Profile(Option *o)
+  : opt(o)
+{
+}
+
+void Profile::dump(Formatter *f) const
+{
+  f->dump_string("level", Option::level_to_str(opt->level));
+  f->dump_string("desc", opt->desc);
+  f->dump_string("fmt_desc", opt->long_desc);
+  f->open_object_section("values");
+  for (auto& i : profile) {
+    f->open_object_section(i.first.c_str());
+    for (auto& j : i.second.options) {
+      f->dump_string(j.first.c_str(), j.second.raw_value);
+    }
+    f->close_section();
+  }
+  f->close_section();
+}
+
+int Profile::parse(
+  CephContext *cct,
+  const std::string& input,
+  std::function<const Option *(const std::string&)> get_opt)
+{
+  json_spirit::mValue json;
+  try {
+    // try json parsing first
+    json_spirit::read_or_throw(input, json);
+    if (json.type() != json_spirit::obj_type) {
+      return -EINVAL;
+    }
+    for (auto& i : json.get_obj()) { // profile_value -> {}
+      if (i.first == "level") {
+	if (i.second.type() != json_spirit::str_type) {
+	  return -EINVAL;
+	}
+	if (i.second.get_str() == "basic") {
+	  opt->level = Option::LEVEL_BASIC;
+	} else if (i.second.get_str() == "advanced") {
+	  opt->level = Option::LEVEL_ADVANCED;
+	} else if (i.second.get_str() == "dev") {
+	  opt->level = Option::LEVEL_DEV;
+	}
+      }
+      else if (i.first == "desc") {
+	if (i.second.type() != json_spirit::str_type) {
+	  return -EINVAL;
+	}
+	opt->desc = i.second.get_str();
+      }
+      else if (i.first == "fmt_desc") {
+	if (i.second.type() != json_spirit::str_type) {
+	  return -EINVAL;
+	}
+	opt->long_desc = i.second.get_str();
+      }
+      else if (i.first == "values") {
+	if (i.second.type() != json_spirit::obj_type) {
+	  return -EINVAL;
+	}
+	for (auto& j : i.second.get_obj()) { // profile_value -> {}
+	  if (j.second.type() != json_spirit::obj_type) {
+	    return -EINVAL;
+	  }
+	  ldout(cct, 10) << __func__ << " value " << j.first << dendl;
+	  auto r = profile.insert(make_pair(j.first, Section()));
+	  opt->enum_allowed.push_back(r.first->first.c_str());
+	  for (auto& k : j.second.get_obj()) { // { key -> value }
+	    if (k.second.type() != json_spirit::str_type) {
+	      return -EINVAL;
+	    }
+	    std::string name = k.first;
+	    ldout(cct, 10) << __func__ << "   option " << name << dendl;
+	    const Option *opt = get_opt(name);
+	    ceph_assert(opt);
+	    MaskedOption o(opt);
+	    o.raw_value = k.second.get_str();
+	    profile[j.first].options.insert(make_pair(name, std::move(o)));
+	  }
+	}
+      } else {
+	return -EINVAL;
+      }
+    }
+  } catch (json_spirit::Error_position &e) {
+    return -EINVAL;
+  }
+  return 0;
+}
+
+
+// ------------
+
 void ConfigMap::dump(Formatter *f) const
 {
   f->dump_object("global", global);
@@ -129,6 +225,11 @@ void ConfigMap::dump(Formatter *f) const
   f->close_section();
   f->open_object_section("by_id");
   for (auto& i : by_id) {
+    f->dump_object(i.first.c_str(), i.second);
+  }
+  f->close_section();
+  f->open_object_section("profiles");
+  for (auto& i : profiles) {
     f->dump_object(i.first.c_str(), i.second);
   }
   f->close_section();
@@ -166,9 +267,15 @@ ConfigMap::generate_entity_map(
   std::map<std::string,std::string,std::less<>> out;
   MaskedOption *prev = nullptr;
   for (auto s : sections) {
+    // apply profile content first
     for (auto& i : s.second->options) {
-      auto& o = i.second;
+      auto p = profiles.find(i.first);
+      if (p == profiles.end()) {
+	continue;
+      }
+
       // match against crush location, class
+      auto& o = i.second;
       if (o.mask.device_class.size() &&
 	  o.mask.device_class != device_class) {
 	continue;
@@ -187,10 +294,50 @@ ConfigMap::generate_entity_map(
 	  prev->get_precision(crush) < o.get_precision(crush)) {
 	continue;
       }
+
+      // apply profile options
+      auto q = p->second.profile.find(o.raw_value);
+      if (q != p->second.profile.end()) {
+	for (auto& [opt, v] : q->second.options) {
+	  out[opt] = v.raw_value;
+	  if (src) {
+	    (*src)[opt] = ConfigMap::ValueSource(s.first, &v, i.first, o.raw_value);
+	  }
+	}
+      }
+
+      prev = &o;
+    }
+
+    // ...then apply (all) options
+    prev = nullptr;
+    for (auto& i : s.second->options) {
+      // match against crush location, class
+      auto& o = i.second;
+      if (o.mask.device_class.size() &&
+	  o.mask.device_class != device_class) {
+	continue;
+      }
+      if (o.mask.location_type.size()) {
+	auto p = crush_location.find(o.mask.location_type);
+	if (p == crush_location.end() ||
+	    p->second != o.mask.location_value) {
+	  continue;
+	}
+      }
+      if (prev && prev->opt->name != i.first) {
+	prev = nullptr;
+      }
+      if (prev &&
+	  prev->get_precision(crush) < o.get_precision(crush)) {
+	continue;
+      }
+
       out[i.first] = o.raw_value;
       if (src) {
 	(*src).emplace(i.first, ConfigMap::ValueSource(s.first, &o));
       }
+
       prev = &o;
     }
   }
@@ -261,14 +408,7 @@ int ConfigMap::add_option(
   const std::string& orig_value,
   std::function<const Option *(const std::string&)> get_opt)
 {
-  const Option *opt = get_opt(name);
-  if (!opt) {
-    ldout(cct, 10) << __func__ << " unrecognized option '" << name << "'" << dendl;
-    stray_options.push_back(
-      std::unique_ptr<Option>(
-	new Option(name, Option::TYPE_STR, Option::LEVEL_UNKNOWN)));
-    opt = stray_options.back().get();
-  }
+  const Option *opt = get_option(cct, name, get_opt);
 
   string err;
   string value = orig_value;
@@ -306,6 +446,53 @@ int ConfigMap::add_option(
   return ret;
 }
 
+const Option *ConfigMap::get_option(
+  CephContext *cct,
+  const std::string& name,
+  std::function<const Option *(const std::string&)> get_opt)
+{
+  const Option *opt = get_opt(name);
+  if (!opt) {
+    auto p = profiles.find(name);
+    if (p != profiles.end()) {
+      return p->second.opt;
+    }
+    ldout(cct, 10) << __func__ << " unrecognized option '" << name << "'" << dendl;
+    stray_options.push_back(
+      std::unique_ptr<Option>(
+	new Option(name, Option::TYPE_STR, Option::LEVEL_UNKNOWN)));
+    opt = stray_options.back().get();
+  }
+  return opt;
+}
+
+int ConfigMap::add_profile(
+  CephContext *cct,
+  const std::string& name,
+  const std::string& def,
+  std::function<const Option *(const std::string&)> get_opt)
+{
+  stray_options.push_back(
+    std::unique_ptr<Option>(
+      new Option(name, Option::TYPE_STR, Option::LEVEL_UNKNOWN)));
+  auto it = profiles.emplace(name, Profile(stray_options.back().get()));
+  int r = it.first->second.parse(
+    cct,
+    def,
+    [&](const std::string& name) {
+      return get_option(cct, name, get_opt);
+    }
+  );
+  if (r < 0) {
+    profiles.erase(name);
+    return -1;
+  }
+
+  // mark the profile option as a runtime option, even though it is a string
+  it.first->second.opt->set_flag(Option::FLAG_RUNTIME);
+
+  return 0;
+}
 
 // --------------
 

--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -136,7 +136,7 @@ ConfigMap::generate_entity_map(
   const map<std::string,std::string>& crush_location,
   const CrushWrapper *crush,
   const std::string& device_class,
-  std::map<std::string,pair<std::string,const MaskedOption*>> *src)
+  std::map<std::string,ValueSource> *src)
 {
   // global, then by type, then by name prefix component(s), then name.
   // name prefix components are .-separated,
@@ -185,7 +185,7 @@ ConfigMap::generate_entity_map(
       }
       out[i.first] = o.raw_value;
       if (src) {
-	(*src)[i.first] = make_pair(s.first, &o);
+	(*src).emplace(i.first, ConfigMap::ValueSource(s.first, &o));
       }
       prev = &o;
     }

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -97,19 +97,46 @@ struct Section {
   std::string get_minimal_conf() const;
 };
 
+struct Profile {
+  Option *opt;
+  std::map<std::string, Section> profile;
+
+  Profile(Option *o);
+
+  int parse(
+    CephContext *cct,
+    const std::string& input,
+    std::function<const Option *(const std::string&)> get_opt);
+  void clear() {
+    profile.clear();
+  }
+  void dump(ceph::Formatter *f) const;
+};
+
 struct ConfigMap {
   struct ValueSource {
     std::string section;
     const MaskedOption *option = 0;
+    std::string profile_name;
+    std::string profile_value;
     ValueSource() {}
     ValueSource(const std::string& s, const MaskedOption *o)
       : section(s), option(o) {}
+    ValueSource(const std::string& s, const MaskedOption *o,
+		const std::string& pn, const std::string& pv)
+      : section(s), option(o), profile_name(pn), profile_value(pv) {}
   };
 
   Section global;
   std::map<std::string,Section, std::less<>> by_type;
   std::map<std::string,Section, std::less<>> by_id;
+  std::map<std::string,Profile,std::less<>> profiles;
   std::list<std::unique_ptr<Option>> stray_options;
+
+  const Option *get_option(
+    CephContext *cct,
+    const std::string& name,
+    std::function<const Option *(const std::string&)> get_opt);
 
   Section *find_section(const std::string& name) {
     if (name == "global") {
@@ -129,6 +156,7 @@ struct ConfigMap {
     global.clear();
     by_type.clear();
     by_id.clear();
+    profiles.clear();
     stray_options.clear();
   }
   void dump(ceph::Formatter *f) const;
@@ -154,6 +182,12 @@ struct ConfigMap {
     const std::string& name,
     const std::string& who,
     const std::string& value,
+    std::function<const Option *(const std::string&)> get_opt);
+
+  int add_profile(
+    CephContext *cct,
+    const std::string& name,
+    const std::string& def,
     std::function<const Option *(const std::string&)> get_opt);
 };
 

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -97,6 +97,14 @@ struct Section {
 };
 
 struct ConfigMap {
+  struct ValueSource {
+    std::string section;
+    const MaskedOption *option = 0;
+    ValueSource() {}
+    ValueSource(const std::string& s, const MaskedOption *o)
+      : section(s), option(o) {}
+  };
+
   Section global;
   std::map<std::string,Section, std::less<>> by_type;
   std::map<std::string,Section, std::less<>> by_id;
@@ -123,12 +131,13 @@ struct ConfigMap {
     stray_options.clear();
   }
   void dump(ceph::Formatter *f) const;
+
   std::map<std::string,std::string,std::less<>> generate_entity_map(
     const EntityName& name,
     const std::map<std::string,std::string>& crush_location,
     const CrushWrapper *crush,
     const std::string& device_class,
-    std::map<std::string,std::pair<std::string,const MaskedOption*>> *src=0);
+    std::map<std::string,ValueSource> *src=0);
 
   void parse_key(
     const std::string& key,

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -133,6 +133,14 @@ struct ConfigMap {
   std::map<std::string,Profile,std::less<>> profiles;
   std::list<std::unique_ptr<Option>> stray_options;
 
+  const Option *get_profile_option(const std::string& name) {
+    auto p = profiles.find(name);
+    if (p == profiles.end()) {
+      return nullptr;
+    }
+    return p->second.opt;
+  }
+
   const Option *get_option(
     CephContext *cct,
     const std::string& name,

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -13,6 +13,7 @@
 #include "common/entity_name.h"
 
 class CrushWrapper;
+class CephContext;
 
 // the precedence is thus:
 //
@@ -147,6 +148,13 @@ struct ConfigMap {
     const std::string& in,
     std::string *section,
     OptionMask *mask);
+
+  int add_option(
+    CephContext *cct,
+    const std::string& name,
+    const std::string& who,
+    const std::string& value,
+    std::function<const Option *(const std::string&)> get_opt);
 };
 
 

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -91,6 +91,7 @@ void ConfigMonitor::create_pending()
   dout(10) << " " << version << dendl;
   pending.clear();
   pending_cleanup.clear();
+  pending_profiles.clear();
   pending_description.clear();
 }
 
@@ -139,8 +140,20 @@ void ConfigMonitor::encode_pending_to_kvmon()
       dout(20) << __func__ << " set " << key << dendl;
       mon.kvmon()->enqueue_set(key, *p.second);
       mon.kvmon()->enqueue_set(history + "+" + p.first, *p.second);
-   } else {
+    } else {
       dout(20) << __func__ << " rm " << key << dendl;
+      mon.kvmon()->enqueue_rm(key);
+    }
+  }
+
+  // profile
+  for (auto& p : pending_profiles) {
+    string key = PROFILE_PREFIX + p.first;
+    if (p.second) {
+      dout(20) << __func__ << " profile set " << key << dendl;
+      mon.kvmon()->enqueue_set(key, *p.second);
+    } else {
+      dout(20) << __func__ << " profile rm " << key << dendl;
       mon.kvmon()->enqueue_rm(key);
     }
   }

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -781,9 +781,10 @@ void ConfigMonitor::load_config()
 
   unsigned num = 0;
   KeyValueDB::Iterator it = mon.store->get_iterator(KV_PREFIX);
-  it->lower_bound(KEY_PREFIX);
-  while (it->valid() &&
-	 it->key().compare(0, KEY_PREFIX.size(), KEY_PREFIX) == 0) {
+  for (it->lower_bound(KEY_PREFIX);
+       it->valid() &&
+	 it->key().compare(0, KEY_PREFIX.size(), KEY_PREFIX) == 0;
+       it->next(), ++num) {
     string key = it->key().substr(KEY_PREFIX.size());
     string value = it->value().to_str();
 
@@ -807,57 +808,19 @@ void ConfigMonitor::load_config()
       }
     }
 
-    const Option *opt = g_conf().find_option(name);
-    if (!opt) {
-      opt = mon.mgrmon()->find_module_option(name);
-    }
-    if (!opt) {
-      dout(10) << __func__ << " unrecognized option '" << name << "'" << dendl;
-      config_map.stray_options.push_back(
-	std::unique_ptr<Option>(
-	  new Option(name, Option::TYPE_STR, Option::LEVEL_UNKNOWN)));
-      opt = config_map.stray_options.back().get();
-    }
-
-    string err;
-    int r = opt->pre_validate(&value, &err);
-    if (r < 0) {
-      dout(10) << __func__ << " pre-validate failed on '" << name << "' = '"
-	       << value << "' for " << name << dendl;
-    }
-    
-    MaskedOption mopt(opt);
-    mopt.raw_value = value;
-    string section_name;
-    if (who.size() &&
-	!ConfigMap::parse_mask(who, &section_name, &mopt.mask)) {
-      derr << __func__ << " invalid mask for key " << key << dendl;
-      pending_cleanup[key].reset();
-    } else if (opt->has_flag(Option::FLAG_NO_MON_UPDATE)) {
-      dout(10) << __func__ << " NO_MON_UPDATE option '"
-	       << name << "' = '" << value << "' for " << name
-	       << dendl;
-      pending_cleanup[key].reset();
-    } else {
-      if (section_name.empty()) {
-	// we prefer global/$option instead of just $option
-	derr << __func__ << " adding global/ prefix to key '" << key << "'"
-	     << dendl;
-	pending_cleanup[key].reset();
-	pending_cleanup["global/"s + key] = it->value();
-      }
-      Section *section = &config_map.global;;
-      if (section_name.size() && section_name != "global") {
-	if (section_name.find('.') != std::string::npos) {
-	  section = &config_map.by_id[section_name];
-	} else {
-	  section = &config_map.by_type[section_name];
+    int r = config_map.add_option(
+      g_ceph_context, name, who, value,
+      [&](const std::string& name) {
+	const Option *opt = g_conf().find_option(name);
+	if (!opt) {
+	  opt = mon.mgrmon()->find_module_option(name);
 	}
-      }
-      section->options.insert(make_pair(name, std::move(mopt)));
-      ++num;
+	return opt;
+      });
+    if (r == -EINVAL) {
+      dout(10) << __func__ << " will clean up key " << key << dendl;
+      pending_cleanup[key].reset();
     }
-    it->next();
   }
   dout(10) << __func__ << " got " << num << " keys" << dendl;
 

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -71,7 +71,7 @@ void ConfigMonitor::create_initial()
 {
   dout(10) << __func__ << dendl;
   version = 0;
-  pending.clear();
+  create_pending();
 }
 
 void ConfigMonitor::update_from_paxos(bool *need_bootstrap)
@@ -89,6 +89,7 @@ void ConfigMonitor::create_pending()
 {
   dout(10) << " " << version << dendl;
   pending.clear();
+  pending_cleanup.clear();
   pending_description.clear();
 }
 
@@ -775,12 +776,12 @@ void ConfigMonitor::load_config()
     { "mds_session_blacklist_on_evict", "mds_session_blocklist_on_evict" },
   };
 
+  config_map.clear();
+  current.clear();
+
   unsigned num = 0;
   KeyValueDB::Iterator it = mon.store->get_iterator(KV_PREFIX);
   it->lower_bound(KEY_PREFIX);
-  config_map.clear();
-  current.clear();
-  pending_cleanup.clear();
   while (it->valid() &&
 	 it->key().compare(0, KEY_PREFIX.size(), KEY_PREFIX) == 0) {
     string key = it->key().substr(KEY_PREFIX.size());

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -210,6 +210,9 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
     if (!opt) {
       opt = mon.mgrmon()->find_module_option(name);
     }
+    if (!opt) {
+      opt = config_map.get_profile_option(name);
+    }
     if (opt) {
       if (f) {
 	f->dump_object("option", *opt);
@@ -230,6 +233,13 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
     ostringstream ss;
     if (f) {
       f->open_array_section("options");
+    }
+    for (auto& i : config_map.profiles) {
+      if (f) {
+	f->dump_string("option", i.first);
+      } else {
+	ss << i.first << "\n";
+      }
     }
     for (auto& i : ceph_options) {
       if (f) {
@@ -565,6 +575,9 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
       const Option *opt = g_conf().find_option(name);
       if (!opt) {
 	opt = mon.mgrmon()->find_module_option(name);
+      }
+      if (!opt) {
+	opt = config_map.get_profile_option(name);
       }
       if (!opt) {
 	ss << "unrecognized config option '" << name << "'";

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -366,6 +366,7 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
 	tbl.define_column("OPTION", TextTable::LEFT, TextTable::LEFT);
 	tbl.define_column("VALUE", TextTable::LEFT, TextTable::LEFT);
 	tbl.define_column("RO", TextTable::LEFT, TextTable::LEFT);
+	tbl.define_column("PROFILE", TextTable::LEFT, TextTable::LEFT);
       } else {
 	f->open_object_section("config");
       }
@@ -382,6 +383,13 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
 	  tbl << p->first;
 	  tbl << p->second;
 	  tbl << (q->second.option->opt->can_update_at_runtime() ? "" : "*");
+	  if (q->second.profile_name.size()) {
+	    ostringstream ss;
+	    ss << q->second.profile_name << "=" << q->second.profile_value;
+	    tbl << ss.str();
+	  } else {
+	    tbl << "";
+	  }
 	  tbl << TextTable::endrow;
 	} else {
 	  f->open_object_section(p->first.c_str());
@@ -390,6 +398,8 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
 	  f->dump_object("mask", q->second.option->mask);
 	  f->dump_bool("can_update_at_runtime",
 		       q->second.option->opt->can_update_at_runtime());
+	  f->dump_string("profile_name", q->second.profile_name);
+	  f->dump_string("profile_value", q->second.profile_value);
 	  f->close_section();
 	}
       }

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -57,6 +57,7 @@ static ostream& _prefix(std::ostream *_dout, const Monitor &mon,
 
 const string KEY_PREFIX("config/");
 const string HISTORY_PREFIX("config-history/");
+const string PROFILE_PREFIX("config-profile/");
 
 ConfigMonitor::ConfigMonitor(Monitor &m, Paxos &p, const string& service_name)
   : PaxosService(m, p, service_name) {
@@ -779,8 +780,35 @@ void ConfigMonitor::load_config()
   config_map.clear();
   current.clear();
 
-  unsigned num = 0;
   KeyValueDB::Iterator it = mon.store->get_iterator(KV_PREFIX);
+
+  // load profiles
+  for (it->lower_bound(PROFILE_PREFIX);
+       it->valid() &&
+	 it->key().compare(0, PROFILE_PREFIX.size(), PROFILE_PREFIX) == 0;
+       it->next()) {
+    string name = it->key().substr(PROFILE_PREFIX.size());
+    string def = it->value().to_str();
+    int r = config_map.add_profile(
+      g_ceph_context,
+      name,
+      def,
+      [&](const std::string& name) {
+	const Option *opt = g_conf().find_option(name);
+	if (!opt) {
+	  opt = mon.mgrmon()->find_module_option(name);
+	}
+	return opt;
+      });
+    if (r == -EINVAL) {
+      dout(10) << __func__ << " failed to load profile " << name << ": " << def
+	       << dendl;
+    } else {
+      dout(10) << __func__ << " loaded profile " << name << ": " << def << dendl;
+    }
+  }
+
+  unsigned num = 0;
   for (it->lower_bound(KEY_PREFIX);
        it->valid() &&
 	 it->key().compare(0, KEY_PREFIX.size(), KEY_PREFIX) == 0;

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -313,7 +313,7 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
 	       << " class " << device_class << dendl;
     }
 
-    std::map<std::string,pair<std::string,const MaskedOption*>> src;
+    std::map<std::string,ConfigMap::ValueSource> src;
     auto config = config_map.generate_entity_map(
       entity,
       crush_location,
@@ -375,20 +375,20 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
 	  continue;
 	}
 	if (!f) {
-	  tbl << q->second.first;
-	  tbl << q->second.second->mask.to_str();
-	  tbl << Option::level_to_str(q->second.second->opt->level);
+	  tbl << q->second.section;
+	  tbl << q->second.option->mask.to_str();
+	  tbl << Option::level_to_str(q->second.option->opt->level);
 	  tbl << p->first;
 	  tbl << p->second;
-	  tbl << (q->second.second->opt->can_update_at_runtime() ? "" : "*");
+	  tbl << (q->second.option->opt->can_update_at_runtime() ? "" : "*");
 	  tbl << TextTable::endrow;
 	} else {
 	  f->open_object_section(p->first.c_str());
 	  f->dump_string("value", p->second);
-	  f->dump_string("section", q->second.first);
-	  f->dump_object("mask", q->second.second->mask);
+	  f->dump_string("section", q->second.section);
+	  f->dump_object("mask", q->second.option->mask);
 	  f->dump_bool("can_update_at_runtime",
-		       q->second.second->opt->can_update_at_runtime());
+		       q->second.option->opt->can_update_at_runtime());
 	  f->close_section();
 	}
       }

--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -14,9 +14,11 @@ class ConfigMonitor : public PaxosService
 {
   version_t version = 0;
   ConfigMap config_map;
+
   std::map<std::string,std::optional<ceph::buffer::list>> pending;
   std::string pending_description;
   std::map<std::string,std::optional<ceph::buffer::list>> pending_cleanup;
+  std::map<std::string,std::optional<ceph::buffer::list>> pending_profiles;
 
   std::map<std::string,ceph::buffer::list> current;
 

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -18,6 +18,13 @@ add_executable(ceph_test_mon_msg
   )
 target_link_libraries(ceph_test_mon_msg os osdc global ${UNITTEST_LIBS})
 
+# unittest_config_map
+add_executable(unittest_config_map
+  test_config_map.cc
+  )
+add_ceph_unittest(unittest_config_map)
+target_link_libraries(unittest_config_map mon global)
+
 # unittest_mon_moncap
 add_executable(unittest_mon_moncap
   moncap.cc

--- a/src/test/mon/test_config_map.cc
+++ b/src/test/mon/test_config_map.cc
@@ -1,0 +1,143 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "mon/ConfigMap.h"
+
+#include <iostream>
+#include <string>
+#include "crush/CrushWrapper.h"
+#include "common/ceph_context.h"
+#include "global/global_context.h"
+#include "gtest/gtest.h"
+
+
+TEST(ConfigMap, parse_key)
+{
+  ConfigMap cm;
+  {
+    std::string name, who;
+    cm.parse_key("global/foo", &name, &who);
+    ASSERT_EQ("foo", name);
+    ASSERT_EQ("global", who);
+  }
+  {
+    std::string name, who;
+    cm.parse_key("mon/foo", &name, &who);
+    ASSERT_EQ("foo", name);
+    ASSERT_EQ("mon", who);
+  }
+  {
+    std::string name, who;
+    cm.parse_key("mon.a/foo", &name, &who);
+    ASSERT_EQ("foo", name);
+    ASSERT_EQ("mon.a", who);
+  }
+  {
+    std::string name, who;
+    cm.parse_key("mon.a/mgr/foo", &name, &who);
+    ASSERT_EQ("mgr/foo", name);
+    ASSERT_EQ("mon.a", who);
+  }
+  {
+    std::string name, who;
+    cm.parse_key("mon.a/a=b/foo", &name, &who);
+    ASSERT_EQ("foo", name);
+    ASSERT_EQ("mon.a/a=b", who);
+  }
+  {
+    std::string name, who;
+    cm.parse_key("mon.a/a=b/c=d/foo", &name, &who);
+    ASSERT_EQ("foo", name);
+    ASSERT_EQ("mon.a/a=b/c=d", who);
+  }
+}
+
+TEST(ConfigMap, add_option)
+{
+  ConfigMap cm;
+  auto cct = new CephContext(CEPH_ENTITY_TYPE_MON);
+  int r;
+
+  r = cm.add_option(
+    cct, "foo", "global", "fooval",
+    [&](const std::string& name) {
+      return nullptr;
+    });
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(1, cm.global.options.size());
+
+  r = cm.add_option(
+    cct, "foo", "mon", "fooval",
+    [&](const std::string& name) {
+      return nullptr;
+    });
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(1, cm.by_type.size());
+  ASSERT_EQ(1, cm.by_type["mon"].options.size());
+  
+  r = cm.add_option(
+    cct, "foo", "mon.a", "fooval",
+    [&](const std::string& name) {
+      return nullptr;
+    });
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(1, cm.by_id.size());
+  ASSERT_EQ(1, cm.by_id["mon.a"].options.size());
+}
+
+
+TEST(ConfigMap, result_sections)
+{
+  ConfigMap cm;
+  auto cct = new CephContext(CEPH_ENTITY_TYPE_MON);
+  auto crush = new CrushWrapper;
+  crush->finalize();
+
+  int r;
+
+  r = cm.add_option(
+    cct, "foo", "global", "g",
+    [&](const std::string& name) {
+      return nullptr;
+    });
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(1, cm.global.options.size());
+
+  r = cm.add_option(
+    cct, "foo", "mon", "m",
+    [&](const std::string& name) {
+      return nullptr;
+    });
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(1, cm.by_type.size());
+  ASSERT_EQ(1, cm.by_type["mon"].options.size());
+
+  r = cm.add_option(
+    cct, "foo", "mon.a", "a",
+    [&](const std::string& name) {
+      return nullptr;
+    });
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(1, cm.by_id.size());
+  ASSERT_EQ(1, cm.by_id["mon.a"].options.size());
+
+  EntityName n;
+  n.set(CEPH_ENTITY_TYPE_MON, "a");
+  auto c = cm.generate_entity_map(
+    n, {}, crush, "none", nullptr);
+  ASSERT_EQ(1, c.size());
+  ASSERT_EQ("a", c["foo"]);
+
+  n.set(CEPH_ENTITY_TYPE_MON, "b");
+  c = cm.generate_entity_map(
+    n, {}, crush, "none", nullptr);
+  ASSERT_EQ(1, c.size());
+  ASSERT_EQ("m", c["foo"]);
+
+  n.set(CEPH_ENTITY_TYPE_MDS, "c");
+  c = cm.generate_entity_map(
+    n, {}, crush, "none", nullptr);
+  ASSERT_EQ(1, c.size());
+  ASSERT_EQ("g", c["foo"]);
+}
+

--- a/src/test/mon/test_config_map.cc
+++ b/src/test/mon/test_config_map.cc
@@ -141,3 +141,104 @@ TEST(ConfigMap, result_sections)
   ASSERT_EQ("g", c["foo"]);
 }
 
+TEST(ConfigMap, add_profile)
+{
+  ConfigMap cm;
+  auto cct = new CephContext(CEPH_ENTITY_TYPE_MON);
+  int r;
+
+  r = cm.add_profile(
+    cct, "foo", "{\"level\": \"basic\", \"values\": {\"a\": {\"opt\": \"aaa\"}, \"b\": {\"opt\": \"bbb\"}}}",
+    [&](const std::string& name) {
+      return nullptr;
+    });
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(1, cm.profiles.size());
+  Profile& foo = cm.profiles.begin()->second;
+  ASSERT_EQ(2, foo.profile.size());
+  ASSERT_EQ(Option::LEVEL_BASIC, foo.opt->level);
+  ASSERT_EQ(1, foo.profile["a"].options.size());
+  ASSERT_EQ(1, foo.profile["b"].options.size());
+  ASSERT_EQ(1, foo.profile["b"].options.count("opt"));
+}
+
+TEST(ConfigMap, result_profile)
+{
+  ConfigMap cm;
+  auto cct = new CephContext(CEPH_ENTITY_TYPE_MON);
+  auto crush = new CrushWrapper;
+  crush->finalize();
+
+  int r;
+
+  r = cm.add_profile(
+    cct, "bar", "{\"level\": \"basic\", \"values\": {\"a\": {\"foo\": \"aaa\"}, \"b\": {\"foo\": \"bbb\"}}}",
+    [&](const std::string& name) {
+      return nullptr;
+    });
+  
+  r = cm.add_option(
+    cct, "foo", "global", "g",
+    [&](const std::string& name) {
+      return nullptr;
+    });
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(1, cm.global.options.size());
+
+  r = cm.add_option(
+    cct, "foo", "mon", "m",
+    [&](const std::string& name) {
+      return nullptr;
+    });
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(1, cm.by_type.size());
+  ASSERT_EQ(1, cm.by_type["mon"].options.size());
+
+  r = cm.add_option(
+    cct, "foo", "mon.a", "a",
+    [&](const std::string& name) {
+      return nullptr;
+    });
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(1, cm.by_id.size());
+  ASSERT_EQ(1, cm.by_id["mon.a"].options.size());
+
+  r = cm.add_option(
+    cct, "bar", "mon.a", "a",
+    [&](const std::string& name) {
+      return nullptr;
+    });
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(1, cm.by_id.size());
+  ASSERT_EQ(2, cm.by_id["mon.a"].options.size());
+
+  r = cm.add_option(
+    cct, "bar", "mon.b", "b",
+    [&](const std::string& name) {
+      return nullptr;
+    });
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(2, cm.by_id.size());
+  ASSERT_EQ(1, cm.by_id["mon.b"].options.size());
+
+  EntityName n;
+  n.set(CEPH_ENTITY_TYPE_MON, "a");
+  auto c = cm.generate_entity_map(
+    n, {}, crush, "none", nullptr);
+  ASSERT_EQ(2, c.size());
+  ASSERT_EQ("a", c["foo"]);
+  ASSERT_EQ("a", c["bar"]);
+
+  n.set(CEPH_ENTITY_TYPE_MON, "b");
+  c = cm.generate_entity_map(
+    n, {}, crush, "none", nullptr);
+  ASSERT_EQ(2, c.size());
+  ASSERT_EQ("bbb", c["foo"]);
+  ASSERT_EQ("b", c["bar"]);
+
+  n.set(CEPH_ENTITY_TYPE_MDS, "c");
+  c = cm.generate_entity_map(
+    n, {}, crush, "none", nullptr);
+  ASSERT_EQ(1, c.size());
+  ASSERT_EQ("g", c["foo"]);
+}


### PR DESCRIPTION
Allow dynamic definition of a config profile, which is basically a set of values for an arbitrary set of other config options.

These are defined in config-key.  We likely want to create some default profiles that are added on cluster creation or at upgrade time.

In a future PR we may want to create a CLI/API for managing config profiles?






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>