### PR TITLE
cephadm: pass CEPH_VOLUME_DEBUG env var

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2858,6 +2858,7 @@ def deploy_daemon_units(
                     cname='ceph-%s-%s.%s-activate' % (fsid, daemon_type, daemon_id),
                     memory_request=ctx.memory_request,
                     memory_limit=ctx.memory_limit,
+                    envs=ctx.env,
                 )
                 _write_container_cmd_to_bash(ctx, f, prestart, 'LVM OSDs use ceph-volume lvm activate')
         elif daemon_type == CephIscsi.daemon_type:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1099,6 +1099,7 @@ class CephadmServe:
                         }),
                         '--config-json', '-',
                     ] + daemon_spec.extra_args,
+                    env_vars=["CEPH_VOLUME_DEBUG=1"],
                     stdin=json.dumps(daemon_spec.final_config),
                     image=image)
 


### PR DESCRIPTION
There's currently no way to get the python trace when a ceph-volume
failure happens.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
