### PR TITLE
cmake: test for 16-byte atomic support on mips also

### DIFF
--- a/cmake/modules/CheckCxxAtomic.cmake
+++ b/cmake/modules/CheckCxxAtomic.cmake
@@ -11,7 +11,7 @@ function(check_cxx_atomics var)
 #include <atomic>
 #include <cstdint>
 
-#if __s390x__
+#if defined(__s390x__) || defined(__mips__)
 // Boost needs 16-byte atomics for tagged pointers.
 // These are implemented via inline instructions on the platform
 // if 16-byte alignment can be proven, and are delegated to libatomic


### PR DESCRIPTION
it's reported that a mips64el build host is able to pass the test of
CheckCxxAtomic without linking against libatomic, while librbd.so
fails to link due to failures like
```
/usr/bin/ld: ../../../lib/librbd.so.1.16.0: undefined reference to `__atomic_store_16'
/usr/bin/ld: ../../../lib/librbd.so.1.16.0: undefined reference to `__atomic_load_16'
/usr/bin/ld: ../../../lib/librbd.so.1.16.0: undefined reference to `__atomic_compare_exchange_16'
```
so we have to check the existence of __atomic_load_16 instruction on
mips architecture.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
- Teuthology
  - [ ] Completed teuthology run
  - [x] No teuthology test necessary (e.g., documentation)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
