### PR TITLE
qa/standalone: osd-scrub-repair.sh: fix expected "not scrubbed since"…

### DIFF
--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -5926,10 +5926,15 @@ function TEST_scrub_warning() {
 
     ceph health
     ceph health detail
-    ceph health | grep -q "$deep_scrubs pgs not deep-scrubbed in time" || return 1
-    ceph health | grep -q "$scrubs pgs not scrubbed in time" || return 1
+    ceph health | grep -q " pgs not deep-scrubbed in time" || return 1
+    ceph health | grep -q " pgs not scrubbed in time" || return 1
+
+    # note that the 'ceph tell pg deep_scrub' command now also sets the regular scrub
+    # time-stamp. I.e. - all 'late for deep scrubbing' pgs are also late for
+    # regular scrubbing. For now, we'll allow both responses.
     COUNT=$(ceph health detail | grep "not scrubbed since" | wc -l)
-    if [ "$COUNT" != $scrubs ]; then
+
+    if (( $COUNT != $scrubs && $COUNT != $(expr $scrubs+$deep_scrubs) )); then
       ceph health detail | grep "not scrubbed since"
       return 1
     fi


### PR DESCRIPTION
… warnings count

Following PR#43244, the 'ceph tell pg deep_scrub' now sets both
deep-scrub and "regular" scrub time-stamps. This necessitated a modification
to TEST_scrub_warning, as more PGs in this test are late for their regular scrubbing.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
