### PR TITLE
mgr/dashboard: add some test for controllers/pool.py

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_pool.py
+++ b/src/pybind/mgr/dashboard/tests/test_pool.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     import unittest.mock as mock
 
+from .. import mgr
 from ..controllers.pool import Pool
 from ..controllers.task import Task
 from ..tests import ControllerTestCase
@@ -119,3 +120,61 @@ class PoolControllerTest(ControllerTestCase):
         self.assertEqual(_get.call_count, 6)
         self.assertEqual(task.percentages, [0, 5, 50, 73, 98])
         TaskManager.current_task = orig_method
+
+    @mock.patch('dashboard.controllers.osd.CephService.get_pool_list_with_stats')
+    @mock.patch('dashboard.controllers.osd.CephService.get_pool_list')
+    def test_pool_list(self, get_pool_list, get_pool_list_with_stats):
+        get_pool_list.return_value = [{
+            'type': 3,
+            'crush_rule': 1,
+            'application_metadata': {
+                'test_key': 'test_metadata'
+            },
+            'pool_name': 'test_name'
+        }]
+        mgr.get.side_effect = lambda key: {
+            'osd_map_crush': {
+                'rules': [{
+                    'rule_id': 1,
+                    'rule_name': 'test-rule'
+                }]
+            }
+        }[key]
+        Pool._pool_list()
+        mgr.get.assert_called_with('osd_map_crush')
+        self.assertEqual(get_pool_list.call_count, 1)
+        # with stats
+        get_pool_list_with_stats.return_value = get_pool_list.return_value
+        Pool._pool_list(attrs='type', stats='True')
+        self.assertEqual(get_pool_list_with_stats.call_count, 1)
+
+    @mock.patch('dashboard.controllers.pool.Pool._get')
+    @mock.patch('dashboard.services.ceph_service.CephService.send_command')
+    def test_set_pool_name(self, send_command, _get):
+        _get.return_value = {
+            'options': {
+                'compression_min_blob_size': '1'
+            },
+            'application_metadata': ['data1', 'data2']
+        }
+
+        def _send_cmd(*args, **kwargs):  # pylint: disable=unused-argument
+            pass
+
+        send_command.side_effect = _send_cmd
+        NotificationQueue.start_queue()
+        TaskManager.init()
+        self._task_put('/api/pool/test-pool', {
+            "flags": "ec_overwrites",
+            "application_metadata": ['data3', 'data2'],
+            "configuration": "test-conf",
+            "compression_mode": 'unset',
+            'compression_min_blob_size': '1',
+            'compression_max_blob_size': '1',
+            'compression_required_ratio': '1',
+            'pool': 'test-pool',
+            'pg_num': 64
+        })
+        NotificationQueue.stop()
+        self.assertEqual(_get.call_count, 1)
+        self.assertEqual(send_command.call_count, 10)


### PR DESCRIPTION
Signed-off-by: wangbo-yw <wangbo2_yewu@cmss.chinamobile.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
