### PR TITLE
qa/suites/upgrade: upgrade test autoscale bulk flag

### DIFF
--- a/qa/suites/upgrade/pacific-x/autoscale/test-bulk-flag-upgrade.yaml
+++ b/qa/suites/upgrade/pacific-x/autoscale/test-bulk-flag-upgrade.yaml
@@ -1,0 +1,42 @@
+roles:
+- - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+- - client.0
+
+tasks:
+- install:
+  branch: pacific
+- print: "**** done pacific install"
+- ceph:
+    create_rbd_pool: false
+    log-ignorelist:
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(OBJECT_
+      - \(SLOW_OPS\)
+      - \(REQUEST_SLOW\)
+      - \(TOO_FEW_PGS\)
+      - slow request
+
+- install.upgrade:
+    mon.a:
+    client.0:
+- ceph.restart:
+    daemons: [mon.a, mgr.x, osd.0, osd.1, osd.2, osd.3]
+    wait-for-healthy: true
+    wait-for-osds-up: true
+- print: "**** done upgrade to master ceph.restart all mon/mgr/osd "
+
+- workunit:
+    clients:
+      client.0:
+        - mgr/upgrade/test_autoscale_bulk_flag.sh
+- print: "*** done mgr/upgrade/test_autoscale_bulk_flag.sh"

--- a/qa/workunits/mgr/upgrade/test_autoscale_bulk_flag.sh
+++ b/qa/workunits/mgr/upgrade/test_autoscale_bulk_flag.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -ex
+
+# This test evaluates if the pool created before upgrade has False bulk value.
+# Moreover, it evaluates the bulk value of pools created after the upgrade.
+
+function eval_actual_expected_val() {
+    local actual_value=$1
+    local expected_value=$2
+    if [[ $actual_value = $expected_value ]]
+    then
+     echo "Success: " $actual_value "=" $expected_value
+    else
+      echo "Error: " $actual_value "!=" $expected_value  
+      exit 1
+    fi
+}
+
+
+ceph osd pool create test_pool1 --bulk
+
+ceph osd pool create test_pool2
+
+DEFAULT_POOL=$(ceph osd pool autoscale-status | grep -o -m 1 'device_health_metrics\|.mgr' || true)
+
+if [[ -z $DEFAULT_POOL ]]
+then
+  echo "Error:" $DEFAULT_POOL "pool doesn't exist"
+  exit 1
+fi
+
+BULK_FLAG1=$(ceph osd pool autoscale-status | grep $DEFAULT_POOL | grep -o -m 1 'True\|False' || true)
+
+if [[ -z $BULK_FLAG1 ]]
+then
+  echo "Error:" $DEFAULT_POOL "BULK value is empty!"
+  exit 1
+fi
+
+sleep 5
+
+BULK_FLAG2=$(ceph osd pool autoscale-status | grep 'test_pool1' | grep -o -m 1 'True\|False' || true)
+
+if [[ -z $BULK_FLAG2 ]]
+then
+  echo "Error: test_pool1 BULK value is empty!"
+  exit 1
+fi
+
+BULK_FLAG3=$(ceph osd pool autoscale-status | grep 'test_pool2' | grep -o -m 1 'True\|False' || true)
+
+if [[ -z $BULK_FLAG3 ]]
+then
+  echo "Error: test_pool2 BULK value is empty!"
+  exit 1
+fi
+
+eval_actual_expected_val $BULK_FLAG_1 'False'
+eval_actual_expected_val $BULK_FLAG_2 'True'
+eval_actual_expected_val $BULK_FLAG_3 'False'
+
+echo OK


### PR DESCRIPTION
Introduce an upgrade test for the autoscale bulk flag.
We evaluate the `bulk` value of pools created before and
after upgrade, making sure that `bulk` value is
what we expect.

Signed-off-by: Kamoltat <ksirivad@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
