### PR TITLE
[WIP] mgr/cephadm: cephadm support password connect

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4378,6 +4378,10 @@ def prepare_ssh(
         }
         cli(['cephadm', 'set-ssh-config', '-i', '/tmp/cephadm-ssh-config'], extra_mounts=mounts)
 
+    if ctx.ssh_password:
+        logger.info('Using provided ssh password...')
+        cli(['cephadm', 'set-password', ctx.ssh_password])
+
     if ctx.ssh_private_key and ctx.ssh_public_key:
         logger.info('Using provided ssh keys...')
         mounts = {
@@ -7991,6 +7995,9 @@ def _get_parser():
         '--ssh-user',
         default='root',
         help='set user for SSHing to cluster hosts, passwordless sudo will be needed for non-root users')
+    parser_bootstrap.add_argument(
+        '--ssh-password',
+        help='set password for SSHing to cluster hosts')
     parser_bootstrap.add_argument(
         '--skip-mon-network',
         action='store_true',

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -75,7 +75,11 @@ class SSHManager:
 
             with self.redirect_log(host, addr):
                 try:
-                    conn = await asyncssh.connect(addr, username=self.mgr.ssh_user, client_keys=[self.mgr.tkey.name], known_hosts=None, config=[self.mgr.ssh_config_fname], preferred_auth=['publickey'])
+                    conn = await asyncssh.connect(addr, username=self.mgr.ssh_user, client_keys=[self.mgr.tkey.name],
+                                                  known_hosts=None, config=[self.mgr.ssh_config_fname],
+                                                  password=self.mgr.ssh_password if self.mgr.ssh_password else None,
+                                                  preferred_auth=['password'] if self.mgr.ssh_password else [
+                                                      'publickey'])
                 except OSError:
                     raise
                 except asyncssh.Error:
@@ -256,7 +260,11 @@ class SSHManager:
             ssh_options += ['-F', self.mgr.ssh_config_fname]
         self.mgr.ssh_config = ssh_config
 
-        # identity
+        # password identity
+        ssh_password = self.mgr.get_store("ssh_password", default='')
+        self.mgr.ssh_password = ssh_password
+
+        # sshkey identity
         ssh_key = self.mgr.get_store("ssh_identity_key")
         ssh_pub = self.mgr.get_store("ssh_identity_pub")
         self.mgr.ssh_pub = ssh_pub


### PR DESCRIPTION
In some scenes sshkey is not permitted. So password need be supported when deploy ceph cluster by means of cephadm.

Reference: https://lists.ceph.io/hyperkitty/list/dev@ceph.io/message/FGFHNWWFAUH5F33ETI5MYMB5ASRZCCT5/

Signed-off-by: jianglong01 <jianglong01@qianxin.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
