### PR TITLE
ceph-volume: remove --root param from nsenter cmd

### DIFF
--- a/src/ceph-volume/ceph_volume/process.py
+++ b/src/ceph-volume/ceph_volume/process.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 host_rootfs = '/rootfs'
 run_host_cmd = [
         'nsenter',
-        '--root={}'.format(host_rootfs),
         '--mount={}/proc/1/ns/mnt'.format(host_rootfs),
         '--ipc={}/proc/1/ns/ipc'.format(host_rootfs),
         '--net={}/proc/1/ns/net'.format(host_rootfs),


### PR DESCRIPTION
This is redundant and makes nsenter throw messages like following:
```
  Failed to find sysfs mount point
  dev/block/11:0/holders/: opendir failed: Not a directory
  dev/block/252:0/holders/: opendir failed: Not a directory
  dev/block/253:0/holders/: opendir failed: Not a directory
  dev/block/252:1/holders/: opendir failed: Not a directory
  dev/block/253:1/holders/: opendir failed: Not a directory
  dev/block/252:2/holders/: opendir failed: Not a directory
  dev/block/253:2/holders/: opendir failed: Not a directory
  dev/block/252:3/holders/: opendir failed: Not a directory
  dev/block/253:3/holders/: opendir failed: Not a directory
  dev/block/252:16/holders/: opendir failed: Not a directory
  dev/block/252:32/holders/: opendir failed: Not a directory
  dev/block/252:48/holders/: opendir failed: Not a directory
  dev/block/252:64/holders/: opendir failed: Not a directory
  ```

Fixes: https://tracker.ceph.com/issues/52926

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
