### PR TITLE
os/bluestore: bug-fix for NCB-FSCK

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18674,7 +18674,7 @@ int BlueStore::add_existing_bluefs_allocation(Allocator* allocator, read_alloc_s
     }
     for (auto itr = bluefs_extents.begin(); itr != bluefs_extents.end(); extent_count++, itr++) {
       //dout(5) << "BlueFS[" << extent_count << "] <" << itr.get_start() << "," << itr.get_len() << ">" << dendl;
-      shared_alloc.a->init_rm_free(itr.get_start(), itr.get_len());
+      allocator->init_rm_free(itr.get_start(), itr.get_len());
       stats.extent_count++;
     }
   }


### PR DESCRIPTION
Signed-off-by: Gabriel Benhanokh <gbenhano@redhat.com>

BlueStore:NCB-FSCK
PR-42762 changed the allocator used by NCB-FSCK code from the function private allocator to the global shared-allocator.
This PR returns the allocator to its correct value

      Fixes: https://tracker.ceph.com/issues/53381
      Signed-off-by: gbenhano@redhat.com
