### PR TITLE
pacific: mgr/dashboard: dashboard does not show degraded objects if they are less than 0.5% under "Dashboard->Capacity->Objects block

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
@@ -340,8 +340,9 @@ describe('HealthComponent', () => {
       expect(component['calcPercentage'](undefined, 1)).toEqual(0);
       expect(component['calcPercentage'](null, 1)).toEqual(0);
       expect(component['calcPercentage'](0, 1)).toEqual(0);
-      expect(component['calcPercentage'](2.346, 10)).toEqual(23);
-      expect(component['calcPercentage'](2.35, 10)).toEqual(24);
+      expect(component['calcPercentage'](1, 100000)).toEqual(0.01);
+      expect(component['calcPercentage'](2.346, 10)).toEqual(23.46);
+      expect(component['calcPercentage'](2.56, 10)).toEqual(25.6);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
@@ -249,6 +249,6 @@ export class HealthComponent implements OnInit, OnDestroy {
       return 0;
     }
 
-    return Math.round((dividend / divisor) * 100);
+    return Math.ceil((dividend / divisor) * 100 * 100) / 100;
   }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53383

---

backport of https://github.com/ceph/ceph/pull/43905
parent tracker: https://tracker.ceph.com/issues/53242

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh