### PR TITLE
pacific: rbd-mirror: make RemoveImmediateUpdate test synchronous

### DIFF
--- a/src/test/rbd_mirror/test_mock_MirrorStatusUpdater.cc
+++ b/src/test/rbd_mirror/test_mock_MirrorStatusUpdater.cc
@@ -566,9 +566,9 @@ TEST_F(TestMockMirrorStatusUpdater, RemoveImmediateUpdate) {
   mock_mirror_status_updater.set_mirror_image_status("1", {}, false);
 
   C_SaferCond ctx;
-  expect_work_queue(true);
-  expect_work_queue(true);
+  expect_work_queue(false);
   expect_mirror_status_removes({"1"}, 0);
+  expect_work_queue(false);
   mock_mirror_status_updater.remove_mirror_image_status("1", true, &ctx);
   ASSERT_EQ(0, ctx.wait());
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53386

---

backport of https://github.com/ceph/ceph/pull/44064
parent tracker: https://tracker.ceph.com/issues/53375

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh