### PR TITLE
octopus: osd/OSDMap.cc: clean up pg_temp for nonexistent pgs

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1779,6 +1779,12 @@ void OSDMap::clean_temps(CephContext *cct,
       pending_inc->new_pg_temp[pg.first].clear();
       continue;
     }
+    if (!nextmap.pg_exists(pg.first)) {
+      ldout(cct, 10) << __func__ << " removing pg_temp " << pg.first
+                     << " for nonexistent pg " << dendl;
+      pending_inc->new_pg_temp[pg.first].clear();
+      continue;
+    }
     // all osds down?
     unsigned num_up = 0;
     for (auto o : pg.second) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53389

---

backport of https://github.com/ceph/ceph/pull/43989
parent tracker: https://tracker.ceph.com/issues/53308

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh