### PR TITLE
qa/suites/cephadm: Also test haproxy 2.2

### DIFF
--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/rgw-ingress-haproxy-2.2.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/rgw-ingress-haproxy-2.2.yaml
@@ -1,0 +1,61 @@
+tasks:
+- vip:
+
+# make sure cephadm notices the new IP
+- cephadm.shell:
+    host.a:
+      - ceph config set mgr mgr/cephadm/container_image_haproxy docker.io/library/haproxy:2.2
+      - ceph orch device ls --refresh
+
+# deploy rgw + ingress
+- cephadm.apply:
+    specs:
+      - service_type: rgw
+        service_id: foo
+        placement:
+          count: 4
+          host_pattern: "*"
+        spec:
+          rgw_frontend_port: 8000
+      - service_type: ingress
+        service_id: rgw.foo
+        placement:
+          count: 2
+        spec:
+          backend_service: rgw.foo
+          frontend_port: 9000
+          monitor_port: 9001
+          virtual_ip: "{{VIP0}}/{{VIPPREFIXLEN}}"
+- cephadm.wait_for_service:
+    service: rgw.foo
+- cephadm.wait_for_service:
+    service: ingress.rgw.foo
+
+# take each component down in turn and ensure things still work
+- cephadm.shell:
+    host.a:
+      - |
+        echo "Check while healthy..."
+        curl http://{{VIP0}}:9000/
+
+        # stop each rgw in turn
+        echo "Check with each rgw stopped in turn..."
+        for rgw in `ceph orch ps | grep ^rgw.foo. | awk '{print $1}'`; do
+          ceph orch daemon stop $rgw
+          while ! ceph orch ps | grep $rgw | grep stopped; do sleep 1 ; done
+          while ! curl http://{{VIP0}}:9000/ ; do sleep 1 ; done
+          ceph orch daemon start $rgw
+          while ! ceph orch ps | grep $rgw | grep running; do sleep 1 ; done
+        done
+
+        # stop each haproxy in turn
+        echo "Check with each haproxy down in turn..."
+        for haproxy in `ceph orch ps | grep ^haproxy.rgw.foo. | awk '{print $1}'`; do
+          ceph orch daemon stop $haproxy
+          while ! ceph orch ps | grep $haproxy | grep stopped; do sleep 1 ; done
+          while ! curl http://{{VIP0}}:9000/ ; do sleep 1 ; done
+          ceph orch daemon start $haproxy
+          while ! ceph orch ps | grep $haproxy | grep running; do sleep 1 ; done
+        done
+
+        while ! curl http://{{VIP0}}:9000/ ; do sleep 1 ; done


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sewagner@redhat.com>

This is something downstream is interested in. Is there any value for having this in upstream as well?


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
