### PR TITLE
librbd: fix various memory leaks

### DIFF
--- a/src/librbd/crypto/BlockCrypto.cc
+++ b/src/librbd/crypto/BlockCrypto.cc
@@ -4,6 +4,7 @@
 #include "librbd/crypto/BlockCrypto.h"
 #include "include/byteorder.h"
 #include "include/ceph_assert.h"
+#include "include/scope_guard.h"
 
 #include <stdlib.h>
 
@@ -53,6 +54,10 @@ int BlockCrypto<T>::crypt(ceph::bufferlist* data, uint64_t image_offset,
     lderr(m_cct) << "unable to get crypt context" << dendl;
     return -EIO;
   }
+
+  auto sg = make_scope_guard([&] {
+      m_data_cryptor->return_context(ctx, mode); });
+
   auto sector_number = image_offset / 512;
   auto appender = data->get_contiguous_appender(src.length());
   unsigned char* out_buf_ptr = nullptr;
@@ -106,8 +111,6 @@ int BlockCrypto<T>::crypt(ceph::bufferlist* data, uint64_t image_offset,
       out_buf_ptr += crypto_output_length;
     }
   }
-
-  m_data_cryptor->return_context(ctx, mode);
 
   return 0;
 }

--- a/src/librbd/crypto/ShutDownCryptoRequest.cc
+++ b/src/librbd/crypto/ShutDownCryptoRequest.cc
@@ -39,14 +39,15 @@ void ShutDownCryptoRequest<I>::send() {
 
 template <typename I>
 void ShutDownCryptoRequest<I>::shut_down_object_dispatch() {
-   auto ctx = create_context_callback<
-          ShutDownCryptoRequest<I>,
-          &ShutDownCryptoRequest<I>::handle_shut_down_object_dispatch>(this);
   if (!m_image_ctx->io_object_dispatcher->exists(
           io::OBJECT_DISPATCH_LAYER_CRYPTO)) {
     finish(0);
     return;
   }
+
+  auto ctx = create_context_callback<
+          ShutDownCryptoRequest<I>,
+          &ShutDownCryptoRequest<I>::handle_shut_down_object_dispatch>(this);
 
   m_image_ctx->io_object_dispatcher->shut_down_dispatch(
           io::OBJECT_DISPATCH_LAYER_CRYPTO, ctx);

--- a/src/librbd/crypto/ShutDownCryptoRequest.cc
+++ b/src/librbd/crypto/ShutDownCryptoRequest.cc
@@ -30,10 +30,6 @@ ShutDownCryptoRequest<I>::ShutDownCryptoRequest(
 
 template <typename I>
 void ShutDownCryptoRequest<I>::send() {
-  m_image_ctx->image_lock.lock_shared();
-  m_crypto = m_image_ctx->crypto;
-  m_image_ctx->image_lock.unlock_shared();
-
   shut_down_object_dispatch();
 }
 

--- a/src/librbd/crypto/ShutDownCryptoRequest.h
+++ b/src/librbd/crypto/ShutDownCryptoRequest.h
@@ -34,7 +34,6 @@ public:
 private:
     I* m_image_ctx;
     Context* m_on_finish;
-    ceph::ref_t<CryptoInterface> m_crypto;
 };
 
 } // namespace crypto

--- a/src/librbd/crypto/openssl/DataCryptor.h
+++ b/src/librbd/crypto/openssl/DataCryptor.h
@@ -35,6 +35,7 @@ public:
 private:
     CephContext* m_cct;
     unsigned char* m_key = nullptr;
+    uint16_t m_key_size = 0;
     const EVP_CIPHER* m_cipher;
     uint32_t m_iv_size;
 

--- a/src/test/librbd/cache/test_mock_ParentCacheObjectDispatch.cc
+++ b/src/test/librbd/cache/test_mock_ParentCacheObjectDispatch.cc
@@ -107,8 +107,8 @@ public :
     EXPECT_CALL(*(mparent_image_cache.get_cache_client()),
                 lookup_object(_, _, _, _, _, _))
       .WillOnce(WithArg<5>(Invoke([cache_path](CacheGenContextURef on_finish) {
-        auto ack = new ObjectCacheReadReplyData(RBDSC_READ_REPLY, 0, cache_path);
-        on_finish.release()->complete(ack);
+        ObjectCacheReadReplyData ack(RBDSC_READ_REPLY, 0, cache_path);
+        on_finish.release()->complete(&ack);
       })));
   }
 

--- a/src/test/librbd/crypto/luks/test_mock_FormatRequest.cc
+++ b/src/test/librbd/crypto/luks/test_mock_FormatRequest.cc
@@ -46,9 +46,14 @@ struct TestMockCryptoLuksFormatRequest : public TestMockFixture {
     librbd::ImageCtx *ictx;
     ASSERT_EQ(0, open_image(m_image_name, &ictx));
     mock_image_ctx = new MockImageCtx(*ictx);
+    crypto = nullptr;
   }
 
   void TearDown() override {
+    if (crypto != nullptr) {
+      crypto->put();
+      crypto = nullptr;
+    }
     delete mock_image_ctx;
     TestMockFixture::TearDown();
   }

--- a/src/test/librbd/crypto/luks/test_mock_LoadRequest.cc
+++ b/src/test/librbd/crypto/luks/test_mock_LoadRequest.cc
@@ -56,6 +56,7 @@ struct TestMockCryptoLuksLoadRequest : public TestMockFixture {
   void TearDown() override {
     delete mock_image_ctx;
     if (crypto != nullptr) {
+      crypto->put();
       crypto = nullptr;
     }
     TestMockFixture::TearDown();

--- a/src/test/librbd/crypto/openssl/test_DataCryptor.cc
+++ b/src/test/librbd/crypto/openssl/test_DataCryptor.cc
@@ -110,6 +110,7 @@ TEST_F(TestCryptoOpensslDataCryptor, InvalidIVLength) {
   ASSERT_NE(ctx, nullptr);
 
   ASSERT_EQ(-EINVAL, cryptor->init_context(ctx, TEST_IV, 1));
+  cryptor->return_context(ctx, CipherMode::CIPHER_MODE_ENC);
 }
 
 } // namespace openssl

--- a/src/test/librbd/crypto/openssl/test_DataCryptor.cc
+++ b/src/test/librbd/crypto/openssl/test_DataCryptor.cc
@@ -26,7 +26,7 @@ struct TestCryptoOpensslDataCryptor : public TestFixture {
 
     void TearDown() override {
       delete cryptor;
-      Test::TearDown();
+      TestFixture::TearDown();
     }
 };
 

--- a/src/test/librbd/crypto/test_mock_BlockCrypto.cc
+++ b/src/test/librbd/crypto/test_mock_BlockCrypto.cc
@@ -22,7 +22,7 @@ MATCHER_P(CompareArrayToString, s, "") {
 }
 
 struct TestMockCryptoBlockCrypto : public TestFixture {
-    MockDataCryptor cryptor;
+    MockDataCryptor* cryptor;
     ceph::ref_t<BlockCrypto<MockCryptoContext>> bc;
     int cryptor_block_size = 16;
     int cryptor_iv_size = 16;
@@ -33,35 +33,37 @@ struct TestMockCryptoBlockCrypto : public TestFixture {
     void SetUp() override {
       TestFixture::SetUp();
 
-      cryptor.block_size = cryptor_block_size;
+      cryptor = new MockDataCryptor();
+      cryptor->block_size = cryptor_block_size;
       bc = new BlockCrypto<MockCryptoContext>(
-              reinterpret_cast<CephContext*>(m_ioctx.cct()), &cryptor,
+              reinterpret_cast<CephContext*>(m_ioctx.cct()), cryptor,
               block_size, data_offset);
       expectation_set = new ExpectationSet();
     }
 
     void TearDown() override {
       delete expectation_set;
+      bc->put();
       TestFixture::TearDown();
     }
 
     void expect_get_context(CipherMode mode) {
       _set_last_expectation(
-              EXPECT_CALL(cryptor, get_context(mode))
+              EXPECT_CALL(*cryptor, get_context(mode))
               .After(*expectation_set).WillOnce(Return(
                       new MockCryptoContext())));
     }
 
     void expect_init_context(const std::string& iv) {
       _set_last_expectation(
-              EXPECT_CALL(cryptor, init_context(_, CompareArrayToString(iv),
+              EXPECT_CALL(*cryptor, init_context(_, CompareArrayToString(iv),
                                                 cryptor_iv_size))
               .After(*expectation_set));
     }
 
     void expect_update_context(const std::string& in_str, int out_ret) {
       _set_last_expectation(
-              EXPECT_CALL(cryptor, update_context(_,
+              EXPECT_CALL(*cryptor, update_context(_,
                                                   CompareArrayToString(in_str),
                                                   _, in_str.length()))
               .After(*expectation_set).WillOnce(Return(out_ret)));
@@ -93,7 +95,7 @@ TEST_F(TestMockCryptoBlockCrypto, Encrypt) {
   expect_update_context(std::string(2048, '1') + std::string(2048, '2'), 4096);
   expect_init_context(std::string("\x38\x12\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16));
   expect_update_context(std::string(2048, '2') + std::string(2048, '3'), 4096);
-  EXPECT_CALL(cryptor, return_context(_, CipherMode::CIPHER_MODE_ENC));
+  EXPECT_CALL(*cryptor, return_context(_, CipherMode::CIPHER_MODE_ENC));
 
   ASSERT_EQ(0, bc->encrypt(&data, image_offset));
 
@@ -115,7 +117,7 @@ TEST_F(TestMockCryptoBlockCrypto, UnalignedDataLength) {
 TEST_F(TestMockCryptoBlockCrypto, GetContextError) {
   ceph::bufferlist data;
   data.append(std::string(4096, '1'));
-  EXPECT_CALL(cryptor, get_context(CipherMode::CIPHER_MODE_ENC)).WillOnce(
+  EXPECT_CALL(*cryptor, get_context(CipherMode::CIPHER_MODE_ENC)).WillOnce(
           Return(nullptr));
   ASSERT_EQ(-EIO, bc->encrypt(&data, 0));
 }
@@ -124,7 +126,7 @@ TEST_F(TestMockCryptoBlockCrypto, InitContextError) {
   ceph::bufferlist data;
   data.append(std::string(4096, '1'));
   expect_get_context(CipherMode::CIPHER_MODE_ENC);
-  EXPECT_CALL(cryptor, init_context(_, _, _)).WillOnce(Return(-123));
+  EXPECT_CALL(*cryptor, init_context(_, _, _)).WillOnce(Return(-123));
   ASSERT_EQ(-123, bc->encrypt(&data, 0));
 }
 
@@ -132,8 +134,8 @@ TEST_F(TestMockCryptoBlockCrypto, UpdateContextError) {
   ceph::bufferlist data;
   data.append(std::string(4096, '1'));
   expect_get_context(CipherMode::CIPHER_MODE_ENC);
-  EXPECT_CALL(cryptor, init_context(_, _, _));
-  EXPECT_CALL(cryptor, update_context(_, _, _, _)).WillOnce(Return(-123));
+  EXPECT_CALL(*cryptor, init_context(_, _, _));
+  EXPECT_CALL(*cryptor, update_context(_, _, _, _)).WillOnce(Return(-123));
   ASSERT_EQ(-123, bc->encrypt(&data, 0));
 }
 

--- a/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
+++ b/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
@@ -147,6 +147,7 @@ struct TestMockCryptoCryptoObjectDispatch : public TestMockFixture {
     mock_crypto_object_dispatch->shut_down(on_finish);
     ASSERT_EQ(0, cond.wait());
 
+    delete mock_crypto_object_dispatch;
     delete mock_image_ctx;
 
     TestMockFixture::TearDown();

--- a/src/test/librbd/crypto/test_mock_LoadRequest.cc
+++ b/src/test/librbd/crypto/test_mock_LoadRequest.cc
@@ -89,7 +89,7 @@ struct TestMockCryptoLoadRequest : public TestMockFixture {
 };
 
 TEST_F(TestMockCryptoLoadRequest, CryptoAlreadyLoaded) {
-  mock_image_ctx->crypto = new MockCryptoInterface();
+  mock_image_ctx->crypto = crypto;
   mock_load_request->send();
   ASSERT_EQ(-EEXIST, finished_cond.wait());
 }

--- a/src/test/librbd/crypto/test_mock_ShutDownCryptoRequest.cc
+++ b/src/test/librbd/crypto/test_mock_ShutDownCryptoRequest.cc
@@ -35,6 +35,7 @@ struct TestMockShutDownCryptoRequest : public TestMockFixture {
   C_SaferCond finished_cond;
   Context *on_finish = &finished_cond;
   MockShutDownCryptoRequest* mock_shutdown_crypto_request;
+  MockCryptoInterface* crypto;
   Context* shutdown_object_dispatch_context;
   Context* shutdown_image_dispatch_context;
 
@@ -44,12 +45,14 @@ struct TestMockShutDownCryptoRequest : public TestMockFixture {
     librbd::ImageCtx *ictx;
     ASSERT_EQ(0, open_image(m_image_name, &ictx));
     mock_image_ctx = new MockTestImageCtx(*ictx);
-    mock_image_ctx->crypto = new MockCryptoInterface();
+    crypto = new MockCryptoInterface();
+    mock_image_ctx->crypto = crypto;
     mock_shutdown_crypto_request = MockShutDownCryptoRequest::create(
           mock_image_ctx, on_finish);
   }
 
   void TearDown() override {
+    crypto->put();
     delete mock_image_ctx;
     TestMockFixture::TearDown();
   }


### PR DESCRIPTION
This PR aims to fix all current (i.e. contained in master branch) errors that are reported by running:
`RBD_FEATURES=61 valgrind --tool=memcheck --leak-check=full ./bin/unittest_librbd`

Fixes: https://tracker.ceph.com/issues/53419

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
