### PR TITLE
crimson/os/seastore: wait for logical cached extents' pin to be set if it's found in cache

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -791,6 +791,9 @@ private:
     TCachedExtentRef<T>&& extent
   ) {
     extent->set_io_wait();
+    if constexpr (std::is_base_of_v<LogicalCachedExtent, T>) {
+      extent->set_pin_wait();
+    }
     return reader.read(
       extent->get_paddr(),
       extent->get_length(),

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
@@ -279,6 +279,7 @@ LBABtree::init_cached_extent_ret LBABtree::init_cached_extent(
 	  iter.get_key() == logn->get_laddr() &&
 	  iter.get_val().paddr == logn->get_paddr()) {
 	logn->set_pin(iter.get_pin());
+	logn->pin_wait_signal();
 	ceph_assert(iter.get_val().len == e->get_length());
 	if (c.pins) {
 	  c.pins->add_pin(

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -157,6 +157,7 @@ public:
 	assert(!(pin->has_been_invalidated() || ref->has_been_invalidated()));
 	ref->set_pin(std::move(pin));
 	lba_manager->add_pin(ref->get_pin());
+	ref->pin_wait_signal();
       }
       DEBUGT("got extent {}", t, *ref);
       return pin_to_extent_ret<T>(


### PR DESCRIPTION
There are circumstances in which a transaction tries to load an extent from disk, and before
the extent's pin is set and after it is read from disk, another transaction finds it in cache.
If this is the case, the latter transaction would continue with an extent whose pin is empty,
which is problematic

Fixes: https://tracker.ceph.com/issues/53267
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
