### PR TITLE
crimson/os/seastore: make JournalSubmitter aware of header merging

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -59,4 +59,9 @@ options:
   type: uint
   level: dev
   desc: The io depth limit to submit journal records
-  default: 2
+  default: 5
+- name: seastore_journal_batch_preferred_fullness
+  type: float
+  level: dev
+  desc: The record fullness threshold to flush a journal batch
+  default: 0.95

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1095,6 +1095,11 @@ record_t Cache::prepare_record(Transaction &t)
   record_header_fullness.inline_stats.filled_bytes += record_size.get_raw_mdlength();
   record_header_fullness.inline_stats.total_bytes += record_size.get_mdlength();
 
+  // FIXME: prevent submitting empty records
+  if (record.is_empty()) {
+    ERRORT("record is empty!", t);
+  }
+
   return record;
 }
 

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1033,6 +1033,16 @@ record_t Cache::prepare_record(Transaction &t)
     assert(ool_stats.is_clear());
     ++(efforts.num_trans);
   } else {
+    DEBUGT("record is ready to submit, src={}, mdsize={}, dsize={}; "
+           "{} ool records, mdsize={}, dsize={}, fillness={}",
+           t, t.get_src(),
+           record.size.get_raw_mdlength(),
+           record.size.dlength,
+           ool_stats.num_records,
+           ool_stats.header_raw_bytes,
+           ool_stats.data_bytes,
+           ((double)(ool_stats.header_raw_bytes + ool_stats.data_bytes) /
+            (ool_stats.header_bytes + ool_stats.data_bytes)));
     if (t.get_src() == Transaction::src_t::CLEANER_TRIM ||
         t.get_src() == Transaction::src_t::CLEANER_RECLAIM) {
       // CLEANER transaction won't contain any onode tree operations

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1087,6 +1087,7 @@ record_t Cache::prepare_record(Transaction &t)
   record_header_fullness.ool_stats.filled_bytes += ool_stats.header_raw_bytes;
   record_header_fullness.ool_stats.total_bytes += ool_stats.header_bytes;
 
+  // TODO: move to Journal to get accurate result
   auto record_size = record_group_size_t(
       record.size, reader.get_block_size());
   auto inline_overhead =

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -734,7 +734,7 @@ private:
     effort_t fresh_ool_written;
     counter_by_extent_t<uint64_t> num_trans_invalidated;
     uint64_t num_ool_records = 0;
-    uint64_t ool_record_overhead_bytes = 0;
+    uint64_t ool_record_bytes = 0;
   };
 
   struct commit_trans_efforts_t {
@@ -747,8 +747,10 @@ private:
     counter_by_extent_t<effort_t> fresh_ool_by_ext;
     uint64_t num_trans = 0; // the number of inline records
     uint64_t num_ool_records = 0;
-    uint64_t ool_record_overhead_bytes = 0;
-    uint64_t inline_record_overhead_bytes = 0;
+    uint64_t ool_record_padding_bytes = 0;
+    uint64_t ool_record_metadata_bytes = 0;
+    uint64_t ool_record_data_bytes = 0;
+    uint64_t inline_record_metadata_bytes = 0; // metadata exclude the delta bytes
   };
 
   struct success_read_trans_efforts_t {
@@ -769,16 +771,6 @@ private:
   template <typename CounterT>
   using counter_by_src_t = std::array<CounterT, Transaction::SRC_MAX>;
 
-  struct fill_stat_t {
-    uint64_t filled_bytes = 0;
-    uint64_t total_bytes = 0;
-  };
-
-  struct record_header_fullness_t {
-    fill_stat_t inline_stats;
-    fill_stat_t ool_stats;
-  };
-
   static constexpr std::size_t NUM_SRC_COMB =
       Transaction::SRC_MAX * (Transaction::SRC_MAX + 1) / 2;
 
@@ -787,7 +779,6 @@ private:
     counter_by_src_t<commit_trans_efforts_t> committed_efforts_by_src;
     counter_by_src_t<invalid_trans_efforts_t> invalidated_efforts_by_src;
     counter_by_src_t<query_counters_t> cache_query_by_src;
-    counter_by_src_t<record_header_fullness_t> record_header_fullness_by_src;
     success_read_trans_efforts_t success_read_efforts;
     uint64_t dirty_bytes = 0;
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -742,7 +742,7 @@ private:
     counter_by_extent_t<effort_t> mutate_by_ext;
     counter_by_extent_t<uint64_t> delta_bytes_by_ext;
     counter_by_extent_t<effort_t> retire_by_ext;
-    counter_by_extent_t<effort_t> fresh_invalid_by_ext;
+    counter_by_extent_t<effort_t> fresh_invalid_by_ext; // inline but is already invalid (retired)
     counter_by_extent_t<effort_t> fresh_inline_by_ext;
     counter_by_extent_t<effort_t> fresh_ool_by_ext;
     uint64_t num_trans = 0; // the number of inline records

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -95,41 +95,24 @@ public:
 
   /// Creates empty transaction by source
   TransactionRef create_transaction(
-      Transaction::src_t src) {
+      Transaction::src_t src,
+      const char* name,
+      bool is_weak) {
     LOG_PREFIX(Cache::create_transaction);
 
     ++(get_by_src(stats.trans_created_by_src, src));
 
     auto ret = std::make_unique<Transaction>(
       get_dummy_ordering_handle(),
-      false,
+      is_weak,
       src,
       last_commit,
       [this](Transaction& t) {
         return on_transaction_destruct(t);
       }
     );
-    DEBUGT("created source={}", *ret, src);
-    return ret;
-  }
-
-  /// Creates empty weak transaction by source
-  TransactionRef create_weak_transaction(
-      Transaction::src_t src) {
-    LOG_PREFIX(Cache::create_weak_transaction);
-
-    ++(get_by_src(stats.trans_created_by_src, src));
-
-    auto ret = std::make_unique<Transaction>(
-      get_dummy_ordering_handle(),
-      true,
-      src,
-      last_commit,
-      [this](Transaction& t) {
-        return on_transaction_destruct(t);
-      }
-    );
-    DEBUGT("created source={}", *ret, src);
+    DEBUGT("created name={}, source={}, is_weak={}",
+           *ret, name, src, is_weak);
     return ret;
   }
 

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -42,6 +42,8 @@ std::ostream &operator<<(std::ostream &out, CachedExtent::extent_state_t state)
     return out << "INITIAL_WRITE_PENDING";
   case CachedExtent::extent_state_t::MUTATION_PENDING:
     return out << "MUTATION_PENDING";
+  case CachedExtent::extent_state_t::CLEAN_PENDING:
+    return out << "CLEAN_PENDING";
   case CachedExtent::extent_state_t::CLEAN:
     return out << "CLEAN";
   case CachedExtent::extent_state_t::DIRTY:

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -83,6 +83,7 @@ class CachedExtent : public boost::intrusive_ref_counter<
   enum class extent_state_t : uint8_t {
     INITIAL_WRITE_PENDING, // In Transaction::write_set and fresh_block_list
     MUTATION_PENDING,      // In Transaction::write_set and mutated_block_list
+    CLEAN_PENDING,         // CLEAN, but not yet read out
     CLEAN,                 // In Cache::extent_index, Transaction::read_set
                            //  during write, contents match disk, version == 0
     DIRTY,                 // Same as CLEAN, but contents do not match disk,
@@ -174,7 +175,10 @@ public:
 	<< ", state=" << state
 	<< ", last_committed_crc=" << last_committed_crc
 	<< ", refcount=" << use_count();
-    print_detail(out);
+    if (state != extent_state_t::INVALID &&
+        state != extent_state_t::CLEAN_PENDING) {
+      print_detail(out);
+    }
     return out << ")";
   }
 
@@ -253,7 +257,8 @@ public:
   bool is_clean() const {
     ceph_assert(is_valid());
     return state == extent_state_t::INITIAL_WRITE_PENDING ||
-      state == extent_state_t::CLEAN;
+           state == extent_state_t::CLEAN ||
+           state == extent_state_t::CLEAN_PENDING;
   }
 
   /// Returns true if extent is dirty (has deltas on disk)

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -170,6 +170,7 @@ public:
 	<< ", version=" << version
 	<< ", dirty_from_or_retired_at=" << dirty_from_or_retired_at
 	<< ", paddr=" << get_paddr()
+	<< ", length=" << get_length()
 	<< ", state=" << state
 	<< ", last_committed_crc=" << last_committed_crc
 	<< ", refcount=" << use_count();

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -94,6 +94,7 @@ SegmentedAllocator::Writer::_write(
   stats.extents.bytes += record_size.dlength;
   stats.header_raw_bytes += record_size.get_raw_mdlength();
   stats.header_bytes += record_size.get_mdlength();
+  stats.data_bytes += record_size.dlength;
   stats.num_records += 1;
 
   return trans_intr::make_interruptible(

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -71,10 +71,9 @@ SegmentedAllocator::Writer::_write(
   Transaction& t,
   ool_record_t& record)
 {
-  record_size_t record_size = record.get_encoded_record_length();
-  allocated_to += record_size.mdlength + record_size.dlength;
+  auto record_size = record.get_encoded_record_length();
+  allocated_to += record_size.get_encoded_length();
   bufferlist bl = record.encode(
-      record_size,
       current_segment->segment->get_segment_id(),
       0);
   seastar::promise<> pr;
@@ -93,8 +92,8 @@ SegmentedAllocator::Writer::_write(
   auto& stats = t.get_ool_write_stats();
   stats.extents.num += record.get_num_extents();
   stats.extents.bytes += record_size.dlength;
-  stats.header_raw_bytes += record_size.raw_mdlength;
-  stats.header_bytes += record_size.mdlength;
+  stats.header_raw_bytes += record_size.get_raw_mdlength();
+  stats.header_bytes += record_size.get_mdlength();
   stats.num_records += 1;
 
   return trans_intr::make_interruptible(

--- a/src/crimson/os/seastore/extent_reader.cc
+++ b/src/crimson/os/seastore/extent_reader.cc
@@ -252,8 +252,13 @@ ExtentReader::read_validate_record_metadata(
         std::nullopt);
     }
     auto& seg_addr = start.as_seg_paddr();
-    if (seg_addr.get_segment_off() + header.mdlength >
-        (int64_t)segment_manager.get_segment_size()) {
+    if (header.mdlength < block_size ||
+        header.mdlength % block_size != 0 ||
+        header.dlength % block_size != 0 ||
+        (header.committed_to != journal_seq_t() &&
+         header.committed_to.offset.as_seg_paddr().get_segment_off() % block_size != 0) ||
+        (seg_addr.get_segment_off() + header.mdlength + header.dlength >
+         (int64_t)segment_manager.get_segment_size())) {
       logger().error("read_validate_record_metadata: failed, invalid header");
       return crimson::ct_error::input_output_error::make();
     }

--- a/src/crimson/os/seastore/extent_reader.h
+++ b/src/crimson/os/seastore/extent_reader.h
@@ -56,11 +56,11 @@ public:
     size_t>;
   using found_record_handler_t = std::function<
     scan_valid_records_ertr::future<>(
-      paddr_t record_block_base,
+      record_locator_t record_locator,
       // callee may assume header and bl will remain valid until
       // returned future resolves
       const record_header_t &header,
-      const bufferlist &bl)>;
+      const bufferlist &mdbuf)>;
   scan_valid_records_ret scan_valid_records(
     scan_valid_records_cursor &cursor, ///< [in, out] cursor, updated during call
     segment_nonce_t nonce,             ///< [in] nonce for segment

--- a/src/crimson/os/seastore/extent_reader.h
+++ b/src/crimson/os/seastore/extent_reader.h
@@ -59,7 +59,7 @@ public:
       record_locator_t record_locator,
       // callee may assume header and bl will remain valid until
       // returned future resolves
-      const record_header_t &header,
+      const record_group_header_t &header,
       const bufferlist &mdbuf)>;
   scan_valid_records_ret scan_valid_records(
     scan_valid_records_cursor &cursor, ///< [in, out] cursor, updated during call
@@ -92,7 +92,7 @@ private:
   using read_validate_record_metadata_ertr = read_ertr;
   using read_validate_record_metadata_ret =
     read_validate_record_metadata_ertr::future<
-      std::optional<std::pair<record_header_t, bufferlist>>
+      std::optional<std::pair<record_group_header_t, bufferlist>>
     >;
   read_validate_record_metadata_ret read_validate_record_metadata(
     paddr_t start,
@@ -103,8 +103,8 @@ private:
   using read_validate_data_ret = read_validate_data_ertr::future<bool>;
   read_validate_data_ret read_validate_data(
     paddr_t record_base,
-    const record_header_t &header  ///< caller must ensure lifetime through
-                                   ///  future resolution
+    const record_group_header_t &header  ///< caller must ensure lifetime through
+                                         ///  future resolution
   );
 
   using consume_record_group_ertr = scan_valid_records_ertr;

--- a/src/crimson/os/seastore/extent_reader.h
+++ b/src/crimson/os/seastore/extent_reader.h
@@ -112,6 +112,13 @@ private:
                                    ///  future resolution
   );
 
+  using consume_record_group_ertr = scan_valid_records_ertr;
+  consume_record_group_ertr::future<> consume_next_records(
+      scan_valid_records_cursor& cursor,
+      found_record_handler_t& handler,
+      std::size_t& budget_used);
+
+
   /// validate embedded metadata checksum
   static bool validate_metadata(const bufferlist &bl);
 

--- a/src/crimson/os/seastore/extent_reader.h
+++ b/src/crimson/os/seastore/extent_reader.h
@@ -98,11 +98,6 @@ private:
     paddr_t start,
     segment_nonce_t nonce);
 
-  /// attempts to decode extent infos from bl, return nullopt if unsuccessful
-  std::optional<std::vector<extent_info_t>> try_decode_extent_infos(
-    record_header_t header,
-    const bufferlist &bl);
-
   /// read and validate data
   using read_validate_data_ertr = read_ertr;
   using read_validate_data_ret = read_validate_data_ertr::future<bool>;
@@ -117,10 +112,6 @@ private:
       scan_valid_records_cursor& cursor,
       found_record_handler_t& handler,
       std::size_t& budget_used);
-
-
-  /// validate embedded metadata checksum
-  static bool validate_metadata(const bufferlist &bl);
 
   friend class TransactionManager;
 };

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -19,27 +19,6 @@ namespace {
 
 namespace crimson::os::seastore {
 
-std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
-{
-  return out << "segment_header_t("
-	     << "segment_seq=" << header.journal_segment_seq
-	     << ", physical_segment_id=" << header.physical_segment_id
-	     << ", journal_tail=" << header.journal_tail
-	     << ", segment_nonce=" << header.segment_nonce
-	     << ", out-of-line=" << header.out_of_line
-	     << ")";
-}
-
-
-std::ostream &operator<<(std::ostream &out, const extent_info_t &info)
-{
-  return out << "extent_info_t("
-	     << " type: " << info.type
-	     << " addr: " << info.addr
-	     << " len: " << info.len
-	     << ")";
-}
-
 segment_nonce_t generate_nonce(
   segment_seq_t seq,
   const seastore_meta_t &meta)

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -144,26 +144,6 @@ Journal::prep_replay_segments(
     std::move(ret));
 }
 
-std::optional<std::vector<delta_info_t>> Journal::try_decode_deltas(
-  record_header_t header,
-  const bufferlist &bl)
-{
-  auto bliter = bl.cbegin();
-  bliter += ceph::encoded_sizeof_bounded<record_header_t>();
-  bliter += sizeof(checksum_t) /* crc */;
-  bliter += header.extents  * ceph::encoded_sizeof_bounded<extent_info_t>();
-  logger().debug("Journal::try_decode_deltas: decoding {} deltas", header.deltas);
-  std::vector<delta_info_t> deltas(header.deltas);
-  for (auto &&i : deltas) {
-    try {
-      decode(i, bliter);
-    } catch (ceph::buffer::error &e) {
-      return std::nullopt;
-    }
-  }
-  return deltas;
-}
-
 Journal::replay_ertr::future<>
 Journal::replay_segment(
   journal_seq_t seq,
@@ -191,14 +171,18 @@ Journal::replay_segment(
 
       return seastar::do_with(
         std::move(*maybe_record_deltas_list),
-        [=](auto &deltas)
+        [locator,
+         this,
+         &handler](record_deltas_t& record_deltas)
       {
         logger().debug("Journal::replay_segment: decoded {} deltas at block_base {}",
-                       deltas.size(),
+                       record_deltas.deltas.size(),
                        locator.record_block_base);
         return crimson::do_for_each(
-          deltas,
-          [=](auto &delta)
+          record_deltas.deltas,
+          [locator,
+           this,
+           &handler](delta_info_t& delta)
         {
           /* The journal may validly contain deltas for extents in
            * since released segments.  We can detect those cases by
@@ -213,7 +197,7 @@ Journal::replay_segment(
           auto& seg_addr = delta.paddr.as_seg_paddr();
           if (delta.paddr != P_ADDR_NULL &&
               (segment_provider->get_seq(seg_addr.get_segment_id()) >
-               seq.segment_seq)) {
+               locator.write_result.start_seq.segment_seq)) {
             return replay_ertr::now();
           } else {
             return handler(locator, delta);
@@ -438,21 +422,23 @@ Journal::JournalSegmentManager::initialize_segment(Segment& segment)
 Journal::RecordBatch::add_pending_ret
 Journal::RecordBatch::add_pending(
   record_t&& record,
-  const record_size_t& rsize)
+  extent_len_t block_size)
 {
+  auto new_encoded_length = get_encoded_length_after(record, block_size);
   logger().debug(
     "Journal::RecordBatch::add_pending: batches={}, write_size={}",
-    records.size() + 1,
-    get_encoded_length(rsize));
+    pending.get_size() + 1,
+    new_encoded_length);
   assert(state != state_t::SUBMITTING);
-  assert(can_batch(rsize));
+  assert(can_batch(record, block_size) == new_encoded_length);
 
-  auto block_start_offset = encoded_length + rsize.mdlength;
-  records.push_back(std::move(record));
-  record_sizes.push_back(rsize);
-  auto new_encoded_length = get_encoded_length(rsize);
-  assert(new_encoded_length < MAX_SEG_OFF);
-  encoded_length = new_encoded_length;
+  auto block_start_offset = record.size.get_mdlength(block_size);
+  if (state != state_t::EMPTY) {
+    block_start_offset += pending.size.get_encoded_length();
+  }
+  pending.push_back(
+      std::move(record), block_size);
+  assert(pending.size.get_encoded_length() == new_encoded_length);
   if (state == state_t::EMPTY) {
     assert(!io_promise.has_value());
     io_promise = seastar::shared_promise<maybe_result_t>();
@@ -477,33 +463,24 @@ Journal::RecordBatch::add_pending(
   });
 }
 
-ceph::bufferlist Journal::RecordBatch::encode_records(
-  size_t block_size,
+ceph::bufferlist Journal::RecordBatch::encode_batch(
   const journal_seq_t& committed_to,
   segment_nonce_t segment_nonce)
 {
   logger().debug(
-    "Journal::RecordBatch::encode_records: batches={}, committed_to={}",
-    records.size(),
+    "Journal::RecordBatch::encode_batch: batches={}, committed_to={}",
+    pending.get_size(),
     committed_to);
   assert(state == state_t::PENDING);
-  assert(records.size());
-  assert(records.size() == record_sizes.size());
+  assert(pending.get_size() > 0);
   assert(io_promise.has_value());
 
   state = state_t::SUBMITTING;
-  ceph::bufferlist bl;
-  std::size_t i = 0;
-  do {
-    auto record_bl = encode_record(
-        record_sizes[i],
-        std::move(records[i]),
-        block_size,
-        committed_to,
-        segment_nonce);
-    bl.claim_append(record_bl);
-  } while ((++i) < records.size());
-  assert(bl.length() == (std::size_t)encoded_length);
+  submitting_size = pending.get_size();
+  submitting_length = pending.size.get_encoded_length();
+  auto bl = encode_records(pending, committed_to, segment_nonce);
+  // Note: pending is cleared here
+  assert(bl.length() == (std::size_t)submitting_length);
   return bl;
 }
 
@@ -513,47 +490,45 @@ void Journal::RecordBatch::set_result(
   if (maybe_write_result.has_value()) {
     logger().debug(
       "Journal::RecordBatch::set_result: batches={}, write_start {} + {}",
-      records.size(),
+      submitting_size,
       maybe_write_result->start_seq,
       maybe_write_result->length);
-    assert(maybe_write_result->length == encoded_length);
+    assert(maybe_write_result->length == submitting_length);
   } else {
     logger().error(
       "Journal::RecordBatch::set_result: batches={}, write is failed!",
-      records.size());
+      submitting_size);
   }
   assert(state == state_t::SUBMITTING);
   assert(io_promise.has_value());
 
   state = state_t::EMPTY;
-  encoded_length = 0;
-  records.clear();
-  record_sizes.clear();
+  submitting_size = 0;
+  submitting_length = 0;
   io_promise->set_value(maybe_write_result);
   io_promise.reset();
 }
 
-ceph::bufferlist Journal::RecordBatch::submit_pending_fast(
+std::pair<ceph::bufferlist, record_group_size_t>
+Journal::RecordBatch::submit_pending_fast(
   record_t&& record,
-  const record_size_t& rsize,
-  size_t block_size,
+  extent_len_t block_size,
   const journal_seq_t& committed_to,
   segment_nonce_t segment_nonce)
 {
+  auto encoded_length = get_encoded_length_after(record, block_size);
   logger().debug(
     "Journal::RecordBatch::submit_pending_fast: write_size={}",
-    get_encoded_length(rsize));
+    encoded_length);
   assert(state == state_t::EMPTY);
-  assert(can_batch(rsize));
+  assert(can_batch(record, block_size) == encoded_length);
 
-  auto bl = encode_record(
-      rsize,
-      std::move(record),
-      block_size,
-      committed_to,
-      segment_nonce);
-  assert(bl.length() == get_encoded_length(rsize));
-  return bl;
+  auto group = record_group_t(std::move(record), block_size);
+  auto size = group.size;
+  auto bl = encode_records(group, committed_to, segment_nonce);
+  assert(bl.length() == encoded_length);
+  assert(bl.length() == size.get_encoded_length());
+  return std::make_pair(bl, size);
 }
 
 Journal::RecordSubmitter::RecordSubmitter(
@@ -583,20 +558,21 @@ Journal::RecordSubmitter::submit(
   OrderingHandle& handle)
 {
   assert(write_pipeline);
-  auto rsize = get_encoded_record_length(
-    record, journal_segment_manager.get_block_size());
-  auto total = rsize.mdlength + rsize.dlength;
+  auto expected_size = record_group_size_t(
+      record.size,
+      journal_segment_manager.get_block_size()
+  ).get_encoded_length();
   auto max_record_length = journal_segment_manager.get_max_write_length();
-  if (total > max_record_length) {
+  if (expected_size > max_record_length) {
     logger().error(
       "Journal::RecordSubmitter::submit: record size {} exceeds max {}",
-      total,
+      expected_size,
       max_record_length
     );
     return crimson::ct_error::erange::make();
   }
 
-  return do_submit(std::move(record), rsize, handle);
+  return do_submit(std::move(record), handle);
 }
 
 void Journal::RecordSubmitter::update_state()
@@ -630,8 +606,7 @@ void Journal::RecordSubmitter::flush_current_batch()
   pop_free_batch();
 
   increment_io();
-  ceph::bufferlist to_write = p_batch->encode_records(
-    journal_segment_manager.get_block_size(),
+  ceph::bufferlist to_write = p_batch->encode_batch(
     journal_segment_manager.get_committed_to(),
     journal_segment_manager.get_nonce());
   std::ignore = journal_segment_manager.write(to_write
@@ -655,27 +630,25 @@ void Journal::RecordSubmitter::flush_current_batch()
 Journal::RecordSubmitter::submit_pending_ret
 Journal::RecordSubmitter::submit_pending(
   record_t&& record,
-  const record_size_t& rsize,
   OrderingHandle& handle,
   bool flush)
 {
   assert(!p_current_batch->is_submitting());
   record_batch_stats.increment(
       p_current_batch->get_num_records() + 1);
-  auto write_fut = [this, flush, record=std::move(record), &rsize]() mutable {
+  auto write_fut = [this, flush, record=std::move(record)]() mutable {
     if (flush && p_current_batch->is_empty()) {
       // fast path with direct write
       increment_io();
-      ceph::bufferlist to_write = p_current_batch->submit_pending_fast(
+      auto [to_write, sizes] = p_current_batch->submit_pending_fast(
         std::move(record),
-        rsize,
         journal_segment_manager.get_block_size(),
         journal_segment_manager.get_committed_to(),
         journal_segment_manager.get_nonce());
       return journal_segment_manager.write(to_write
-      ).safe_then([rsize](auto write_result) {
+      ).safe_then([mdlength = sizes.get_mdlength()](auto write_result) {
         return record_locator_t{
-          write_result.start_seq.offset.add_offset(rsize.mdlength),
+          write_result.start_seq.offset.add_offset(mdlength),
           write_result
         };
       }).finally([this] {
@@ -684,7 +657,7 @@ Journal::RecordSubmitter::submit_pending(
     } else {
       // indirect write with or without the existing pending records
       auto write_fut = p_current_batch->add_pending(
-        std::move(record), rsize);
+        std::move(record), journal_segment_manager.get_block_size());
       if (flush) {
         flush_current_batch();
       }
@@ -707,35 +680,36 @@ Journal::RecordSubmitter::submit_pending(
 Journal::RecordSubmitter::do_submit_ret
 Journal::RecordSubmitter::do_submit(
   record_t&& record,
-  const record_size_t& rsize,
   OrderingHandle& handle)
 {
   assert(!p_current_batch->is_submitting());
   if (state <= state_t::PENDING) {
     // can increment io depth
     assert(!wait_submit_promise.has_value());
-    auto batched_size = p_current_batch->can_batch(rsize);
+    auto batched_size = p_current_batch->can_batch(
+        record, journal_segment_manager.get_block_size());
     if (batched_size == 0 ||
         batched_size > journal_segment_manager.get_max_write_length()) {
       assert(p_current_batch->is_pending());
       flush_current_batch();
-      return do_submit(std::move(record), rsize, handle);
+      return do_submit(std::move(record), handle);
     } else if (journal_segment_manager.needs_roll(batched_size)) {
       if (p_current_batch->is_pending()) {
         flush_current_batch();
       }
       return journal_segment_manager.roll(
-      ).safe_then([this, record=std::move(record), rsize, &handle]() mutable {
-        return do_submit(std::move(record), rsize, handle);
+      ).safe_then([this, record=std::move(record), &handle]() mutable {
+        return do_submit(std::move(record), handle);
       });
     } else {
-      return submit_pending(std::move(record), rsize, handle, true);
+      return submit_pending(std::move(record), handle, true);
     }
   }
 
   assert(state == state_t::FULL);
   // cannot increment io depth
-  auto batched_size = p_current_batch->can_batch(rsize);
+  auto batched_size = p_current_batch->can_batch(
+      record, journal_segment_manager.get_block_size());
   if (batched_size == 0 ||
       batched_size > journal_segment_manager.get_max_write_length() ||
       journal_segment_manager.needs_roll(batched_size)) {
@@ -743,11 +717,11 @@ Journal::RecordSubmitter::do_submit(
       wait_submit_promise = seastar::promise<>();
     }
     return wait_submit_promise->get_future(
-    ).then([this, record=std::move(record), rsize, &handle]() mutable {
-      return do_submit(std::move(record), rsize, handle);
+    ).then([this, record=std::move(record), &handle]() mutable {
+      return do_submit(std::move(record), handle);
     });
   } else {
-    return submit_pending(std::move(record), rsize, handle, false);
+    return submit_pending(std::move(record), handle, false);
   }
 }
 

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -429,12 +429,7 @@ private:
       free_batch_ptrs.pop_front();
     }
 
-    void account_submission(const record_group_size_t& size) {
-      stats.record_group_padding_bytes +=
-        (size.get_mdlength() - size.get_raw_mdlength());
-      stats.record_group_metadata_bytes += size.get_raw_mdlength();
-      stats.record_group_data_bytes += size.dlength;
-    }
+    void account_submission(std::size_t, const record_group_size_t&);
 
     using maybe_result_t = RecordBatch::maybe_result_t;
     void finish_submit_batch(RecordBatch*, maybe_result_t);

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -359,6 +359,7 @@ private:
     RecordSubmitter(std::size_t io_depth,
                     std::size_t batch_capacity,
                     std::size_t batch_flush_size,
+                    double preferred_fullness,
                     JournalSegmentManager&);
 
     grouped_io_stats get_record_batch_stats() const {
@@ -449,6 +450,7 @@ private:
     state_t state = state_t::IDLE;
     std::size_t num_outstanding_io = 0;
     std::size_t io_depth_limit;
+    double preferred_fullness;
 
     WritePipeline* write_pipeline = nullptr;
     JournalSegmentManager& journal_segment_manager;

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -327,8 +327,14 @@ private:
     record_group_t pending;
     std::size_t submitting_size = 0;
     segment_off_t submitting_length = 0;
+    segment_off_t submitting_mdlength = 0;
 
-    std::optional<seastar::shared_promise<maybe_result_t> > io_promise;
+    struct promise_result_t {
+      write_result_t write_result;
+      segment_off_t mdlength;
+    };
+    using maybe_promise_result_t = std::optional<promise_result_t>;
+    std::optional<seastar::shared_promise<maybe_promise_result_t> > io_promise;
   };
 
   class RecordSubmitter {

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -253,9 +253,9 @@ private:
       return pending.get_size();
     }
 
-    // return the expected write size if allows to batch,
-    // otherwise, return 0
-    std::size_t can_batch(
+    // return the expected write sizes if allows to batch,
+    // otherwise, return nullopt
+    std::optional<record_group_size_t> can_batch(
         const record_t& record,
         extent_len_t block_size) const {
       assert(state != state_t::SUBMITTING);
@@ -263,7 +263,7 @@ private:
           (pending.get_size() > 0 &&
            pending.size.get_encoded_length() > batch_flush_size)) {
         assert(state == state_t::PENDING);
-        return 0;
+        return std::nullopt;
       }
       return get_encoded_length_after(record, block_size);
     }
@@ -312,7 +312,7 @@ private:
         segment_nonce_t segment_nonce);
 
   private:
-    std::size_t get_encoded_length_after(
+    record_group_size_t get_encoded_length_after(
         const record_t& record,
         extent_len_t block_size) const {
       return pending.size.get_encoded_length_after(

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -154,6 +154,14 @@ std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
 	     << ")";
 }
 
+extent_len_t record_size_t::get_raw_mdlength() const
+{
+  // FIXME: prevent submitting empty records
+  // assert(!is_empty());
+  return plain_mdlength +
+         ceph::encoded_sizeof_bounded<record_header_t>();
+}
+
 void record_size_t::account_extent(extent_len_t extent_len)
 {
   assert(extent_len);
@@ -183,10 +191,7 @@ void record_group_size_t::account(
   assert(_block_size > 0);
   assert(rsize.dlength % _block_size == 0);
   assert(block_size == 0 || block_size == _block_size);
-  plain_mdlength += (
-      rsize.plain_mdlength +
-      ceph::encoded_sizeof_bounded<record_header_t>()
-  );
+  plain_mdlength += rsize.get_raw_mdlength();
   dlength += rsize.dlength;
   block_size = _block_size;
 }

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -158,6 +158,8 @@ void record_group_size_t::account(
     const record_size_t& rsize,
     extent_len_t _block_size)
 {
+  // FIXME: prevent submitting empty records
+  // assert(!rsize.is_empty());
   assert(_block_size > 0);
   assert(rsize.dlength % _block_size == 0);
   assert(block_size == 0 || block_size == _block_size);

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -134,6 +134,26 @@ std::ostream &operator<<(std::ostream &lhs, const delta_info_t &rhs)
 	     << ")";
 }
 
+std::ostream &operator<<(std::ostream &out, const extent_info_t &info)
+{
+  return out << "extent_info_t("
+	     << "type: " << info.type
+	     << ", addr: " << info.addr
+	     << ", len: " << info.len
+	     << ")";
+}
+
+std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
+{
+  return out << "segment_header_t("
+	     << "segment_seq=" << header.journal_segment_seq
+	     << ", physical_segment_id=" << header.physical_segment_id
+	     << ", journal_tail=" << header.journal_tail
+	     << ", segment_nonce=" << header.segment_nonce
+	     << ", out-of-line=" << header.out_of_line
+	     << ")";
+}
+
 void record_size_t::account_extent(extent_len_t extent_len)
 {
   assert(extent_len);

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1196,6 +1196,11 @@ struct record_size_t {
   extent_len_t plain_mdlength = 0; // mdlength without the record header
   extent_len_t dlength = 0;
 
+  bool is_empty() const {
+    return plain_mdlength == 0 &&
+           dlength == 0;
+  }
+
   void account_extent(extent_len_t extent_len);
 
   void account(const extent_t& extent) {
@@ -1233,6 +1238,11 @@ struct record_t {
     for (auto& d: _deltas) {
       push_back(std::move(d));
     }
+  }
+
+  bool is_empty() const {
+    return extents.size() == 0 &&
+           deltas.size() == 0;
   }
 
   // the size of extents and delta buffers

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1262,6 +1262,20 @@ ceph::bufferlist encode_record(
   const journal_seq_t& committed_to,
   segment_nonce_t current_segment_nonce = 0);
 
+struct write_result_t {
+  journal_seq_t start_seq;
+  segment_off_t length;
+
+  journal_seq_t get_end_seq() const {
+    return start_seq.add_offset(length);
+  }
+};
+
+struct record_locator_t {
+  paddr_t record_block_base;
+  write_result_t write_result;
+};
+
 /// scan segment for end incrementally
 struct scan_valid_records_cursor {
   bool last_valid_header_found = false;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1196,6 +1196,8 @@ struct record_size_t {
   extent_len_t plain_mdlength = 0; // mdlength without the record header
   extent_len_t dlength = 0;
 
+  extent_len_t get_raw_mdlength() const;
+
   bool is_empty() const {
     return plain_mdlength == 0 &&
            dlength == 0;
@@ -1231,15 +1233,14 @@ struct record_t {
            deltas.size() == 0;
   }
 
-  // the size of extents and delta buffers
-  std::size_t get_raw_data_size() const {
+  std::size_t get_delta_size() const {
     auto delta_size = std::accumulate(
         deltas.begin(), deltas.end(), 0,
         [](uint64_t sum, auto& delta) {
           return sum + delta.bl.length();
         }
     );
-    return size.dlength + delta_size;
+    return delta_size;
   }
 
   void push_back(extent_t&& extent) {

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1211,6 +1211,7 @@ struct record_size_t {
 
   void account(const delta_info_t& delta);
 };
+WRITE_EQ_OPERATORS_2(record_size_t, plain_mdlength, dlength);
 
 struct record_t {
   std::vector<extent_t> extents;
@@ -1314,17 +1315,18 @@ struct record_group_size_t {
     return get_mdlength() + dlength;
   }
 
-  extent_len_t get_encoded_length_after(
+  record_group_size_t get_encoded_length_after(
       const record_size_t& rsize,
       extent_len_t block_size) const {
     record_group_size_t tmp = *this;
     tmp.account(rsize, block_size);
-    return tmp.get_encoded_length();
+    return tmp;
   }
 
   void account(const record_size_t& rsize,
                extent_len_t block_size);
 };
+WRITE_EQ_OPERATORS_3(record_group_size_t, plain_mdlength, dlength, block_size);
 
 struct record_group_t {
   std::vector<record_t> records;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1323,6 +1323,12 @@ struct record_group_size_t {
     return tmp;
   }
 
+  double get_fullness() const {
+    assert(block_size > 0);
+    return ((double)(get_raw_mdlength() + dlength) /
+            get_encoded_length());
+  }
+
   void account(const record_size_t& rsize,
                extent_len_t block_size);
 };

--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -309,7 +309,10 @@ SegmentCleaner::gc_trim_journal_ret SegmentCleaner::gc_trim_journal()
 {
   return repeat_eagain([this] {
     return ecb->with_transaction_intr(
-        Transaction::src_t::CLEANER_TRIM, [this](auto& t) {
+      Transaction::src_t::CLEANER_TRIM,
+      "trim_journal",
+      [this](auto& t)
+    {
       return rewrite_dirty(t, get_dirty_tail()
       ).si_then([this, &t] {
         return ecb->submit_transaction_direct(t);
@@ -349,8 +352,10 @@ SegmentCleaner::gc_reclaim_space_ret SegmentCleaner::gc_reclaim_space()
           "SegmentCleaner::gc_reclaim_space: processing {} extents",
           extents.size());
         return ecb->with_transaction_intr(
-            Transaction::src_t::CLEANER_RECLAIM,
-            [this, &extents](auto& t) {
+          Transaction::src_t::CLEANER_RECLAIM,
+          "reclaim_space",
+          [this, &extents](auto& t)
+        {
           return trans_intr::do_for_each(
               extents,
               [this, &t](auto &extent) {

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -472,13 +472,17 @@ public:
   public:
     virtual ~ExtentCallbackInterface() = default;
 
-    virtual TransactionRef create_transaction(Transaction::src_t) = 0;
+    virtual TransactionRef create_transaction(
+        Transaction::src_t, const char*) = 0;
 
     /// Creates empty transaction with interruptible context
     template <typename Func>
-    auto with_transaction_intr(Transaction::src_t src, Func &&f) {
+    auto with_transaction_intr(
+        Transaction::src_t src,
+        const char* name,
+        Func &&f) {
       return seastar::do_with(
-        create_transaction(src),
+        create_transaction(src, name),
         [f=std::forward<Func>(f)](auto &ref_t) mutable {
           return with_trans_intr(
             *ref_t,

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -190,6 +190,10 @@ public:
   struct io_stat_t {
     uint64_t num = 0;
     uint64_t bytes = 0;
+
+    bool is_clear() const {
+      return (num == 0 && bytes == 0);
+    }
   };
   const io_stat_t& get_fresh_block_stats() const {
     return fresh_block_stats;
@@ -317,6 +321,13 @@ public:
     uint64_t header_raw_bytes = 0;
     uint64_t header_bytes = 0;
     uint64_t num_records = 0;
+
+    bool is_clear() const {
+      return (extents.is_clear() &&
+              header_raw_bytes == 0 &&
+              header_bytes == 0 &&
+              num_records == 0);
+    }
   };
   ool_write_stats_t& get_ool_write_stats() {
     return ool_write_stats;

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -320,12 +320,14 @@ public:
     io_stat_t extents;
     uint64_t header_raw_bytes = 0;
     uint64_t header_bytes = 0;
+    uint64_t data_bytes = 0;
     uint64_t num_records = 0;
 
     bool is_clear() const {
       return (extents.is_clear() &&
               header_raw_bytes == 0 &&
               header_bytes == 0 &&
+              data_bytes == 0 &&
               num_records == 0);
     }
   };

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -42,7 +42,10 @@ TransactionManager::mkfs_ertr::future<> TransactionManager::mkfs()
     DEBUG("about to do_with");
     segment_cleaner->init_mkfs(addr);
     return with_transaction_intr(
-        Transaction::src_t::MUTATE, [this, FNAME](auto& t) {
+      Transaction::src_t::MUTATE,
+      "mkfs_tm",
+      [this, FNAME](auto& t)
+    {
       DEBUGT("about to cache->mkfs", t);
       cache->init();
       return cache->mkfs(t
@@ -89,7 +92,8 @@ TransactionManager::mount_ertr::future<> TransactionManager::mount()
   }).safe_then([this, FNAME](auto addr) {
     segment_cleaner->set_journal_head(addr);
     return seastar::do_with(
-      create_weak_transaction(Transaction::src_t::READ),
+      create_weak_transaction(
+        Transaction::src_t::READ, "mount"),
       [this, FNAME](auto &tref) {
 	return with_trans_intr(
 	  *tref,

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -88,14 +88,16 @@ public:
 
   /// Creates empty transaction
   TransactionRef create_transaction(
-      Transaction::src_t src) final {
-    return cache->create_transaction(src);
+      Transaction::src_t src,
+      const char* name) final {
+    return cache->create_transaction(src, name, false);
   }
 
   /// Creates empty weak transaction
   TransactionRef create_weak_transaction(
-      Transaction::src_t src) {
-    return cache->create_weak_transaction(src);
+      Transaction::src_t src,
+      const char* name) {
+    return cache->create_transaction(src, name, true);
   }
 
   /// Resets transaction

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -85,7 +85,8 @@ struct btree_test_base :
       return journal->open_for_write();
     }).safe_then([this](auto addr) {
       return seastar::do_with(
-	cache->create_transaction(Transaction::src_t::MUTATE),
+	cache->create_transaction(
+            Transaction::src_t::MUTATE, "test_set_up_fut", false),
 	[this](auto &ref_t) {
 	  return with_trans_intr(*ref_t, [&](auto &t) {
 	    cache->init();
@@ -152,7 +153,8 @@ struct lba_btree_test : btree_test_base {
 
   template <typename F>
   auto lba_btree_update(F &&f) {
-    auto tref = cache->create_transaction(Transaction::src_t::MUTATE);
+    auto tref = cache->create_transaction(
+        Transaction::src_t::MUTATE, "test_btree_update", false);
     auto &t = *tref;
     with_trans_intr(
       t,
@@ -178,7 +180,8 @@ struct lba_btree_test : btree_test_base {
 
   template <typename F>
   auto lba_btree_read(F &&f) {
-    auto t = cache->create_transaction(Transaction::src_t::READ);
+    auto t = cache->create_transaction(
+        Transaction::src_t::READ, "test_btree_read", false);
     return with_trans_intr(
       *t,
       [this, f=std::forward<F>(f)](auto &t) mutable {
@@ -303,7 +306,8 @@ struct btree_lba_manager_test : btree_test_base {
 
   auto create_transaction(bool create_fake_extent=true) {
     auto t = test_transaction_t{
-      cache->create_transaction(Transaction::src_t::MUTATE),
+      cache->create_transaction(
+          Transaction::src_t::MUTATE, "test_mutate_lba", false),
       test_lba_mappings
     };
     if (create_fake_extent) {
@@ -314,7 +318,8 @@ struct btree_lba_manager_test : btree_test_base {
 
   auto create_weak_transaction() {
     auto t = test_transaction_t{
-      cache->create_weak_transaction(Transaction::src_t::READ),
+      cache->create_transaction(
+          Transaction::src_t::READ, "test_read_weak", true),
       test_lba_mappings
     };
     return t;

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -67,7 +67,8 @@ struct cache_test_t : public seastar_test_suite_t {
   }
 
   auto get_transaction() {
-    return cache->create_transaction(Transaction::src_t::MUTATE);
+    return cache->create_transaction(
+        Transaction::src_t::MUTATE, "test_cache", false);
   }
 
   template <typename T, typename... Args>

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -167,15 +167,18 @@ protected:
   }
 
   auto create_mutate_transaction() {
-    return tm->create_transaction(Transaction::src_t::MUTATE);
+    return tm->create_transaction(
+        Transaction::src_t::MUTATE, "test_mutate");
   }
 
   auto create_read_transaction() {
-    return tm->create_transaction(Transaction::src_t::READ);
+    return tm->create_transaction(
+        Transaction::src_t::READ, "test_read");
   }
 
   auto create_weak_transaction() {
-    return tm->create_weak_transaction(Transaction::src_t::READ);
+    return tm->create_weak_transaction(
+        Transaction::src_t::READ, "test_read_weak");
   }
 
   auto submit_transaction_fut2(Transaction& t) {


### PR DESCRIPTION
This PR starts at commit "crimson/os/seastore: add debug logs to print transaction name" and implements TODOs from https://github.com/ceph/ceph/pull/44041

1. As a result, this PR with #44041 together reduces writes for 4KB-aligned padding from ratio ~0.65 to ~0.2, reducing 70% writes from metadata padding:
  1.1. before: ![before](https://user-images.githubusercontent.com/7736006/143805928-dc121e48-78ec-477a-b844-52754f869906.png)
  1.2. after: ![after_new_1](https://user-images.githubusercontent.com/7736006/143805942-395688b9-7445-4860-ab84-c5229f3521e7.png)

2. This feature still allows both batching and concurrent io when submitting journals:
  2.1. before: ![before_2](https://user-images.githubusercontent.com/7736006/143811519-eafe7197-1823-4cb3-b231-111aafbda307.png)
  2.2. after: ![after_new_2](https://user-images.githubusercontent.com/7736006/143811541-bf44240b-ab4a-4608-b17a-dfd7adc9c5b4.png)

3. From overall write amplification analysis, this feature reduces the gap (overhead) between the device-level write and the cache-level data commits:
  3.1. before (see SEGMENTED_WRITE vs VALID_EXTENT_WRITE): ![before_4](https://user-images.githubusercontent.com/7736006/143812157-bc6cfa1f-18b1-404a-97f5-9cceb0d4f850.png)
  3.2. after (see SEGMENTED_WRITE vs AW_VALID_DATA): ![after_new_4](https://user-images.githubusercontent.com/7736006/143812182-6d6fc4cf-0ec6-411a-913f-ac66383caa1a.png)

4. The final improvements to rados bench throughput/latency is minor, I think there are reasons:
  4.1. The test workload makes SeaStore to be CPU-bound instead of IO-bound, because the reactor utilization reaches ~100%: ![reactorutil](https://user-images.githubusercontent.com/7736006/143813013-36d591c7-0c61-4316-ab18-8150d770bd0b.png)
  4.2. Cleaning overhead with the side-effects are too significant, see 3.2 AW_VALID_DATA vs MUTATE_TRANS_DATA_WRITE;
  4.3. Device read overhead is too significant due to lacking cache LRU, see 3.2 SEGMENTED_READ vs SEGMENTED_WRITE;

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
