### PR TITLE
Fixed the issue that packets are directly discarded due to insufficient mbuf.

### DIFF
--- a/src/msg/async/dpdk/DPDK.cc
+++ b/src/msg/async/dpdk/DPDK.cc
@@ -1045,7 +1045,7 @@ void DPDKQueuePair::tx_buf::set_cluster_offload_info(const Packet& p, const DPDK
 }
 
 DPDKQueuePair::tx_buf* DPDKQueuePair::tx_buf::from_packet_zc(
-        CephContext *cct, Packet&& p, DPDKQueuePair& qp)
+        CephContext *cct, Packet& p, DPDKQueuePair& qp)
 {
   // Too fragmented - linearize
   if (p.nr_frags() > max_frags) {
@@ -1162,7 +1162,7 @@ void DPDKQueuePair::tx_buf::copy_packet_to_cluster(const Packet& p, rte_mbuf* he
   }
 }
 
-DPDKQueuePair::tx_buf* DPDKQueuePair::tx_buf::from_packet_copy(Packet&& p, DPDKQueuePair& qp)
+DPDKQueuePair::tx_buf* DPDKQueuePair::tx_buf::from_packet_copy(Packet& p, DPDKQueuePair& qp)
 {
   // sanity
   if (!p.len()) {

--- a/src/msg/async/dpdk/DPDK.h
+++ b/src/msg/async/dpdk/DPDK.h
@@ -541,7 +541,7 @@ class DPDKQueuePair {
   uint32_t send(circular_buffer<Packet>& pb) {
     // Zero-copy send
     return _send(pb, [&] (Packet& p) {
-      return tx_buf::from_packet_zc(cct, p, *this);
+      return tx_buf::from_packet_copy(p, *this);
     });
   }
 

--- a/src/msg/async/dpdk/DPDK.h
+++ b/src/msg/async/dpdk/DPDK.h
@@ -145,7 +145,7 @@ class DPDKQueuePair {
      *         failure
      */
     static tx_buf* from_packet_zc(
-            CephContext *cct, Packet&& p, DPDKQueuePair& qp);
+            CephContext *cct, Packet& p, DPDKQueuePair& qp);
 
     /**
      * Copy the contents of the "packet" into the given cluster of
@@ -168,7 +168,7 @@ class DPDKQueuePair {
      * @return the HEAD tx_buf of the cluster or nullptr in case of a
      *         failure
      */
-    static tx_buf* from_packet_copy(Packet&& p, DPDKQueuePair& qp);
+    static tx_buf* from_packet_copy(Packet& p, DPDKQueuePair& qp);
 
     /**
      * Zero-copy handling of a single fragment.
@@ -540,8 +540,8 @@ class DPDKQueuePair {
 
   uint32_t send(circular_buffer<Packet>& pb) {
     // Zero-copy send
-    return _send(pb, [&] (Packet&& p) {
-      return tx_buf::from_packet_zc(cct, std::move(p), *this);
+    return _send(pb, [&] (Packet& p) {
+      return tx_buf::from_packet_zc(cct, p, *this);
     });
   }
 
@@ -554,11 +554,11 @@ class DPDKQueuePair {
   template <class Func>
   uint32_t _send(circular_buffer<Packet>& pb, Func &&packet_to_tx_buf_p) {
     if (_tx_burst.size() == 0) {
-      for (auto&& p : pb) {
+      for (auto& p : pb) {
         // TODO: ceph_assert() in a fast path! Remove me ASAP!
         ceph_assert(p.len());
 
-        tx_buf* buf = packet_to_tx_buf_p(std::move(p));
+        tx_buf* buf = packet_to_tx_buf_p(p);
         if (!buf) {
           break;
         }


### PR DESCRIPTION
msg/async/dpdk: Release only when the packet is successfully copied 

When the mbuf allocation fails, the data packet will not be copied to the mbuf
and will still be released. This will cause packet loss.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>