### PR TITLE
crimson/os/seastore/segment_cleaner: correct available space calculation

### DIFF
--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -11,7 +11,7 @@
 #include "crimson/common/log.h"
 #include "crimson/common/errorator.h"
 
-#define INTR_FUT_DEBUG(FMT_MSG, ...) crimson::get_logger(ceph_subsys_osd).trace(FMT_MSG, ##__VA_ARGS__)
+#define INTR_FUT_DEBUG(FMT_MSG, ...) crimson::get_logger(ceph_subsys_).trace(FMT_MSG, ##__VA_ARGS__)
 
 // The interrupt condition generally works this way:
 //

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -73,6 +73,10 @@ SegmentedAllocator::Writer::_write(
 {
   auto record_size = record.get_encoded_record_length();
   allocated_to += record_size.get_encoded_length();
+  segment_provider.update_segment_avail_bytes(
+    paddr_t::make_seg_paddr(
+      current_segment->segment->get_segment_id(),
+      allocated_to));
   bufferlist bl = record.encode(
       current_segment->segment->get_segment_id(),
       0);

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -231,6 +231,15 @@ public:
     return device_to_segments[id.device_id()][id.device_segment_id()];
   }
 
+  bool contains(segment_id_t id) {
+    bool b = id.device_id() < device_to_segments.size();
+    if (!b) {
+      return b;
+    }
+    b = id.device_segment_id() < device_to_segments[id.device_id()].size();
+    return b;
+  }
+
   auto begin() {
     return iterator<false>::lower_bound(*this, 0, 0);
   }

--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -193,7 +193,12 @@ void SegmentCleaner::register_metrics()
 		    [this] {
 		      return segments.get_available_bytes();
 		    },
-		    sm::description("the size of the space not occupied"))
+		    sm::description("the size of the space not occupied")),
+    sm::make_derive("opened_segments",
+		    [this] {
+		      return segments.get_opened_segments();
+		    },
+		    sm::description("the number of segments whose state is open"))
   });
 }
 

--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -179,6 +179,21 @@ void SegmentCleaner::register_metrics()
   metrics.add_group("segment_cleaner", {
     sm::make_counter("segments_released", stats.segments_released,
 		     sm::description("total number of extents released by SegmentCleaner")),
+    sm::make_counter("accumulated_blocked_ios", stats.accumulated_blocked_ios,
+		     sm::description("accumulated total number of ios that were blocked by gc")),
+    sm::make_derive("empty_segments", stats.empty_segments,
+		    sm::description("current empty segments")),
+    sm::make_derive("ios_blocking", stats.ios_blocking,
+		    sm::description("IOs that are blocking on space usage")),
+    sm::make_derive("used_bytes", stats.used_bytes,
+		    sm::description("the size of the space occupied by live extents")),
+    sm::make_derive("projected_used_bytes", stats.projected_used_bytes,
+		    sm::description("the size of the space going to be occupied by new extents")),
+    sm::make_derive("avail_bytes",
+		    [this] {
+		      return segments.get_available_bytes();
+		    },
+		    sm::description("the size of the space not occupied"))
   });
 }
 

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -40,6 +40,8 @@ struct btree_test_base :
 
   btree_test_base() = default;
 
+  void update_segment_avail_bytes(paddr_t offset) final {}
+
   get_segment_ret get_segment(device_id_t id) final {
     auto ret = next;
     next = segment_id_t{

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -82,6 +82,8 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
 
   journal_test_t() = default;
 
+  void update_segment_avail_bytes(paddr_t offset) final {}
+
   get_segment_ret get_segment(device_id_t id) final {
     auto ret = next;
     next = segment_id_t{


### PR DESCRIPTION
Current available space calculation is wrong, it just counts the space occupied
by extents, deltas and other stuff are not taken into account.
    
Fixes: https://tracker.ceph.com/issues/53409
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
