### PR TITLE
pacific: mgr/prometheus: Fix the per method stats exported

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1179,7 +1179,7 @@ class Module(MgrModule):
                 'prometheus_collect_duration_seconds_count',
                 'The amount of metrics gathered for this exporter',
                 ('method',))
-            self.metrics['prometheus_collect_duration_seconds_sum'] = count_metric
+            self.metrics['prometheus_collect_duration_seconds_count'] = count_metric
 
         # Collect all timing data and make it available as metric, excluding the
         # `collect` method because it has not finished at this point and hence


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53435

---

backport of https://github.com/ceph/ceph/pull/44082
parent tracker: https://tracker.ceph.com/issues/53379

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh