### PR TITLE
 crimson: bump up Seastar to recent master and fix FTBFS

### DIFF
--- a/src/crimson/os/alienstore/alien_collection.h
+++ b/src/crimson/os/alienstore/alien_collection.h
@@ -21,6 +21,13 @@ public:
 
   template <typename Func, typename Result = std::invoke_result_t<Func>>
   seastar::futurize_t<Result> with_lock(Func&& func) {
+    // newer versions of Seastar provide two variants of `with_lock`
+    //   - generic, friendly towards throwing move constructors of Func,
+    //   - specialized for `noexcept`.
+    // unfortunately, the former has a limitation: the return value
+    // of `Func` must be compatible with `current_exception_as_future()`
+    // which boils down to returning `seastar::future<void>`.
+    static_assert(std::is_nothrow_move_constructible_v<Func>);
     return seastar::with_lock(mutex, std::forward<Func>(func));
   }
 

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -429,7 +429,8 @@ seastar::future<> AlienStore::do_transaction(CollectionRef ch,
     [this, ch, id] (auto &txn, auto &done) {
       return seastar::with_gate(transaction_gate, [this, ch, id, &txn, &done] {
 	AlienCollection* alien_coll = static_cast<AlienCollection*>(ch.get());
-	return alien_coll->with_lock([this, ch, id, &txn, &done] {
+        // moving the `ch` is crucial for buildability on newer S* versions.
+	return alien_coll->with_lock([this, ch=std::move(ch), id, &txn, &done] {
 	  Context *crimson_wrapper =
 	    ceph::os::Transaction::collect_all_contexts(txn);
 	  assert(tp);


### PR DESCRIPTION
Seastar since c4516f564197da409c1e5a012bd24c35457a9a40 provides two variants of `with_lock`:
  - generic, friendly towards throwing move constructors of the passed callable,
  - specialized for `noexcept`.
 
Unfortunately, the former has a limitation: the return value of callable must be compatible with `current_exception_as_future()`
which boils down to returning `seastar::future<void>`. Therefore we must to use the latter. The obstacle is `boost::intrusive_ptr` we use for `CollectionRef` as it has the move constructor defined without `noexcept`:

```cpp
template<class T> class intrusive_ptr
{
    //
    BOOST_CONSTEXPR intrusive_ptr() BOOST_SP_NOEXCEPT : px( 0 )
    {
    }

    // ...

    template<class U>

    intrusive_ptr( intrusive_ptr<U> const & rhs, typename boost::detail::sp_enable_if_convertible<U,T>::type = boost::detail::sp_empty() )

    intrusive_ptr( intrusive_ptr<U> const & rhs )

    : px( rhs.get() )
    {
        if( px != 0 ) intrusive_ptr_add_ref( px );
    }

    // ...

    intrusive_ptr(intrusive_ptr && rhs) BOOST_SP_NOEXCEPT : px( rhs.px )
    {
        rhs.px = 0;
    }

    intrusive_ptr & operator=(intrusive_ptr && rhs) BOOST_SP_NOEXCEPT
    {
        this_type( static_cast< intrusive_ptr && >( rhs ) ).swap(*this);
        return *this;
    }

```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
