### PR TITLE
pacific: mgr/dashboard: avoid tooltip if disk_usage=null and fast-diff enabled

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -31,7 +31,7 @@
 
 <ng-template #provisionedNotAvailableTooltipTpl
              let-row="row">
-  <span *ngIf="row.disk_usage === null; else provisioned"
+  <span *ngIf="row.disk_usage === null && !row.features_name.includes('fast-diff'); else provisioned"
         [ngbTooltip]="usageNotAvailableTooltipTpl"
         placement="top"
         i18n>N/A</span>
@@ -41,7 +41,7 @@
 
 <ng-template #totalProvisionedNotAvailableTooltipTpl
              let-row="row">
-  <span *ngIf="row.total_disk_usage === null; else totalProvisioned"
+  <span *ngIf="row.total_disk_usage === null && !row.features_name.includes('fast-diff'); else totalProvisioned"
         [ngbTooltip]="usageNotAvailableTooltipTpl"
         placement="top"
         i18n>N/A</span>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53437

---

backport of https://github.com/ceph/ceph/pull/44115
parent tracker: https://tracker.ceph.com/issues/53404

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh