### PR TITLE
octopus: mgr/dashboard: all pyfakefs must be pinned on same version

### DIFF
--- a/src/pybind/mgr/dashboard/requirements-test.txt
+++ b/src/pybind/mgr/dashboard/requirements-test.txt
@@ -1,4 +1,4 @@
 mock; python_version <= '3.3'
 pytest-cov
 pytest-instafail
-pyfakefs
+pyfakefs==4.5.0


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53094

---

backport of https://github.com/ceph/ceph/pull/43738
parent tracker: https://tracker.ceph.com/issues/53088

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh