### PR TITLE
mgr: make python notifications more efficient

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -539,9 +539,12 @@ void ActivePyModules::notify_all(const std::string &notify_type,
 
   dout(10) << __func__ << ": notify_all " << notify_type << dendl;
   for (auto& [name, module] : modules) {
+    if (!py_module_registry.should_notify(name, notify_type)) {
+      continue;
+    }
     // Send all python calls down a Finisher to avoid blocking
     // C++ code, and avoid any potential lock cycles.
-    dout(15) << "queuing notify to " << name << dendl;
+    dout(15) << "queuing notify (" << notify_type << ") to " << name << dendl;
     // workaround for https://bugs.llvm.org/show_bug.cgi?id=35984
     finisher.queue(new LambdaContext([module=module, notify_type, notify_id]
       (int r){
@@ -556,6 +559,9 @@ void ActivePyModules::notify_all(const LogEntry &log_entry)
 
   dout(10) << __func__ << ": notify_all (clog)" << dendl;
   for (auto& [name, module] : modules) {
+    if (!py_module_registry.should_notify(name, "clog")) {
+      continue;
+    }
     // Send all python calls down a Finisher to avoid blocking
     // C++ code, and avoid any potential lock cycles.
     //

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -678,9 +678,11 @@ bool DaemonServer::handle_report(const ref_t<MMgrReport>& m)
   }
 
   // if there are any schema updates, notify the python modules
+  /* no users currently
   if (!m->declare_types.empty() || !m->undeclare_types.empty()) {
     py_modules.notify_all("perf_schema_update", ceph::to_string(key));
   }
+  */
 
   if (m->get_connection()->peer_is_osd()) {
     osd_perf_metric_collector.process_reports(m->osd_perf_metric_reports);

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -630,7 +630,7 @@ bool Mgr::ms_dispatch2(const ref_t<Message>& m)
       break;
     case MSG_SERVICE_MAP:
       handle_service_map(ref_cast<MServiceMap>(m));
-      py_module_registry->notify_all("service_map", "");
+      //no users: py_module_registry->notify_all("service_map", "");
       break;
     case MSG_LOG:
       handle_log(ref_cast<MLog>(m));
@@ -778,7 +778,7 @@ void Mgr::handle_mgr_digest(ref_t<MMgrDigest> m)
   dout(10) << m->mon_status_json.length() << dendl;
   dout(10) << m->health_json.length() << dendl;
   cluster_state.load_digest(m.get());
-  py_module_registry->notify_all("mon_status", "");
+  //no users: py_module_registry->notify_all("mon_status", "");
   py_module_registry->notify_all("health", "");
 
   // Hack: use this as a tick/opportunity to prompt python-land that

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -398,6 +398,8 @@ int PyModule::load(PyThreadState *pMainThreadState)
       return r;
     }
 
+    load_notify_types();
+
     // We've imported the module and found a MgrModule subclass, at this
     // point the module is considered loaded.  It might still not be
     // runnable though, can_run populated later...
@@ -506,6 +508,39 @@ int PyModule::register_options(PyObject *cls)
          << dendl;
     derr << handle_pyerror(true, module_name, "PyModule::register_options") << dendl;
   }
+  return 0;
+}
+
+int PyModule::load_notify_types()
+{
+  PyObject *ls = PyObject_GetAttrString(pClass, "NOTIFY_TYPES");
+  if (ls == nullptr) {
+    derr << "Module " << get_name() << " has missing NOTIFY_TYPES member" << dendl;
+    return -EINVAL;
+  }
+  if (!PyObject_TypeCheck(ls, &PyList_Type)) {
+    // Relatively easy mistake for human to make, e.g. defining COMMANDS
+    // as a {} instead of a []
+    derr << "Module " << get_name() << " has NOTIFY_TYPES that is not a list" << dendl;
+    return -EINVAL;
+  }
+
+  const size_t list_size = PyList_Size(ls);
+  for (size_t i = 0; i < list_size; ++i) {
+    PyObject *notify_type = PyList_GetItem(ls, i);
+    ceph_assert(notify_type != nullptr);
+
+    if (!PyObject_TypeCheck(notify_type, &PyUnicode_Type)) {
+      derr << "Module " << get_name() << " has non-string entry in NOTIFY_TYPES list"
+	   << dendl;
+      return -EINVAL;
+    }
+
+    notify_types.insert(PyUnicode_AsUTF8(notify_type));
+  }
+  Py_DECREF(ls);
+  dout(10) << "Module " << get_name() << " notify_types " << notify_types << dendl;
+
   return 0;
 }
 

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -87,6 +87,9 @@ private:
   int load_options();
   std::map<std::string, MgrMap::ModuleOption> options;
 
+  int load_notify_types();
+  std::set<std::string> notify_types;
+
 public:
   static std::string mgr_store_prefix;
 
@@ -153,6 +156,10 @@ public:
   bool is_failed() const { std::lock_guard l(lock) ; return failed; }
   bool is_loaded() const { std::lock_guard l(lock) ; return loaded; }
   bool is_always_on() const { std::lock_guard l(lock) ; return always_on; }
+
+  bool should_notify(const std::string& notify_type) const {
+    return notify_types.count(notify_type);
+  }
 
   const std::string &get_name() const {
     std::lock_guard l(lock) ; return module_name;

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -191,6 +191,11 @@ public:
     }
   }
 
+  bool should_notify(const std::string& name,
+		     const std::string& notify_type) {
+    return modules.at(name)->should_notify(notify_type);
+  }
+
   std::map<std::string, std::string> get_services() const
   {
     ceph_assert(active_modules);

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -31,7 +31,7 @@ from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.agent import CherryPyThread, CephadmAgentHelpers
 
 
-from mgr_module import MgrModule, HandleCommandResult, Option
+from mgr_module import MgrModule, HandleCommandResult, Option, NotifyType
 import orchestrator
 from orchestrator.module import to_format, Format
 
@@ -434,7 +434,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.apply_spec_fails: List[Tuple[str, str]] = []
             self.max_osd_draining_count = 10
 
-        self.notify('mon_map', None)
+        self.notify(NotifyType.mon_map, None)
         self.config_notify()
 
         path = self.get_ceph_option('cephadm_path')
@@ -580,8 +580,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         self.event.set()
 
-    def notify(self, notify_type: str, notify_id: Optional[str]) -> None:
-        if notify_type == "mon_map":
+    def notify(self, notify_type: NotifyType, notify_id: Optional[str]) -> None:
+        if notify_type == NotifyType.mon_map:
             # get monmap mtime so we can refresh configs when mons change
             monmap = self.get('mon_map')
             self.last_monmap = str_to_datetime(monmap['modified'])
@@ -590,7 +590,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             if getattr(self, 'manage_etc_ceph_ceph_conf', False):
                 # getattr, due to notify() being called before config_notify()
                 self._kick_serve_loop()
-        if notify_type == "pg_summary":
+        if notify_type == NotifyType.pg_summary:
             self._trigger_osd_removal()
 
     def _trigger_osd_removal(self) -> None:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -123,6 +123,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     _STORE_HOST_PREFIX = "host"
 
     instance = None
+    NOTIFY_TYPES = [NotifyType.mon_map, NotifyType.pg_summary]
     NATIVE_OPTIONS = []  # type: List[Any]
     MODULE_OPTIONS = [
         Option(

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
         from typing_extensions import Literal
 
 from mgr_module import CLICommand, CLIWriteCommand, HandleCommandResult, \
-    MgrModule, MgrStandbyModule, Option, _get_localized_key
+    MgrModule, MgrStandbyModule, NotifyType, Option, _get_localized_key
 from mgr_util import ServerConfigException, build_url, \
     create_self_signed_cert, get_default_addr, verify_tls_files
 
@@ -478,8 +478,8 @@ class Module(MgrModule, CherryPyConfig):
         return (-errno.EINVAL, '', 'Command not found \'{0}\''
                 .format(cmd['prefix']))
 
-    def notify(self, notify_type, notify_id):
-        NotificationQueue.new_notification(notify_type, notify_id)
+    def notify(self, notify_type: NotifyType, notify_id):
+        NotificationQueue.new_notification(str(notify_type), notify_id)
 
     def get_updated_pool_stats(self):
         df = self.get('df')

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -277,6 +277,8 @@ class Module(MgrModule, CherryPyConfig):
     for options in PLUGIN_MANAGER.hook.get_options() or []:
         MODULE_OPTIONS.extend(options)
 
+    NOTIFY_TYPES = [NotifyType.clog]
+
     __pool_stats = collections.defaultdict(lambda: collections.defaultdict(
         lambda: collections.deque(maxlen=10)))  # type: dict
 

--- a/src/pybind/mgr/insights/module.py
+++ b/src/pybind/mgr/insights/module.py
@@ -4,7 +4,7 @@ import re
 import threading
 
 from mgr_module import CLICommand, CLIReadCommand, HandleCommandResult
-from mgr_module import MgrModule, CommandResult
+from mgr_module import MgrModule, CommandResult, NotifyType
 from . import health as health_util
 
 # hours of crash history to report
@@ -50,9 +50,9 @@ class Module(MgrModule):
         return { k: v for k, v in self._store.items() if k.startswith(prefix) }
 
 
-    def notify(self, ttype, ident):
+    def notify(self, ttype: NotifyType, ident):
         """Queue updates for processing"""
-        if ttype == "health":
+        if ttype == NotifyType.health:
             self.log.info("Received health check update {} pending".format(
                 len(self._pending_health)))
             health = json.loads(self.get("health")["json"])

--- a/src/pybind/mgr/insights/module.py
+++ b/src/pybind/mgr/insights/module.py
@@ -20,6 +20,9 @@ ON_DISK_VERSION = 1
 
 
 class Module(MgrModule):
+
+    NOTIFY_TYPES = [NotifyType.health]
+
     def __init__(self, *args, **kwargs):
         super(Module, self).__init__(*args, **kwargs)
 

--- a/src/pybind/mgr/k8sevents/module.py
+++ b/src/pybind/mgr/k8sevents/module.py
@@ -1051,6 +1051,7 @@ class Module(MgrModule):
          'default': 7,
          'desc': "Days to hold ceph event information within local cache"}
     ]
+    NOTIFY_TYPES = [NotifyType.clog]
 
     def __init__(self, *args, **kwargs):
         self.run = True

--- a/src/pybind/mgr/k8sevents/module.py
+++ b/src/pybind/mgr/k8sevents/module.py
@@ -40,7 +40,7 @@ from urllib3.exceptions import MaxRetryError,ProtocolError
 from collections import OrderedDict
 
 import rados
-from mgr_module import MgrModule
+from mgr_module import MgrModule, NotifyType
 from mgr_util import verify_cacrt, ServerConfigException
 
 try:
@@ -1138,7 +1138,7 @@ class Module(MgrModule):
         else:
             self.log.warning("Unexpected clog message format received - skipped: {}".format(log_message))
 
-    def notify(self, notify_type, notify_id):
+    def notify(self, notify_type: NotifyType, notify_id):
         """
         Called by the ceph-mgr service to notify the Python plugin
         that new state is available.
@@ -1153,7 +1153,7 @@ class Module(MgrModule):
         """
         
         # only interested in cluster log (clog) messages for now
-        if notify_type == 'clog':
+        if notify_type == NotifyType.clog:
             self.log.debug("received a clog entry from mgr.notify")
             if isinstance(notify_id, dict):
                 # create a log object to process

--- a/src/pybind/mgr/localpool/module.py
+++ b/src/pybind/mgr/localpool/module.py
@@ -46,6 +46,7 @@ class Module(MgrModule):
             desc='name prefix for any created local pool',
             runtime=True),
     ]
+    NOTIFY_TYPES = [NotifyType.osd_map]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(Module, self).__init__(*args, **kwargs)

--- a/src/pybind/mgr/localpool/module.py
+++ b/src/pybind/mgr/localpool/module.py
@@ -1,4 +1,4 @@
-from mgr_module import MgrModule, CommandResult, Option
+from mgr_module import MgrModule, CommandResult, Option, NotifyType
 import json
 import threading
 from typing import cast, Any
@@ -51,8 +51,8 @@ class Module(MgrModule):
         super(Module, self).__init__(*args, **kwargs)
         self.serve_event = threading.Event()
 
-    def notify(self, notify_type: str, notify_id: str) -> None:
-        if notify_type == 'osd_map':
+    def notify(self, notify_type: NotifyType, notify_id: str) -> None:
+        if notify_type == NotifyType.osd_map:
             self.handle_osd_map()
 
     def handle_osd_map(self) -> None:

--- a/src/pybind/mgr/mds_autoscaler/module.py
+++ b/src/pybind/mgr/mds_autoscaler/module.py
@@ -4,7 +4,7 @@ Automatically scale MDSs based on status of the file-system using the FSMap
 
 import logging
 from typing import Any, Optional
-from mgr_module import MgrModule
+from mgr_module import MgrModule, NotifyType
 from ceph.deployment.service_spec import ServiceSpec
 import orchestrator
 import copy
@@ -84,8 +84,8 @@ class MDSAutoscaler(orchestrator.OrchestratorClientMixin, MgrModule):
             self.log.exception(f"fs {fs_name}: exception while updating service: {e}")
             pass
 
-    def notify(self, notify_type: str, notify_id: str) -> None:
-        if notify_type != 'fs_map':
+    def notify(self, notify_type: NotifyType, notify_id: str) -> None:
+        if notify_type != NotifyType.fs_map:
             return
         fs_map = self.get('fs_map')
         if not fs_map:

--- a/src/pybind/mgr/mds_autoscaler/module.py
+++ b/src/pybind/mgr/mds_autoscaler/module.py
@@ -16,6 +16,8 @@ class MDSAutoscaler(orchestrator.OrchestratorClientMixin, MgrModule):
     """
     MDS autoscaler.
     """
+    NOTIFY_TYPES = [NotifyType.fs_map]
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         MgrModule.__init__(self, *args, **kwargs)
         self.set_mgr(self)

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -17,7 +17,7 @@ import json
 import subprocess
 import threading
 from collections import defaultdict
-from enum import IntEnum
+from enum import IntEnum, Enum
 import rados
 import re
 import socket
@@ -82,6 +82,23 @@ PG_STATES = [
 
 NFS_GANESHA_SUPPORTED_FSALS = ['CEPH', 'RGW']
 NFS_POOL_NAME = '.nfs'
+
+
+class NotifyType(str, Enum):
+    mon_map = 'mon_map'
+    pg_summary = 'pg_summary'
+    health = 'health'
+    clog = 'clog'
+    osd_map = 'osd_map'
+    fs_map = 'fs_map'
+    command = 'command'
+
+    # these are disabled because there are no users.
+    #  see Mgr.cc:
+    # service_map = 'service_map'
+    # mon_status = 'mon_status'
+    #  see DaemonServer.cc:
+    # perf_schema_update = 'perf_schema_update'
 
 
 class CommandResult(object):
@@ -1169,7 +1186,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         """
         return self._ceph_get_context()
 
-    def notify(self, notify_type: str, notify_id: str) -> None:
+    def notify(self, notify_type: NotifyType, notify_id: str) -> None:
         """
         Called by the ceph-mgr service to notify the Python plugin
         that new state is available.

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1189,7 +1189,9 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
     def notify(self, notify_type: NotifyType, notify_id: str) -> None:
         """
         Called by the ceph-mgr service to notify the Python plugin
-        that new state is available.
+        that new state is available.  This method is *only* called for
+        notify_types that are listed in the NOTIFY_TYPES string list
+        member of the module class.
 
         :param notify_type: string indicating what kind of notification,
                             such as osd_map, mon_map, fs_map, mon_status,

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -15,6 +15,7 @@ import rados
 
 from mgr_util import RTimer, CephfsClient, open_filesystem,\
     CephfsConnectionException
+from mgr_module import NotifyType
 from .blocklist import blocklist
 from .notify import Notifier, InstanceWatcher
 from .utils import INSTANCE_ID_PREFIX, MIRROR_OBJECT_NAME, Finisher, \
@@ -288,9 +289,9 @@ class FSSnapshotMirror:
         self.refresh_pool_policy()
         self.local_fs = CephfsClient(mgr)
 
-    def notify(self, notify_type):
+    def notify(self, notify_type: NotifyType):
         log.debug(f'got notify type {notify_type}')
-        if notify_type == 'fs_map':
+        if notify_type == NotifyType.fs_map:
             with self.lock:
                 self.fs_map = self.mgr.get('fs_map')
                 self.refresh_pool_policy_locked()

--- a/src/pybind/mgr/mirroring/module.py
+++ b/src/pybind/mgr/mirroring/module.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from mgr_module import MgrModule, CLIReadCommand, CLIWriteCommand, Option
+from mgr_module import MgrModule, CLIReadCommand, CLIWriteCommand, Option, NotifyType
 
 from .fs.snapshot_mirror import FSSnapshotMirror
 
@@ -11,7 +11,7 @@ class Module(MgrModule):
         super().__init__(*args, **kwargs)
         self.fs_snapshot_mirror = FSSnapshotMirror(self)
 
-    def notify(self, notify_type, notify_id):
+    def notify(self, notify_type: NotifyType, notify_id):
         self.fs_snapshot_mirror.notify(notify_type)
 
     @CLIWriteCommand('fs snapshot mirror enable')

--- a/src/pybind/mgr/mirroring/module.py
+++ b/src/pybind/mgr/mirroring/module.py
@@ -6,6 +6,7 @@ from .fs.snapshot_mirror import FSSnapshotMirror
 
 class Module(MgrModule):
     MODULE_OPTIONS: List[Option] = []
+    NOTIFY_TYPES = [NotifyType.fs_map]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -23,7 +23,7 @@ from pecan.rest import RestController
 from werkzeug.serving import make_server, make_ssl_devcert
 
 from .hooks import ErrorHook
-from mgr_module import MgrModule, CommandResult
+from mgr_module import MgrModule, CommandResult, NotifyType
 from mgr_util import build_url
 
 
@@ -360,15 +360,15 @@ class Module(MgrModule):
             self.log.error(str(traceback.format_exc()))
 
 
-    def notify(self, notify_type, tag):
+    def notify(self, notify_type: NotifyType, tag: str):
         try:
             self._notify(notify_type, tag)
         except:
             self.log.error(str(traceback.format_exc()))
 
 
-    def _notify(self, notify_type, tag):
-        if notify_type != "command":
+    def _notify(self, notify_type: NotifyType, tag):
+        if notify_type != NotifyType.command:
             self.log.debug("Unhandled notification type '%s'", notify_type)
             return
         # we can safely skip all the sequential commands

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -227,6 +227,8 @@ class Module(MgrModule):
         },
     ]
 
+    NOTIFY_TYPES = [NotifyType.command]
+
     def __init__(self, *args, **kwargs):
         super(Module, self).__init__(*args, **kwargs)
         context.instance = self

--- a/src/pybind/mgr/stats/module.py
+++ b/src/pybind/mgr/stats/module.py
@@ -5,7 +5,7 @@ performance stats for ceph filesystem (for now...)
 import json
 from typing import List, Dict
 
-from mgr_module import MgrModule, Option
+from mgr_module import MgrModule, Option, NotifyType
 
 from .fs.perf_stats import FSPerfStats
 
@@ -26,8 +26,8 @@ class Module(MgrModule):
         super(Module, self).__init__(*args, **kwargs)
         self.fs_perf_stats = FSPerfStats(self)
 
-    def notify(self, notify_type, notify_id):
-        if notify_type == "command":
+    def notify(self, notify_type: NotifyType, notify_id):
+        if notify_type == NotifyType.command:
             self.fs_perf_stats.notify(notify_id)
 
     def handle_command(self, inbuf, cmd):

--- a/src/pybind/mgr/stats/module.py
+++ b/src/pybind/mgr/stats/module.py
@@ -21,6 +21,7 @@ class Module(MgrModule):
         },
     ]
     MODULE_OPTIONS: List[Option] = []
+    NOTIFY_TYPES = [NotifyType.command]
 
     def __init__(self, *args, **kwargs):
         super(Module, self).__init__(*args, **kwargs)


### PR DESCRIPTION
- remove unused notifications
- only delivery a notification if the module wants one







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>