### PR TITLE
octopus: osd: fix partial recovery become whole object recovery after restart osd

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -942,8 +942,7 @@ void PGLog::_write_log_and_missing(
       if (!missing.is_missing(obj, &item)) {
 	to_remove.insert(key);
       } else {
-	uint64_t features = missing.may_include_deletes ? CEPH_FEATURE_OSD_RECOVERY_DELETES : 0;
-	encode(make_pair(obj, item), (*km)[key], features);
+	encode(make_pair(obj, item), (*km)[key], CEPH_FEATUREMASK_SERVER_OCTOPUS);
       }
     });
   if (require_rollback) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52710

---

backport of https://github.com/ceph/ceph/pull/43146
parent tracker: https://tracker.ceph.com/issues/52583

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh