### PR TITLE
octopus: mds: PurgeQueue.cc fix for 32bit compilation

### DIFF
--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -503,7 +503,8 @@ void PurgeQueue::_execute_item(
 
   in_flight[expire_to] = item;
   logger->set(l_pq_executing, in_flight.size());
-  files_high_water = std::max(files_high_water, in_flight.size());
+  files_high_water = std::max<uint64_t>(files_high_water,
+                              in_flight.size());
   logger->set(l_pq_executing_high_water, files_high_water);
   auto ops = _calculate_ops(item);
   ops_in_flight += ops;
@@ -581,7 +582,8 @@ void PurgeQueue::_execute_item(
     logger->set(l_pq_executing_ops_high_water, ops_high_water);
     in_flight.erase(expire_to);
     logger->set(l_pq_executing, in_flight.size());
-    files_high_water = std::max(files_high_water, in_flight.size());
+    files_high_water = std::max<uint64_t>(files_high_water,
+                                in_flight.size());
     logger->set(l_pq_executing_high_water, files_high_water);
     return;
   }
@@ -659,7 +661,8 @@ void PurgeQueue::_execute_item_complete(
 
   in_flight.erase(iter);
   logger->set(l_pq_executing, in_flight.size());
-  files_high_water = std::max(files_high_water, in_flight.size());
+  files_high_water = std::max<uint64_t>(files_high_water,
+                              in_flight.size());
   logger->set(l_pq_executing_high_water, files_high_water);
   dout(10) << "in_flight.size() now " << in_flight.size() << dendl;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50850

---

backport of https://github.com/ceph/ceph/pull/41235
parent tracker: https://tracker.ceph.com/issues/50707

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh