### PR TITLE
octopus: rgw: disable prefetch in rgw_file to fix 3x read amplification

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -2164,6 +2164,8 @@ public:
     return 0;
   }
 
+  bool prefetch_data() override { return false; }
+
 }; /* RGWReadRequest */
 
 /*

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -966,7 +966,7 @@ int RGWGetObj::verify_permission()
 {
   obj = rgw_obj(s->bucket, s->object);
   store->getRados()->set_atomic(s->obj_ctx, obj);
-  if (get_data) {
+  if (prefetch_data()) {
     store->getRados()->set_prefetch_data(s->obj_ctx, obj);
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53133

---

backport of https://github.com/ceph/ceph/pull/38167
parent tracker: https://tracker.ceph.com/issues/48289

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh