### PR TITLE
octopus: rgw: user stats showing 0 value for "size_utilized" and "size_kb_utilized" fields

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7499,7 +7499,8 @@ next:
       }
     }
 
-    RGWStorageStats stats;
+    constexpr bool omit_utilized_stats = false;
+    RGWStorageStats stats(omit_utilized_stats);
     ceph::real_time last_stats_sync;
     ceph::real_time last_stats_update;
     int ret = store->ctl()->user->read_stats(user_id, &stats, &last_stats_sync, &last_stats_update);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -14,8 +14,7 @@
  * 
  */
 
-#ifndef CEPH_RGW_COMMON_H
-#define CEPH_RGW_COMMON_H
+#pragma once
 
 #include <array>
 
@@ -1250,17 +1249,20 @@ struct RGWStorageStats
   RGWObjCategory category;
   uint64_t size;
   uint64_t size_rounded;
-  uint64_t size_utilized{0}; //< size after compression, encryption
   uint64_t num_objects;
+  uint64_t size_utilized{0}; //< size after compression, encryption
+  bool dump_utilized;        // whether dump should include utilized values
 
-  RGWStorageStats()
+  RGWStorageStats(bool _dump_utilized=true)
     : category(RGWObjCategory::None),
       size(0),
       size_rounded(0),
-      num_objects(0) {}
+      num_objects(0),
+      dump_utilized(_dump_utilized)
+  {}
 
   void dump(Formatter *f) const;
-};
+}; // RGWStorageStats
 
 class RGWEnv;
 
@@ -2453,5 +2455,3 @@ int decode_bl(bufferlist& bl, T& t)
   }
   return 0;
 }
-
-#endif

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -683,10 +683,14 @@ void RGWStorageStats::dump(Formatter *f) const
 {
   encode_json("size", size, f);
   encode_json("size_actual", size_rounded, f);
-  encode_json("size_utilized", size_utilized, f);
+  if (dump_utilized) {
+    encode_json("size_utilized", size_utilized, f);
+  }
   encode_json("size_kb", rgw_rounded_kb(size), f);
   encode_json("size_kb_actual", rgw_rounded_kb(size_rounded), f);
-  encode_json("size_kb_utilized", rgw_rounded_kb(size_utilized), f);
+  if (dump_utilized) {
+    encode_json("size_kb_utilized", rgw_rounded_kb(size_utilized), f);
+  }
   encode_json("num_objects", num_objects, f);
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52074

---

backport of https://github.com/ceph/ceph/pull/42531
parent tracker: https://tracker.ceph.com/issues/51941

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh