### PR TITLE
pacific: osd: set r only if succeed in FillInVerifyExtent

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5187,11 +5187,11 @@ struct FillInVerifyExtent : public Context {
     r(r), rval(rv), outdatap(blp), maybe_crc(mc),
     size(size), osd(osd), soid(soid), flags(flags) {}
   void finish(int len) override {
-    *r = len;
     if (len < 0) {
       *rval = len;
       return;
     }
+    *r = len;
     *rval = 0;
 
     // whole object?  can we verify the checksum?


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51150

---

backport of https://github.com/ceph/ceph/pull/41727
parent tracker: https://tracker.ceph.com/issues/51115

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh