### PR TITLE
crimson/os/seastore: initialize logical pins before exposing to cache

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -325,7 +325,7 @@ public:
 	  return get_extent_iertr::make_ready_future<TCachedExtentRef<T>>();
 	} else {
 	  DEBUGT(
-	    "Found extent at offset {} in cache: {}",
+	    "Read extent at offset {} in cache: {}",
 	    t, offset, *ref);
 	  t.add_to_read_set(ref);
 	  return get_extent_iertr::make_ready_future<TCachedExtentRef<T>>(

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
@@ -384,6 +384,24 @@ public:
   using init_cached_extent_ret = init_cached_extent_iertr::future<CachedExtentRef>;
   init_cached_extent_ret init_cached_extent(op_context_t c, CachedExtentRef e);
 
+  /// get_leaf_if_live: get leaf node at laddr/addr if still live
+  using get_leaf_if_live_iertr = base_iertr;
+  using get_leaf_if_live_ret = get_leaf_if_live_iertr::future<CachedExtentRef>;
+  get_leaf_if_live_ret get_leaf_if_live(
+    op_context_t c,
+    paddr_t addr,
+    laddr_t laddr,
+    segment_off_t len);
+
+  /// get_internal_if_live: get internal node at laddr/addr if still live
+  using get_internal_if_live_iertr = base_iertr;
+  using get_internal_if_live_ret = get_internal_if_live_iertr::future<CachedExtentRef>;
+  get_internal_if_live_ret get_internal_if_live(
+    op_context_t c,
+    paddr_t addr,
+    laddr_t laddr,
+    segment_off_t len);
+
   /**
    * rewrite_lba_extent
    *


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
