### PR TITLE
mds/MDLog: use a larger segment size if the event max size is too large

### DIFF
--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -534,11 +534,12 @@ options:
   services:
   - mds
   with_legacy: true
-# segment size for mds log, default to default file_layout_t
+# expected segment size for mds log, default to default file_layout_t
 - name: mds_log_segment_size
   type: size
   level: advanced
-  desc: size in bytes of each MDS log segment
+  desc: expected size in bytes of each MDS log segment, the actual segment size probably
+    will be large than or less than it.
   default: 0
   services:
   - mds
@@ -546,11 +547,22 @@ options:
 - name: mds_log_segment_size_factor
   type: float
   level: advanced
-  desc: ratio of max(MDLog's segment size, maximum size of every 10000 events) at which
-    the MDLog will start a new LogSegment immediately if the maximum size of the 10000
-    events is larger than half of the segment size. Set a value less than or equal to 1
-    to disable it.
+  desc: ratio of max(MDLog's expected segment size, maximum size of every 10000 events)
+    at which the MDLog will start a new LogSegment immediately if the maximum size of
+    the 10000 events is larger than half of the expected segment size. Set a value less
+    than or equal to 1 to disable it.
   default: 2
+  services:
+  - mds
+  with_legacy: true
+- name: mds_log_max_average_segment_size_factor
+  type: float
+  level: advanced
+  desc: ratio of expected segment size, if the average of the actual segments size is
+    larger than it the MDS will try to trim the segments. It must equal to or be lager
+    than mds_log_segment_size_factor. Set a value less than mds_log_segment_size_factor
+    will be ignored and 64 will be used as default.
+  default: 64
   services:
   - mds
   with_legacy: true

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -543,6 +543,17 @@ options:
   services:
   - mds
   with_legacy: true
+- name: mds_log_segment_size_factor
+  type: float
+  level: advanced
+  desc: ratio of max(MDLog's segment size, maximum size of every 10000 events) at which
+    the MDLog will start a new LogSegment immediately if the maximum size of the 10000
+    events is larger than half of the segment size. Set a value less than or equal to 1
+    to disable it.
+  default: 2
+  services:
+  - mds
+  with_legacy: true
 - name: mds_log_max_segments
   type: uint
   level: advanced

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -257,6 +257,7 @@ protected:
   }
 
   int num_events = 0; // in events
+  int total_events = 0; // total events submitted till now
   int unflushed = 0;
   bool mds_is_shutting_down = false;
 
@@ -308,5 +309,8 @@ private:
 
   // -- events --
   LogEvent *cur_event = nullptr;
+
+  // The latest 10000 events' maximum size
+  uint32_t max_events_batch_size = 0;
 };
 #endif


### PR DESCRIPTION
# issue1

In some case the ESubtreeMap event's size will be very large, which could
reach up to 4MB or larger. Then it's very possibly there will be many new
created LogSegments only contain two events, the first is ESubtreeMap event
and the second is an any other type event.

In this case the network bandwith usage maybe very high, which is mainly
writing the ESubtreeMap events to metatdata pool.

Add the "mds_log_segment_size_factor" option, which is the ratio of maximum
of MDLog's segment size and maximum size of every 10000 events at which
the MDLog will start a new LogSegment immediately if the maximum size of
the 10000 events is larger than half of the sigment size. Set a value less
than or equal to 1 will disable it. This will make sure that there won't be
to many big events in the network traffic.

Fixes: https://tracker.ceph.com/issues/53542
Fixes: https://tracker.ceph.com/issues/53623


# issue2

In heavy load case the MDLog's actual segment size is very probably
larger than the expected segment size, which is Rados object's size.
Such as it could be 100 * Rados object's size, so in this case in
the worst case the journal logs could occupy around 200 * 4MB * 128,
which is 100GB or even larger.

Here we will limit it to mds_log_max_average_segment_size_factor as
default, if the actual average size of the segments is larger than
the factor * expected segment size, try to trim the segments.

And at the same time switch `submit_mutex` to fair mutex.

Fixes: https://tracker.ceph.com/issues/40002








<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
