### PR TITLE
crimson/osd: fix assertion failure in InternalClientRequest.

### DIFF
--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -52,7 +52,7 @@ seastar::future<> InternalClientRequest::start()
           return with_blocking_future_interruptible<interruptor::condition>(
             handle.enter(pp().recover_missing)
           ).then_interruptible([this] {
-            return do_recover_missing(pg, {});
+            return do_recover_missing(pg, get_target_oid());
           }).then_interruptible([this] {
             return with_blocking_future_interruptible<interruptor::condition>(
               handle.enter(pp().get_obc)


### PR DESCRIPTION
```
DEBUG 2021-12-01 07:55:10,541 [shard 0] osd - internal_client_request(id=1, detail=): in repeat
TRACE 2021-12-01 07:55:10,541 [shard 0] osd - with_interruption_cond: interrupt_cond: 0x0
TRACE 2021-12-01 07:55:10,541 [shard 0] osd - call_with_interruption_impl: may_interrupt: false, local interrupt_condintion: 0x603000b5d270, global interrupt_cond: 0x0,N7crimson3osd20IOInterruptConditionE
TRACE 2021-12-01 07:55:10,541 [shard 0] osd - set: interrupt_cond: 0x603000b5d270, ref_count: 1
TRACE 2021-12-01 07:55:10,541 [shard 0] osd - call_with_interruption_impl clearing interrupt_cond: 0x603000b5d270,N7crimson3osd20IOInterruptConditionE
TRACE 2021-12-01 07:55:10,541 [shard 0] osd - call_with_interruption_impl: may_interrupt: false, local interrupt_condintion: 0x603000b5d270, global interrupt_cond: 0x0,N7crimson3osd20IOInterruptConditionE
TRACE 2021-12-01 07:55:10,541 [shard 0] osd - set: interrupt_cond: 0x603000b5d270, ref_count: 1
TRACE 2021-12-01 07:55:10,541 [shard 0] osd - call_with_interruption_impl clearing interrupt_cond: 0x603000b5d270,N7crimson3osd20IOInterruptConditionE
TRACE 2021-12-01 07:55:10,541 [shard 0] osd - call_with_interruption_impl: may_interrupt: false, local interrupt_condintion: 0x603000b5d270, global interrupt_cond: 0x0,N7crimson3osd20IOInterruptConditionE
TRACE 2021-12-01 07:55:10,541 [shard 0] osd - set: interrupt_cond: 0x603000b5d270, ref_count: 1
TRACE 2021-12-01 07:55:10,541 [shard 0] osd - call_with_interruption_impl clearing interrupt_cond: 0x603000b5d270,N7crimson3osd20IOInterruptConditionE
TRACE 2021-12-01 07:55:10,542 [shard 0] osd - call_with_interruption_impl: may_interrupt: false, local interrupt_condintion: 0x603000b5d270, global interrupt_cond: 0x0,N7crimson3osd20IOInterruptConditionE
TRACE 2021-12-01 07:55:10,542 [shard 0] osd - set: interrupt_cond: 0x603000b5d270, ref_count: 1
DEBUG 2021-12-01 07:55:10,542 [shard 0] osd - do_recover_missing check for recovery, MIN
ERROR 2021-12-01 07:55:10,542 [shard 0] none - /home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/17.0.0-8902-g52fd47fe/rpm/el8/BUILD/ceph-17.0.0-8902-g52fd47fe/src/crimson/osd/pg.cc:1195 : In function 'bool crimson::osd::PG::is_degraded_or_backfilling_object(const hobject_t&) const', ceph_assert(%s)
!get_acting_recovery_backfill().empty()
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
