### PR TITLE
monitoring/grafana: improve grafana unit tests variable substitution

### DIFF
--- a/monitoring/grafana/dashboards/CMakeLists.txt
+++ b/monitoring/grafana/dashboards/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 if(WITH_GRAFANA)
   include(AddCephTest)
   add_tox_test(grafana-check TOX_ENVS grafonnet-check)
-  add_tox_test(grafana-query-test TOX_ENVS promql-query-test)
+  add_tox_test(promql-query-test TOX_ENVS promql-query-test)
   add_tox_test(grafana-lint TOX_ENVS lint)
   set(ver 0.1.0)
   set(name grafonnet-lib)
@@ -32,7 +32,7 @@ if(WITH_GRAFANA)
     ${name})
   ExternalProject_Get_Property(${name} SOURCE_DIR)
   set_property(
-    TEST run-tox-grafana-check run-tox-grafana-query-test run-tox-grafana-lint
+    TEST run-tox-grafana-check run-tox-promql-query-test run-tox-grafana-lint
     APPEND
     PROPERTY ENVIRONMENT
     GRAFONNET_PATH=${SOURCE_DIR}/grafonnet)

--- a/monitoring/grafana/dashboards/tests/__init__.py
+++ b/monitoring/grafana/dashboards/tests/__init__.py
@@ -171,7 +171,8 @@ class PromqlTest:
 
         for variable, value in self.variables.items():
             expr = self.promql_expr_test.expr
-            new_expr = re.sub(r'\${0}'.format(variable), str(value), expr)
+            regex = fr'\${variable}(?=\W)'
+            new_expr = re.sub(regex, fr'{str(value)}', expr)
             self.set_expression(new_expr)
 
         test_as_dict = asdict(self.test_file)

--- a/monitoring/grafana/dashboards/tests/__init__.py
+++ b/monitoring/grafana/dashboards/tests/__init__.py
@@ -7,6 +7,8 @@ from typing import Any, List
 
 import yaml
 
+from .util import replace_grafana_expr_variables
+
 
 @dataclass
 class InputSeries:
@@ -171,8 +173,7 @@ class PromqlTest:
 
         for variable, value in self.variables.items():
             expr = self.promql_expr_test.expr
-            regex = fr'\${variable}(?=\W)'
-            new_expr = re.sub(regex, fr'{str(value)}', expr)
+            new_expr = replace_grafana_expr_variables(expr, variable, value)
             self.set_expression(new_expr)
 
         test_as_dict = asdict(self.test_file)

--- a/monitoring/grafana/dashboards/tox.ini
+++ b/monitoring/grafana/dashboards/tox.ini
@@ -41,4 +41,5 @@ deps =
 depends = grafonnet-check
 setenv =
 commands =
+    python -m doctest tests/util.py
     behave tests/features 


### PR DESCRIPTION
Promql tests were failing locally because of wrong matching with regex, I haven't seen this problem on master but just in case let's improve this matching expression.
Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
