### PR TITLE
pacific: librbd/cache/pwl: misc backports

### DIFF
--- a/qa/suites/rbd/persistent-writeback-cache/5-cache-mode/ssd.yaml
+++ b/qa/suites/rbd/persistent-writeback-cache/5-cache-mode/ssd.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd_persistent_cache_mode: ssd

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -801,7 +801,9 @@ librados::IoCtx duplicate_io_ctx(librados::IoCtx& io_ctx) {
     if (sparse_read_threshold_bytes == 0) {
       sparse_read_threshold_bytes = get_object_size();
     }
-    if (!skip_partial_discard) {
+
+    bool dirty_cache = test_features(RBD_FEATURE_DIRTY_CACHE);
+    if (!skip_partial_discard || dirty_cache) {
       discard_granularity_bytes = 0;
     }
 

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -26,6 +26,8 @@
 #include "librbd/image/PreRemoveRequest.h"
 #include "librbd/io/ImageDispatcherInterface.h"
 #include "librbd/io/ObjectDispatcherInterface.h"
+#include "librbd/io/AioCompletion.h"
+#include "librbd/io/ImageDispatchSpec.h"
 #include <boost/scope_exit.hpp>
 
 #define dout_subsys ceph_subsys_rbd
@@ -677,6 +679,22 @@ int Image<I>::deep_copy(I *src, librados::IoCtx& dest_md_ctx,
 template <typename I>
 int Image<I>::deep_copy(I *src, I *dest, bool flatten,
                         ProgressContext &prog_ctx) {
+  // ensure previous writes are visible to dest
+  C_SaferCond flush_ctx;
+  {
+    std::shared_lock owner_locker{src->owner_lock};
+    auto aio_comp = io::AioCompletion::create_and_start(&flush_ctx, src,
+                                                        io::AIO_TYPE_FLUSH);
+    auto req = io::ImageDispatchSpec::create_flush(
+      *src, io::IMAGE_DISPATCH_LAYER_INTERNAL_START,
+      aio_comp, io::FLUSH_SOURCE_INTERNAL, {});
+    req->send();
+  }
+  int r = flush_ctx.wait();
+  if (r < 0) {
+    return r;
+  }
+
   librados::snap_t snap_id_start = 0;
   librados::snap_t snap_id_end;
   {
@@ -693,7 +711,7 @@ int Image<I>::deep_copy(I *src, I *dest, bool flatten,
     src, dest, snap_id_start, snap_id_end, 0U, flatten, boost::none,
     asio_engine.get_work_queue(), &snap_seqs, &progress_handler, &cond);
   req->send();
-  int r = cond.wait();
+  r = cond.wait();
   if (r < 0) {
     return r;
   }

--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -1744,10 +1744,6 @@ void AbstractWriteLog<I>::process_writeback_dirty_entries() {
         break;
       }
 
-      if (m_flush_ops_will_send) {
-	ldout(cct, 20) << "Previous flush-ops is still not sent" << dendl;
-	break;
-      }
       auto candidate = m_dirty_log_entries.front();
       bool flushable = can_flush_entry(candidate);
       if (flushable) {
@@ -1764,7 +1760,6 @@ void AbstractWriteLog<I>::process_writeback_dirty_entries() {
 	    m_lowest_flushing_sync_gen = candidate->ram_entry.sync_gen_number;
 	  }
 	  m_flush_ops_in_flight += 1;
-	  m_flush_ops_will_send += 1;
 	  /* For write same this is the bytes affected by the flush op, not the bytes transferred */
 	  m_flush_bytes_in_flight += candidate->ram_entry.write_bytes;
 	}

--- a/src/librbd/cache/pwl/AbstractWriteLog.h
+++ b/src/librbd/cache/pwl/AbstractWriteLog.h
@@ -178,6 +178,9 @@ private:
 
   bool m_persist_on_write_until_flush = true;
 
+  pwl::WriteLogGuard m_flush_guard;
+  mutable ceph::mutex m_flush_guard_lock;
+
  /* Debug counters for the places m_async_op_tracker is used */
   std::atomic<int> m_async_complete_ops = {0};
   std::atomic<int> m_async_null_flush_finish = {0};
@@ -225,7 +228,6 @@ private:
   void detain_guarded_request(C_BlockIORequestT *request,
                               pwl::GuardedRequestFunctionContext *guarded_ctx,
                               bool is_barrier);
-
   void perf_start(const std::string name);
   void perf_stop();
   void log_perf();
@@ -348,6 +350,8 @@ protected:
       std::shared_ptr<pwl::GenericLogEntry> log_entry) = 0;
   Context *construct_flush_entry(
       const std::shared_ptr<pwl::GenericLogEntry> log_entry, bool invalidating);
+  void detain_flush_guard_request(std::shared_ptr<GenericLogEntry> log_entry,
+                                  GuardedRequestFunctionContext *guarded_ctx);
   void process_writeback_dirty_entries();
   bool can_retire_entry(const std::shared_ptr<pwl::GenericLogEntry> log_entry);
 

--- a/src/librbd/cache/pwl/AbstractWriteLog.h
+++ b/src/librbd/cache/pwl/AbstractWriteLog.h
@@ -296,7 +296,6 @@ protected:
   std::atomic<int> m_async_flush_ops = {0};
   std::atomic<int> m_async_append_ops = {0};
 
-  std::atomic<int> m_flush_ops_will_send = {0};
   /* Acquire locks in order declared here */
 
   mutable ceph::mutex m_log_retire_lock;

--- a/src/librbd/cache/pwl/InitRequest.cc
+++ b/src/librbd/cache/pwl/InitRequest.cc
@@ -178,12 +178,6 @@ void InitRequest<I>::handle_set_feature_bit(int r) {
     shutdown_image_cache();
   }
 
-  if (m_image_ctx.discard_granularity_bytes) {
-    ldout(cct, 1) << "RWL image cache is enabled and "
-                  << "set discard_granularity_bytes = 0." << dendl;
-    m_image_ctx.discard_granularity_bytes = 0;
-  }
-
   // Register RWL dispatch
   auto image_dispatch = new cache::WriteLogImageDispatch<I>(
     &m_image_ctx, m_image_cache, m_plugin_api);

--- a/src/librbd/cache/pwl/LogEntry.h
+++ b/src/librbd/cache/pwl/LogEntry.h
@@ -27,6 +27,7 @@ public:
   WriteLogCacheEntry *cache_entry = nullptr;
   uint64_t log_entry_index = 0;
   bool completed = false;
+  BlockGuardCell* m_cell = nullptr;
   GenericLogEntry(uint64_t image_offset_bytes = 0, uint64_t write_bytes = 0)
     : ram_entry(image_offset_bytes, write_bytes) {
   };

--- a/src/librbd/cache/pwl/rwl/WriteLog.cc
+++ b/src/librbd/cache/pwl/rwl/WriteLog.cc
@@ -595,7 +595,6 @@ void WriteLog<I>::construct_flush_entries(pwl::GenericLogEntries entries_to_flus
 		  ldout(m_image_ctx.cct, 15) << "flushing:" << log_entry
 		                             << " " << *log_entry << dendl;
 		  log_entry->writeback(this->m_image_writeback, ctx);
-		  this->m_flush_ops_will_send -= 1;
 	      }), 0);
 	  });
 	}

--- a/src/librbd/cache/pwl/ssd/WriteLog.cc
+++ b/src/librbd/cache/pwl/ssd/WriteLog.cc
@@ -563,7 +563,6 @@ void WriteLog<I>::construct_flush_entries(pwl::GenericLogEntries entries_to_flus
 	            ldout(m_image_ctx.cct, 15) << "flushing:" << log_entry
                                                << " " << *log_entry << dendl;
 	            log_entry->writeback(this->m_image_writeback, ctx);
-	            this->m_flush_ops_will_send -= 1;
 	          }), 0);
 	      });
             }
@@ -612,7 +611,6 @@ void WriteLog<I>::construct_flush_entries(pwl::GenericLogEntries entries_to_flus
 			                       << " " << *log_entry << dendl;
 		    log_entry->writeback_bl(this->m_image_writeback, ctx,
                                             std::move(captured_entry_bl));
-		    this->m_flush_ops_will_send -= 1;
 	          }), 0);
 	      });
 	  } else {
@@ -625,7 +623,6 @@ void WriteLog<I>::construct_flush_entries(pwl::GenericLogEntries entries_to_flus
 		    ldout(m_image_ctx.cct, 15) << "flushing:" << log_entry
                                                << " " << *log_entry << dendl;
 		    log_entry->writeback(this->m_image_writeback, ctx);
-		    this->m_flush_ops_will_send -= 1;
 		  }), 0);
             });
 	  }

--- a/src/librbd/cache/pwl/ssd/WriteLog.cc
+++ b/src/librbd/cache/pwl/ssd/WriteLog.cc
@@ -550,82 +550,90 @@ void WriteLog<I>::construct_flush_entries(pwl::GenericLogEntries entries_to_flus
 
   if (invalidating || !has_write_entry) {
     for (auto &log_entry : entries_to_flush) {
-      Context *ctx = this->construct_flush_entry(log_entry, invalidating);
+      GuardedRequestFunctionContext *guarded_ctx =
+        new GuardedRequestFunctionContext([this, log_entry, invalidating]
+          (GuardedRequestFunctionContext &guard_ctx) {
+            log_entry->m_cell = guard_ctx.cell;
+            Context *ctx = this->construct_flush_entry(log_entry, invalidating);
 
-      if (!invalidating) {
-        ctx = new LambdaContext(
-        [this, log_entry, ctx](int r) {
-          m_image_ctx.op_work_queue->queue(new LambdaContext(
-	    [this, log_entry, ctx](int r) {
-	      ldout(m_image_ctx.cct, 15) << "flushing:" << log_entry
-                                         << " " << *log_entry << dendl;
-	      log_entry->writeback(this->m_image_writeback, ctx);
-	      this->m_flush_ops_will_send -= 1;
-	    }), 0);
-	});
-      }
-      post_unlock.add(ctx);
+            if (!invalidating) {
+              ctx = new LambdaContext([this, log_entry, ctx](int r) {
+                m_image_ctx.op_work_queue->queue(new LambdaContext(
+	          [this, log_entry, ctx](int r) {
+	            ldout(m_image_ctx.cct, 15) << "flushing:" << log_entry
+                                               << " " << *log_entry << dendl;
+	            log_entry->writeback(this->m_image_writeback, ctx);
+	            this->m_flush_ops_will_send -= 1;
+	          }), 0);
+	      });
+            }
+            ctx->complete(0);
+        });
+      this->detain_flush_guard_request(log_entry, guarded_ctx);
     }
   } else {
     int count = entries_to_flush.size();
-    std::vector<std::shared_ptr<GenericWriteLogEntry>> log_entries;
+    std::vector<std::shared_ptr<GenericWriteLogEntry>> write_entries;
     std::vector<bufferlist *> read_bls;
-    std::vector<Context *> contexts;
 
-    log_entries.reserve(count);
+    write_entries.reserve(count);
     read_bls.reserve(count);
-    contexts.reserve(count);
 
     for (auto &log_entry : entries_to_flush) {
-      // log_entry already removed from m_dirty_log_entries and
-      // in construct_flush_entry() it will inc(m_flush_ops_in_flight).
-      // We call this func here to make ops can track.
-      Context *ctx = this->construct_flush_entry(log_entry, invalidating);
       if (log_entry->is_write_entry()) {
 	bufferlist *bl = new bufferlist;
 	auto write_entry = static_pointer_cast<WriteLogEntry>(log_entry);
 	write_entry->inc_bl_refs();
-	log_entries.push_back(write_entry);
+	write_entries.push_back(write_entry);
 	read_bls.push_back(bl);
       }
-      contexts.push_back(ctx);
     }
 
     Context *ctx = new LambdaContext(
-      [this, entries_to_flush, read_bls, contexts](int r) {
-        int i = 0, j = 0;
+      [this, entries_to_flush, read_bls](int r) {
+        int i = 0;
+	GuardedRequestFunctionContext *guarded_ctx = nullptr;
 
 	for (auto &log_entry : entries_to_flush) {
-          Context *ctx = contexts[j++];
-
 	  if (log_entry->is_write_entry()) {
 	    bufferlist captured_entry_bl;
-
 	    captured_entry_bl.claim_append(*read_bls[i]);
 	    delete read_bls[i++];
 
-	    m_image_ctx.op_work_queue->queue(new LambdaContext(
-	      [this, log_entry, entry_bl=std::move(captured_entry_bl), ctx](int r) {
-		auto captured_entry_bl = std::move(entry_bl);
-		ldout(m_image_ctx.cct, 15) << "flushing:" << log_entry
-				           << " " << *log_entry << dendl;
-		log_entry->writeback_bl(this->m_image_writeback, ctx,
-					std::move(captured_entry_bl));
-		this->m_flush_ops_will_send -= 1;
-	      }), 0);
+	    guarded_ctx = new GuardedRequestFunctionContext([this, log_entry, captured_entry_bl]
+              (GuardedRequestFunctionContext &guard_ctx) {
+                log_entry->m_cell = guard_ctx.cell;
+                Context *ctx = this->construct_flush_entry(log_entry, false);
+
+	        m_image_ctx.op_work_queue->queue(new LambdaContext(
+	          [this, log_entry, entry_bl=std::move(captured_entry_bl), ctx](int r) {
+		    auto captured_entry_bl = std::move(entry_bl);
+		    ldout(m_image_ctx.cct, 15) << "flushing:" << log_entry
+			                       << " " << *log_entry << dendl;
+		    log_entry->writeback_bl(this->m_image_writeback, ctx,
+                                            std::move(captured_entry_bl));
+		    this->m_flush_ops_will_send -= 1;
+	          }), 0);
+	      });
 	  } else {
-	      m_image_ctx.op_work_queue->queue(new LambdaContext(
-		[this, log_entry, ctx](int r) {
-		  ldout(m_image_ctx.cct, 15) << "flushing:" << log_entry
-                                             << " " << *log_entry << dendl;
-		  log_entry->writeback(this->m_image_writeback, ctx);
-		  this->m_flush_ops_will_send -= 1;
-		}), 0);
+	    guarded_ctx = new GuardedRequestFunctionContext([this, log_entry]
+              (GuardedRequestFunctionContext &guard_ctx) {
+                log_entry->m_cell = guard_ctx.cell;
+                Context *ctx = this->construct_flush_entry(log_entry, false);
+	        m_image_ctx.op_work_queue->queue(new LambdaContext(
+		  [this, log_entry, ctx](int r) {
+		    ldout(m_image_ctx.cct, 15) << "flushing:" << log_entry
+                                               << " " << *log_entry << dendl;
+		    log_entry->writeback(this->m_image_writeback, ctx);
+		    this->m_flush_ops_will_send -= 1;
+		  }), 0);
+            });
 	  }
+          this->detain_flush_guard_request(log_entry, guarded_ctx);
 	}
       });
 
-    aio_read_data_blocks(log_entries, read_bls, ctx);
+    aio_read_data_blocks(write_entries, read_bls, ctx);
   }
 }
 

--- a/src/librbd/exclusive_lock/PreReleaseRequest.cc
+++ b/src/librbd/exclusive_lock/PreReleaseRequest.cc
@@ -100,7 +100,8 @@ void PreReleaseRequest<I>::send_set_require_lock() {
   // setting the lock as required will automatically cause the IO
   // queue to re-request the lock if any IO is queued
   if (m_image_ctx.clone_copy_on_read ||
-      m_image_ctx.test_features(RBD_FEATURE_JOURNALING)) {
+      m_image_ctx.test_features(RBD_FEATURE_JOURNALING) ||
+      m_image_ctx.test_features(RBD_FEATURE_DIRTY_CACHE)) {
     m_image_dispatch->set_require_lock(m_shutting_down,
                                        io::DIRECTION_BOTH, ctx);
   } else {

--- a/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
@@ -102,9 +102,14 @@ public:
     if (!mock_image_ctx.clone_copy_on_read) {
       expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING,
                            ((mock_image_ctx.features & RBD_FEATURE_JOURNALING) != 0));
+      if ((mock_image_ctx.features & RBD_FEATURE_JOURNALING) == 0) {
+        expect_test_features(mock_image_ctx, RBD_FEATURE_DIRTY_CACHE,
+                             ((mock_image_ctx.features & RBD_FEATURE_DIRTY_CACHE) != 0));
+      }
     }
     if (mock_image_ctx.clone_copy_on_read ||
-        (mock_image_ctx.features & RBD_FEATURE_JOURNALING) != 0) {
+        (mock_image_ctx.features & RBD_FEATURE_JOURNALING) != 0 ||
+        (mock_image_ctx.features & RBD_FEATURE_DIRTY_CACHE) != 0) {
       expect_set_require_lock(mock_image_dispatch, init_shutdown,
                               librbd::io::DIRECTION_BOTH, r);
     } else {


### PR DESCRIPTION
Use BlockGuard control to fix ops order when flushing to OSD
Fixes: https://tracker.ceph.com/issues/49876
Fixes: https://tracker.ceph.com/issues/53108

Function apply_meta can overwrite discard_granularity_bytes
based on option.
Fixes:https://tracker.ceph.com/issues/53434

added qa tests for ssd mode
https://github.com/ceph/ceph/pull/40006

DeepCopy flush
copy/deep_copy use object_map to judge whether object exist.
If w/ librbdo pwl cache, flush can't flush data to osd which change
objectmap state. So we should send flush w/ FLUSH_SOURCE_INTERNAL to
make data flush to osd.
Fixes:https://tracker.ceph.com/issues/53057
https://github.com/ceph/ceph/pull/43659

[pwl] possible data corruption in TEST_F(TestLibRBD, TestFUA)
Fixes: https://tracker.ceph.com/issues/51438
https://github.com/ceph/ceph/pull/43038/
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>


> Do we have backport tickets for these? If we do then it would be nice to list them in the description.

