### PR TITLE
pacific: mgr/prometheus: define module options for standby

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1422,6 +1422,9 @@ class Module(MgrModule):
 
 
 class StandbyModule(MgrStandbyModule):
+
+    MODULE_OPTIONS = Module.MODULE_OPTIONS
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(StandbyModule, self).__init__(*args, **kwargs)
         self.shutdown_event = threading.Event()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53488

---

backport of https://github.com/ceph/ceph/pull/44132
parent tracker: https://tracker.ceph.com/issues/53287

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh