### PR TITLE
pacific: ceph-volume: human_readable_size() refactor

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -1163,7 +1163,7 @@ def get_lv_by_fullname(full_name):
     """
     try:
         vg_name, lv_name = full_name.split('/')
-        res_lv = get_first_lv(filters={'lv_name': lv_name,
+        res_lv = get_single_lv(filters={'lv_name': lv_name,
                                         'vg_name': vg_name})
     except ValueError:
         res_lv = None

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_migrate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_migrate.py
@@ -47,7 +47,7 @@ class TestFindAssociatedDevices(object):
         return self.mock_volumes.pop(0)
 
     mock_single_volumes = {}
-    def mock_get_first_lv(self, *args, **kwargs):
+    def mock_get_single_lv(self, *args, **kwargs):
         p = kwargs['filters']['lv_path']
         return self.mock_single_volumes[p]
 
@@ -64,7 +64,7 @@ class TestFindAssociatedDevices(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': vol}
 
         monkeypatch.setattr(migrate.api, 'get_lvs', self.mock_get_lvs)
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
         monkeypatch.setattr(process, 'call', lambda x, **kw: ('', '', 0))
 
         result = migrate.find_associated_devices(osd_id='0', osd_fsid='1234')
@@ -89,7 +89,7 @@ class TestFindAssociatedDevices(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': vol, '/dev/VolGroup/lv2': vol2}
 
         monkeypatch.setattr(migrate.api, 'get_lvs', self.mock_get_lvs)
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
         monkeypatch.setattr(process, 'call', lambda x, **kw: ('', '', 0))
 
         result = migrate.find_associated_devices(osd_id='0', osd_fsid='1234')
@@ -126,7 +126,7 @@ class TestFindAssociatedDevices(object):
                                     '/dev/VolGroup/lv3': vol3}
 
         monkeypatch.setattr(migrate.api, 'get_lvs', self.mock_get_lvs)
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
         monkeypatch.setattr(process, 'call', lambda x, **kw: ('', '', 0))
 
         result = migrate.find_associated_devices(osd_id='0', osd_fsid='1234')
@@ -159,7 +159,7 @@ class TestFindAssociatedDevices(object):
 
 class TestVolumeTagTracker(object):
     mock_single_volumes = {}
-    def mock_get_first_lv(self, *args, **kwargs):
+    def mock_get_single_lv(self, *args, **kwargs):
         p = kwargs['filters']['lv_path']
         return self.mock_single_volumes[p]
 
@@ -185,7 +185,7 @@ class TestVolumeTagTracker(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol,
                                     '/dev/VolGroup/lv2': db_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -233,7 +233,7 @@ class TestVolumeTagTracker(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol,
                                     '/dev/VolGroup/lv2': db_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -297,7 +297,7 @@ class TestVolumeTagTracker(object):
                                     '/dev/VolGroup/lv2': db_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -355,7 +355,7 @@ class TestVolumeTagTracker(object):
                                     '/dev/VolGroup/lv2': db_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -426,7 +426,7 @@ class TestVolumeTagTracker(object):
                                     '/dev/VolGroup/lv2': db_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -512,7 +512,7 @@ class TestNew(object):
         return ('', '', 0)
 
     mock_single_volumes = {}
-    def mock_get_first_lv(self, *args, **kwargs):
+    def mock_get_single_lv(self, *args, **kwargs):
         p = kwargs['filters']['lv_path']
         return self.mock_single_volumes[p]
 
@@ -590,8 +590,8 @@ class TestNew(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -681,8 +681,8 @@ class TestNew(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -746,8 +746,8 @@ class TestNew(object):
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol,
                                     '/dev/VolGroup/lv3': wal_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -826,7 +826,7 @@ class TestNew(object):
 
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -889,7 +889,7 @@ class TestNew(object):
 
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -937,7 +937,7 @@ class TestNew(object):
 
         self.mock_single_volumes = {'/dev/VolGroup/lv1': data_vol}
 
-        monkeypatch.setattr(migrate.api, 'get_first_lv', self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv', self.mock_get_single_lv)
 
         self.mock_process_input = []
         monkeypatch.setattr(process, 'call', self.mock_process)
@@ -1006,7 +1006,7 @@ class TestMigrate(object):
         return ('', '', 0)
 
     mock_single_volumes = {}
-    def mock_get_first_lv(self, *args, **kwargs):
+    def mock_get_single_lv(self, *args, **kwargs):
         p = kwargs['filters']['lv_path']
         return self.mock_single_volumes[p]
 
@@ -1042,8 +1042,8 @@ class TestMigrate(object):
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2', lv_uuid='y',
                                       vg_name='vg',
@@ -1168,8 +1168,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv1': data_vol,
             '/dev/VolGroup/lv2': db_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
                                       vg_name='vg',
@@ -1266,8 +1266,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv1': data_vol,
             '/dev/VolGroup/lv2': db_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
                                       vg_name='vg',
@@ -1329,8 +1329,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv1': data_vol,
             '/dev/VolGroup/lv2': db_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
                                       vg_name='vg',
@@ -1437,8 +1437,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
                                       vg_name='vg',
@@ -1561,8 +1561,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
                                       vg_name='vg',
@@ -1680,8 +1680,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv1': data_vol,
             '/dev/VolGroup/lv2': db_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = api.Volume(lv_name='volume2_new', lv_uuid='new-db-uuid',
                                       vg_name='vg',
@@ -1759,8 +1759,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = wal_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',
@@ -1835,8 +1835,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = db_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',
@@ -1911,8 +1911,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = db_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',
@@ -1982,8 +1982,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = db_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',
@@ -2063,8 +2063,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = db_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',
@@ -2162,8 +2162,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = db_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',
@@ -2234,8 +2234,8 @@ Example calls for supported scenarios:
             '/dev/VolGroup/lv2': db_vol,
             '/dev/VolGroup/lv3': wal_vol,
         }
-        monkeypatch.setattr(migrate.api, 'get_first_lv',
-            self.mock_get_first_lv)
+        monkeypatch.setattr(migrate.api, 'get_single_lv',
+            self.mock_get_single_lv)
 
         self.mock_volume = db_vol
         monkeypatch.setattr(api, 'get_lv_by_fullname',

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -124,6 +124,9 @@ class TestHumanReadableSize(object):
         result = disk.human_readable_size(81.2*1024*1024*1024*1024)
         assert result == '81.20 TB'
 
+    def test_petabytes(self):
+        result = disk.human_readable_size(9.23*1024*1024*1024*1024*1024)
+        assert result == '9.23 PB'
 
 class TestSizeFromHumanReadable(object):
 
@@ -143,9 +146,13 @@ class TestSizeFromHumanReadable(object):
         result = disk.size_from_human_readable('2 G')
         assert result == disk.Size(gb=2)
 
-    def test_terrabytes(self):
+    def test_terabytes(self):
         result = disk.size_from_human_readable('2 T')
         assert result == disk.Size(tb=2)
+
+    def test_petabytes(self):
+        result = disk.size_from_human_readable('2 P')
+        assert result == disk.Size(pb=2)
 
     def test_case(self):
         result = disk.size_from_human_readable('2 t')
@@ -182,9 +189,13 @@ class TestSizeParse(object):
         result = disk.Size.parse('2G')
         assert result == disk.Size(gb=2)
 
-    def test_terrabytes(self):
+    def test_terabytes(self):
         result = disk.Size.parse('2T')
         assert result == disk.Size(tb=2)
+
+    def test_petabytes(self):
+        result = disk.Size.parse('2P')
+        assert result == disk.Size(pb=2)
 
     def test_tb(self):
         result = disk.Size.parse('2Tb')

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -402,6 +402,8 @@ class FloatKB(BaseFloatUnit):
 class FloatTB(BaseFloatUnit):
     pass
 
+class FloatPB(BaseFloatUnit):
+    pass
 
 class Size(object):
     """
@@ -456,10 +458,10 @@ class Size(object):
     @classmethod
     def parse(cls, size):
         if (len(size) > 2 and
-            size[-2].lower() in ['k', 'm', 'g', 't'] and
+            size[-2].lower() in ['k', 'm', 'g', 't', 'p'] and
             size[-1].lower() == 'b'):
             return cls(**{size[-2:].lower(): float(size[0:-2])})
-        elif size[-1].lower() in ['b', 'k', 'm', 'g', 't']:
+        elif size[-1].lower() in ['b', 'k', 'm', 'g', 't', 'p']:
             return cls(**{size[-1].lower(): float(size[0:-1])})
         else:
             return cls(b=float(size))
@@ -474,6 +476,7 @@ class Size(object):
             [('m', 'mb', 'megabytes'), self._multiplier ** 2],
             [('g', 'gb', 'gigabytes'), self._multiplier ** 3],
             [('t', 'tb', 'terabytes'), self._multiplier ** 4],
+            [('p', 'pb', 'petabytes'), self._multiplier ** 5]
         ]
         # and mappings for units-to-formatters, including bytes and aliases for
         # each
@@ -483,6 +486,7 @@ class Size(object):
             [('mb', 'megabytes'), FloatMB],
             [('gb', 'gigabytes'), FloatGB],
             [('tb', 'terabytes'), FloatTB],
+            [('pb', 'petabytes'), FloatPB],
         ]
         self._formatters = {}
         for key, value in format_aliases:
@@ -516,7 +520,7 @@ class Size(object):
         than 1024. This allows to represent size in the most readable format
         available
         """
-        for unit in ['b', 'kb', 'mb', 'gb', 'tb']:
+        for unit in ['b', 'kb', 'mb', 'gb', 'tb', 'pb']:
             if getattr(self, unit) > 1024:
                 continue
             return getattr(self, unit)
@@ -632,14 +636,15 @@ def human_readable_size(size):
     Take a size in bytes, and transform it into a human readable size with up
     to two decimals of precision.
     """
-    suffixes = ['B', 'KB', 'MB', 'GB', 'TB']
-    suffix_index = 0
-    while size > 1024:
-        suffix_index += 1
-        size = size / 1024.0
+    suffixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+    for suffix in suffixes:
+        if size >= 1024:
+            size = size / 1024
+        else:
+            break
     return "{size:.2f} {suffix}".format(
         size=size,
-        suffix=suffixes[suffix_index])
+        suffix=suffix)
 
 
 def size_from_human_readable(s):
@@ -651,6 +656,8 @@ def size_from_human_readable(s):
     if s[-1].isdigit():
         return Size(b=float(s))
     n = float(s[:-1])
+    if s[-1].lower() == 'p':
+        return Size(pb=n)
     if s[-1].lower() == 't':
         return Size(tb=n)
     if s[-1].lower() == 'g':


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53371

---

backport of https://github.com/ceph/ceph/pull/43982
parent tracker: https://tracker.ceph.com/issues/48492

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh