### PR TITLE
mon: increase mon_down_mkfs_grace to 2m

### DIFF
--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -99,6 +99,9 @@
 	mon_warn_on_insecure_global_id_reclaim = false
 	mon_warn_on_insecure_global_id_reclaim_allowed = false
 
+	# 1m isn't quite enough
+	mon_down_mkfs_grace = 2m
+
 [client]
 	rgw cache enabled = true
 	rgw enable ops log = true


### PR DESCRIPTION
1m isn't quite enough for teuthology, mainly because ceph.py
creates the monmap, then does --mkfs on all mons and osds (to create
the initial keyring), and *then* starts the mons.

2m looks like it'll be enough for most cases.

sage-2021-12-02_14:45:50-rados-wip-sage2-testing-2021-12-01-2041-distro-basic-smithi/6540015

Signed-off-by: Sage Weil <sage@newdream.net>