### PR TITLE
ceph-volume: fix error 'KeyError' with inventory

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -8,7 +8,7 @@ import os
 import uuid
 from itertools import repeat
 from math import floor
-from ceph_volume import process, util
+from ceph_volume import process, util, conf
 from ceph_volume.exceptions import SizeAllocationError
 
 logger = logging.getLogger(__name__)
@@ -839,7 +839,7 @@ class Volume(object):
             report = {
                 'name': self.lv_name,
                 'osd_id': self.tags['ceph.osd_id'],
-                'cluster_name': self.tags['ceph.cluster_name'],
+                'cluster_name': self.tags.get('ceph.cluster_name', conf.cluster),
                 'type': type_,
                 'osd_fsid': self.tags['ceph.osd_fsid'],
                 'cluster_fsid': self.tags['ceph.cluster_fsid'],


### PR DESCRIPTION
The tag ceph.cluster_name is always set at the end.
The only way it could be absent was if the osd prepare
has been interrupted between [1] and [2].

[1] https://github.com/ceph/ceph/blob/v14.2.11/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py#L355-L387
[2] https://github.com/ceph/ceph/blob/v14.2.11/src/ceph-volume/ceph_volume/devices/lvm/prepare.py

Although the code received tremendous changes meantime
and this error shouldn't show up again, we need to handle
the case where this tag wouldn't have been set.

Fixes: https://tracker.ceph.com/issues/44356

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
