### PR TITLE
crimson/os/seastore: avoid onode/omap laddr hint conflicts as much as possible

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -65,3 +65,13 @@ options:
   level: dev
   desc: The record fullness threshold to flush a journal batch
   default: 0.95
+- name: seastore_default_max_object_size
+  type: uint
+  level: dev
+  desc: default logical address space reservation for seastore objects' data
+  default: 16777216
+- name: seastore_default_object_metadata_reservation
+  type: uint
+  level: dev
+  desc: default logical address space reservation for seastore objects' metadata
+  default: 16777216

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -10,8 +10,11 @@
 
 #include "crimson/common/log.h"
 #include "crimson/common/errorator.h"
-
+#ifndef NDEBUG
 #define INTR_FUT_DEBUG(FMT_MSG, ...) crimson::get_logger(ceph_subsys_).trace(FMT_MSG, ##__VA_ARGS__)
+#else
+#define INTR_FUT_DEBUG(FMT_MSG, ...)
+#endif
 
 // The interrupt condition generally works this way:
 //

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -24,7 +24,7 @@ namespace crimson::os::seastore {
  * mappings (necessary for clone), we'll add the ability to grow and shrink
  * these regions and remove this assumption.
  */
-static constexpr extent_len_t MAX_OBJECT_SIZE = 16<<20;
+static constexpr extent_len_t MAX_OBJECT_SIZE = Onode::DEFAULT_DATA_RESERVATION;
 #define assert_aligned(x) ceph_assert(((x)%ctx.tm.get_block_size()) == 0)
 
 using context_t = ObjectDataHandler::context_t;
@@ -272,11 +272,11 @@ ObjectDataHandler::write_ret ObjectDataHandler::prepare_data_reservation(
   } else {
     DEBUGT("reserving: {}~{}",
            ctx.t,
-           ctx.onode.get_hint(),
+           ctx.onode.get_data_hint(),
            MAX_OBJECT_SIZE);
     return ctx.tm.reserve_region(
       ctx.t,
-      ctx.onode.get_hint(),
+      ctx.onode.get_data_hint(),
       MAX_OBJECT_SIZE
     ).si_then([&object_data](auto pin) {
       ceph_assert(pin->get_length() == MAX_OBJECT_SIZE);

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -50,6 +50,8 @@ class ObjectDataHandler {
 public:
   using base_iertr = TransactionManager::base_iertr;
 
+  ObjectDataHandler(uint32_t mos) : max_object_size(mos) {}
+
   struct context_t {
     TransactionManager &tm;
     Transaction &t;
@@ -104,6 +106,16 @@ private:
     context_t ctx,
     object_data_t &object_data,
     extent_len_t size);
+private:
+  /**
+   * max_object_size
+   *
+   * For now, we allocate a fixed region of laddr space of size max_object_size
+   * for any object.  In the future, once we have the ability to remap logical
+   * mappings (necessary for clone), we'll add the ability to grow and shrink
+   * these regions and remove this assumption.
+   */
+  const uint32_t max_object_size = 0;
 };
 
 }

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -54,19 +54,23 @@ class Onode : public boost::intrusive_ref_counter<
 {
 protected:
   virtual laddr_t get_hint() const = 0;
+  const uint32_t default_metadata_offset = 0;
+  const uint32_t default_metadata_range = 0;
 public:
-  static constexpr uint32_t DEFAULT_DATA_RESERVATION = 16<<20;
-  static constexpr uint32_t DEFAULT_METADATA_OFFSET =
-    DEFAULT_DATA_RESERVATION;
-  static constexpr uint32_t DEFAULT_METADATA_RANGE = 16<<20;
+  Onode(uint32_t ddr, uint32_t dmr)
+    : default_metadata_offset(ddr),
+      default_metadata_range(dmr)
+  {}
 
   virtual const onode_layout_t &get_layout() const = 0;
   virtual onode_layout_t &get_mutable_layout(Transaction &t) = 0;
   virtual ~Onode() = default;
 
   laddr_t get_metadata_hint() const {
-    return get_hint() + DEFAULT_METADATA_OFFSET +
-      ((uint32_t)std::rand() % DEFAULT_METADATA_RANGE);
+    assert(default_metadata_offset);
+    assert(default_metadata_range);
+    return get_hint() + default_metadata_offset +
+      ((uint32_t)std::rand() % default_metadata_range);
   }
   laddr_t get_data_hint() const {
     return get_hint();

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -52,12 +52,25 @@ class Onode : public boost::intrusive_ref_counter<
   Onode,
   boost::thread_unsafe_counter>
 {
+protected:
+  virtual laddr_t get_hint() const = 0;
 public:
+  static constexpr uint32_t DEFAULT_DATA_RESERVATION = 16<<20;
+  static constexpr uint32_t DEFAULT_METADATA_OFFSET =
+    DEFAULT_DATA_RESERVATION;
+  static constexpr uint32_t DEFAULT_METADATA_RANGE = 16<<20;
 
   virtual const onode_layout_t &get_layout() const = 0;
   virtual onode_layout_t &get_mutable_layout(Transaction &t) = 0;
   virtual ~Onode() = default;
-  virtual laddr_t get_hint() const = 0;
+
+  laddr_t get_metadata_hint() const {
+    return get_hint() + DEFAULT_METADATA_OFFSET +
+      ((uint32_t)std::rand() % DEFAULT_METADATA_RANGE);
+  }
+  laddr_t get_data_hint() const {
+    return get_hint();
+  }
 };
 
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
@@ -27,7 +27,10 @@ FLTreeOnodeManager::get_onode_ret FLTreeOnodeManager::get_onode(
       DEBUGT("no entry for {}", trans, hoid);
       return crimson::ct_error::enoent::make();
     }
-    auto val = OnodeRef(new FLTreeOnode(cursor.value()));
+    auto val = OnodeRef(new FLTreeOnode(
+	default_data_reservation,
+	default_metadata_range,
+	cursor.value()));
     return get_onode_iertr::make_ready_future<OnodeRef>(
       val
     );
@@ -43,10 +46,13 @@ FLTreeOnodeManager::get_or_create_onode(
   return tree.insert(
     trans, hoid,
     OnodeTree::tree_value_config_t{sizeof(onode_layout_t)}
-  ).si_then([&trans, &hoid, FNAME](auto p)
+  ).si_then([this, &trans, &hoid, FNAME](auto p)
               -> get_or_create_onode_ret {
     auto [cursor, created] = std::move(p);
-    auto val = OnodeRef(new FLTreeOnode(cursor.value()));
+    auto val = OnodeRef(new FLTreeOnode(
+	default_data_reservation,
+	default_metadata_range,
+	cursor.value()));
     if (created) {
       DEBUGT("created onode for entry for {}", trans, hoid);
       val->get_mutable_layout(trans) = onode_layout_t{};

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -37,7 +37,14 @@ struct FLTreeOnode final : Onode, Value {
   FLTreeOnode& operator=(const FLTreeOnode&) = delete;
 
   template <typename... T>
-  FLTreeOnode(T&&... args) : Value(std::forward<T>(args)...) {}
+  FLTreeOnode(uint32_t ddr, uint32_t dmr, T&&... args)
+    : Onode(ddr, dmr),
+      Value(std::forward<T>(args)...) {}
+
+  template <typename... T>
+  FLTreeOnode(T&&... args)
+    : Onode(0, 0),
+      Value(std::forward<T>(args)...) {}
 
   struct Recorder : public ValueDeltaRecorder {
     Recorder(bufferlist &bl) : ValueDeltaRecorder(bl) {}
@@ -102,12 +109,23 @@ struct FLTreeOnode final : Onode, Value {
 
 using OnodeTree = Btree<FLTreeOnode>;
 
+using crimson::common::get_conf;
+
 class FLTreeOnodeManager : public crimson::os::seastore::OnodeManager {
   OnodeTree tree;
 
+  uint32_t default_data_reservation = 0;
+  uint32_t default_metadata_offset = 0;
+  uint32_t default_metadata_range = 0;
 public:
   FLTreeOnodeManager(TransactionManager &tm) :
-    tree(NodeExtentManager::create_seastore(tm)) {}
+    tree(NodeExtentManager::create_seastore(tm)),
+    default_data_reservation(
+      get_conf<uint64_t>("seastore_default_max_object_size")),
+    default_metadata_offset(default_data_reservation),
+    default_metadata_range(
+      get_conf<uint64_t>("seastore_default_object_metadata_reservation"))
+  {}
 
   mkfs_ret mkfs(Transaction &t) {
     return tree.mkfs(t);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -509,7 +509,7 @@ SeaStore::get_attr_errorator::future<ceph::bufferlist> SeaStore::get_attr(
       }
       return _omap_get_value(
         t,
-        layout.xattr_root.get(onode.get_hint()),
+        layout.xattr_root.get(onode.get_metadata_hint()),
         name);
     }
   ).handle_error(crimson::ct_error::input_output_error::handle([FNAME] {
@@ -607,7 +607,8 @@ SeaStore::omap_get_values(
     "omap_get_values",
     op_type_t::OMAP_GET_VALUES,
     [this, keys](auto &t, auto &onode) {
-      omap_root_t omap_root = onode.get_layout().omap_root.get(onode.get_hint());
+      omap_root_t omap_root = onode.get_layout().omap_root.get(
+	onode.get_metadata_hint());
       return _omap_get_values(
 	t,
 	std::move(omap_root),
@@ -685,7 +686,7 @@ SeaStore::_omap_list_ret SeaStore::_omap_list(
   const std::optional<std::string>& start,
   OMapManager::omap_list_config_t config) const
 {
-  auto root = omap_root.get(onode.get_hint());
+  auto root = omap_root.get(onode.get_metadata_hint());
   if (root.is_null()) {
     return seastar::make_ready_future<_omap_list_bare_ret>(
       true, omap_values_t{}
@@ -1089,13 +1090,13 @@ SeaStore::_omap_set_kvs(
 {
   return seastar::do_with(
     BtreeOMapManager(*transaction_manager),
-    omap_root.get(onode->get_hint()),
+    omap_root.get(onode->get_metadata_hint()),
     [&, keys=std::move(kvs)](auto &omap_manager, auto &root) {
       tm_iertr::future<> maybe_create_root =
         !root.is_null() ?
         tm_iertr::now() :
         omap_manager.initialize_omap(
-          t, onode->get_hint()
+          t, onode->get_metadata_hint()
         ).si_then([&root](auto new_root) {
           root = new_root;
         });
@@ -1146,13 +1147,13 @@ SeaStore::tm_ret SeaStore::_omap_rmkeys(
 {
   LOG_PREFIX(SeaStore::_omap_rmkeys);
   DEBUGT("{} {} keys", *ctx.transaction, *onode, keys.size());
-  auto omap_root = onode->get_layout().omap_root.get(onode->get_hint());
+  auto omap_root = onode->get_layout().omap_root.get(onode->get_metadata_hint());
   if (omap_root.is_null()) {
     return seastar::now();
   } else {
     return seastar::do_with(
       BtreeOMapManager(*transaction_manager),
-      onode->get_layout().omap_root.get(onode->get_hint()),
+      onode->get_layout().omap_root.get(onode->get_metadata_hint()),
       std::move(keys),
       [&ctx, &onode](
 	auto &omap_manager,

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -305,6 +305,7 @@ private:
   TransactionManagerRef transaction_manager;
   CollectionManagerRef collection_manager;
   OnodeManagerRef onode_manager;
+  const uint32_t max_object_size = 0;
 
   using tm_iertr = TransactionManager::base_iertr;
   using tm_ret = tm_iertr::future<>;

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -31,15 +31,15 @@ struct onode_item_t {
   void initialize(Transaction& t, Onode& value) const {
     auto& layout = value.get_mutable_layout(t);
     layout.size = size;
-    layout.omap_root.update(omap_root_t(id, cnt_modify, value.get_hint()));
+    layout.omap_root.update(omap_root_t(id, cnt_modify, value.get_metadata_hint()));
     validate(value);
   }
 
   void validate(Onode& value) const {
     auto& layout = value.get_layout();
     ceph_assert(laddr_t(layout.size) == laddr_t{size});
-    ceph_assert(layout.omap_root.get(value.get_hint()).addr == id);
-    ceph_assert(layout.omap_root.get(value.get_hint()).depth == cnt_modify);
+    ceph_assert(layout.omap_root.get(value.get_metadata_hint()).addr == id);
+    ceph_assert(layout.omap_root.get(value.get_metadata_hint()).depth == cnt_modify);
   }
 
   void modify(Transaction& t, Onode& value) {


### PR DESCRIPTION
When profiling crimson-osd + seastore, we found that `BtreeLBAManager::alloc_extent` occupied much of cpu time. It seems that this is because there are many conflicts when trying to alloc omap onodes.

The following is the cpu time overhead of `BtreeLBAManager::alloc_extent` before and after this pr's optimization(purple blocks correspond to `BtreeLBAManager::alloc_extent`):
Before:
![image](https://user-images.githubusercontent.com/3112624/144988456-ac3a7d5a-1239-4de2-8125-58b142e59c01.png)

After:
![image](https://user-images.githubusercontent.com/3112624/144988518-b36728b0-e3bd-4eb5-9fdc-02322c46e811.png)

Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
