### PR TITLE
rbd: add persistent-cache command group

### DIFF
--- a/doc/rbd/rbd-persistent-write-log-cache.rst
+++ b/doc/rbd/rbd-persistent-write-log-cache.rst
@@ -99,20 +99,20 @@ For example::
                 hit_bytes: 192 MiB / 66%
                 miss_bytes: 97 MiB
 
-Discard Cache
--------------
+Invalidate Cache
+----------------
 
-To discard a cache file with ``rbd``, specify the ``image-cache invalidate``
-option, the pool name and the image name.  ::
+To invalidate (discard) a cache file with ``rbd``, specify the
+``persistent-cache invalidate`` command, the pool name and the image name.  ::
 
-        rbd image-cache invalidate {pool-name}/{image-name}
+        rbd persistent-cache invalidate {pool-name}/{image-name}
 
-The command removes the cache metadata of the corresponding image, disable
+The command removes the cache metadata of the corresponding image, disables
 the cache feature and deletes the local cache file if it exists.
 
 For example::
 
-        $ rbd image-cache invalidate rbd/foo
+        $ rbd persistent-cache invalidate rbd/foo
 
 .. _section: ../../rados/configuration/ceph-conf/#configuration-sections
 .. _commands: ../../man/8/rbd#commands

--- a/doc/rbd/rbd-persistent-write-log-cache.rst
+++ b/doc/rbd/rbd-persistent-write-log-cache.rst
@@ -99,6 +99,21 @@ For example::
                 hit_bytes: 192 MiB / 66%
                 miss_bytes: 97 MiB
 
+Flush Cache
+-----------
+
+To flush a cache file with ``rbd``, specify the ``persistent-cache flush``
+command, the pool name and the image name.  ::
+
+        rbd persistent-cache flush {pool-name}/{image-name}
+
+If the application dies unexpectedly, this command can also be used to flush
+the cache back to OSDs.
+
+For example::
+
+        $ rbd persistent-cache flush rbd/foo
+
 Invalidate Cache
 ----------------
 

--- a/src/librbd/cache/Types.h
+++ b/src/librbd/cache/Types.h
@@ -20,7 +20,7 @@ enum ImageCacheType {
 
 typedef std::list<Context *> Contexts;
 
-const std::string IMAGE_CACHE_STATE = ".librbd/image_cache_state";
+const std::string PERSISTENT_CACHE_STATE = ".rbd_persistent_cache_state";
 
 } // namespace cache
 } // namespace librbd

--- a/src/librbd/cache/pwl/DiscardRequest.cc
+++ b/src/librbd/cache/pwl/DiscardRequest.cc
@@ -68,7 +68,13 @@ void DiscardRequest<I>::delete_image_cache_file() {
   if (m_cache_state->present &&
       !m_cache_state->host.compare(ceph_get_short_hostname()) &&
       fs::exists(m_cache_state->path)) {
-    fs::remove(m_cache_state->path);
+    std::error_code ec;
+    fs::remove(m_cache_state->path, ec);
+    if (ec) {
+      lderr(cct) << "failed to remove persistent cache file: " << ec.message()
+                 << dendl;
+      // not fatal
+    }
   }
 
   remove_image_cache_state();

--- a/src/librbd/cache/pwl/DiscardRequest.cc
+++ b/src/librbd/cache/pwl/DiscardRequest.cc
@@ -113,10 +113,6 @@ void DiscardRequest<I>::remove_feature_bit() {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 10) << dendl;
 
-  if (!(m_image_ctx.features &&RBD_FEATURE_DIRTY_CACHE)) {
-    finish();
-    return;
-  }
   uint64_t new_features = m_image_ctx.features & ~RBD_FEATURE_DIRTY_CACHE;
   uint64_t features_mask = RBD_FEATURE_DIRTY_CACHE;
   ldout(cct, 10) << "old_features=" << m_image_ctx.features

--- a/src/librbd/cache/pwl/ImageCacheState.cc
+++ b/src/librbd/cache/pwl/ImageCacheState.cc
@@ -85,7 +85,7 @@ void ImageCacheState<I>::write_image_cache_state(Context *on_finish) {
 
   ldout(m_image_ctx->cct, 20) << __func__ << " Store state: "
                               << image_state_json << dendl;
-  m_plugin_api.execute_image_metadata_set(m_image_ctx, IMAGE_CACHE_STATE,
+  m_plugin_api.execute_image_metadata_set(m_image_ctx, PERSISTENT_CACHE_STATE,
                                           image_state_json, on_finish);
 }
 
@@ -94,7 +94,7 @@ void ImageCacheState<I>::clear_image_cache_state(Context *on_finish) {
   std::shared_lock owner_lock{m_image_ctx->owner_lock};
   ldout(m_image_ctx->cct, 20) << __func__ << " Remove state: " << dendl;
   m_plugin_api.execute_image_metadata_remove(
-    m_image_ctx, IMAGE_CACHE_STATE, on_finish);
+    m_image_ctx, PERSISTENT_CACHE_STATE, on_finish);
 }
 
 template <typename I>
@@ -107,7 +107,7 @@ ImageCacheState<I>* ImageCacheState<I>::create_image_cache_state(
   bool dirty_cache = plugin_api.test_image_features(image_ctx, RBD_FEATURE_DIRTY_CACHE);
   if (dirty_cache) {
     cls_client::metadata_get(&image_ctx->md_ctx, image_ctx->header_oid,
-                             IMAGE_CACHE_STATE, &cache_state_str);
+                             PERSISTENT_CACHE_STATE, &cache_state_str);
   }
 
   ldout(image_ctx->cct, 20) << "image_cache_state: " << cache_state_str << dendl;
@@ -155,7 +155,7 @@ ImageCacheState<I>* ImageCacheState<I>::get_image_cache_state(
   ImageCacheState<I>* cache_state = nullptr;
   string cache_state_str;
   cls_client::metadata_get(&image_ctx->md_ctx, image_ctx->header_oid,
-			   IMAGE_CACHE_STATE, &cache_state_str);
+			   PERSISTENT_CACHE_STATE, &cache_state_str);
   if (!cache_state_str.empty()) {
     // ignore errors, best effort
     cache_state = new ImageCacheState<I>(image_ctx, plugin_api);

--- a/src/librbd/cache/pwl/ShutdownRequest.cc
+++ b/src/librbd/cache/pwl/ShutdownRequest.cc
@@ -132,7 +132,7 @@ void ShutdownRequest<I>::send_remove_image_cache_state() {
   Context *ctx = create_context_callback<klass, &klass::handle_remove_image_cache_state>(
     this);
   std::shared_lock owner_lock{m_image_ctx.owner_lock};
-  m_plugin_api.execute_image_metadata_remove(&m_image_ctx, IMAGE_CACHE_STATE, ctx);
+  m_plugin_api.execute_image_metadata_remove(&m_image_ctx, PERSISTENT_CACHE_STATE, ctx);
 }
 
 template <typename I>

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -56,7 +56,6 @@
       group snap remove (... rm)        Remove a snapshot from a group.
       group snap rename                 Rename group's snapshot.
       group snap rollback               Rollback group to snapshot.
-      image-cache invalidate            Discard existing / dirty image cache
       image-meta get                    Image metadata get the value associated
                                         with the key.
       image-meta list (image-meta ls)   Image metadata list keys with values.
@@ -125,6 +124,8 @@
       object-map rebuild                Rebuild an invalid object map.
       perf image iostat                 Display image IO statistics.
       perf image iotop                  Display a top-like IO monitor.
+      persistent-cache invalidate       Invalidate (discard) existing / dirty
+                                        persistent cache.
       pool init                         Initialize pool for use by RBD.
       pool stats                        Display pool statistics.
       remove (rm)                       Delete an image.
@@ -1106,23 +1107,6 @@
     --namespace arg      namespace name
     --group arg          group name
     --snap arg           snapshot name
-  
-  rbd help image-cache invalidate
-  usage: rbd image-cache invalidate [--pool <pool>] [--namespace <namespace>] 
-                                    [--image <image>] [--image-id <image-id>] 
-                                    <image-spec> 
-  
-  Discard existing / dirty image cache
-  
-  Positional arguments
-    <image-spec>         image specification
-                         (example: [<pool-name>/[<namespace>/]]<image-name>)
-  
-  Optional arguments
-    -p [ --pool ] arg    pool name
-    --namespace arg      namespace name
-    --image arg          image name
-    --image-id arg       image id
   
   rbd help image-meta get
   usage: rbd image-meta get [--pool <pool>] [--namespace <namespace>] 
@@ -2123,6 +2107,25 @@
   Optional arguments
     -p [ --pool ] arg    pool name
     --namespace arg      namespace name
+  
+  rbd help persistent-cache invalidate
+  usage: rbd persistent-cache invalidate
+                                        [--pool <pool>] 
+                                        [--namespace <namespace>] 
+                                        [--image <image>] [--image-id <image-id>] 
+                                        <image-spec> 
+  
+  Invalidate (discard) existing / dirty persistent cache.
+  
+  Positional arguments
+    <image-spec>         image specification
+                         (example: [<pool-name>/[<namespace>/]]<image-name>)
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    --namespace arg      namespace name
+    --image arg          image name
+    --image-id arg       image id
   
   rbd help pool init
   usage: rbd pool init [--pool <pool>] [--force] 

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -124,6 +124,7 @@
       object-map rebuild                Rebuild an invalid object map.
       perf image iostat                 Display image IO statistics.
       perf image iotop                  Display a top-like IO monitor.
+      persistent-cache flush            Flush persistent cache.
       persistent-cache invalidate       Invalidate (discard) existing / dirty
                                         persistent cache.
       pool init                         Initialize pool for use by RBD.
@@ -2107,6 +2108,23 @@
   Optional arguments
     -p [ --pool ] arg    pool name
     --namespace arg      namespace name
+  
+  rbd help persistent-cache flush
+  usage: rbd persistent-cache flush [--pool <pool>] [--namespace <namespace>] 
+                                    [--image <image>] [--image-id <image-id>] 
+                                    <image-spec> 
+  
+  Flush persistent cache.
+  
+  Positional arguments
+    <image-spec>         image specification
+                         (example: [<pool-name>/[<namespace>/]]<image-name>)
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    --namespace arg      namespace name
+    --image arg          image name
+    --image-id arg       image id
   
   rbd help persistent-cache invalidate
   usage: rbd persistent-cache invalidate

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -26,7 +26,6 @@ set(rbd_srcs
   action/Flatten.cc
   action/Ggate.cc
   action/Group.cc
-  action/ImageCache.cc
   action/ImageMeta.cc
   action/Import.cc
   action/Info.cc
@@ -43,6 +42,7 @@ set(rbd_srcs
   action/Nbd.cc
   action/ObjectMap.cc
   action/Perf.cc
+  action/PersistentCache.cc
   action/Pool.cc
   action/Remove.cc
   action/Rename.cc

--- a/src/tools/rbd/action/PersistentCache.cc
+++ b/src/tools/rbd/action/PersistentCache.cc
@@ -59,10 +59,63 @@ int execute_invalidate(const po::variables_map &vm,
   return 0;
 }
 
+void get_arguments_flush(po::options_description *positional,
+                         po::options_description *options) {
+  at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_image_id_option(options);
+}
+
+int execute_flush(const po::variables_map &vm,
+                  const std::vector<std::string> &ceph_global_init_args) {
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string namespace_name;
+  std::string image_name;
+  std::string snap_name;
+  int r = utils::get_pool_image_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &namespace_name,
+    &image_name, &snap_name, true, utils::SNAPSHOT_PRESENCE_NONE,
+    utils::SPEC_VALIDATION_NONE);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  librbd::Image image;
+  r = utils::init_and_open_image(pool_name, namespace_name, image_name, "", "",
+                                 false, &rados, &io_ctx, &image);
+  if (r < 0) {
+    return r;
+  }
+
+  uint64_t features;
+  r = image.features(&features);
+  if (r < 0) {
+    return r;
+  }
+
+  if (features & RBD_FEATURE_DIRTY_CACHE) {
+    r = image.flush();
+    if (r < 0) {
+      std::cerr << "rbd: flushing persistent cache failed: "
+                << cpp_strerror(r) << std::endl;
+      return r;
+    }
+  } else {
+    std::cout << "rbd: persistent cache is clean or disabled" << std::endl;
+  }
+
+  return 0;
+}
+
 Shell::Action action_invalidate(
   {"persistent-cache", "invalidate"}, {},
   "Invalidate (discard) existing / dirty persistent cache.", "",
   &get_arguments_invalidate, &execute_invalidate);
+Shell::Action action_flush(
+  {"persistent-cache", "flush"}, {}, "Flush persistent cache.", "",
+  &get_arguments_flush, &execute_flush);
 
 } // namespace persistent_cache
 } // namespace action

--- a/src/tools/rbd/action/Status.cc
+++ b/src/tools/rbd/action/Status.cc
@@ -9,6 +9,7 @@
 #include "tools/rbd/Utils.h"
 #include "include/rbd_types.h"
 #include "include/stringify.h"
+#include "librbd/cache/Types.h"
 #include <iostream>
 #include <boost/program_options.hpp>
 
@@ -18,12 +19,6 @@ namespace status {
 
 namespace at = argument_types;
 namespace po = boost::program_options;
-
-namespace {
-
-const std::string IMAGE_CACHE_STATE = ".librbd/image_cache_state";
-
-} // anonymous namespace
 
 static int do_show_status(librados::IoCtx& io_ctx, const std::string &image_name,
                           librbd::Image &image, Formatter *f)
@@ -133,7 +128,7 @@ static int do_show_status(librados::IoCtx& io_ctx, const std::string &image_name
   } cache_state;
   std::string cache_str;
   if (features & RBD_FEATURE_DIRTY_CACHE) {
-    r = image.metadata_get(IMAGE_CACHE_STATE, &cache_str);
+    r = image.metadata_get(librbd::cache::PERSISTENT_CACHE_STATE, &cache_str);
     if (r < 0) {
       std::cerr << "rbd: getting persistent cache state failed: " << cpp_strerror(r)
                 << std::endl;


### PR DESCRIPTION
Update command for persistent cache.
`invalidate` command can discard cache and reset image cache state. If
cache file is lost, users can use this command to reset pwl image cache
state, which avoids the inability to use the cache due to file loss.

`flush `command can write cache files back to the osd. Explicitly
write back data.

update `help.t` and document.

Signed-off-by: Yin Congmin <congmin.yin@intel.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
