### PR TITLE
ceph-volume: make it possible to skip needs_root()

### DIFF
--- a/src/ceph-volume/ceph_volume/decorators.py
+++ b/src/ceph-volume/ceph_volume/decorators.py
@@ -11,7 +11,7 @@ def needs_root(func):
     """
     @wraps(func)
     def is_root(*a, **kw):
-        if not os.getuid() == 0:
+        if not os.getuid() == 0 and not os.environ.get('CEPH_VOLUME_SKIP_NEEDS_ROOT', False):
             raise exceptions.SuperUserError()
         return func(*a, **kw)
     return is_root

--- a/src/ceph-volume/ceph_volume/tests/test_decorators.py
+++ b/src/ceph-volume/ceph_volume/tests/test_decorators.py
@@ -11,6 +11,13 @@ class TestNeedsRoot(object):
         monkeypatch.setattr(decorators.os, 'getuid', lambda: 0)
         assert decorators.needs_root(func)() is True
 
+    def test_is_not_root_env_var_skip_needs_root(self, monkeypatch):
+        def func():
+            return True
+        monkeypatch.setattr(decorators.os, 'getuid', lambda: 123)
+        monkeypatch.setattr(decorators.os, 'environ', {'CEPH_VOLUME_SKIP_NEEDS_ROOT': '1'})
+        assert decorators.needs_root(func)() is True
+
     def test_is_not_root(self, monkeypatch):
         def func():
             return True # pragma: no cover


### PR DESCRIPTION
Add the possibility to skip the `needs_root()` decorator.
See linked tracker for details.

Fixes: https://tracker.ceph.com/issues/53511

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
