### PR TITLE
crimson/osd: fix heartbeat front and back blank ip

### DIFF
--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -36,12 +36,14 @@ using Throttle = crimson::common::Throttle;
 using SocketPolicy = ceph::net::Policy<Throttle>;
 
 class Messenger {
-  entity_name_t my_name;
-  entity_addrvec_t my_addrs;
   uint32_t crc_flags = 0;
   crimson::auth::AuthClient* auth_client = nullptr;
   crimson::auth::AuthServer* auth_server = nullptr;
   bool require_authorizer = true;
+
+protected:
+  entity_name_t my_name;
+  entity_addrvec_t my_addrs;
 
 public:
   Messenger(const entity_name_t& name)
@@ -61,6 +63,7 @@ public:
     my_addrs = addrs;
     return seastar::now();
   }
+  virtual bool set_addr_unknowns(const entity_addrvec_t &addrs) = 0;
 
   using bind_ertr = crimson::errorator<
     crimson::ct_error::address_in_use, // The address (range) is already bound

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -63,6 +63,7 @@ class SocketMessenger final : public Messenger {
 
   seastar::future<> set_myaddrs(const entity_addrvec_t& addr) override;
 
+  bool set_addr_unknowns(const entity_addrvec_t &addr) override;
   // Messenger interfaces are assumed to be called from its own shard, but its
   // behavior should be symmetric when called from any shard.
   bind_ertr::future<> bind(const entity_addrvec_t& addr) override;

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -107,6 +107,16 @@ const entity_addrvec_t& Heartbeat::get_back_addrs() const
   return back_msgr->get_myaddrs();
 }
 
+crimson::net::MessengerRef Heartbeat::get_front_msgr() const
+{
+  return front_msgr;
+}
+
+crimson::net::MessengerRef Heartbeat::get_back_msgr() const
+{
+  return back_msgr;
+}
+
 void Heartbeat::set_require_authorizer(bool require_authorizer)
 {
   if (front_msgr->get_require_authorizer() != require_authorizer) {

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -45,6 +45,8 @@ public:
   const entity_addrvec_t& get_front_addrs() const;
   const entity_addrvec_t& get_back_addrs() const;
 
+  crimson::net::MessengerRef get_front_msgr() const;
+  crimson::net::MessengerRef get_back_msgr() const;
   void set_require_authorizer(bool);
 
   // Dispatcher methods


### PR DESCRIPTION
when ceph.conf not set public ip & cluster ip, heartbeat will get blank ip address. when osd::_send_boot , classic osd will check if heartbeat front and back addrs are blank ip, if they are blank ip, will use public ip which is learned from mon to set into them. So implement them in crimson osd.

Signed-off-by: chunmei-liu <chunmei.liu@intel.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
