### PR TITLE
seastar: pick up change to fix FTBFS with old cryptopp

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -103,7 +103,7 @@ seastar::future<> make_keyring()
     if (exists &&
         keyring.load(nullptr, path) == 0 &&
         keyring.get_auth(name, auth)) {
-      seastar::fprint(std::cerr, "already have key in keyring: %s\n", path);
+      fmt::print(std::cerr, "already have key in keyring: {}\n", path);
       return seastar::now();
     } else {
       auth.key.create(std::make_unique<CephContext>().get(), CEPH_CRYPTO_AES);
@@ -115,7 +115,7 @@ seastar::future<> make_keyring()
       return crimson::write_file(std::move(bl), path, permissions);
     }
   }).handle_exception_type([path](const std::filesystem::filesystem_error& e) {
-    seastar::fprint(std::cerr, "FATAL: writing new keyring to %s: %s\n", path, e.what());
+    fmt::print(std::cerr, "FATAL: writing new keyring to {}: {}\n", path, e.what());
     throw e;
   });
 }
@@ -167,7 +167,7 @@ seastar::future<> fetch_config()
       msgr->shutdown().get();
     });
     monc.start().handle_exception([] (auto ep) {
-      seastar::fprint(std::cerr, "FATAL: unable to connect to cluster: {}\n", ep);
+      fmt::print(std::cerr, "FATAL: unable to connect to cluster: {}\n", ep);
       return seastar::make_exception_future<>(ep);
     }).get();
     auto stop_monc = seastar::defer([&] {
@@ -359,7 +359,7 @@ int main(int argc, char* argv[])
       });
     });
   } catch (...) {
-    seastar::fprint(std::cerr, "FATAL: Exception during startup, aborting: %s\n", std::current_exception());
+    fmt::print(std::cerr, "FATAL: Exception during startup, aborting: {}\n", std::current_exception());
     return EXIT_FAILURE;
   }
 }


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kefu@xsky.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
