### PR TITLE
mgr/telemetry: introduce new design for varying report data

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -111,6 +111,16 @@
 
   https://docs.ceph.com/en/latest/rados/operations/placement-groups/
 
+* telemetry: Improved the opt-in flow so that users can keep sharing the same
+  data, even when new data collections are available. A new 'perf' channel
+  that collects various performance metrics is now avaiable to opt-in to with:
+  `ceph telemetry on`
+  `ceph telemetry enable channel perf`
+  See a sample report with `ceph telemetry preview`
+  For more details, see:
+
+  https://docs.ceph.com/en/latest/mgr/telemetry/
+
 >=16.0.0
 --------
 * mgr/nfs: ``nfs`` module is moved out of volumes plugin. Prior using the

--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -178,29 +178,23 @@ List all collections with::
 
   ceph telemetry collection ls
 
-  NAME                  ENROLLED    STATUS    DEFAULT    DESC
-  basic_base            FALSE       OFF       ON         Basic information about the cluster (capacity, number and type of daemons, version, etc.)
-  basic_mds_metadata    FALSE       OFF       ON         MDS metadata
-  crash_base            FALSE       OFF       ON         Information about daemon crashes (daemon type and version, backtrace, etc.)
-  device_base           FALSE       OFF       ON         Information about device health metrics
-  ident_base            FALSE       OFF       OFF        User-provided identifying information about the cluster
-  perf_perf             FALSE       OFF       OFF        Information about performance of the cluster
+  NAME                  STATUS                                               DESC
+  basic_base            REPORTING                                            Basic information about the cluster (capacity, number and type of daemons, version, etc.)
+  basic_mds_metadata    NOT REPORTING: NOT OPTED-IN                          MDS metadata
+  crash_base            REPORTING                                            Information about daemon crashes (daemon type and version, backtrace, etc.)
+  device_base           REPORTING                                            Information about device health metrics
+  ident_base            NOT REPORTING: CHANNEL ident IS OFF                  User-provided identifying information about the cluster
+  perf_perf             NOT REPORTING: NOT OPTED-IN, CHANNEL perf IS OFF     Information about performance counters of the cluster
+
 
 Where:
 
 **NAME**: Collection name; prefix indicates the channel the collection belongs to.
 
-**ENROLLED**: Signifies the collections that were available in the module when
-the user last opted-in to telemetry. Please note: Even if a collection is
-'enrolled', its metrics will be reported only if its channel is enabled.
-The STATUS column indicates whether the collection is being reported.
-
 **STATUS**: Indicates whether the collection metrics are reported; this is
 determined by the status (enabled / disabled) of the channel the collection
-belongs to, along with the enrollment status of the collection.
-
-**DEFAULT**: The default status (enabled / disabled) of the channel the
-collection belongs to.
+belongs to, along with the enrollment status of the collection (whether the user
+is opted-in to this collection).
 
 **DESC**: General description of the collection.
 

--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -83,6 +83,11 @@ Multiple channels can be enabled or disabled with::
   ceph telemetry enable channel basic crash device ident perf
   ceph telemetry disable channel basic crash device ident perf
 
+Channels can be enabled or disabled all at once with::
+
+  ceph telemetry enable channel all
+  ceph telemetry disable channel all
+
 Please note that telemetry should be on for these commands to take effect.
 
 List all channels with::

--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -64,37 +64,38 @@ the way Ceph is used.
 
 Data is sent secured to *https://telemetry.ceph.com*.
 
-Sample report
--------------
-
-You can look at what data is reported at any time with the command::
-
-  ceph telemetry show
-
-To protect your privacy, device reports are generated separately, and data such
-as hostname and device serial number is anonymized. The device telemetry is
-sent to a different endpoint and does not associate the device data with a
-particular cluster. To see a preview of the device report use the command::
-
-  ceph telemetry show-device
-
-Please note: In order to generate the device report we use Smartmontools
-version 7.0 and up, which supports JSON output. 
-If you have any concerns about privacy with regard to the information included in
-this report, please contact the Ceph developers.
-
-Channels
---------
-
 Individual channels can be enabled or disabled with::
 
-  ceph config set mgr mgr/telemetry/channel_ident false
-  ceph config set mgr mgr/telemetry/channel_basic false
-  ceph config set mgr mgr/telemetry/channel_crash false
-  ceph config set mgr mgr/telemetry/channel_device false
-  ceph config set mgr mgr/telemetry/channel_perf false
-  ceph telemetry show
-  ceph telemetry show-device
+  ceph telemetry enable channel basic
+  ceph telemetry enable channel crash
+  ceph telemetry enable channel device
+  ceph telemetry enable channel ident
+  ceph telemetry enable channel perf
+
+  ceph telemetry disable channel basic
+  ceph telemetry disable channel crash
+  ceph telemetry disable channel device
+  ceph telemetry disable channel ident
+  ceph telemetry disable channel perf
+
+Multiple channels can be enabled or disabled with::
+
+  ceph telemetry enable channel basic crash device ident perf
+  ceph telemetry disable channel basic crash device ident perf
+
+Please note that telemetry should be on for these commands to take effect.
+
+List all channels with::
+
+  ceph telemetry channel ls
+
+  NAME      ENABLED    DEFAULT    DESC
+  basic     ON         ON         Share basic cluster information (size, version)
+  crash     ON         ON         Share metadata about Ceph daemon crashes (version, stack straces, etc)
+  device    ON         ON         Share device health metrics (e.g., SMART data, minus potentially identifying info like serial numbers)
+  ident     OFF        OFF        Share a user-provided description and/or contact email for the cluster
+  perf      ON         OFF        Share various performance metrics of a cluster
+
 
 Enabling Telemetry
 ------------------
@@ -107,10 +108,114 @@ Please note: Telemetry data is licensed under the Community Data License
 Agreement - Sharing - Version 1.0 (https://cdla.io/sharing-1-0/). Hence,
 telemetry module can be enabled only after you add '--license sharing-1-0' to
 the 'ceph telemetry on' command.
+Once telemetry is on, please consider enabling channels which are off by
+default, such as the 'perf' channel. 'ceph telemetry on' output will list the
+exact command to enable these channels.
 
 Telemetry can be disabled at any time with::
 
   ceph telemetry off
+
+Sample report
+-------------
+
+You can look at what data is reported at any time with the command::
+
+  ceph telemetry show
+
+If telemetry is off, you can preview a sample report with::
+
+  ceph telemetry preview
+
+Generating a sample report might take a few moments in big clusters (clusters
+with hundreds of OSDs or more).
+
+To protect your privacy, device reports are generated separately, and data such
+as hostname and device serial number is anonymized. The device telemetry is
+sent to a different endpoint and does not associate the device data with a
+particular cluster. To see a preview of the device report use the command::
+
+  ceph telemetry show-device
+
+If telemetry is off, you can preview a sample device report with::
+
+  ceph telemetry preview-device
+
+Please note: In order to generate the device report we use Smartmontools
+version 7.0 and up, which supports JSON output. 
+If you have any concerns about privacy with regard to the information included in
+this report, please contact the Ceph developers.
+
+In case you prefer to have a single output of both reports, and telemetry is on, use::
+
+  ceph telemetry show-all
+
+If you would like to view a single output of both reports, and telemetry is off, use::
+
+  ceph telemetry preview-all
+
+**Sample report by channel**
+
+When telemetry is on you can see what data is reported by channel with::
+
+  ceph telemetry show <channel_name>
+
+Please note: If telemetry is on, and <channel_name> is disabled, the command
+above will output a sample report by that channel, according to the collections
+the user is enrolled to. However this data is not reported, since the channel
+is disabled.
+
+If telemetry is off you can preview a sample report by channel with::
+
+  ceph telemetry preview <channel_name>
+
+Collections
+-----------
+
+Collections represent different aspects of data that we collect within a channel.
+
+List all collections with::
+
+  ceph telemetry collection ls
+
+  NAME                  ENROLLED    STATUS    DEFAULT    DESC
+  basic_base            FALSE       OFF       ON         Basic information about the cluster (capacity, number and type of daemons, version, etc.)
+  basic_mds_metadata    FALSE       OFF       ON         MDS metadata
+  crash_base            FALSE       OFF       ON         Information about daemon crashes (daemon type and version, backtrace, etc.)
+  device_base           FALSE       OFF       ON         Information about device health metrics
+  ident_base            FALSE       OFF       OFF        User-provided identifying information about the cluster
+  perf_perf             FALSE       OFF       OFF        Information about performance of the cluster
+
+Where:
+
+**NAME**: Collection name; prefix indicates the channel the collection belongs to.
+
+**ENROLLED**: Signifies the collections that were available in the module when
+the user last opted-in to telemetry. Please note: Even if a collection is
+'enrolled', its metrics will be reported only if its channel is enabled.
+The STATUS column indicates whether the collection is being reported.
+
+**STATUS**: Indicates whether the collection metrics are reported; this is
+determined by the status (enabled / disabled) of the channel the collection
+belongs to, along with the enrollment status of the collection.
+
+**DEFAULT**: The default status (enabled / disabled) of the channel the
+collection belongs to.
+
+**DESC**: General description of the collection.
+
+See the diff between the collections you are enrolled to, and the new,
+available collections with::
+
+  ceph telemetry diff
+
+Enroll to the most recent collections with::
+
+  ceph telemetry on
+
+Then enable new channels that are off with::
+
+  ceph telemetry enable channel <channel_name>
 
 Interval
 --------

--- a/src/pybind/mgr/dashboard/controllers/telemetry.py
+++ b/src/pybind/mgr/dashboard/controllers/telemetry.py
@@ -213,7 +213,7 @@ class Telemetry(RESTController):
         :return: Ceph and device report data
         :rtype: dict
         """
-        return mgr.remote('telemetry', 'get_report', 'all')
+        return mgr.remote('telemetry', 'get_report_locked', 'all')
 
     def singleton_set(self, enable=True, license_name=None):
         """

--- a/src/pybind/mgr/telemetry/__init__.py
+++ b/src/pybind/mgr/telemetry/__init__.py
@@ -1,1 +1,9 @@
-from .module import Module
+import os
+
+if 'UNITTEST' in os.environ:
+    import tests
+
+try:
+    from .module import Module
+except ImportError:
+    pass

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -169,7 +169,7 @@ class Module(MgrModule):
         Option(name='channel_perf',
                type='bool',
                default=False,
-               desc='Share perf counter metrics summed across the whole cluster'),
+               desc='Share various performance metrics of a cluster'),
     ]
 
     @property

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1493,7 +1493,48 @@ To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
                 desc,
             ))
 
-        return 0, table.get_string(), ''
+        return 0, table.get_string(sortby="NAME"), ''
+
+    @CLIReadCommand('telemetry collection ls')
+    def collection_ls(self) -> Tuple[int, str, str]:
+        '''
+        List all collections
+        '''
+        table = PrettyTable(
+            [
+                'NAME', 'ENROLLED', 'STATUS', 'DEFAULT', 'DESC',
+            ],
+            border=False)
+        table.align['NAME'] = 'l'
+        table.align['ENROLLED'] = 'l'
+        table.align['STATUS'] = 'l'
+        table.align['DEFAULT'] = 'l'
+        table.align['DESC'] = 'l'
+        table.left_padding_width = 0
+        table.right_padding_width = 4
+
+        for c in MODULE_COLLECTION:
+            name = c['name']
+            enrolled = "TRUE" if self.is_enabled_collection(name) else "FALSE"
+            status = "ON" if getattr(self, f"channel_{c['channel']}") and self.is_enabled_collection(name) \
+                    else "OFF"
+            # default value of *channel*, since we check for active channels
+            # when generating reports
+            for o in self.MODULE_OPTIONS:
+                if o['name'] == f"channel_{c['channel']}":
+                    default = "ON" if o.get('default', None) else "OFF"
+
+            desc = c['description']
+
+            table.add_row((
+                name,
+                enrolled,
+                status,
+                default,
+                desc,
+            ))
+
+        return 0, table.get_string(sortby="NAME"), ''
 
     @CLICommand('telemetry send')
     def do_send(self,

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1295,22 +1295,17 @@ class Module(MgrModule):
         # they are displayed horizontally instead of vertically.
         try:
             # Formatting ranges and values in osd_perf_histograms
-            modes_to_be_formatted = ['osd_perf_histograms_aggregated', 'osd_perf_histograms_separated']
-            for mode in modes_to_be_formatted:
-                for config in report[mode]:
-                    for histogram in config:
-                        # Adjust ranges by converting lists into strings
-                        for axis in config[histogram]['axes']:
-                            for i in range(0, len(axis['ranges'])):
-                                axis['ranges'][i] = str(axis['ranges'][i])
-                        # Adjust values by converting lists into strings
-                        if mode == 'osd_perf_histograms_aggregated':
-                            for i in range(0, len(config[histogram]['values'])):
-                                config[histogram]['values'][i] = str(config[histogram]['values'][i])
-                        else: # if mode == 'osd_perf_histograms_separated'
-                            for osd in config[histogram]['osds']:
-                                for i in range(0, len(osd['values'])):
-                                    osd['values'][i] = str(osd['values'][i])
+            mode = 'osd_perf_histograms'
+            for config in report[mode]:
+                for histogram in config:
+                    # Adjust ranges by converting lists into strings
+                    for axis in config[histogram]['axes']:
+                        for i in range(0, len(axis['ranges'])):
+                            axis['ranges'][i] = str(axis['ranges'][i])
+
+                    for osd in config[histogram]['osds']:
+                        for i in range(0, len(osd['values'])):
+                            osd['values'][i] = str(osd['values'][i])
         except KeyError:
             # If the perf channel is not enabled, there should be a KeyError since
             # 'osd_perf_histograms' would not be present in the report. In that case,

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1073,7 +1073,7 @@ class Module(MgrModule):
             report['crashes'] = self.gather_crashinfo()
 
         if 'perf' in channels:
-            if self.is_enabled_collection(Collection.perf):
+            if self.is_enabled_collection(Collection.perf_perf):
                 report['perf_counters'] = self.gather_perf_counters('separated')
                 report['stats_per_pool'] = self.get_stats_per_pool()
                 report['stats_per_pg'] = self.get_stats_per_pg()
@@ -1126,10 +1126,9 @@ class Module(MgrModule):
         new_collection : List[Collection] = []
 
         for c in MODULE_COLLECTION:
-            for k, v in c.items():
-                if k == 'name' and v.name not in self.db_collection:
-                    if c['channel'] in channels:
-                        new_collection.append(v)
+            if c['name'].name not in self.db_collection:
+                if c['channel'] in channels:
+                    new_collection.append(c['name'])
 
         return new_collection
 
@@ -1175,11 +1174,10 @@ class Module(MgrModule):
         # that we should nag about
         if self.db_collection is not None:
             for c in MODULE_COLLECTION:
-                for k, v in c.items():
-                    if k == 'name' and v.name not in self.db_collection:
-                        if c['nag'] == True:
-                            self.log.debug(f"The collection: {v} is not reported, and we should nag about it")
-                            return True
+                if c['name'].name not in self.db_collection:
+                    if c['nag'] == True:
+                        self.log.debug(f"The collection: {c['name']} is not reported")
+                        return True
 
         # user might be opted-in to the most recent collection, or there is no
         # new collection which requires nagging about
@@ -1236,9 +1234,8 @@ class Module(MgrModule):
             raise RuntimeError('db_collection is None after initial setting')
 
         for c in MODULE_COLLECTION:
-            for k, v in c.items():
-                if k == 'name' and v.name not in self.db_collection:
-                    self.db_collection.append(v.name)
+            if c['name'].name not in self.db_collection:
+                self.db_collection.append(c['name'])
 
         self.set_store('collection', json.dumps(self.db_collection))
 
@@ -1373,10 +1370,8 @@ class Module(MgrModule):
         keys = ['nag']
 
         for c in MODULE_COLLECTION:
-            for k, v in c.items():
-                if k == 'name':
-                    if not self.is_enabled_collection(Collection(v)):
-                        diff.append({key: val for key, val in c.items() if key not in keys})
+            if not self.is_enabled_collection(c['name']):
+                diff.append({key: val for key, val in c.items() if key not in keys})
 
         r = None
         if diff == []:
@@ -1595,9 +1590,7 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
                 next_collection = []
 
                 for c in MODULE_COLLECTION:
-                    for k, v in c.items():
-                        if k == 'name':
-                            next_collection.append(v.name)
+                    next_collection.append(c['name'].name)
 
                 opted_in_collection = self.db_collection
                 self.db_collection = next_collection
@@ -1651,9 +1644,7 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
             next_collection = []
 
             for c in MODULE_COLLECTION:
-                for k, v in c.items():
-                    if k == 'name':
-                        next_collection.append(v.name)
+                next_collection.append(c['name'].name)
 
             opted_in_collection = self.db_collection
             self.db_collection = next_collection
@@ -1699,9 +1690,7 @@ Please consider enabling the telemetry module with 'ceph telemetry on'.'''
             next_collection = []
 
             for c in MODULE_COLLECTION:
-                for k, v in c.items():
-                    if k == 'name':
-                        next_collection.append(v.name)
+                next_collection.append(c['name'].name)
 
             opted_in_collection = self.db_collection
             self.db_collection = next_collection

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1347,15 +1347,6 @@ class Module(MgrModule):
 
         return 0, msg, ''
 
-    def restore_default_opt_setting(self, opt_name: str) -> None:
-        for o in self.MODULE_OPTIONS:
-            if o['name'] == opt_name:
-                default_val = o.get('default', None)
-                self.set_module_option(opt_name, default_val)
-                setattr(self,
-                        opt_name,
-                        default_val)
-
     @CLIReadCommand('telemetry status')
     def status(self) -> Tuple[int, str, str]:
         '''
@@ -1444,10 +1435,7 @@ To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
         self.set_store('last_opted_out_ceph_version', str(mon_min))
         self.last_opted_out_ceph_version = mon_min
 
-        for c in ALL_CHANNELS:
-            self.restore_default_opt_setting(f"channel_{c}")
-
-        msg = 'Telemetry is now disabled. Channels settings are restored to default.'
+        msg = 'Telemetry is now disabled.'
         return 0, msg, ''
 
     @CLIReadCommand('telemetry enable channel')

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1180,8 +1180,15 @@ class Module(MgrModule):
                         return True
 
         # user might be opted-in to the most recent collection, or there is no
-        # new collection which requires nagging about
-        return self.is_major_upgrade()
+        # new collection which requires nagging about; thus nag in case it's a
+        # major upgrade and there are new collections
+        # (which their own nag == False):
+        new_collections = False
+        col_delta = self.collection_delta()
+        if col_delta is not None and len(col_delta) > 0:
+            new_collections = True
+
+        return self.is_major_upgrade() and new_collections
 
     def init_collection(self) -> None:
         # We fetch from db the collections the user had already opted-in to.

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -15,6 +15,7 @@ import requests
 import uuid
 import time
 from datetime import datetime, timedelta
+from prettytable import PrettyTable
 from threading import Event, Lock
 from collections import defaultdict
 from typing import cast, Any, DefaultDict, Dict, List, Optional, Tuple, TypeVar, TYPE_CHECKING, Union
@@ -1438,6 +1439,39 @@ To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
         Disable a list of channels
         '''
         return self.toggle_channel('disable', channels)
+
+    @CLIReadCommand('telemetry channel ls')
+    def channel_ls(self) -> Tuple[int, str, str]:
+        '''
+        List all channels
+        '''
+        table = PrettyTable(
+            [
+                'NAME', 'ENABLED', 'DEFAULT', 'DESC',
+            ],
+            border=False)
+        table.align['NAME'] = 'l'
+        table.align['ENABLED'] = 'l'
+        table.align['DEFAULT'] = 'l'
+        table.align['DESC'] = 'l'
+        table.left_padding_width = 0
+        table.right_padding_width = 4
+
+        for c in ALL_CHANNELS:
+            enabled = "ON" if getattr(self, f"channel_{c}") else "OFF"
+            for o in self.MODULE_OPTIONS:
+                if o['name'] == f"channel_{c}":
+                    default = "ON" if o.get('default', None) else "OFF"
+                    desc = o.get('desc', None)
+
+            table.add_row((
+                c,
+                enabled,
+                default,
+                desc,
+            ))
+
+        return 0, table.get_string(), ''
 
     @CLICommand('telemetry send')
     def do_send(self,

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1438,12 +1438,26 @@ To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
         msg = 'Telemetry is now disabled.'
         return 0, msg, ''
 
+    @CLIReadCommand('telemetry enable channel all')
+    def enable_channel_all(self, channels: List[str] = ALL_CHANNELS) -> Tuple[int, str, str]:
+        '''
+        Enable all channels
+        '''
+        return self.toggle_channel('enable', channels)
+
     @CLIReadCommand('telemetry enable channel')
     def enable_channel(self, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:
         '''
         Enable a list of channels
         '''
         return self.toggle_channel('enable', channels)
+
+    @CLIReadCommand('telemetry disable channel all')
+    def disable_channel_all(self, channels: List[str] = ALL_CHANNELS) -> Tuple[int, str, str]:
+        '''
+        Disable all channels
+        '''
+        return self.toggle_channel('disable', channels)
 
     @CLIReadCommand('telemetry disable channel')
     def disable_channel(self, channels: Optional[List[str]] = None) -> Tuple[int, str, str]:

--- a/src/pybind/mgr/telemetry/tests/test_telemetry.py
+++ b/src/pybind/mgr/telemetry/tests/test_telemetry.py
@@ -1,0 +1,121 @@
+import json
+import pytest
+import unittest
+from unittest import mock
+
+import telemetry
+from typing import cast, Any, DefaultDict, Dict, List, Optional, Tuple, TypeVar, TYPE_CHECKING, Union
+
+OptionValue = Optional[Union[bool, int, float, str]]
+
+Collection = telemetry.module.Collection
+ALL_CHANNELS = telemetry.module.ALL_CHANNELS
+MODULE_COLLECTION = telemetry.module.MODULE_COLLECTION
+
+COLLECTION_BASE = ["basic_base", "device_base", "crash_base", "ident_base"]
+
+class TestTelemetry:
+    @pytest.mark.parametrize("preconfig,postconfig,prestore,poststore,expected",
+            [
+                (
+                    # user is not opted-in
+                    {
+                        'last_opt_revision': 1,
+                        'enabled': False,
+                    },
+                    {
+                        'last_opt_revision': 1,
+                        'enabled': False,
+                    },
+                    {
+                        # None
+                    },
+                    {
+                        'collection': []
+                    },
+                    {
+                        'is_opted_in': False,
+                        'is_enabled_collection':
+                        {
+                            'basic_base': False,
+                            'basic_mds_metadata': False,
+                        },
+                    },
+                ),
+                (
+                    # user is opted-in to an old revision
+                    {
+                        'last_opt_revision': 2,
+                        'enabled': True,
+                    },
+                    {
+                        'last_opt_revision': 2,
+                        'enabled': True,
+                    },
+                    {
+                        # None
+                    },
+                    {
+                        'collection': []
+                    },
+                    {
+                        'is_opted_in': False,
+                        'is_enabled_collection':
+                        {
+                            'basic_base': False,
+                            'basic_mds_metadata': False,
+                        },
+                    },
+                ),
+                (
+                    # user is opted-in to the latest revision
+                    {
+                        'last_opt_revision': 3,
+                        'enabled': True,
+                    },
+                    {
+                        'last_opt_revision': 3,
+                        'enabled': True,
+                    },
+                    {
+                        # None
+                    },
+                    {
+                        'collection': COLLECTION_BASE
+                    },
+                    {
+                        'is_opted_in': True,
+                        'is_enabled_collection':
+                        {
+                            'basic_base': True,
+                            'basic_mds_metadata': False,
+                        },
+                    },
+                ),
+            ])
+    def test_upgrade(self,
+                preconfig: Dict[str, Any], \
+                postconfig: Dict[str, Any], \
+                prestore: Dict[str, Any], \
+                poststore: Dict[str, Any], \
+                expected: Dict[str, Any]) -> None:
+
+        m = telemetry.Module('telemetry', '', '')
+
+        if preconfig is not None:
+            for k, v in preconfig.items():
+                # no need to mock.patch since _ceph_set_module_option() which
+                # is called from set_module_option() is already mocked for
+                # tests, and provides setting default values for all module
+                # options
+                m.set_module_option(k, v)
+
+        m.config_update_module_option()
+        m.load()
+
+        collection = json.loads(m.get_store('collection'))
+
+        assert collection == poststore['collection']
+        assert m.is_opted_in() == expected['is_opted_in']
+        assert m.is_enabled_collection(Collection.basic_base) == expected['is_enabled_collection']['basic_base']
+        assert m.is_enabled_collection(Collection.basic_mds_metadata) == expected['is_enabled_collection']['basic_mds_metadata']

--- a/src/pybind/mgr/telemetry/tox.ini
+++ b/src/pybind/mgr/telemetry/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist =
+    py3
+    mypy
+skipsdist = true
+
+[testenv]
+deps =
+    mock
+    pytest
+commands =
+    pytest {posargs}


### PR DESCRIPTION
The current design requires increasing the telemetry revision each time we add new data to the report. As a result, users need to re-opt-in to telemetry. This new design allows for adding new data to the report, while allowing users to keep sending only what they already opted-in to, hence no re-opt-in is required. In case users wish to report the new data as well, they need to re-opt-in and enable any new channels. 

Trello card: https://trello.com/c/8QsLwe9h/625-telemetry-vary-shared-data

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
