### PR TITLE
crimson/os/seastore: do not write empty mutate records

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -526,9 +526,10 @@ public:
   /**
    * prepare_record
    *
-   * Construct the record for Journal from transaction.
+   * Construct the record for Journal from transaction. Return nullopt if the
+   * emtpy transaction can be ignored.
    */
-  record_t prepare_record(
+  std::optional<record_t> prepare_record(
     Transaction &t ///< [in, out] current transaction
   );
 

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -90,13 +90,13 @@ public:
     crimson::ct_error::input_output_error
     >;
   using submit_record_ret = submit_record_ertr::future<
-    record_locator_t
+    std::optional<record_locator_t>
     >;
   submit_record_ret submit_record(
-    record_t &&record,
+    std::optional<record_t>&& maybe_record,
     OrderingHandle &handle
   ) {
-    return record_submitter.submit(std::move(record), handle);
+    return record_submitter.submit(std::move(maybe_record), handle);
   }
 
   /**
@@ -390,8 +390,9 @@ private:
       write_pipeline = _write_pipeline;
     }
 
+    using submit_ertr = Journal::submit_record_ertr;
     using submit_ret = Journal::submit_record_ret;
-    submit_ret submit(record_t&&, OrderingHandle&);
+    submit_ret submit(std::optional<record_t>&&, OrderingHandle&);
 
   private:
     void update_state();
@@ -436,6 +437,8 @@ private:
     void finish_submit_batch(RecordBatch*, maybe_result_t);
 
     void flush_current_batch();
+
+    seastar::future<> submit_noop(OrderingHandle& handle);
 
     using submit_pending_ertr = JournalSegmentManager::write_ertr;
     using submit_pending_ret = submit_pending_ertr::future<

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -156,7 +156,7 @@ std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
 
 extent_len_t record_size_t::get_raw_mdlength() const
 {
-  // empty record is allowed to submit
+  // empty record from cleaner is allowed to submit
   return plain_mdlength +
          ceph::encoded_sizeof_bounded<record_header_t>();
 }
@@ -185,7 +185,7 @@ void record_group_size_t::account(
     const record_size_t& rsize,
     extent_len_t _block_size)
 {
-  // empty record is allowed to submit
+  // empty record from cleaner is allowed to submit
   assert(_block_size > 0);
   assert(rsize.dlength % _block_size == 0);
   assert(block_size == 0 || block_size == _block_size);

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -30,8 +30,12 @@ struct cache_test_t : public seastar_test_suite_t {
 
   seastar::future<paddr_t> submit_transaction(
     TransactionRef t) {
-    auto record = cache->prepare_record(*t);
+    auto maybe_record = cache->prepare_record(*t);
+    if (!maybe_record.has_value()) {
+      return seastar::make_ready_future<paddr_t>(current);
+    }
 
+    auto& record = *maybe_record;
     bufferlist bl;
     for (auto &&block : record.extents) {
       bl.append(block.bl);

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -218,9 +218,10 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
     auto record{std::forward<T>(_record)...};
     records.push_back(record);
     OrderingHandle handle = get_dummy_ordering_handle();
-    auto [addr, _] = journal->submit_record(
+    auto maybe_result = journal->submit_record(
       std::move(record),
       handle).unsafe_get0();
+    auto [addr, _] = *maybe_result;
     records.back().record_final_offset = addr;
     return addr;
   }


### PR DESCRIPTION
Splitted out of https://github.com/ceph/ceph/pull/44127

See commit `crimson/os/seastore: do not write empty mutate records`

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
