### PR TITLE
doc:index order error in ceph object gateway

### DIFF
--- a/doc/radosgw/index.rst
+++ b/doc/radosgw/index.rst
@@ -41,8 +41,8 @@ you may write data with one API and retrieve it with the other.
    :maxdepth: 1
 
    HTTP Frontends <frontends>
-   Pool Placement and Storage Classes <placement>
    Multisite Configuration <multisite>
+   Pool Placement and Storage Classes <placement>
    Multisite Sync Policy Configuration <multisite-sync-policy>
    Configuring Pools <pools>
    Config Reference <config-ref>


### PR DESCRIPTION
In the Pool Placement and Storage Classes page, there is a saying: "If you have not done any previous Multisite Configuration, ...", so Multisite Configuration page should be before Pool Placement and Storage Classes page.

Signed-off-by: gaoweinan <gaoweinan@inspur.com>

