### PR TITLE
octopus: osd/OSDMap: Add health warning if 'require-osd-release' != current release

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,9 @@
+15.2.16
+-------
+
+* A health warning will now be reported if the ``require-osd-release`` flag is not
+  set to the appropriate release after a cluster upgrade.
+
 15.2.14
 -------
 

--- a/qa/suites/upgrade/nautilus-x/parallel/3-upgrade-sequence/upgrade-mon-osd-mds.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/3-upgrade-sequence/upgrade-mon-osd-mds.yaml
@@ -43,11 +43,13 @@ upgrade-sequence:
        duration: 60
    - ceph.restart:
        daemons: [osd.8, osd.9, osd.10, osd.11]
-       wait-for-healthy: true
+       wait-for-healthy: false
+       wait-for-osds-up: true
    - sleep:
        duration: 60
    - ceph.restart:
        daemons: [rgw.*]
-       wait-for-healthy: true
+       wait-for-healthy: false
+       wait-for-osds-up: true
    - sleep:
        duration: 60

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5924,7 +5924,13 @@ void OSDMap::check_health(CephContext *cct,
   }
 
   // OSD_UPGRADE_FINISHED
-  // none of these (yet) since we don't run until luminous upgrade is done.
+  if (auto require_release = pending_require_osd_release()) {
+    ostringstream ss;
+    ss << "all OSDs are running " << *require_release << " or later but"
+       << " require_osd_release < " << *require_release;
+    auto& d = checks->add("OSD_UPGRADE_FINISHED", HEALTH_WARN, ss.str(), 0);
+    d.detail.push_back(ss.str());
+  }
 
   // POOL_NEARFULL/BACKFILLFULL/FULL
   {
@@ -6140,4 +6146,18 @@ unsigned OSDMap::get_device_class_flags(int id) const
   if (it != device_class_flags.end())
     flags = it->second;
   return flags;
+}
+
+std::optional<std::string> OSDMap::pending_require_osd_release() const
+{
+  if (HAVE_FEATURE(get_up_osd_features(), SERVER_OCTOPUS) &&
+      require_osd_release < ceph_release_t::octopus) {
+    return "octopus";
+  }
+  if (HAVE_FEATURE(get_up_osd_features(), SERVER_NAUTILUS) &&
+      require_osd_release < ceph_release_t::nautilus) {
+    return "nautilus";
+  }
+
+  return std::nullopt;
 }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1529,6 +1529,7 @@ public:
 			std::ostream *ss) const;
 
   float pool_raw_used_rate(int64_t poolid) const;
+  std::optional<std::string> pending_require_osd_release() const;
 
 };
 WRITE_CLASS_ENCODER_FEATURES(OSDMap)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53550

---

backport of https://github.com/ceph/ceph/pull/44090
parent tracker: https://tracker.ceph.com/issues/51984

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh