### PR TITLE
test/rgw: disable cls_rgw_gc test cases with defer_gc()

### DIFF
--- a/src/test/cls_rgw_gc/test_cls_rgw_gc.cc
+++ b/src/test/cls_rgw_gc/test_cls_rgw_gc.cc
@@ -207,6 +207,7 @@ TEST(cls_rgw_gc, gc_queue_ops2)
   ASSERT_EQ("chain-1", it.tag);
 }
 
+#if 0 // TODO: fix or remove defer_gc()
 TEST(cls_rgw_gc, gc_queue_ops3)
 {
   //Testing remove queue entries
@@ -359,6 +360,7 @@ TEST(cls_rgw_gc, gc_queue_ops4)
   ASSERT_EQ(0, list_info2.size());
 
 }
+#endif // defer_gc() disabled
 
 TEST(cls_rgw_gc, gc_queue_ops5)
 {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/53325

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
