### PR TITLE
nautilus: osd/OSDMap: Add health warning if 'require-osd-release' != current release

### DIFF
--- a/qa/suites/upgrade/luminous-x/parallel/3-upgrade-sequence/upgrade-mon-osd-mds.yaml
+++ b/qa/suites/upgrade/luminous-x/parallel/3-upgrade-sequence/upgrade-mon-osd-mds.yaml
@@ -45,6 +45,7 @@ upgrade-sequence:
        duration: 60
    - ceph.restart:
        daemons: [osd.8, osd.9, osd.10, osd.11]
-       wait-for-healthy: true
+       wait-for-healthy: false
+       wait-for-osds-up: true
    - sleep:
        duration: 60

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1506,6 +1506,7 @@ public:
 			ostream *ss) const;
 
   float pool_raw_used_rate(int64_t poolid) const;
+  std::optional<std::string> pending_require_osd_release() const;
 
 };
 WRITE_CLASS_ENCODER_FEATURES(OSDMap)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53549

---

backport of https://github.com/ceph/ceph/pull/44090
parent tracker: https://tracker.ceph.com/issues/51984

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh