### PR TITLE
cmake: do not use GCC extension when detecting 16-byte atomic op

### DIFF
--- a/cmake/modules/CheckCxxAtomic.cmake
+++ b/cmake/modules/CheckCxxAtomic.cmake
@@ -10,8 +10,9 @@ function(check_cxx_atomics var)
     check_cxx_source_compiles("
 #include <atomic>
 #include <cstdint>
+#include <cstddef>
 
-#if defined(__s390x__) || defined(__mips__)
+#if defined(__SIZEOF_INT128__)
 // Boost needs 16-byte atomics for tagged pointers.
 // These are implemented via inline instructions on the platform
 // if 16-byte alignment can be proven, and are delegated to libatomic
@@ -21,13 +22,26 @@ function(check_cxx_atomics var)
 // We specifically test access via an otherwise unknown pointer here
 // to ensure we get the most complex case.  If this access can be
 // done without libatomic, then all accesses can be done.
-bool atomic16(std::atomic<unsigned __int128> *ptr)
+struct tagged_ptr {
+  int* ptr;
+  std::size_t tag;
+};
+
+void atomic16(std::atomic<tagged_ptr> *ptr)
 {
-  return *ptr != 0;
+  tagged_ptr p{nullptr, 1};
+  ptr->store(p);
+  tagged_ptr f = ptr->load();
+  tagged_ptr new_tag{nullptr, 0};
+  ptr->compare_exchange_strong(f, new_tag);
 }
 #endif
 
 int main() {
+#if defined(__SIZEOF_INT128__)
+  std::atomic<tagged_ptr> ptr;
+  atomic16(&ptr);
+#endif
   std::atomic<uint8_t> w1;
   std::atomic<uint16_t> w2;
   std::atomic<uint32_t> w4;


### PR DESCRIPTION
we have following error when trying to compile the C++ source
file on mipsel:

/usr/bin/c++ -DHAVE_CXX11_ATOMIC  -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -g1 -Wdate-time -D_FORTIFY_SOURCE=2  -std=c++11 -fPIE -o CMakeFiles/cmTC_9f34f.dir/src.cxx.o -c /<<PKGBUILDDIR>>/obj-mipsel-linux-gnu/CMakeFiles/CMakeTmp/src.cxx
/<<PKGBUILDDIR>>/obj-mipsel-linux-gnu/CMakeFiles/CMakeTmp/src.cxx:15:44: error: template argument 1 is invalid
   15 | bool atomic16(std::atomic<unsigned __int128> *ptr)
      |                                            ^
/<<PKGBUILDDIR>>/obj-mipsel-linux-gnu/CMakeFiles/CMakeTmp/src.cxx:15:44: error: template argument 1 is invalid
/<<PKGBUILDDIR>>/obj-mipsel-linux-gnu/CMakeFiles/CMakeTmp/src.cxx:15:44: error: template argument 1 is invalid
/<<PKGBUILDDIR>>/obj-mipsel-linux-gnu/CMakeFiles/CMakeTmp/src.cxx:15:44: error: template argument 1 is invalid
/<<PKGBUILDDIR>>/obj-mipsel-linux-gnu/CMakeFiles/CMakeTmp/src.cxx:15:47: error: ‘ptr’ was not declared in this scope
   15 | bool atomic16(std::atomic<unsigned __int128> *ptr)
      |                                               ^~~

the compiler was GCC 11.2.0.

in this change, instead of detecting the architecture, check for
the macro of `__SIZEOF_INT128__`, which is respected by GCC and Clang.
so it's more readable. also, instead of using the `unsigned __int128`
type provided as a GCC extension, use a struct to mimic the use case
of boost::lockfree library.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
