### PR TITLE
octopus: qa: account for split of the kclient "metrics" debugfs file

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -505,3 +505,6 @@ print(find_socket("{client_name}"))
 
     def set_cache_size(self, size):
         return self.admin_socket(['config', 'set', 'client_cache_size', str(size)])
+
+    def get_op_read_count(self):
+        return self.admin_socket(['perf', 'dump', 'objecter'])['objecter']['osdop_read']

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -261,3 +261,10 @@ class KernelMount(CephFSMount):
         epoch, barrier = int(first_line_tokens[1]), int(first_line_tokens[3])
 
         return epoch, barrier
+
+    def get_op_read_count(self):
+        buf = self.read_debug_file("metrics")
+        if buf is None:
+            return 0
+        else:
+            return int(re.findall(r'read.*', buf)[0].split()[1])

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -263,7 +263,7 @@ class KernelMount(CephFSMount):
         return epoch, barrier
 
     def get_op_read_count(self):
-        buf = self.read_debug_file("metrics")
+        buf = self.read_debug_file("metrics/size")
         if buf is None:
             return 0
         else:

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -597,6 +597,9 @@ class CephFSMount(object):
     def get_osd_epoch(self):
         raise NotImplementedError()
 
+    def get_op_read_count(self):
+        raise NotImplementedError()
+
     def lstat(self, fs_path, follow_symlinks=False, wait=True):
         return self.stat(fs_path, follow_symlinks=False, wait=True)
 

--- a/qa/tasks/cephfs/test_readahead.py
+++ b/qa/tasks/cephfs/test_readahead.py
@@ -17,14 +17,14 @@ class TestReadahead(CephFSTestCase):
         self.mount_a.umount_wait()
         self.mount_a.mount_wait()
 
-        initial_op_r = self.mount_a.admin_socket(['perf', 'dump', 'objecter'])['objecter']['op_r']
+        initial_op_read = self.mount_a.admin_socket(['perf', 'dump', 'objecter'])['objecter']['osdop_read']
         self.mount_a.run_shell(["dd", "if=foo", "of=/dev/null", "bs=128k", "count=32"])
-        op_r = self.mount_a.admin_socket(['perf', 'dump', 'objecter'])['objecter']['op_r']
-        assert op_r >= initial_op_r
-        op_r -= initial_op_r
-        log.info("read operations: {0}".format(op_r))
+        op_read = self.mount_a.admin_socket(['perf', 'dump', 'objecter'])['objecter']['osdop_read']
+        assert op_read >= initial_op_read
+        op_read -= initial_op_read
+        log.info("read operations: {0}".format(op_read))
 
         # with exponentially increasing readahead, we should see fewer than 10 operations
         # but this test simply checks if the client is doing a remote read for each local read
-        if op_r >= 32:
+        if op_read >= 32:
             raise RuntimeError("readahead not working")


### PR DESCRIPTION
https://tracker.ceph.com/issues/53444


Had to pull in couple of commits for clean cherry-pick.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
