### PR TITLE
octopus: doc: prerequisites fix for cephFS mount

### DIFF
--- a/doc/cephfs/mount-prerequisites.rst
+++ b/doc/cephfs/mount-prerequisites.rst
@@ -2,9 +2,11 @@ Mount CephFS: Prerequisites
 ===========================
 
 You can use CephFS by mounting it to your local filesystem or by using
-`cephfs-shell`_. CephFS can be mounted `using kernel`_ as well as `using
-FUSE`_. Both have their own advantages. Read the following section to
-understand more about both of these ways to mount CephFS.
+`cephfs-shell`_. Mounting CephFS requires superuser privileges to trim
+dentries by issuing a remount of itself. CephFS can be mounted
+`using kernel`_ as well as `using FUSE`_. Both have their own
+advantages. Read the following section to understand more about both of
+these ways to mount CephFS.
 
 Which CephFS Client?
 --------------------

--- a/doc/cephfs/mount-using-fuse.rst
+++ b/doc/cephfs/mount-using-fuse.rst
@@ -9,17 +9,11 @@ clients can be more manageable, especially while upgrading CephFS.
 Prerequisites
 =============
 
-Complete General Prerequisites
-------------------------------
 Go through the prerequisites required by both, kernel as well as FUSE mounts,
 in `Mount CephFS: Prerequisites`_ page.
 
-``fuse.conf`` option
---------------------
-
-#. If you are mounting Ceph with FUSE not as superuser/root user/system admin
-   you would need to add the option ``user_allow_other`` to ``/etc/fuse.conf``
-   (under no section in the conf).
+.. note:: Mounting CephFS using FUSE requires superuser privileges to trim dentries
+   by issuing a remount of itself.
 
 Synopsis
 ========


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53331

---

backport of https://github.com/ceph/ceph/pull/43886
parent tracker: https://tracker.ceph.com/issues/53054

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh