### PR TITLE
pacific: mgr/dashboard: introduce HAProxy metrics for RGW 

### DIFF
--- a/monitoring/grafana/dashboards/radosgw-overview.json
+++ b/monitoring/grafana/dashboards/radosgw-overview.json
@@ -579,6 +579,499 @@
                "show": true
             }
          ]
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 12,
+            "w": 9,
+            "x": 0,
+            "y": 12
+         },
+         "id": 9,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "RGW Overview - HAProxy Metrics",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "",
+         "fill": 1,
+         "gridPos": {
+            "h": 12,
+            "w": 5,
+            "x": 0,
+            "y": 12
+         },
+         "id": 10,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [
+            [
+               {
+                  "alias": "/.*Back.*/",
+                  "transform": "negative-Y"
+               },
+               {
+                  "alias": "/.*1.*/"
+               },
+               {
+                  "alias": "/.*2.*/"
+               },
+               {
+                  "alias": "/.*3.*/"
+               },
+               {
+                  "alias": "/.*4.*/"
+               },
+               {
+                  "alias": "/.*5.*/"
+               },
+               {
+                  "alias": "/.*other.*/"
+               }
+            ]
+         ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(irate(haproxy_frontend_http_responses_total{code=~\"$code\",instance=~\"$ingress_service\",proxy=~\"frontend\"}[5m])) by (code)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "Frontend {{ code }}",
+               "refId": "A"
+            },
+            {
+               "expr": "sum(irate(haproxy_backend_http_responses_total{code=~\"$code\",instance=~\"$ingress_service\",proxy=~\"backend\"}[5m])) by (code)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "Backend {{ code }}",
+               "refId": "B"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Total responses by HTTP code",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "",
+         "fill": 1,
+         "gridPos": {
+            "h": 12,
+            "w": 5,
+            "x": 5,
+            "y": 12
+         },
+         "id": 11,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [
+            [
+               {
+                  "alias": "/.*Response.*/",
+                  "transform": "negative-Y"
+               },
+               {
+                  "alias": "/.*Backend.*/",
+                  "transform": "negative-Y"
+               }
+            ]
+         ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(irate(haproxy_frontend_http_requests_total{proxy=~\"frontend\",instance=~\"$ingress_service\"}[5m])) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "Requests",
+               "refId": "A"
+            },
+            {
+               "expr": "sum(irate(haproxy_backend_response_errors_total{proxy=~\"backend\",instance=~\"$ingress_service\"}[5m])) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Response errors",
+               "refId": "B"
+            },
+            {
+               "expr": "sum(irate(haproxy_frontend_request_errors_total{proxy=~\"frontend\",instance=~\"$ingress_service\"}[5m])) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "Requests errors",
+               "refId": "C"
+            },
+            {
+               "expr": "sum(irate(haproxy_backend_redispatch_warnings_total{proxy=~\"backend\",instance=~\"$ingress_service\"}[5m])) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Backend redispatch",
+               "refId": "D"
+            },
+            {
+               "expr": "sum(irate(haproxy_backend_retry_warnings_total{proxy=~\"backend\",instance=~\"$ingress_service\"}[5m])) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Backend retry",
+               "refId": "E"
+            },
+            {
+               "expr": "sum(irate(haproxy_frontend_requests_denied_total{proxy=~\"frontend\",instance=~\"$ingress_service\"}[5m])) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Request denied",
+               "refId": "F"
+            },
+            {
+               "expr": "sum(haproxy_backend_current_queue{proxy=~\"backend\",instance=~\"$ingress_service\"}) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Backend Queued",
+               "refId": "G"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Total requests / responses",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "",
+         "fill": 1,
+         "gridPos": {
+            "h": 12,
+            "w": 5,
+            "x": 10,
+            "y": 12
+         },
+         "id": 12,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [
+            [
+               {
+                  "alias": "/.*Back.*/",
+                  "transform": "negative-Y"
+               }
+            ]
+         ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(irate(haproxy_frontend_connections_total{proxy=~\"frontend\",instance=~\"$ingress_service\"}[5m])) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "Front",
+               "refId": "A"
+            },
+            {
+               "expr": "sum(irate(haproxy_backend_connection_attempts_total{proxy=~\"backend\",instance=~\"$ingress_service\"}[5m])) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "Back",
+               "refId": "B"
+            },
+            {
+               "expr": "sum(irate(haproxy_backend_connection_errors_total{proxy=~\"backend\",instance=~\"$ingress_service\"}[5m])) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "Back errors",
+               "refId": "C"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Total number of connections",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "$datasource",
+         "description": "",
+         "fill": 1,
+         "gridPos": {
+            "h": 12,
+            "w": 6,
+            "x": 15,
+            "y": 12
+         },
+         "id": 13,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [
+            [
+               {
+                  "alias": "/.*OUT.*/",
+                  "transform": "negative-Y"
+               }
+            ]
+         ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "sum(irate(haproxy_frontend_bytes_in_total{proxy=~\"frontend\",instance=~\"$ingress_service\"}[5m])*8) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 1,
+               "legendFormat": "IN Front",
+               "refId": "A"
+            },
+            {
+               "expr": "sum(irate(haproxy_frontend_bytes_out_total{proxy=~\"frontend\",instance=~\"$ingress_service\"}[5m])*8) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "OUT Front",
+               "refId": "B"
+            },
+            {
+               "expr": "sum(irate(haproxy_backend_bytes_in_total{proxy=~\"backend\",instance=~\"$ingress_service\"}[5m])*8) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "IN Back",
+               "refId": "C"
+            },
+            {
+               "expr": "sum(irate(haproxy_backend_bytes_out_total{proxy=~\"backend\",instance=~\"$ingress_service\"}[5m])*8) by (instance)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "OUT Back",
+               "refId": "D"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Current total of incoming / outgoing bytes",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            }
+         ]
       }
    ],
    "refresh": "15s",
@@ -601,6 +1094,46 @@
             "name": "rgw_servers",
             "options": [ ],
             "query": "label_values(ceph_rgw_req, ceph_daemon)",
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "$datasource",
+            "hide": 0,
+            "includeAll": true,
+            "label": "HTTP Code",
+            "multi": false,
+            "name": "code",
+            "options": [ ],
+            "query": "label_values(haproxy_server_http_responses_total{instance=~\"$ingress_service\"}, code)",
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "$datasource",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Ingress Service",
+            "multi": false,
+            "name": "ingress_service",
+            "options": [ ],
+            "query": "label_values(haproxy_server_status, instance)",
             "refresh": 1,
             "regex": "",
             "sort": 1,

--- a/monitoring/grafana/dashboards/tests/features/radosgw_overview.feature
+++ b/monitoring/grafana/dashboards/tests/features/radosgw_overview.feature
@@ -1,0 +1,212 @@
+Feature: RGW Overview Dashboard
+
+Scenario: "Test Average GET Latencies"
+  Given the following series:
+    | metrics | values |
+    | ceph_rgw_get_initial_lat_sum{ceph_daemon="rgw.foo",instance="127.0.0.1", job="ceph"} | 10 50 100 |
+    | ceph_rgw_get_initial_lat_count{ceph_daemon="rgw.foo", instance="127.0.0.1", job="ceph"} | 20 60 80 |
+  When interval is `30s`
+  Then Grafana panel `Average GET/PUT Latencies` with legend `GET AVG` shows:
+    | metrics | values |
+    | {ceph_daemon="rgw.foo",instance="127.0.0.1", job="ceph"} | 2.5000000000000004 |
+
+Scenario: "Test Average PUT Latencies"
+  Given the following series:
+    | metrics | values |
+    | ceph_rgw_put_initial_lat_sum{ceph_daemon="rgw.foo",instance="127.0.0.1", job="ceph"} | 15 35 55 |
+    | ceph_rgw_put_initial_lat_count{ceph_daemon="rgw.foo", instance="127.0.0.1", job="ceph"} | 10 30 50 |
+  When interval is `30s`
+  Then Grafana panel `Average GET/PUT Latencies` with legend `PUT AVG` shows:
+    | metrics | values |
+    | {ceph_daemon="rgw.foo",instance="127.0.0.1", job="ceph"} | 1 |
+
+Scenario: "Test Total Requests/sec by RGW Instance"
+  Given the following series:
+    | metrics | values |
+    | ceph_rgw_req{ceph_daemon="rgw.1",instance="127.0.0.1",job="ceph"} | 10 50 100 |
+  When interval is `30s`
+  Then Grafana panel `Total Requests/sec by RGW Instance` with legend `{{rgw_host}}` shows:
+    | metrics | values |
+    | {rgw_host="1"} | 1.6666666666666667 |
+
+Scenario: "Test Bandwidth Consumed by Type- GET"
+  Given the following series:
+    | metrics | values |
+    | ceph_rgw_get_b{ceph_daemon="rgw.1",instance="127.0.0.1",job="ceph"} | 10 50 100 |
+  When evaluation time is `1m`
+  And interval is `30s`
+  Then Grafana panel `Bandwidth Consumed by Type` with legend `GETs` shows:
+    | metrics | values |
+    | {} | 1.6666666666666667 |
+
+Scenario: "Test Bandwidth Consumed by Type- PUT"
+  Given the following series:
+    | metrics | values |
+    | ceph_rgw_put_b{ceph_daemon="rgw.1",instance="127.0.0.1",job="ceph"} | 5 20 50 |
+  When evaluation time is `1m`
+  And interval is `30s`
+  Then Grafana panel `Bandwidth Consumed by Type` with legend `PUTs` shows:
+    | metrics | values |
+    | {} | 1 |
+
+Scenario: "Test Total backend responses by HTTP code"
+  Given the following series:
+    | metrics | values |
+    | haproxy_backend_http_responses_total{code="200",instance="ingress.rgw.1",proxy="backend"} | 10 100 |
+    | haproxy_backend_http_responses_total{code="404",instance="ingress.rgw.1",proxy="backend"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  When variable `code` is `200`
+  Then Grafana panel `Total responses by HTTP code` with legend `Backend {{ code }}` shows:
+    | metrics | values |
+    | {code="200"} | 1.5 |
+
+Scenario: "Test Total frontend responses by HTTP code"
+  Given the following series:
+    | metrics | values |
+    | haproxy_frontend_http_responses_total{code="200",instance="ingress.rgw.1",proxy="frontend"} | 10 100 |
+    | haproxy_frontend_http_responses_total{code="404",instance="ingress.rgw.1",proxy="frontend"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  When variable `code` is `200`
+  Then Grafana panel `Total responses by HTTP code` with legend `Frontend {{ code }}` shows:
+    | metrics | values |
+    | {code="200"} | 1.5 |
+
+Scenario: "Test Total http frontend requests by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_frontend_http_requests_total{proxy="frontend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_frontend_http_requests_total{proxy="frontend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Total requests / responses` with legend `Requests` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 3 |
+
+Scenario: "Test Total backend response errors by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_backend_response_errors_total{proxy="backend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_backend_response_errors_total{proxy="backend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Total requests / responses` with legend `Response errors` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 3 |
+
+Scenario: "Test Total frontend requests errors by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_frontend_request_errors_total{proxy="frontend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_frontend_request_errors_total{proxy="frontend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Total requests / responses` with legend `Requests errors` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 3 |
+
+Scenario: "Test Total backend redispatch warnings by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_backend_redispatch_warnings_total{proxy="backend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_backend_redispatch_warnings_total{proxy="backend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Total requests / responses` with legend `Backend redispatch` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 3 |
+
+Scenario: "Test Total backend retry warnings by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_backend_retry_warnings_total{proxy="backend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_backend_retry_warnings_total{proxy="backend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Total requests / responses` with legend `Backend retry` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 3 |
+
+Scenario: "Test Total frontend requests denied by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_frontend_requests_denied_total{proxy="frontend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_frontend_requests_denied_total{proxy="frontend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Total requests / responses` with legend `Request denied` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 3 |
+
+Scenario: "Test Total backend current queue by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_backend_current_queue{proxy="backend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_backend_current_queue{proxy="backend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Total requests / responses` with legend `Backend Queued` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 200 |
+
+Scenario: "Test Total frontend connections by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_frontend_connections_total{proxy="frontend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_frontend_connections_total{proxy="frontend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Total number of connections` with legend `Front` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 3 |
+
+Scenario: "Test Total backend connections attempts by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_backend_connection_attempts_total{proxy="backend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_backend_connection_attempts_total{proxy="backend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Total number of connections` with legend `Back` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 3 |
+
+Scenario: "Test Total backend connections error by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_backend_connection_errors_total{proxy="backend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_backend_connection_errors_total{proxy="backend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Total number of connections` with legend `Back errors` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 3 |
+
+Scenario: "Test Total frontend bytes incoming by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_frontend_bytes_in_total{proxy="frontend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_frontend_bytes_in_total{proxy="frontend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Current total of incoming / outgoing bytes` with legend `IN Front` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 24 |
+
+Scenario: "Test Total frontend bytes outgoing by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_frontend_bytes_out_total{proxy="frontend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_frontend_bytes_out_total{proxy="frontend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Current total of incoming / outgoing bytes` with legend `OUT Front` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 24 |
+
+Scenario: "Test Total backend bytes incoming by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_backend_bytes_in_total{proxy="backend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_backend_bytes_in_total{proxy="backend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Current total of incoming / outgoing bytes` with legend `IN Back` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 24 |
+
+Scenario: "Test Total backend bytes outgoing by instance"
+  Given the following series:
+    | metrics | values |
+    | haproxy_backend_bytes_out_total{proxy="backend",instance="ingress.rgw.1"} | 10 100 |
+    | haproxy_backend_bytes_out_total{proxy="backend",instance="ingress.rgw.1"} | 20 200 |
+  When variable `ingress_service` is `ingress.rgw.1`
+  Then Grafana panel `Current total of incoming / outgoing bytes` with legend `OUT Back` shows:
+    | metrics | values |
+    | {instance="ingress.rgw.1"} | 24 |


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53576

---

backport of https://github.com/ceph/ceph/pull/43991
parent tracker: https://tracker.ceph.com/issues/53311

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh