### PR TITLE
msg/async/dpdk: add NIC whitelist configuration

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1441,6 +1441,13 @@ options:
   type: str
   level: advanced
   with_legacy: true
+- name: ms_dpdk_devs_allowlist
+  type: str
+  level: advanced
+  desc: NIC's PCIe address are allowed to use
+  long_desc: for a single NIC use ms_dpdk_devs_allowlist=-a 0000:7d:010 or --allow=0000:7d:010;
+    for a bond nics use ms_dpdk_devs_allowlist=--allow=0000:7d:01.0 --allow=0000:7d:02.6
+    --vdev=net_bonding0,mode=2,slave=0000:7d:01.0,slave=0000:7d:02.6.
 - name: ms_dpdk_host_ipv4_addr
   type: str
   level: advanced

--- a/src/msg/async/dpdk/dpdk_rte.cc
+++ b/src/msg/async/dpdk/dpdk_rte.cc
@@ -23,6 +23,8 @@
 #include <rte_ethdev.h>
 #include <rte_version.h>
 
+#include "include/str_map.h"
+
 #include "DPDK.h"
 #include "dpdk_rte.h"
 
@@ -122,6 +124,14 @@ namespace dpdk {
       } else if (!cct->_conf->ms_dpdk_pmd.empty()) {
         args.push_back(string2vector("--no-huge"));
       }
+
+      for_each_pair(cct->_conf.get_val<std::string>("ms_dpdk_devs_allowlist"), " ",
+		    [&args] (std::string_view key, std::string_view val) {
+		      args.push_back(string2vector(std::string(key)));
+		      if (!val.empty()) {
+                        args.push_back(string2vector(std::string(val)));
+                      }
+		    });
 
       std::string rte_file_prefix;
       rte_file_prefix = "rte_";


### PR DESCRIPTION
Each DPDK process uses some exclusive network adapters.The network adapters to
be used are specified in the whitelist to prevent data sharing between multiple
DPDK process.The following is an example:
1)Configure a single NIC.
-a 0000:7d:010 or --allow=0000:7d:010
2)Configure the Bond Network Adapter
ms_dpdk_port_options=--allow=0000:7d:01.0 --allow=0000:7d:02.6
--vdev=net_bonding0,mode=2,slave=0000:7d:01.0,slave=0000:7d:02.6

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>
Reviewed-by: luo rixin <luorixin@huawei.com>
Reviewed-by: Han Fengzhe  <hanfengzhe@hisilicon.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
