### PR TITLE
msg/async/dpdk: replacing rte_exit with ceph_assert to avoid exit fai…

### DIFF
--- a/src/msg/async/dpdk/DPDK.cc
+++ b/src/msg/async/dpdk/DPDK.cc
@@ -232,9 +232,11 @@ int DPDKDevice::init_port_start()
     } else if (_dev_info.hash_key_size == 52) {
       _rss_key = default_rsskey_52bytes;
     } else if (_dev_info.hash_key_size != 0) {
-      rte_exit(EXIT_FAILURE,
-               "Port %d: We support only 40 or 52 bytes RSS hash keys, %d bytes key requested",
-               _port_idx, _dev_info.hash_key_size);
+      lderr(cct) << "Port " << int(_port_idx)
+	         << ": We support only 40 or 52 bytes RSS hash keys, "
+	         << int(_dev_info.hash_key_size) << " bytes key requested"
+	         << dendl;
+      return -EINVAL;
     } else {
       _rss_key = default_rsskey_40bytes;
       _dev_info.hash_key_size = 40;
@@ -1250,7 +1252,7 @@ std::unique_ptr<DPDKDevice> create_dpdk_net_device(
 {
   // Check that we have at least one DPDK-able port
   if (rte_eth_dev_count_avail() == 0) {
-    rte_exit(EXIT_FAILURE, "No Ethernet ports - bye\n");
+    ceph_assert(false && "No Ethernet ports - bye\n");
   } else {
     ldout(cct, 10) << __func__ << " ports number: " << int(rte_eth_dev_count_avail()) << dendl;
   }

--- a/src/msg/async/dpdk/DPDK.h
+++ b/src/msg/async/dpdk/DPDK.h
@@ -811,7 +811,7 @@ class DPDKDevice {
     /* now initialise the port we will use */
     int ret = init_port_start();
     if (ret != 0) {
-      rte_exit(EXIT_FAILURE, "Cannot initialise port %u\n", _port_idx);
+      ceph_assert(false && "Cannot initialise port\n");
     }
     std::string name(std::string("port") + std::to_string(port_idx));
     PerfCountersBuilder plb(cct, name, l_dpdk_dev_first, l_dpdk_dev_last);


### PR DESCRIPTION
In the DPDK example program,rte_exit is invoked only in the master thread.
The DPDK worker thread cannot invoke rte_exit to avoid waiting forever.

Fixes: https://tracker.ceph.com/issues/53481
Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>
Reviewed-by: luo rixin <luorixin@huawei.com>
Reviewed-by: Han Fengzhe  <hanfengzhe@hisilicon.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
