### PR TITLE
msg/async/dpdk:Add the TSO configuration

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1465,6 +1465,10 @@ options:
   level: advanced
   default: true
   with_legacy: true
+- name: ms_dpdk_enable_tso
+  type: bool
+  level: advanced
+  default: true
 - name: ms_dpdk_hw_flow_control
   type: bool
   level: advanced

--- a/src/msg/async/dpdk/DPDK.cc
+++ b/src/msg/async/dpdk/DPDK.cc
@@ -310,7 +310,10 @@ int DPDKDevice::init_port_start()
   }
 
   // TSO is supported starting from DPDK v1.8
-  if (_dev_info.tx_offload_capa & DEV_TX_OFFLOAD_TCP_TSO) {
+  // TSO is abnormal in some DPDK versions (eg.dpdk-20.11-3.e18.aarch64), try
+  // disable TSO by ms_dpdk_enable_tso=false
+  if ((_dev_info.tx_offload_capa & DEV_TX_OFFLOAD_TCP_TSO) &&
+       cct->_conf.get_val<bool>("ms_dpdk_enable_tso")) {
     ldout(cct, 1) << __func__ << " TSO is supported" << dendl;
     _hw_features.tx_tso = 1;
   }


### PR DESCRIPTION
Some DPDK versions (eg.dpdk-20.11-3.e18.aarch64) or NIC TSOs are abnormal.
The TSO configuration switch is added to control.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>
Reviewed-by: luo rixin <luorixin@huawei.com>
Reviewed-by: Han Fengzhe  <hanfengzhe@hisilicon.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
