### PR TITLE
cephfs-shell: add the ability to mount a named filesystem

### DIFF
--- a/doc/man/8/cephfs-shell.rst
+++ b/doc/man/8/cephfs-shell.rst
@@ -32,13 +32,17 @@ Behaviour of CephFS Shell can be tweaked using ``cephfs-shell.conf``. Refer to
 Options
 =======
 
+.. option:: -b, --batch FILE
+
+   Path to batch file.
+
 .. option:: -c, --config FILE
 
    Path to cephfs-shell.conf
 
-.. option:: -b, --batch FILE
+.. option:: -f, --fs FS
 
-   Path to batch file.
+   Name of filesystem to mount.
 
 .. option:: -t, --test FILE
 

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -386,7 +386,7 @@ def dirwalk(path):
 class CephFSShell(Cmd):
 
     def __init__(self):
-        super().__init__(use_ipython=False)
+        super().__init__()
         self.working_dir = cephfs.getcwd().decode('utf-8')
         self.set_prompt()
         self.interactive = False

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -1498,14 +1498,14 @@ class CephFSShell(Cmd):
 #
 #####################################################
 
-def setup_cephfs():
+def setup_cephfs(args):
     """
     Mounting a cephfs
     """
     global cephfs
     try:
         cephfs = libcephfs.LibCephFS(conffile='')
-        cephfs.mount()
+        cephfs.mount(filesystem_name=args.fs)
     except libcephfs.ObjectNotFound as e:
         print('couldn\'t find ceph configuration not found')
         sys.exit(e.get_error_code())
@@ -1580,12 +1580,15 @@ def get_shell_conffile_path(arg_conf=''):
 
 def manage_args():
     main_parser = argparse.ArgumentParser(description='')
-    main_parser.add_argument('-c', '--config', action='store',
-                             help='Path to Ceph configuration file.',
-                             type=str)
     main_parser.add_argument('-b', '--batch', action='store',
                              help='Path to CephFS shell script/batch file'
                                   'containing CephFS shell commands',
+                             type=str)
+    main_parser.add_argument('-c', '--config', action='store',
+                             help='Path to Ceph configuration file.',
+                             type=str)
+    main_parser.add_argument('-f', '--fs', action='store',
+                             help='Name of filesystem to mount.',
                              type=str)
     main_parser.add_argument('-t', '--test', action='store',
                              help='Test against transcript(s) in FILE',
@@ -1620,7 +1623,7 @@ def manage_sys_argv(args):
     sys.argv.append(exe)
     sys.argv.extend([i.strip() for i in ' '.join(args.commands).split(',')])
 
-    setup_cephfs()
+    setup_cephfs(args)
 
 
 def execute_cmd_args(args):


### PR DESCRIPTION
This PR fixes a bug that prevents cephfs-shell from working on Fedora 35, and also adds the ability for it to mount a named fs.

Fixes: https://tracker.ceph.com/issues/50235

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
