### PR TITLE
rgw: allow specifying ssl certificate for radosgw-admin operations

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1046,6 +1046,13 @@ options:
   see_also:
   - rgw_keystone_verify_ssl
   with_legacy: true
+- name: rgw_verify_ssl_cacert
+  type: str
+  level: advanced
+  desc: Path of custom CA certificate file for ssl client requests.
+  services:
+  - rgw
+  with_legacy: true
 # The following are tunables for caches of RGW NFS (and other file
 # client) objects.
 #

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -318,6 +318,11 @@ std::ostream& RGWHTTPClient::gen_prefix(std::ostream& out) const
 
 void RGWHTTPClient::init()
 {
+  if (!cct->_conf->rgw_verify_ssl_cacert.empty()) {
+    set_ca_path(cct->_conf->rgw_verify_ssl_cacert);
+    dout(20) << "custom ca cert "<< std::quoted(ca_path) << " configured for ssl client" << dendl;
+  }
+
   auto pos = url.find("://");
   if (pos == string::npos) {
     host = url;


### PR DESCRIPTION
examples of radosgw-admin operation requiring setting certificate:

```
../src/mrun c2 radosgw-admin realm pull --url=https://localhost:1443 --access-key a2345678901234567890 --secret a234567890123456789012345678901234567890 --default --rgw_verify_ssl_cacert=./cert.pem

../src/mrun c2 radosgw-admin period pull --url=https://localhost:1443 --access-key a2345678901234567890 --secret a234567890123456789012345678901234567890 --default --rgw_verify_ssl_cacert=./cert.pem

../src/mrun c2 radosgw-admin period update --commit --rgw_verify_ssl_cacert=./cert.pem

../src/mrun c2 radosgw-admin sync status --rgw_verify_ssl_cacert=./cert.pem
```

fixes: https://tracker.ceph.com/issues/53588

Signed-off-by: Mark Kogan <mkogan@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
