### PR TITLE
msg/async/dpdk: support DPDK interrupt mode

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1501,6 +1501,11 @@ options:
   level: advanced
   default: 8192
   with_legacy: true
+- name: ms_async_dpdk_polling_ms
+  type: millisecs
+  level: advanced
+  default: 50
+  desc: number of milliseconds before stop polling and turn off irqs
 - name: inject_early_sigterm
   type: bool
   level: dev

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -74,11 +74,12 @@ class EventDriver {
  public:
   virtual ~EventDriver() {}       // we want a virtual destructor!!!
   virtual int init(EventCenter *center, int nevent) = 0;
+  virtual int get_epfd() { return -1; };
   virtual int add_event(int fd, int cur_mask, int mask) = 0;
   virtual int del_event(int fd, int cur_mask, int del_mask) = 0;
   virtual int event_wait(std::vector<FiredFileEvent> &fired_events, struct timeval *tp) = 0;
   virtual int resize_events(int newsize) = 0;
-  virtual bool need_wakeup() { return true; }
+  virtual int reserved_wakeup_fd(int fd) { return -1; }
 };
 
 /*
@@ -155,6 +156,7 @@ class EventCenter {
   CephContext *cct;
   std::string type;
   int nevent;
+  int polling = 0;
   // Used only to external event
   pthread_t owner = 0;
   std::mutex external_lock;

--- a/src/msg/async/EventEpoll.h
+++ b/src/msg/async/EventEpoll.h
@@ -39,6 +39,7 @@ class EpollDriver : public EventDriver {
   }
 
   int init(EventCenter *c, int nevent) override;
+  int get_epfd() { return epfd; };
   int add_event(int fd, int cur_mask, int add_mask) override;
   int del_event(int fd, int cur_mask, int del_mask) override;
   int resize_events(int newsize) override;

--- a/src/msg/async/dpdk/DPDKStack.cc
+++ b/src/msg/async/dpdk/DPDKStack.cc
@@ -55,6 +55,10 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "dpdkstack "
 
+#ifndef RTE_LCORE_FOREACH_WORKER
+  #define RTE_LCORE_FOREACH_WORKER RTE_LCORE_FOREACH_SLAVE
+#endif
+
 static int dpdk_thread_adaptor(void* f)
 {
   (*static_cast<std::function<void ()>*>(f))();
@@ -259,7 +263,7 @@ void DPDKStack::spawn_worker(std::function<void ()> &&func)
   unsigned nr_worker = funcs.size();
   ceph_assert(rte_lcore_count() >= nr_worker);
   unsigned core_id;
-  RTE_LCORE_FOREACH_SLAVE(core_id) {
+  RTE_LCORE_FOREACH_WORKER(core_id) {
     if (--nr_worker == 0) {
       break;
     }

--- a/src/msg/async/dpdk/EventDPDK.cc
+++ b/src/msg/async/dpdk/EventDPDK.cc
@@ -13,7 +13,7 @@
  * Foundation.  See file COPYING.
  *
  */
-
+#include <rte_ethdev.h>
 #include "common/errno.h"
 #include "DPDKStack.h"
 #include "EventDPDK.h"
@@ -25,61 +25,108 @@
 
 #undef dout_prefix
 #define dout_prefix *_dout << "DPDKDriver."
+#define EVENTS_MAX 64
 
 int DPDKDriver::init(EventCenter *c, int nevent)
 {
+	epfd = epoll_create(EVENTS_MAX);
+	if (epfd < 0) {
+            ldout(cct, 0) << __func__ << "can't create epoll fd" << dendl;
+	    return -EIO;
+	}
+	if (::fcntl(epfd, F_SETFD, FD_CLOEXEC) == -1) {
+	   int e = errno;
+	   ::close(epfd);
+	   lderr(cct) << __func__<< " unable to set cloexec: " << strerror(errno) << dendl;
+
+	   return e;
+	}
 	return 0;
 }
 
 int DPDKDriver::add_event(int fd, int cur_mask, int add_mask)
 {
 	ldout(cct, 20) << __func__ << " add event fd=" << fd << " cur_mask=" << cur_mask
-								 << " add_mask=" << add_mask << dendl;
-
-	int r = manager.listen(fd, add_mask);
-	if (r < 0) {
-		lderr(cct) << __func__ << " add fd=" << fd << " failed. "
-		           << cpp_strerror(-r) << dendl;
-		return -errno;
+		       << " add_mask=" << add_mask << dendl;
+        int r;
+	if (fd != wakeup_fd) {
+	   r = manager.listen(fd, add_mask);
+	} else {
+	    struct epoll_event ee;
+	    ee.events = EPOLLIN | EPOLLET;
+	    ee.data.u64 = 0;
+	    ee.data.fd = wakeup_fd;
+	    r = epoll_ctl(epfd, EPOLL_CTL_ADD, wakeup_fd, &ee);
 	}
-
+        if (r < 0) {
+	    lderr(cct) << __func__<< " add fd=" << fd << " failed. " << cpp_strerror(-r) << dendl;
+	    return -errno;
+	}
 	return 0;
 }
 
 int DPDKDriver::del_event(int fd, int cur_mask, int delmask)
 {
-	ldout(cct, 20) << __func__ << " del event fd=" << fd << " cur_mask=" << cur_mask
-								 << " delmask=" << delmask << dendl;
-	int r = 0;
+	ldout(cct, 20) << __func__ << " del event fd=" << fd << " cur_mask=" << cur_mask << " delmask=" << delmask << dendl;
+	if (delmask == EVENT_NONE)
+	return 0;
 
-	if (delmask != EVENT_NONE) {
-		if ((r = manager.unlisten(fd, delmask)) < 0) {
-			lderr(cct) << __func__ << " delete fd=" << fd << " delmask=" << delmask
-								 << " failed." << cpp_strerror(-r) << dendl;
-			return r;
-		}
+	int r;
+        if (fd != wakeup_fd) {
+	   r = manager.unlisten(fd, delmask);
+	} else {
+	   r = epoll_ctl(epfd, EPOLL_CTL_DEL, wakeup_fd, nullptr);
+	}
+	if (r < 0) {
+	   lderr(cct) << __func__ << " delete fd=" << fd << " delmask=" << delmask
+		      << " failed." << cpp_strerror(-r) << dendl;
+	   return r;
 	}
 	return 0;
 }
 
 int DPDKDriver::resize_events(int newsize)
 {
-	return 0;
+        return 0;
 }
 
 int DPDKDriver::event_wait(std::vector<FiredFileEvent> &fired_events, struct timeval *tvp)
 {
-	int num_events = 512;
-	int events[num_events];
-  int masks[num_events];
+        int num_events = 512;
+        int events[num_events];
+        int masks[num_events];
+        int i = 0;
 
-	int retval = manager.poll(events, masks, num_events, tvp);
-	if (retval > 0) {
-		fired_events.resize(retval);
-		for (int i = 0; i < retval; i++) {
-			fired_events[i].fd = events[i];
-			fired_events[i].mask = masks[i];
-		}
-	}
-	return retval;
+        int timeout = tvp ? (tvp->tv_sec * 1000 + tvp ->tv_usec / 1000) : -1;
+        if (timeout) {
+           struct epoll_event ee[EVENTS_MAX];
+           int retval = epoll_wait(epfd, ee, EVENTS_MAX, timeout);
+           for (int event_id = 0;event_id < retval; event_id++) {
+               struct epoll_event *e = &ee[event_id];
+               if (e->data.u64 & 0xFFFFFFFF00000000) {
+                 struct rte_epoll_event *rev = static_cast <struct rte_epoll_event *>(e->data.ptr);
+                 if (!rev || !rte_atomic32_cmpset(&rev->status, RTE_EPOLL_VALID, RTE_EPOLL_EXEC))
+                   continue;
+                 if (rev->epdata.cb_fun)
+                   rev->epdata.cb_fun(rev->fd, rev->epdata.cb_arg);
+
+                 (*static_cast<std::function<void ()>*>(rev->epdata.data))();
+                 rte_compiler_barrier();
+                 rev->status = RTE_EPOLL_VALID;
+                 continue;
+               }
+               fired_events.push_back({e->data.fd, EVENT_READABLE});
+               i++;
+           }
+        }
+
+        int retval = manager.poll(events, masks, num_events, tvp);
+        if (retval > 0) {
+           fired_events.resize(retval + i);
+           for (int k=0; k < retval; k++, i++) {
+             fired_events[i].fd = events[k];
+             fired_events[i].mask = masks[k];
+           }
+        }
+        return i;
 }

--- a/src/msg/async/dpdk/EventDPDK.h
+++ b/src/msg/async/dpdk/EventDPDK.h
@@ -16,12 +16,15 @@
 #ifndef CEPH_EVENTDPDK_H
 #define CEPH_EVENTDPDK_H
 
+#include "common/ceph_time.h"
 #include "msg/async/Event.h"
 #include "msg/async/Stack.h"
 #include "UserspaceEvent.h"
 
 class DPDKDriver : public EventDriver {
   CephContext *cct;
+  int epfd;
+  int wakeup_fd;
 
  public:
   UserspaceEventManager manager;
@@ -34,7 +37,14 @@ class DPDKDriver : public EventDriver {
   int del_event(int fd, int cur_mask, int del_mask) override;
   int resize_events(int newsize) override;
   int event_wait(std::vector<FiredFileEvent> &fired_events, struct timeval *tp) override;
-  bool need_wakeup() override { return false; }
+  int reserved_wakeup_fd(int fd) override {
+    manager.reserved_wakeup_fd(fd);
+    wakeup_fd = fd;
+    return 0;
+  };
+  int get_epfd() override {
+    return epfd;
+  };
 };
 
-#endif //CEPH_EVENTDPDK_H
+#endif // CEPH_EVENTDPDK_H

--- a/src/msg/async/dpdk/UserspaceEvent.cc
+++ b/src/msg/async/dpdk/UserspaceEvent.cc
@@ -30,6 +30,8 @@ int UserspaceEventManager::get_eventfd()
     unused_fds.pop_front();
   } else {
     fd = ++max_fd;
+    if (fd == wakeup_fd)
+      fd = ++max_fd;
     fds.resize(fd + 1);
   }
 

--- a/src/msg/async/dpdk/UserspaceEvent.h
+++ b/src/msg/async/dpdk/UserspaceEvent.h
@@ -44,6 +44,7 @@ class UserspaceEventManager {
   std::vector<std::optional<UserspaceFDImpl> > fds;
   std::vector<int> waiting_fds;
   std::list<uint32_t> unused_fds;
+  int wakeup_fd;
 
  public:
   explicit UserspaceEventManager(CephContext *c): cct(c) {
@@ -100,6 +101,10 @@ class UserspaceEventManager {
         return false;
     }
     return true;
+  }
+
+  void reserved_wakeup_fd(int fd) {
+    wakeup_fd = fd;
   }
 };
 


### PR DESCRIPTION
The TX and external events are woken up by using the event pipe fd, and
the RX is woken up by using the NIC queue interrupt. The configuration
item is added to enter the interrupt mode after a period of delay
without an event.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>
Reviewed-by: luo rixin <luorixin@huawei.com>
Reviewed-by: Han Fengzhe  <hanfengzhe@hisilicon.com>