### PR TITLE
mgr/balancer: Improve error prompt when balance with crush_compat

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -1217,7 +1217,7 @@ class Module(MgrModule):
                           pe.score)
             plan.compat_ws = {}
             return -errno.EDOM, 'Unable to find further optimization, ' \
-                                'change balancer mode or adjust target_max_misplaced_ratio config and retry might help'
+                                'changing the balancer mode or adjusting the target_max_misplaced_ratio config, then retrying, might help'
 
     def get_compat_weight_set_weights(self, ms: MappingState):
         have_choose_args = CRUSHMap.have_default_choose_args(ms.crush_dump)

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -1217,7 +1217,7 @@ class Module(MgrModule):
                           pe.score)
             plan.compat_ws = {}
             return -errno.EDOM, 'Unable to find further optimization, ' \
-                                'change balancer mode and retry might help'
+                                'change balancer mode or adjust target_max_misplaced_ratio config and retry might help'
 
     def get_compat_weight_set_weights(self, ms: MappingState):
         have_choose_args = CRUSHMap.have_default_choose_args(ms.crush_dump)


### PR DESCRIPTION
Signed-off-by: wangbo-yw <wangbo2_yewu@cmss.chinamobile.com>
    I recently encountered a problem when using the balancer function. It told me "Error EDOM: Unable to find further optimization, change balancer mode and retry might help" even though my cluster was not yet in a balanced turntable. This prompt message does not allow me to find the reason for the failure.
    After many attempts and reading the code, I found that I can gradually adjust target_max_misplaced_ratio config to make balance success. So I want to add this prompt when it fails.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
