### PR TITLE
ceph-volume: improve mpath devices support

### DIFF
--- a/doc/ceph-volume/lvm/prepare.rst
+++ b/doc/ceph-volume/lvm/prepare.rst
@@ -253,7 +253,7 @@ work for both bluestore and filestore OSDs::
 
 ``multipath`` support
 ---------------------
-``multipath`` devices are support if ``lvm`` is configured properly.
+``multipath`` devices are supported if ``lvm`` is configured properly.
 
 **Leave it to LVM**
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -266,7 +266,7 @@ class Zap(object):
 
         for device in devices:
             mlogger.info("Zapping: %s", device.abspath)
-            if device.is_mapper:
+            if device.is_mapper and not device.is_mpath:
                 terminal.error("Refusing to zap the mapper device: {}".format(device))
                 raise SystemExit(1)
             if device.is_lvm_member:

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -130,12 +130,12 @@ class TestDevice(object):
         disk = device.Device("/dev/sda1")
         assert disk.is_partition
 
-    def test_is_not_acceptable_device(self, device_info):
-        data = {"/dev/dm-0": {"foo": "bar"}}
+    def test_mpath_device_is_device(self, device_info):
+        data = {"/dev/foo": {"foo": "bar"}}
         lsblk = {"TYPE": "mpath"}
         device_info(devices=data, lsblk=lsblk)
-        disk = device.Device("/dev/dm-0")
-        assert not disk.is_device
+        disk = device.Device("/dev/foo")
+        assert disk.is_device is True
 
     def test_is_not_lvm_memeber(self, device_info):
         data = {"/dev/sda1": {"foo": "bar"}}

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -137,14 +137,14 @@ class TestDevice(object):
         disk = device.Device("/dev/foo")
         assert disk.is_device is True
 
-    def test_is_not_lvm_memeber(self, device_info):
+    def test_is_not_lvm_member(self, device_info):
         data = {"/dev/sda1": {"foo": "bar"}}
         lsblk = {"TYPE": "part", "PKNAME": "sda"}
         device_info(devices=data, lsblk=lsblk)
         disk = device.Device("/dev/sda1")
         assert not disk.is_lvm_member
 
-    def test_is_lvm_memeber(self, device_info):
+    def test_is_lvm_member(self, device_info):
         data = {"/dev/sda1": {"foo": "bar"}}
         lsblk = {"TYPE": "part", "PKNAME": "sda"}
         device_info(devices=data, lsblk=lsblk)

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -368,6 +368,17 @@ class Device(object):
         return self.path.startswith(('/dev/mapper', '/dev/dm-'))
 
     @property
+    def device_type(self):
+        if self.disk_api:
+            return self.disk_api['TYPE']
+        elif self.blkid_api:
+            return self.blkid_api['TYPE']
+
+    @property
+    def is_mpath(self):
+        return self.device_type == 'mpath'
+
+    @property
     def is_lv(self):
         return self.lv_api is not None
 
@@ -387,10 +398,7 @@ class Device(object):
         elif self.blkid_api:
             api = self.blkid_api
         if api:
-            is_device = api['TYPE'] == 'device'
-            is_disk = api['TYPE'] == 'disk'
-            if is_device or is_disk:
-                return True
+            return self.device_type in ['disk', 'device', 'mpath']
         return False
 
     @property


### PR DESCRIPTION
ee8887f4c0ff4f91117f31b621b95c8d08019130 was intended for adding
mpath devices support in ceph-volume but it has missed the lvm batch scenario.
This also fixes the zapping of mpath devices prepared with `ceph-volume raw`

Fixes: https://tracker.ceph.com/issues/52908

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>