### PR TITLE
cephadm: deal with ambiguity within normalize_image_digest

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4009,16 +4009,29 @@ def command_inspect_image(ctx):
 
 
 def normalize_image_digest(digest: str) -> str:
-    # normal case:
-    #   ceph/ceph -> docker.io/ceph/ceph
-    # edge cases that shouldn't ever come up:
-    #   ubuntu -> docker.io/ubuntu    (ubuntu alias for library/ubuntu)
-    # no change:
-    #   quay.ceph.io/ceph/ceph -> ceph
-    #   docker.io/ubuntu -> no change
-    bits = digest.split('/')
-    if '.' not in bits[0] and len(bits) < 3:
-        digest = DEFAULT_REGISTRY + '/' + digest
+    """
+    Normal case:
+    >>> normalize_image_digest('ceph/ceph', 'docker.io')
+    'docker.io/ceph/ceph'
+
+    No change:
+    >>> normalize_image_digest('quay.ceph.io/ceph/ceph', 'docker.io')
+    'quay.ceph.io/ceph/ceph'
+
+    >>> normalize_image_digest('docker.io/ubuntu', 'docker.io')
+    'docker.io/ubuntu'
+
+    >>> normalize_image_digest('localhost/ceph', 'docker.io')
+    'localhost/ceph'
+    """
+    known_shortnames = [
+        'ceph/ceph',
+        'ceph/daemon',
+        'ceph/daemon-base',
+    ]
+    for image in known_shortnames:
+        if digest.startswith(image):
+            return f'{DEFAULT_REGISTRY}/{digest}'
     return digest
 
 

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -56,8 +56,10 @@ commands =
 
 [testenv:flake8]
 basepython = python3
+allowlist_externals = bash
 deps =
     flake8
     flake8-quotes
 commands =
     flake8 --config=tox.ini {posargs:cephadm}
+    bash -c "test $(grep 'docker.io' cephadm | wc -l) == 10"

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -282,19 +282,19 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             'registry_url',
             type='str',
             default=None,
-            desc='Custom repository url'
+            desc='Registry url for login purposes. This is not the default registry'
         ),
         Option(
             'registry_username',
             type='str',
             default=None,
-            desc='Custom repository username'
+            desc='Custom repository username. Only used for logging into a registry.'
         ),
         Option(
             'registry_password',
             type='str',
             default=None,
-            desc='Custom repository password'
+            desc='Custom repository password. Only used for logging into a registry.'
         ),
         Option(
             'registry_insecure',
@@ -318,7 +318,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             'default_registry',
             type='str',
             default='docker.io',
-            desc='Registry to which we should normalize unqualified image names',
+            desc='Search-registry to which we should normalize unqualified image names. '
+                 'This is not the default registry',
         ),
         Option(
             'max_count_per_host',

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -17,19 +17,19 @@ def test_upgrade_start(cephadm_module: CephadmOrchestrator):
         with with_host(cephadm_module, 'test2'):
             with with_service(cephadm_module, ServiceSpec('mgr', placement=PlacementSpec(count=2)), status_running=True):
                 assert wait(cephadm_module, cephadm_module.upgrade_start(
-                    'image_id', None)) == 'Initiating upgrade to docker.io/image_id'
+                    'image_id', None)) == 'Initiating upgrade to image_id'
 
                 assert wait(cephadm_module, cephadm_module.upgrade_status()
-                            ).target_image == 'docker.io/image_id'
+                            ).target_image == 'image_id'
 
                 assert wait(cephadm_module, cephadm_module.upgrade_pause()
-                            ) == 'Paused upgrade to docker.io/image_id'
+                            ) == 'Paused upgrade to image_id'
 
                 assert wait(cephadm_module, cephadm_module.upgrade_resume()
-                            ) == 'Resumed upgrade to docker.io/image_id'
+                            ) == 'Resumed upgrade to image_id'
 
                 assert wait(cephadm_module, cephadm_module.upgrade_stop()
-                            ) == 'Stopped upgrade to docker.io/image_id'
+                            ) == 'Stopped upgrade to image_id'
 
 
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
@@ -57,10 +57,10 @@ def test_upgrade_run(use_repo_digest, cephadm_module: CephadmOrchestrator):
                            }):
                 version_mock.return_value = 'ceph version 18.2.1 (somehash)'
                 assert wait(cephadm_module, cephadm_module.upgrade_start(
-                    'to_image', None)) == 'Initiating upgrade to docker.io/to_image'
+                    'to_image', None)) == 'Initiating upgrade to to_image'
 
                 assert wait(cephadm_module, cephadm_module.upgrade_status()
-                            ).target_image == 'docker.io/to_image'
+                            ).target_image == 'to_image'
 
                 def _versions_mock(cmd):
                     return json.dumps({
@@ -114,7 +114,7 @@ def test_upgrade_run(use_repo_digest, cephadm_module: CephadmOrchestrator):
                 if use_repo_digest:
                     assert image == 'to_image@repo_digest'
                 else:
-                    assert image == 'docker.io/to_image'
+                    assert image == 'to_image'
 
 
 def test_upgrade_state_null(cephadm_module: CephadmOrchestrator):

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -27,20 +27,24 @@ def normalize_image_digest(digest: str, default_registry: str) -> str:
     >>> normalize_image_digest('ceph/ceph', 'docker.io')
     'docker.io/ceph/ceph'
 
-    Edge cases that shouldn't ever come up. (ubuntu alias for library/ubuntu)
-    >>> normalize_image_digest('ubuntu', 'docker.io')
-    'docker.io/ubuntu'
-
     No change:
     >>> normalize_image_digest('quay.ceph.io/ceph/ceph', 'docker.io')
     'quay.ceph.io/ceph/ceph'
 
     >>> normalize_image_digest('docker.io/ubuntu', 'docker.io')
     'docker.io/ubuntu'
+
+    >>> normalize_image_digest('localhost/ceph', 'docker.io')
+    'localhost/ceph'
     """
-    bits = digest.split('/')
-    if '.' not in bits[0] or len(bits) < 3:
-        digest = 'docker.io/' + digest
+    known_shortnames = [
+        'ceph/ceph',
+        'ceph/daemon',
+        'ceph/daemon-base',
+    ]
+    for image in known_shortnames:
+        if digest.startswith(image):
+            return f'{default_registry}/{digest}'
     return digest
 
 

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -22,13 +22,22 @@ CEPH_MDSMAP_ALLOW_STANDBY_REPLAY = (1 << 5)
 
 
 def normalize_image_digest(digest: str, default_registry: str) -> str:
-    # normal case:
-    #   ceph/ceph -> docker.io/ceph/ceph
-    # edge cases that shouldn't ever come up:
-    #   ubuntu -> docker.io/ubuntu    (ubuntu alias for library/ubuntu)
-    # no change:
-    #   quay.ceph.io/ceph/ceph -> ceph
-    #   docker.io/ubuntu -> no change
+    """
+    Normal case:
+    >>> normalize_image_digest('ceph/ceph', 'docker.io')
+    'docker.io/ceph/ceph'
+
+    Edge cases that shouldn't ever come up. (ubuntu alias for library/ubuntu)
+    >>> normalize_image_digest('ubuntu', 'docker.io')
+    'docker.io/ubuntu'
+
+    No change:
+    >>> normalize_image_digest('quay.ceph.io/ceph/ceph', 'docker.io')
+    'quay.ceph.io/ceph/ceph'
+
+    >>> normalize_image_digest('docker.io/ubuntu', 'docker.io')
+    'docker.io/ubuntu'
+    """
     bits = digest.split('/')
     if '.' not in bits[0] or len(bits) < 3:
         digest = 'docker.io/' + digest

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -144,6 +144,7 @@ commands =
 basepython = python3
 deps =
     flake8
+allowlist_externals = bash
 modules =
     alerts
     balancer
@@ -161,6 +162,7 @@ modules =
 commands =
     flake8 --config=tox.ini {posargs} \
       {posargs:{[testenv:flake8]modules}}
+    bash -c 'test $(git ls-files cephadm | grep ".py$" | grep -v tests | xargs grep "docker.io" | wc -l) == 12'
 
 [testenv:jinjalint]
 basepython = python3


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/53594


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
