### PR TITLE
doc/cephfs: mds default cache memory limit is now 4GB

### DIFF
--- a/doc/cephfs/health-messages.rst
+++ b/doc/cephfs/health-messages.rst
@@ -181,7 +181,7 @@ other daemons, please see :ref:`health-checks`.
     limit set by the administrator.  If the MDS cache becomes too large, the daemon
     may exhaust available memory and crash.  By default, this message appears if
     the actual cache size (in memory) is at least 50% greater than
-    ``mds_cache_memory_limit`` (default 1GB). Modify ``mds_health_cache_threshold``
+    ``mds_cache_memory_limit`` (default 4GB). Modify ``mds_health_cache_threshold``
     to set the warning ratio.
 
 ``FS_WITH_FAILED_MDS``

--- a/doc/cephfs/mount-using-kernel-driver.rst
+++ b/doc/cephfs/mount-using-kernel-driver.rst
@@ -24,7 +24,7 @@ Is mount helper is present?
 ---------------------------
 ``mount.ceph`` helper is installed by Ceph packages. The helper passes the
 monitor address(es) and CephX user keyrings automatically saving the Ceph
-admin the effort to pass these details explicitly while mountng CephFS. In
+admin the effort to pass these details explicitly while mounting CephFS. In
 case the helper is not present on the client machine, CephFS can still be
 mounted using kernel but by passing these details explicitly to the ``mount``
 command. To check whether it is present on your system, do::


### PR DESCRIPTION
MDS default cache memory limit is now 4GB.

Signed-off-by: wangxinyu <wangxinyu@inspur.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
