### PR TITLE
pacific: ceph-volume: make it possible to skip needs_root()

### DIFF
--- a/src/ceph-volume/ceph_volume/decorators.py
+++ b/src/ceph-volume/ceph_volume/decorators.py
@@ -11,7 +11,7 @@ def needs_root(func):
     """
     @wraps(func)
     def is_root(*a, **kw):
-        if not os.getuid() == 0:
+        if not os.getuid() == 0 and not os.environ.get('CEPH_VOLUME_SKIP_NEEDS_ROOT', False):
             raise exceptions.SuperUserError()
         return func(*a, **kw)
     return is_root

--- a/src/ceph-volume/ceph_volume/tests/test_decorators.py
+++ b/src/ceph-volume/ceph_volume/tests/test_decorators.py
@@ -11,6 +11,13 @@ class TestNeedsRoot(object):
         monkeypatch.setattr(decorators.os, 'getuid', lambda: 0)
         assert decorators.needs_root(func)() is True
 
+    def test_is_not_root_env_var_skip_needs_root(self, monkeypatch):
+        def func():
+            return True
+        monkeypatch.setattr(decorators.os, 'getuid', lambda: 123)
+        monkeypatch.setattr(decorators.os, 'environ', {'CEPH_VOLUME_SKIP_NEEDS_ROOT': '1'})
+        assert decorators.needs_root(func)() is True
+
     def test_is_not_root(self, monkeypatch):
         def func():
             return True # pragma: no cover


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53617

---

backport of https://github.com/ceph/ceph/pull/44239
parent tracker: https://tracker.ceph.com/issues/53511

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh