### PR TITLE
cmake: add ceph-common DENABLE_SHARED=OFF support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -546,7 +546,7 @@ add_library(common STATIC ${ceph_common_objs})
 target_link_libraries(common ${ceph_common_deps})
 add_dependencies(common legacy-option-headers)
 
-add_library(ceph-common SHARED ${ceph_common_objs})
+add_library(ceph-common ${CEPH_SHARED} ${ceph_common_objs})
 target_link_libraries(ceph-common ${ceph_common_deps})
 add_dependencies(ceph-common legacy-option-headers)
 # appease dpkg-shlibdeps


### PR DESCRIPTION
I needed to build librados STATIC, for this purpose i found DENABLE_SHARED=OFF. 
But librados depends on ceph-common which is always build dynamic. So i had this problem:
![image](https://user-images.githubusercontent.com/8061177/146221262-5f1f9f2a-c3ab-400e-833c-ec05e2eacb85.png)
This small patch fixes this issue.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests