### PR TITLE
rgw/amqp: add default case to silence compiler warning

### DIFF
--- a/src/rgw/rgw_amqp.cc
+++ b/src/rgw/rgw_amqp.cc
@@ -322,8 +322,9 @@ std::string to_string(amqp_status_enum s) {
       return "AMQP_STATUS_SSL_CONNECTION_FAILED";
     case _AMQP_STATUS_SSL_NEXT_VALUE:
       return "AMQP_STATUS_INTERNAL"; 
+    default:
+      return "AMQP_STATUS_UNKNOWN";
   }
-  return "AMQP_STATUS_UNKNOWN";
 }
 
 // TODO: add status_to_string on the connection object to prinf full status


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/53252

```
Building CXX object src/rgw/CMakeFiles/rgw_common.dir/rgw_amqp.cc.o
/home/cbodley/ceph/src/rgw/rgw_amqp.cc: In function ‘std::string rgw::amqp::to_string(amqp_status_enum)’:
/home/cbodley/ceph/src/rgw/rgw_amqp.cc:262:10: warning: enumeration value ‘AMQP_STATUS_SSL_SET_ENGINE_FAILED’ not handled in switch [-Wswitch]
  262 |   switch (s) {
      |          ^
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
