### PR TITLE
pacific: mgr/devicehealth: fix missing timezone from time delta calculation

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -8,7 +8,7 @@ from mgr_module import MgrModule, CommandResult, CLICommand, Option
 import operator
 import rados
 from threading import Event
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import cast, Any, Dict, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 TIME_FORMAT = '%Y%m%d-%H%M%S'
@@ -545,7 +545,7 @@ class Module(MgrModule):
         devs = self.get("devices")
         osds_in = {}
         osds_out = {}
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)  # e.g. '2021-09-22 13:18:45.021712+00:00'
         osdmap = self.get("osd_map")
         assert osdmap is not None
         for dev in devs['devices']:
@@ -560,7 +560,7 @@ class Module(MgrModule):
                 continue
             # life_expectancy_(min/max) is in the format of:
             # '%Y-%m-%dT%H:%M:%S.%f%z', e.g.:
-            # '2019-01-20T21:12:12.000000Z'
+            # '2019-01-20 21:12:12.000000+00:00'
             life_expectancy_max = datetime.strptime(
                 dev['life_expectancy_max'],
                 '%Y-%m-%dT%H:%M:%S.%f%z')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53621

---

backport of https://github.com/ceph/ceph/pull/43412
parent tracker: https://tracker.ceph.com/issues/52327

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh