### PR TITLE
rgw/rgw_file: fix librgw lru lane weak lock

### DIFF
--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -74,6 +74,8 @@ namespace cohort {
 
       virtual bool reclaim(const ObjectFactory* newobj_fac) = 0;
 
+      virtual bool remove() = 0;
+
       virtual ~Object() {}
 
     private:
@@ -207,6 +209,7 @@ namespace cohort {
 	      Object::Queue::s_iterator_to(*o);
 	    lane.q.erase(it);
 	    tdo = o;
+	    tdo->remove();
 	  }
 	  lane.lock.unlock();
 	} else if (unlikely(refcnt == SENTINEL_REFCNT)) {
@@ -221,6 +224,7 @@ namespace cohort {
 	    /* hiwat check */
 	    if (lane.q.size() > lane_hiwat) {
 	      tdo = o;
+	      tdo->remove();
 	    } else {
 	      lane.q.push_back(*o);
 	    }


### PR DESCRIPTION
A RGWFileHandle is been unref (rgw::RGWLibFS::unref), it may be used for other thread operation at the same time because of handle sharing. When lru length overpass `rgw_nfs_lru_lane_hiwat`, lru object will be deleted out of lru lane lock. Then, something bad will be happend.

Fixes: https://tracker.ceph.com/issues/53354

Signed-off-by: Dai Zhiwei <daizhiwei3@huawei.com>
Signed-off-by: luorixin <luorixin@huawei.com>