### PR TITLE
mgr/telemetry: add heap stats and pool application to the perf channel

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -520,6 +520,9 @@ class Module(MgrModule):
 
         return result
 
+    def get_stats_per_pg(self) -> dict:
+        return self.get('pg_dump')['pg_stats']
+
     def gather_crashinfo(self) -> List[Dict[str, str]]:
         crashlist: List[Dict[str, str]] = list()
         errno, crashids, err = self.remote('crash', 'ls')
@@ -970,7 +973,7 @@ class Module(MgrModule):
         if 'perf' in channels:
             report['perf_counters'] = self.gather_perf_counters('separated')
             report['stats_per_pool'] = self.get_stats_per_pool()
-            report['stats_per_pg'] = self.get('pg_dump')['pg_stats']
+            report['stats_per_pg'] = self.get_stats_per_pg()
             report['io_rate'] = self.get_io_rate()
             report['osd_perf_histograms'] = self.get_osd_histograms('separated')
             report['mempool'] = self.get_mempool('separated')

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -306,6 +306,47 @@ class Module(MgrModule):
             'active_changed': sorted(list(active)),
         }
 
+    def get_heap_stats(self) -> Dict[str, dict]:
+        # Initialize result dict
+        result: Dict[str, dict] = defaultdict(lambda: defaultdict(int))
+
+        # Get list of osd ids from the metadata
+        osd_metadata = self.get('osd_metadata')
+
+        # Grab output from the "osd.x heap stats" command
+        for osd_id in osd_metadata:
+            cmd_dict = {
+                'prefix': 'heap',
+                'heapcmd': 'stats',
+                'id': str(osd_id),
+            }
+            r, outb, outs = self.osd_command(cmd_dict)
+            if r != 0:
+                self.log.debug("Invalid command dictionary.")
+                continue
+            else:
+                if 'tcmalloc heap stats' in outs:
+                    values = [int(i) for i in outs.split() if i.isdigit()]
+                    if len(values) != 12:
+                        self.log.debug('Received unexpected output: | outs: {} ' \
+                                '| values: {} |'.format(outs, values))
+                        return {}
+
+                    categories = ['use_by_application', 'page_heap_freelist',
+                                  'central_cache_freelist', 'transfer_cache_freelist',
+                                  'thread_cache_freelists', 'malloc_metadata',
+                                  'actual_memory_used', 'released_to_os',
+                                  'virtual_address_space_used', 'spans_in_use',
+                                  'thread_heaps_in_use', 'tcmalloc_page_size']
+
+                    osd = 'osd.' + str(osd_id)
+                    result[osd] = dict(zip(categories, values))
+                else:
+                    self.log.debug('No heap stats available: {}'.format(outs))
+                    return {}
+
+        return result
+
     def get_mempool(self, mode: str = 'separated') -> Dict[str, dict]:
         # Initialize result dict
         result: Dict[str, dict] = defaultdict(lambda: defaultdict(int))
@@ -912,6 +953,7 @@ class Module(MgrModule):
             report['io_rate'] = self.get_io_rate()
             report['osd_perf_histograms'] = self.get_osd_histograms('separated')
             report['mempool'] = self.get_mempool('separated')
+            report['heap_stats'] = self.get_heap_stats()
 
         # NOTE: We do not include the 'device' channel in this report; it is
         # sent to a different endpoint.


### PR DESCRIPTION
Changes:
1. A `heap_stats` field has been added to the perf channel. It is the parsed output of `ceph tell osd.* heap stats`.
2. An `application` field has been added to `stats_per_pool` to indicate the type of each pool (i.e. "rbd" or "cephfs").
3. A separate helper function has been created for `stats_per_pg` to keep uniformity with the rest of the perf channel implementations. This will make it easier to modify this function in the future if needed.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
