### PR TITLE
crimson/osd: removing an unneeded make_unique()

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -106,7 +106,8 @@ seastar::future<> make_keyring()
       fmt::print(std::cerr, "already have key in keyring: {}\n", path);
       return seastar::now();
     } else {
-      auth.key.create(std::make_unique<CephContext>().get(), CEPH_CRYPTO_AES);
+      CephContext temp_cct{};
+      auth.key.create(&temp_cct, CEPH_CRYPTO_AES);
       keyring.add(name, auth);
       bufferlist bl;
       keyring.encode_plaintext(bl);


### PR DESCRIPTION
As the desired lifetime of the object matches the lifetime if
allocated on the stack, and as no ownership is transferred,
there is no point in using a unique_ptr here.

And see Google's guidance (https://abseil.io/tips/187),
under "Common Anti-Pattern: Avoiding &".

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>


