### PR TITLE
mds: fix crash when exporting unlinked dir

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -846,6 +846,31 @@ class CephFSMount(object):
 
         return rproc
 
+    def open_dir_background(self, basename):
+        """
+        Create and hold a capability to a directory.
+        """
+        assert(self.is_mounted())
+
+        path = os.path.join(self.hostfs_mntpt, basename)
+
+        pyscript = dedent("""
+            import time
+            import os
+
+            os.mkdir("{path}")
+            fd = os.open("{path}", os.O_RDONLY)
+            while True:
+                time.sleep(1)
+            """).format(path=path)
+
+        rproc = self._run_python(pyscript)
+        self.background_procs.append(rproc)
+
+        self.wait_for_visible(basename)
+
+        return rproc
+
     def wait_for_dir_empty(self, dirname, timeout=30):
         dirpath = os.path.join(self.hostfs_mntpt, dirname)
         with safe_while(sleep=5, tries=(timeout//5)) as proceed:

--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -602,7 +602,6 @@ class TestStrays(CephFSTestCase):
         """
         :param to_id: MDS id to move it to
         :param path: Filesystem path (string) to move
-        :param watch_ino: Inode number to look for at destination to confirm move
         :return: None
         """
         self.mount_a.run_shell(["setfattr", "-n", "ceph.dir.pin", "-v", str(rank), path])
@@ -699,6 +698,46 @@ ln dir_1/original dir_2/linkto
 
         # See that the stray counter on rank 0 has incremented
         self.assertEqual(self.get_mdc_stat("strays_created", rank_0_id), 1)
+
+    def test_migrate_unlinked_dir(self):
+        """
+        Reproduce https://tracker.ceph.com/issues/53597
+        """
+        rank_0_id, rank_1_id = self._setup_two_ranks()
+
+        self.mount_a.run_shell_payload("""
+mkdir pin
+touch pin/placeholder
+""")
+
+        self._force_migrate("pin")
+
+        # Hold the dir open so it cannot be purged
+        p = self.mount_a.open_dir_background("pin/to-be-unlinked")
+
+        # Unlink the dentry
+        self.mount_a.run_shell(["rmdir", "pin/to-be-unlinked"])
+
+        # Wait to see the stray count increment
+        self.wait_until_equal(
+            lambda: self.get_mdc_stat("num_strays", mds_id=rank_1_id),
+            expect_val=1, timeout=60, reject_fn=lambda x: x > 1)
+        # but not purged
+        self.assertEqual(self.get_mdc_stat("strays_created", mds_id=rank_1_id), 1)
+        self.assertEqual(self.get_mdc_stat("strays_enqueued", mds_id=rank_1_id), 0)
+
+        # Test loading unlinked dir into cache
+        self.fs.mds_asok(['flush', 'journal'], rank_1_id)
+        self.fs.mds_asok(['cache', 'drop'], rank_1_id)
+
+        # Shut down rank 1
+        self.fs.set_max_mds(1)
+        self.fs.wait_for_daemons(timeout=120)
+        # Now the stray should be migrated to rank 0
+        # self.assertEqual(self.get_mdc_stat("strays_created", mds_id=rank_0_id), 1)
+        # https://github.com/ceph/ceph/pull/44335#issuecomment-1125940158
+
+        self.mount_a.kill_background(p)
 
     def assert_backtrace(self, ino, expected_path):
         """

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1475,6 +1475,20 @@ void CDir::mark_new(LogSegment *ls)
   mdcache->mds->queue_waiters(waiters);
 }
 
+void CDir::set_fresh_fnode(fnode_const_ptr&& ptr) {
+  ceph_assert(inode->is_auth());
+  ceph_assert(!is_projected());
+  ceph_assert(!state_test(STATE_COMMITTING));
+  reset_fnode(std::move(ptr));
+  projected_version = committing_version = committed_version = get_version();
+
+  if (state_test(STATE_REJOINUNDEF)) {
+    ceph_assert(mdcache->mds->is_rejoin());
+    state_clear(STATE_REJOINUNDEF);
+    mdcache->opened_undef_dirfrag(this);
+  }
+}
+
 void CDir::mark_clean()
 {
   dout(10) << __func__ << " " << *this << " version " << get_version() << dendl;
@@ -1547,16 +1561,9 @@ void CDir::fetch(std::string_view dname, snapid_t last,
       pdir && pdir->inode->is_stray() && !inode->snaprealm) {
     dout(7) << "fetch dirfrag for unlinked directory, mark complete" << dendl;
     if (get_version() == 0) {
-      ceph_assert(inode->is_auth());
       auto _fnode = allocate_fnode();
       _fnode->version = 1;
-      reset_fnode(std::move(_fnode));
-
-      if (state_test(STATE_REJOINUNDEF)) {
-	ceph_assert(mdcache->mds->is_rejoin());
-	state_clear(STATE_REJOINUNDEF);
-	mdcache->opened_undef_dirfrag(this);
-      }
+      set_fresh_fnode(std::move(_fnode));
     }
     mark_complete();
 
@@ -2043,17 +2050,7 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
   // take the loaded fnode?
   // only if we are a fresh CDir* with no prior state.
   if (get_version() == 0) {
-    ceph_assert(!is_projected());
-    ceph_assert(!state_test(STATE_COMMITTING));
-    auto _fnode = allocate_fnode(got_fnode);
-    reset_fnode(std::move(_fnode));
-    projected_version = committing_version = committed_version = get_version();
-
-    if (state_test(STATE_REJOINUNDEF)) {
-      ceph_assert(mdcache->mds->is_rejoin());
-      state_clear(STATE_REJOINUNDEF);
-      mdcache->opened_undef_dirfrag(this);
-    }
+    set_fresh_fnode(allocate_fnode(got_fnode));
   }
 
   list<CInode*> undef_inodes;

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -247,6 +247,7 @@ public:
   void reset_fnode(fnode_const_ptr&& ptr) {
     fnode = std::move(ptr);
   }
+  void set_fresh_fnode(fnode_const_ptr&& ptr);
 
   const fnode_const_ptr& get_fnode() const {
     return fnode;


### PR DESCRIPTION
When fetch() an unlinked dir, we set fnode->version = 1, but leave projected_version = 0. This will trigger the assert `dir->get_projected_version() == dir->get_version()` in Migrator::encode_export_dir().

projected_version should equal to `fnode->version` unless this dir is projected.

Fix this by introducing a new helper CDir::set_fresh_fnode(), which will ensure versions are correctly set.

Fixes: https://tracker.ceph.com/issues/53597
Signed-off-by: 胡玮文 <huww98@outlook.com>

I'm the reporter of the above tracker ticket. I just read the code and logs, but not tested this patch. Please help me test it if possible.

And it is a bit strange if I'm not missing something. This bug seems pretty easy to reproduce. We have above 100 of such directories with just less than 30 clients. So why didn't anybody report it before?

example crash logs when reducing max_mds from 2 to 1:
```log
2021-12-16T06:25:13.749+0000 7f04aa738700 10 MDSContext::complete: 25C_IO_Dir_OMAP_FetchedMore
2021-12-16T06:25:13.749+0000 7f04b0744700  7 mds.1.cache handle_discover mds.0 wants basedir+ has [inode 0x20007e2462d [...2,head] ~mds1/stray8/20007e2462d/ auth{0=1} v82292168 ap=3 FROZEN_AUTHPIN f(v0 m2021-12-12T14:07:02.907234+0000) n(v0 rc2021-12-12T14:07:02.907234+0000 1=0+1) (ilink xlock x=1 by 0x5622a6ddcc00) (isnap xlock x=1 by 0x5622a6ddcc00) (inest lock) (iversion lock x=1 by 0x5622a6ddcc00) caps={8134535=p/-@1},l=8134535 | request=1 lock=3 caps=1 frozen=0 replicated=1 waiter=0 authpin=1 0x56207f099180]
2021-12-16T06:25:13.749+0000 7f04b0744700 15 mds.1.cache.ino(0x20007e2462d) maybe_export_pin update=0 [inode 0x20007e2462d [...2,head] ~mds1/stray8/20007e2462d/ auth{0=1} v82292168 ap=3 FROZEN_AUTHPIN f(v0 m2021-12-12T14:07:02.907234+0000) n(v0 rc2021-12-12T14:07:02.907234+0000 1=0+1) (ilink xlock x=1 by 0x5622a6ddcc00) (isnap xlock x=1 by 0x5622a6ddcc00) (inest lock) (iversion lock x=1 by 0x5622a6ddcc00) caps={8134535=p/-@1},l=8134535 | request=1 lock=3 caps=1 frozen=0 replicated=1 waiter=0 authpin=1 0x56207f099180]
2021-12-16T06:25:13.749+0000 7f04b0744700  7 mds.1.cache incomplete dir contents for [dir 0x20007e2462d ~mds1/stray8/20007e2462d/ [2,head] auth v=0 cv=0/0 state=1073741824 f() n() hs=0+0,ss=0+0 0x5623e3221b00], fetching
2021-12-16T06:25:13.749+0000 7f04b0744700 10 mds.1.cache.dir(0x20007e2462d) fetch on [dir 0x20007e2462d ~mds1/stray8/20007e2462d/ [2,head] auth v=0 cv=0/0 state=1073741824 f() n() hs=0+0,ss=0+0 0x5623e3221b00]
2021-12-16T06:25:13.749+0000 7f04b0744700  7 mds.1.cache.dir(0x20007e2462d) fetch dirfrag for unlinked directory, mark complete
2021-12-16T06:25:13.749+0000 7f04b0744700  7 mds.1.79799 mds has 1 queued contexts
2021-12-16T06:25:13.749+0000 7f04b0744700 10 mds.1.79799  finish 0x562258e68840
2021-12-16T06:25:13.749+0000 7f04b0744700 10 MDSContext::complete: 18C_MDS_RetryMessage
--
2021-12-16T06:25:17.873+0000 7f04aa738700 10 MDSContext::complete: 12C_M_ExportGo
2021-12-16T06:25:17.873+0000 7f04aa738700  7 mds.1.mig export_go_synced [dir 0x20007e2462d ~mds0/stray8/20007e2462d/ [2,head] auth{0=2} v=1 cv=0/0 dir_auth=1,1 state=1073742851|complete|frozentree|exporting f() n() hs=0+0,ss=0+0 | ptrwaiter=1 request=0 frozen=1 subtree=1 replicated=1 waiter=0 authpin=0 0x5623e3221b00] to 0
2021-12-16T06:25:17.873+0000 7f04aa738700 10 mds.1.cache number of subtrees = 96; not printing subtrees
2021-12-16T06:25:17.873+0000 7f04aa738700  7 mds.1.cache adjust_subtree_auth 1,1 -> 1,0 on [dir 0x20007e2462d ~mds0/stray8/20007e2462d/ [2,head] auth{0=2} v=1 cv=0/0 dir_auth=1,1 state=1073742851|complete|frozentree|exporting f() n() hs=0+0,ss=0+0 | ptrwaiter=1 request=0 frozen=1 subtree=1 replicated=1 waiter=0 authpin=0 0x5623e3221b00]
2021-12-16T06:25:17.873+0000 7f04aa738700 10 mds.1.cache number of subtrees = 96; not printing subtrees
2021-12-16T06:25:17.873+0000 7f04aa738700  7 mds.1.cache  current root is [dir 0x20007e2462d ~mds0/stray8/20007e2462d/ [2,head] auth{0=2} v=1 cv=0/0 dir_auth=1,1 state=1073742851|complete|frozentree|exporting f() n() hs=0+0,ss=0+0 | ptrwaiter=1 request=0 frozen=1 subtree=1 replicated=1 waiter=0 authpin=0 0x5623e3221b00]
2021-12-16T06:25:17.873+0000 7f04aa738700 10 mds.1.cache.dir(0x20007e2462d) setting dir_auth=1,0 from 1,1 on [dir 0x20007e2462d ~mds0/stray8/20007e2462d/ [2,head] auth{0=2} v=1 cv=0/0 dir_auth=1,1 state=1073742851|complete|frozentree|exporting f() n() hs=0+0,ss=0+0 | ptrwaiter=1 request=0 frozen=1 subtree=1 replicated=1 waiter=0 authpin=0 0x5623e3221b00]
2021-12-16T06:25:17.873+0000 7f04aa738700 10 mds.1.cache number of subtrees = 96; not printing subtrees
2021-12-16T06:25:17.873+0000 7f04aa738700  7 mds.1.mig encode_export_dir [dir 0x20007e2462d ~mds0/stray8/20007e2462d/ [2,head] auth{0=2} v=1 cv=0/0 dir_auth=1,0 state=1073742851|complete|frozentree|exporting f() n() hs=0+0,ss=0+0 | ptrwaiter=1 request=0 frozen=1 subtree=1 replicated=1 waiter=0 authpin=0 0x5623e3221b00] 0 head items
2021-12-16T06:25:17.877+0000 7f04aa738700 -1 /home/jenkins-build/build/workspace/ceph-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/16.2.6/rpm/el8/BUILD/ceph-16.2.6/src/mds/Migrator.cc: In function 'void Migrator::encode_export_dir(ceph::bufferlist&, CDir*, std::map<client_t, entity_inst_t>&, std::map<client_t, client_metadata_t>&, uint64_t&)' thread 7f04aa738700 time 2021-12-16T06:25:17.877684+0000
/home/jenkins-build/build/workspace/ceph-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/16.2.6/rpm/el8/BUILD/ceph-16.2.6/src/mds/Migrator.cc: 1753: FAILED ceph_assert(dir->get_projected_version() == dir->get_version())
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
