### PR TITLE
qa/rgw: enable sse-s3 in vault transit configuration

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
+++ b/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
@@ -13,6 +13,8 @@ overrides:
   rgw:
     client.0:
       use-vault-role: client.0
+  s3tests:
+    with-sse-s3: true
 
 tasks:
 - vault:

--- a/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
+++ b/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
@@ -6,6 +6,10 @@ overrides:
         rgw crypt vault auth: token
         rgw crypt vault secret engine: transit
         rgw crypt vault prefix: /v1/transit/
+        rgw crypt sse s3 backend: vault
+        rgw crypt sse s3 vault auth: token
+        rgw crypt sse s3 vault secret engine: transit
+        rgw crypt sse s3 vault prefix: /v1/transit/
   rgw:
     client.0:
       use-vault-role: client.0

--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -138,9 +138,12 @@ def start_rgw(ctx, config, clients):
             ctx.cluster.only(client).run(args=['sudo', 'chmod', '600', token_path])
             ctx.cluster.only(client).run(args=['sudo', 'chown', 'ceph', token_path])
 
+            vault_addr = "{}:{}".format(*ctx.vault.endpoints[vault_role])
             rgw_cmd.extend([
-                '--rgw_crypt_vault_addr', "{}:{}".format(*ctx.vault.endpoints[vault_role]),
-                '--rgw_crypt_vault_token_file', token_path
+                '--rgw_crypt_vault_addr', vault_addr,
+                '--rgw_crypt_vault_token_file', token_path,
+                '--rgw_crypt_sse_s3_vault_addr', vault_addr,
+                '--rgw_crypt_sse_s3_vault_token_file', token_path,
             ])
         elif pykmip_role is not None:
             if not hasattr(ctx, 'pykmip'):

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -424,6 +424,8 @@ def run_tests(ctx, config):
         attrs = ["!fails_on_rgw", "!lifecycle_expiration", "!fails_strict_rfc2616","!test_of_sts","!webidentity_test"]
         if client_config.get('calling-format') != 'ordinary':
             attrs += ['!fails_with_subdomain']
+        if not client_config.get('with-sse-s3'):
+            attrs += ['!sse-s3']
        
         if 'extra_attrs' in client_config:
             attrs = client_config.get('extra_attrs') 


### PR DESCRIPTION
adds sse-s3 configuration from https://github.com/ceph/ceph/pull/42522 and runs the related test cases from https://github.com/ceph/s3-tests/pull/407

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
