### PR TITLE
crimson/osd: honor discarding old backfill messages

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1116,8 +1116,7 @@ void PG::handle_rep_op_reply(crimson::net::ConnectionRef conn,
   }
 }
 
-template <typename MsgType>
-bool PG::can_discard_replica_op(const MsgType& m) const
+bool PG::can_discard_replica_op(const Message& m, epoch_t m_map_epoch) const
 {
   // if a repop is replied after a replica goes down in a new osdmap, and
   // before the pg advances to this new osdmap, the repop replies before this
@@ -1135,15 +1134,15 @@ bool PG::can_discard_replica_op(const MsgType& m) const
   // sent by replicas not in the acting set, since
   // if such a replica goes down it does not cause
   // a new interval.
-  if (osdmap->get_down_at(from_osd) >= m.map_epoch) {
+  if (osdmap->get_down_at(from_osd) >= m_map_epoch) {
     return true;
   }
   // same pg?
   //  if pg changes *at all*, we reset and repeer!
   if (epoch_t lpr = peering_state.get_last_peering_reset();
-      lpr > m.map_epoch) {
+      lpr > m_map_epoch) {
     logger().debug("{}: pg changed {} after {}, dropping",
-                   __func__, get_info().history, m.map_epoch);
+                   __func__, get_info().history, m_map_epoch);
     return true;
   }
   return false;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -707,6 +707,11 @@ public:
     return seastar::now();
   }
 
+  template <typename MsgType>
+  bool can_discard_replica_op(const MsgType& m) const {
+    return can_discard_replica_op(m, m.map_epoch);
+  }
+
 private:
   // instead of seastar::gate, we use a boolean flag to indicate
   // whether the system is shutting down, as we don't need to track
@@ -746,8 +751,7 @@ private:
     return seastar::make_ready_future<bool>(true);
   }
 
-  template <typename MsgType>
-  bool can_discard_replica_op(const MsgType& m) const;
+  bool can_discard_replica_op(const Message& m, epoch_t m_map_epoch) const;
   bool can_discard_op(const MOSDOp& m) const;
   bool is_missing_object(const hobject_t& soid) const {
     return peering_state.get_pg_log().get_missing().get_items().count(soid);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -707,6 +707,8 @@ public:
     return seastar::now();
   }
 
+  bool old_peering_msg(epoch_t map_epoch) const;
+
   template <typename MsgType>
   bool can_discard_replica_op(const MsgType& m) const {
     return can_discard_replica_op(m, m.map_epoch);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -707,7 +707,7 @@ public:
     return seastar::now();
   }
 
-  bool old_peering_msg(epoch_t map_epoch) const;
+  bool old_peering_msg(epoch_t reply_epoch, epoch_t query_epoch) const;
 
   template <typename MsgType>
   bool can_discard_replica_op(const MsgType& m) const {


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
