### PR TITLE
doc/cephadm/install.rst: airgap: Add monitoring images 

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -229,49 +229,6 @@ available options.
 
 .. _cephadm-enable-cli:
 
-Different deployment scenarios
-==============================
-
-Single host
------------
-
-To configure a Ceph cluster to run on a single host, use the ``--single-host-defaults`` flag when bootstrapping.
-
-Deployment in an isolated environment
--------------------------------------
-
-You can install Cephadm in an isolated environment by using a custom container registry and configuring Docker to use an insecure registry. Ensure your container image is inside the registry and that you have access to all hosts you wish to add to the cluster. Currently, to add multiple hosts to a Ceph cluster in an isolated environment, you must use Docker. This may require you to uninstall Podman if it's present on your host as Cephadm prefers to use Podman over Docker.
-
-Run a local container registry:
-
-.. prompt:: bash #
-
-   docker run --privileged -d --name registry -p 5000:5000 -v /var/lib/registry:/var/lib/registry --restart=always registry:2
-
-Edit the ``/etc/docker/daemon.json`` file with the hostname and port where the registry is running:
-
-.. code-block:: bash
-
-   { "insecure-registries":["*<hostname>*:5000"] }
-
-.. note:: For every host which accesses the local registry, you will need to repeat this step and edit the ``/etc/docker/daemon.json`` file on the host.
-
-Restart docker:
-
-.. prompt:: bash #
-
-   systemctl daemon-reload
-   systemctl restart docker
-   
-Next, push your container image to your local registry.
-
-Then run bootstrap using the ``--image`` flag with your container image. For example:
-
-.. prompt:: bash #
-
-   cephadm --image *<hostname>*:5000/ceph/ceph bootstrap --mon-ip *<mon-ip>*
-
-
 Enable Ceph CLI
 ===============
 

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -356,20 +356,28 @@ Different deployment scenarios
 Single host
 -----------
 
-To configure a Ceph cluster to run on a single host, use the ``--single-host-defaults`` flag when bootstrapping. For use cases of this, see :ref:`one-node-cluster`.
+To configure a Ceph cluster to run on a single host, use the 
+``--single-host-defaults`` flag when bootstrapping. For use cases 
+of this, see :ref:`one-node-cluster`.
 
-The ``--single-host-defaults`` flag sets the following configuration options::
+The ``--single-host-defaults`` flag sets the following configuration 
+options::
 
   global/osd_crush_choose_leaf_type = 0
   global/osd_pool_default_size = 2
   mgr/mgr_standby_modules = False
    
-For more information on these options, see :ref:`one-node-cluster` and ``mgr_standby_modules`` in :ref:`mgr-administrator-guide`.
+For more information on these options, see :ref:`one-node-cluster` 
+and ``mgr_standby_modules`` in :ref:`mgr-administrator-guide`.
 
 Deployment in an isolated environment
 -------------------------------------
 
-You can install Cephadm in an isolated environment by using a custom container registry. You can either configure Podman or Docker to use an insecure registry, or make the registry secure. Ensure your container image is inside the registry and that you have access to all hosts you wish to add to the cluster.
+You can install Cephadm in an isolated environment by using a custom 
+container registry. You can either configure Podman or Docker to use 
+an insecure registry, or make the registry secure. Ensure your container 
+image is inside the registry and that you have access to all hosts 
+you wish to add to the cluster.
 
 Run a local container registry:
 
@@ -377,13 +385,18 @@ Run a local container registry:
 
    podman run --privileged -d --name registry -p 5000:5000 -v /var/lib/registry:/var/lib/registry --restart=always registry:2
 
-If you are using an insecure registry, configure Podman or Docker with the hostname and port where the registry is running.
+If you are using an insecure registry, configure Podman or Docker 
+with the hostname and port where the registry is running.
 
-.. note:: For every host which accesses the local insecure registry, you will need to repeat this step on the host.
+.. note:: 
+
+  For every host which accesses the local insecure registry, you will 
+  need to repeat this step on the host.
 
 Next, push your container image to your local registry.
 
-Then run bootstrap using the ``--image`` flag with your container image. For example:
+Then run bootstrap using the ``--image`` flag with your container 
+image. For example:
 
 .. prompt:: bash #
 

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -370,6 +370,8 @@ options::
 For more information on these options, see :ref:`one-node-cluster` 
 and ``mgr_standby_modules`` in :ref:`mgr-administrator-guide`.
 
+.. _cephadm-airgap:
+
 Deployment in an isolated environment
 -------------------------------------
 
@@ -403,7 +405,7 @@ Next, push your container image to your local registry:
 * Alertmanager container image
 
 Now, create a temporary configuration file for setting the montoring
-images::
+images. (See :ref:`cephadm_monitoring-images`)::
 
       $ cat <<EOF > initial-ceph.conf
       [mgr]

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -374,7 +374,8 @@ Deployment in an isolated environment
 -------------------------------------
 
 You can install Cephadm in an isolated environment by using a custom 
-container registry. You can either configure Podman or Docker to use 
+container registry. Sometimes also referred as airgap. 
+You can either configure Podman or Docker to use 
 an insecure registry, or make the registry secure. Ensure your container 
 image is inside the registry and that you have access to all hosts 
 you wish to add to the cluster.

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -393,14 +393,34 @@ with the hostname and port where the registry is running.
   For every host which accesses the local insecure registry, you will 
   need to repeat this step on the host.
 
-Next, push your container image to your local registry.
+Next, push your container image to your local registry:
 
-Then run bootstrap using the ``--image`` flag with your container 
+* Ceph container iamge. See :ref:`containers`.
+* Prometheus container image
+* Node exporter container image
+* Grafana container image
+* Alertmanager container image
+
+Now, create a temporary configuration file for setting the montoring
+images::
+
+      $ cat <<EOF > initial-ceph.conf
+      [mgr]
+      mgr/cephadm/container_image_prometheus *<hostname>*:5000/prometheus
+      mgr/cephadm/container_image_node_exporter *<hostname>*:5000/node_exporter
+      mgr/cephadm/container_image_grafana *<hostname>*:5000/grafana
+      mgr/cephadm/container_image_alertmanager *<hostname>*:5000/alertmanger
+      EOF
+
+Then run bootstrap using the ``--image`` flag with your Ceph container 
 image. For example:
 
 .. prompt:: bash #
 
-   cephadm --image *<hostname>*:5000/ceph/ceph bootstrap --mon-ip *<mon-ip>*
+   cephadm \
+     --image *<hostname>*:5000/ceph/ceph bootstrap \
+     --mon-ip *<mon-ip>* \
+     --config initial-ceph.conf
 
 
 .. _cluster network: ../rados/configuration/network-config-ref#cluster-network

--- a/doc/cephadm/services/monitoring.rst
+++ b/doc/cephadm/services/monitoring.rst
@@ -103,6 +103,8 @@ example spec file:
     spec:
       port: 4200
 
+.. _cephadm_monitoring-images:
+
 Using custom images
 ~~~~~~~~~~~~~~~~~~~
 
@@ -160,6 +162,8 @@ For example, if you had changed the prometheus image
      .. code-block:: bash
 
           ceph config rm mgr mgr/cephadm/container_image_prometheus
+
+See also :ref:`cephadm-airgap`.
 
 .. _cephadm-overwrite-jinja2-templates:
 


### PR DESCRIPTION
Unfortunately also related to https://tracker.ceph.com/issues/53594#note-1 

- [ ] Depends on https://github.com/ceph/ceph-build/pull/1942

See also https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/thread/AONVR432UGG6RSGEQ2U7QL644DRGQMJM/ 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
