### PR TITLE
os/bluestore: make pinning logic simpler

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3656,7 +3656,7 @@ void BlueStore::Onode::calc_omap_tail(
 }
 
 void BlueStore::Onode::get() {
-  if (++nref >= 2 && !pinned) {
+  if (++nref >= 1 && !pinned) {
     OnodeCacheShard* ocs = c->get_onode_cache();
     ocs->lock.lock();
     // It is possible that during waiting split_cache moved us to different OnodeCacheShard.

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3656,7 +3656,9 @@ void BlueStore::Onode::calc_omap_tail(
 }
 
 void BlueStore::Onode::get() {
-  if (++nref >= 1 && !pinned) {
+  ++nref;
+  ceph_assert(nref >= 1);
+  if (!pinned) {
     OnodeCacheShard* ocs = c->get_onode_cache();
     ocs->lock.lock();
     // It is possible that during waiting split_cache moved us to different OnodeCacheShard.
@@ -3666,9 +3668,9 @@ void BlueStore::Onode::get() {
       ocs->lock.lock();
     }
     bool was_pinned = pinned;
+    ceph_assert(nref >= 1);
     pinned = nref >= 2;
-    bool r = !was_pinned && pinned;
-    if (cached && r) {
+    if (cached && !was_pinned && pinned) {
       ocs->_pin(this);
     }
     ocs->lock.unlock();
@@ -3676,8 +3678,7 @@ void BlueStore::Onode::get() {
 }
 void BlueStore::Onode::put() {
   ++put_nref;
-  int n = --nref;
-  if (n == 1) {
+  if (--nref == 1) {
     OnodeCacheShard* ocs = c->get_onode_cache();
     ocs->lock.lock();
     // It is possible that during waiting split_cache moved us to different OnodeCacheShard.
@@ -3686,21 +3687,24 @@ void BlueStore::Onode::put() {
       ocs = c->get_onode_cache();
       ocs->lock.lock();
     }
-    bool need_unpin = pinned;
-    pinned = pinned && nref >= 2;
-    need_unpin = need_unpin && !pinned;
-    if (cached && need_unpin) {
+    // on 1st glance pinned == true always
+    // on 2nd inspection we see that some other thread could have beaten us to unpinning
+    bool was_pinned = pinned;
+    if (nref >= 2) ceph_assert(pinned);
+    pinned = nref >= 2;
+    if (cached && was_pinned && !pinned) {
       if (exists) {
         ocs->_unpin(this);
       } else {
         ocs->_unpin_and_rm(this);
         // remove will also decrement nref
         c->onode_map._remove(oid);
+	ceph_assert(nref == 0);
       }
     }
     ocs->lock.unlock();
   }
-  auto pn = --put_nref;
+  int pn = --put_nref;
   if (nref == 0 && pn == 0) {
     delete this;
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3657,7 +3657,6 @@ void BlueStore::Onode::calc_omap_tail(
 
 void BlueStore::Onode::get() {
   ++nref;
-  ceph_assert(nref >= 1);
   if (!pinned) {
     OnodeCacheShard* ocs = c->get_onode_cache();
     ocs->lock.lock();
@@ -3668,7 +3667,6 @@ void BlueStore::Onode::get() {
       ocs->lock.lock();
     }
     bool was_pinned = pinned;
-    ceph_assert(nref >= 1);
     pinned = nref >= 2;
     if (cached && !was_pinned && pinned) {
       ocs->_pin(this);
@@ -3690,7 +3688,6 @@ void BlueStore::Onode::put() {
     // on 1st glance pinned == true always
     // on 2nd inspection we see that some other thread could have beaten us to unpinning
     bool was_pinned = pinned;
-    if (nref >= 2) ceph_assert(pinned);
     pinned = nref >= 2;
     if (cached && was_pinned && !pinned) {
       if (exists) {
@@ -3699,7 +3696,6 @@ void BlueStore::Onode::put() {
         ocs->_unpin_and_rm(this);
         // remove will also decrement nref
         c->onode_map._remove(oid);
-	ceph_assert(nref == 0);
       }
     }
     ocs->lock.unlock();


### PR DESCRIPTION
This is a follow-up of  #44311, sitting on top of it.

Branch with more ceph_assert wip-aclamk-cleanup-onode-pin-test is going to teuthology for testing.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
