### PR TITLE
common,mon: use fmt::print(cerr, ...) for stderr logging

### DIFF
--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -498,7 +498,7 @@ void global_init_daemonize(CephContext *cct)
  */
 int reopen_as_null(CephContext *cct, int fd)
 {
-  int newfd = open(DEV_NULL, O_RDONLY | O_CLOEXEC);
+  int newfd = open(DEV_NULL, O_RDWR | O_CLOEXEC);
   if (newfd < 0) {
     int err = errno;
     lderr(cct) << __func__ << " failed to open /dev/null: " << cpp_strerror(err)

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -578,8 +578,7 @@ void global_init_chdir(const CephContext *cct)
 int global_init_shutdown_stderr(CephContext *cct)
 {
   reopen_as_null(cct, STDERR_FILENO);
-  int l = cct->_conf->err_to_stderr ? -1 : -2;
-  cct->_log->set_stderr_level(l, l);
+  cct->_log->set_stderr_level(-2, -2);
   return 0;
 }
 

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -488,6 +488,14 @@ void global_init_daemonize(CephContext *cct)
 #endif
 }
 
+/* Make file descriptors 0, 1, and possibly 2 point to /dev/null.
+ *
+ * Instead of just closing fd, we redirect it to /dev/null with dup2().
+ * We have to do this because otherwise some arbitrary call to open() later
+ * in the program might get back one of these file descriptors. It's hard to
+ * guarantee that nobody ever writes to stdout, even though they're not
+ * supposed to.
+ */
 int reopen_as_null(CephContext *cct, int fd)
 {
   int newfd = open(DEV_NULL, O_RDONLY | O_CLOEXEC);
@@ -521,14 +529,6 @@ void global_init_postfork_start(CephContext *cct)
   cct->_log->start();
   cct->notify_post_fork();
 
-  /* This is the old trick where we make file descriptors 0, 1, and possibly 2
-   * point to /dev/null.
-   *
-   * We have to do this because otherwise some arbitrary call to open() later
-   * in the program might get back one of these file descriptors. It's hard to
-   * guarantee that nobody ever writes to stdout, even though they're not
-   * supposed to.
-   */
   reopen_as_null(cct, STDIN_FILENO);
 
   const auto& conf = cct->_conf;
@@ -575,10 +575,6 @@ void global_init_chdir(const CephContext *cct)
   }
 }
 
-/* Map stderr to /dev/null. This isn't really re-entrant; we rely on the old unix
- * behavior that the file descriptor that gets assigned is the lowest
- * available one.
- */
 int global_init_shutdown_stderr(CephContext *cct)
 {
   reopen_as_null(cct, STDERR_FILENO);

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -26,6 +26,7 @@
 #include <set>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #define MAX_LOG_BUF 65536
 
@@ -312,12 +313,12 @@ void Log::_flush(EntryVector& t, bool crash)
         syslog(LOG_USER|LOG_INFO, "%s", pos);
       }
 
-      if (do_stderr) {
-        std::cerr << m_log_stderr_prefix << std::string_view(pos, used) << std::endl;
-      }
-
       /* now add newline */
       pos[used++] = '\n';
+
+      if (do_stderr) {
+        fmt::print(std::cerr, "{}{}", m_log_stderr_prefix, std::string_view(pos, used));
+      }
 
       if (do_fd) {
         m_log_buf.resize(cur + used);

--- a/src/mon/LogMonitor.h
+++ b/src/mon/LogMonitor.h
@@ -51,7 +51,7 @@ private:
   version_t external_log_to = 0;
   std::map<std::string, int> channel_fds;
 
-  fmt::memory_buffer file_log_buffer;
+  fmt::memory_buffer log_buffer;
   std::atomic<bool> log_rotated = false;
 
   struct log_channel_info {


### PR DESCRIPTION
Reduce the number of syscalls to improve performance.

Also reduce the probability of https://tracker.ceph.com/issues/49551, since conmon is less likely to read partial log line.

Test shows that `cerr << fmt::format()` is as performant as calling `writev` directly. And it is portable and safe in handling short write.

fmt::print is not used because it can throw exception.

Fixes: https://tracker.ceph.com/issues/53682
Signed-off-by: 胡玮文 <huww98@outlook.com>

Hopes this can be backported to the stable versions. The cephadm logging problem is really annoying.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
