### PR TITLE
mgr, python-common/ceph/rgw: start fixing LGTM.com alerts

### DIFF
--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 import os
-import subprocess
 
 from mgr_module import MgrModule, CLICommand, HandleCommandResult, Option
 import orchestrator

--- a/src/pybind/mgr/telegraf/module.py
+++ b/src/pybind/mgr/telegraf/module.py
@@ -224,10 +224,10 @@ class Module(MgrModule):
                                 measurement['tags'], now)
                     self.log.debug(line.to_line_protocol())
                     s.send(line.to_line_protocol())
-        except (socket.error, RuntimeError, IOError, OSError):
-            self.log.exception('Failed to send statistics to Telegraf:')
         except FileNotFoundError:
             self.log.exception('Failed to open Telegraf at: %s', url.geturl())
+        except (socket.error, RuntimeError, IOError, OSError):
+            self.log.exception('Failed to send statistics to Telegraf:')
 
     def shutdown(self) -> None:
         self.log.info('Stopping Telegraf module')

--- a/src/pybind/mgr/volumes/fs/operations/trash.py
+++ b/src/pybind/mgr/volumes/fs/operations/trash.py
@@ -30,7 +30,9 @@ class Trash(GroupTemplate):
         """
         return os.path.join(self.path, str(uuid.uuid4()).encode('utf-8'))
 
-    def _get_single_dir_entry(self, exclude_list=[]):
+    def _get_single_dir_entry(self, exclude_list=None):
+        if exclude_list is None:
+            exclude_list = []
         exclude_list.extend((b".", b".."))
         try:
             with self.fs.opendir(self.path) as d:

--- a/src/python-common/ceph/rgw/rgwam_core.py
+++ b/src/python-common/ceph/rgw/rgwam_core.py
@@ -14,6 +14,7 @@ import logging
 import errno
 
 from urllib.parse import urlparse
+from typing import Tuple
 
 from .types import RGWAMException, RGWAMCmdRunException, RGWPeriod, RGWUser, RealmToken
 from .diff import RealmsEPs
@@ -152,7 +153,7 @@ class RGWCmdBase:
             opt_arg(self.cmd_suffix, '--rgw-zone', zone_env.zone.name)
             opt_arg(self.cmd_suffix, '--zone-id', zone_env.zone.id)
 
-    def run(self, cmd):
+    def run(self, cmd: str) -> Tuple[int, str, str]:
         args = cmd + self.cmd_suffix
         cmd, returncode, stdout, stderr = self.mgr.tool_exec(self.prog, args)
 
@@ -165,7 +166,7 @@ class RGWCmdBase:
                       (returncode, cmd_str, stdout, stderr))
             raise RGWAMCmdRunException(cmd_str, -returncode, stdout, stderr)
 
-        return (stdout, stderr)
+        return (returncode, stdout, stderr)
 
 
 class RGWAdminCmd(RGWCmdBase):
@@ -842,6 +843,6 @@ class RGWAM:
         if debug_rgw:
             params += ['--debug-rgw', debug_rgw]
 
-        (retcode, stdout, stderr) = RGWCmd(self.env).run(params)
+        (returncode, stdout, stderr) = RGWCmd(self.env).run(params)
 
-        return (retcode, stdout, stderr)
+        return (returncode, stdout, stderr)


### PR DESCRIPTION
Fixes some LGTM.com errors, see:
https://lgtm.com/projects/g/ceph/ceph/?severity=error

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
