### PR TITLE
examples: typos found by codespell

### DIFF
--- a/examples/boto3/delete_notification.py
+++ b/examples/boto3/delete_notification.py
@@ -26,7 +26,7 @@ client = boto3.client('s3',
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key)
 
-# deleting a specific notification congifuration from a bucket (when NotificationId is provided) or 
+# deleting a specific notification configuration from a bucket (when NotificationId is provided) or 
 # deleting all notification configurations on a bucket (without deleting the bucket itself) are extension to AWS S3 API
 
 if notification_name == "":

--- a/examples/boto3/list_unordered.py
+++ b/examples/boto3/list_unordered.py
@@ -20,6 +20,6 @@ client = boto3.client('s3',
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key)
 
-# geting an unordered list of objets is an extension to AWS S3 API
+# getting an unordered list of objects is an extension to AWS S3 API
 
 print(client.list_objects(Bucket=bucketname, AllowUnordered=True))

--- a/examples/rgw-cache/nginx-default.conf
+++ b/examples/rgw-cache/nginx-default.conf
@@ -83,7 +83,7 @@ server {
         proxy_cache_revalidate on;
         # Lock the cache so that only one request can populate it at a time
         proxy_cache_lock on;
-        # prevent convertion of head requests to get requests
+        # prevent conversion of head requests to get requests
         proxy_cache_convert_head off;
         # Listing all buckets should not be cached 
         if ($request_uri = "/") {

--- a/examples/rgw-cache/nginx-noprefetch.conf
+++ b/examples/rgw-cache/nginx-noprefetch.conf
@@ -80,7 +80,7 @@ server {
         proxy_cache_revalidate on;
         # Lock the cache so that only one request can populate it at a time
         proxy_cache_lock on;
-        # prevent convertion of head requests to get requests
+        # prevent conversion of head requests to get requests
         proxy_cache_convert_head off;
         # Listing all buckets should not be cached 
         if ($request_uri = "/") {

--- a/examples/rgw-cache/nginx-slicing.conf
+++ b/examples/rgw-cache/nginx-slicing.conf
@@ -85,7 +85,7 @@ server {
         proxy_cache_revalidate on;
         # Lock the cache so that only one request can populate it at a time
         proxy_cache_lock on;
-        # prevent convertion of head requests to get requests
+        # prevent conversion of head requests to get requests
         proxy_cache_convert_head off;
         # Listing all buckets should not be cached 
         if ($request_uri = "/") {


### PR DESCRIPTION
Fix a few typos in code comment in examples.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
