### PR TITLE
pacific: mgr/dashboard: run-backend-api-tests.sh: Older setuptools

### DIFF
--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -43,7 +43,7 @@ setup_teuthology() {
 
     ${TEUTHOLOGY_PYTHON_BIN:-/usr/bin/python3} -m venv venv
     source venv/bin/activate
-    pip install -U pip 'setuptools >= 12'
+    pip install -U pip 'setuptools>=12,<60'
     pip install git+https://github.com/ceph/teuthology#egg=teuthology[test]
     pushd $CURR_DIR
     pip install -r requirements.txt -c constraints.txt


### PR DESCRIPTION
failure happened in one of my pacific backport PR: https://jenkins.ceph.com/job/ceph-api/29310/
backport tracker: https://tracker.ceph.com/issues/53679

---

backport of https://github.com/ceph/ceph/pull/44368
parent tracker: https://tracker.ceph.com/issues/53675

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh