### PR TITLE
crimson: fix exceptional future ignored.

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1192,11 +1192,10 @@ seastar::future<> OSD::committed_osd_maps(version_t first,
 seastar::future<> OSD::handle_osd_op(crimson::net::ConnectionRef conn,
                                      Ref<MOSDOp> m)
 {
-  (void) shard_services.start_operation<ClientRequest>(
+  return shard_services.start_operation<ClientRequest>(
     *this,
     conn,
-    std::move(m));
-  return seastar::now();
+    std::move(m)).second;
 }
 
 seastar::future<> OSD::send_incremental_map(crimson::net::ConnectionRef conn,
@@ -1229,11 +1228,10 @@ seastar::future<> OSD::handle_rep_op(crimson::net::ConnectionRef conn,
 				     Ref<MOSDRepOp> m)
 {
   m->finish_decode();
-  (void) shard_services.start_operation<RepRequest>(
+  return shard_services.start_operation<RepRequest>(
     *this,
     std::move(conn),
-    std::move(m));
-  return seastar::now();
+    std::move(m)).second;
 }
 
 seastar::future<> OSD::handle_rep_op_reply(crimson::net::ConnectionRef conn,
@@ -1283,11 +1281,10 @@ seastar::future<> OSD::handle_mark_me_down(crimson::net::ConnectionRef conn,
 seastar::future<> OSD::handle_recovery_subreq(crimson::net::ConnectionRef conn,
 				   Ref<MOSDFastDispatchOp> m)
 {
-  (void) shard_services.start_operation<RecoverySubRequest>(
+  return shard_services.start_operation<RecoverySubRequest>(
     *this,
     conn,
-    std::move(m));
-  return seastar::now();
+    std::move(m)).second;
 }
 
 bool OSD::should_restart() const
@@ -1375,14 +1372,13 @@ seastar::future<> OSD::handle_peering_op(
   const int from = m->get_source().num();
   logger().debug("handle_peering_op on {} from {}", m->get_spg(), from);
   std::unique_ptr<PGPeeringEvent> evt(m->get_event());
-  (void) shard_services.start_operation<RemotePeeringEvent>(
+  return shard_services.start_operation<RemotePeeringEvent>(
     *this,
     conn,
     shard_services,
     pg_shard_t{from, m->get_spg().shard},
     m->get_spg(),
-    std::move(*evt));
-  return seastar::now();
+    std::move(*evt)).second;
 }
 
 seastar::future<> OSD::check_osdmap_features()


### PR DESCRIPTION
seastar - Exceptional future ignored: fmt::v6::format_error (argument index out of range), backtrace: 0x5f0647b 0x5f04c8f 0x5f0581c 0x5f06093 0x5c0d349 0x5c0d429 0x3b03468 0x3afefb5 0x3cc4f68 0x3cef49a 0x5c6f3cc 0x5c7009f 0x5c711e5 0x5c70462 0x5be827d 0x5be79f0 0x3b829b1 /lib/x86_64-linux-gnu/libc.so.6+0x270b2 0x3af5f4d
2021-12-17T15:10:24.283 INFO:tasks.ceph.osd.0.real302.stderr:   --------
2021-12-17T15:10:24.284 INFO:tasks.ceph.osd.0.real302.stderr:   seastar::continuation<seastar::internal::promise_base_with_type<void>, crimson::osd::ShardServices::start_operation<crimson::osd::RepRequest, crimson::osd::OSD&, seastar::shared_ptr<crimson::net::Connection>, boost::intrusive_ptr<MOSDRepOp> >(crimson::osd::OSD&, seastar::shared_ptr<crimson::net::Connection>&&, boost::intrusive_ptr<MOSDRepOp>&&)::{lambda()#1}, seastar::future<void>::then_impl_nrvo<{lambda()#1}, seastar::future>({lambda()#1}&&)::{lambda(seastar::internal::promise_base_with_type<void>&&, {lambda()#1}&, seastar::future_state<seastar::internal::monostate>&&)#1}, void>
2021-12-17T15:10:24.284 INFO:tasks.ceph.osd.0.real302.stderr:WARN  2021-12-17 15:15:30,493 [shard 0] seastar - Exceptional future ignored: fmt::v6::format_error (argument index out of range), backtrace: 0x5f0647b 0x5f04c8f 0x5f0581c 0x5f06093 0x5c0d349 0x5c0d475 0x3afef29 0x3b505ed 0x3b78539 0x3b79d27 0x3cef441 0x3cef4ad 0x5c6f3cc 0x5c7009f 0x5c711e5 0x5c70462 0x5be827d 0x5be79f0 0x3b829b1 /lib/x86_64-linux-gnu/libc.so.6+0x270b2 0x3af5f4d


seastar - Exceptional future ignored: fmt::v6::format_error (argument index out of range), backtrace: 0x5f0647b 0x5f04c8f 0x5f0581c 0x5f06093 0x5c0d349 0x5c0d429 0x3b03468 0x3afefb5 0x3cc4abe 0x3cef5da 0x5c6f3cc 0x5c7009f 0x5c711e5 0x5c70462 0x5be827d 0x5be79f0 0x3b829b1 /lib/x86_64-linux-gnu/libc.so.6+0x270b2 0x3af5f4d
2021-12-17T15:10:24.286 INFO:tasks.ceph.osd.1.real302.stderr:   --------
2021-12-17T15:10:24.286 INFO:tasks.ceph.osd.1.real302.stderr:   seastar::continuation<seastar::internal::promise_base_with_type<void>, crimson::osd::ShardServices::start_operation<crimson::osd::ClientRequest, crimson::osd::OSD&, seastar::shared_ptr<crimson::net::Connection>&, boost::intrusive_ptr<_mosdop::MOSDOp<std::vector<OSDOp, std::allocator<OSDOp> > > > >(crimson::osd::OSD&, seastar::shared_ptr<crimson::net::Connection>&, boost::intrusive_ptr<_mosdop::MOSDOp<std::vector<OSDOp, std::allocator<OSDOp> > > >&&)::{lambda()#1}, seastar::future<void>::then_impl_nrvo<{lambda()#1}, seastar::future>({lambda()#1}&&)::{lambda(seastar::internal::promise_base_with_type<void>&&, {lambda()#1}&, seastar::future_state<seastar::internal::monostate>&&)#1}, void>
2021-12-17T15:10:24.286 INFO:tasks.ceph.osd.1.real302.stderr:DEBUG 2021-12-17 15:15:30,496 [shard 0] osd - client_request(id=150, detail=m=[osd_op(client.4174.0:47 3.d 3:bcc4f6df:::teuth-238736-12:head {setxattr _header (54) in=61b, truncate 2184877} snapc 0={} ondisk+write+known_if_redirected+supports_pool_eio e15) v8]): destroying
2021-12-17T15:10:24.286 INFO:tasks.ceph.osd.1.real302.stderr:WARN  2021-12-17 15:15:30,496 [shard 0] seastar - Exceptional future ignored: fmt::v6::format_error (argument index out of range), backtrace: 0x5f0647b 0x5f04c8f 0x5f0581c 0x5f06093 0x5c0d349 0x5c0d475 0x3afef29 0x3b505ed 0x3b78539 0x3b79d27 0x3cef581 0x3cef5ed 0x5c6f3cc 0x5c7009f 0x5c711e5 0x5c70462 0x5be827d 0x5be79f0 0x3b829b1 /lib/x86_64-linux-gnu/libc.so.6+0x270b2 0x3af5f4d
Signed-off-by: chunmei-liu <chunmei.liu@intel.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
