### PR TITLE
Wip gc optimization

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
@@ -25,8 +25,8 @@
  * - Specially optimized for onode key structures and seastore
  *   delta/transaction semantics;
  *
- * Note: User should not hold any Cursor/Value when call
- * submit_transaction() because of validations implemented in ~tree_cursor_t().
+ * Note: Cursor/Value are transactional, they cannot be used outside the scope
+ * of the according transaction, or the behavior is undefined.
  */
 
 namespace crimson::os::seastore::onode {


### PR DESCRIPTION
Before this optimization, the gc procedure is:

1. scan extent infos on disk;
2. travers the lba tree for each of the above extent info to see if it's still live

The above two steps both involves many extent reads. Right now, this optimization works as follows:

1. track segments' space usage with bitmaps
2. when doing gc, check the bitmaps to see if an extent is still live instead of traversing the lba tree

This should spare the extent read efforts involved by the old gc strategy's 2nd step. The perf comparison is shown in the following two graphs: before the optimization, when the space usage hard limit is reached, crimson iops drops to 100s level; after the optimization, crimson defends 1000+ iops. This is a visible performance lift, although not a large one.

Our next step is to utilize the bitmaps to eliminate disk reads involved by the old gc strategy's 1st step. Hopefully, this may give the gc a performance boost:-)

before optimization:
![gc_opt_comp](https://user-images.githubusercontent.com/3112624/147057459-18c2fa69-daf9-4b93-9236-98524980312e.png)

after optimization:
![gc_opt](https://user-images.githubusercontent.com/3112624/147057500-3ac6a507-1bc9-4696-8d25-8987d9c117de.png)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
