### PR TITLE
doc/install: Update quay.io URL for ceph-ci builds

### DIFF
--- a/doc/install/containers.rst
+++ b/doc/install/containers.rst
@@ -94,7 +94,7 @@ Development builds
 We automatically build container images for development ``wip-*``
 branches in the ceph-ci.git repositories and push them to Quay at::
 
-  https://quay.io/organization/ceph-ci
+  https://quay.ceph.io/organization/ceph-ci
 
 ceph-ci/ceph
 ^^^^^^^^^^^^


### PR DESCRIPTION
doc/install: Update quay.io URL for ceph-ci builds

The existing URL for dev / WIP builds doesn't work; changing to the URL helpfully provided by @neha-ojha .


Signed-off-by: Anthony D'Atri <anthony.datri@gmail.com>