### PR TITLE
crimson/test: fix SeastarRunner when app is not started

### DIFF
--- a/src/test/crimson/gtest_seastar.cc
+++ b/src/test/crimson/gtest_seastar.cc
@@ -17,7 +17,11 @@ int main(int argc, char **argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
 
-  seastar_test_suite_t::seastar_env.init(argc, argv);
+  int ret = seastar_test_suite_t::seastar_env.init(argc, argv);
+  if (ret != 0) {
+    seastar_test_suite_t::seastar_env.stop();
+    return ret;
+  }
 
   // HACK: differntiate between the `make check` bot and human user
   // for the sake of log flooding
@@ -38,7 +42,7 @@ int main(int argc, char **argv)
     });
   });
 
-  int ret = RUN_ALL_TESTS();
+  ret = RUN_ALL_TESTS();
 
   seastar_test_suite_t::seastar_env.run([] {
     return crimson::common::sharded_perf_coll().stop().then([] {

--- a/src/test/crimson/seastar_runner.h
+++ b/src/test/crimson/seastar_runner.h
@@ -14,43 +14,65 @@
 #include <seastar/core/thread.hh>
 
 struct SeastarRunner {
+  static constexpr eventfd_t APP_RUNNING = 1;
+  static constexpr eventfd_t APP_NOT_RUN = 2;
+
   seastar::app_template app;
   seastar::file_desc begin_fd;
   std::unique_ptr<seastar::readable_eventfd> on_end;
 
   std::thread thread;
 
+  bool begin_signaled = false;
+
   SeastarRunner() :
     begin_fd{seastar::file_desc::eventfd(0, 0)} {}
 
   ~SeastarRunner() {}
 
-  void init(int argc, char **argv)
+  bool is_running() const {
+    return !!on_end;
+  }
+
+  int init(int argc, char **argv)
   {
     thread = std::thread([argc, argv, this] { reactor(argc, argv); });
-    eventfd_t result = 0;
+    eventfd_t result;
     if (int r = ::eventfd_read(begin_fd.get(), &result); r < 0) {
       std::cerr << "unable to eventfd_read():" << errno << std::endl;
-      throw std::runtime_error("Cannot start seastar");
+      return r;
+    }
+    assert(begin_signaled == true);
+    if (result == APP_RUNNING) {
+      assert(is_running());
+      return 0;
+    } else {
+      assert(result == APP_NOT_RUN);
+      assert(!is_running());
+      return 1;
     }
   }
   
   void stop()
   {
-    run([this] {
-      on_end->write_side().signal(1);
-      return seastar::now();
-    });
+    if (is_running()) {
+      run([this] {
+        on_end->write_side().signal(1);
+        return seastar::now();
+      });
+    }
     thread.join();
   }
 
   void reactor(int argc, char **argv)
   {
-    app.run(argc, argv, [this] {
+    auto ret = app.run(argc, argv, [this] {
       on_end.reset(new seastar::readable_eventfd);
       return seastar::now().then([this] {
-	::eventfd_write(begin_fd.get(), 1);
-	  return seastar::now();
+	auto r = ::eventfd_write(begin_fd.get(), APP_RUNNING);
+	assert(r == 0);
+	begin_signaled = true;
+	return seastar::now();
       }).then([this] {
 	return on_end->wait().then([](size_t){});
       }).handle_exception([](auto ep) {
@@ -59,10 +81,18 @@ struct SeastarRunner {
 	on_end.reset();
       });
     });
+    if (ret != 0) {
+      std::cerr << "Seastar app returns " << ret << std::endl;
+    }
+    if (!begin_signaled) {
+      ::eventfd_write(begin_fd.get(), APP_NOT_RUN);
+      begin_signaled = true;
+    }
   }
 
   template <typename Func>
   void run(Func &&func) {
+    assert(is_running());
     auto fut = seastar::alien::submit_to(app.alien(), 0,
 					 std::forward<Func>(func));
     fut.get();


### PR DESCRIPTION
Support the case when the SeastarRunner isn't able to start the app,
for example, when start with --help.

Signed-off-by: Yingxin Cheng <yingxin.cheng@intel.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
