### PR TITLE
crimson/osd: fix and improve args processing

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -215,10 +215,9 @@ int main(int argc, char* argv[])
      "Prometheus metrics prefix");
 
   auto [ceph_args, app_args] = partition_args(app, argv, argv + argc);
-  if (ceph_argparse_need_usage(ceph_args) &&
-      std::find(app_args.begin(), app_args.end(), "--help") == app_args.end()) {
+  if (ceph_argparse_need_usage(ceph_args) ||
+      ceph_argparse_need_usage(app_args)) {
     usage(argv[0]);
-    return EXIT_SUCCESS;
   }
   override_seastar_opts(app_args);
   std::string cluster_name{"ceph"};

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -37,8 +37,8 @@ seastar::logger& logger() {
 }
 
 void usage(const char* prog) {
-  std::cout << "usage: " << prog << " -i <ID>\n"
-            << "  --help-seastar    show Seastar help messages\n";
+  std::cout << "usage: " << prog << "\n"
+            << "  -i <ID>\n";
   generic_server_usage();
 }
 
@@ -71,11 +71,7 @@ auto partition_args(seastar::app_template& app, char** argv_begin, char** argv_e
     for (; unknown != unknown_args.end() &&
            argv != argv_end &&
            *unknown == *argv; ++argv, ++unknown) {
-      if (std::strcmp(*argv, "--help-seastar") == 0) {
-        app_args.push_back("--help");
-      } else {
-        ceph_args.push_back(*argv);
-      }
+      ceph_args.push_back(*argv);
     }
     return argv;
   };

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -59,6 +59,7 @@ auto partition_args(seastar::app_template& app, char** argv_begin, char** argv_e
   // options. and ceph wins
   auto consume_conf_arg = [&](char** argv) {
     if (std::strcmp(*argv, "-c") == 0) {
+      std::cout << "warn: apply '-c FILE' as ceph option" << std::endl;
       ceph_args.push_back(*argv++);
       if (argv != argv_end) {
         ceph_args.push_back(*argv++);
@@ -189,6 +190,7 @@ static void override_seastar_opts(std::vector<const char*>& args)
     // with the deployment tools, like cephadm and rook, which don't set, for
     // instance, aio-max-nr for us. but we should fix this, once crimson is able
     // to run on a multi-core system, i.e., once m-to-n problem is resolved.
+    std::cout << "warn: added seastar option --smp 1" << std::endl;
     args.emplace_back("--smp");
     args.emplace_back("1");
   }


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
