### PR TITLE
msg/async: support zerocopy in posixstack send

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1323,6 +1323,11 @@ options:
   min: 1
   max: 24
   with_legacy: true
+- name: ms_async_tcp_zerocopy
+  type: bool
+  level: advanced
+  desc: TCP send big packet using tcp zerocopy
+  default: false
 - name: ms_async_reap_threshold
   type: uint
   level: dev

--- a/src/msg/async/PosixStack.h
+++ b/src/msg/async/PosixStack.h
@@ -23,13 +23,14 @@
 #include "msg/async/net_handler.h"
 
 #include "Stack.h"
-
+class PosixNetworkStack;
 class PosixWorker : public Worker {
   ceph::NetHandler net;
+  PosixNetworkStack *stack;
   void initialize() override;
  public:
-  PosixWorker(CephContext *c, unsigned i)
-      : Worker(c, i), net(c) {}
+  PosixWorker(PosixNetworkStack *stack, CephContext *c, unsigned i)
+      : Worker(c, i), net(c), stack(stack) {}
   int listen(entity_addr_t &sa,
 	     unsigned addr_slot,
 	     const SocketOptions &opt,
@@ -39,20 +40,52 @@ class PosixWorker : public Worker {
 
 class PosixNetworkStack : public NetworkStack {
   std::vector<std::thread> threads;
+  CephContext *cct;
+  std::thread poll;
+  bool done = false;
+  int epfd = -1;
+  std::mutex lock;
+  std::unordered_map<int, ConnectedSocketImpl *> poll_conn;
 
   virtual Worker* create_worker(CephContext *c, unsigned worker_id) override {
-    return new PosixWorker(c, worker_id);
+    return new PosixWorker(this, c, worker_id);
   }
 
+  int polling();
  public:
   explicit PosixNetworkStack(CephContext *c);
 
   void spawn_worker(std::function<void ()> &&func) override {
     threads.emplace_back(std::move(func));
+    if (cct->_conf.get_val<bool>("ms_async_tcp_zerocopy")) {
+      if (!poll.joinable())
+        poll = std::thread(&PosixNetworkStack::polling, this);
+    }
   }
+
   void join_worker(unsigned i) override {
     ceph_assert(threads.size() > i && threads[i].joinable());
     threads[i].join();
+
+    if (cct->_conf.get_val<bool>("ms_async_tcp_zerocopy")) {
+      if (i + 1 == threads.size()) {
+        done = true;
+        poll.join();
+      }
+    }
+  }
+
+  int get_epfd() { return epfd; }
+  void register_poll(int fd, ConnectedSocketImpl *conn) {
+    std::unique_lock<std::mutex> locker(lock);
+    poll_conn.emplace(fd, conn);
+  }
+
+  void unregister_poll(int fd, ConnectedSocketImpl *conn) {
+    std::unique_lock<std::mutex> locker(lock);
+    auto it = poll_conn.find(fd);
+    if (it != poll_conn.end())
+      poll_conn.erase(it);
   }
 };
 

--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -168,6 +168,21 @@ void NetHandler::set_priority(int sd, int prio, int domain)
 #endif	// SO_PRIORITY
 }
 
+int NetHandler::set_zerocopy(int sd, int enable)
+{
+#ifdef SO_ZEROCOPY
+  int r = ::setsockopt(sd, SOL_SOCKET, SO_ZEROCOPY, (char*)&enable, sizeof(enable));
+  if (r < 0) {
+     r = -errno;
+     ldout(cct,0) << __func__ << " couldn't set SO_ZEROCOPY to " << enable
+	     << ": " << cpp_strerror(r) << dendl;
+  }
+  return r;
+#else
+  return -EINVAL;
+#endif // SO_ZEROCOPY
+}
+
 int NetHandler::generic_connect(const entity_addr_t& addr, const entity_addr_t &bind_addr, bool nonblock)
 {
   int ret;

--- a/src/msg/async/net_handler.h
+++ b/src/msg/async/net_handler.h
@@ -28,6 +28,7 @@ namespace ceph {
     explicit NetHandler(CephContext *c): cct(c) {}
     int set_nonblock(int sd);
     int set_socket_options(int sd, bool nodelay, int size);
+    int set_zerocopy(int sd, int zerocopy);
     int connect(const entity_addr_t &addr, const entity_addr_t& bind_addr);
     
     /**


### PR DESCRIPTION
The PosixStack supports the zero-copy feature of sending packets, which
can be enabled using ms_async_tcp_zerocopy=true.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>