### PR TITLE
Implement the priority thread control feature

### DIFF
--- a/src/common/numa.h
+++ b/src/common/numa.h
@@ -7,6 +7,7 @@
 #include <sched.h>
 #include <ostream>
 #include <set>
+#include <functional>
 
 int parse_cpu_set_list(const char *s,
 		       size_t *cpu_set_size,
@@ -20,5 +21,6 @@ int get_numa_node_cpu_set(int node,
 			  size_t *cpu_set_size,
 			  cpu_set_t *cpu_set);
 
-int set_cpu_affinity_all_threads(size_t cpu_set_size,
-				 cpu_set_t *cpu_set);
+int set_cpu_affinity_all_threads(size_t cpu_set_size, cpu_set_t *cpu_set);
+int set_cpu_affinity_all_threads(std::function<int (pid_t, std::string &)> &&func);
+

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -27,6 +27,32 @@ options:
   - osd_numa_auto_affinity
   flags:
   - startup
+- name: osd_priority_threads
+  type: str
+  level: advanced
+  desc: High-priority thread collection
+  default: msgr-worker,tp_osd_tp,bstore_kv_sync
+  flags:
+  - startup
+- name: osd_priority_cores
+  type: str
+  level: advanced
+  desc: Logic cores for priority thread collection
+  flags:
+  - startup
+- name: osd_misc_threads
+  type: str
+  level: advanced
+  desc: Non-priority thread collection
+  default: bstore_kv_final,bstore_aio
+  flags:
+  - startup
+- name: osd_misc_cores
+  type: str
+  level: advanced
+  desc: Logic cores for Non-priority thread collection
+  flags:
+  - startup
 - name: osd_smart_report_timeout
   type: uint
   level: advanced


### PR DESCRIPTION
common: Implement the priority thread control feature

Give high priority to latency-critical tasks, so that a write operation can be
completed with low latency (by priority thead) while reducing CPU consumption
by flushing writes in a batch processing manner (by non-priority thread).

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>
