### PR TITLE
cmake: detect linux/blk/zoned support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,12 +193,6 @@ if(WITH_ZFS)
   set(HAVE_LIBZFS ${ZFS_FOUND})
 endif()
 
-option(WITH_ZNS "enable zns support" OFF)
-if (WITH_ZNS)
-  # TODO: add detection, need kernel header >= 5.5
-  set(HAVE_ZNS ON)
-endif()
-
 option(WITH_BLUESTORE "Bluestore OSD backend" ON)
 if(WITH_BLUESTORE)
   if(LINUX)

--- a/cmake/modules/FindLinuxZNS.cmake
+++ b/cmake/modules/FindLinuxZNS.cmake
@@ -1,0 +1,18 @@
+# Try to find linux/blkzoned.h
+
+find_path(LinuxZNS_INCLUDE_DIR NAMES
+  "linux/blkzoned.h")
+
+find_package_handle_standard_args(LinuxZNS
+  REQUIRED_VARS
+  LinuxZNS_INCLUDE_DIR)
+
+mark_as_advanced(
+  LinuxZNS_INCLUDE_DIR)
+
+if(LinuxZNS_FOUND AND NOT (TARGET Linux::ZNS))
+  add_library(Linux::ZNS INTERFACE IMPORTED)
+  set_target_properties(Linux::ZNS PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${LinuxZNS_INCLUDE_DIR}"
+    INTERFACE_COMPILE_DEFINITIONS HAVE_ZNS=1)
+endif()

--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -43,7 +43,10 @@ set(crimson_seastore_srcs
   ${PROJECT_SOURCE_DIR}/src/os/Transaction.cc
 	)
 
-if(HAVE_ZNS)
+CMAKE_DEPENDENT_OPTION(WITH_ZNS "enable Linux ZNS support" OFF
+  "CMAKE_SYSTEM_NAME STREQUAL Linux" OFF)
+if(WITH_ZNS)
+  find_package(LinuxZNS REQUIRED)
   list(APPEND crimson_seastore_srcs
     segment_manager/zns.cc)
 endif()
@@ -53,5 +56,10 @@ add_library(crimson-seastore STATIC
 
 target_link_libraries(crimson-seastore
   crimson)
+if(WITH_ZNS)
+  target_link_libraries(crimson-seastore
+    Linux::ZNS)
+endif()
+
 set_target_properties(crimson-seastore PROPERTIES
   JOB_POOL_COMPILE heavy_compile_job_pool)

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -108,9 +108,6 @@
 /* Define to 1 if you have libxfs */
 #cmakedefine HAVE_LIBXFS 1
 
-/* Define to 1 if zns support enabled */
-#cmakedefine HAVE_ZNS
-
 /* SPDK conditional compilation */
 #cmakedefine HAVE_SPDK
 


### PR DESCRIPTION
* add find_package() support for detecting the existence of
  linux/blkzoned.h before using it.
* link against Linux::ZNS for adding the compilation definition of
  HAVE_ZNS instead of including it in the global config.h
* move the CMake option closer to where it is used for
  better readability. as this option takes effect only if
  crimson is compiled.
* make WITH_ZNS an option which depends on the value of
  CMAKE_SYSTEM_NAME. it is hidden and off if CMAKE_SYSTEM_NAME
  is not "Linux".

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
