### PR TITLE
crimson: leverage --default-log-level to configure the global log level

### DIFF
--- a/src/test/crimson/gtest_seastar.cc
+++ b/src/test/crimson/gtest_seastar.cc
@@ -15,23 +15,33 @@ SeastarRunner seastar_test_suite_t::seastar_env;
 
 int main(int argc, char **argv)
 {
-  ::testing::InitGoogleTest(&argc, argv);
+  // preprocess args
+  std::vector<const char*> args;
+  bool global_log_level_is_set = false;
+  const char* prefix_log_level = "--default-log-level";
+  for (int i = 0; i < argc; ++i) {
+    if (std::strncmp(argv[i], prefix_log_level,
+                     std::strlen(prefix_log_level)) == 0) {
+      global_log_level_is_set = true;
+    }
+    args.push_back(argv[i]);
+  }
+  // HACK: differentiate between the `make check` bot and human user
+  // for the sake of log flooding
+  if (!global_log_level_is_set && !std::getenv("FOR_MAKE_CHECK")) {
+    std::cout << "WARNING: set default seastar log level to debug" << std::endl;
+    ++argc;
+    args.push_back("--default-log-level=debug");
+  }
 
-  int ret = seastar_test_suite_t::seastar_env.init(argc, argv);
+  auto app_argv = const_cast<char**>(args.data());
+  auto app_argc = static_cast<int>(args.size());
+  ::testing::InitGoogleTest(&app_argc, app_argv);
+
+  int ret = seastar_test_suite_t::seastar_env.init(app_argc, app_argv);
   if (ret != 0) {
     seastar_test_suite_t::seastar_env.stop();
     return ret;
-  }
-
-  // HACK: differntiate between the `make check` bot and human user
-  // for the sake of log flooding
-  if (std::getenv("FOR_MAKE_CHECK")) {
-    std::cout << "WARNING: bumping log level skipped due to FOR_MAKE_CHECK!"
-              << std::endl;
-  } else {
-    seastar::global_logger_registry().set_all_loggers_level(
-      seastar::log_level::debug
-    );
   }
 
   seastar_test_suite_t::seastar_env.run([] {


### PR DESCRIPTION
So that we can customize individual log levels from command-line or ceph.conf while setting the global default level.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
