### PR TITLE
rgw: remove bucket API returns NoSuchKey than NoSuchBucket

### DIFF
--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -225,6 +225,9 @@ void RGWOp_Bucket_Remove::execute(optional_yield y)
   op_ret = store->get_bucket(s, s->user.get(), string(), bucket_name, &bucket, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "get_bucket returned ret=" << op_ret << dendl;
+    if (op_ret == -ENOENT) {
+      op_ret = -ERR_NO_SUCH_BUCKET;
+    }
     return;
   }
 
@@ -405,4 +408,3 @@ RGWOp *RGWHandler_Bucket::op_delete()
 
   return new RGWOp_Bucket_Remove;
 }
-

--- a/src/rgw/services/svc_bucket_sobj.cc
+++ b/src/rgw/services/svc_bucket_sobj.cc
@@ -642,4 +642,3 @@ int RGWSI_Bucket_SObj::read_buckets_stats(RGWSI_Bucket_X_Ctx& ctx,
 
   return m.size();
 }
-


### PR DESCRIPTION
Remove bucket API returns NoSuchKey but NoSuchBucket is appropriate in this case.

Code path:
RGWRadosStore::get_bucket  # returns -ENOENT as is. Should convert this to -ERR_NO_SUCH_BUCKET
-> RGWRadosBucket::get_bucket_info
-> RGWBucketCtl::read_bucket_info
-> RGWBucketCtl::read_bucket_entrypoint_info
-> RGWSI_Bucket_SObj::read_bucket_entrypoint_info
-> RGWSI_MetaBackend_SObj::get_entry
-> rgw_get_system_obj
-> RGWSI_SysObj::Obj::ROp::stat
-> RGWSI_SysObj_Core::stat # return -ENOENT here.

[1]: https://docs.ceph.com/en/pacific/radosgw/adminops/#remove-bucket

Fixes: https://tracker.ceph.com/issues/53731

Signed-off-by: Satoru Takeuchi <satoru.takeuchi@gmail.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
