### PR TITLE
rgw/multisite/test: allow passing rgw parameter to multisite script

### DIFF
--- a/src/test/rgw/test-rgw-common.sh
+++ b/src/test/rgw/test-rgw-common.sh
@@ -76,9 +76,13 @@ function rgw_admin {
 }
 
 function rgw {
-  [ $# -ne 2 ] && echo "rgw() needs 2 params" && exit 1
+  [ $# -lt 2 ] && echo "rgw() needs at least 2 params" && exit 1
 
-  echo "$mrgw $1 $2 $rgw_flags"
+  name=$1
+  port=$2
+  shift 2
+
+  echo "$mrgw $name $port $rgw_flags $@"
 }
 
 function init_first_zone {

--- a/src/test/rgw/test-rgw-multisite.sh
+++ b/src/test/rgw/test-rgw-multisite.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-[ $# -lt 1 ] && echo "usage: $0 <num-clusters>" && exit 1
+[ $# -lt 1 ] && echo "usage: $0 <num-clusters> [rgw parameters...]" && exit 1
 
 num_clusters=$1
+shift
 
 [ $num_clusters -lt 1 ] && echo "clusters num must be at least 1" && exit 1
 
@@ -22,7 +23,7 @@ x $(start_ceph_cluster c1) -n
 
 # create realm, zonegroup, zone, start rgw
 init_first_zone c1 $realm_name $zg ${zg}-1 8001 $system_access_key $system_secret
-x $(rgw c1 8001)
+x $(rgw c1 8001 "$@")
 
 output=`$(rgw_admin c1) realm get`
 
@@ -36,7 +37,7 @@ while [ $i -le $num_clusters ]; do
 
   # create new zone, start rgw
   init_zone_in_existing_zg c$i $realm_name $zg ${zg}-${i} 8001 $((8000+$i)) $zone_port $system_access_key $system_secret
-  x $(rgw c$i $((8000+$i)))
+  x $(rgw c$i $((8000+$i)) "$@")
 
   i=$((i+1))
 done


### PR DESCRIPTION
this allows changing rgw conf when setting the test script. e.g.
```
MON=1 OSD=1 MDS=0 MGR=1 ../src/test/rgw/test-rgw-multisite.sh 2 --rgw_max_objs_per_shard=50
```

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
