### PR TITLE
crimson/os: Don't limit the amount of returned keys per omap get call

### DIFF
--- a/src/crimson/os/cyanstore/cyan_store.cc
+++ b/src/crimson/os/cyanstore/cyan_store.cc
@@ -311,7 +311,7 @@ CyanStore::omap_get_values(CollectionRef ch,
   }
   omap_values_t values;
   for (auto i = start ? o->omap.upper_bound(*start) : o->omap.begin();
-       values.size() < MAX_KEYS_PER_OMAP_GET_CALL && i != o->omap.end();
+       i != o->omap.end();
        ++i) {
     values.insert(*i);
   }

--- a/src/crimson/os/cyanstore/cyan_store.h
+++ b/src/crimson/os/cyanstore/cyan_store.h
@@ -27,8 +27,6 @@ namespace crimson::os {
 class Collection;
 
 class CyanStore final : public FuturizedStore {
-  constexpr static unsigned MAX_KEYS_PER_OMAP_GET_CALL = 32;
-
   const std::string path;
   std::unordered_map<coll_t, boost::intrusive_ptr<Collection>> coll_map;
   std::map<coll_t, boost::intrusive_ptr<Collection>> new_coll_map;


### PR DESCRIPTION
Users of `FuturizedStore::omap_get_values()` expect to get all the keys
that are currently in the omap, but behind the scenes we were limiting
`CyanStore::omap_get_values()` to return only a hardcoded number of values,
specifically `MAX_KEYS_PER_OMAP_GET_CALL` which is 32.

Signed-off-by: Amnon Hanuhov <AmnonSWE@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
