### PR TITLE
crimson/os/seastore/cache: add lru

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -75,3 +75,8 @@ options:
   level: dev
   desc: default logical address space reservation for seastore objects' metadata
   default: 16777216
+- name: seastore_cache_lru_size
+  type: size
+  level: advanced
+  desc: Size in bytes of extents to keep in cache.
+  default: 64_M

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -7,6 +7,7 @@
 #include <string_view>
 
 #include "crimson/os/seastore/logging.h"
+#include "crimson/common/config_proxy.h"
 
 // included for get_extent_by_type
 #include "crimson/os/seastore/collection_manager/collection_flat_node.h"
@@ -23,7 +24,9 @@ namespace crimson::os::seastore {
 
 Cache::Cache(
   ExtentReader &reader)
-  : reader(reader)
+  : reader(reader),
+    lru(crimson::common::get_conf<Option::size_t>(
+	  "seastore_cache_lru_size"))
 {
   register_metrics();
 }
@@ -31,6 +34,7 @@ Cache::Cache(
 Cache::~Cache()
 {
   LOG_PREFIX(Cache::~Cache);
+  lru.clear();
   for (auto &i: extents) {
     ERROR("extent {} still alive", i);
   }
@@ -453,6 +457,20 @@ void Cache::register_metrics()
         stats.dirty_bytes,
         sm::description("total bytes of dirty extents")
       ),
+      sm::make_counter(
+	"cache_lru_size_bytes",
+	[this] {
+	  return lru.get_current_contents_bytes();
+	},
+	sm::description("total bytes pinned by the lru")
+      ),
+      sm::make_counter(
+	"cache_lru_size_extents",
+	[this] {
+	  return lru.get_current_contents_extents();
+	},
+	sm::description("total extents pinned by the lru")
+      ),
     }
   );
 
@@ -600,9 +618,9 @@ void Cache::add_extent(CachedExtentRef ref)
 
   if (ref->is_dirty()) {
     add_to_dirty(ref);
-  } else {
-    ceph_assert(!ref->primary_ref_list_hook.is_linked());
-  }
+  } else if (!ref->is_placeholder()) {
+    lru.add_to_lru(*ref);
+  } 
   DEBUG("extent {}", *ref);
 }
 
@@ -614,6 +632,7 @@ void Cache::mark_dirty(CachedExtentRef ref)
     return;
   }
 
+  lru.remove_from_lru(*ref);
   add_to_dirty(ref);
   ref->state = CachedExtent::extent_state_t::DIRTY;
 
@@ -646,7 +665,11 @@ void Cache::remove_extent(CachedExtentRef ref)
   LOG_PREFIX(Cache::remove_extent);
   DEBUG("extent {}", *ref);
   assert(ref->is_valid());
-  remove_from_dirty(ref);
+  if (ref->is_dirty()) {
+    remove_from_dirty(ref);
+  } else {
+    lru.remove_from_lru(*ref);
+  }
   extents.erase(*ref);
 }
 
@@ -658,7 +681,12 @@ void Cache::commit_retire_extent(
   DEBUGT("extent {}", t, *ref);
   assert(ref->is_valid());
 
-  remove_from_dirty(ref);
+  // TODO: why does this duplicate remove_extent?
+  if (ref->is_dirty()) {
+    remove_from_dirty(ref);
+  } else {
+    lru.remove_from_lru(*ref);
+  }
   ref->dirty_from_or_retired_at = JOURNAL_SEQ_MAX;
 
   invalidate_extent(t, *ref);
@@ -694,6 +722,7 @@ void Cache::commit_replace_extent(
     intrusive_ptr_release(&*prev);
     intrusive_ptr_add_ref(&*next);
   } else {
+    lru.remove_from_lru(*prev);
     add_to_dirty(next);
   }
 
@@ -1147,7 +1176,7 @@ void Cache::init() {
   }
   root = new RootBlock();
   root->state = CachedExtent::extent_state_t::CLEAN;
-  add_extent(root);
+  extents.insert(*root);
 }
 
 Cache::mkfs_iertr::future<> Cache::mkfs(Transaction &t)
@@ -1173,6 +1202,7 @@ Cache::close_ertr::future<> Cache::close()
     intrusive_ptr_release(ptr);
   }
   assert(stats.dirty_bytes == 0);
+  clear_lru();
   return close_ertr::now();
 }
 

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -34,7 +34,6 @@ Cache::Cache(
 Cache::~Cache()
 {
   LOG_PREFIX(Cache::~Cache);
-  lru.clear();
   for (auto &i: extents) {
     ERROR("extent {} still alive", i);
   }
@@ -618,9 +617,9 @@ void Cache::add_extent(CachedExtentRef ref)
 
   if (ref->is_dirty()) {
     add_to_dirty(ref);
-  } else if (!ref->is_placeholder()) {
-    lru.add_to_lru(*ref);
-  } 
+  } else {
+    touch_extent(*ref);
+  }
   DEBUG("extent {}", *ref);
 }
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -747,6 +747,7 @@ private:
 	intrusive_ptr_add_ref(&extent);
 	lru.push_back(extent);
       }
+      trim_to_capacity();
     }
 
     void remove_from_lru(CachedExtent &extent) {

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -725,16 +725,6 @@ private:
 	remove_from_lru(lru.front());
       }
     }
-  public:
-    LRU(size_t capacity) : capacity(capacity) {}
-
-    size_t get_current_contents_bytes() const {
-      return contents;
-    }
-
-    size_t get_current_contents_extents() const {
-      return lru.size();
-    }
 
     void add_to_lru(CachedExtent &extent) {
       assert(
@@ -748,6 +738,17 @@ private:
 	lru.push_back(extent);
       }
       trim_to_capacity();
+    }
+
+  public:
+    LRU(size_t capacity) : capacity(capacity) {}
+
+    size_t get_current_contents_bytes() const {
+      return contents;
+    }
+
+    size_t get_current_contents_extents() const {
+      return lru.size();
     }
 
     void remove_from_lru(CachedExtent &extent) {
@@ -787,7 +788,7 @@ private:
     }
 
     ~LRU() {
-      assert(lru.empty());
+      clear();
     }
   } lru;
 

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -277,6 +277,11 @@ public:
     return !is_valid() || (prior_instance && !prior_instance->is_valid());
   }
 
+  /// Returns true if extent is a plcaeholder
+  bool is_placeholder() const {
+    return get_type() == extent_types_t::RETIRED_PLACEHOLDER;
+  }
+
   /// Return journal location of oldest relevant delta, only valid while DIRTY
   auto get_dirty_from() const {
     ceph_assert(is_dirty());

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -470,9 +470,7 @@ TransactionManager::get_extent_if_live_ret TransactionManager::get_extent_if_liv
   });
 }
 
-TransactionManager::~TransactionManager() {
-  cache->clear_lru();
-}
+TransactionManager::~TransactionManager() {}
 
 void TransactionManager::register_metrics()
 {

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -470,7 +470,9 @@ TransactionManager::get_extent_if_live_ret TransactionManager::get_extent_if_liv
   });
 }
 
-TransactionManager::~TransactionManager() {}
+TransactionManager::~TransactionManager() {
+  cache->clear_lru();
+}
 
 void TransactionManager::register_metrics()
 {


### PR DESCRIPTION
## performance

After adding the lru cache, 

- random read performance improved 38%.
    
    It is notable that the Seastore meets the cpu bound situation in random read so the actually cache performance should have been better. 
    
- random write performance improved 3%.
- sequence read performance improved 6%.
- sequence write performance improved 5%.

## cache size

In order to know the best cache size and the performance of lru cache, I did the following tests. All test were run in the environment that Seastore is completely stressed up.

The hit_ratio includes the dirty extents hit.

1. random read
    
    
    | cache size(MB) | disk read(MB) | read bandwidth(MB) | hit_ratio |
    | --- | --- | --- | --- |
    | 2048 | 0 | 69.2926 | 1 |
    | 1024 | 0 | 69.09 | 1 |
    | 512 | 0 | 69.2407 | 1 |
    | 256 | 4.5 | 69.4341 | 0.997 |
    | 128 | 14.3 | 73.2239 | 0.988 |
    | 64 | 23 | 76.5218 | 0.980 |
    | 32 | 33 | 77.0769 | 0.976 |
    | 0 | 83 | 55.4467 | 0.943 |
    
    According to the table, the disk read decreased(cache afforded many disk read operations) and the read bandwidth increased while cache size increased can infer that that the lru cache did work and the most suitable cache size could be 64MB.
    
2. sequence read
    
    
    | cache size(MB) | disk read(MB) | read bandwidth(MB) | hit_ratio |
    | --- | --- | --- | --- |
    | 2048 | 520 | 520.731 | 0.934 |
    | 1024 | 520 | 519.715 | 0.925 |
    | 512 | 520 | 519.353 | 0.905 |
    | 256 | 520 | 519.03 | 0.883 |
    | 128 | 520 | 518.527 | 0.872 |
    | 64 | 520 | 516.503 | 0.848 |
    | 32 | 520 | 517.691 | 0.842 |
    | 0 | 520 | 501.727 | 0.770 |
    
    It’s normal that there will be nearly no difference between disk read and the read bandwidth in the sequence read because no extents will be read twice in this situation so that the cache doesn’t help.
    
3. random write
    
    
    | cache size(MB) | disk read(MB) | read bandwidth(MB) |
    | --- | --- | --- |
    | 2048 | 0 | 16.1840 |
    | 1024 | 0 | 17.0723 |
    | 512 | 0 | 17.2491 |
    | 256 | 0 | 16.0152 |
    | 128 | 0 | 16.1437 |
    | 64 | 0 | 16.7762 |
    | 32 | 1.5 | 17.6262 |
    | 0 | 20 | 15.8711 |
    
    Disk read is almost 0 when cache size is lager than 64MB.
    
4. sequence write
    
    
    | cache size(MB) | disk read(MB) | write bandwidth(MB) |
    | --- | --- | --- |
    | 2048 | 0 | 405.569 |
    | 1024 | 0 | 406.509 |
    | 512 | 0 | 400.88 |
    | 256 | 0 | 389.729 |
    | 128 | 0 | 382.527 |
    | 64 | 0 | 372.606 |
    | 32 | 0 | 375.462 |
    | 0 | 2 | 355.315 |

According to all of the test data above, 64MB would be a good choice for cache size.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
