### PR TITLE
rgwlc:  introduce optional_cookie to LCEntry and cognate types

### DIFF
--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1267,6 +1267,8 @@ struct cls_rgw_lc_entry {
   std::string bucket;
   uint64_t start_time; // if in_progress
   uint32_t status;
+  std::string optional_cookie; // boot-time identifier of the rgw which
+			       // last updated the entry (or "")
 
   cls_rgw_lc_entry()
     : start_time(0), status(0) {}
@@ -1277,10 +1279,11 @@ struct cls_rgw_lc_entry {
     : bucket(b), start_time(t), status(s) {};
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(bucket, bl);
     encode(start_time, bl);
     encode(status, bl);
+    encode(optional_cookie, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -1289,6 +1292,9 @@ struct cls_rgw_lc_entry {
     decode(bucket, bl);
     decode(start_time, bl);
     decode(status, bl);
+    if (struct_v > 1) {
+      decode(optional_cookie, bl);
+    }
     DECODE_FINISH(bl);
   }
 };

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -428,6 +428,16 @@ options:
   default: 10_min
   services:
   - rgw
+- name: rgw_lc_flags
+  type: str
+  level: advanced
+  desc: a set of optional runtime flags that customize lifecycle processing
+  long_desc: A comma delimited list of flags that customize lifecycle processing, as defined below
+    ``clear_stale_entries`` process entries even if marked already active by a prior/different rgw instance (does not override locks)
+  fmt_desc: Customizes the lifecycle processing behavior, whether started from radosgw or radosgw-admin lc process
+    Currently supported flags are ``clear_stale_entries`` process entries even if marked already active by a prior/different rgw instance (does not override locks)
+  services:
+  - rgw
 - name: rgw_script_uri
   type: str
   level: dev

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -325,6 +325,7 @@ int RGWLC::bucket_lc_prepare(int index, LCWorker* worker)
     for (auto& entry : entries) {
       entry.start_time = ceph_clock_now();
       entry.status = lc_uninitial; // lc_uninitial? really?
+      entry.optional_cookie = cookie; // claim this entry
       ret = sal_lc->set_entry(obj_names[index], entry);
       if (ret < 0) {
         ldpp_dout(this, 0)

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -544,7 +544,7 @@ public:
   int process_bucket(int index, int max_lock_secs, LCWorker* worker,
 		     const std::string& bucket_entry_marker, bool once);
   bool if_already_run_today(time_t start_date);
-  bool expired_session(time_t started);
+  bool expired_session(const rgw::sal::Lifecycle::LCEntry& entry);
   time_t thread_stop_at();
   int list_lc_progress(std::string& marker, uint32_t max_entries,
 		       std::vector<rgw::sal::Lifecycle::LCEntry>&, int& index);

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -5,6 +5,8 @@
 #define CEPH_RGW_LC_H
 
 #include <map>
+#include <array>
+#include <vector>
 #include <string>
 #include <iostream>
 
@@ -467,6 +469,25 @@ class RGWLC : public DoutPrefixProvider {
   std::atomic<bool> down_flag = { false };
   std::string cookie;
 
+  class Flags
+  {
+  public:
+    enum class flag_value : uint8_t
+    {
+      clear_stale_entries = 0,
+      last_option
+    };
+
+    void initialize(CephContext* cct);
+
+    bool have_flag(const flag_value &k) const {
+      return flags[uint8_t(k)];
+    }
+
+  private:
+    std::array<bool, uint8_t(flag_value::last_option)> flags;
+  };
+
 public:
 
   class WorkPool;
@@ -507,6 +528,7 @@ public:
 
   friend class RGWRados;
 
+  Flags global_flags;
   std::vector<std::unique_ptr<RGWLC::LCWorker>> workers;
 
   RGWLC() : cct(nullptr), store(nullptr) {}

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1282,9 +1282,14 @@ public:
     std::string bucket;
     uint64_t start_time{0};
     uint32_t status{0};
+    std::string optional_cookie;
 
     LCEntry() = default;
-    LCEntry(std::string& _bucket, uint64_t _time, uint32_t _status) : bucket(_bucket), start_time(_time), status(_status) {}
+    LCEntry(std::string& _bucket, uint64_t _time, uint32_t _status,
+	    std::string& _optional_cookie) : bucket(_bucket), start_time(_time),
+					     status(_status),
+					     optional_cookie(_optional_cookie)
+      {}
   };
 
   Lifecycle() = default;

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -2494,6 +2494,7 @@ int RadosLifecycle::set_entry(const std::string& oid, const LCEntry& entry)
   cls_entry.bucket = entry.bucket;
   cls_entry.start_time = entry.start_time;
   cls_entry.status = entry.status;
+  cls_entry.optional_cookie = entry.optional_cookie;
 
   return cls_rgw_lc_set_entry(*store->getRados()->get_lc_pool_ctx(), oid, cls_entry);
 }
@@ -2510,7 +2511,8 @@ int RadosLifecycle::list_entries(const std::string& oid, const std::string& mark
     return ret;
 
   for (auto& entry : cls_entries) {
-    entries.push_back(LCEntry(entry.bucket, entry.start_time, entry.status));
+    entries.push_back(LCEntry(entry.bucket, entry.start_time, entry.status,
+			entry.optional_cookie));
   }
 
   return ret;

--- a/src/rgw/store/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/store/dbstore/tests/dbstore_tests.cc
@@ -45,6 +45,7 @@ namespace gtest {
         delete db;
       }
 
+	  string cookie; // server instance
       string tenant;
       DB *db;
       string db_type;
@@ -1064,12 +1065,12 @@ TEST_F(DBStoreTest, LCEntry) {
   std::string index2 = "lcindex2";
   typedef enum {lc_uninitial = 1, lc_complete} status;
   std::string ents[] = {"bucket1", "bucket2", "bucket3", "bucket4"};
+  std::string& cookie = gtest::env->cookie;
   rgw::sal::Lifecycle::LCEntry entry;
-  rgw::sal::Lifecycle::LCEntry entry1 = {ents[0], lc_time, lc_uninitial};
-  rgw::sal::Lifecycle::LCEntry entry2 = {ents[1], lc_time, lc_uninitial};
-  rgw::sal::Lifecycle::LCEntry entry3 = {ents[2], lc_time, lc_uninitial};
-  rgw::sal::Lifecycle::LCEntry entry4 = {ents[3], lc_time, lc_uninitial};
-
+  rgw::sal::Lifecycle::LCEntry entry1 = {ents[0], lc_time, lc_uninitial, cookie};
+  rgw::sal::Lifecycle::LCEntry entry2 = {ents[1], lc_time, lc_uninitial, cookie};
+  rgw::sal::Lifecycle::LCEntry entry3 = {ents[2], lc_time, lc_uninitial, cookie};
+  rgw::sal::Lifecycle::LCEntry entry4 = {ents[3], lc_time, lc_uninitial, cookie};
   vector<rgw::sal::Lifecycle::LCEntry> lc_entries;
 
   ret = db->set_entry(index1, entry1);
@@ -1086,6 +1087,7 @@ TEST_F(DBStoreTest, LCEntry) {
   ASSERT_EQ(ret, 0);
   ASSERT_EQ(entry.status, lc_uninitial);
   ASSERT_EQ(entry.start_time, lc_time);
+  ASSERT_EQ(entry.optional_cookie, cookie);
 
   // get next entry index1, entry2
   ret = db->get_next_entry(index1, ents[1], entry); 
@@ -1093,6 +1095,7 @@ TEST_F(DBStoreTest, LCEntry) {
   ASSERT_EQ(entry.bucket, ents[2]);
   ASSERT_EQ(entry.status, lc_uninitial);
   ASSERT_EQ(entry.start_time, lc_time);
+  ASSERT_EQ(entry.optional_cookie, cookie);
 
   // update entry4 to entry5
   entry4.status = lc_complete;
@@ -1101,6 +1104,7 @@ TEST_F(DBStoreTest, LCEntry) {
   ret = db->get_entry(index2, ents[3], entry); 
   ASSERT_EQ(ret, 0);
   ASSERT_EQ(entry.status, lc_complete);
+  ASSERT_EQ(entry.optional_cookie, cookie);
 
   // list entries
   ret = db->list_entries(index1, "", 5, lc_entries);
@@ -1173,6 +1177,7 @@ int main(int argc, char **argv)
   gtest::env = new gtest::Environment();
   gtest::env->logfile = c_logfile;
   gtest::env->loglevel = c_loglevel;
+  gtest::env->cookie  = "cookie";
   ::testing::AddGlobalTestEnvironment(gtest::env);
 
   ret = RUN_ALL_TESTS();


### PR DESCRIPTION
The optional_cookie tracks value of RGWLC::cookie, which is a random
value set at server/instance boot time.  IOW, this is a way to detect
whether the current, running radosgw instance is the one which last
updated a given LC entry.  The intended use is to robustify detection
of stale LC entries.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
