### PR TITLE
rgw/dbstore: Misc fixes

### DIFF
--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -92,6 +92,7 @@ rgw::sal::Store* StoreManager::init_storage_provider(const DoutPrefixProvider* d
     user->get_info().user_email = "tester@ceph.com";
     RGWAccessKey k1("0555b35654ad1656d804", "h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q==");
     user->get_info().access_keys["0555b35654ad1656d804"] = k1;
+    user->get_info().max_buckets = RGW_DEFAULT_MAX_BUCKETS;
 
     int r = user->store_user(dpp, null_yield, true);
     if (r < 0) {

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -234,6 +234,32 @@ namespace rgw::sal {
 
     /* XXX: handle delete_children */
 
+    if (!delete_children) {
+      /* Check if there are any objects */
+      rgw::sal::Bucket::ListParams params;
+      params.list_versions = true;
+      params.allow_unordered = true;
+
+      rgw::sal::Bucket::ListResults results;
+
+      results.objs.clear();
+
+      ret = list(dpp, params, 2, results, null_yield);
+
+      if (ret < 0) {
+        ldpp_dout(dpp, 20) << __func__ << ": Bucket list objects returned " <<
+        ret << dendl;
+        return ret;
+      }
+
+      if (!results.objs.empty()) {
+        ret = -ENOTEMPTY;
+        ldpp_dout(dpp, -1) << __func__ << ": Bucket Not Empty.. returning " <<
+        ret << dendl;
+        return ret;
+      }
+    }
+
     ret = store->getDB()->remove_bucket(dpp, info);
 
     return ret;

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -565,9 +565,7 @@ namespace rgw::sal {
 
   int DBObject::get_obj_state(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, RGWObjState **state, optional_yield y, bool follow_olh)
   {
-    if (!*state) {
-      *state = new RGWObjState();
-    }
+    *state = &(this->state);
     DB::Object op_target(store->getDB(), get_bucket()->get_info(), get_obj());
     return op_target.get_obj_state(dpp, get_bucket()->get_info(), get_obj(), follow_olh, state);
   }

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -438,7 +438,7 @@ protected:
       /* XXX: to be removed. Till Dan's patch comes, a placeholder
        * for RGWObjState
        */
-      RGWObjState* state;
+      RGWObjState state;
 
     public:
       struct DBReadOp : public ReadOp {
@@ -475,13 +475,13 @@ protected:
       DBObject(DBStore *_st, const rgw_obj_key& _k)
         : Object(_k),
         store(_st),
-        acls() {
-        }
+        acls() {}
+
       DBObject(DBStore *_st, const rgw_obj_key& _k, Bucket* _b)
         : Object(_k, _b),
         store(_st),
-        acls() {
-        }
+        acls() {}
+
       DBObject(DBObject& _o) = default;
 
       virtual int delete_object(const DoutPrefixProvider* dpp,

--- a/src/rgw/store/dbstore/common/dbstore.cc
+++ b/src/rgw/store/dbstore/common/dbstore.cc
@@ -279,6 +279,12 @@ int DB::get_user(const DoutPrefixProvider *dpp,
   if (ret)
     goto out;
 
+  /* Verify if its a valid user */
+  if (params.op.user.uinfo.access_keys.empty()) {
+    ldpp_dout(dpp, 0)<<"In GetUser - No user with query(" <<query_str.c_str()<<"), user_id(" << uinfo.user_id <<") found" << dendl;
+    return -ENOENT;
+  }
+
   uinfo = params.op.user.uinfo;
 
   if (pattrs) {

--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -620,8 +620,9 @@ class DBOp {
     const string ListAllQ = "SELECT  * from '{}'";
 
   public:
-    DBOp() {};
-    virtual ~DBOp() {};
+    DBOp() {}
+    virtual ~DBOp() {}
+    std::mutex mtx; // to protect prepared stmt
 
     string CreateTableSchema(string type, DBOpParams *params) {
       if (!type.compare("User"))
@@ -663,10 +664,11 @@ class DBOp {
     }
 
     virtual int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params) { return 0; }
+    virtual int Bind(const DoutPrefixProvider *dpp, DBOpParams *params) { return 0; }
     virtual int Execute(const DoutPrefixProvider *dpp, DBOpParams *params) { return 0; }
 };
 
-class InsertUserOp : public DBOp {
+class InsertUserOp : virtual public DBOp {
   private:
     /* For existing entires, -
      * (1) INSERT or REPLACE - it will delete previous entry and then
@@ -711,7 +713,7 @@ class InsertUserOp : public DBOp {
 
 };
 
-class RemoveUserOp: public DBOp {
+class RemoveUserOp: virtual public DBOp {
   private:
     const string Query =
       "DELETE from '{}' where UserID = {}";
@@ -725,7 +727,7 @@ class RemoveUserOp: public DBOp {
     }
 };
 
-class GetUserOp: public DBOp {
+class GetUserOp: virtual public DBOp {
   private:
     /* If below query columns are updated, make sure to update the indexes
      * in list_user() cbk in sqliteDB.cc */
@@ -786,7 +788,7 @@ class GetUserOp: public DBOp {
     }
 };
 
-class InsertBucketOp: public DBOp {
+class InsertBucketOp: virtual public DBOp {
   private:
     const string Query =
       "INSERT OR REPLACE INTO '{}' \
@@ -822,7 +824,7 @@ class InsertBucketOp: public DBOp {
     }
 };
 
-class UpdateBucketOp: public DBOp {
+class UpdateBucketOp: virtual public DBOp {
   private:
     // Updates Info, Mtime, Version
     const string InfoQuery =
@@ -875,7 +877,7 @@ class UpdateBucketOp: public DBOp {
     }
 };
 
-class RemoveBucketOp: public DBOp {
+class RemoveBucketOp: virtual public DBOp {
   private:
     const string Query =
       "DELETE from '{}' where BucketName = {}";
@@ -889,7 +891,7 @@ class RemoveBucketOp: public DBOp {
     }
 };
 
-class GetBucketOp: public DBOp {
+class GetBucketOp: virtual public DBOp {
   private:
     const string Query = "SELECT  \
                           BucketName, BucketTable.Tenant, Marker, BucketID, Size, SizeRounded, CreationTime, \
@@ -912,7 +914,7 @@ class GetBucketOp: public DBOp {
     }
 };
 
-class ListUserBucketsOp: public DBOp {
+class ListUserBucketsOp: virtual public DBOp {
   private:
     // once we have stats also stored, may have to update this query to join
     // these two tables.
@@ -935,7 +937,7 @@ class ListUserBucketsOp: public DBOp {
     }
 };
 
-class PutObjectOp: public DBOp {
+class PutObjectOp: virtual public DBOp {
   private:
     const string Query =
       "INSERT OR REPLACE INTO '{}' \
@@ -984,7 +986,7 @@ class PutObjectOp: public DBOp {
     }
 };
 
-class DeleteObjectOp: public DBOp {
+class DeleteObjectOp: virtual public DBOp {
   private:
     const string Query =
       "DELETE from '{}' where BucketName = {} and ObjName = {} and ObjInstance = {}";
@@ -1000,7 +1002,7 @@ class DeleteObjectOp: public DBOp {
     }
 };
 
-class GetObjectOp: public DBOp {
+class GetObjectOp: virtual public DBOp {
   private:
     const string Query =
       "SELECT  \
@@ -1027,7 +1029,7 @@ class GetObjectOp: public DBOp {
     }
 };
 
-class ListBucketObjectsOp: public DBOp {
+class ListBucketObjectsOp: virtual public DBOp {
   private:
     // once we have stats also stored, may have to update this query to join
     // these two tables.
@@ -1056,7 +1058,7 @@ class ListBucketObjectsOp: public DBOp {
     }
 };
 
-class UpdateObjectOp: public DBOp {
+class UpdateObjectOp: virtual public DBOp {
   private:
     // Updates Omap
     const string OmapQuery =
@@ -1144,7 +1146,7 @@ class UpdateObjectOp: public DBOp {
     }
 };
 
-class PutObjectDataOp: public DBOp {
+class PutObjectDataOp: virtual public DBOp {
   private:
     const string Query =
       "INSERT OR REPLACE INTO '{}' \
@@ -1168,7 +1170,7 @@ class PutObjectDataOp: public DBOp {
     }
 };
 
-class UpdateObjectDataOp: public DBOp {
+class UpdateObjectDataOp: virtual public DBOp {
   private:
     const string Query =
       "UPDATE '{}' \
@@ -1189,7 +1191,7 @@ class UpdateObjectDataOp: public DBOp {
           params.op.bucket.bucket_name.c_str());
     }
 };
-class GetObjectDataOp: public DBOp {
+class GetObjectDataOp: virtual public DBOp {
   private:
     const string Query =
       "SELECT  \
@@ -1208,7 +1210,7 @@ class GetObjectDataOp: public DBOp {
     }
 };
 
-class DeleteObjectDataOp: public DBOp {
+class DeleteObjectDataOp: virtual public DBOp {
   private:
     const string Query =
       "DELETE from '{}' where BucketName = {} and ObjName = {} and ObjInstance = {}";
@@ -1225,7 +1227,7 @@ class DeleteObjectDataOp: public DBOp {
     }
 };
 
-class InsertLCEntryOp: public DBOp {
+class InsertLCEntryOp: virtual public DBOp {
   private:
     const string Query =
       "INSERT OR REPLACE INTO '{}' \
@@ -1242,7 +1244,7 @@ class InsertLCEntryOp: public DBOp {
     }
 };
 
-class RemoveLCEntryOp: public DBOp {
+class RemoveLCEntryOp: virtual public DBOp {
   private:
     const string Query =
       "DELETE from '{}' where LCIndex = {} and BucketName = {}";
@@ -1256,7 +1258,7 @@ class RemoveLCEntryOp: public DBOp {
     }
 };
 
-class GetLCEntryOp: public DBOp {
+class GetLCEntryOp: virtual public DBOp {
   private:
     const string Query = "SELECT  \
                           LCIndex, BucketName, StartTime, Status \
@@ -1279,7 +1281,7 @@ class GetLCEntryOp: public DBOp {
     }
 };
 
-class ListLCEntriesOp: public DBOp {
+class ListLCEntriesOp: virtual public DBOp {
   private:
     const string Query = "SELECT  \
                           LCIndex, BucketName, StartTime, Status \
@@ -1295,7 +1297,7 @@ class ListLCEntriesOp: public DBOp {
     }
 };
 
-class InsertLCHeadOp: public DBOp {
+class InsertLCHeadOp: virtual public DBOp {
   private:
     const string Query =
       "INSERT OR REPLACE INTO '{}' \
@@ -1312,7 +1314,7 @@ class InsertLCHeadOp: public DBOp {
     }
 };
 
-class RemoveLCHeadOp: public DBOp {
+class RemoveLCHeadOp: virtual public DBOp {
   private:
     const string Query =
       "DELETE from '{}' where LCIndex = {}";
@@ -1326,7 +1328,7 @@ class RemoveLCHeadOp: public DBOp {
     }
 };
 
-class GetLCHeadOp: public DBOp {
+class GetLCHeadOp: virtual public DBOp {
   private:
     const string Query = "SELECT  \
                           LCIndex, Marker, StartDate \
@@ -1372,12 +1374,6 @@ class DB {
     const string lc_head_table;
     const string lc_entry_table;
     static map<string, class ObjectOp*> objectmap;
-    pthread_mutex_t mutex; // to protect objectmap and other shared
-    // objects if any. This mutex is taken
-    // before processing every fop (i.e, in
-    // ProcessOp()). If required this can be
-    // made further granular by taking separate
-    // locks for objectmap and db operations etc.
 
   protected:
     void *db;
@@ -1387,6 +1383,9 @@ class DB {
     // XXX: default ObjStripeSize or ObjChunk size - 4M, make them configurable?
     uint64_t ObjHeadSize = 1024; /* 1K - default head data size */
     uint64_t ObjChunkSize = (get_blob_limit() - 1000); /* 1000 to accommodate other fields */
+    // Below mutex is to protect objectmap and other shared
+    // objects if any.
+    std::mutex mtx;
 
   public:	
     DB(string db_name, CephContext *_cct) : db_name(db_name),
@@ -1448,7 +1447,7 @@ class DB {
     int InitializeParams(const DoutPrefixProvider *dpp, string Op, DBOpParams *params);
     int ProcessOp(const DoutPrefixProvider *dpp, string Op, DBOpParams *params);
     DBOp* getDBOp(const DoutPrefixProvider *dpp, string Op, struct DBOpParams *params);
-    int objectmapInsert(const DoutPrefixProvider *dpp, string bucket, void *ptr);
+    int objectmapInsert(const DoutPrefixProvider *dpp, string bucket, class ObjectOp* ptr);
     int objectmapDelete(const DoutPrefixProvider *dpp, string bucket);
 
     virtual uint64_t get_blob_limit() { return 0; };

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.cc
@@ -118,6 +118,7 @@
 
 #define SQL_EXECUTE(dpp, params, stmt, cbk, args...) \
   do{						\
+    const std::lock_guard<std::mutex> lk(((DBOp*)(this))->mtx); \
     if (!stmt) {				\
       ret = Prepare(dpp, params);		\
     }					\

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.cc
@@ -2669,10 +2669,10 @@ int SQLGetLCEntry::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params
   } else {
     pstmt = &stmt;
   }
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.index.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *pstmt, index, p_params.op.lc_entry.index.c_str(), sdb);
   SQL_BIND_TEXT(dpp, *pstmt, index, params->op.lc_entry.index.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *pstmt, index, p_params.op.lc_entry.bucket_name.c_str(), sdb);
   SQL_BIND_TEXT(dpp, *pstmt, index, params->op.lc_entry.entry.bucket.c_str(), sdb);
 
 out:

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.cc
@@ -40,7 +40,11 @@
 
 #define SQL_BIND_TEXT(dpp, stmt, index, str, sdb)			\
   do {								\
-    rc = sqlite3_bind_text(stmt, index, str, -1, SQLITE_TRANSIENT); 	\
+    if (strcmp(str, "null") == 0) {          \
+      rc = sqlite3_bind_text(stmt, index, "", -1, SQLITE_TRANSIENT); 	\
+    } else {                                                       \
+      rc = sqlite3_bind_text(stmt, index, str, -1, SQLITE_TRANSIENT); 	\
+    }                                   \
     \
     if (rc != SQLITE_OK) {					      	\
       ldpp_dout(dpp, 0)<<"sqlite bind text failed for index("     	\

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.h
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.h
@@ -13,7 +13,7 @@
 using namespace std;
 using namespace rgw::store;
 
-class SQLiteDB : public DB, public DBOp{
+class SQLiteDB : public DB, virtual public DBOp {
   private:
     sqlite3_mutex *mutex = NULL;
 


### PR DESCRIPTION
This PR contains below fixes in DBStore -

*  a s3 test 'test_bucket_delete_nonempty'   - return ENOTEMPTY on delete of the bucket if not empty
* Fix null ptr reference of ObjState returned
* Use mutex to protect DB objectmap and DBOps prepared statements when multiple threads are using same DB connection
* Validate the user returned by GetUser()