### PR TITLE
[WIP] rgw/dbstore: Create a connection pool for DB connections

### DIFF
--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -417,7 +417,7 @@ namespace rgw::sal {
 
     results.objs.clear();
 
-    DB::Bucket target(store->getDB(), get_info());
+    DB::Bucket target(store->getDB().get(), get_info());
     DB::Bucket::List list_op(&target);
 
     list_op.params.prefix = params.prefix;
@@ -534,7 +534,7 @@ namespace rgw::sal {
     if (!*state) {
       *state = new RGWObjState();
     }
-    DB::Object op_target(store->getDB(), get_bucket()->get_info(), get_obj());
+    DB::Object op_target(store->getDB().get(), get_bucket()->get_info(), get_obj());
     return op_target.get_obj_state(dpp, get_bucket()->get_info(), get_obj(), follow_olh, state);
   }
 
@@ -551,14 +551,14 @@ namespace rgw::sal {
   int DBObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj)
   {
     Attrs empty;
-    DB::Object op_target(store->getDB(),
+    DB::Object op_target(store->getDB().get(),
         get_bucket()->get_info(), target_obj ? *target_obj : get_obj());
     return op_target.set_attrs(dpp, setattrs ? *setattrs : empty, delattrs);
   }
 
   int DBObject::get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj)
   {
-    DB::Object op_target(store->getDB(), get_bucket()->get_info(), get_obj());
+    DB::Object op_target(store->getDB().get(), get_bucket()->get_info(), get_obj());
     DB::Object::Read read_op(&op_target);
 
     return read_attrs(dpp, read_op, y, target_obj);
@@ -622,7 +622,7 @@ namespace rgw::sal {
       std::map<std::string, bufferlist> *m,
       bool* pmore, optional_yield y)
   {
-    DB::Object op_target(store->getDB(),
+    DB::Object op_target(store->getDB().get(),
         get_bucket()->get_info(), get_obj());
     return op_target.obj_omap_get_vals(dpp, marker, count, m, pmore);
   }
@@ -630,7 +630,7 @@ namespace rgw::sal {
   int DBObject::omap_get_all(const DoutPrefixProvider *dpp, std::map<std::string, bufferlist> *m,
       optional_yield y)
   {
-    DB::Object op_target(store->getDB(),
+    DB::Object op_target(store->getDB().get(),
         get_bucket()->get_info(), get_obj());
     return op_target.obj_omap_get_all(dpp, m);
   }
@@ -639,7 +639,7 @@ namespace rgw::sal {
       const std::set<std::string>& keys,
       Attrs* vals)
   {
-    DB::Object op_target(store->getDB(),
+    DB::Object op_target(store->getDB().get(),
         get_bucket()->get_info(), get_obj());
     return op_target.obj_omap_get_vals_by_keys(dpp, oid, keys, vals);
   }
@@ -647,7 +647,7 @@ namespace rgw::sal {
   int DBObject::omap_set_val_by_key(const DoutPrefixProvider *dpp, const std::string& key, bufferlist& val,
       bool must_exist, optional_yield y)
   {
-    DB::Object op_target(store->getDB(),
+    DB::Object op_target(store->getDB().get(),
         get_bucket()->get_info(), get_obj());
     return op_target.obj_omap_set_val_by_key(dpp, key, val, must_exist);
   }
@@ -687,7 +687,7 @@ namespace rgw::sal {
   DBObject::DBReadOp::DBReadOp(DBObject *_source, RGWObjectCtx *_rctx) :
     source(_source),
     rctx(_rctx),
-    op_target(_source->store->getDB(),
+    op_target(_source->store->getDB().get(),
         _source->get_bucket()->get_info(),
         _source->get_obj()),
     parent_op(&op_target)
@@ -737,7 +737,7 @@ namespace rgw::sal {
   DBObject::DBDeleteOp::DBDeleteOp(DBObject *_source, RGWObjectCtx *_rctx) :
     source(_source),
     rctx(_rctx),
-    op_target(_source->store->getDB(),
+    op_target(_source->store->getDB().get(),
         _source->get_bucket()->get_info(),
         _source->get_obj()),
     parent_op(&op_target)
@@ -772,7 +772,7 @@ namespace rgw::sal {
 
   int DBObject::delete_object(const DoutPrefixProvider* dpp, RGWObjectCtx* obj_ctx, optional_yield y, bool prevent_versioning)
   {
-    DB::Object del_target(store->getDB(), bucket->get_info(), *obj_ctx, get_obj());
+    DB::Object del_target(store->getDB().get(), bucket->get_info(), *obj_ctx, get_obj());
     DB::Object::Delete del_op(&del_target);
 
     del_op.params.bucket_owner = bucket->get_info().owner;
@@ -884,7 +884,7 @@ namespace rgw::sal {
     mp_obj.init(oid, upload_id);
     obj = get_meta_obj();
 
-    DB::Object op_target(store->getDB(), obj->get_bucket()->get_info(),
+    DB::Object op_target(store->getDB().get(), obj->get_bucket()->get_info(),
 			       obj->get_obj());
     DB::Object::Write obj_op(&op_target);
 
@@ -919,7 +919,7 @@ namespace rgw::sal {
     parts.clear();
     int ret;
 
-    DB::Object op_target(store->getDB(),
+    DB::Object op_target(store->getDB().get(),
         obj->get_bucket()->get_info(), obj->get_obj());
     ret = op_target.get_mp_parts_list(dpp, parts_map);
     if (ret < 0) {
@@ -1062,7 +1062,7 @@ namespace rgw::sal {
      * from 'head_obj.name + "." + upload_id' to head_obj.name) */
 
     /* Original head object */
-    DB::Object op_target(store->getDB(),
+    DB::Object op_target(store->getDB().get(),
 			     target_obj->get_bucket()->get_info(),
 			     target_obj->get_obj());
     DB::Object::Write obj_op(&op_target);
@@ -1070,7 +1070,7 @@ namespace rgw::sal {
 
     /* Meta object */
     std::unique_ptr<rgw::sal::Object> meta_obj = get_meta_obj();
-    DB::Object meta_op_target(store->getDB(),
+    DB::Object meta_op_target(store->getDB().get(),
 			     meta_obj->get_bucket()->get_info(),
 			     meta_obj->get_obj());
     DB::Object::Write mp_op(&meta_op_target);
@@ -1192,7 +1192,7 @@ namespace rgw::sal {
                 oid(head_obj->get_name() + "." + upload_id +
                     "." + std::to_string(part_num)),
                 meta_obj(((DBMultipartUpload*)upload)->get_meta_obj()),
-                op_target(_store->getDB(), meta_obj->get_bucket()->get_info(), meta_obj->get_obj()),
+                op_target(_store->getDB().get(), meta_obj->get_bucket()->get_info(), meta_obj->get_obj()),
                 parent_op(&op_target), part_num(_part_num),
                 part_num_str(_part_num_str) { parent_op.prepare(NULL);}
 
@@ -1313,7 +1313,7 @@ namespace rgw::sal {
     info.modified = real_clock::now();
     //info.manifest = manifest;
 
-    DB::Object op_target(store->getDB(),
+    DB::Object op_target(store->getDB().get(),
         meta_obj->get_bucket()->get_info(), meta_obj->get_obj());
     ret = op_target.add_mp_part(dpp, info);
     if (ret < 0) {
@@ -1338,7 +1338,7 @@ namespace rgw::sal {
                 olh_epoch(_olh_epoch),
                 unique_tag(_unique_tag),
                 obj(_store, _head_obj->get_key(), _head_obj->get_bucket()),
-                op_target(_store->getDB(), obj.get_bucket()->get_info(), obj.get_obj()),
+                op_target(_store->getDB().get(), obj.get_bucket()->get_info(), obj.get_obj()),
                 parent_op(&op_target) {}
 
   int DBAtomicWriter::prepare(optional_yield y)
@@ -1874,14 +1874,14 @@ extern "C" {
         delete store; store = nullptr;
       }
 
-      DB *db = dbsm->getDB();
+      DB *db = dbsm->getDefaultDB();
       if (!db) {
         delete dbsm;
         delete store; store = nullptr;
       }
 
       store->setDBStoreManager(dbsm);
-      store->setDB(db);
+      store->setDefaultDB(db);
       db->set_store((rgw::sal::Store*)store);
       db->set_context(cct);
     }

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -803,7 +803,9 @@ public:
       DBStoreManager *getDBStoreManager(void) { return dbsm; }
 
       void setDB(DB * st) { db = st; }
-      DB *getDB(void) { return db; }
+      void setDefaultDB(DB * st) { db = st; }
+      std::shared_ptr<DB> getDB(void) { return dbsm->getDB(); }
+      DB *getDefaultDB(void) { return db; }
 
       DB *getDB(string tenant) { return dbsm->getDB(tenant, false); }
   };

--- a/src/rgw/store/dbstore/dbstore_mgr.h
+++ b/src/rgw/store/dbstore/dbstore_mgr.h
@@ -12,6 +12,7 @@
 #include "common/ceph_context.h"
 #include "common/dbstore.h"
 #include "sqlite/sqliteDB.h"
+#include <boost/lockfree/queue.hpp>
 
 using namespace std;
 using namespace rgw::store;
@@ -19,8 +20,11 @@ using DB = rgw::store::DB;
 
 /* XXX: Should be a dbstore config option */
 const static string default_tenant = "default_ns";
+#define MAX_QUEUE_DEFAULT 20 // make it configurable
 
 using namespace std;
+
+typedef boost::lockfree::queue<DB*, boost::lockfree::fixed_sized<true>> DBStoreQueue;
 
 class DBStoreManager {
 private:
@@ -28,10 +32,30 @@ private:
   DB *default_db = NULL;
   CephContext *cct;
 
+  // used in the dtor for dbstore conn cleanup
+  static std::atomic<uint64_t> max_conn; // XXX: make it configurable
+  static std::atomic<uint64_t> total_conn; // total connections created so far
+
+  static DBStoreQueue db_connections;
+  static std::mutex db_mutex;
+  static std::condition_variable db_cond;
+
+  static void delete_conn(const DB* db) {
+    delete db;
+  }
 public:
   DBStoreManager(CephContext *_cct): DBStoreHandles() {
     cct = _cct;
 	default_db = createDB(default_tenant);
+
+    for(uint32_t i = 0; i < DBStoreManager::max_conn; i++)  {
+      DB* db = createDB(default_tenant);
+
+      if (db) {
+        DBStoreManager::db_connections.push(db);
+        DBStoreManager::total_conn++;
+      }
+    }
   };
   DBStoreManager(string logfile, int loglevel): DBStoreHandles() {
     /* No ceph context. Create one with log args provided */
@@ -41,15 +65,49 @@ public:
     cct->_log->set_log_file(logfile);
     cct->_log->reopen_log_file();
     cct->_conf->subsys.set_log_level(dout_subsys, loglevel);
+
+    for(uint32_t i = 0; i < DBStoreManager::max_conn; i++)  {
+      DB* db = createDB(default_tenant);
+
+      if (db) {
+        DBStoreManager::db_connections.push(db);
+        DBStoreManager::total_conn++;
+      }
+    }
   };
-  ~DBStoreManager() { destroyAllHandles(); };
+  ~DBStoreManager() {
+     destroyAllHandles();
+     DBStoreManager::db_connections.consume_all(delete_conn);};
 
   /* XXX: TBD based on testing
    * 1)  Lock to protect DBStoreHandles map.
    * 2) Refcount of each DBStore to protect from
    * being deleted while using it.
    */
-  DB* getDB () { return default_db; };
+  DB* getDefaultDB () { return default_db; };
+  std::shared_ptr<DB> getDB() {
+    DB* db;
+    {
+      std::unique_lock<std::mutex> guard(DBStoreManager::db_mutex);
+      DBStoreManager::db_cond.wait(guard, [&](){return (DBStoreManager::total_conn > 0);});
+
+      ceph_assert(!DBStoreManager::db_connections.empty());
+
+      DBStoreManager::db_connections.pop(std::ref(db));
+      DBStoreManager::total_conn--; 
+    } 
+      ldout(cct, 0) << "In getDB() tenant(" << default_tenant << "), total count is :"<< DBStoreManager::total_conn << " , newly created db:" << db << dendl;
+
+
+    std::shared_ptr<DB> sh(db,
+         [](DB* p){
+           std::lock_guard<std::mutex> guard(DBStoreManager::db_mutex);
+           DBStoreManager::db_connections.push(p);
+           DBStoreManager::total_conn++;
+           DBStoreManager::db_cond.notify_all();
+         });
+    return sh;
+  }
   DB* getDB (string tenant, bool create);
   DB* createDB (string tenant);
   void deleteDB (string tenant);


### PR DESCRIPTION
Instead of using a single DB connection for all the Ops processing, create and maintain a connection pool of fixed
size (XXX: Make the size configurable). This is needed to use SQLite transactions in a multi-threaded environment.

Set PRAGMA busy_timeout to specify the min amount of time for any SQLite transaction to wait and retry before returning SQLITE_BUSY error - https://www.sqlite.org/c3ref/busy_timeout.html

XXX: Need to compare performance of single vs multiple connection handles.

Signed-off-by: Soumya Koduri <skoduri@redhat.com>
