### PR TITLE
WIP: librbd: don't deep copy if migration source has no snapshots

### DIFF
--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -600,7 +600,17 @@ bool CopyupRequest<I>::is_copyup_required() {
 template <typename I>
 bool CopyupRequest<I>::is_deep_copy() const {
   ceph_assert(ceph_mutex_is_locked(m_image_ctx->image_lock));
-  return !m_image_ctx->migration_info.empty();
+  if (m_image_ctx->migration_info.empty()) {
+    return false;
+  }
+
+  // return true if migration source contains any snapshot
+  for (const auto& pair : m_image_ctx->migration_info.snap_map) {
+    if (pair.first != CEPH_NOSNAP) {
+      return true;
+    }
+  }
+  return false;
 }
 
 template <typename I>


### PR DESCRIPTION
Consider the following use-case.
You're migrating from a local-block device, using RawFormat.
Most of the data is zeros.
With the current code, a very "fat" image will be created.
But you don't actually have to create objects whose data is all zeros.

CopyupRequest already has this check to skip object creation if parent data is all zeros.
However, this flow is skipped if ImageCtx.migration_info exists.

So I see 2 ways to overcome this:
1. What we have in this PR: change the condition for deep-copy to require that migration source has snapshots.
2. Change `RawFormat` to detect zeros, by adding a new read flag `READ_FLAG_ENOENT_ON_ZEROS`.

The first solution seems easier, but I don't understand copyup / deep-copy fully to understand if it's correct.
Is the condition I implemented (requiring `migration_info.snap_map` contains only CEPH_NOSNAP) good? should I require no destination snapshots as well?

@trociny @idryomov will be happy to get your thoughts.