### PR TITLE
pacific: mgr/dashboard: cheroot now ships type hints

### DIFF
--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -89,9 +89,6 @@ ignore_missing_imports = True
 [mypy-cherrypy.*]
 ignore_missing_imports = True
 
-[mypy-cheroot.*]
-ignore_missing_imports = True
-
 [mypy-bcrypt]
 ignore_missing_imports = True
 

--- a/src/pybind/mgr/dashboard/cherrypy_backports.py
+++ b/src/pybind/mgr/dashboard/cherrypy_backports.py
@@ -74,7 +74,7 @@ def patch_builtin_ssl_wrap(v, new_wrap):
     if v < StrictVersion("9.0.0"):
         from cherrypy.wsgiserver.ssl_builtin import BuiltinSSLAdapter as builtin_ssl
     else:
-        from cheroot.ssl.builtin import BuiltinSSLAdapter as builtin_ssl
+        from cheroot.ssl.builtin import BuiltinSSLAdapter as builtin_ssl  # type: ignore
     builtin_ssl.wrap = new_wrap(builtin_ssl.wrap)
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53764

---

backport of https://github.com/ceph/ceph/pull/44453
parent tracker: https://tracker.ceph.com/issues/53763

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh