### PR TITLE
mount.ceph: fix the handling of new-syntax device names

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -17,8 +17,8 @@
 #################################################################################
 # conditional build section
 #
-# please read http://rpm.org/user_doc/conditional_builds.html for explanation of
-# bcond syntax!
+# please read this for explanation of bcond syntax:
+# https://rpm-software-management.github.io/rpm/manual/conditionalbuilds.html
 #################################################################################
 %bcond_with make_check
 %bcond_with zbd

--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -176,7 +176,6 @@ static void record_name(const char *name, struct ceph_mount_info *cmi)
 	int name_pos = 0;
 	int name_len = 0;
 
-	name_pos = safe_cat(&cmi->cmi_name, &name_len, name_pos, "client.");
 	name_pos = safe_cat(&cmi->cmi_name, &name_len, name_pos, name);
 }
 
@@ -394,11 +393,19 @@ static int fetch_config_info(struct ceph_mount_info *cmi)
 	}
 
 	if (pid == 0) {
+		char *entity_name = NULL;
+		int name_pos = 0;
+		int name_len = 0;
+
 		/* child */
 		ret = drop_capabilities();
 		if (ret)
 			exit(1);
-		mount_ceph_get_config_info(cmi->cmi_conf, cmi->cmi_name, v2_addrs, cci);
+
+		name_pos = safe_cat(&entity_name, &name_len, name_pos, "client.");
+		name_pos = safe_cat(&entity_name, &name_len, name_pos, cmi->cmi_name);
+		mount_ceph_get_config_info(cmi->cmi_conf, entity_name, v2_addrs, cci);
+		free(entity_name);
 		exit(0);
 	} else {
 		/* parent */


### PR DESCRIPTION
The main patch in this fixes the handling of new-syntax device names. The code currently prepends "client." to the device string that it passes to the kernel, but it can't accept that syntax later if someone tries to recreate the mount.

Also, fix the URL in the specfile that points to the "bcond_" doc pages.

Fixes: https://tracker.ceph.com/issues/53765