### PR TITLE
crimson/os/seastore: cleanup with empty transactions

### DIFF
--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -156,8 +156,7 @@ std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
 
 extent_len_t record_size_t::get_raw_mdlength() const
 {
-  // FIXME: prevent submitting empty records
-  // assert(!is_empty());
+  // empty record is allowed to submit
   return plain_mdlength +
          ceph::encoded_sizeof_bounded<record_header_t>();
 }
@@ -186,8 +185,7 @@ void record_group_size_t::account(
     const record_size_t& rsize,
     extent_len_t _block_size)
 {
-  // FIXME: prevent submitting empty records
-  // assert(!rsize.is_empty());
+  // empty record is allowed to submit
   assert(_block_size > 0);
   assert(rsize.dlength % _block_size == 0);
   assert(block_size == 0 || block_size == _block_size);

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -221,6 +221,7 @@ seastar::future<> OSD::_write_superblock()
         ceph::os::Transaction t;
         meta_coll->create(t);
         meta_coll->store_superblock(t, superblock);
+        logger().debug("OSD::_write_superblock: do_transaction...");
         return store.do_transaction(meta_coll->collection(), std::move(t));
       });
     }
@@ -1106,6 +1107,7 @@ seastar::future<> OSD::handle_osd_map(crimson::net::ConnectionRef conn,
         superblock.clean_thru = last;
       }
       meta_coll->store_superblock(t, superblock);
+      logger().debug("OSD::handle_osd_map: do_transaction...");
       return store.do_transaction(meta_coll->collection(), std::move(t));
     });
   }).then([=] {

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -130,6 +130,7 @@ PG::PG(
 PG::~PG() {}
 
 bool PG::try_flush_or_schedule_async() {
+  logger().debug("PG::try_flush_or_schedule_async: do_transaction...");
   (void)shard_services.get_store().do_transaction(
     coll_ref,
     ObjectStore::Transaction()).then(
@@ -1100,6 +1101,7 @@ PG::interruptible_future<> PG::handle_rep_op(Ref<MOSDRepOp> req)
   decode(log_entries, p);
   peering_state.append_log(std::move(log_entries), req->pg_trim_to,
       req->version, req->min_last_complete_ondisk, txn, !txn.empty(), false);
+  logger().debug("PG::handle_rep_op: do_transaction...");
   return interruptor::make_interruptible(shard_services.get_store().do_transaction(
 	coll_ref, std::move(txn))).then_interruptible(
       [req, lcod=peering_state.get_info().last_complete, this] {

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -103,6 +103,7 @@ RecoveryBackend::handle_backfill_progress(
     m.stats,
     m.op == MOSDPGBackfill::OP_BACKFILL_PROGRESS,
     t);
+  logger().debug("RecoveryBackend::handle_backfill_progress: do_transaction...");
   return shard_services.get_store().do_transaction(
     pg.get_collection_ref(), std::move(t)).or_terminate();
 }
@@ -158,6 +159,7 @@ RecoveryBackend::handle_backfill_remove(
     t.remove(pg.get_collection_ref()->get_cid(),
 	      ghobject_t(soid, ghobject_t::NO_GEN, pg.get_pg_whoami().shard));
   }
+  logger().debug("RecoveryBackend::handle_backfill_remove: do_transaction...");
   return shard_services.get_store().do_transaction(
     pg.get_collection_ref(), std::move(t)).or_terminate();
 }

--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -60,6 +60,7 @@ ReplicatedBackend::_submit_transaction(std::set<pg_shard_t>&& pg_shards,
   bufferlist encoded_txn;
   encode(txn, encoded_txn);
 
+  logger().debug("ReplicatedBackend::_submit_transaction: do_transaction...");
   auto all_completed = interruptor::make_interruptible(
       shard_services.get_store().do_transaction(coll, std::move(txn)))
   .then_interruptible([this, peers=pending_txn->second.weak_from_this()] {

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -197,6 +197,7 @@ ReplicatedRecoveryBackend::on_local_recover_persist(
   logger().debug("{}", __func__);
   ceph::os::Transaction t;
   pg.get_recovery_handler()->on_local_recover(soid, _recovery_info, is_delete, t);
+  logger().debug("ReplicatedRecoveryBackend::on_local_recover_persist: do_transaction...");
   return interruptor::make_interruptible(
       shard_services.get_store().do_transaction(coll, std::move(t)))
   .then_interruptible(
@@ -220,6 +221,7 @@ ReplicatedRecoveryBackend::local_recover_delete(
 	[this, lomt = std::move(lomt)](auto& txn) {
 	return backend->remove(lomt->os, txn).then_interruptible(
 	  [this, &txn]() mutable {
+	  logger().debug("ReplicatedRecoveryBackend::local_recover_delete: do_transaction...");
 	  return shard_services.get_store().do_transaction(coll,
 							   std::move(txn));
 	});
@@ -740,6 +742,7 @@ ReplicatedRecoveryBackend::handle_pull_response(
       return _handle_pull_response(from, pop, &response, &t).then_interruptible(
 	[this, &t](bool complete) {
 	epoch_t epoch_frozen = pg.get_osdmap_epoch();
+	logger().debug("ReplicatedRecoveryBackend::handle_pull_response: do_transaction...");
 	return shard_services.get_store().do_transaction(coll, std::move(t))
 	  .then([this, epoch_frozen, complete,
 	  last_complete = pg.get_info().last_complete] {
@@ -824,6 +827,7 @@ ReplicatedRecoveryBackend::handle_push(
       return _handle_push(m->from, pop, &response, &t).then_interruptible(
 	[this, &t] {
 	epoch_t epoch_frozen = pg.get_osdmap_epoch();
+	logger().debug("ReplicatedRecoveryBackend::handle_push: do_transaction...");
 	return interruptor::make_interruptible(
 	    shard_services.get_store().do_transaction(coll, std::move(t))).then_interruptible(
 	  [this, epoch_frozen, last_complete = pg.get_info().last_complete] {

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -106,6 +106,7 @@ seastar::future<> ShardServices::send_to_osd(
 
 seastar::future<> ShardServices::dispatch_context_transaction(
   crimson::os::CollectionRef col, PeeringCtx &ctx) {
+  logger().debug("ShardServices::dispatch_context_transaction: do_transaction...");
   auto ret = store.do_transaction(
     col,
     std::move(ctx.transaction));


### PR DESCRIPTION
* Add logs to identify OSD operation that submits transaction;
* Mark empty transactions as debug log;
* Misc cleanup;

Signed-off-by: Yingxin Cheng <yingxin.cheng@intel.com>

Dropped the optimization part from https://github.com/ceph/ceph/pull/44256



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
