### PR TITLE
rgw: Externalize Keystone secret key cache TTL

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -808,6 +808,16 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_keystone_token_cache_ttl
+  type: int
+  level: advanced
+  desc: Keystone token secret key cache TTL
+  long_desc: The TTL for secret keys that are loaded from Keystone and stored in the cache system.
+  fmt_desc: The maximum TTL that a secret loaded from Keystone is maintained in the token cache system.
+  default: 300
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_keystone_verify_ssl
   type: bool
   level: advanced

--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -101,7 +101,7 @@ class SecretCache {
     : cct(g_ceph_context),
       lock(),
       max(cct->_conf->rgw_keystone_token_cache_size),
-      s3_token_expiry_length(300, 0) {
+      s3_token_expiry_length(cct->_conf->rgw_keystone_token_cache_ttl, 0) {
   }
 
   ~SecretCache() {}


### PR DESCRIPTION
The Keystone secret key TTL is hardcoded to 300 seconds (5 minutes).
For some use cases, the TTL could be increased, and as a consequence, the number of requests to Keystone is reduced.

Therefore, we propose to externalize this configuration to an option that provides this flexibility to operators. The default is maintained as 300 seconds (5 minutes).





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
