### PR TITLE
crimson/os/seastore/cache: fix debug macro usage

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -782,7 +782,7 @@ private:
     void clear() {
       LOG_PREFIX(Cache::LRU::clear);
       for (auto iter = lru.begin(); iter != lru.end();) {
-	DEBUG("clearing {}", *iter);
+	SUBDEBUG(seastore_cache, "clearing {}", *iter);
 	remove_from_lru(*(iter++));
       }
     }


### PR DESCRIPTION
Introduced via conflict between 277e57 and 632916.

Fixes: https://tracker.ceph.com/issues/53783
Signed-off-by: Samuel Just <sjust@redhat.com>