### PR TITLE
pacific: rgw/sts: createbucket op should take session_policies into account

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -2106,6 +2106,7 @@ bool verify_user_permission(const DoutPrefixProvider* dpp,
                             struct req_state * const s,
                             RGWAccessControlPolicy * const user_acl,
                             const vector<rgw::IAM::Policy>& user_policies,
+                            const vector<rgw::IAM::Policy>& session_policies,
                             const rgw::ARN& res,
                             const uint64_t op);
 bool verify_user_permission_no_policy(const DoutPrefixProvider* dpp,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52784

---

backport of https://github.com/ceph/ceph/pull/42247
parent tracker: https://tracker.ceph.com/issues/51598

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh