### PR TITLE
common: Use thread-local pointer variables to save the *shard

### DIFF
--- a/src/common/mempool.cc
+++ b/src/common/mempool.cc
@@ -15,7 +15,7 @@
 #include "include/mempool.h"
 #include "include/demangle.h"
 
-
+static thread_local mempool::shard_t *thread_shard = NULL;
 // default to debug_mode off
 bool mempool::debug_mode = false;
 
@@ -92,9 +92,9 @@ size_t mempool::pool_t::allocated_items() const
 
 void mempool::pool_t::adjust_count(ssize_t items, ssize_t bytes)
 {
-  shard_t *shard = pick_a_shard();
-  shard->items += items;
-  shard->bytes += bytes;
+  thread_shard = (thread_shard == NULL) ? pick_a_shard() : thread_shard;
+  thread_shard->items += items;
+  thread_shard->bytes += bytes;
 }
 
 void mempool::pool_t::get_stats(

--- a/src/common/mempool.cc
+++ b/src/common/mempool.cc
@@ -15,7 +15,7 @@
 #include "include/mempool.h"
 #include "include/demangle.h"
 
-static thread_local mempool::shard_t *thread_shard = NULL;
+static thread_local mempool::shard_t *thread_shard = nullptr;
 // default to debug_mode off
 bool mempool::debug_mode = false;
 
@@ -92,7 +92,7 @@ size_t mempool::pool_t::allocated_items() const
 
 void mempool::pool_t::adjust_count(ssize_t items, ssize_t bytes)
 {
-  thread_shard = (thread_shard == NULL) ? pick_a_shard() : thread_shard;
+  thread_shard = (thread_shard == nullptr) ? pick_a_shard() : thread_shard;
   thread_shard->items += items;
   thread_shard->bytes += bytes;
 }


### PR DESCRIPTION
…d by this thread.

Signed-off-by: liqiang <liqiang64@huawei.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
