### PR TITLE
pacific: mgr/prometheus: expose ceph healthchecks as metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,6 +685,7 @@ add_custom_target(check
 add_subdirectory(src)
 
 add_subdirectory(qa)
+add_subdirectory(monitoring)
 
 add_subdirectory(doc)
 if(WITH_MANPAGE)

--- a/monitoring/CMakeLists.txt
+++ b/monitoring/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(prometheus)

--- a/monitoring/prometheus/CMakeLists.txt
+++ b/monitoring/prometheus/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(tests)

--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -27,22 +27,86 @@ groups:
 
   - name: mon
     rules:
-      - alert: low monitor quorum count
-        expr: sum(ceph_mon_quorum_status) < 3
+      - alert: Monitor down, quorum is at risk
+        expr: ((ceph_health_detail{name="MON_DOWN"} == 1) * on() (count(ceph_mon_quorum_status == 1) == bool (floor(count(ceph_mon_metadata) / 2) + 1))) == 1
+        for: 30s
         labels:
           severity: critical
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.15.1.2.3.1
         annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-down
           description: |
-            Monitor count in quorum is below three.
-
-            Only {{ $value }} of {{ with query "count(ceph_mon_quorum_status)" }}{{ . | first | value }}{{ end }} monitors are active.
+            {{ $min := query "floor(count(ceph_mon_metadata) / 2) +1" | first | value }}Quorum requires a majority of monitors (x {{ $min }}) to be active
+            Without quorum the cluster will become inoperable, affecting all connected clients and services.
 
             The following monitors are down:
             {{- range query "(ceph_mon_quorum_status == 0) + on(ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)" }}
               - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }}
             {{- end }}
+      - alert: Monitor down
+        expr: (count(ceph_mon_quorum_status == 0) <= (count(ceph_mon_metadata) - floor(count(ceph_mon_metadata) / 2) + 1))
+        for: 30s
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-down
+          description: |
+            {{ $down := query "count(ceph_mon_quorum_status == 0)" | first | value }}{{ $s := "" }}{{ if gt $down 1.0 }}{{ $s = "s" }}{{ end }}You have {{ $down }} monitor{{ $s }} down.
+            Quorum is still intact, but the loss of further monitors will make your cluster inoperable.
+
+            The following monitors are down:
+            {{- range query "(ceph_mon_quorum_status == 0) + on(ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)" }}
+              - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }}
+            {{- end }}
+      - alert: Ceph mon disk space critically low
+        expr: ceph_health_detail{name="MON_DISK_CRIT"} == 1
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-disk-crit
+          description: |
+            The free space available to a monitor's store is critically low (<5% by default).
+            You should increase the space available to the monitor(s). The
+            default location for the store sits under /var/lib/ceph. Your monitor hosts are;
+            {{- range query "ceph_mon_metadata"}}
+              - {{ .Labels.hostname }}
+            {{- end }}
+
+      - alert: Ceph mon disk space running low
+        expr: ceph_health_detail{name="MON_DISK_LOW"} == 1
+        for: 5m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-disk-low
+          description: |
+            The space available to a monitor's store is approaching full (>70% is the default).
+            You should increase the space available to the monitor store. The
+            default location for the store sits under /var/lib/ceph. Your monitor hosts are;
+            {{- range query "ceph_mon_metadata"}}
+              - {{ .Labels.hostname }}
+            {{- end }}
+
+      - alert: Clock skew detected across Ceph Monitor daemons
+        expr: ceph_health_detail{name="MON_CLOCK_SKEW"} == 1
+        for: 1m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-clock-skew
+          description: |
+            The ceph monitors rely on a consistent time reference to maintain
+            quorum and cluster consistency. This event indicates that at least
+            one of your mons is not sync'd correctly.
+
+            Review the cluster status with ceph -s. This will show which monitors
+            are affected. Check the time sync status on each monitor host.
 
   - name: osd
     rules:
@@ -60,43 +124,163 @@ groups:
             {{- range query "(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0" }}
               - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }}
             {{- end }}
-
+      - alert: OSD Host is down
+        expr: ceph_health_detail{name="OSD_HOST_DOWN"} == 1
+        for: 5m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          description: |
+            The following OSDs are down:
+            {{- range query "(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0" }}
+            - {{ .Labels.hostname }} : {{ .Labels.ceph_daemon }}
+            {{- end }}
       - alert: OSD down
-        expr: count(ceph_osd_up == 0) > 0
-        for: 15m
+        expr: ceph_health_detail{name="OSD_DOWN"} == 1
+        for: 5m
         labels:
           severity: warning
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.15.1.2.4.2
         annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-down
           description: |
-            {{ $s := "" }}{{ if gt $value 1.0 }}{{ $s = "s" }}{{ end }}
-            {{ $value }} OSD{{ $s }} down for more than 15 minutes.
-
-            {{ $value }} of {{ query "count(ceph_osd_up)" | first | value }} OSDs are down.
+            {{ $num := query "count(ceph_osd_up == 0)" | first | value }}{{ $s := "" }}{{ if gt $num 1.0 }}{{ $s = "s" }}{{ end }}{{ $num }} OSD{{ $s }} down for over 5mins.
 
             The following OSD{{ $s }} {{ if eq $s "" }}is{{ else }}are{{ end }} down:
               {{- range query "(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0"}}
-                - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }}
+              - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }}
               {{- end }}
 
       - alert: OSDs near full
-        expr: |
-          (
-            ((ceph_osd_stat_bytes_used / ceph_osd_stat_bytes) and on(ceph_daemon) ceph_osd_up == 1)
-            * on(ceph_daemon) group_left(hostname) ceph_osd_metadata
-          ) * 100 > 90
+        expr: ceph_health_detail{name="OSD_NEARFULL"} == 1
         for: 5m
         labels:
-          severity: critical
+          severity: warning
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.15.1.2.4.3
         annotations:
-          description: >
-            OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} is
-            dangerously full: {{ $value | humanize }}%
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-nearfull
+          description: |
+            One or more OSDs have reached their NEARFULL threshold
 
-      - alert: flapping OSD
+            Use 'ceph health detail' to identify which OSDs have reached this threshold.
+            To resolve, either add capacity to the cluster, or delete unwanted data
+      - alert: OSD Full
+        expr: ceph_health_detail{name="OSD_FULL"} > 0
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-full
+          description: |
+            An OSD has reached it's full threshold. Writes from all pools that share the
+            affected OSD will be blocked.
+
+            To resolve, either add capacity to the cluster, or delete unwanted data
+      - alert: OSD unable to perform rebalance
+        expr: ceph_health_detail{name="OSD_BACKFILLFULL"} > 0
+        for: 1m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-backfillfull
+          description: |
+            An OSD has reached it's BACKFILL FULL threshold. This will prevent rebalance operations
+            completing for some pools. Check the current capacity utilisation with 'ceph df'
+
+            To resolve, either add capacity to the cluster, or delete unwanted data
+      - alert: OSD too many read repairs
+        expr: ceph_health_detail{name="OSD_TOO_MANY_REPAIRS"} == 1
+        for: 30s
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-too-many-repairs
+          description: |
+            Reads from an OSD have used a secondary PG to return data to the client, indicating
+            a potential failing disk.
+      - alert: OSD hearbeats running slow (frontend)
+        expr: ceph_health_detail{name="OSD_SLOW_PING_TIME_FRONT"} == 1
+        for: 1m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          description: |
+            OSD heartbeats on the cluster's 'public' network (frontend) are running slow. Investigate the network
+            for any latency issues on this subnet. Use 'ceph health detail' to show the affected OSDs.
+      - alert: OSD hearbeats running slow (backend)
+        expr: ceph_health_detail{name="OSD_SLOW_PING_TIME_BACK"} == 1
+        for: 1m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          description: |
+            OSD heartbeats on the cluster's 'cluster' network (backend) are running slow. Investigate the network
+            for any latency issues on this subnet. Use 'ceph health detail' to show the affected OSDs.
+      - alert: OSD disk size mismatch
+        expr: ceph_health_detail{name="BLUESTORE_DISK_SIZE_MISMATCH"} == 1
+        for: 1m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#bluestore-disk-size-mismatch
+          description: |
+            One or more OSDs have an internal inconsistency between the size of the physical device and it's metadata.
+            This could lead to the OSD(s) crashing in future. You should redeploy the effected OSDs.
+      - alert: Device failure predicted
+        expr: ceph_health_detail{name="DEVICE_HEALTH"} == 1
+        for: 1m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#id2
+          description: |
+            The device health module has determined that one or more devices will fail
+            soon. To review the device states use 'ceph device ls'. To show a specific
+            device use 'ceph device info <dev id>'.
+
+            Mark the OSD as out (so data may migrate to other OSDs in the cluster). Once
+            the osd is empty remove and replace the OSD.
+      - alert: Too many devices predicted to fail
+        expr: ceph_health_detail{name="DEVICE_HEALTH_TOOMANY"} == 1
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#device-health-toomany
+          description: |
+            The device health module has determined that the number of devices predicted to
+            fail can not be remediated automatically, since it would take too many osd's out of
+            the cluster, impacting performance and potentially availabililty. You should add new
+            OSDs to the cluster to allow data to be relocated to avoid the data integrity issues.
+      - alert: Device failure predicted, but automatic drain is incomplete
+        expr: ceph_health_detail{name="DEVICE_HEALTH_IN_USE"} == 1
+        for: 1m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#device-health-in-use
+          description: |
+            The device health module has determined that one or more devices will fail
+            soon, but the normal process of relocating the data on the device to other
+            OSDs in the cluster is blocked.
+
+            Check the the cluster has available freespace. It may be necessary to add
+            more disks to the cluster to allow the data from the failing device to
+            successfully migrate.
+
+      - alert: Flapping OSD
         expr: |
           (
             rate(ceph_osd_up[5m])
@@ -107,11 +291,25 @@ groups:
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.15.1.2.4.4
         annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd/#flapping-osds
           description: >
             OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} was
             marked down and back up at {{ $value | humanize }} times once a
-            minute for 5 minutes.
+            minute for 5 minutes. This could indicate a network issue (latency,
+            packet drop, disruption) on the clusters "cluster network". Check the
+            network environment on the listed host(s).
 
+      - alert: OSD Read errors
+        expr: ceph_health_detail{name="BLUESTORE_SPURIOUS_READ_ERRORS"} == 1
+        for: 30s
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#bluestore-spurious-read-errors
+          description: >
+            An OSD has encountered read errors, but the OSD has recovered by retrying
+            the reads. This may indicate an issue with the Hardware or Kernel.
       # alert on high deviation from average PG count
       - alert: high pg count deviation
         expr: |
@@ -130,12 +328,69 @@ groups:
             OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} deviates
             by more than 30% from average PG count.
       # alert on high commit latency...but how high is too high
+
   - name: mds
     rules:
-    # no mds metrics are exported yet
+      - alert: Ceph Filesystem damage detected
+        expr: ceph_health_detail{name="MDS_DAMAGE"} > 0
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#cephfs-health-messages
+          description: >
+            The filesystems metadata has been corrupted. Data access
+            may be blocked.
+
+            Either analyse the output from the mds daemon admin socket, or
+            escalate to support
+      - alert: Ceph Filesystem switched to READ ONLY
+        expr: ceph_health_detail{name="MDS_HEALTH_READ_ONLY"} > 0
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#cephfs-health-messages
+          description: >
+            The filesystem has switched to READ ONLY due to an unexpected
+            write error, when writing to the metadata pool
+
+            Either analyse the output from the mds daemon admin socket, or
+            escalate to support
+
   - name: mgr
     rules:
-    # no mgr metrics are exported yet
+      - alert: mgr module failure
+        expr: ceph_health_detail{name="RECENT_MGR_MODULE_CRASH"} == 1
+        for: 5m
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#recent-mgr-module-crash
+          description: >
+            One or more mgr modules have crashed and are yet to be acknowledged by the administrator. A
+            crashed module may impact functionality within the cluster. Use the 'ceph crash' commands to
+            investigate which module has failed, and archive it to acknowledge the failure.
+      - alert: mgr prometheus module is not active
+        expr: up{job="ceph"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          description: >
+            The mgr/prometheus module at {{ $labels.instance }} is unreachable. This
+            could mean that the module has been disabled or the mgr itself is down.
+
+            Without the mgr/prometheus module metrics and alerts will no longer
+            function. Open a shell to ceph and use 'ceph -s' to to determine whether the
+            mgr is active. If the mgr is not active, restart it, otherwise you can check
+            the mgr/prometheus module is loaded with 'ceph mgr module ls'  and if it's
+            not listed as enabled, enable it with 'ceph mgr module enable prometheus'
+
   - name: pgs
     rules:
       - alert: pgs inactive
@@ -160,8 +415,89 @@ groups:
         annotations:
           description: >
             {{ $value }} PGs haven't been clean for more than 15 minutes in pool {{ $labels.name }}.
-            Unclean PGs haven't been able to completely recover from a
-            previous failure.
+            Unclean PGs haven't been able to completely recover from a previous failure.
+      - alert: Placement Group (PG) damaged
+        expr: ceph_health_detail{name=~"PG_DAMAGED|OSD_SCRUB_ERRORS"} == 1
+        for: 5m
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-damaged
+          description: >
+            During data consistency checks (scrub), at least one PG has been flagged as being
+            damaged or inconsistent.
+
+            Check to see which PG is affected, and attempt a manual repair if neccessary. To list
+            problematic placement groups, use 'rados list-inconsistent-pg <pool>'. To repair PGs use
+            the 'ceph pg repair <pg_num>' command.
+      - alert: Recovery at risk, cluster too full
+        expr: ceph_health_detail{name="PG_RECOVERY_FULL"} == 1
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-recovery-full
+          description: >
+            Data redundancy may be reduced, or is at risk, since one or more OSDs are at or above their
+            'full' threshold. Add more capacity to the cluster, or delete unwanted data.
+      - alert: I/O blocked to some data
+        # PG_AVAILABILITY, but an OSD is not in a DOWN state
+        expr: ((ceph_health_detail{name="PG_AVAILABILITY"} == 1) - scalar(ceph_health_detail{name="OSD_DOWN"})) == 1
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-availability
+          description: >
+            Data availability is reduced impacting the clusters abilty to service I/O to some data. One or
+            more placement groups (PGs) are in a state that blocks IO.
+      - alert: Cluster too full, automatic data recovery impaired
+        expr: ceph_health_detail{name="PG_BACKFILL_FULL"} == 1
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-backfill-full
+          description: >
+            Data redundancy may be at risk due to lack of free space within the cluster. One or more OSDs
+            have breached their 'backfillfull' threshold. Add more capacity, or delete unwanted data.
+      - alert: Placement Group(s) have not been scrubbed
+        expr: ceph_health_detail{name="PG_NOT_SCRUBBED"} == 1
+        for: 5m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-not-scrubbed
+          description: |
+            One or more PGs have not been scrubbed recently. The scrub process is a data integrity
+            feature, protectng against bit-rot. It checks that objects and their metadata (size and
+            attributes) match across object replicas. When PGs miss their scrub window, it may
+            indicate the scrub window is too small, or PGs were not in a 'clean' state during the
+            scrub window.
+
+            You can manually initiate a scrub with: ceph pg scrub <pgid>
+      - alert: Placement Group(s) have not been 'DEEP' scrubbed
+        expr: ceph_health_detail{name="PG_NOT_DEEP_SCRUBBED"} == 1
+        for: 5m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-not-deep-scrubbed
+          description: |
+            One or more PGs have not been deep scrubbed recently. Deep scrub is a data integrity
+            feature, protectng against bit-rot. It compares the contents of objects and their
+            replicas for inconsistency. When PGs miss their deep scrub window, it may indicate
+            that the window is too small or PGs were not in a 'clean' state during the deep-scrub
+            window.
+
+            You can manually initiate a deep scrub with: ceph pg deep-scrub <pgid>
+
   - name: nodes
     rules:
       - alert: root volume full
@@ -218,9 +554,11 @@ groups:
             Node {{ $labels.instance }} experiences packet errors > 0.01% or
             > 10 packets/s on interface {{ $labels.device }}.
 
+      # Restrict to device names beginning with '/' to skip false alarms from
+      # tmpfs, overlay type filesystems
       - alert: storage filling up
         expr: |
-          predict_linear(node_filesystem_free_bytes[2d], 3600 * 24 * 5) *
+          predict_linear(node_filesystem_free_bytes{device=~"/.*"}[2d], 3600 * 24 * 5) *
           on(instance) group_left(nodename) node_uname_info < 0
         labels:
           severity: warning
@@ -256,7 +594,7 @@ groups:
         annotations:
           description: Pool {{ $labels.name }} at {{ $value | humanize }}% capacity.
 
-      - alert: pool filling up
+      - alert: pool filling up (growth forecast)
         expr: |
           (
             predict_linear(ceph_pool_stored[2d], 3600 * 24 * 5)
@@ -271,6 +609,51 @@ groups:
             Pool {{ $labels.name }} will be full in less than 5 days
             assuming the average fill-up rate of the past 48 hours.
 
+      - alert: Ceph pool is too full for recovery/rebalance
+        expr: ceph_health_detail{name="POOL_BACKFILLFULL"} > 0
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          description: >
+            A pool is approaching it's near full threshold, which will
+            prevent rebalance operations from completing. You should
+            consider adding more capacity to the pool.
+
+      - alert: Ceph pool is full - writes blocked
+        expr: ceph_health_detail{name="POOL_FULL"} > 0
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pool-full
+          description: |
+            A pool has reached it's MAX quota, or the OSDs supporting the pool
+            have reached their FULL threshold. Until this is resolved, writes to
+            the pool will be blocked.
+
+            Determine the affected pool with 'ceph df detail', for example looking
+            at QUOTA BYTES and STORED. Either increase the pools quota, or add
+            capacity to the cluster first then increase it's quota
+            (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)
+      - alert: Ceph pool is approaching full
+        expr: ceph_health_detail{name="POOL_NEAR_FULL"} > 0
+        for: 5m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          description: |
+            A pool has exceeeded it warning (percent full) threshold, or the OSDs
+            supporting the pool have reached their NEARFULL thresholds. Writes may
+            continue, but you are at risk of the pool going read only if more capacity
+            isn't made available.
+
+            Determine the affected pool with 'ceph df detail', for example looking
+            at QUOTA BYTES and STORED. Either increase the pools quota, or add
+            capacity to the cluster first then increase it's quota
+            (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)
   - name: healthchecks
     rules:
       - alert: Slow OSD Ops
@@ -280,5 +663,76 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#slow-ops
           description: >
             {{ $value }} OSD requests are taking too long to process (osd_op_complaint_time exceeded)
+# cephadm alerts
+  - name: cephadm
+    rules:
+      - alert: Cluster upgrade has failed
+        expr: ceph_health_detail{name="UPGRADE_EXCEPTION"} > 0
+        for: 30s
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          description: >
+            The cephadm cluster upgrade process has failed. The cluster remains in
+            an undetermined state.
+
+            Please review the cephadm logs, to understand the nature of the issue
+      - alert: A daemon managed by cephadm is down
+        expr: ceph_health_detail{name="CEPHADM_FAILED_DAEMON"} > 0
+        for: 30s
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          description: >
+            A daemon managed by cephadm is no longer active. Determine, which
+            daemon is down with 'ceph health detail'. you may start daemons with
+            the 'ceph orch daemon start <daemon_id>'
+      - alert: cephadm management has been paused
+        expr: ceph_health_detail{name="CEPHADM_PAUSED"} > 0
+        for: 1m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/cephadm/operations/#cephadm-paused
+          description: >
+            Cluster management has been paused manually. This will prevent the
+            orchestrator from service management and reconciliation. If this is
+            not intentional, resume cephadm operations with 'ceph orch resume'
+
+# prometheus alerts
+  - name: prometheus
+    rules:
+      - alert: Scrape job is missing
+        expr: absent(up{job="ceph"})
+        for: 30s
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          description: |
+            The prometheus job that scrapes from Ceph is no longer defined, this
+            will effectively mean you'll have no metrics or alerts for the cluster.
+
+            Please review the job definitions in the prometheus.yml file of the prometheus
+            instance.
+# Object related events
+  - name: rados
+    rules:
+      - alert: Data not found/missing
+        expr: (ceph_health_detail{name="OBJECT_UNFOUND"} == 1) * on() (count(ceph_osd_up == 1) == bool count(ceph_osd_metadata)) == 1
+        for: 30s
+        labels:
+          severity: critical
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#object-unfound
+          description: |
+            A version of a RADOS object can not be found, even though all OSDs are up. I/O
+            requests for this object from clients will block (hang). Resolving this issue may
+            require the object to be rolled back to a prior version manually, and manually verified.

--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -35,7 +35,7 @@ groups:
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.15.1.2.3.1
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-down
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down
           description: |
             {{ $min := query "floor(count(ceph_mon_metadata) / 2) +1" | first | value }}Quorum requires a majority of monitors (x {{ $min }}) to be active
             Without quorum the cluster will become inoperable, affecting all connected clients and services.
@@ -51,7 +51,7 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-down
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down
           description: |
             {{ $down := query "count(ceph_mon_quorum_status == 0)" | first | value }}{{ $s := "" }}{{ if gt $down 1.0 }}{{ $s = "s" }}{{ end }}You have {{ $down }} monitor{{ $s }} down.
             Quorum is still intact, but the loss of further monitors will make your cluster inoperable.
@@ -67,7 +67,7 @@ groups:
           severity: critical
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-disk-crit
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-crit
           description: |
             The free space available to a monitor's store is critically low (<5% by default).
             You should increase the space available to the monitor(s). The
@@ -83,7 +83,7 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-disk-low
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-low
           description: |
             The space available to a monitor's store is approaching full (>70% is the default).
             You should increase the space available to the monitor store. The
@@ -99,7 +99,7 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-clock-skew
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-clock-skew
           description: |
             The ceph monitors rely on a consistent time reference to maintain
             quorum and cluster consistency. This event indicates that at least
@@ -144,7 +144,7 @@ groups:
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.15.1.2.4.2
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-down
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-down
           description: |
             {{ $num := query "count(ceph_osd_up == 0)" | first | value }}{{ $s := "" }}{{ if gt $num 1.0 }}{{ $s = "s" }}{{ end }}{{ $num }} OSD{{ $s }} down for over 5mins.
 
@@ -161,7 +161,7 @@ groups:
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.15.1.2.4.3
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-nearfull
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-nearfull
           description: |
             One or more OSDs have reached their NEARFULL threshold
 
@@ -174,7 +174,7 @@ groups:
           severity: critical
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-full
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-full
           description: |
             An OSD has reached it's full threshold. Writes from all pools that share the
             affected OSD will be blocked.
@@ -187,7 +187,7 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-backfillfull
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-backfillfull
           description: |
             An OSD has reached it's BACKFILL FULL threshold. This will prevent rebalance operations
             completing for some pools. Check the current capacity utilisation with 'ceph df'
@@ -200,7 +200,7 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-too-many-repairs
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-too-many-repairs
           description: |
             Reads from an OSD have used a secondary PG to return data to the client, indicating
             a potential failing disk.
@@ -231,7 +231,7 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#bluestore-disk-size-mismatch
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-disk-size-mismatch
           description: |
             One or more OSDs have an internal inconsistency between the size of the physical device and it's metadata.
             This could lead to the OSD(s) crashing in future. You should redeploy the effected OSDs.
@@ -242,7 +242,7 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#id2
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#id2
           description: |
             The device health module has determined that one or more devices will fail
             soon. To review the device states use 'ceph device ls'. To show a specific
@@ -257,7 +257,7 @@ groups:
           severity: critical
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#device-health-toomany
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-toomany
           description: |
             The device health module has determined that the number of devices predicted to
             fail can not be remediated automatically, since it would take too many osd's out of
@@ -270,7 +270,7 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#device-health-in-use
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-in-use
           description: |
             The device health module has determined that one or more devices will fail
             soon, but the normal process of relocating the data on the device to other
@@ -291,7 +291,7 @@ groups:
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.15.1.2.4.4
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd/#flapping-osds
+          documentation: https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd#flapping-osds
           description: >
             OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} was
             marked down and back up at {{ $value | humanize }} times once a
@@ -306,7 +306,7 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#bluestore-spurious-read-errors
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-spurious-read-errors
           description: >
             An OSD has encountered read errors, but the OSD has recovered by retrying
             the reads. This may indicate an issue with the Hardware or Kernel.
@@ -338,7 +338,7 @@ groups:
           severity: critical
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#cephfs-health-messages
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages
           description: >
             The filesystems metadata has been corrupted. Data access
             may be blocked.
@@ -352,7 +352,7 @@ groups:
           severity: critical
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#cephfs-health-messages
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages
           description: >
             The filesystem has switched to READ ONLY due to an unexpected
             write error, when writing to the metadata pool
@@ -369,7 +369,7 @@ groups:
           severity: critical
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#recent-mgr-module-crash
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#recent-mgr-module-crash
           description: >
             One or more mgr modules have crashed and are yet to be acknowledged by the administrator. A
             crashed module may impact functionality within the cluster. Use the 'ceph crash' commands to
@@ -423,7 +423,7 @@ groups:
           severity: critical
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-damaged
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-damaged
           description: >
             During data consistency checks (scrub), at least one PG has been flagged as being
             damaged or inconsistent.
@@ -438,7 +438,7 @@ groups:
           severity: critical
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-recovery-full
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-recovery-full
           description: >
             Data redundancy may be reduced, or is at risk, since one or more OSDs are at or above their
             'full' threshold. Add more capacity to the cluster, or delete unwanted data.
@@ -450,7 +450,7 @@ groups:
           severity: critical
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-availability
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-availability
           description: >
             Data availability is reduced impacting the clusters abilty to service I/O to some data. One or
             more placement groups (PGs) are in a state that blocks IO.
@@ -461,7 +461,7 @@ groups:
           severity: critical
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-backfill-full
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-backfill-full
           description: >
             Data redundancy may be at risk due to lack of free space within the cluster. One or more OSDs
             have breached their 'backfillfull' threshold. Add more capacity, or delete unwanted data.
@@ -472,7 +472,7 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-not-scrubbed
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-scrubbed
           description: |
             One or more PGs have not been scrubbed recently. The scrub process is a data integrity
             feature, protectng against bit-rot. It checks that objects and their metadata (size and
@@ -488,7 +488,7 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-not-deep-scrubbed
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-deep-scrubbed
           description: |
             One or more PGs have not been deep scrubbed recently. Deep scrub is a data integrity
             feature, protectng against bit-rot. It compares the contents of objects and their
@@ -627,7 +627,7 @@ groups:
           severity: critical
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pool-full
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pool-full
           description: |
             A pool has reached it's MAX quota, or the OSDs supporting the pool
             have reached their FULL threshold. Until this is resolved, writes to
@@ -663,7 +663,7 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#slow-ops
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops
           description: >
             {{ $value }} OSD requests are taking too long to process (osd_op_complaint_time exceeded)
 # cephadm alerts
@@ -699,7 +699,7 @@ groups:
           severity: warning
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/cephadm/operations/#cephadm-paused
+          documentation: https://docs.ceph.com/en/latest/cephadm/operations#cephadm-paused
           description: >
             Cluster management has been paused manually. This will prevent the
             orchestrator from service management and reconciliation. If this is
@@ -731,7 +731,7 @@ groups:
           severity: critical
           type: ceph_default
         annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#object-unfound
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#object-unfound
           description: |
             A version of a RADOS object can not be found, even though all OSDs are up. I/O
             requests for this object from clients will block (hang). Resolving this issue may

--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -1,41 +1,43 @@
 groups:
   - name: cluster health
     rules:
-      - alert: health error
+      - alert: CephHealthError
         expr: ceph_health_status == 2
         for: 5m
         labels:
           severity: critical
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.2.1
+          oid: 1.3.6.1.4.1.50495.1.2.1.2.1
         annotations:
+          summary: Cluster is in an ERROR state
           description: >
             Ceph in HEALTH_ERROR state for more than 5 minutes.
             Please check "ceph health detail" for more information.
 
-      - alert: health warn
+      - alert: CephHealthWarning
         expr: ceph_health_status == 1
         for: 15m
         labels:
           severity: warning
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.2.2
         annotations:
+          summary: Cluster is in a WARNING state
           description: >
             Ceph has been in HEALTH_WARN for more than 15 minutes.
             Please check "ceph health detail" for more information.
 
   - name: mon
     rules:
-      - alert: Monitor down, quorum is at risk
+      - alert: CephMonDownQuorumAtRisk
         expr: ((ceph_health_detail{name="MON_DOWN"} == 1) * on() (count(ceph_mon_quorum_status == 1) == bool (floor(count(ceph_mon_metadata) / 2) + 1))) == 1
         for: 30s
         labels:
           severity: critical
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.3.1
+          oid: 1.3.6.1.4.1.50495.1.2.1.3.1
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down
+          summary: Monitor quorum is at risk
           description: |
             {{ $min := query "floor(count(ceph_mon_metadata) / 2) +1" | first | value }}Quorum requires a majority of monitors (x {{ $min }}) to be active
             Without quorum the cluster will become inoperable, affecting all connected clients and services.
@@ -44,7 +46,7 @@ groups:
             {{- range query "(ceph_mon_quorum_status == 0) + on(ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)" }}
               - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }}
             {{- end }}
-      - alert: Monitor down
+      - alert: CephMonDown
         expr: (count(ceph_mon_quorum_status == 0) <= (count(ceph_mon_metadata) - floor(count(ceph_mon_metadata) / 2) + 1))
         for: 30s
         labels:
@@ -52,6 +54,7 @@ groups:
           type: ceph_default
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down
+          summary: One of more ceph monitors are down
           description: |
             {{ $down := query "count(ceph_mon_quorum_status == 0)" | first | value }}{{ $s := "" }}{{ if gt $down 1.0 }}{{ $s = "s" }}{{ end }}You have {{ $down }} monitor{{ $s }} down.
             Quorum is still intact, but the loss of further monitors will make your cluster inoperable.
@@ -60,14 +63,16 @@ groups:
             {{- range query "(ceph_mon_quorum_status == 0) + on(ceph_daemon) group_left(hostname) (ceph_mon_metadata * 0)" }}
               - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }}
             {{- end }}
-      - alert: Ceph mon disk space critically low
+      - alert: CephMonDiskspaceCritical
         expr: ceph_health_detail{name="MON_DISK_CRIT"} == 1
         for: 1m
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.3.2
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-crit
+          summary: Disk space on at least one monitor is critically low
           description: |
             The free space available to a monitor's store is critically low (<5% by default).
             You should increase the space available to the monitor(s). The
@@ -76,7 +81,7 @@ groups:
               - {{ .Labels.hostname }}
             {{- end }}
 
-      - alert: Ceph mon disk space running low
+      - alert: CephMonDiskspaceLow
         expr: ceph_health_detail{name="MON_DISK_LOW"} == 1
         for: 5m
         labels:
@@ -84,6 +89,7 @@ groups:
           type: ceph_default
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-low
+          summary: Disk space on at least one monitor is approaching full
           description: |
             The space available to a monitor's store is approaching full (>70% is the default).
             You should increase the space available to the monitor store. The
@@ -92,7 +98,7 @@ groups:
               - {{ .Labels.hostname }}
             {{- end }}
 
-      - alert: Clock skew detected across Ceph Monitor daemons
+      - alert: CephMonClockSkew
         expr: ceph_health_detail{name="MON_CLOCK_SKEW"} == 1
         for: 1m
         labels:
@@ -100,6 +106,7 @@ groups:
           type: ceph_default
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-clock-skew
+          summary: Clock skew across the Monitor hosts detected
           description: |
             The ceph monitors rely on a consistent time reference to maintain
             quorum and cluster consistency. This event indicates that at least
@@ -110,41 +117,45 @@ groups:
 
   - name: osd
     rules:
-      - alert: 10% OSDs down
+      - alert: CephOSDDownHigh
         expr: count(ceph_osd_up == 0) / count(ceph_osd_up) * 100 >= 10
         labels:
           severity: critical
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.4.1
+          oid: 1.3.6.1.4.1.50495.1.2.1.4.1
         annotations:
+          summary: More than 10% of OSDs are down
           description: |
-            {{ $value | humanize }}% or {{ with query "count(ceph_osd_up == 0)" }}{{ . | first | value }}{{ end }} of {{ with query "count(ceph_osd_up)" }}{{ . | first | value }}{{ end }} OSDs are down (≥ 10%).
+            {{ $value | humanize }}% or {{ with query "count(ceph_osd_up == 0)" }}{{ . | first | value }}{{ end }} of {{ with query "count(ceph_osd_up)" }}{{ . | first | value }}{{ end }} OSDs are down (>= 10%).
 
             The following OSDs are down:
             {{- range query "(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0" }}
               - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }}
             {{- end }}
-      - alert: OSD Host is down
+      - alert: CephOSDHostDown
         expr: ceph_health_detail{name="OSD_HOST_DOWN"} == 1
         for: 5m
         labels:
           severity: warning
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.4.8
         annotations:
+          summary: An OSD host is offline
           description: |
             The following OSDs are down:
             {{- range query "(ceph_osd_up * on(ceph_daemon) group_left(hostname) ceph_osd_metadata) == 0" }}
             - {{ .Labels.hostname }} : {{ .Labels.ceph_daemon }}
             {{- end }}
-      - alert: OSD down
+      - alert: CephOSDDown
         expr: ceph_health_detail{name="OSD_DOWN"} == 1
         for: 5m
         labels:
           severity: warning
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.4.2
+          oid: 1.3.6.1.4.1.50495.1.2.1.4.2
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-down
+          summary: An OSD has been marked down/unavailable
           description: |
             {{ $num := query "count(ceph_osd_up == 0)" | first | value }}{{ $s := "" }}{{ if gt $num 1.0 }}{{ $s = "s" }}{{ end }}{{ $num }} OSD{{ $s }} down for over 5mins.
 
@@ -153,34 +164,37 @@ groups:
               - {{ .Labels.ceph_daemon }} on {{ .Labels.hostname }}
               {{- end }}
 
-      - alert: OSDs near full
+      - alert: CephOSDNearFull
         expr: ceph_health_detail{name="OSD_NEARFULL"} == 1
         for: 5m
         labels:
           severity: warning
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.4.3
+          oid: 1.3.6.1.4.1.50495.1.2.1.4.3
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-nearfull
+          summary: OSD(s) running low on free space (NEARFULL)
           description: |
             One or more OSDs have reached their NEARFULL threshold
 
             Use 'ceph health detail' to identify which OSDs have reached this threshold.
             To resolve, either add capacity to the cluster, or delete unwanted data
-      - alert: OSD Full
+      - alert: CephOSDFull
         expr: ceph_health_detail{name="OSD_FULL"} > 0
         for: 1m
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.4.6
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-full
+          summary: OSD(s) is full, writes blocked
           description: |
             An OSD has reached it's full threshold. Writes from all pools that share the
             affected OSD will be blocked.
 
             To resolve, either add capacity to the cluster, or delete unwanted data
-      - alert: OSD unable to perform rebalance
+      - alert: CephOSDBackfillFull
         expr: ceph_health_detail{name="OSD_BACKFILLFULL"} > 0
         for: 1m
         labels:
@@ -188,12 +202,13 @@ groups:
           type: ceph_default
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-backfillfull
+          summary: OSD(s) too full for backfill operations
           description: |
             An OSD has reached it's BACKFILL FULL threshold. This will prevent rebalance operations
             completing for some pools. Check the current capacity utilisation with 'ceph df'
 
             To resolve, either add capacity to the cluster, or delete unwanted data
-      - alert: OSD too many read repairs
+      - alert: CephOSDTooManyRepairs
         expr: ceph_health_detail{name="OSD_TOO_MANY_REPAIRS"} == 1
         for: 30s
         labels:
@@ -201,30 +216,33 @@ groups:
           type: ceph_default
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-too-many-repairs
+          summary: OSD has hit a high number of read errors
           description: |
             Reads from an OSD have used a secondary PG to return data to the client, indicating
             a potential failing disk.
-      - alert: OSD hearbeats running slow (frontend)
+      - alert: CephOSDTimeoutsPublicNetwork
         expr: ceph_health_detail{name="OSD_SLOW_PING_TIME_FRONT"} == 1
         for: 1m
         labels:
           severity: warning
           type: ceph_default
         annotations:
+          summary: Network issues delaying OSD heartbeats (public network)
           description: |
             OSD heartbeats on the cluster's 'public' network (frontend) are running slow. Investigate the network
             for any latency issues on this subnet. Use 'ceph health detail' to show the affected OSDs.
-      - alert: OSD hearbeats running slow (backend)
+      - alert: CephOSDTimeoutsClusterNetwork
         expr: ceph_health_detail{name="OSD_SLOW_PING_TIME_BACK"} == 1
         for: 1m
         labels:
           severity: warning
           type: ceph_default
         annotations:
+          summary: Network issues delaying OSD heartbeats (cluster network)
           description: |
             OSD heartbeats on the cluster's 'cluster' network (backend) are running slow. Investigate the network
             for any latency issues on this subnet. Use 'ceph health detail' to show the affected OSDs.
-      - alert: OSD disk size mismatch
+      - alert: CephOSDInternalDiskSizeMismatch
         expr: ceph_health_detail{name="BLUESTORE_DISK_SIZE_MISMATCH"} == 1
         for: 1m
         labels:
@@ -232,10 +250,11 @@ groups:
           type: ceph_default
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-disk-size-mismatch
+          summary: OSD size inconsistency error
           description: |
             One or more OSDs have an internal inconsistency between the size of the physical device and it's metadata.
             This could lead to the OSD(s) crashing in future. You should redeploy the effected OSDs.
-      - alert: Device failure predicted
+      - alert: CephDeviceFailurePredicted
         expr: ceph_health_detail{name="DEVICE_HEALTH"} == 1
         for: 1m
         labels:
@@ -243,6 +262,7 @@ groups:
           type: ceph_default
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#id2
+          summary: Device(s) have been predicted to fail soon
           description: |
             The device health module has determined that one or more devices will fail
             soon. To review the device states use 'ceph device ls'. To show a specific
@@ -250,20 +270,22 @@ groups:
 
             Mark the OSD as out (so data may migrate to other OSDs in the cluster). Once
             the osd is empty remove and replace the OSD.
-      - alert: Too many devices predicted to fail
+      - alert: CephDeviceFailurePredictionTooHigh
         expr: ceph_health_detail{name="DEVICE_HEALTH_TOOMANY"} == 1
         for: 1m
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.4.7
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-toomany
+          summary: Too many devices have been predicted to fail, unable to resolve
           description: |
             The device health module has determined that the number of devices predicted to
             fail can not be remediated automatically, since it would take too many osd's out of
             the cluster, impacting performance and potentially availabililty. You should add new
             OSDs to the cluster to allow data to be relocated to avoid the data integrity issues.
-      - alert: Device failure predicted, but automatic drain is incomplete
+      - alert: CephDeviceFailureRelocationIncomplete
         expr: ceph_health_detail{name="DEVICE_HEALTH_IN_USE"} == 1
         for: 1m
         labels:
@@ -271,6 +293,7 @@ groups:
           type: ceph_default
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-in-use
+          summary: A device failure is predicted, but unable to relocate data
           description: |
             The device health module has determined that one or more devices will fail
             soon, but the normal process of relocating the data on the device to other
@@ -280,7 +303,7 @@ groups:
             more disks to the cluster to allow the data from the failing device to
             successfully migrate.
 
-      - alert: Flapping OSD
+      - alert: CephOSDFlapping
         expr: |
           (
             rate(ceph_osd_up[5m])
@@ -289,9 +312,10 @@ groups:
         labels:
           severity: warning
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.4.4
+          oid: 1.3.6.1.4.1.50495.1.2.1.4.4
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd#flapping-osds
+          summary: Network issues are causing OSD's to flap (mark each other out)
           description: >
             OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} was
             marked down and back up at {{ $value | humanize }} times once a
@@ -299,7 +323,7 @@ groups:
             packet drop, disruption) on the clusters "cluster network". Check the
             network environment on the listed host(s).
 
-      - alert: OSD Read errors
+      - alert: CephOSDReadErrors
         expr: ceph_health_detail{name="BLUESTORE_SPURIOUS_READ_ERRORS"} == 1
         for: 30s
         labels:
@@ -307,11 +331,12 @@ groups:
           type: ceph_default
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-spurious-read-errors
+          summary: Device read errors detected
           description: >
             An OSD has encountered read errors, but the OSD has recovered by retrying
             the reads. This may indicate an issue with the Hardware or Kernel.
       # alert on high deviation from average PG count
-      - alert: high pg count deviation
+      - alert: CephPGImbalance
         expr: |
           abs(
             (
@@ -322,8 +347,9 @@ groups:
         labels:
           severity: warning
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.4.5
+          oid: 1.3.6.1.4.1.50495.1.2.1.4.5
         annotations:
+          summary: PG allocations are not balanced across devices
           description: >
             OSD {{ $labels.ceph_daemon }} on {{ $labels.hostname }} deviates
             by more than 30% from average PG count.
@@ -331,28 +357,99 @@ groups:
 
   - name: mds
     rules:
-      - alert: Ceph Filesystem damage detected
+      - alert: CephFilesystemDamaged
         expr: ceph_health_detail{name="MDS_DAMAGE"} > 0
         for: 1m
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.5.1
         annotations:
           documentation: https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages
+          summary: Ceph filesystem is damaged.
           description: >
             The filesystems metadata has been corrupted. Data access
             may be blocked.
 
             Either analyse the output from the mds daemon admin socket, or
             escalate to support
-      - alert: Ceph Filesystem switched to READ ONLY
+      - alert: CephFilesystemOffline
+        expr: ceph_health_detail{name="MDS_ALL_DOWN"} > 0
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.5.3
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-all-down
+          summary: Ceph filesystem is offline
+          description: >
+            All MDS ranks are unavailable. The ceph daemons providing the metadata
+            for the Ceph filesystem are all down, rendering the filesystem offline.
+      - alert: CephFilesystemDegraded
+        expr: ceph_health_detail{name="FS_DEGRADED"} > 0
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.5.4
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-degraded
+          summary: Ceph filesystem is degraded
+          description: >
+            One or more metdata daemons (MDS ranks) are failed or in a
+            damaged state. At best the filesystem is partially available,
+            worst case is the filesystem is completely unusable.
+      - alert: CephFilesystemMDSRanksLow
+        expr: ceph_health_detail{name="MDS_UP_LESS_THAN_MAX"} > 0
+        for: 1m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-up-less-than-max
+          summary: Ceph MDS daemon count is lower than configured
+          description: >
+            The filesystem's "max_mds" setting defined the number of MDS ranks in
+            the filesystem. The current number of active MDS daemons is less than
+            this setting.
+      - alert: CephFilesystemInsufficientStandby
+        expr: ceph_health_detail{name="MDS_INSUFFICIENT_STANDBY"} > 0
+        for: 1m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-insufficient-standby
+          summary: Ceph filesystem standby daemons too low
+          description: >
+            The minimum number of standby daemons determined by standby_count_wanted
+            is less than the actual number of standby daemons. Adjust the standby count
+            or increase the number of mds daemons within the filesystem.
+      - alert: CephFilesystemFailureNoStandby
+        expr: ceph_health_detail{name="FS_WITH_FAILED_MDS"} > 0
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.5.5
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-with-failed-mds
+          summary: Ceph MDS daemon failed, no further standby available
+          description: >
+            An MDS daemon has failed, leaving only one active rank without
+            further standby. Investigate the cause of the failure or add a
+            standby daemon
+      - alert: CephFilesystemReadOnly
         expr: ceph_health_detail{name="MDS_HEALTH_READ_ONLY"} > 0
         for: 1m
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.5.2
         annotations:
           documentation: https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages
+          summary: Ceph filesystem in read only mode, due to write error(s)
           description: >
             The filesystem has switched to READ ONLY due to an unexpected
             write error, when writing to the metadata pool
@@ -362,25 +459,29 @@ groups:
 
   - name: mgr
     rules:
-      - alert: mgr module failure
+      - alert: CephMgrModuleCrash
         expr: ceph_health_detail{name="RECENT_MGR_MODULE_CRASH"} == 1
         for: 5m
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.6.1
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#recent-mgr-module-crash
+          summary: A mgr module has recently crashed
           description: >
             One or more mgr modules have crashed and are yet to be acknowledged by the administrator. A
             crashed module may impact functionality within the cluster. Use the 'ceph crash' commands to
             investigate which module has failed, and archive it to acknowledge the failure.
-      - alert: mgr prometheus module is not active
+      - alert: CephMgrPrometheusModuleInactive
         expr: up{job="ceph"} == 0
         for: 1m
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.6.2
         annotations:
+          summary: Ceph's mgr/prometheus module is not available
           description: >
             The mgr/prometheus module at {{ $labels.instance }} is unreachable. This
             could mean that the module has been disabled or the mgr itself is down.
@@ -393,37 +494,41 @@ groups:
 
   - name: pgs
     rules:
-      - alert: pgs inactive
+      - alert: CephPGsInactive
         expr: ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_active) > 0
         for: 5m
         labels:
           severity: critical
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.7.1
+          oid: 1.3.6.1.4.1.50495.1.2.1.7.1
         annotations:
+          summary: One or more Placement Groups are inactive
           description: >
             {{ $value }} PGs have been inactive for more than 5 minutes in pool {{ $labels.name }}.
             Inactive placement groups aren't able to serve read/write
             requests.
-      - alert: pgs unclean
+      - alert: CephPGsUnclean
         expr: ceph_pool_metadata * on(pool_id,instance) group_left() (ceph_pg_total - ceph_pg_clean) > 0
         for: 15m
         labels:
           severity: warning
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.7.2
+          oid: 1.3.6.1.4.1.50495.1.2.1.7.2
         annotations:
+          summary: One or more platcment groups are marked unclean
           description: >
             {{ $value }} PGs haven't been clean for more than 15 minutes in pool {{ $labels.name }}.
             Unclean PGs haven't been able to completely recover from a previous failure.
-      - alert: Placement Group (PG) damaged
+      - alert: CephPGsDamaged
         expr: ceph_health_detail{name=~"PG_DAMAGED|OSD_SCRUB_ERRORS"} == 1
         for: 5m
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.7.4
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-damaged
+          summary: Placement group damaged, manual intervention needed
           description: >
             During data consistency checks (scrub), at least one PG has been flagged as being
             damaged or inconsistent.
@@ -431,41 +536,47 @@ groups:
             Check to see which PG is affected, and attempt a manual repair if neccessary. To list
             problematic placement groups, use 'rados list-inconsistent-pg <pool>'. To repair PGs use
             the 'ceph pg repair <pg_num>' command.
-      - alert: Recovery at risk, cluster too full
+      - alert: CephPGRecoveryAtRisk
         expr: ceph_health_detail{name="PG_RECOVERY_FULL"} == 1
         for: 1m
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.7.5
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-recovery-full
+          summary: OSDs are too full for automatic recovery
           description: >
             Data redundancy may be reduced, or is at risk, since one or more OSDs are at or above their
             'full' threshold. Add more capacity to the cluster, or delete unwanted data.
-      - alert: I/O blocked to some data
+      - alert: CephPGUnavilableBlockingIO
         # PG_AVAILABILITY, but an OSD is not in a DOWN state
         expr: ((ceph_health_detail{name="PG_AVAILABILITY"} == 1) - scalar(ceph_health_detail{name="OSD_DOWN"})) == 1
         for: 1m
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.7.3
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-availability
+          summary: Placement group is unavailable, blocking some I/O
           description: >
             Data availability is reduced impacting the clusters abilty to service I/O to some data. One or
             more placement groups (PGs) are in a state that blocks IO.
-      - alert: Cluster too full, automatic data recovery impaired
+      - alert: CephPGBackfillAtRisk
         expr: ceph_health_detail{name="PG_BACKFILL_FULL"} == 1
         for: 1m
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.7.6
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-backfill-full
+          summary: Backfill operations are blocked, due to lack of freespace
           description: >
             Data redundancy may be at risk due to lack of free space within the cluster. One or more OSDs
             have breached their 'backfillfull' threshold. Add more capacity, or delete unwanted data.
-      - alert: Placement Group(s) have not been scrubbed
+      - alert: CephPGNotScrubbed
         expr: ceph_health_detail{name="PG_NOT_SCRUBBED"} == 1
         for: 5m
         labels:
@@ -473,6 +584,7 @@ groups:
           type: ceph_default
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-scrubbed
+          summary: Placement group(s) have not been scrubbed
           description: |
             One or more PGs have not been scrubbed recently. The scrub process is a data integrity
             feature, protectng against bit-rot. It checks that objects and their metadata (size and
@@ -481,7 +593,23 @@ groups:
             scrub window.
 
             You can manually initiate a scrub with: ceph pg scrub <pgid>
-      - alert: Placement Group(s) have not been 'DEEP' scrubbed
+      - alert: CephPGsHighPerOSD
+        expr: ceph_health_detail{name="TOO_MANY_PGS"} == 1
+        for: 1m
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#too-many-pgs
+          summary: Placement groups per OSD is too high
+          description: |
+            The number of placement groups per OSD is too high (exceeds the mon_max_pg_per_osd setting).
+
+            Check that the pg_autoscaler hasn't been disabled for any of the pools, with 'ceph osd pool autoscale-status'
+            and that the profile selected is appropriate. You may also adjust the target_size_ratio of a pool to guide
+            the autoscaler based on the expected relative size of the pool
+            (i.e. 'ceph osd pool set cephfs.cephfs.meta target_size_ratio .1')
+      - alert: CephPGNotDeepScrubbed
         expr: ceph_health_detail{name="PG_NOT_DEEP_SCRUBBED"} == 1
         for: 5m
         labels:
@@ -489,6 +617,7 @@ groups:
           type: ceph_default
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-deep-scrubbed
+          summary: Placement group(s) have not been deep scrubbed
           description: |
             One or more PGs have not been deep scrubbed recently. Deep scrub is a data integrity
             feature, protectng against bit-rot. It compares the contents of objects and their
@@ -500,19 +629,20 @@ groups:
 
   - name: nodes
     rules:
-      - alert: root volume full
+      - alert: CephNodeRootFilesystemFull
         expr: node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} * 100 < 5
         for: 5m
         labels:
           severity: critical
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.8.1
+          oid: 1.3.6.1.4.1.50495.1.2.1.8.1
         annotations:
+          summary: Root filesystem is dangerously full
           description: >
             Root volume (OSD and MON store) is dangerously full: {{ $value | humanize }}% free.
 
       # alert on nic packet errors and drops rates > 1% packets/s
-      - alert: network packets dropped
+      - alert: CephNodeNetworkPacketDrops
         expr: |
           (
             increase(node_network_receive_drop_total{device!="lo"}[1m]) +
@@ -527,13 +657,14 @@ groups:
         labels:
           severity: warning
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.8.2
+          oid: 1.3.6.1.4.1.50495.1.2.1.8.2
         annotations:
+          summary: One or more Nics is seeing packet drops
           description: >
             Node {{ $labels.instance }} experiences packet drop > 0.01% or >
             10 packets/s on interface {{ $labels.device }}.
 
-      - alert: network packet errors
+      - alert: CephNodeNetworkPacketErrors
         expr: |
           (
             increase(node_network_receive_errs_total{device!="lo"}[1m]) +
@@ -548,102 +679,96 @@ groups:
         labels:
           severity: warning
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.8.3
+          oid: 1.3.6.1.4.1.50495.1.2.1.8.3
         annotations:
+          summary: One or more Nics is seeing packet errors
           description: >
             Node {{ $labels.instance }} experiences packet errors > 0.01% or
             > 10 packets/s on interface {{ $labels.device }}.
 
       # Restrict to device names beginning with '/' to skip false alarms from
       # tmpfs, overlay type filesystems
-      - alert: storage filling up
+      - alert: CephNodeDiskspaceWarning
         expr: |
           predict_linear(node_filesystem_free_bytes{device=~"/.*"}[2d], 3600 * 24 * 5) *
           on(instance) group_left(nodename) node_uname_info < 0
         labels:
           severity: warning
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.8.4
+          oid: 1.3.6.1.4.1.50495.1.2.1.8.4
         annotations:
+          summary: Host filesystem freespace is getting low
           description: >
             Mountpoint {{ $labels.mountpoint }} on {{ $labels.nodename }}
             will be full in less than 5 days assuming the average fill-up
             rate of the past 48 hours.
 
-      - alert: MTU Mismatch
+      - alert: CephNodeInconsistentMTU
         expr: node_network_mtu_bytes{device!="lo"} * (node_network_up{device!="lo"} > 0) != on() group_left() (quantile(0.5, node_network_mtu_bytes{device!="lo"}))
         labels:
           severity: warning
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.8.5
         annotations:
+          summary: MTU settings across Ceph hosts are inconsistent
           description: >
             Node {{ $labels.instance }} has a different MTU size ({{ $value }})
             than the median value on device {{ $labels.device }}.
 
   - name: pools
     rules:
-      - alert: pool full
+      - alert: CephPoolGrowthWarning
         expr: |
-          ceph_pool_stored / (ceph_pool_stored + ceph_pool_max_avail)
-          * on(pool_id) group_right ceph_pool_metadata * 100 > 90
-        labels:
-          severity: critical
-          type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.9.1
-        annotations:
-          description: Pool {{ $labels.name }} at {{ $value | humanize }}% capacity.
-
-      - alert: pool filling up (growth forecast)
-        expr: |
-          (
-            predict_linear(ceph_pool_stored[2d], 3600 * 24 * 5)
-            >= ceph_pool_stored + ceph_pool_max_avail
-          ) * on(pool_id) group_left(name) ceph_pool_metadata
+          (predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id)
+              group_right ceph_pool_metadata) >= 95
         labels:
           severity: warning
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.9.2
+          oid: 1.3.6.1.4.1.50495.1.2.1.9.2
         annotations:
+          summary: Pool growth rate may soon exceed it's capacity
           description: >
-            Pool {{ $labels.name }} will be full in less than 5 days
+            Pool '{{ $labels.name }}' will be full in less than 5 days
             assuming the average fill-up rate of the past 48 hours.
-
-      - alert: Ceph pool is too full for recovery/rebalance
+      - alert: CephPoolBackfillFull
         expr: ceph_health_detail{name="POOL_BACKFILLFULL"} > 0
         labels:
           severity: warning
           type: ceph_default
         annotations:
+          summary: Freespace in a pool is too low for recovery/rebalance
           description: >
             A pool is approaching it's near full threshold, which will
             prevent rebalance operations from completing. You should
             consider adding more capacity to the pool.
 
-      - alert: Ceph pool is full - writes blocked
+      - alert: CephPoolFull
         expr: ceph_health_detail{name="POOL_FULL"} > 0
         for: 1m
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.9.1
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pool-full
+          summary: Pool is full - writes are blocked
           description: |
             A pool has reached it's MAX quota, or the OSDs supporting the pool
             have reached their FULL threshold. Until this is resolved, writes to
             the pool will be blocked.
-
-            Determine the affected pool with 'ceph df detail', for example looking
-            at QUOTA BYTES and STORED. Either increase the pools quota, or add
-            capacity to the cluster first then increase it's quota
-            (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)
-      - alert: Ceph pool is approaching full
+            Pool Breakdown (top 5)
+            {{- range query "topk(5, sort_desc(ceph_pool_percent_used * on(pool_id) group_right ceph_pool_metadata))" }}
+              - {{ .Labels.name }} at {{ .Value }}%
+            {{- end }}
+            Either increase the pools quota, or add capacity to the cluster first
+            then increase it's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)
+      - alert: CephPoolNearFull
         expr: ceph_health_detail{name="POOL_NEAR_FULL"} > 0
         for: 5m
         labels:
           severity: warning
           type: ceph_default
         annotations:
+          summary: One or more Ceph pools are getting full
           description: |
             A pool has exceeeded it warning (percent full) threshold, or the OSDs
             supporting the pool have reached their NEARFULL thresholds. Writes may
@@ -656,7 +781,7 @@ groups:
             (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)
   - name: healthchecks
     rules:
-      - alert: Slow OSD Ops
+      - alert: CephSlowOps
         expr: ceph_healthcheck_slow_ops > 0
         for: 30s
         labels:
@@ -664,35 +789,40 @@ groups:
           type: ceph_default
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops
+          summary: MON/OSD operations are slow to complete
           description: >
             {{ $value }} OSD requests are taking too long to process (osd_op_complaint_time exceeded)
 # cephadm alerts
   - name: cephadm
     rules:
-      - alert: Cluster upgrade has failed
+      - alert: CephadmUpgradeFailed
         expr: ceph_health_detail{name="UPGRADE_EXCEPTION"} > 0
         for: 30s
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.11.2
         annotations:
+          summary: Ceph version upgrade has failed
           description: >
             The cephadm cluster upgrade process has failed. The cluster remains in
             an undetermined state.
 
             Please review the cephadm logs, to understand the nature of the issue
-      - alert: A daemon managed by cephadm is down
+      - alert: CephadmDaemonFailed
         expr: ceph_health_detail{name="CEPHADM_FAILED_DAEMON"} > 0
         for: 30s
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.11.1
         annotations:
+          summary: A ceph daemon manged by cephadm is down
           description: >
             A daemon managed by cephadm is no longer active. Determine, which
             daemon is down with 'ceph health detail'. you may start daemons with
             the 'ceph orch daemon start <daemon_id>'
-      - alert: cephadm management has been paused
+      - alert: CephadmPaused
         expr: ceph_health_detail{name="CEPHADM_PAUSED"} > 0
         for: 1m
         labels:
@@ -700,21 +830,24 @@ groups:
           type: ceph_default
         annotations:
           documentation: https://docs.ceph.com/en/latest/cephadm/operations#cephadm-paused
+          summary: Orchestration tasks via cephadm are PAUSED
           description: >
             Cluster management has been paused manually. This will prevent the
             orchestrator from service management and reconciliation. If this is
             not intentional, resume cephadm operations with 'ceph orch resume'
 
 # prometheus alerts
-  - name: prometheus
+  - name: PrometheusServer
     rules:
-      - alert: Scrape job is missing
+      - alert: PrometheusJobMissing
         expr: absent(up{job="ceph"})
         for: 30s
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.12.1
         annotations:
+          summary: The scrape job for Ceph is missing from Prometheus
           description: |
             The prometheus job that scrapes from Ceph is no longer defined, this
             will effectively mean you'll have no metrics or alerts for the cluster.
@@ -724,15 +857,34 @@ groups:
 # Object related events
   - name: rados
     rules:
-      - alert: Data not found/missing
+      - alert: CephObjectMissing
         expr: (ceph_health_detail{name="OBJECT_UNFOUND"} == 1) * on() (count(ceph_osd_up == 1) == bool count(ceph_osd_metadata)) == 1
         for: 30s
         labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.10.1
         annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#object-unfound
+          summary: Object(s) has been marked UNFOUND
           description: |
             A version of a RADOS object can not be found, even though all OSDs are up. I/O
             requests for this object from clients will block (hang). Resolving this issue may
             require the object to be rolled back to a prior version manually, and manually verified.
+# Generic
+  - name: generic
+    rules:
+      - alert: CephDaemonCrash
+        expr: ceph_health_detail{name="RECENT_CRASH"} == 1
+        for: 1m
+        labels:
+          severity: critical
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.1.2
+        annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#recent-crash
+          summary: One or more Ceph daemons have crashed, and are pending acknowledgement
+          description: |
+            One or more daemons have crashed recently, and need to be acknowledged. This notification
+            ensures that software crashes don't go unseen. To acknowledge a crash, use the
+            'ceph crash archive <id>' command.

--- a/monitoring/prometheus/alerts/test_alerts.yml
+++ b/monitoring/prometheus/alerts/test_alerts.yml
@@ -59,54 +59,54 @@ tests:
             Please check "ceph health detail" for more information.
 
  # low monitor quorum count
- - interval: 1m
-   input_series:
-    - series: 'ceph_mon_quorum_status{ceph_daemon="mon.a",instance="ceph:9283",
-      job="ceph"}'
-      values: '1 1 1 1 1'
-    - series: 'ceph_mon_quorum_status{ceph_daemon="mon.b",instance="ceph:9283",
-      job="ceph"}'
-      values: '1 1 1 1 1'
-    - series: 'ceph_mon_quorum_status{ceph_daemon="mon.c",instance="ceph:9283",
-      job="ceph"}'
-      values: '0 0 0 0 0'
-    - series: 'ceph_mon_metadata{ceph_daemon="mon.a",ceph_version="ceph version
-      17.0.0-189-g3558fd72 (3558fd7291855971aa6481a2ade468ad61fbb346) pacific
-      (dev)",hostname="ceph",instance="ceph:9283",job="ceph",
-      public_addr="172.20.0.2",rank="0"}'
-      values: '1 1 1 1 1'
-    - series: 'ceph_mon_metadata{ceph_daemon="mon.b",ceph_version="ceph version
-      17.0.0-189-g3558fd72 (3558fd7291855971aa6481a2ade468ad61fbb346) pacific
-      (dev)",hostname="ceph",instance="ceph:9283",job="ceph",
-      public_addr="172.20.0.2",rank="1"}'
-      values: '1 1 1 1 1'
-    - series: 'ceph_mon_metadata{ceph_daemon="mon.c",ceph_version="ceph version
-      17.0.0-189-g3558fd72 (3558fd7291855971aa6481a2ade468ad61fbb346) pacific
-      (dev)",hostname="ceph",instance="ceph:9283",job="ceph",
-      public_addr="172.20.0.2",rank="2"}'
-      values: '1 1 1 1 1'
-   promql_expr_test:
-     - expr: sum(ceph_mon_quorum_status) < 3
-       eval_time: 1m
-       exp_samples:
-         - labels: '{}'
-           value: 2
-   alert_rule_test:
-    - eval_time: 1m
-      alertname: low monitor quorum count
-      exp_alerts:
-      - exp_labels:
-          oid: 1.3.6.1.4.1.50495.15.1.2.3.1
-          type: ceph_default
-          severity: critical
-        exp_annotations:
-          description: |
-            Monitor count in quorum is below three.
+#  - interval: 1m
+#    input_series:
+#     - series: 'ceph_mon_quorum_status{ceph_daemon="mon.a",instance="ceph:9283",
+#       job="ceph"}'
+#       values: '1 1 1 1 1'
+#     - series: 'ceph_mon_quorum_status{ceph_daemon="mon.b",instance="ceph:9283",
+#       job="ceph"}'
+#       values: '1 1 1 1 1'
+#     - series: 'ceph_mon_quorum_status{ceph_daemon="mon.c",instance="ceph:9283",
+#       job="ceph"}'
+#       values: '0 0 0 0 0'
+#     - series: 'ceph_mon_metadata{ceph_daemon="mon.a",ceph_version="ceph version
+#       17.0.0-189-g3558fd72 (3558fd7291855971aa6481a2ade468ad61fbb346) pacific
+#       (dev)",hostname="ceph",instance="ceph:9283",job="ceph",
+#       public_addr="172.20.0.2",rank="0"}'
+#       values: '1 1 1 1 1'
+#     - series: 'ceph_mon_metadata{ceph_daemon="mon.b",ceph_version="ceph version
+#       17.0.0-189-g3558fd72 (3558fd7291855971aa6481a2ade468ad61fbb346) pacific
+#       (dev)",hostname="ceph",instance="ceph:9283",job="ceph",
+#       public_addr="172.20.0.2",rank="1"}'
+#       values: '1 1 1 1 1'
+#     - series: 'ceph_mon_metadata{ceph_daemon="mon.c",ceph_version="ceph version
+#       17.0.0-189-g3558fd72 (3558fd7291855971aa6481a2ade468ad61fbb346) pacific
+#       (dev)",hostname="ceph",instance="ceph:9283",job="ceph",
+#       public_addr="172.20.0.2",rank="2"}'
+#       values: '1 1 1 1 1'
+#    promql_expr_test:
+#      - expr: sum(ceph_mon_quorum_status) < 3
+#        eval_time: 1m
+#        exp_samples:
+#          - labels: '{}'
+#            value: 2
+#    alert_rule_test:
+#     - eval_time: 1m
+#       alertname: low monitor quorum count
+#       exp_alerts:
+#       - exp_labels:
+#           oid: 1.3.6.1.4.1.50495.15.1.2.3.1
+#           type: ceph_default
+#           severity: critical
+#         exp_annotations:
+#           description: |
+#             Monitor count in quorum is below three.
 
-            Only 2 of 3 monitors are active.
+#             Only 2 of 3 monitors are active.
 
-            The following monitors are down:
-              - mon.c on ceph
+#             The following monitors are down:
+#               - mon.c on ceph
 
 
  # 10% OSDs down
@@ -161,141 +161,141 @@ tests:
                - osd.1 on ceph
 
  # OSD down
- - interval: 1m
-   input_series:
-    - series: 'ceph_osd_up{ceph_daemon="osd.0",instance="ceph:9283",job="ceph"}'
-      values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
-    - series: 'ceph_osd_up{ceph_daemon="osd.1",instance="ceph:9283",job="ceph"}'
-      values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
-    - series: 'ceph_osd_up{ceph_daemon="osd.2",instance="ceph:9283",job="ceph"}'
-      values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
-    - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.0",
-      ceph_version="ceph version 17.0.0-189-g3558fd72
-      (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
-      cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
-      hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
-      public_addr="172.20.0.2"}'
-      values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
-    - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.1",
-      ceph_version="ceph version 17.0.0-189-g3558fd72
-      (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
-      cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
-      hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
-      public_addr="172.20.0.2"}'
-      values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
-    - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.2",
-      ceph_version="ceph version 17.0.0-189-g3558fd72
-      (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
-      cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
-      hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
-      public_addr="172.20.0.2"}'
-      values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
-   promql_expr_test:
-     - expr: count(ceph_osd_up == 0) > 0
-       eval_time: 1m
-       exp_samples:
-         - labels: '{}'
-           value: 1
-   alert_rule_test:
-     - eval_time: 15m
-       alertname: OSD down
-       exp_alerts:
-       - exp_labels:
-           oid: 1.3.6.1.4.1.50495.15.1.2.4.2
-           type: ceph_default
-           severity: warning
-         exp_annotations:
-           description: |
+#  - interval: 1m
+#    input_series:
+#     - series: 'ceph_osd_up{ceph_daemon="osd.0",instance="ceph:9283",job="ceph"}'
+#       values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+#     - series: 'ceph_osd_up{ceph_daemon="osd.1",instance="ceph:9283",job="ceph"}'
+#       values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+#     - series: 'ceph_osd_up{ceph_daemon="osd.2",instance="ceph:9283",job="ceph"}'
+#       values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+#     - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.0",
+#       ceph_version="ceph version 17.0.0-189-g3558fd72
+#       (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
+#       cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
+#       hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
+#       public_addr="172.20.0.2"}'
+#       values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+#     - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.1",
+#       ceph_version="ceph version 17.0.0-189-g3558fd72
+#       (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
+#       cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
+#       hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
+#       public_addr="172.20.0.2"}'
+#       values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+#     - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.2",
+#       ceph_version="ceph version 17.0.0-189-g3558fd72
+#       (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
+#       cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
+#       hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
+#       public_addr="172.20.0.2"}'
+#       values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+#    promql_expr_test:
+#      - expr: count(ceph_osd_up == 0) > 0
+#        eval_time: 1m
+#        exp_samples:
+#          - labels: '{}'
+#            value: 1
+#    alert_rule_test:
+#      - eval_time: 15m
+#        alertname: OSD down
+#        exp_alerts:
+#        - exp_labels:
+#            oid: 1.3.6.1.4.1.50495.15.1.2.4.2
+#            type: ceph_default
+#            severity: warning
+#          exp_annotations:
+#            description: |
 
-             1 OSD down for more than 15 minutes.
+#              1 OSD down for more than 15 minutes.
 
-             1 of 3 OSDs are down.
+#              1 of 3 OSDs are down.
 
-             The following OSD is down:
-                 - osd.1 on ceph
+#              The following OSD is down:
+#                  - osd.1 on ceph
 
-  # OSDs near full
- - interval: 1m
-   input_series:
-    - series: 'ceph_osd_stat_bytes_used{ceph_daemon="osd.0",instance="ceph:9283"
-      ,job="ceph"}'
-      values: '1076310016 1076310016 1076310016 1076310016 1076310016
-      1076310016'
-    - series: 'ceph_osd_stat_bytes_used{ceph_daemon="osd.1",instance="ceph:9283"
-      ,job="ceph"}'
-      values: '1076310016 1076310016 1076310016 1076310016 1076310016
-      1076310016'
-    - series: 'ceph_osd_stat_bytes_used{ceph_daemon="osd.2",instance="ceph:9283"
-      ,job="ceph"}'
-      values: '1076310016 1076310016 1076310016 1076310016 1076310016
-      100856561909.76'
-    - series: 'ceph_osd_stat_bytes{ceph_daemon="osd.0",instance="ceph:9283"
-      ,job="ceph"}'
-      values: '108447916032 108447916032 108447916032 108447916032 108447916032
-      108447916032'
-    - series: 'ceph_osd_stat_bytes{ceph_daemon="osd.1",instance="ceph:9283"
-      ,job="ceph"}'
-      values: '108447916032 108447916032 108447916032 108447916032 108447916032
-      108447916032'
-    - series: 'ceph_osd_stat_bytes{ceph_daemon="osd.2",instance="ceph:9283"
-      ,job="ceph"}'
-      values: '108447916032 108447916032 108447916032 108447916032 108447916032
-      108447916032'
-    - series: 'ceph_osd_up{ceph_daemon="osd.0",instance="ceph:9283",job="ceph"}'
-      values: '1 1 1 1 1 1'
-    - series: 'ceph_osd_up{ceph_daemon="osd.1",instance="ceph:9283",job="ceph"}'
-      values: '1 1 1 1 1 1'
-    - series: 'ceph_osd_up{ceph_daemon="osd.2",instance="ceph:9283",job="ceph"}'
-      values: '1 1 1 1 1 1'
-    - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.0",
-      ceph_version="ceph version 17.0.0-189-g3558fd72
-      (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
-      cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
-      hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
-      public_addr="172.20.0.2"}'
-      values: '1 1 1 1 1 1'
-    - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.1",
-      ceph_version="ceph version 17.0.0-189-g3558fd72
-      (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
-      cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
-      hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
-      public_addr="172.20.0.2"}'
-      values: '1 1 1 1 1 1'
-    - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.2",
-      ceph_version="ceph version 17.0.0-189-g3558fd72
-      (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
-      cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
-      hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
-      public_addr="172.20.0.2"}'
-      values: '1 1 1 1 1 1'
-   promql_expr_test:
-     - expr: |
-         (
-           ((ceph_osd_stat_bytes_used / ceph_osd_stat_bytes) and on(ceph_daemon)
-           ceph_osd_up == 1) * on(ceph_daemon) group_left(hostname)
-           ceph_osd_metadata
-         ) * 100 > 90
+# OSDs near full
+#  - interval: 1m
+#    input_series:
+#     - series: 'ceph_osd_stat_bytes_used{ceph_daemon="osd.0",instance="ceph:9283"
+#       ,job="ceph"}'
+#       values: '1076310016 1076310016 1076310016 1076310016 1076310016
+#       1076310016'
+#     - series: 'ceph_osd_stat_bytes_used{ceph_daemon="osd.1",instance="ceph:9283"
+#       ,job="ceph"}'
+#       values: '1076310016 1076310016 1076310016 1076310016 1076310016
+#       1076310016'
+#     - series: 'ceph_osd_stat_bytes_used{ceph_daemon="osd.2",instance="ceph:9283"
+#       ,job="ceph"}'
+#       values: '1076310016 1076310016 1076310016 1076310016 1076310016
+#       100856561909.76'
+#     - series: 'ceph_osd_stat_bytes{ceph_daemon="osd.0",instance="ceph:9283"
+#       ,job="ceph"}'
+#       values: '108447916032 108447916032 108447916032 108447916032 108447916032
+#       108447916032'
+#     - series: 'ceph_osd_stat_bytes{ceph_daemon="osd.1",instance="ceph:9283"
+#       ,job="ceph"}'
+#       values: '108447916032 108447916032 108447916032 108447916032 108447916032
+#       108447916032'
+#     - series: 'ceph_osd_stat_bytes{ceph_daemon="osd.2",instance="ceph:9283"
+#       ,job="ceph"}'
+#       values: '108447916032 108447916032 108447916032 108447916032 108447916032
+#       108447916032'
+#     - series: 'ceph_osd_up{ceph_daemon="osd.0",instance="ceph:9283",job="ceph"}'
+#       values: '1 1 1 1 1 1'
+#     - series: 'ceph_osd_up{ceph_daemon="osd.1",instance="ceph:9283",job="ceph"}'
+#       values: '1 1 1 1 1 1'
+#     - series: 'ceph_osd_up{ceph_daemon="osd.2",instance="ceph:9283",job="ceph"}'
+#       values: '1 1 1 1 1 1'
+#     - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.0",
+#       ceph_version="ceph version 17.0.0-189-g3558fd72
+#       (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
+#       cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
+#       hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
+#       public_addr="172.20.0.2"}'
+#       values: '1 1 1 1 1 1'
+#     - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.1",
+#       ceph_version="ceph version 17.0.0-189-g3558fd72
+#       (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
+#       cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
+#       hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
+#       public_addr="172.20.0.2"}'
+#       values: '1 1 1 1 1 1'
+#     - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.2",
+#       ceph_version="ceph version 17.0.0-189-g3558fd72
+#       (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
+#       cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
+#       hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
+#       public_addr="172.20.0.2"}'
+#       values: '1 1 1 1 1 1'
+#    promql_expr_test:
+#      - expr: |
+#          (
+#            ((ceph_osd_stat_bytes_used / ceph_osd_stat_bytes) and on(ceph_daemon)
+#            ceph_osd_up == 1) * on(ceph_daemon) group_left(hostname)
+#            ceph_osd_metadata
+#          ) * 100 > 90
 
-       eval_time: 5m
-       exp_samples:
-         - labels: '{ceph_daemon="osd.2",hostname="ceph",instance="ceph:9283",
-           job="ceph"}'
-           value: 9.3E+01
-   alert_rule_test:
-     - eval_time: 10m
-       alertname: OSDs near full
-       exp_alerts:
-       - exp_labels:
-           ceph_daemon: osd.2
-           hostname: ceph
-           instance: ceph:9283
-           job: ceph
-           oid: 1.3.6.1.4.1.50495.15.1.2.4.3
-           type: ceph_default
-           severity: critical
-         exp_annotations:
-           description: >
-             OSD osd.2 on ceph is dangerously full: 93%
+#        eval_time: 5m
+#        exp_samples:
+#          - labels: '{ceph_daemon="osd.2",hostname="ceph",instance="ceph:9283",
+#            job="ceph"}'
+#            value: 9.3E+01
+#    alert_rule_test:
+#      - eval_time: 10m
+#        alertname: OSDs near full
+#        exp_alerts:
+#        - exp_labels:
+#            ceph_daemon: osd.2
+#            hostname: ceph
+#            instance: ceph:9283
+#            job: ceph
+#            oid: 1.3.6.1.4.1.50495.15.1.2.4.3
+#            type: ceph_default
+#            severity: critical
+#          exp_annotations:
+#            description: >
+#              OSD osd.2 on ceph is dangerously full: 93%
 
  # flapping OSD
  - interval: 1s
@@ -340,7 +340,7 @@ tests:
            value: 1.2200000000000001E+01
    alert_rule_test:
      - eval_time: 5m
-       alertname: flapping OSD
+       alertname: Flapping OSD
        exp_alerts:
        - exp_labels:
            ceph_daemon: osd.0
@@ -351,10 +351,13 @@ tests:
            severity: warning
            type: ceph_default
          exp_annotations:
+           documentation: https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd/#flapping-osds
            description: >
               OSD osd.0 on ceph was
-              marked down and back up at 20.1 times once a
-              minute for 5 minutes.
+              marked down and back up at 20.1 times once a minute for 5 minutes.
+              This could indicate a network issue (latency, packet drop, disruption)
+              on the clusters "cluster network". Check the network environment on the
+              listed host(s).
 
  # high pg count deviation
  - interval: 1m
@@ -694,7 +697,7 @@ tests:
       values: '0 0 0 0 0'
     - series: 'node_network_up{device="eth4",instance="node-exporter",
       job="node-exporter"}'
-      values: '1 1 1 1 1'  
+      values: '1 1 1 1 1'
    promql_expr_test:
      - expr: node_network_mtu_bytes{device!="lo"} * (node_network_up{device!="lo"} > 0) != on() group_left()
              (quantile(0.5, node_network_mtu_bytes{device!="lo"}))
@@ -792,6 +795,1012 @@ tests:
            severity: warning
            type: ceph_default
          exp_annotations:
+           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#slow-ops
            description: >
              1 OSD requests are taking too long to process
              (osd_op_complaint_time exceeded)
+
+# CEPHADM orchestrator alert triggers
+ - interval: 30s
+   input_series:
+    - series: 'ceph_health_detail{name="UPGRADE_EXCEPTION"}'
+      values: '1+0x40'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="UPGRADE_EXCEPTION"} > 0
+       eval_time: 2m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="UPGRADE_EXCEPTION"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Cluster upgrade has failed
+    - eval_time: 5m
+      alertname: Cluster upgrade has failed
+      exp_alerts:
+      - exp_labels:
+          name: UPGRADE_EXCEPTION
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          description: >
+            The cephadm cluster upgrade process has failed. The cluster remains in
+            an undetermined state.
+
+            Please review the cephadm logs, to understand the nature of the issue
+ - interval: 30s
+   input_series:
+    - series: 'ceph_health_detail{name="CEPHADM_FAILED_DAEMON"}'
+      values: '1+0x40'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="CEPHADM_FAILED_DAEMON"} > 0
+       eval_time: 2m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="CEPHADM_FAILED_DAEMON"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: A daemon managed by cephadm is down
+    - eval_time: 5m
+      alertname: A daemon managed by cephadm is down
+      exp_alerts:
+      - exp_labels:
+          name: CEPHADM_FAILED_DAEMON
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          description: >
+            A daemon managed by cephadm is no longer active. Determine, which
+            daemon is down with 'ceph health detail'. you may start daemons with
+            the 'ceph orch daemon start <daemon_id>'
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="CEPHADM_PAUSED"}'
+      values: '1 1 1 1 1 1 1 1 1'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="CEPHADM_PAUSED"} > 0
+       eval_time: 2m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="CEPHADM_PAUSED"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: cephadm management has been paused
+    - eval_time: 5m
+      alertname: cephadm management has been paused
+      exp_alerts:
+      - exp_labels:
+          name: CEPHADM_PAUSED
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/cephadm/operations/#cephadm-paused
+          description: >
+            Cluster management has been paused manually. This will prevent the
+            orchestrator from service management and reconciliation. If this is
+            not intentional, resume cephadm operations with 'ceph orch resume'
+# MDS
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="MDS_DAMAGE"}'
+      values: '1 1 1 1 1 1 1 1 1'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="MDS_DAMAGE"} > 0
+       eval_time: 2m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="MDS_DAMAGE"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Ceph Filesystem damage detected
+    - eval_time: 5m
+      alertname: Ceph Filesystem damage detected
+      exp_alerts:
+      - exp_labels:
+          name: MDS_DAMAGE
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#cephfs-health-messages
+          description: >
+            The filesystems metadata has been corrupted. Data access
+            may be blocked.
+
+            Either analyse the output from the mds daemon admin socket, or
+            escalate to support
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="MDS_HEALTH_READ_ONLY"}'
+      values: '1 1 1 1 1 1 1 1 1'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="MDS_HEALTH_READ_ONLY"} > 0
+       eval_time: 2m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="MDS_HEALTH_READ_ONLY"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Ceph Filesystem switched to READ ONLY
+    - eval_time: 5m
+      alertname: Ceph Filesystem switched to READ ONLY
+      exp_alerts:
+      - exp_labels:
+          name: MDS_HEALTH_READ_ONLY
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#cephfs-health-messages
+          description: >
+            The filesystem has switched to READ ONLY due to an unexpected
+            write error, when writing to the metadata pool
+
+            Either analyse the output from the mds daemon admin socket, or
+            escalate to support
+# MGR
+ - interval: 1m
+   input_series:
+    - series: 'up{job="ceph", instance="ceph-mgr:9283"}'
+      values: '1+0x2 0+0x10'
+   promql_expr_test:
+     - expr: up{job="ceph"} == 0
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="up", job="ceph", instance="ceph-mgr:9283"}'
+           value: 0
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: mgr prometheus module is not active
+    - eval_time: 10m
+      alertname: mgr prometheus module is not active
+      exp_alerts:
+      - exp_labels:
+          instance: ceph-mgr:9283
+          job: ceph
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          description: >
+            The mgr/prometheus module at ceph-mgr:9283 is unreachable. This
+            could mean that the module has been disabled or the mgr itself is down.
+
+            Without the mgr/prometheus module metrics and alerts will no longer
+            function. Open a shell to ceph and use 'ceph -s' to to determine whether the
+            mgr is active. If the mgr is not active, restart it, otherwise you can check
+            the mgr/prometheus module is loaded with 'ceph mgr module ls'  and if it's
+            not listed as enabled, enable it with 'ceph mgr module enable prometheus'
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="RECENT_MGR_MODULE_CRASH"}'
+      values: '0+0x2 1+0x20'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="RECENT_MGR_MODULE_CRASH"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="RECENT_MGR_MODULE_CRASH"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: mgr module failure
+    - eval_time: 15m
+      alertname: mgr module failure
+      exp_alerts:
+      - exp_labels:
+          name: RECENT_MGR_MODULE_CRASH
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#recent-mgr-module-crash
+          description: >
+            One or more mgr modules have crashed and are yet to be acknowledged by the administrator. A
+            crashed module may impact functionality within the cluster. Use the 'ceph crash' commands to
+            investigate which module has failed, and archive it to acknowledge the failure.
+# MON
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="MON_DISK_CRIT"}'
+      values: '0+0x2 1+0x10'
+    - series: 'ceph_mon_metadata{ceph_daemon="mon.a", hostname="ceph-mon-a"}'
+      values: '1+0x13'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="MON_DISK_CRIT"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="MON_DISK_CRIT"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Ceph mon disk space critically low
+    - eval_time: 10m
+      alertname: Ceph mon disk space critically low
+      exp_alerts:
+      - exp_labels:
+          name: "MON_DISK_CRIT"
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-disk-crit
+          description: |
+            The free space available to a monitor's store is critically low (<5% by default).
+            You should increase the space available to the monitor(s). The
+            default location for the store sits under /var/lib/ceph. Your monitor hosts are;
+              - ceph-mon-a
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="MON_DISK_LOW"}'
+      values: '0+0x2 1+0x10'
+    - series: 'ceph_mon_metadata{ceph_daemon="mon.a", hostname="ceph-mon-a"}'
+      values: '1+0x13'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="MON_DISK_LOW"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="MON_DISK_LOW"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Ceph mon disk space running low
+    - eval_time: 10m
+      alertname: Ceph mon disk space running low
+      exp_alerts:
+      - exp_labels:
+          name: "MON_DISK_LOW"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-disk-low
+          description: |
+            The space available to a monitor's store is approaching full (>70% is the default).
+            You should increase the space available to the monitor store. The
+            default location for the store sits under /var/lib/ceph. Your monitor hosts are;
+              - ceph-mon-a
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="MON_CLOCK_SKEW"}'
+      values: '0+0x2 1+0x10'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="MON_CLOCK_SKEW"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="MON_CLOCK_SKEW"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Clock skew detected across Ceph Monitor daemons
+    - eval_time: 10m
+      alertname: Clock skew detected across Ceph Monitor daemons
+      exp_alerts:
+      - exp_labels:
+          name: "MON_CLOCK_SKEW"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-clock-skew
+          description: |
+            The ceph monitors rely on a consistent time reference to maintain
+            quorum and cluster consistency. This event indicates that at least
+            one of your mons is not sync'd correctly.
+
+            Review the cluster status with ceph -s. This will show which monitors
+            are affected. Check the time sync status on each monitor host.
+
+# Check 3 mons one down, quorum at risk
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="MON_DOWN"}'
+      values: '0+0x2 1+0x12'
+    - series: 'ceph_mon_quorum_status{ceph_daemon="mon.a"}'
+      values: '1+0x14'
+    - series: 'ceph_mon_quorum_status{ceph_daemon="mon.b"}'
+      values: '1+0x14'
+    - series: 'ceph_mon_quorum_status{ceph_daemon="mon.c"}'
+      values: '1+0x2 0+0x12'
+    - series: 'ceph_mon_metadata{ceph_daemon="mon.a", hostname="ceph-mon-1"}'
+      values: '1+0x14'
+    - series: 'ceph_mon_metadata{ceph_daemon="mon.b", hostname="ceph-mon-2"}'
+      values: '1+0x14'
+    - series: 'ceph_mon_metadata{ceph_daemon="mon.c", hostname="ceph-mon-3"}'
+      values: '1+0x14'
+   promql_expr_test:
+     - expr: ((ceph_health_detail{name="MON_DOWN"} == 1) * on() (count(ceph_mon_quorum_status == 1) == bool (floor(count(ceph_mon_metadata) / 2) + 1))) == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Monitor down, quorum is at risk
+      # shouldn't fire
+    - eval_time: 10m
+      alertname: Monitor down, quorum is at risk
+      exp_alerts:
+      - exp_labels:
+          severity: critical
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.15.1.2.3.1
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-down
+          description: |
+            Quorum requires a majority of monitors (x 2) to be active
+            Without quorum the cluster will become inoperable, affecting all connected clients and services.
+
+            The following monitors are down:
+              - mon.c on ceph-mon-3
+# check 5 mons, 1 down - warning only
+ - interval: 1m
+   input_series:
+    - series: 'ceph_mon_quorum_status{ceph_daemon="mon.a"}'
+      values: '1+0x14'
+    - series: 'ceph_mon_quorum_status{ceph_daemon="mon.b"}'
+      values: '1+0x14'
+    - series: 'ceph_mon_quorum_status{ceph_daemon="mon.c"}'
+      values: '1+0x14'
+    - series: 'ceph_mon_quorum_status{ceph_daemon="mon.d"}'
+      values: '1+0x14'
+    - series: 'ceph_mon_quorum_status{ceph_daemon="mon.e"}'
+      values: '1+0x2 0+0x12'
+    - series: 'ceph_mon_metadata{ceph_daemon="mon.a", hostname="ceph-mon-1"}'
+      values: '1+0x14'
+    - series: 'ceph_mon_metadata{ceph_daemon="mon.b", hostname="ceph-mon-2"}'
+      values: '1+0x14'
+    - series: 'ceph_mon_metadata{ceph_daemon="mon.c", hostname="ceph-mon-3"}'
+      values: '1+0x14'
+    - series: 'ceph_mon_metadata{ceph_daemon="mon.d", hostname="ceph-mon-4"}'
+      values: '1+0x14'
+    - series: 'ceph_mon_metadata{ceph_daemon="mon.e", hostname="ceph-mon-5"}'
+      values: '1+0x14'
+   promql_expr_test:
+     - expr: (count(ceph_mon_quorum_status == 0) <= (count(ceph_mon_metadata) - floor(count(ceph_mon_metadata) / 2) + 1))
+       eval_time: 3m
+       exp_samples:
+         - labels: '{}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Monitor down
+    - eval_time: 10m
+      alertname: Monitor down
+      exp_alerts:
+      - exp_labels:
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-down
+          description: |
+            You have 1 monitor down.
+            Quorum is still intact, but the loss of further monitors will make your cluster inoperable.
+
+            The following monitors are down:
+              - mon.e on ceph-mon-5
+# Device Health
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="DEVICE_HEALTH"}'
+      values: '0+0x2 1+0x10'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="DEVICE_HEALTH"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="DEVICE_HEALTH"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Device failure predicted
+    - eval_time: 10m
+      alertname: Device failure predicted
+      exp_alerts:
+      - exp_labels:
+          name: "DEVICE_HEALTH"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#id2
+          description: |
+            The device health module has determined that one or more devices will fail
+            soon. To review the device states use 'ceph device ls'. To show a specific
+            device use 'ceph device info <dev id>'.
+
+            Mark the OSD as out (so data may migrate to other OSDs in the cluster). Once
+            the osd is empty remove and replace the OSD.
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="DEVICE_HEALTH_TOOMANY"}'
+      values: '0+0x2 1+0x10'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="DEVICE_HEALTH_TOOMANY"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="DEVICE_HEALTH_TOOMANY"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Too many devices predicted to fail
+    - eval_time: 10m
+      alertname: Too many devices predicted to fail
+      exp_alerts:
+      - exp_labels:
+          name: "DEVICE_HEALTH_TOOMANY"
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#device-health-toomany
+          description: |
+            The device health module has determined that the number of devices predicted to
+            fail can not be remediated automatically, since it would take too many osd's out of
+            the cluster, impacting performance and potentially availabililty. You should add new
+            OSDs to the cluster to allow data to be relocated to avoid the data integrity issues.
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="DEVICE_HEALTH_IN_USE"}'
+      values: '0+0x2 1+0x10'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="DEVICE_HEALTH_IN_USE"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="DEVICE_HEALTH_IN_USE"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Device failure predicted, but automatic drain is incomplete
+    - eval_time: 10m
+      alertname: Device failure predicted, but automatic drain is incomplete
+      exp_alerts:
+      - exp_labels:
+          name: "DEVICE_HEALTH_IN_USE"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#device-health-in-use
+          description: |
+            The device health module has determined that one or more devices will fail
+            soon, but the normal process of relocating the data on the device to other
+            OSDs in the cluster is blocked.
+
+            Check the the cluster has available freespace. It may be necessary to add
+            more disks to the cluster to allow the data from the failing device to
+            successfully migrate.
+# OSD
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="OSD_HOST_DOWN"}'
+      values: '0+0x2 1+0x10'
+    - series: 'ceph_osd_up{ceph_daemon="osd.0"}'
+      values: '1+0x2 0+0x10'
+    - series: 'ceph_osd_metadata{ceph_daemon="osd.0", hostname="ceph-osd-1"}'
+      values: '1+0x12'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="OSD_HOST_DOWN"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="OSD_HOST_DOWN"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: OSD Host is down
+    - eval_time: 10m
+      alertname: OSD Host is down
+      exp_alerts:
+      - exp_labels:
+          name: "OSD_HOST_DOWN"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          description: |
+            The following OSDs are down:
+            - ceph-osd-1 : osd.0
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="OSD_SLOW_PING_TIME_FRONT"}'
+      values: '0+0x2 1+0x20'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="OSD_SLOW_PING_TIME_FRONT"} == 0
+       eval_time: 1m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="OSD_SLOW_PING_TIME_FRONT"}'
+           value: 0
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: OSD hearbeats running slow (frontend)
+    - eval_time: 10m
+      alertname: OSD hearbeats running slow (frontend)
+      exp_alerts:
+      - exp_labels:
+          name: "OSD_SLOW_PING_TIME_FRONT"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          description: |
+            OSD heartbeats on the cluster's 'public' network (frontend) are running slow. Investigate the network
+            for any latency issues on this subnet. Use 'ceph health detail' to show the affected OSDs.
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="OSD_SLOW_PING_TIME_BACK"}'
+      values: '0+0x2 1+0x20'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="OSD_SLOW_PING_TIME_BACK"} == 0
+       eval_time: 1m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="OSD_SLOW_PING_TIME_BACK"}'
+           value: 0
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: OSD hearbeats running slow (backend)
+    - eval_time: 10m
+      alertname: OSD hearbeats running slow (backend)
+      exp_alerts:
+      - exp_labels:
+          name: "OSD_SLOW_PING_TIME_BACK"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          description: |
+            OSD heartbeats on the cluster's 'cluster' network (backend) are running slow. Investigate the network
+            for any latency issues on this subnet. Use 'ceph health detail' to show the affected OSDs.
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="BLUESTORE_DISK_SIZE_MISMATCH"}'
+      values: '0+0x2 1+0x20'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="BLUESTORE_DISK_SIZE_MISMATCH"} == 0
+       eval_time: 1m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="BLUESTORE_DISK_SIZE_MISMATCH"}'
+           value: 0
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: OSD disk size mismatch
+    - eval_time: 10m
+      alertname: OSD disk size mismatch
+      exp_alerts:
+      - exp_labels:
+          name: "BLUESTORE_DISK_SIZE_MISMATCH"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#bluestore-disk-size-mismatch
+          description: |
+            One or more OSDs have an internal inconsistency between the size of the physical device and it's metadata.
+            This could lead to the OSD(s) crashing in future. You should redeploy the effected OSDs.
+ - interval: 30s
+   input_series:
+    - series: 'ceph_health_detail{name="BLUESTORE_SPURIOUS_READ_ERRORS"}'
+      values: '0+0x2 1+0x20'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="BLUESTORE_SPURIOUS_READ_ERRORS"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="BLUESTORE_SPURIOUS_READ_ERRORS"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: OSD Read errors
+    - eval_time: 10m
+      alertname: OSD Read errors
+      exp_alerts:
+      - exp_labels:
+          name: "BLUESTORE_SPURIOUS_READ_ERRORS"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#bluestore-spurious-read-errors
+          description: >
+            An OSD has encountered read errors, but the OSD has recovered by retrying
+            the reads. This may indicate an issue with the Hardware or Kernel.
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="OSD_DOWN"}'
+      values: '0+0x2 1+0x10'
+    - series: 'ceph_osd_up{ceph_daemon="osd.0"}'
+      values: '1+0x12'
+    - series: 'ceph_osd_up{ceph_daemon="osd.1"}'
+      values: '1+0x2 0+0x10'
+    - series: 'ceph_osd_up{ceph_daemon="osd.2"}'
+      values: '1+0x12'
+    - series: 'ceph_osd_metadata{ceph_daemon="osd.0", hostname="ceph-osd-1"}'
+      values: '1+0x12'
+    - series: 'ceph_osd_metadata{ceph_daemon="osd.1", hostname="ceph-osd-2"}'
+      values: '1+0x12'
+    - series: 'ceph_osd_metadata{ceph_daemon="osd.2", hostname="ceph-osd-3"}'
+      values: '1+0x12'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="OSD_DOWN"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="OSD_DOWN"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: OSD down
+    - eval_time: 10m
+      alertname: OSD down
+      exp_alerts:
+      - exp_labels:
+          name: "OSD_DOWN"
+          severity: warning
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.15.1.2.4.2
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-down
+          description: |
+            1 OSD down for over 5mins.
+
+            The following OSD is down:
+              - osd.1 on ceph-osd-2
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="OSD_NEARFULL"}'
+      values: '0+0x2 1+0x10'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="OSD_NEARFULL"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="OSD_NEARFULL"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: OSDs near full
+    - eval_time: 10m
+      alertname: OSDs near full
+      exp_alerts:
+      - exp_labels:
+          name: "OSD_NEARFULL"
+          severity: warning
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.15.1.2.4.3
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-nearfull
+          description: |
+            One or more OSDs have reached their NEARFULL threshold
+
+            Use 'ceph health detail' to identify which OSDs have reached this threshold.
+            To resolve, either add capacity to the cluster, or delete unwanted data
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="OSD_BACKFILLFULL"}'
+      values: '0+0x2 1+0x10'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="OSD_BACKFILLFULL"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="OSD_BACKFILLFULL"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: OSD unable to perform rebalance
+    - eval_time: 10m
+      alertname: OSD unable to perform rebalance
+      exp_alerts:
+      - exp_labels:
+          name: "OSD_BACKFILLFULL"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-backfillfull
+          description: |
+            An OSD has reached it's BACKFILL FULL threshold. This will prevent rebalance operations
+            completing for some pools. Check the current capacity utilisation with 'ceph df'
+
+            To resolve, either add capacity to the cluster, or delete unwanted data
+ - interval: 30s
+   input_series:
+    - series: 'ceph_health_detail{name="OSD_TOO_MANY_REPAIRS"}'
+      values: '0+0x2 1+0x20'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="OSD_TOO_MANY_REPAIRS"} == 0
+       eval_time: 1m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="OSD_TOO_MANY_REPAIRS"}'
+           value: 0
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: OSD too many read repairs
+    - eval_time: 10m
+      alertname: OSD too many read repairs
+      exp_alerts:
+      - exp_labels:
+          name: "OSD_TOO_MANY_REPAIRS"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-too-many-repairs
+          description: |
+            Reads from an OSD have used a secondary PG to return data to the client, indicating
+            a potential failing disk.
+# Pools
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="POOL_BACKFILLFULL"}'
+      values: '0+0x2 1+0x10'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="POOL_BACKFILLFULL"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="POOL_BACKFILLFULL"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Ceph pool is too full for recovery/rebalance
+    - eval_time: 5m
+      alertname: Ceph pool is too full for recovery/rebalance
+      exp_alerts:
+      - exp_labels:
+          name: "POOL_BACKFILLFULL"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          description: >
+            A pool is approaching it's near full threshold, which will
+            prevent rebalance operations from completing. You should
+            consider adding more capacity to the pool.
+
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="POOL_FULL"}'
+      values: '0+0x2 1+0x10'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="POOL_FULL"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="POOL_FULL"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Ceph pool is full - writes blocked
+    - eval_time: 10m
+      alertname: Ceph pool is full - writes blocked
+      exp_alerts:
+      - exp_labels:
+          name: "POOL_FULL"
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pool-full
+          description: |
+            A pool has reached it's MAX quota, or the OSDs supporting the pool
+            have reached their FULL threshold. Until this is resolved, writes to
+            the pool will be blocked.
+
+            Determine the affected pool with 'ceph df detail', for example looking
+            at QUOTA BYTES and STORED. Either increase the pools quota, or add
+            capacity to the cluster first then increase it's quota
+            (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="POOL_NEAR_FULL"}'
+      values: '0+0x2 1+0x10'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="POOL_NEAR_FULL"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="POOL_NEAR_FULL"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Ceph pool is approaching full
+    - eval_time: 10m
+      alertname: Ceph pool is approaching full
+      exp_alerts:
+      - exp_labels:
+          name: "POOL_NEAR_FULL"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          description: |
+            A pool has exceeeded it warning (percent full) threshold, or the OSDs
+            supporting the pool have reached their NEARFULL thresholds. Writes may
+            continue, but you are at risk of the pool going read only if more capacity
+            isn't made available.
+
+            Determine the affected pool with 'ceph df detail', for example looking
+            at QUOTA BYTES and STORED. Either increase the pools quota, or add
+            capacity to the cluster first then increase it's quota
+            (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)
+
+# PGs
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="PG_NOT_SCRUBBED"}'
+      values: '0+0x2 1+0x10'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="PG_NOT_SCRUBBED"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="PG_NOT_SCRUBBED"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Placement Group(s) have not been scrubbed
+    - eval_time: 10m
+      alertname: Placement Group(s) have not been scrubbed
+      exp_alerts:
+      - exp_labels:
+          name: "PG_NOT_SCRUBBED"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-not-scrubbed
+          description: |
+            One or more PGs have not been scrubbed recently. The scrub process is a data integrity
+            feature, protectng against bit-rot. It checks that objects and their metadata (size and
+            attributes) match across object replicas. When PGs miss their scrub window, it may
+            indicate the scrub window is too small, or PGs were not in a 'clean' state during the
+            scrub window.
+
+            You can manually initiate a scrub with: ceph pg scrub <pgid>
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="PG_RECOVERY_FULL"}'
+      values: '0+0x2 1+0x20'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="PG_RECOVERY_FULL"} == 0
+       eval_time: 1m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="PG_RECOVERY_FULL"}'
+           value: 0
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Recovery at risk, cluster too full
+    - eval_time: 10m
+      alertname: Recovery at risk, cluster too full
+      exp_alerts:
+      - exp_labels:
+          name: "PG_RECOVERY_FULL"
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-recovery-full
+          description: >
+            Data redundancy may be reduced, or is at risk, since one or more OSDs are at or above their
+            'full' threshold. Add more capacity to the cluster, or delete unwanted data.
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="PG_BACKFILL_FULL"}'
+      values: '0+0x2 1+0x20'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="PG_BACKFILL_FULL"} == 0
+       eval_time: 1m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="PG_BACKFILL_FULL"}'
+           value: 0
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Cluster too full, automatic data recovery impaired
+    - eval_time: 10m
+      alertname: Cluster too full, automatic data recovery impaired
+      exp_alerts:
+      - exp_labels:
+          name: "PG_BACKFILL_FULL"
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-backfill-full
+          description: >
+            Data redundancy may be at risk due to lack of free space within the cluster. One or more OSDs
+            have breached their 'backfillfull' threshold. Add more capacity, or delete unwanted data.
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="PG_AVAILABILITY"}'
+      values: '0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1'
+    - series: 'ceph_health_detail{name="OSD_DOWN"}'
+      values: '0 0 0 1 1 1 1 1 1 0 0 0 0 0 0 0'
+   promql_expr_test:
+     - expr: ((ceph_health_detail{name="PG_AVAILABILITY"} == 1) - scalar(ceph_health_detail{name="OSD_DOWN"}))
+       eval_time: 1m
+       # empty set at 1m
+       exp_samples:
+   alert_rule_test:
+    # PG_AVAILABILITY and OSD_DOWN not firing .. no alert
+    - eval_time: 1m
+      alertname: I/O blocked to some data
+      exp_alerts:
+    # PG_AVAILABILITY firing, but osd_down is active .. no alert
+    - eval_time: 5m
+      alertname: I/O blocked to some data
+      exp_alerts:
+    # PG_AVAILABILITY firing, AND OSD_DOWN is not active...raise the alert
+    - eval_time: 15m
+      alertname: I/O blocked to some data
+      exp_alerts:
+      - exp_labels:
+          name: "PG_AVAILABILITY"
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-availability
+          description: >
+            Data availability is reduced impacting the clusters abilty to service I/O to some data. One or
+            more placement groups (PGs) are in a state that blocks IO.
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="PG_NOT_DEEP_SCRUBBED"}'
+      values: '0+0x2 1+0x10'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="PG_NOT_DEEP_SCRUBBED"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="PG_NOT_DEEP_SCRUBBED"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: Placement Group(s) have not been 'DEEP' scrubbed
+    - eval_time: 10m
+      alertname: Placement Group(s) have not been 'DEEP' scrubbed
+      exp_alerts:
+      - exp_labels:
+          name: "PG_NOT_DEEP_SCRUBBED"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-not-deep-scrubbed
+          description: |
+            One or more PGs have not been deep scrubbed recently. Deep scrub is a data integrity
+            feature, protectng against bit-rot. It compares the contents of objects and their
+            replicas for inconsistency. When PGs miss their deep scrub window, it may indicate
+            that the window is too small or PGs were not in a 'clean' state during the deep-scrub
+            window.
+
+            You can manually initiate a deep scrub with: ceph pg deep-scrub <pgid>
+
+# Prometheus
+ - interval: 1m
+   input_series:
+    - series: 'up{job="myjob"}'
+      values: '1+0x10'
+   promql_expr_test:
+     - expr: absent(up{job="ceph"})
+       eval_time: 1m
+       exp_samples:
+         - labels: '{job="ceph"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 5m
+      alertname: Scrape job is missing
+      exp_alerts:
+      - exp_labels:
+          job: ceph
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          description: |
+            The prometheus job that scrapes from Ceph is no longer defined, this
+            will effectively mean you'll have no metrics or alerts for the cluster.
+
+            Please review the job definitions in the prometheus.yml file of the prometheus
+            instance.
+# RADOS
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="OBJECT_UNFOUND"}'
+      values: '0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+    - series: 'ceph_osd_up{ceph_daemon="osd.0"}'
+      values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+    - series: 'ceph_osd_up{ceph_daemon="osd.1"}'
+      values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+    - series: 'ceph_osd_up{ceph_daemon="osd.2"}'
+      values: '1 1 1 0 0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+    - series: 'ceph_osd_metadata{ceph_daemon="osd.0"}'
+      values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+    - series: 'ceph_osd_metadata{ceph_daemon="osd.1"}'
+      values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+    - series: 'ceph_osd_metadata{ceph_daemon="osd.2"}'
+      values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+   promql_expr_test:
+     - expr: (ceph_health_detail{name="OBJECT_UNFOUND"} == 1) * on() (count(ceph_osd_up == 1) == bool count(ceph_osd_metadata)) == 1
+       eval_time: 1m
+       exp_samples:
+   alert_rule_test:
+    # OBJECT_UNFOUND but osd.2 is down, so don't fire
+    - eval_time: 5m
+      alertname: Data not found/missing
+      exp_alerts:
+    # OBJECT_UNFOUND and all osd's are online, so fire
+    - eval_time: 15m
+      alertname: Data not found/missing
+      exp_alerts:
+      - exp_labels:
+          severity: critical
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#object-unfound
+          description: |
+            A version of a RADOS object can not be found, even though all OSDs are up. I/O
+            requests for this object from clients will block (hang). Resolving this issue may
+            require the object to be rolled back to a prior version manually, and manually verified.

--- a/monitoring/prometheus/tests/CMakeLists.txt
+++ b/monitoring/prometheus/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
 if(WITH_TESTS)
   include(AddCephTest)
-  add_tox_test(prometheus-alerts ${CMAKE_CURRENT_SOURCE_DIR} TOX_ENVS py3)
+  # add_tox_test(prometheus-alerts ${CMAKE_CURRENT_SOURCE_DIR} TOX_ENVS py3)
 endif()

--- a/monitoring/prometheus/tests/CMakeLists.txt
+++ b/monitoring/prometheus/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+if(WITH_TESTS)
+  include(AddCephTest)
+  add_tox_test(prometheus-alerts ${CMAKE_CURRENT_SOURCE_DIR} TOX_ENVS py3)
+endif()

--- a/monitoring/prometheus/tests/README.md
+++ b/monitoring/prometheus/tests/README.md
@@ -1,0 +1,92 @@
+
+## Alert Rule Standards
+
+The alert rules should adhere to the following principles
+- each alert must have a unique name
+- each alert should define a common structure
+  - labels : must contain severity and type
+  - annotations : must provide description
+  - expr : must define the promql expression 
+  - alert : defines the alert name 
+- alerts that have a corresponding section within docs.ceph.com must include a 
+  documentation field in the annotations section
+- critical alerts should declare an oid in the labels section
+- critical alerts should have a corresponding entry in the Ceph MIB
+
+&nbsp;
+## Testing Prometheus Rules
+Once you have updated the `ceph_default_alerts.yml` file, you should use the 
+`validate_rules.py` script directly, or via `tox` to ensure the format of any update 
+or change aligns to our rule structure guidelines. The validate_rules.py script will
+process the rules and look for any configuration anomalies and output a report if
+problems are detected.
+
+Here's an example run, to illustrate the format and the kinds of issues detected.
+
+```
+[paul@myhost tests]$ ./validate_rules.py 
+
+Checking rule groups
+        cluster health : ..
+        mon            : E.W..
+        osd            : E...W......W.E..
+        mds            : WW
+        mgr            : WW
+        pgs            : ..WWWW..
+        nodes          : .EEEE
+        pools          : EEEW.
+        healthchecks   : .
+        cephadm        : WW.
+        prometheus     : W
+        rados          : W
+
+Summary
+
+Rule file             : ../alerts/ceph_default_alerts.yml
+Unit Test file        : test_alerts.yml
+
+Rule groups processed :  12
+Rules processed       :  51
+Rule errors           :  10
+Rule warnings         :  16
+Rule name duplicates  :   0
+Unit tests missing    :   4
+
+Problem Report
+
+  Group       Severity  Alert Name                                          Problem Description
+  -----       --------  ----------                                          -------------------
+  cephadm     Warning   Cluster upgrade has failed                          critical level alert is missing an SNMP oid entry
+  cephadm     Warning   A daemon managed by cephadm is down                 critical level alert is missing an SNMP oid entry
+  mds         Warning   Ceph Filesystem damage detected                     critical level alert is missing an SNMP oid entry
+  mds         Warning   Ceph Filesystem switched to READ ONLY               critical level alert is missing an SNMP oid entry
+  mgr         Warning   mgr module failure                                  critical level alert is missing an SNMP oid entry
+  mgr         Warning   mgr prometheus module is not active                 critical level alert is missing an SNMP oid entry
+  mon         Error     Monitor down, quorum is at risk                     documentation link error: #mon-downwah not found on the page
+  mon         Warning   Ceph mon disk space critically low                  critical level alert is missing an SNMP oid entry
+  nodes       Error     network packets dropped                             invalid alert structure. Missing field: for
+  nodes       Error     network packet errors                               invalid alert structure. Missing field: for
+  nodes       Error     storage filling up                                  invalid alert structure. Missing field: for
+  nodes       Error     MTU Mismatch                                        invalid alert structure. Missing field: for
+  osd         Error     10% OSDs down                                       invalid alert structure. Missing field: for
+  osd         Error     Flapping OSD                                        invalid alert structure. Missing field: for
+  osd         Warning   OSD Full                                            critical level alert is missing an SNMP oid entry
+  osd         Warning   Too many devices predicted to fail                  critical level alert is missing an SNMP oid entry
+  pgs         Warning   Placement Group (PG) damaged                        critical level alert is missing an SNMP oid entry
+  pgs         Warning   Recovery at risk, cluster too full                  critical level alert is missing an SNMP oid entry
+  pgs         Warning   I/O blocked to some data                            critical level alert is missing an SNMP oid entry
+  pgs         Warning   Cluster too full, automatic data recovery impaired  critical level alert is missing an SNMP oid entry
+  pools       Error     pool full                                           invalid alert structure. Missing field: for
+  pools       Error     pool filling up (growth forecast)                   invalid alert structure. Missing field: for
+  pools       Error     Ceph pool is too full for recovery/rebalance        invalid alert structure. Missing field: for
+  pools       Warning   Ceph pool is full - writes blocked                  critical level alert is missing an SNMP oid entry
+  prometheus  Warning   Scrape job is missing                               critical level alert is missing an SNMP oid entry
+  rados       Warning   Data not found/missing                              critical level alert is missing an SNMP oid entry
+
+Unit tests are incomplete. Tests missing for the following alerts;
+  - Placement Group (PG) damaged
+  - OSD Full
+  - storage filling up
+  - pool filling up (growth forecast)
+
+```

--- a/monitoring/prometheus/tests/requirements.txt
+++ b/monitoring/prometheus/tests/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+bs4

--- a/monitoring/prometheus/tests/settings.py
+++ b/monitoring/prometheus/tests/settings.py
@@ -1,0 +1,2 @@
+ALERTS_FILE = '../alerts/ceph_default_alerts.yml'
+UNIT_TESTS_FILE = 'test_alerts.yml'

--- a/monitoring/prometheus/tests/test_alerts.yml
+++ b/monitoring/prometheus/tests/test_alerts.yml
@@ -1,5 +1,5 @@
 rule_files:
-  - ceph_default_alerts.yml
+  - ../alerts/ceph_default_alerts.yml
 evaluation_interval: 5m
 tests:
  # health error
@@ -351,7 +351,7 @@ tests:
            severity: warning
            type: ceph_default
          exp_annotations:
-           documentation: https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd/#flapping-osds
+           documentation: https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd#flapping-osds
            description: >
               OSD osd.0 on ceph was
               marked down and back up at 20.1 times once a minute for 5 minutes.
@@ -795,7 +795,7 @@ tests:
            severity: warning
            type: ceph_default
          exp_annotations:
-           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#slow-ops
+           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops
            description: >
              1 OSD requests are taking too long to process
              (osd_op_complaint_time exceeded)
@@ -873,7 +873,7 @@ tests:
           severity: warning
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/cephadm/operations/#cephadm-paused
+          documentation: https://docs.ceph.com/en/latest/cephadm/operations#cephadm-paused
           description: >
             Cluster management has been paused manually. This will prevent the
             orchestrator from service management and reconciliation. If this is
@@ -900,7 +900,7 @@ tests:
           severity: critical
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#cephfs-health-messages
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages
           description: >
             The filesystems metadata has been corrupted. Data access
             may be blocked.
@@ -928,7 +928,7 @@ tests:
           severity: critical
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#cephfs-health-messages
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages
           description: >
             The filesystem has switched to READ ONLY due to an unexpected
             write error, when writing to the metadata pool
@@ -988,7 +988,7 @@ tests:
           severity: critical
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#recent-mgr-module-crash
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#recent-mgr-module-crash
           description: >
             One or more mgr modules have crashed and are yet to be acknowledged by the administrator. A
             crashed module may impact functionality within the cluster. Use the 'ceph crash' commands to
@@ -1017,7 +1017,7 @@ tests:
           severity: critical
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-disk-crit
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-crit
           description: |
             The free space available to a monitor's store is critically low (<5% by default).
             You should increase the space available to the monitor(s). The
@@ -1046,7 +1046,7 @@ tests:
           severity: warning
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-disk-low
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-low
           description: |
             The space available to a monitor's store is approaching full (>70% is the default).
             You should increase the space available to the monitor store. The
@@ -1073,7 +1073,7 @@ tests:
           severity: warning
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-clock-skew
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-clock-skew
           description: |
             The ceph monitors rely on a consistent time reference to maintain
             quorum and cluster consistency. This event indicates that at least
@@ -1117,7 +1117,7 @@ tests:
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.15.1.2.3.1
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-down
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down
           description: |
             Quorum requires a majority of monitors (x 2) to be active
             Without quorum the cluster will become inoperable, affecting all connected clients and services.
@@ -1163,7 +1163,7 @@ tests:
           severity: warning
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#mon-down
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down
           description: |
             You have 1 monitor down.
             Quorum is still intact, but the loss of further monitors will make your cluster inoperable.
@@ -1192,7 +1192,7 @@ tests:
           severity: warning
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#id2
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#id2
           description: |
             The device health module has determined that one or more devices will fail
             soon. To review the device states use 'ceph device ls'. To show a specific
@@ -1221,7 +1221,7 @@ tests:
           severity: critical
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#device-health-toomany
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-toomany
           description: |
             The device health module has determined that the number of devices predicted to
             fail can not be remediated automatically, since it would take too many osd's out of
@@ -1248,7 +1248,7 @@ tests:
           severity: warning
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#device-health-in-use
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-in-use
           description: |
             The device health module has determined that one or more devices will fail
             soon, but the normal process of relocating the data on the device to other
@@ -1355,7 +1355,7 @@ tests:
           severity: warning
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#bluestore-disk-size-mismatch
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-disk-size-mismatch
           description: |
             One or more OSDs have an internal inconsistency between the size of the physical device and it's metadata.
             This could lead to the OSD(s) crashing in future. You should redeploy the effected OSDs.
@@ -1380,7 +1380,7 @@ tests:
           severity: warning
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#bluestore-spurious-read-errors
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-spurious-read-errors
           description: >
             An OSD has encountered read errors, but the OSD has recovered by retrying
             the reads. This may indicate an issue with the Hardware or Kernel.
@@ -1418,7 +1418,7 @@ tests:
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.15.1.2.4.2
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-down
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-down
           description: |
             1 OSD down for over 5mins.
 
@@ -1446,7 +1446,7 @@ tests:
           type: ceph_default
           oid: 1.3.6.1.4.1.50495.15.1.2.4.3
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-nearfull
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-nearfull
           description: |
             One or more OSDs have reached their NEARFULL threshold
 
@@ -1473,7 +1473,7 @@ tests:
           severity: warning
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-backfillfull
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-backfillfull
           description: |
             An OSD has reached it's BACKFILL FULL threshold. This will prevent rebalance operations
             completing for some pools. Check the current capacity utilisation with 'ceph df'
@@ -1500,7 +1500,7 @@ tests:
           severity: warning
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#osd-too-many-repairs
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-too-many-repairs
           description: |
             Reads from an OSD have used a secondary PG to return data to the client, indicating
             a potential failing disk.
@@ -1552,7 +1552,7 @@ tests:
           severity: critical
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pool-full
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pool-full
           description: |
             A pool has reached it's MAX quota, or the OSDs supporting the pool
             have reached their FULL threshold. Until this is resolved, writes to
@@ -1616,7 +1616,7 @@ tests:
           severity: warning
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-not-scrubbed
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-scrubbed
           description: |
             One or more PGs have not been scrubbed recently. The scrub process is a data integrity
             feature, protectng against bit-rot. It checks that objects and their metadata (size and
@@ -1646,7 +1646,7 @@ tests:
           severity: critical
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-recovery-full
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-recovery-full
           description: >
             Data redundancy may be reduced, or is at risk, since one or more OSDs are at or above their
             'full' threshold. Add more capacity to the cluster, or delete unwanted data.
@@ -1671,7 +1671,7 @@ tests:
           severity: critical
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-backfill-full
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-backfill-full
           description: >
             Data redundancy may be at risk due to lack of free space within the cluster. One or more OSDs
             have breached their 'backfillfull' threshold. Add more capacity, or delete unwanted data.
@@ -1704,7 +1704,7 @@ tests:
           severity: critical
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-availability
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-availability
           description: >
             Data availability is reduced impacting the clusters abilty to service I/O to some data. One or
             more placement groups (PGs) are in a state that blocks IO.
@@ -1729,7 +1729,7 @@ tests:
           severity: warning
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#pg-not-deep-scrubbed
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-deep-scrubbed
           description: |
             One or more PGs have not been deep scrubbed recently. Deep scrub is a data integrity
             feature, protectng against bit-rot. It compares the contents of objects and their
@@ -1799,7 +1799,7 @@ tests:
           severity: critical
           type: ceph_default
         exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#object-unfound
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#object-unfound
           description: |
             A version of a RADOS object can not be found, even though all OSDs are up. I/O
             requests for this object from clients will block (hang). Resolving this issue may

--- a/monitoring/prometheus/tests/test_alerts.yml
+++ b/monitoring/prometheus/tests/test_alerts.yml
@@ -15,17 +15,18 @@ tests:
          value: 2
    alert_rule_test:
     - eval_time: 1m
-      alertname: health error
+      alertname: CephHealthError
     - eval_time: 6m
-      alertname: health error
+      alertname: CephHealthError
       exp_alerts:
       - exp_labels:
           instance: ceph:9283
           job: ceph
-          oid: 1.3.6.1.4.1.50495.15.1.2.2.1
+          oid: 1.3.6.1.4.1.50495.1.2.1.2.1
           type: ceph_default
           severity: critical
         exp_annotations:
+          summary: Cluster is in an ERROR state
           description: >
             Ceph in HEALTH_ERROR state for more than 5 minutes.
             Please check "ceph health detail" for more information.
@@ -43,71 +44,20 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 10m
-      alertname: health warn
+      alertname: CephHealthWarning
     - eval_time: 20m
-      alertname: health warn
+      alertname: CephHealthWarning
       exp_alerts:
       - exp_labels:
           instance: ceph:9283
           job: ceph
-          oid: 1.3.6.1.4.1.50495.15.1.2.2.2
           type: ceph_default
           severity: warning
         exp_annotations:
+          summary: Cluster is in a WARNING state
           description: >
             Ceph has been in HEALTH_WARN for more than 15 minutes.
             Please check "ceph health detail" for more information.
-
- # low monitor quorum count
-#  - interval: 1m
-#    input_series:
-#     - series: 'ceph_mon_quorum_status{ceph_daemon="mon.a",instance="ceph:9283",
-#       job="ceph"}'
-#       values: '1 1 1 1 1'
-#     - series: 'ceph_mon_quorum_status{ceph_daemon="mon.b",instance="ceph:9283",
-#       job="ceph"}'
-#       values: '1 1 1 1 1'
-#     - series: 'ceph_mon_quorum_status{ceph_daemon="mon.c",instance="ceph:9283",
-#       job="ceph"}'
-#       values: '0 0 0 0 0'
-#     - series: 'ceph_mon_metadata{ceph_daemon="mon.a",ceph_version="ceph version
-#       17.0.0-189-g3558fd72 (3558fd7291855971aa6481a2ade468ad61fbb346) pacific
-#       (dev)",hostname="ceph",instance="ceph:9283",job="ceph",
-#       public_addr="172.20.0.2",rank="0"}'
-#       values: '1 1 1 1 1'
-#     - series: 'ceph_mon_metadata{ceph_daemon="mon.b",ceph_version="ceph version
-#       17.0.0-189-g3558fd72 (3558fd7291855971aa6481a2ade468ad61fbb346) pacific
-#       (dev)",hostname="ceph",instance="ceph:9283",job="ceph",
-#       public_addr="172.20.0.2",rank="1"}'
-#       values: '1 1 1 1 1'
-#     - series: 'ceph_mon_metadata{ceph_daemon="mon.c",ceph_version="ceph version
-#       17.0.0-189-g3558fd72 (3558fd7291855971aa6481a2ade468ad61fbb346) pacific
-#       (dev)",hostname="ceph",instance="ceph:9283",job="ceph",
-#       public_addr="172.20.0.2",rank="2"}'
-#       values: '1 1 1 1 1'
-#    promql_expr_test:
-#      - expr: sum(ceph_mon_quorum_status) < 3
-#        eval_time: 1m
-#        exp_samples:
-#          - labels: '{}'
-#            value: 2
-#    alert_rule_test:
-#     - eval_time: 1m
-#       alertname: low monitor quorum count
-#       exp_alerts:
-#       - exp_labels:
-#           oid: 1.3.6.1.4.1.50495.15.1.2.3.1
-#           type: ceph_default
-#           severity: critical
-#         exp_annotations:
-#           description: |
-#             Monitor count in quorum is below three.
-
-#             Only 2 of 3 monitors are active.
-
-#             The following monitors are down:
-#               - mon.c on ceph
-
 
  # 10% OSDs down
  - interval: 1m
@@ -147,155 +97,19 @@ tests:
            value: 3.333333333333333E+01
    alert_rule_test:
      - eval_time: 1m
-       alertname: 10% OSDs down
+       alertname: CephOSDDownHigh
        exp_alerts:
        - exp_labels:
-           oid: 1.3.6.1.4.1.50495.15.1.2.4.1
+           oid: 1.3.6.1.4.1.50495.1.2.1.4.1
            type: ceph_default
            severity: critical
          exp_annotations:
+           summary: More than 10% of OSDs are down
            description: |
-             33.33% or 1 of 3 OSDs are down (≥ 10%).
+             33.33% or 1 of 3 OSDs are down (>= 10%).
 
              The following OSDs are down:
                - osd.1 on ceph
-
- # OSD down
-#  - interval: 1m
-#    input_series:
-#     - series: 'ceph_osd_up{ceph_daemon="osd.0",instance="ceph:9283",job="ceph"}'
-#       values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
-#     - series: 'ceph_osd_up{ceph_daemon="osd.1",instance="ceph:9283",job="ceph"}'
-#       values: '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
-#     - series: 'ceph_osd_up{ceph_daemon="osd.2",instance="ceph:9283",job="ceph"}'
-#       values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
-#     - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.0",
-#       ceph_version="ceph version 17.0.0-189-g3558fd72
-#       (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
-#       cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
-#       hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
-#       public_addr="172.20.0.2"}'
-#       values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
-#     - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.1",
-#       ceph_version="ceph version 17.0.0-189-g3558fd72
-#       (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
-#       cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
-#       hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
-#       public_addr="172.20.0.2"}'
-#       values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
-#     - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.2",
-#       ceph_version="ceph version 17.0.0-189-g3558fd72
-#       (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
-#       cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
-#       hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
-#       public_addr="172.20.0.2"}'
-#       values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
-#    promql_expr_test:
-#      - expr: count(ceph_osd_up == 0) > 0
-#        eval_time: 1m
-#        exp_samples:
-#          - labels: '{}'
-#            value: 1
-#    alert_rule_test:
-#      - eval_time: 15m
-#        alertname: OSD down
-#        exp_alerts:
-#        - exp_labels:
-#            oid: 1.3.6.1.4.1.50495.15.1.2.4.2
-#            type: ceph_default
-#            severity: warning
-#          exp_annotations:
-#            description: |
-
-#              1 OSD down for more than 15 minutes.
-
-#              1 of 3 OSDs are down.
-
-#              The following OSD is down:
-#                  - osd.1 on ceph
-
-# OSDs near full
-#  - interval: 1m
-#    input_series:
-#     - series: 'ceph_osd_stat_bytes_used{ceph_daemon="osd.0",instance="ceph:9283"
-#       ,job="ceph"}'
-#       values: '1076310016 1076310016 1076310016 1076310016 1076310016
-#       1076310016'
-#     - series: 'ceph_osd_stat_bytes_used{ceph_daemon="osd.1",instance="ceph:9283"
-#       ,job="ceph"}'
-#       values: '1076310016 1076310016 1076310016 1076310016 1076310016
-#       1076310016'
-#     - series: 'ceph_osd_stat_bytes_used{ceph_daemon="osd.2",instance="ceph:9283"
-#       ,job="ceph"}'
-#       values: '1076310016 1076310016 1076310016 1076310016 1076310016
-#       100856561909.76'
-#     - series: 'ceph_osd_stat_bytes{ceph_daemon="osd.0",instance="ceph:9283"
-#       ,job="ceph"}'
-#       values: '108447916032 108447916032 108447916032 108447916032 108447916032
-#       108447916032'
-#     - series: 'ceph_osd_stat_bytes{ceph_daemon="osd.1",instance="ceph:9283"
-#       ,job="ceph"}'
-#       values: '108447916032 108447916032 108447916032 108447916032 108447916032
-#       108447916032'
-#     - series: 'ceph_osd_stat_bytes{ceph_daemon="osd.2",instance="ceph:9283"
-#       ,job="ceph"}'
-#       values: '108447916032 108447916032 108447916032 108447916032 108447916032
-#       108447916032'
-#     - series: 'ceph_osd_up{ceph_daemon="osd.0",instance="ceph:9283",job="ceph"}'
-#       values: '1 1 1 1 1 1'
-#     - series: 'ceph_osd_up{ceph_daemon="osd.1",instance="ceph:9283",job="ceph"}'
-#       values: '1 1 1 1 1 1'
-#     - series: 'ceph_osd_up{ceph_daemon="osd.2",instance="ceph:9283",job="ceph"}'
-#       values: '1 1 1 1 1 1'
-#     - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.0",
-#       ceph_version="ceph version 17.0.0-189-g3558fd72
-#       (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
-#       cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
-#       hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
-#       public_addr="172.20.0.2"}'
-#       values: '1 1 1 1 1 1'
-#     - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.1",
-#       ceph_version="ceph version 17.0.0-189-g3558fd72
-#       (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
-#       cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
-#       hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
-#       public_addr="172.20.0.2"}'
-#       values: '1 1 1 1 1 1'
-#     - series: 'ceph_osd_metadata{back_iface="eth0",ceph_daemon="osd.2",
-#       ceph_version="ceph version 17.0.0-189-g3558fd72
-#       (3558fd7291855971aa6481a2ade468ad61fbb346) pacific (dev)",
-#       cluster_addr="172.20.0.2",device_class="hdd",front_iface="eth0",
-#       hostname="ceph",instance="ceph:9283",job="ceph",objectstore="bluestore",
-#       public_addr="172.20.0.2"}'
-#       values: '1 1 1 1 1 1'
-#    promql_expr_test:
-#      - expr: |
-#          (
-#            ((ceph_osd_stat_bytes_used / ceph_osd_stat_bytes) and on(ceph_daemon)
-#            ceph_osd_up == 1) * on(ceph_daemon) group_left(hostname)
-#            ceph_osd_metadata
-#          ) * 100 > 90
-
-#        eval_time: 5m
-#        exp_samples:
-#          - labels: '{ceph_daemon="osd.2",hostname="ceph",instance="ceph:9283",
-#            job="ceph"}'
-#            value: 9.3E+01
-#    alert_rule_test:
-#      - eval_time: 10m
-#        alertname: OSDs near full
-#        exp_alerts:
-#        - exp_labels:
-#            ceph_daemon: osd.2
-#            hostname: ceph
-#            instance: ceph:9283
-#            job: ceph
-#            oid: 1.3.6.1.4.1.50495.15.1.2.4.3
-#            type: ceph_default
-#            severity: critical
-#          exp_annotations:
-#            description: >
-#              OSD osd.2 on ceph is dangerously full: 93%
 
  # flapping OSD
  - interval: 1s
@@ -340,18 +154,19 @@ tests:
            value: 1.2200000000000001E+01
    alert_rule_test:
      - eval_time: 5m
-       alertname: Flapping OSD
+       alertname: CephOSDFlapping
        exp_alerts:
        - exp_labels:
            ceph_daemon: osd.0
            hostname: ceph
            instance: ceph:9283
            job: ceph
-           oid: 1.3.6.1.4.1.50495.15.1.2.4.4
+           oid: 1.3.6.1.4.1.50495.1.2.1.4.4
            severity: warning
            type: ceph_default
          exp_annotations:
            documentation: https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd#flapping-osds
+           summary: Network issues are causing OSD's to flap (mark each other out)
            description: >
               OSD osd.0 on ceph was
               marked down and back up at 20.1 times once a minute for 5 minutes.
@@ -418,17 +233,18 @@ tests:
            value: 6E-01
    alert_rule_test:
      - eval_time: 10m
-       alertname: high pg count deviation
+       alertname: CephPGImbalance
        exp_alerts:
        - exp_labels:
            ceph_daemon: osd.1
            hostname: ceph
            instance: ceph:9283
            job: ceph
-           oid: 1.3.6.1.4.1.50495.15.1.2.4.5
+           oid: 1.3.6.1.4.1.50495.1.2.1.4.5
            severity: warning
            type: ceph_default
          exp_annotations:
+           summary: PG allocations are not balanced across devices
            description: >
               OSD osd.1 on ceph deviates
               by more than 30% from average PG count.
@@ -468,17 +284,18 @@ tests:
            value: 1
    alert_rule_test:
      - eval_time: 5m
-       alertname: pgs inactive
+       alertname: CephPGsInactive
        exp_alerts:
        - exp_labels:
            instance: ceph:9283
            job: ceph
            name: device_health_metrics
-           oid: 1.3.6.1.4.1.50495.15.1.2.7.1
+           oid: 1.3.6.1.4.1.50495.1.2.1.7.1
            pool_id: 3
            severity: critical
            type: ceph_default
          exp_annotations:
+           summary: One or more Placement Groups are inactive
            description: >
               1 PGs have been inactive for more than 5 minutes in pool
               device_health_metrics.
@@ -523,17 +340,18 @@ tests:
            value: 1
    alert_rule_test:
      - eval_time: 16m
-       alertname: pgs unclean
+       alertname: CephPGsUnclean
        exp_alerts:
        - exp_labels:
            instance: ceph:9283
            job: ceph
            name: device_health_metrics
-           oid: 1.3.6.1.4.1.50495.15.1.2.7.2
+           oid: 1.3.6.1.4.1.50495.1.2.1.7.2
            pool_id: 3
            severity: warning
            type: ceph_default
          exp_annotations:
+           summary: One or more platcment groups are marked unclean
            description: >
               1 PGs haven't been clean for more than 15 minutes in pool
               device_health_metrics.
@@ -564,7 +382,7 @@ tests:
            value: 4.8E+00
    alert_rule_test:
      - eval_time: 10m
-       alertname: root volume full
+       alertname: CephNodeRootFilesystemFull
        exp_alerts:
        - exp_labels:
            device: /dev/mapper/fedora_localhost --live-home
@@ -572,12 +390,13 @@ tests:
            instance: node-exporter
            job: node-exporter
            mountpoint: /
-           oid: 1.3.6.1.4.1.50495.15.1.2.8.1
+           oid: 1.3.6.1.4.1.50495.1.2.1.8.1
            severity: critical
            type: ceph_default
          exp_annotations:
+           summary: Root filesystem is dangerously full
            description: >
-              Root volume (OSD and MON store) is dangerously full: 4.811% free.
+             Root volume (OSD and MON store) is dangerously full: 4.811% free.
 
  # network packets dropped
  - interval: 1s
@@ -608,19 +427,20 @@ tests:
            value: 1.2E+02
    alert_rule_test:
      - eval_time: 5m
-       alertname: network packets dropped
+       alertname: CephNodeNetworkPacketDrops
        exp_alerts:
        - exp_labels:
            device: eth0
            instance: node-exporter
            job: node-exporter
-           oid: 1.3.6.1.4.1.50495.15.1.2.8.2
+           oid: 1.3.6.1.4.1.50495.1.2.1.8.2
            severity: warning
            type: ceph_default
          exp_annotations:
+           summary: One or more Nics is seeing packet drops
            description: >
-              Node node-exporter experiences packet drop > 0.01% or >
-              10 packets/s on interface eth0.
+             Node node-exporter experiences packet drop > 0.01% or >
+             10 packets/s on interface eth0.
 
  # network packets errors
  - interval: 1s
@@ -651,20 +471,63 @@ tests:
            value: 1.2E+02
    alert_rule_test:
      - eval_time: 5m
-       alertname: network packet errors
+       alertname: CephNodeNetworkPacketErrors
        exp_alerts:
        - exp_labels:
            device: eth0
            instance: node-exporter
            job: node-exporter
-           oid: 1.3.6.1.4.1.50495.15.1.2.8.3
+           oid: 1.3.6.1.4.1.50495.1.2.1.8.3
            severity: warning
            type: ceph_default
          exp_annotations:
+           summary: One or more Nics is seeing packet errors
            description: >
-              Node node-exporter experiences packet errors > 0.01% or > 10
-              packets/s on interface eth0.
+             Node node-exporter experiences packet errors > 0.01% or > 10
+             packets/s on interface eth0.
 
+# Node Storage disk space filling up
+ - interval: 1m
+   # 20GB = 21474836480, 256MB = 268435456
+   input_series:
+    - series: 'node_filesystem_free_bytes{device="/dev/mapper/vg-root",
+      fstype="xfs",instance="node-1",mountpoint="/rootfs"}'
+      values: '21474836480-268435456x48'
+    - series: 'node_filesystem_free_bytes{device="/dev/mapper/vg-root",
+      fstype="xfs",instance="node-2",mountpoint="/rootfs"}'
+      values: '21474836480+0x48'
+    - series: 'node_uname_info{instance="node-1", nodename="node-1.unittests.com"}'
+      values: 1+0x48
+    - series: 'node_uname_info{instance="node-2", nodename="node-2.unittests.com"}'
+      values: 1+0x48
+   promql_expr_test:
+     - expr: |
+         predict_linear(node_filesystem_free_bytes{device=~"/.*"}[2d], 3600 * 24 * 5) *
+          on(instance) group_left(nodename) node_uname_info < 0
+       eval_time: 5m
+       exp_samples:
+         - labels: '{device="/dev/mapper/vg-root",instance="node-1",fstype="xfs",
+         mountpoint="/rootfs",nodename="node-1.unittests.com"}'
+           value: -1.912602624E+12
+   alert_rule_test:
+     - eval_time: 5m
+       alertname: CephNodeDiskspaceWarning
+       exp_alerts:
+       - exp_labels:
+           severity: warning
+           type: ceph_default
+           oid: 1.3.6.1.4.1.50495.1.2.1.8.4
+           device: /dev/mapper/vg-root
+           fstype: xfs
+           instance: node-1
+           mountpoint: /rootfs
+           nodename: node-1.unittests.com
+         exp_annotations:
+           summary: Host filesystem freespace is getting low
+           description: >
+             Mountpoint /rootfs on node-1.unittests.com
+             will be full in less than 5 days assuming the average fill-up
+             rate of the past 48 hours.
  # MTU Mismatch
  - interval: 1m
    input_series:
@@ -707,72 +570,88 @@ tests:
            value: 9000
    alert_rule_test:
      - eval_time: 1m
-       alertname: MTU Mismatch
+       alertname: CephNodeInconsistentMTU
        exp_alerts:
        - exp_labels:
            device: eth4
            instance: node-exporter
            job: node-exporter
-           oid: 1.3.6.1.4.1.50495.15.1.2.8.5
            severity: warning
            type: ceph_default
          exp_annotations:
+           summary: MTU settings across Ceph hosts are inconsistent
            description: >
                Node node-exporter has a different MTU size (9000)
                than the median value on device eth4.
 
- # pool full
+ # pool full, data series has 6 but using topk(5) so to ensure the
+ # results are working as expected
  - interval: 1m
    input_series:
-    - series: 'ceph_pool_stored{instance="ceph:9283",job="ceph",pool_id="1"}'
-      values: '0 0 0 0 0 0 0 0 0'
-    - series: 'ceph_pool_stored{instance="ceph:9283",job="ceph",pool_id="2"}'
-      values: '1850 1850 1850 1850 1850 1850 1850'
-    - series: 'ceph_pool_stored{instance="ceph:9283",job="ceph",pool_id="3"}'
-      values: '900 900 23524 23524 23524 23524 23524 23524
-      23524'
-    - series: 'ceph_pool_max_avail{instance="ceph:9283",job="ceph",pool_id="1"}'
-      values: '106287063040 106287063040 106287063040 106287063040 106287063040
-      106287063040 106287063040'
-    - series: 'ceph_pool_max_avail{instance="ceph:9283",job="ceph",pool_id="2"}'
-      values: '106287063040 106287063040 106287063040 106287063040 106287063040
-      106287063040 106287063040'
-    - series: 'ceph_pool_max_avail{instance="ceph:9283",job="ceph",pool_id="3"}'
-      values: '37.5 37.5 37.5 37.5 37.5 37.5 37.5'
+    - series: 'ceph_health_detail{name="POOL_FULL"}'
+      values: '0 0 0 1 1 1 1 1 1 1 1'
+    - series: 'ceph_pool_percent_used{pool_id="1"}'
+      values: '32+0x10'
+    - series: 'ceph_pool_percent_used{pool_id="2"}'
+      values: '96+0x10'
+    - series: 'ceph_pool_percent_used{pool_id="3"}'
+      values: '90+0x10'
+    - series: 'ceph_pool_percent_used{pool_id="4"}'
+      values: '72+0x10'
+    - series: 'ceph_pool_percent_used{pool_id="5"}'
+      values: '19+0x10'
+    - series: 'ceph_pool_percent_used{pool_id="6"}'
+      values: '10+0x10'
     - series: 'ceph_pool_metadata{instance="ceph:9283",job="ceph",
-      name="device_health_metrics",pool_id="1"}'
+      name="cephfs_data",pool_id="1"}'
       values: '1 1 1 1 1 1 1 1 1'
     - series: 'ceph_pool_metadata{instance="ceph:9283",job="ceph",
-      name=".rgw.root",pool_id="2"}'
+      name="rbd",pool_id="2"}'
       values: '1 1 1 1 1 1 1 1 1'
     - series: 'ceph_pool_metadata{instance="ceph:9283",job="ceph",
-      name="default.rgw.log",pool_id="3"}'
+      name="iscsi",pool_id="3"}'
+      values: '1 1 1 1 1 1 1 1 1'
+    - series: 'ceph_pool_metadata{instance="ceph:9283",job="ceph",
+      name="default.rgw.index",pool_id="4"}'
+      values: '1 1 1 1 1 1 1 1 1'
+    - series: 'ceph_pool_metadata{instance="ceph:9283",job="ceph",
+      name="default.rgw.log",pool_id="5"}'
+      values: '1 1 1 1 1 1 1 1 1'
+    - series: 'ceph_pool_metadata{instance="ceph:9283",job="ceph",
+      name="dummy",pool_id="6"}'
       values: '1 1 1 1 1 1 1 1 1'
    promql_expr_test:
-     - expr: |
-         ceph_pool_stored / (ceph_pool_stored + ceph_pool_max_avail)
-         * on(pool_id) group_right ceph_pool_metadata * 100 > 90
-
-       eval_time: 1m
+     - expr: ceph_health_detail{name="POOL_FULL"} > 0
+       eval_time: 5m
        exp_samples:
-         - labels: '{instance="ceph:9283", job="ceph", name="default.rgw.log",
-           pool_id="3"}'
-           value: 9.6E+01
+         - labels:  '{__name__="ceph_health_detail", name="POOL_FULL"}'
+           value: 1
    alert_rule_test:
-     - eval_time: 2m
-       alertname: pool full
+     - eval_time: 1m
+       alertname: CephPoolFull
+     - eval_time: 10m
+       alertname: CephPoolFull
        exp_alerts:
        - exp_labels:
-           instance: ceph:9283
-           job: ceph
-           name: default.rgw.log
-           oid: 1.3.6.1.4.1.50495.15.1.2.9.1
-           pool_id: 3
+           name: POOL_FULL
            severity: critical
            type: ceph_default
+           oid: 1.3.6.1.4.1.50495.1.2.1.9.1
          exp_annotations:
-           description: Pool default.rgw.log at 96% capacity.
-
+           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pool-full
+           summary: Pool is full - writes are blocked
+           description: |
+             A pool has reached it's MAX quota, or the OSDs supporting the pool
+             have reached their FULL threshold. Until this is resolved, writes to
+             the pool will be blocked.
+             Pool Breakdown (top 5)
+               - rbd at 96%
+               - iscsi at 90%
+               - default.rgw.index at 72%
+               - cephfs_data at 32%
+               - default.rgw.log at 19%
+             Either increase the pools quota, or add capacity to the cluster first
+             then increase it's quota (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)
  # slow OSD ops
  - interval : 1m
    input_series:
@@ -787,7 +666,7 @@ tests:
            value: 1
    alert_rule_test:
      - eval_time: 20m
-       alertname: Slow OSD Ops
+       alertname: CephSlowOps
        exp_alerts:
        - exp_labels:
            instance: ceph:9283
@@ -796,6 +675,7 @@ tests:
            type: ceph_default
          exp_annotations:
            documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#slow-ops
+           summary: MON/OSD operations are slow to complete
            description: >
              1 OSD requests are taking too long to process
              (osd_op_complaint_time exceeded)
@@ -813,15 +693,17 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Cluster upgrade has failed
+      alertname: CephadmUpgradeFailed
     - eval_time: 5m
-      alertname: Cluster upgrade has failed
+      alertname: CephadmUpgradeFailed
       exp_alerts:
       - exp_labels:
           name: UPGRADE_EXCEPTION
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.11.2
         exp_annotations:
+          summary: Ceph version upgrade has failed
           description: >
             The cephadm cluster upgrade process has failed. The cluster remains in
             an undetermined state.
@@ -839,15 +721,17 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: A daemon managed by cephadm is down
+      alertname: CephadmDaemonFailed
     - eval_time: 5m
-      alertname: A daemon managed by cephadm is down
+      alertname: CephadmDaemonFailed
       exp_alerts:
       - exp_labels:
           name: CEPHADM_FAILED_DAEMON
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.11.1
         exp_annotations:
+          summary: A ceph daemon manged by cephadm is down
           description: >
             A daemon managed by cephadm is no longer active. Determine, which
             daemon is down with 'ceph health detail'. you may start daemons with
@@ -864,9 +748,9 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: cephadm management has been paused
+      alertname: CephadmPaused
     - eval_time: 5m
-      alertname: cephadm management has been paused
+      alertname: CephadmPaused
       exp_alerts:
       - exp_labels:
           name: CEPHADM_PAUSED
@@ -874,6 +758,7 @@ tests:
           type: ceph_default
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/cephadm/operations#cephadm-paused
+          summary: Orchestration tasks via cephadm are PAUSED
           description: >
             Cluster management has been paused manually. This will prevent the
             orchestrator from service management and reconciliation. If this is
@@ -891,16 +776,18 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Ceph Filesystem damage detected
+      alertname: CephFilesystemDamaged
     - eval_time: 5m
-      alertname: Ceph Filesystem damage detected
+      alertname: CephFilesystemDamaged
       exp_alerts:
       - exp_labels:
           name: MDS_DAMAGE
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.5.1
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages
+          summary: Ceph filesystem is damaged.
           description: >
             The filesystems metadata has been corrupted. Data access
             may be blocked.
@@ -919,22 +806,161 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Ceph Filesystem switched to READ ONLY
+      alertname: CephFilesystemReadOnly
     - eval_time: 5m
-      alertname: Ceph Filesystem switched to READ ONLY
+      alertname: CephFilesystemReadOnly
       exp_alerts:
       - exp_labels:
           name: MDS_HEALTH_READ_ONLY
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.5.2
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/cephfs/health-messages#cephfs-health-messages
+          summary: Ceph filesystem in read only mode, due to write error(s)
           description: >
             The filesystem has switched to READ ONLY due to an unexpected
             write error, when writing to the metadata pool
 
             Either analyse the output from the mds daemon admin socket, or
             escalate to support
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="MDS_ALL_DOWN"}'
+      values: '0 0 1 1 1 1 1 1 1 1 1'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="MDS_ALL_DOWN"} > 0
+       eval_time: 2m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="MDS_ALL_DOWN"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: CephFilesystemOffline
+    - eval_time: 10m
+      alertname: CephFilesystemOffline
+      exp_alerts:
+      - exp_labels:
+          name: MDS_ALL_DOWN
+          severity: critical
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.5.3
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-all-down
+          summary: Ceph filesystem is offline
+          description: >
+            All MDS ranks are unavailable. The ceph daemons providing the metadata
+            for the Ceph filesystem are all down, rendering the filesystem offline.
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="FS_DEGRADED"}'
+      values: '0 0 1 1 1 1 1 1 1 1 1'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="FS_DEGRADED"} > 0
+       eval_time: 2m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="FS_DEGRADED"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: CephFilesystemDegraded
+    - eval_time: 10m
+      alertname: CephFilesystemDegraded
+      exp_alerts:
+      - exp_labels:
+          name: FS_DEGRADED
+          severity: critical
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.5.4
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-degraded
+          summary: Ceph filesystem is degraded
+          description: >
+            One or more metdata daemons (MDS ranks) are failed or in a
+            damaged state. At best the filesystem is partially available,
+            worst case is the filesystem is completely unusable.
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="MDS_INSUFFICIENT_STANDBY"}'
+      values: '0 0 1 1 1 1 1 1 1 1 1'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="MDS_INSUFFICIENT_STANDBY"} > 0
+       eval_time: 2m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="MDS_INSUFFICIENT_STANDBY"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: CephFilesystemInsufficientStandby
+    - eval_time: 10m
+      alertname: CephFilesystemInsufficientStandby
+      exp_alerts:
+      - exp_labels:
+          name: MDS_INSUFFICIENT_STANDBY
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-insufficient-standby
+          summary: Ceph filesystem standby daemons too low
+          description: >
+            The minimum number of standby daemons determined by standby_count_wanted
+            is less than the actual number of standby daemons. Adjust the standby count
+            or increase the number of mds daemons within the filesystem.
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="FS_WITH_FAILED_MDS"}'
+      values: '0 0 1 1 1 1 1 1 1 1 1'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="FS_WITH_FAILED_MDS"} > 0
+       eval_time: 2m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="FS_WITH_FAILED_MDS"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: CephFilesystemFailureNoStandby
+    - eval_time: 10m
+      alertname: CephFilesystemFailureNoStandby
+      exp_alerts:
+      - exp_labels:
+          name: FS_WITH_FAILED_MDS
+          severity: critical
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.5.5
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-with-failed-mds
+          summary: Ceph MDS daemon failed, no further standby available
+          description: >
+            An MDS daemon has failed, leaving only one active rank without
+            further standby. Investigate the cause of the failure or add a
+            standby daemon
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="MDS_UP_LESS_THAN_MAX"}'
+      values: '0 0 1 1 1 1 1 1 1 1 1'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="MDS_UP_LESS_THAN_MAX"} > 0
+       eval_time: 2m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="MDS_UP_LESS_THAN_MAX"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: CephFilesystemMDSRanksLow
+    - eval_time: 10m
+      alertname: CephFilesystemMDSRanksLow
+      exp_alerts:
+      - exp_labels:
+          name: MDS_UP_LESS_THAN_MAX
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#mds-up-less-than-max
+          summary: Ceph MDS daemon count is lower than configured
+          description: >
+            The filesystem's "max_mds" setting defined the number of MDS ranks in
+            the filesystem. The current number of active MDS daemons is less than
+            this setting.
 # MGR
  - interval: 1m
    input_series:
@@ -948,16 +974,18 @@ tests:
            value: 0
    alert_rule_test:
     - eval_time: 1m
-      alertname: mgr prometheus module is not active
+      alertname: CephMgrPrometheusModuleInactive
     - eval_time: 10m
-      alertname: mgr prometheus module is not active
+      alertname: CephMgrPrometheusModuleInactive
       exp_alerts:
       - exp_labels:
           instance: ceph-mgr:9283
           job: ceph
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.6.2
         exp_annotations:
+          summary: Ceph's mgr/prometheus module is not available
           description: >
             The mgr/prometheus module at ceph-mgr:9283 is unreachable. This
             could mean that the module has been disabled or the mgr itself is down.
@@ -979,16 +1007,18 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: mgr module failure
+      alertname: CephMgrModuleCrash
     - eval_time: 15m
-      alertname: mgr module failure
+      alertname: CephMgrModuleCrash
       exp_alerts:
       - exp_labels:
           name: RECENT_MGR_MODULE_CRASH
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.6.1
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#recent-mgr-module-crash
+          summary: A mgr module has recently crashed
           description: >
             One or more mgr modules have crashed and are yet to be acknowledged by the administrator. A
             crashed module may impact functionality within the cluster. Use the 'ceph crash' commands to
@@ -1008,16 +1038,18 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Ceph mon disk space critically low
+      alertname: CephMonDiskspaceCritical
     - eval_time: 10m
-      alertname: Ceph mon disk space critically low
+      alertname: CephMonDiskspaceCritical
       exp_alerts:
       - exp_labels:
           name: "MON_DISK_CRIT"
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.3.2
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-crit
+          summary: Disk space on at least one monitor is critically low
           description: |
             The free space available to a monitor's store is critically low (<5% by default).
             You should increase the space available to the monitor(s). The
@@ -1037,9 +1069,9 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Ceph mon disk space running low
+      alertname: CephMonDiskspaceLow
     - eval_time: 10m
-      alertname: Ceph mon disk space running low
+      alertname: CephMonDiskspaceLow
       exp_alerts:
       - exp_labels:
           name: "MON_DISK_LOW"
@@ -1047,6 +1079,7 @@ tests:
           type: ceph_default
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-disk-low
+          summary: Disk space on at least one monitor is approaching full
           description: |
             The space available to a monitor's store is approaching full (>70% is the default).
             You should increase the space available to the monitor store. The
@@ -1064,9 +1097,9 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Clock skew detected across Ceph Monitor daemons
+      alertname: CephMonClockSkew
     - eval_time: 10m
-      alertname: Clock skew detected across Ceph Monitor daemons
+      alertname: CephMonClockSkew
       exp_alerts:
       - exp_labels:
           name: "MON_CLOCK_SKEW"
@@ -1074,6 +1107,7 @@ tests:
           type: ceph_default
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-clock-skew
+          summary: Clock skew across the Monitor hosts detected
           description: |
             The ceph monitors rely on a consistent time reference to maintain
             quorum and cluster consistency. This event indicates that at least
@@ -1107,17 +1141,18 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Monitor down, quorum is at risk
+      alertname: CephMonDownQuorumAtRisk
       # shouldn't fire
     - eval_time: 10m
-      alertname: Monitor down, quorum is at risk
+      alertname: CephMonDownQuorumAtRisk
       exp_alerts:
       - exp_labels:
           severity: critical
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.3.1
+          oid: 1.3.6.1.4.1.50495.1.2.1.3.1
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down
+          summary: Monitor quorum is at risk
           description: |
             Quorum requires a majority of monitors (x 2) to be active
             Without quorum the cluster will become inoperable, affecting all connected clients and services.
@@ -1155,15 +1190,16 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Monitor down
+      alertname: CephMonDown
     - eval_time: 10m
-      alertname: Monitor down
+      alertname: CephMonDown
       exp_alerts:
       - exp_labels:
           severity: warning
           type: ceph_default
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#mon-down
+          summary: One of more ceph monitors are down
           description: |
             You have 1 monitor down.
             Quorum is still intact, but the loss of further monitors will make your cluster inoperable.
@@ -1183,9 +1219,9 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Device failure predicted
+      alertname: CephDeviceFailurePredicted
     - eval_time: 10m
-      alertname: Device failure predicted
+      alertname: CephDeviceFailurePredicted
       exp_alerts:
       - exp_labels:
           name: "DEVICE_HEALTH"
@@ -1193,6 +1229,7 @@ tests:
           type: ceph_default
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#id2
+          summary: Device(s) have been predicted to fail soon
           description: |
             The device health module has determined that one or more devices will fail
             soon. To review the device states use 'ceph device ls'. To show a specific
@@ -1212,16 +1249,18 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Too many devices predicted to fail
+      alertname: CephDeviceFailurePredictionTooHigh
     - eval_time: 10m
-      alertname: Too many devices predicted to fail
+      alertname: CephDeviceFailurePredictionTooHigh
       exp_alerts:
       - exp_labels:
           name: "DEVICE_HEALTH_TOOMANY"
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.4.7
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-toomany
+          summary: Too many devices have been predicted to fail, unable to resolve
           description: |
             The device health module has determined that the number of devices predicted to
             fail can not be remediated automatically, since it would take too many osd's out of
@@ -1239,9 +1278,9 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Device failure predicted, but automatic drain is incomplete
+      alertname: CephDeviceFailureRelocationIncomplete
     - eval_time: 10m
-      alertname: Device failure predicted, but automatic drain is incomplete
+      alertname: CephDeviceFailureRelocationIncomplete
       exp_alerts:
       - exp_labels:
           name: "DEVICE_HEALTH_IN_USE"
@@ -1249,6 +1288,7 @@ tests:
           type: ceph_default
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#device-health-in-use
+          summary: A device failure is predicted, but unable to relocate data
           description: |
             The device health module has determined that one or more devices will fail
             soon, but the normal process of relocating the data on the device to other
@@ -1274,15 +1314,17 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: OSD Host is down
+      alertname: CephOSDHostDown
     - eval_time: 10m
-      alertname: OSD Host is down
+      alertname: CephOSDHostDown
       exp_alerts:
       - exp_labels:
           name: "OSD_HOST_DOWN"
           severity: warning
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.4.8
         exp_annotations:
+          summary: An OSD host is offline
           description: |
             The following OSDs are down:
             - ceph-osd-1 : osd.0
@@ -1298,15 +1340,16 @@ tests:
            value: 0
    alert_rule_test:
     - eval_time: 1m
-      alertname: OSD hearbeats running slow (frontend)
+      alertname: CephOSDTimeoutsPublicNetwork
     - eval_time: 10m
-      alertname: OSD hearbeats running slow (frontend)
+      alertname: CephOSDTimeoutsPublicNetwork
       exp_alerts:
       - exp_labels:
           name: "OSD_SLOW_PING_TIME_FRONT"
           severity: warning
           type: ceph_default
         exp_annotations:
+          summary: Network issues delaying OSD heartbeats (public network)
           description: |
             OSD heartbeats on the cluster's 'public' network (frontend) are running slow. Investigate the network
             for any latency issues on this subnet. Use 'ceph health detail' to show the affected OSDs.
@@ -1322,15 +1365,16 @@ tests:
            value: 0
    alert_rule_test:
     - eval_time: 1m
-      alertname: OSD hearbeats running slow (backend)
+      alertname: CephOSDTimeoutsClusterNetwork
     - eval_time: 10m
-      alertname: OSD hearbeats running slow (backend)
+      alertname: CephOSDTimeoutsClusterNetwork
       exp_alerts:
       - exp_labels:
           name: "OSD_SLOW_PING_TIME_BACK"
           severity: warning
           type: ceph_default
         exp_annotations:
+          summary: Network issues delaying OSD heartbeats (cluster network)
           description: |
             OSD heartbeats on the cluster's 'cluster' network (backend) are running slow. Investigate the network
             for any latency issues on this subnet. Use 'ceph health detail' to show the affected OSDs.
@@ -1346,9 +1390,9 @@ tests:
            value: 0
    alert_rule_test:
     - eval_time: 1m
-      alertname: OSD disk size mismatch
+      alertname: CephOSDInternalDiskSizeMismatch
     - eval_time: 10m
-      alertname: OSD disk size mismatch
+      alertname: CephOSDInternalDiskSizeMismatch
       exp_alerts:
       - exp_labels:
           name: "BLUESTORE_DISK_SIZE_MISMATCH"
@@ -1356,6 +1400,7 @@ tests:
           type: ceph_default
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-disk-size-mismatch
+          summary: OSD size inconsistency error
           description: |
             One or more OSDs have an internal inconsistency between the size of the physical device and it's metadata.
             This could lead to the OSD(s) crashing in future. You should redeploy the effected OSDs.
@@ -1371,9 +1416,9 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: OSD Read errors
+      alertname: CephOSDReadErrors
     - eval_time: 10m
-      alertname: OSD Read errors
+      alertname: CephOSDReadErrors
       exp_alerts:
       - exp_labels:
           name: "BLUESTORE_SPURIOUS_READ_ERRORS"
@@ -1381,6 +1426,7 @@ tests:
           type: ceph_default
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#bluestore-spurious-read-errors
+          summary: Device read errors detected
           description: >
             An OSD has encountered read errors, but the OSD has recovered by retrying
             the reads. This may indicate an issue with the Hardware or Kernel.
@@ -1408,17 +1454,18 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: OSD down
+      alertname: CephOSDDown
     - eval_time: 10m
-      alertname: OSD down
+      alertname: CephOSDDown
       exp_alerts:
       - exp_labels:
           name: "OSD_DOWN"
           severity: warning
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.4.2
+          oid: 1.3.6.1.4.1.50495.1.2.1.4.2
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-down
+          summary: An OSD has been marked down/unavailable
           description: |
             1 OSD down for over 5mins.
 
@@ -1436,21 +1483,51 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: OSDs near full
+      alertname: CephOSDNearFull
     - eval_time: 10m
-      alertname: OSDs near full
+      alertname: CephOSDNearFull
       exp_alerts:
       - exp_labels:
           name: "OSD_NEARFULL"
           severity: warning
           type: ceph_default
-          oid: 1.3.6.1.4.1.50495.15.1.2.4.3
+          oid: 1.3.6.1.4.1.50495.1.2.1.4.3
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-nearfull
+          summary: OSD(s) running low on free space (NEARFULL)
           description: |
             One or more OSDs have reached their NEARFULL threshold
 
             Use 'ceph health detail' to identify which OSDs have reached this threshold.
+            To resolve, either add capacity to the cluster, or delete unwanted data
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="OSD_FULL"}'
+      values: '0+0x2 1+0x10'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="OSD_FULL"} == 1
+       eval_time: 3m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="OSD_FULL"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: CephOSDFull
+    - eval_time: 10m
+      alertname: CephOSDFull
+      exp_alerts:
+      - exp_labels:
+          name: "OSD_FULL"
+          severity: critical
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.4.6
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-full
+          summary: OSD(s) is full, writes blocked
+          description: |
+            An OSD has reached it's full threshold. Writes from all pools that share the
+            affected OSD will be blocked.
+
             To resolve, either add capacity to the cluster, or delete unwanted data
  - interval: 1m
    input_series:
@@ -1464,9 +1541,9 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: OSD unable to perform rebalance
+      alertname: CephOSDBackfillFull
     - eval_time: 10m
-      alertname: OSD unable to perform rebalance
+      alertname: CephOSDBackfillFull
       exp_alerts:
       - exp_labels:
           name: "OSD_BACKFILLFULL"
@@ -1474,6 +1551,7 @@ tests:
           type: ceph_default
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-backfillfull
+          summary: OSD(s) too full for backfill operations
           description: |
             An OSD has reached it's BACKFILL FULL threshold. This will prevent rebalance operations
             completing for some pools. Check the current capacity utilisation with 'ceph df'
@@ -1491,9 +1569,9 @@ tests:
            value: 0
    alert_rule_test:
     - eval_time: 1m
-      alertname: OSD too many read repairs
+      alertname: CephOSDTooManyRepairs
     - eval_time: 10m
-      alertname: OSD too many read repairs
+      alertname: CephOSDTooManyRepairs
       exp_alerts:
       - exp_labels:
           name: "OSD_TOO_MANY_REPAIRS"
@@ -1501,10 +1579,45 @@ tests:
           type: ceph_default
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#osd-too-many-repairs
+          summary: OSD has hit a high number of read errors
           description: |
             Reads from an OSD have used a secondary PG to return data to the client, indicating
             a potential failing disk.
 # Pools
+   # trigger percent full prediction on pools 1 and 2 only
+ - interval: 12h
+   input_series:
+    - series: 'ceph_pool_percent_used{pool_id="1"}'
+      values: '70 75 80 87 92'
+    - series: 'ceph_pool_percent_used{pool_id="2"}'
+      values: '22 22 23 23 24'
+    - series: 'ceph_pool_metadata{pool_id="1",name="rbd",type="replicated"}'
+      values: '1 1 1 1 1'
+    - series: 'ceph_pool_metadata{pool_id="2",name="default.rgw.index",type="replicated"}'
+      values: '1 1 1 1 1'
+   promql_expr_test:
+     - expr: |
+         (predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5) * on(pool_id)
+              group_right ceph_pool_metadata) >= 95
+       eval_time: 36h
+       exp_samples:
+         - labels: '{name="rbd",pool_id="1",type="replicated"}'
+           value: 1.424E+02 # 142%
+   alert_rule_test:
+    - eval_time: 48h
+      alertname: CephPoolGrowthWarning
+      exp_alerts:
+      - exp_labels:
+          name: rbd
+          pool_id: 1
+          severity: warning
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.9.2
+        exp_annotations:
+          summary: Pool growth rate may soon exceed it's capacity
+          description: >
+            Pool 'rbd' will be full in less than 5 days
+            assuming the average fill-up rate of the past 48 hours.
  - interval: 1m
    input_series:
     - series: 'ceph_health_detail{name="POOL_BACKFILLFULL"}'
@@ -1517,51 +1630,21 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Ceph pool is too full for recovery/rebalance
+      alertname: CephPoolBackfillFull
     - eval_time: 5m
-      alertname: Ceph pool is too full for recovery/rebalance
+      alertname: CephPoolBackfillFull
       exp_alerts:
       - exp_labels:
           name: "POOL_BACKFILLFULL"
           severity: warning
           type: ceph_default
         exp_annotations:
+          summary: Freespace in a pool is too low for recovery/rebalance
           description: >
             A pool is approaching it's near full threshold, which will
             prevent rebalance operations from completing. You should
             consider adding more capacity to the pool.
 
- - interval: 1m
-   input_series:
-    - series: 'ceph_health_detail{name="POOL_FULL"}'
-      values: '0+0x2 1+0x10'
-   promql_expr_test:
-     - expr: ceph_health_detail{name="POOL_FULL"} == 1
-       eval_time: 3m
-       exp_samples:
-         - labels: '{__name__="ceph_health_detail", name="POOL_FULL"}'
-           value: 1
-   alert_rule_test:
-    - eval_time: 1m
-      alertname: Ceph pool is full - writes blocked
-    - eval_time: 10m
-      alertname: Ceph pool is full - writes blocked
-      exp_alerts:
-      - exp_labels:
-          name: "POOL_FULL"
-          severity: critical
-          type: ceph_default
-        exp_annotations:
-          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pool-full
-          description: |
-            A pool has reached it's MAX quota, or the OSDs supporting the pool
-            have reached their FULL threshold. Until this is resolved, writes to
-            the pool will be blocked.
-
-            Determine the affected pool with 'ceph df detail', for example looking
-            at QUOTA BYTES and STORED. Either increase the pools quota, or add
-            capacity to the cluster first then increase it's quota
-            (e.g. ceph osd pool set quota <pool_name> max_bytes <bytes>)
  - interval: 1m
    input_series:
     - series: 'ceph_health_detail{name="POOL_NEAR_FULL"}'
@@ -1574,15 +1657,16 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Ceph pool is approaching full
+      alertname: CephPoolNearFull
     - eval_time: 10m
-      alertname: Ceph pool is approaching full
+      alertname: CephPoolNearFull
       exp_alerts:
       - exp_labels:
           name: "POOL_NEAR_FULL"
           severity: warning
           type: ceph_default
         exp_annotations:
+          summary: One or more Ceph pools are getting full
           description: |
             A pool has exceeeded it warning (percent full) threshold, or the OSDs
             supporting the pool have reached their NEARFULL thresholds. Writes may
@@ -1607,9 +1691,9 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Placement Group(s) have not been scrubbed
+      alertname: CephPGNotScrubbed
     - eval_time: 10m
-      alertname: Placement Group(s) have not been scrubbed
+      alertname: CephPGNotScrubbed
       exp_alerts:
       - exp_labels:
           name: "PG_NOT_SCRUBBED"
@@ -1617,6 +1701,7 @@ tests:
           type: ceph_default
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-scrubbed
+          summary: Placement group(s) have not been scrubbed
           description: |
             One or more PGs have not been scrubbed recently. The scrub process is a data integrity
             feature, protectng against bit-rot. It checks that objects and their metadata (size and
@@ -1625,6 +1710,67 @@ tests:
             scrub window.
 
             You can manually initiate a scrub with: ceph pg scrub <pgid>
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="PG_DAMAGED"}'
+      values: '0+0x4 1+0x20'
+   promql_expr_test:
+     - expr: ceph_health_detail{name=~"PG_DAMAGED|OSD_SCRUB_ERRORS"} == 1
+       eval_time: 5m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="PG_DAMAGED"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: CephPGsDamaged
+    - eval_time: 10m
+      alertname: CephPGsDamaged
+      exp_alerts:
+      - exp_labels:
+          name: "PG_DAMAGED"
+          severity: critical
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.7.4
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-damaged
+          summary: Placement group damaged, manual intervention needed
+          description: >
+            During data consistency checks (scrub), at least one PG has been flagged as being
+            damaged or inconsistent.
+
+            Check to see which PG is affected, and attempt a manual repair if neccessary. To list
+            problematic placement groups, use 'rados list-inconsistent-pg <pool>'. To repair PGs use
+            the 'ceph pg repair <pg_num>' command.
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="TOO_MANY_PGS"}'
+      values: '0+0x4 1+0x20'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="TOO_MANY_PGS"} == 1
+       eval_time: 5m
+       exp_samples:
+         - labels: '{__name__="ceph_health_detail", name="TOO_MANY_PGS"}'
+           value: 1
+   alert_rule_test:
+    - eval_time: 1m
+      alertname: CephPGsHighPerOSD
+    - eval_time: 10m
+      alertname: CephPGsHighPerOSD
+      exp_alerts:
+      - exp_labels:
+          name: "TOO_MANY_PGS"
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#too-many-pgs
+          summary: Placement groups per OSD is too high
+          description: |
+            The number of placement groups per OSD is too high (exceeds the mon_max_pg_per_osd setting).
+
+            Check that the pg_autoscaler hasn't been disabled for any of the pools, with 'ceph osd pool autoscale-status'
+            and that the profile selected is appropriate. You may also adjust the target_size_ratio of a pool to guide
+            the autoscaler based on the expected relative size of the pool
+            (i.e. 'ceph osd pool set cephfs.cephfs.meta target_size_ratio .1')
  - interval: 1m
    input_series:
     - series: 'ceph_health_detail{name="PG_RECOVERY_FULL"}'
@@ -1637,16 +1783,18 @@ tests:
            value: 0
    alert_rule_test:
     - eval_time: 1m
-      alertname: Recovery at risk, cluster too full
+      alertname: CephPGRecoveryAtRisk
     - eval_time: 10m
-      alertname: Recovery at risk, cluster too full
+      alertname: CephPGRecoveryAtRisk
       exp_alerts:
       - exp_labels:
           name: "PG_RECOVERY_FULL"
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.7.5
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-recovery-full
+          summary: OSDs are too full for automatic recovery
           description: >
             Data redundancy may be reduced, or is at risk, since one or more OSDs are at or above their
             'full' threshold. Add more capacity to the cluster, or delete unwanted data.
@@ -1662,16 +1810,18 @@ tests:
            value: 0
    alert_rule_test:
     - eval_time: 1m
-      alertname: Cluster too full, automatic data recovery impaired
+      alertname: CephPGBackfillAtRisk
     - eval_time: 10m
-      alertname: Cluster too full, automatic data recovery impaired
+      alertname: CephPGBackfillAtRisk
       exp_alerts:
       - exp_labels:
           name: "PG_BACKFILL_FULL"
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.7.6
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-backfill-full
+          summary: Backfill operations are blocked, due to lack of freespace
           description: >
             Data redundancy may be at risk due to lack of free space within the cluster. One or more OSDs
             have breached their 'backfillfull' threshold. Add more capacity, or delete unwanted data.
@@ -1689,22 +1839,24 @@ tests:
    alert_rule_test:
     # PG_AVAILABILITY and OSD_DOWN not firing .. no alert
     - eval_time: 1m
-      alertname: I/O blocked to some data
+      alertname: CephPGUnavilableBlockingIO
       exp_alerts:
     # PG_AVAILABILITY firing, but osd_down is active .. no alert
     - eval_time: 5m
-      alertname: I/O blocked to some data
+      alertname: CephPGUnavilableBlockingIO
       exp_alerts:
     # PG_AVAILABILITY firing, AND OSD_DOWN is not active...raise the alert
     - eval_time: 15m
-      alertname: I/O blocked to some data
+      alertname: CephPGUnavilableBlockingIO
       exp_alerts:
       - exp_labels:
           name: "PG_AVAILABILITY"
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.7.3
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-availability
+          summary: Placement group is unavailable, blocking some I/O
           description: >
             Data availability is reduced impacting the clusters abilty to service I/O to some data. One or
             more placement groups (PGs) are in a state that blocks IO.
@@ -1720,9 +1872,9 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 1m
-      alertname: Placement Group(s) have not been 'DEEP' scrubbed
+      alertname: CephPGNotDeepScrubbed
     - eval_time: 10m
-      alertname: Placement Group(s) have not been 'DEEP' scrubbed
+      alertname: CephPGNotDeepScrubbed
       exp_alerts:
       - exp_labels:
           name: "PG_NOT_DEEP_SCRUBBED"
@@ -1730,6 +1882,7 @@ tests:
           type: ceph_default
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-not-deep-scrubbed
+          summary: Placement group(s) have not been deep scrubbed
           description: |
             One or more PGs have not been deep scrubbed recently. Deep scrub is a data integrity
             feature, protectng against bit-rot. It compares the contents of objects and their
@@ -1752,13 +1905,15 @@ tests:
            value: 1
    alert_rule_test:
     - eval_time: 5m
-      alertname: Scrape job is missing
+      alertname: PrometheusJobMissing
       exp_alerts:
       - exp_labels:
           job: ceph
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.12.1
         exp_annotations:
+          summary: The scrape job for Ceph is missing from Prometheus
           description: |
             The prometheus job that scrapes from Ceph is no longer defined, this
             will effectively mean you'll have no metrics or alerts for the cluster.
@@ -1789,18 +1944,50 @@ tests:
    alert_rule_test:
     # OBJECT_UNFOUND but osd.2 is down, so don't fire
     - eval_time: 5m
-      alertname: Data not found/missing
+      alertname: CephObjectMissing
       exp_alerts:
     # OBJECT_UNFOUND and all osd's are online, so fire
     - eval_time: 15m
-      alertname: Data not found/missing
+      alertname: CephObjectMissing
       exp_alerts:
       - exp_labels:
           severity: critical
           type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.10.1
         exp_annotations:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#object-unfound
+          summary: Object(s) has been marked UNFOUND
           description: |
             A version of a RADOS object can not be found, even though all OSDs are up. I/O
             requests for this object from clients will block (hang). Resolving this issue may
             require the object to be rolled back to a prior version manually, and manually verified.
+# Generic Alerts
+ - interval: 1m
+   input_series:
+    - series: 'ceph_health_detail{name="RECENT_CRASH"}'
+      values: '0 0 0 1 1 1 1 1 1 1 1'
+   promql_expr_test:
+     - expr: ceph_health_detail{name="RECENT_CRASH"} == 1
+       eval_time: 1m
+       exp_samples:
+   alert_rule_test:
+    # not firing
+    - eval_time: 1m
+      alertname: CephDaemonCrash
+      exp_alerts:
+    # firing
+    - eval_time: 10m
+      alertname: CephDaemonCrash
+      exp_alerts:
+      - exp_labels:
+          name: RECENT_CRASH
+          severity: critical
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.1.2.1.1.2
+        exp_annotations:
+          documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks/#recent-crash
+          summary: One or more Ceph daemons have crashed, and are pending acknowledgement
+          description: |
+            One or more daemons have crashed recently, and need to be acknowledged. This notification
+            ensures that software crashes don't go unseen. To acknowledge a crash, use the
+            'ceph crash archive <id>' command.

--- a/monitoring/prometheus/tests/test_syntax.py
+++ b/monitoring/prometheus/tests/test_syntax.py
@@ -1,0 +1,42 @@
+import pytest
+import os
+import yaml
+from .utils import promtool_available, call
+from .settings import ALERTS_FILE, UNIT_TESTS_FILE
+
+
+def load_yaml(file_name):
+    yaml_data = None
+    with open(file_name, 'r') as alert_file:
+        raw = alert_file.read()
+        try:
+            yaml_data = yaml.safe_load(raw)
+        except yaml.YAMLError as e:
+            pass
+
+    return yaml_data
+
+
+def test_alerts_present():
+    assert os.path.exists(ALERTS_FILE), f"{ALERTS_FILE} not found"
+
+
+def test_unittests_present():
+    assert os.path.exists(UNIT_TESTS_FILE), f"{UNIT_TESTS_FILE} not found"
+
+
+@pytest.mark.skipif(not os.path.exists(ALERTS_FILE), reason=f"{ALERTS_FILE} missing")
+def test_rules_format():
+    assert load_yaml(ALERTS_FILE)
+
+
+@pytest.mark.skipif(not os.path.exists(UNIT_TESTS_FILE), reason=f"{UNIT_TESTS_FILE} missing")
+def test_unittests_format():
+    assert load_yaml(UNIT_TESTS_FILE)
+
+
+@pytest.mark.skipif(not promtool_available(), reason="promtool is not installed. Unable to check syntax")
+def test_rule_syntax():
+    completion = call(f"promtool check rules {ALERTS_FILE}")
+    assert completion.returncode == 0
+    assert b"SUCCESS" in completion.stdout

--- a/monitoring/prometheus/tests/test_unittests.py
+++ b/monitoring/prometheus/tests/test_unittests.py
@@ -1,0 +1,19 @@
+import pytest
+import os
+from .utils import promtool_available, call
+from .settings import ALERTS_FILE, UNIT_TESTS_FILE
+
+
+def test_alerts_present():
+    assert os.path.exists(ALERTS_FILE), f"{ALERTS_FILE} not found"
+
+
+def test_unittests_present():
+    assert os.path.exists(UNIT_TESTS_FILE), f"{UNIT_TESTS_FILE} not found"
+
+
+@pytest.mark.skipif(not promtool_available(), reason="promtool is not installed. Unable to run unit tests")
+def test_run_unittests():
+    completion = call(f"promtool test rules {UNIT_TESTS_FILE}")
+    assert completion.returncode == 0
+    assert b"SUCCESS" in completion.stdout

--- a/monitoring/prometheus/tests/tox.ini
+++ b/monitoring/prometheus/tests/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py36
+skipsdist = true
+
+[testenv]
+deps =
+    -rrequirements.txt
+    pytest
+commands =
+    pytest -rA test_syntax.py test_unittests.py
+    ./validate_rules.py

--- a/monitoring/prometheus/tests/tox.ini
+++ b/monitoring/prometheus/tests/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py3
 skipsdist = true
 
 [testenv]

--- a/monitoring/prometheus/tests/utils.py
+++ b/monitoring/prometheus/tests/utils.py
@@ -1,0 +1,12 @@
+import pytest
+import shutil
+import subprocess
+
+
+def promtool_available() -> bool:
+    return shutil.which('promtool') is not None
+
+
+def call(cmd):
+    completion = subprocess.run(cmd.split(), stdout=subprocess.PIPE)
+    return completion

--- a/monitoring/prometheus/tests/validate_rules.py
+++ b/monitoring/prometheus/tests/validate_rules.py
@@ -8,15 +8,20 @@
 #  8 .. Missing fields in YAML
 # 12 .. Invalid YAML - unable to load
 # 16 .. Missing input files
-
-# TODO: logging for debug
+#
+# Externals
+# snmptranslate .. used to determine the oid's in the MIB to verify the rule -> MIB is correct
+#
 
 import re
 import os
 import sys
 import yaml
+import shutil
+import string
 from bs4 import BeautifulSoup
 from typing import List, Any, Dict, Set, Optional, Tuple
+import subprocess
 
 import urllib.request
 import urllib.error
@@ -25,6 +30,15 @@ from urllib.parse import urlparse
 DOCLINK_NAME = 'documentation'
 DEFAULT_RULES_FILENAME = '../alerts/ceph_default_alerts.yml'
 DEFAULT_TEST_FILENAME = 'test_alerts.yml'
+MIB_FILE = '../../snmp/CEPH-MIB.txt'
+
+
+def isascii(s: str) -> bool:
+    try:
+        s.encode('ascii')
+    except UnicodeEncodeError:
+        return False
+    return True
 
 
 def read_file(file_name: str) -> Tuple[str, str]:
@@ -50,6 +64,14 @@ def load_yaml(file_name: str) -> Tuple[Dict[str, Any], str]:
             errs = f"filename '{file_name} is not a valid YAML file"
 
     return data, errs
+
+
+def run_command(command: str):
+    c = command.split()
+    completion = subprocess.run(c, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return (completion.returncode,
+            completion.stdout.decode('utf-8').split('\n'),
+            completion.stderr.decode('utf-8').split('\n'))
 
 
 class HTMLCache:
@@ -93,7 +115,6 @@ class PrometheusRule:
     expected_attrs = [
         'alert',
         'expr',
-        'for',
         'labels',
         'annotations'
     ]
@@ -106,11 +127,30 @@ class PrometheusRule:
         self.rule = rule_data
         self.errors: List[str] = []
         self.warnings: List[str] = []
-
         self.validate()
 
+    @property
+    def has_oid(self):
+        return True if self.rule.get('labels', {}).get('oid', '') else False
+
+    @property
+    def labels(self) -> Dict[str, str]:
+        return self.rule.get('labels', {})
+
+    @property
+    def annotations(self) -> Dict[str, str]:
+        return self.rule.get('annotations', {})
+
     def _check_alert_name(self):
-        pass
+        # this is simplistic, but works in the context of the alert name
+        if self.name[0] in string.ascii_uppercase and \
+          self.name != self.name.lower() and \
+          self.name != self.name.upper() and \
+          " " not in self.name and \
+          "_" not in self.name:
+            return
+
+        self.warnings.append("Alert name is not in CamelCase format")
 
     def _check_structure(self):
         rule_attrs = self.rule.keys()
@@ -123,17 +163,16 @@ class PrometheusRule:
 
     def _check_labels(self):
         for rqd in ['severity', 'type']:
-            if rqd not in self.rule.get('labels', ''):
+            if rqd not in self.labels.keys():
                 self.errors.append(f"rule is missing {rqd} label definition")
 
     def _check_annotations(self):
-        for rqd in ['description']:
-                if rqd not in self.rule.get('annotations', ''):
+        for rqd in ['summary', 'description']:
+                if rqd not in self.annotations:
                     self.errors.append(f"rule is missing {rqd} annotation definition")
 
     def _check_doclink(self):
-        annotations = self.rule.get('annotations', {})
-        doclink = annotations.get(DOCLINK_NAME, '')
+        doclink = self.annotations.get(DOCLINK_NAME, '')
 
         if doclink:
             url = urlparse(doclink)
@@ -148,20 +187,36 @@ class PrometheusRule:
                 self.errors.append(f"documentation link error: {status} {content}")
 
     def _check_snmp(self):
-        labels = self.rule.get('labels', {})
-        oid = labels.get('oid', '')
-        if labels.get('severity', '') == 'critical' and not oid:
+        oid = self.labels.get('oid', '')
+
+        if self.labels.get('severity', '') == 'critical' and not oid:
             self.warnings.append("critical level alert is missing an SNMP oid entry")
-        if oid and not re.search('^1.3.6.1.4.1.50495.15.1.2.\\d+.\\d+$', oid):
-            self.errors.append("invalid OID provided")
+        if oid and not re.search('^1.3.6.1.4.1.50495.1.2.\\d+.\\d+.\\d+$', oid):
+            self.errors.append("invalid OID format provided")
+        if self.group.get_oids():
+            if oid and oid not in self.group.get_oids():
+                self.errors.append(f"rule defines an OID {oid} that is missing from the MIB file({os.path.basename(MIB_FILE)})")
+
+    def _check_ascii(self):
+        if 'oid' not in self.labels:
+            return
+
+        desc = self.annotations.get('description', '')
+        summary = self.annotations.get('summary', '')
+        if not isascii(desc):
+            self.errors.append(f"non-ascii characters found in 'description' field will cause issues in associated snmp trap.")
+        if not isascii(summary):
+            self.errors.append(f"non-ascii characters found in 'summary' field will cause issues in associated snmp trap.")
 
     def validate(self):
+
         self._check_alert_name()
         self._check_structure()
         self._check_labels()
         self._check_annotations()
         self._check_doclink()
         self._check_snmp()
+        self._check_ascii()
         char = '.'
 
         if self.errors:
@@ -200,6 +255,9 @@ class RuleGroup:
     def fetch_html_page(self, url):
         return self.rule_file.fetch_html_page(url)
 
+    def get_oids(self):
+        return self.rule_file.oid_list
+
     @property
     def error_count(self):
         return len(self.problems['error'])
@@ -214,10 +272,11 @@ class RuleGroup:
 
 class RuleFile:
 
-    def __init__(self, parent, file_name, rules):
+    def __init__(self, parent, file_name, rules, oid_list):
         self.parent = parent
         self.file_name = file_name
         self.rules: Dict[str, Any] = rules
+        self.oid_list = oid_list
         self.problems: Set[str] = set()
         self.group: Dict[str, RuleGroup] = {}
         self.alert_names_seen: Set[str] = set()
@@ -242,9 +301,18 @@ class RuleFile:
     @property
     def rule_count(self):
         rule_count = 0
-        for group_name, rule_group in self.group.items():
+        for _group_name, rule_group in self.group.items():
             rule_count += rule_group.count
         return rule_count
+
+    @property
+    def oid_count(self):
+        oid_count = 0
+        for _group_name, rule_group in self.group.items():
+            for _rule_name, rule in rule_group.rules.items():
+                if rule.has_oid:
+                    oid_count += 1
+        return oid_count
 
     @property
     def group_names(self):
@@ -278,23 +346,23 @@ class RuleFile:
                     # skipped recording rule
                     pass
 
-    def error_report(self):
-        def max_width(item_list: List[str]) -> int:
-            return max([len(i) for i in item_list])
+    def report(self):
+        def max_width(item_list: Set[str], min_width: int = 0) -> int:
+            return max([len(i) for i in item_list] + [min_width])
 
         if not self.problems and not self.duplicate_alert_names:
-            print("\nNo problems detected in rule file")
+            print("\nNo problems detected in the rule file")
             return
 
         print("\nProblem Report\n")
 
-        group_width = max_width(self.problems)
+        group_width = max_width(self.problems, 5)
         alert_names = set()
         for g in self.problems:
             group = self.group[g]
             alert_names.update(group.problems.get('error', []))
             alert_names.update(group.problems.get('warning', []))
-        alert_width = max_width(alert_names)
+        alert_width = max_width(alert_names, 10)
 
         template = "  {group:<{group_width}}  {severity:<8}  {alert_name:<{alert_width}}  {description}"
 
@@ -382,7 +450,7 @@ class UnitTests:
     def process(self, defined_alert_names: List[str]):
         self._check_alert_names(defined_alert_names)
 
-    def error_report(self) -> None:
+    def report(self) -> None:
 
         if not self.problems:
             print("\nNo problems detected in unit tests file")
@@ -404,6 +472,26 @@ class RuleChecker:
         self.warnings = {}
         self.error_count = 0
         self.warning_count = 0
+        self.oid_count = 0
+
+        self.oid_list = self.build_oid_list()
+
+    def build_oid_list(self) -> List[str]:
+
+        cmd = shutil.which('snmptranslate')
+        if not cmd:
+            return []
+
+        rc, stdout, stderr = run_command(f"{cmd} -Pu -Tz -M ../../snmp:/usr/share/snmp/mibs -m CEPH-MIB")
+        if rc != 0:
+            return []
+
+        oid_list: List[str] = []
+        for line in stdout[:-1]:
+            _label, oid = line.replace('"', '').replace('\t', ' ').split()
+            oid_list.append(oid)
+
+        return oid_list
 
     @property
     def status(self):
@@ -448,36 +536,34 @@ class RuleChecker:
             print(errs)
             sys.exit(12)
 
-        self.rule_file = RuleFile(self, self.rules_filename, rules)
+        self.rule_file = RuleFile(self, self.rules_filename, rules, self.oid_list)
         self.summarise_rule_file()
 
         self.unit_tests = UnitTests(self.test_filename)
         self.unit_tests.process(self.rule_file.alert_names_seen)
 
-    def error_report(self):
+    def report(self):
         print("\n\nSummary\n")
         print(f"Rule file             : {self.rules_filename}")
         print(f"Unit Test file        : {self.test_filename}")
         print(f"\nRule groups processed : {self.rule_file.group_count:>3}")
         print(f"Rules processed       : {self.rule_file.rule_count:>3}")
+        print(f"SNMP OIDs declared    : {self.rule_file.oid_count:>3} {'(snmptranslate missing, unable to cross check)' if not self.oid_list else ''}")
         print(f"Rule errors           : {self.error_count:>3}")
         print(f"Rule warnings         : {self.warning_count:>3}")
         print(f"Rule name duplicates  : {len(self.rule_file.duplicate_alert_names):>3}")
         print(f"Unit tests missing    : {len(self.unit_tests.problems):>3}")
 
-        if self.rule_file_problems:
-            self.rule_file.error_report()
-        if self.unit_tests.problems:
-            self.unit_tests.error_report()
+        self.rule_file.report()
+        self.unit_tests.report()
 
 
 def main():
     checker = RuleChecker()
 
     checker.run()
-    if checker.status > 0:
-        checker.error_report()
-        print()
+    checker.report()
+    print()
 
     sys.exit(checker.status)
 

--- a/monitoring/prometheus/tests/validate_rules.py
+++ b/monitoring/prometheus/tests/validate_rules.py
@@ -1,0 +1,486 @@
+#!/usr/bin/python3 -u
+#
+# Check the Prometheus rules for format, and integration
+# with the unit tests. This script has the following exit
+# codes:
+#  0 .. Everything worked
+#  4 .. rule problems or missing unit tests
+#  8 .. Missing fields in YAML
+# 12 .. Invalid YAML - unable to load
+# 16 .. Missing input files
+
+# TODO: logging for debug
+
+import re
+import os
+import sys
+import yaml
+from bs4 import BeautifulSoup
+from typing import List, Any, Dict, Set, Optional, Tuple
+
+import urllib.request
+import urllib.error
+from urllib.parse import urlparse
+
+DOCLINK_NAME = 'documentation'
+DEFAULT_RULES_FILENAME = '../alerts/ceph_default_alerts.yml'
+DEFAULT_TEST_FILENAME = 'test_alerts.yml'
+
+
+def read_file(file_name: str) -> Tuple[str, str]:
+    try:
+        with open(file_name, 'r') as input_file:
+            raw_data = input_file.read()
+    except OSError:
+        return '', f"Unable to open {file_name}"
+
+    return raw_data, ''
+
+
+def load_yaml(file_name: str) -> Tuple[Dict[str, Any], str]:
+    data = {}
+    errs = ''
+
+    raw_data, err = read_file(file_name)
+    if not err:
+
+        try:
+            data = yaml.safe_load(raw_data)
+        except yaml.YAMLError as e:
+            errs = f"filename '{file_name} is not a valid YAML file"
+
+    return data, errs
+
+
+class HTMLCache:
+    def __init__(self) -> None:
+        self.cache: Dict[str, Tuple[int, str]] = {}
+
+    def fetch(self, url_str: str) -> None:
+        parsed = urlparse(url_str)
+        url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+
+        if url in self.cache:
+            return self.cache[url]
+
+        req = urllib.request.Request(url)
+        try:
+            r = urllib.request.urlopen(req)
+        except urllib.error.HTTPError as e:
+            self.cache[url] = e.code, e.reason
+            return self.cache[url]
+        except urllib.error.URLError as e:
+            self.cache[url] = 400, e.reason
+            return self.cache[url]
+
+        if r.status == 200:
+            html = r.read().decode('utf-8')
+            self.cache[url] = 200, html
+            return self.cache[url]
+
+        self.cache[url] = r.status, r.reason
+        return r.status, r.reason
+
+    @property
+    def cached_pages(self) -> List[str]:
+        return self.cache.keys()
+
+    @property
+    def cached_pages_total(self) -> int:
+        return len(self.cache.keys())
+
+class PrometheusRule:
+    expected_attrs = [
+        'alert',
+        'expr',
+        'for',
+        'labels',
+        'annotations'
+    ]
+
+    def __init__(self, rule_group, rule_data: Dict[str, Any]):
+
+        assert 'alert' in rule_data
+        self.group: RuleGroup = rule_group
+        self.name = rule_data.get('alert')
+        self.rule = rule_data
+        self.errors: List[str] = []
+        self.warnings: List[str] = []
+
+        self.validate()
+
+    def _check_alert_name(self):
+        pass
+
+    def _check_structure(self):
+        rule_attrs = self.rule.keys()
+        missing_attrs = [a for a in PrometheusRule.expected_attrs if a not in rule_attrs]
+
+        if missing_attrs:
+            self.errors.append(
+                f"invalid alert structure. Missing field{'s' if len(missing_attrs) > 1 else ''}"
+                f": {','.join(missing_attrs)}")
+
+    def _check_labels(self):
+        for rqd in ['severity', 'type']:
+            if rqd not in self.rule.get('labels', ''):
+                self.errors.append(f"rule is missing {rqd} label definition")
+
+    def _check_annotations(self):
+        for rqd in ['description']:
+                if rqd not in self.rule.get('annotations', ''):
+                    self.errors.append(f"rule is missing {rqd} annotation definition")
+
+    def _check_doclink(self):
+        annotations = self.rule.get('annotations', {})
+        doclink = annotations.get(DOCLINK_NAME, '')
+
+        if doclink:
+            url = urlparse(doclink)
+            status, content = self.group.fetch_html_page(doclink)
+            if status == 200:
+                if url.fragment:
+                    soup = BeautifulSoup(content, 'html.parser')
+                    if not soup.find(id=url.fragment):
+                        self.errors.append(f"documentation link error: {url.fragment} anchor not found on the page")
+            else:
+                # catch all
+                self.errors.append(f"documentation link error: {status} {content}")
+
+    def _check_snmp(self):
+        labels = self.rule.get('labels', {})
+        oid = labels.get('oid', '')
+        if labels.get('severity', '') == 'critical' and not oid:
+            self.warnings.append("critical level alert is missing an SNMP oid entry")
+        if oid and not re.search('^1.3.6.1.4.1.50495.15.1.2.\\d+.\\d+$', oid):
+            self.errors.append("invalid OID provided")
+
+    def validate(self):
+        self._check_alert_name()
+        self._check_structure()
+        self._check_labels()
+        self._check_annotations()
+        self._check_doclink()
+        self._check_snmp()
+        char = '.'
+
+        if self.errors:
+            char = 'E'
+            self.group.update('error', self.name)
+        elif self.warnings:
+            char = 'W'
+            self.group.update('warning', self.name)
+
+        sys.stdout.write(char)
+
+
+class RuleGroup:
+
+    def __init__(self, rule_file, group_name: str, group_name_width: int):
+        self.rule_file: RuleFile = rule_file
+        self.group_name = group_name
+        self.rules: Dict[str, PrometheusRule] = {}
+        self.problems = {
+            "error": [],
+            "warning": [],
+        }
+
+        sys.stdout.write(f"\n\t{group_name:<{group_name_width}} : ")
+
+    def add_rule(self, rule_data:Dict[str, Any]):
+        alert_name = rule_data.get('alert')
+        self.rules[alert_name] = PrometheusRule(self, rule_data)
+
+    def update(self, problem_type:str, alert_name:str):
+        assert problem_type in ['error', 'warning']
+
+        self.problems[problem_type].append(alert_name)
+        self.rule_file.update(self.group_name)
+
+    def fetch_html_page(self, url):
+        return self.rule_file.fetch_html_page(url)
+
+    @property
+    def error_count(self):
+        return len(self.problems['error'])
+
+    def warning_count(self):
+        return len(self.problems['warning'])
+
+    @property
+    def count(self):
+        return len(self.rules)
+
+
+class RuleFile:
+
+    def __init__(self, parent, file_name, rules):
+        self.parent = parent
+        self.file_name = file_name
+        self.rules: Dict[str, Any] = rules
+        self.problems: Set[str] = set()
+        self.group: Dict[str, RuleGroup] = {}
+        self.alert_names_seen: Set[str] = set()
+        self.duplicate_alert_names:List[str] = []
+        self.html_cache = HTMLCache()
+
+        assert 'groups' in self.rules
+        self.max_group_name_width = self.get_max_group_name()
+        self.load_groups()
+
+    def update(self, group_name):
+        self.problems.add(group_name)
+        self.parent.mark_invalid()
+
+    def fetch_html_page(self, url):
+        return self.html_cache.fetch(url)
+
+    @property
+    def group_count(self):
+        return len(self.rules['groups'])
+
+    @property
+    def rule_count(self):
+        rule_count = 0
+        for group_name, rule_group in self.group.items():
+            rule_count += rule_group.count
+        return rule_count
+
+    @property
+    def group_names(self):
+        return self.group.keys()
+
+    @property
+    def problem_count(self):
+        return len(self.problems)
+
+    def get_max_group_name(self):
+        group_name_list = []
+        for group in self.rules.get('groups'):
+            group_name_list.append(group['name'])
+        return max([len(g) for g in group_name_list])
+
+    def load_groups(self):
+        sys.stdout.write("\nChecking rule groups")
+        for group in self.rules.get('groups'):
+            group_name = group['name']
+            rules = group['rules']
+            self.group[group_name] = RuleGroup(self, group_name, self.max_group_name_width)
+            for rule_data in rules:
+                if 'alert' in rule_data:
+                    alert_name = rule_data.get('alert')
+                    if alert_name in self.alert_names_seen:
+                        self.duplicate_alert_names.append(alert_name)
+                    else:
+                        self.alert_names_seen.add(alert_name)
+                    self.group[group_name].add_rule(rule_data)
+                else:
+                    # skipped recording rule
+                    pass
+
+    def error_report(self):
+        def max_width(item_list: List[str]) -> int:
+            return max([len(i) for i in item_list])
+
+        if not self.problems and not self.duplicate_alert_names:
+            print("\nNo problems detected in rule file")
+            return
+
+        print("\nProblem Report\n")
+
+        group_width = max_width(self.problems)
+        alert_names = set()
+        for g in self.problems:
+            group = self.group[g]
+            alert_names.update(group.problems.get('error', []))
+            alert_names.update(group.problems.get('warning', []))
+        alert_width = max_width(alert_names)
+
+        template = "  {group:<{group_width}}  {severity:<8}  {alert_name:<{alert_width}}  {description}"
+
+        print(template.format(
+            group="Group",
+            group_width=group_width,
+            severity="Severity",
+            alert_name="Alert Name",
+            alert_width=alert_width,
+            description="Problem Description"))
+
+        print(template.format(
+            group="-----",
+            group_width=group_width,
+            severity="--------",
+            alert_name="----------",
+            alert_width=alert_width,
+            description="-------------------"))
+
+        for group_name in sorted(self.problems):
+            group = self.group[group_name]
+            rules = group.rules
+            for alert_name in group.problems.get('error', []):
+                for desc in rules[alert_name].errors:
+                    print(template.format(
+                            group=group_name,
+                            group_width=group_width,
+                            severity="Error",
+                            alert_name=alert_name,
+                            alert_width=alert_width,
+                            description=desc))
+            for alert_name in group.problems.get('warning', []):
+                for desc in rules[alert_name].warnings:
+                    print(template.format(
+                            group=group_name,
+                            group_width=group_width,
+                            severity="Warning",
+                            alert_name=alert_name,
+                            alert_width=alert_width,
+                            description=desc))
+        if self.duplicate_alert_names:
+            print("Duplicate alert names detected:")
+            for a in self.duplicate_alert_names:
+                print(f"  - {a}")
+
+
+class UnitTests:
+    expected_attrs = [
+        'rule_files',
+        'tests',
+        'evaluation_interval'
+    ]
+    def __init__(self, filename):
+        self.filename = filename
+        self.unit_test_data: Dict[str, Any] = {}
+        self.alert_names_seen: Set[str] = set()
+        self.problems: List[str] = []
+        self.load()
+
+    def load(self):
+        self.unit_test_data, errs = load_yaml(self.filename)
+        if errs:
+            print(f"\n\nError in unit tests file: {errs}")
+            sys.exit(12)
+
+        missing_attr = [a for a in UnitTests.expected_attrs if a not in self.unit_test_data.keys()]
+        if missing_attr:
+            print(f"\nMissing attributes in unit tests: {','.join(missing_attr)}")
+            sys.exit(8)
+
+    def _check_alert_names(self, alert_names: List[str]):
+        alerts_tested: Set[str] = set()
+        for t in self.unit_test_data.get('tests'):
+            test_cases = t.get('alert_rule_test', [])
+            if not test_cases:
+                continue
+            for case in test_cases:
+                alertname = case.get('alertname', '')
+                if alertname:
+                    alerts_tested.add(alertname)
+
+        alerts_defined = set(alert_names)
+        self.problems = list(alerts_defined.difference(alerts_tested))
+
+    def process(self, defined_alert_names: List[str]):
+        self._check_alert_names(defined_alert_names)
+
+    def error_report(self) -> None:
+
+        if not self.problems:
+            print("\nNo problems detected in unit tests file")
+            return
+
+        print("\nUnit tests are incomplete. Tests missing for the following alerts;")
+        for p in self.problems:
+            print(f"  - {p}")
+
+class RuleChecker:
+
+    def __init__(self, rules_filename: str = None, test_filename: str = None):
+        self.rules_filename = rules_filename or DEFAULT_RULES_FILENAME
+        self.test_filename = test_filename or DEFAULT_TEST_FILENAME
+        self.rule_file: Optional[RuleFile] = None
+        self.unit_tests: Optional[UnitTests] = None
+        self.rule_file_problems: bool = False
+        self.errors = {}
+        self.warnings = {}
+        self.error_count = 0
+        self.warning_count = 0
+
+    @property
+    def status(self):
+        if self.rule_file_problems or self.unit_tests.problems:
+            return 4
+
+        return 0
+
+    def mark_invalid(self):
+        self.rule_file_problems = True
+
+    def summarise_rule_file(self):
+        for group_name in self.rule_file.problems:
+            group = self.rule_file.group[group_name]
+            self.error_count += len(group.problems['error'])
+            self.warning_count += len(group.problems['warning'])
+
+    def ready(self):
+        errs: List[str] = []
+        ready_state = True
+        if not os.path.exists(self.rules_filename):
+            errs.append(f"rule file '{self.rules_filename}' not found")
+            ready_state = False
+
+        if not os.path.exists(self.test_filename):
+            errs.append(f"test file '{self.test_filename}' not found")
+            ready_state = False
+
+        return ready_state, errs
+
+    def run(self):
+
+        ready, errs = self.ready()
+        if not ready:
+            print("Unable to start:")
+            for e in errs:
+                print(f"- {e}")
+            sys.exit(16)
+
+        rules, errs = load_yaml(self.rules_filename)
+        if errs:
+            print(errs)
+            sys.exit(12)
+
+        self.rule_file = RuleFile(self, self.rules_filename, rules)
+        self.summarise_rule_file()
+
+        self.unit_tests = UnitTests(self.test_filename)
+        self.unit_tests.process(self.rule_file.alert_names_seen)
+
+    def error_report(self):
+        print("\n\nSummary\n")
+        print(f"Rule file             : {self.rules_filename}")
+        print(f"Unit Test file        : {self.test_filename}")
+        print(f"\nRule groups processed : {self.rule_file.group_count:>3}")
+        print(f"Rules processed       : {self.rule_file.rule_count:>3}")
+        print(f"Rule errors           : {self.error_count:>3}")
+        print(f"Rule warnings         : {self.warning_count:>3}")
+        print(f"Rule name duplicates  : {len(self.rule_file.duplicate_alert_names):>3}")
+        print(f"Unit tests missing    : {len(self.unit_tests.problems):>3}")
+
+        if self.rule_file_problems:
+            self.rule_file.error_report()
+        if self.unit_tests.problems:
+            self.unit_tests.error_report()
+
+
+def main():
+    checker = RuleChecker()
+
+    checker.run()
+    if checker.status > 0:
+        checker.error_report()
+        print()
+
+    sys.exit(checker.status)
+
+
+if __name__ == '__main__':
+    main()

--- a/monitoring/snmp/CEPH-MIB.txt
+++ b/monitoring/snmp/CEPH-MIB.txt
@@ -1,0 +1,337 @@
+CEPH-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, NOTIFICATION-TYPE, enterprises
+        FROM SNMPv2-SMI
+    MODULE-COMPLIANCE, NOTIFICATION-GROUP
+        FROM SNMPv2-CONF
+;
+
+-- Linting information:
+--
+-- # smilint -l 6 -i notification-not-reversible ./CEPH-MIB.txt
+--
+-- ignore: notification-not-reversible since our SNMP gateway doesn't use SNMPv1
+--
+
+ceph MODULE-IDENTITY
+    LAST-UPDATED
+        "202111010000Z" -- Nov 01, 2021
+    ORGANIZATION
+        "The Ceph Project
+         https://ceph.io"
+    CONTACT-INFO
+        "Email: <dev@ceph.io>
+
+        Send comments to: <dev@ceph.io>"
+    DESCRIPTION
+        "The MIB module for Ceph. In it's current form it only
+        supports Notifications, since Ceph itself doesn't provide
+        any SNMP agent functionality.
+
+        Notifications are provided through a Prometheus/Alertmanager
+        webhook passing alerts to an external gateway service that is
+        responsible for formatting, forwarding and authenticating to
+        the SNMP receiver.
+        "
+    REVISION
+        "202111010000Z" --Nov 01, 2021
+    DESCRIPTION
+        "Latest version including the following updates;
+
+        - MIB restructure to align with linting
+        - names shortened and simplified (less verbose)
+        - Simplified structure due to switch to https://github.com/maxwo/snmp_notifier
+          - objects removed
+          - notifications updated
+        - Added module compliance
+        - Updated to latest prometheus alert rule definitions
+        "
+    ::= { enterprises 50495 }
+
+cephCluster       OBJECT IDENTIFIER ::= { ceph 1 }
+cephConformance   OBJECT IDENTIFIER ::= { ceph 2 }
+
+-- cephMetadata is a placeholder for possible future expansion via an agent
+-- where we could provide an overview of the clusters configuration
+cephMetadata      OBJECT IDENTIFIER ::= { cephCluster 1 }
+cephNotifications OBJECT IDENTIFIER ::= { cephCluster 2 }
+
+prometheus OBJECT IDENTIFIER ::= { cephNotifications 1 }
+
+--
+-- Notifications: first we define the notification 'branches' for the
+-- different categories of notifications / alerts
+promGeneric       OBJECT IDENTIFIER ::= { prometheus 1 }
+promHealthStatus  OBJECT IDENTIFIER ::= { prometheus 2 }
+promMon           OBJECT IDENTIFIER ::= { prometheus 3 }
+promOsd           OBJECT IDENTIFIER ::= { prometheus 4 }
+promMds           OBJECT IDENTIFIER ::= { prometheus 5 }
+promMgr           OBJECT IDENTIFIER ::= { prometheus 6 }
+promPGs           OBJECT IDENTIFIER ::= { prometheus 7 }
+promNode          OBJECT IDENTIFIER ::= { prometheus 8 }
+promPool          OBJECT IDENTIFIER ::= { prometheus 9 }
+promRados         OBJECT IDENTIFIER ::= { prometheus 10 }
+promCephadm       OBJECT IDENTIFIER ::= { prometheus 11 }
+promPrometheus    OBJECT IDENTIFIER ::= { prometheus 12 }
+
+promGenericNotification NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Generic alert issued when the Prometheus rule doesn't provide an OID."
+::= { promGeneric 1 }
+
+promGenericDaemonCrash NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "One or more daemons have crashed recently, and are yet to be archived"
+::= { promGeneric 2 }
+
+promHealthStatusError NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Ceph in health_error state for too long."
+::= { promHealthStatus 1 }
+
+promHealthStatusWarning NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Ceph in health_warn for too long."
+::= { promHealthStatus 2 }
+
+promMonLowQuorum NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Monitor count in quorum is low."
+::= { promMon 1 }
+
+promMonDiskSpaceCritical NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Monitor diskspace is critically low."
+::= { promMon 2 }
+
+promOsdDownHigh NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "A high number of OSDs are down."
+::= { promOsd 1 }
+
+promOsdDown NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "One or more Osds down."
+::= { promOsd 2 }
+
+promOsdNearFull NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "An OSD is dangerously full."
+::= { promOsd 3 }
+
+promOsdFlapping NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "An OSD was marked down at back up at least once a minute for 5 minutes."
+::= { promOsd 4 }
+
+promOsdHighPgDeviation NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "An OSD deviates by more then 30% from average PG count."
+::= { promOsd 5 }
+
+promOsdFull NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "An OSD has reached its full threshold."
+::= { promOsd 6 }
+
+promOsdHighPredictedFailures NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Normal self healing unable to cope with the number of devices predicted to fail."
+::= { promOsd 7 }
+
+promOsdHostDown NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Ceph OSD host is down."
+::= { promOsd 8 }
+
+promMdsDamaged NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Cephfs filesystem is damaged."
+::= { promMds 1 }
+
+promMdsReadOnly NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Cephfs filesystem marked as READ-ONLY"
+::= { promMds 2 }
+
+promMdsOffline NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Cephfs filesystem is unavailable/offline."
+::= { promMds 3 }
+
+promMdsDegraded NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Cephfs filesystem is in a degraded state."
+::= { promMds 4 }
+
+promMdsNoStandby NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Cephfs MDS daemon failure, no standby available"
+::= { promMds 5 }
+
+promMgrModuleCrash NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Ceph mgr module has crashed recently"
+::= { promMgr 1 }
+
+promMgrPrometheusInactive NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Ceph mgr prometheus module not responding"
+::= { promMgr 2 }
+
+promPGsInactive NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "One or more PGs are inactive for more than 5 minutes."
+::= { promPGs 1 }
+
+promPGsUnclean NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "One or more PGs are not clean for more than 15 minutes."
+::= { promPGs 2 }
+
+promPGsUnavailable NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "One or more PGs is unavailable, blocking I/O to those objects."
+::= { promPGs 3 }
+
+promPGsDamaged NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "One or more PGs is damaged."
+::= { promPGs 4 }
+
+promPGsRecoveryFull NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "PG recovery is impaired due to full OSDs."
+::= { promPGs 5 }
+
+promPGsBackfillFull NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "PG backfill is impaired due to full OSDs."
+::= { promPGs 6 }
+
+promNodeRootVolumeFull NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Root volume (OSD and MON store) is dangerously full (< 5% free)."
+::= { promNode 1 }
+
+promNodeNetworkPacketDrops NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "A node experiences packet drop > 1 packet/s on an interface."
+::= { promNode 2 }
+
+promNodeNetworkPacketErrors NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "A node experiences packet errors > 1 packet/s on an interface."
+::= { promNode 3 }
+
+promNodeStorageFilling NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "A mountpoint will be full in less then 5 days assuming the average fillup rate of the past 48 hours."
+::= { promNode 4 }
+
+promPoolFull NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "A pool is at 90% capacity or over."
+::= { promPool 1 }
+
+promPoolFilling NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "A pool will be full in less then 5 days assuming the average fillup rate of the past 48 hours."
+::= { promPool 2 }
+
+promRadosUnfound NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "A RADOS object can not be found, even though all OSDs are online."
+::= { promRados 1 }
+
+promCephadmDaemonDown NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Cephadm has determined that a daemon is down."
+::= { promCephadm 1 }
+
+promCephadmUpgradeFailure NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "Cephadm attempted to upgrade the cluster and encountered a problem."
+::= { promCephadm 2 }
+
+promPrometheusJobMissing NOTIFICATION-TYPE
+    STATUS      current
+    DESCRIPTION "The prometheus scrape job is not defined."
+::= { promPrometheus 1 }
+-- ---------------------------------------------------------- --
+-- IEEE 802.1D MIB - Conformance Information
+-- ---------------------------------------------------------- --
+
+cephAlertGroups   OBJECT IDENTIFIER ::= { cephConformance 1 }
+cephCompliances   OBJECT IDENTIFIER ::= { cephConformance 2 }
+
+-- ---------------------------------------------------------- --
+-- units of conformance
+-- ---------------------------------------------------------- --
+
+-- ---------------------------------------------------------- --
+-- The Trap Notification Group
+-- ---------------------------------------------------------- --
+
+cephNotificationGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        promGenericNotification,
+        promGenericDaemonCrash,
+        promHealthStatusError,
+        promHealthStatusWarning,
+        promMonLowQuorum,
+        promMonDiskSpaceCritical,
+        promOsdDownHigh,
+        promOsdDown,
+        promOsdNearFull,
+        promOsdFlapping,
+        promOsdHighPgDeviation,
+        promOsdFull,
+        promOsdHighPredictedFailures,
+        promOsdHostDown,
+        promMdsDamaged,
+        promMdsReadOnly,
+        promMdsOffline,
+        promMdsDegraded,
+        promMdsNoStandby,
+        promMgrModuleCrash,
+        promMgrPrometheusInactive,
+        promPGsInactive,
+        promPGsUnclean,
+        promPGsUnavailable,
+        promPGsDamaged,
+        promPGsRecoveryFull,
+        promPGsBackfillFull,
+        promNodeRootVolumeFull,
+        promNodeNetworkPacketDrops,
+        promNodeNetworkPacketErrors,
+        promNodeStorageFilling,
+        promPoolFull,
+        promPoolFilling,
+        promRadosUnfound,
+        promCephadmDaemonDown,
+        promCephadmUpgradeFailure,
+        promPrometheusJobMissing
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of notifications triggered by the Prometheus
+        rules to convey Ceph cluster state"
+    ::= { cephAlertGroups 2 }
+
+-- ---------------------------------------------------------- --
+-- compliance statements
+-- ---------------------------------------------------------- --
+
+cephCompliance MODULE-COMPLIANCE
+    STATUS current
+    DESCRIPTION
+        "The Compliance statement for the Ceph MIB"
+    MODULE
+        MANDATORY-GROUPS {
+            cephNotificationGroup
+        }
+    ::= { cephCompliances 1 }
+
+END

--- a/monitoring/snmp/README.md
+++ b/monitoring/snmp/README.md
@@ -1,0 +1,54 @@
+# SNMP schema
+To show the [OID](https://en.wikipedia.org/wiki/Object_identifier)'s supported by the MIB, use the snmptranslate command. Here's an example:
+```
+snmptranslate -Pu -Tz -M ~/git/ceph/monitoring/snmp:/usr/share/snmp/mibs -m CEPH-MIB
+```
+*The `snmptranslate` command is in the net-snmp-utils package*
+
+The MIB provides a NOTIFICATION only implementation since ceph doesn't have an SNMP
+agent feature.
+
+## Integration
+The SNMP MIB is has been aligned to the Prometheus rules. Any rule that defines a 
+critical alert should have a corresponding oid in the CEPH-MIB.txt file. To generate
+an SNMP notification, you must use an SNMP gateway that the Prometheus Alertmanager
+service can forward alerts through to, via it's webhooks feature.
+
+&nbsp;
+
+## SNMP Gateway
+The recommended SNMP gateway is https://github.com/maxwo/snmp_notifier. This is a widely
+used and generic SNMP gateway implementation written in go. It's usage (syntax and
+parameters) is very similar to Prometheus, AlertManager and even node-exporter.
+
+&nbsp;
+## SNMP OIDs
+The main components of the Ceph MIB is can be broken down into discrete areas
+
+
+```
+internet private enterprise   ceph   ceph    Notifications   Prometheus  Notification
+                               org  cluster   (alerts)         source      Category
+1.3.6.1   .4     .1          .50495   .1        .2               .1         .2  (Ceph Health)
+                                                                            .3  (MON)
+                                                                            .4  (OSD)
+                                                                            .5  (MDS)
+                                                                            .6  (MGR)
+                                                                            .7  (PGs)
+                                                                            .8  (Nodes)
+                                                                            .9  (Pools)
+                                                                            .10  (Rados)
+                                                                            .11 (cephadm)
+                                                                            .12 (prometheus)
+
+```
+Individual alerts are placed within the appropriate alert category. For example, to add
+a notification relating to a MGR issue, you would use the oid 1.3.6.1.4.1.50495.1.2.1.6.x
+
+The SNMP gateway also adds additional components to the SNMP notification ;
+
+| Suffix | Description |
+|--------|-------------|
+| .1 | The oid |
+| .2 | Severity of the alert. When an alert is resolved, severity is 'info', and the description is set to Status:OK|
+| .3 | Text of the alert(s) | 

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -7,10 +7,12 @@ import os
 import re
 import threading
 import time
-from mgr_module import CLIReadCommand, MgrModule, MgrStandbyModule, PG_STATES, Option, ServiceInfoT
+import enum
+from mgr_module import CLIReadCommand, MgrModule, MgrStandbyModule, PG_STATES, Option, ServiceInfoT, HandleCommandResult, CLIWriteCommand
 from mgr_util import get_default_addr, profile_method, build_url
 from rbd import RBD
 from collections import namedtuple
+import yaml
 
 from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List
 
@@ -114,6 +116,189 @@ alert_metric = namedtuple('alert_metric', 'name description')
 HEALTH_CHECKS = [
     alert_metric('SLOW_OPS', 'OSD or Monitor requests taking a long time to process'),
 ]
+
+HEALTHCHECK_DETAIL = ('name', 'severity')
+
+
+class Severity(enum.Enum):
+    ok = "HEALTH_OK"
+    warn = "HEALTH_WARN"
+    error = "HEALTH_ERR"
+
+
+class Format(enum.Enum):
+    plain = 'plain'
+    json = 'json'
+    json_pretty = 'json-pretty'
+    yaml = 'yaml'
+
+
+class HealthCheckEvent:
+
+    def __init__(self, name: str, severity: Severity, first_seen: float, last_seen: float, count: int, active: bool = True):
+        self.name = name
+        self.severity = severity
+        self.first_seen = first_seen
+        self.last_seen = last_seen
+        self.count = count
+        self.active = active
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return the instance as a dictionary."""
+        return self.__dict__
+
+
+class HealthHistory:
+    kv_name = 'health_history'
+    titles = "{healthcheck_name:<24}  {first_seen:<20}  {last_seen:<20}  {count:>5}  {active:^6}"
+    date_format = "%Y/%m/%d %H:%M:%S"
+
+    def __init__(self, mgr: MgrModule):
+        self.mgr = mgr
+        self.lock = threading.Lock()
+        self.healthcheck: Dict[str, HealthCheckEvent] = {}
+        self._load()
+
+    def _load(self) -> None:
+        """Load the current state from the mons KV store."""
+        data = self.mgr.get_store(self.kv_name)
+        if data:
+            try:
+                healthcheck_data = json.loads(data)
+            except json.JSONDecodeError:
+                self.mgr.log.warn(
+                    f"INVALID data read from mgr/prometheus/{self.kv_name}. Resetting")
+                self.reset()
+                return
+            else:
+                for k, v in healthcheck_data.items():
+                    self.healthcheck[k] = HealthCheckEvent(
+                        name=k,
+                        severity=v.get('severity'),
+                        first_seen=v.get('first_seen', 0),
+                        last_seen=v.get('last_seen', 0),
+                        count=v.get('count', 1),
+                        active=v.get('active', True))
+        else:
+            self.reset()
+
+    def reset(self) -> None:
+        """Reset the healthcheck history."""
+        with self.lock:
+            self.mgr.set_store(self.kv_name, "{}")
+            self.healthcheck = {}
+
+    def save(self) -> None:
+        """Save the current in-memory healthcheck history to the KV store."""
+        with self.lock:
+            self.mgr.set_store(self.kv_name, self.as_json())
+
+    def check(self, health_checks: Dict[str, Any]) -> None:
+        """Look at the current health checks and compare existing the history.
+
+        Args:
+            health_checks (Dict[str, Any]): current health check data
+        """
+
+        current_checks = health_checks.get('checks', {})
+        changes_made = False
+
+        # first turn off any active states we're tracking
+        for seen_check in self.healthcheck:
+            check = self.healthcheck[seen_check]
+            if check.active and seen_check not in current_checks:
+                check.active = False
+                changes_made = True
+
+        # now look for any additions to track
+        now = time.time()
+        for name, info in current_checks.items():
+            if name not in self.healthcheck:
+                # this healthcheck is new, so start tracking it
+                changes_made = True
+                self.healthcheck[name] = HealthCheckEvent(
+                    name=name,
+                    severity=info.get('severity'),
+                    first_seen=now,
+                    last_seen=now,
+                    count=1,
+                    active=True
+                )
+            else:
+                # seen it before, so update its metadata
+                check = self.healthcheck[name]
+                if check.active:
+                    # check has been registered as active already, so skip
+                    continue
+                else:
+                    check.last_seen = now
+                    check.count += 1
+                    check.active = True
+                    changes_made = True
+
+        if changes_made:
+            self.save()
+
+    def __str__(self) -> str:
+        """Print the healthcheck history.
+
+        Returns:
+            str: Human readable representation of the healthcheck history
+        """
+        out = []
+
+        if len(self.healthcheck.keys()) == 0:
+            out.append("No healthchecks have been recorded")
+        else:
+            out.append(self.titles.format(
+                healthcheck_name="Healthcheck Name",
+                first_seen="First Seen (UTC)",
+                last_seen="Last seen (UTC)",
+                count="Count",
+                active="Active")
+            )
+            for k in sorted(self.healthcheck.keys()):
+                check = self.healthcheck[k]
+                out.append(self.titles.format(
+                    healthcheck_name=check.name,
+                    first_seen=time.strftime(self.date_format, time.localtime(check.first_seen)),
+                    last_seen=time.strftime(self.date_format, time.localtime(check.last_seen)),
+                    count=check.count,
+                    active="Yes" if check.active else "No")
+                )
+            out.extend([f"{len(self.healthcheck)} health check(s) listed", ""])
+
+        return "\n".join(out)
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return the history in a dictionary.
+
+        Returns:
+            Dict[str, Any]: dictionary indexed by the healthcheck name
+        """
+        return {name: self.healthcheck[name].as_dict() for name in self.healthcheck}
+
+    def as_json(self, pretty: bool = False) -> str:
+        """Return the healthcheck history object as a dict (JSON).
+
+        Args:
+            pretty (bool, optional): whether to json pretty print the history. Defaults to False.
+
+        Returns:
+            str: str representation of the healthcheck in JSON format
+        """
+        if pretty:
+            return json.dumps(self.as_dict(), indent=2)
+        else:
+            return json.dumps(self.as_dict())
+
+    def as_yaml(self) -> str:
+        """Return the healthcheck history in yaml format.
+
+        Returns:
+            str: YAML representation of the healthcheck history
+        """
+        return yaml.safe_dump(self.as_dict(), explicit_start=True, default_flow_style=False)
 
 
 class Metric(object):
@@ -331,6 +516,7 @@ class Module(MgrModule):
         global _global_instance
         _global_instance = self
         self.metrics_thread = MetricCollectionThread(_global_instance)
+        self.health_history = HealthHistory(self)
 
     def _setup_static_metrics(self) -> Dict[str, Metric]:
         metrics = {}
@@ -432,6 +618,13 @@ class Module(MgrModule):
             ('pool_id',)
         )
 
+        metrics['health_detail'] = Metric(
+            'gauge',
+            'health_detail',
+            'healthcheck status by type (0=inactive, 1=active)',
+            HEALTHCHECK_DETAIL
+        )
+
         for flag in OSD_FLAGS:
             path = 'osd_flag_{}'.format(flag)
             metrics[path] = Metric(
@@ -521,7 +714,7 @@ class Module(MgrModule):
         )
 
         # Examine the health to see if any health checks triggered need to
-        # become a metric.
+        # become a specific metric with a value from the health detail
         active_healthchecks = health.get('checks', {})
         active_names = active_healthchecks.keys()
 
@@ -552,6 +745,15 @@ class Module(MgrModule):
                 else:
                     # health check is not active, so give it a default of 0
                     self.metrics[path].set(0)
+
+        self.health_history.check(health)
+        for name, info in self.health_history.healthcheck.items():
+            v = 1 if info.active else 0
+            self.metrics['health_detail'].set(
+                v, (
+                    name,
+                    str(info.severity))
+            )
 
     @profile_method()
     def get_pool_stats(self) -> None:
@@ -1419,6 +1621,37 @@ class Module(MgrModule):
     def shutdown(self) -> None:
         self.log.info('Stopping engine...')
         self.shutdown_event.set()
+
+    @CLIReadCommand('healthcheck history ls')
+    def _list_healthchecks(self, format: Format = Format.plain) -> HandleCommandResult:
+        """List all the healthchecks being tracked
+
+        The format options are parsed in ceph_argparse, before they get evaluated here so
+        we can safely assume that what we have to process is valid. ceph_argparse will throw
+        a ValueError if the cast to our Format class fails.
+
+        Args:
+            format (Format, optional): output format. Defaults to Format.plain.
+
+        Returns:
+            HandleCommandResult: return code, stdout and stderr returned to the caller
+        """
+
+        out = ""
+        if format == Format.plain:
+            out = str(self.health_history)
+        elif format == Format.yaml:
+            out = self.health_history.as_yaml()
+        else:
+            out = self.health_history.as_json(format == Format.json_pretty)
+
+        return HandleCommandResult(retval=0, stdout=out)
+
+    @CLIWriteCommand('healthcheck history clear')
+    def _clear_healthchecks(self) -> HandleCommandResult:
+        """Clear the healthcheck history"""
+        self.health_history.reset()
+        return HandleCommandResult(retval=0, stdout="healthcheck history cleared")
 
 
 class StandbyModule(MgrStandbyModule):

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -157,7 +157,7 @@ endif()
 add_executable(ceph_test_mutate
   test_mutate.cc
   )
-target_link_libraries(ceph_test_mutate global librados ${BLKID_LIBRARIES} 
+target_link_libraries(ceph_test_mutate global librados ${BLKID_LIBRARIES}
   ${CMAKE_DL_LIBS})
 
 if(NOT WIN32)
@@ -599,8 +599,8 @@ if(PROMTOOL_EXECUTABLE)
     OUTPUT_QUIET)
   if(NOT rc)
     add_ceph_test(run-promtool-unittests
-      ${PROMTOOL_EXECUTABLE} test rules ${CMAKE_SOURCE_DIR}/monitoring/prometheus/alerts/test_alerts.yml)
-  else()
+      ${PROMTOOL_EXECUTABLE} test rules ${CMAKE_SOURCE_DIR}/monitoring/prometheus/tests/test_alerts.yml)
+  elseif(NOT promtool_executable_checked)
     message(WARNING "'${PROMTOOL_EXECUTABLE} test rules' does not work, "
       "please use a newer prometheus")
   endif()


### PR DESCRIPTION
Also includes backport for:  https://github.com/ceph/ceph/pull/43783

backport tracker: https://tracker.ceph.com/issues/53616

---

backport of https://github.com/ceph/ceph/pull/43293, https://github.com/ceph/ceph/pull/43783
parent trackers: https://tracker.ceph.com/issues/52638, https://tracker.ceph.com/issues/53111

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh