### PR TITLE
osd: avoid op event duration underflow

### DIFF
--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -224,8 +224,16 @@ public:
 
   // cast to double
   operator double() const {
-    return (double)sec() + ((double)nsec() / 1000000000.0f);
+    return (double)sec() + ((double)nsec() / 1000000000.);
   }
+  double after(const utime_t& r) const {
+    // avoid underflow
+    auto& l = *this;
+    time_t sec = l.sec() - r.sec();
+    int nsec = l.nsec() - r.nsec();
+    return (double)sec + ((double)nsec / 1000000000.);
+  }
+
   operator ceph_timespec() const {
     ceph_timespec ts;
     ts.tv_sec = sec();

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -77,8 +77,7 @@ void OpRequest::_dump(Formatter *f) const
       double duration = 0;
 
       if (i != events.begin()) {
-        auto i_prev = i - 1;
-        duration = i->stamp - i_prev->stamp;
+        duration = i->stamp.after(std::prev(i)->stamp);
       }
 
       f->dump_float("duration", duration);

--- a/src/test/test_utime.cc
+++ b/src/test/test_utime.cc
@@ -65,3 +65,11 @@ TEST(utime_t, parse_date)
     ASSERT_EQ(ss.str(), v[i][1]);
   }
 }
+
+TEST(utime_t, after)
+{
+  ASSERT_EQ(utime_t(1, 200000000).after({0, 100000000}), 1.1);
+  ASSERT_EQ(utime_t(1, 200000000).after({0, 300000000}), 0.9);
+  ASSERT_EQ(utime_t(1, 200000000).after({2, 100000000}), -0.9);
+  ASSERT_EQ(utime_t(1, 200000000).after({2, 300000000}), -1.1);
+}


### PR DESCRIPTION
utime_t use unsigned int. Introduce a new helper `a.after(b)` to
calculate seconds a after b, and property return negative values.

Signed-off-by: 胡玮文 <huww98@outlook.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
