### PR TITLE
librbd/io: list snaps from parent using image dispatches

### DIFF
--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -19,7 +19,7 @@
 #include "librbd/asio/Utils.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/CopyupRequest.h"
-#include "librbd/io/ImageRequest.h"
+#include "librbd/io/ImageDispatchSpec.h"
 #include "librbd/io/Utils.h"
 
 #include <boost/optional.hpp>
@@ -985,11 +985,11 @@ void ObjectListSnapsRequest<I>::list_from_parent() {
    auto list_snaps_flags = (
      m_list_snaps_flags | LIST_SNAPS_FLAG_IGNORE_ZEROED_EXTENTS);
 
-  ImageListSnapsRequest<I> req(
-    *image_ctx->parent, aio_comp, std::move(parent_extents), m_image_area,
-    {0, image_ctx->parent->snap_id}, list_snaps_flags, &m_parent_snapshot_delta,
-    this->m_trace);
-  req.send();
+  auto req = io::ImageDispatchSpec::create_list_snaps(
+    *image_ctx->parent, io::IMAGE_DISPATCH_LAYER_NONE, aio_comp,
+    std::move(parent_extents), m_image_area, {0, image_ctx->parent->snap_id},
+    list_snaps_flags, &m_parent_snapshot_delta, this->m_trace);
+  req->send();
 }
 
 template <typename I>

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -58,38 +58,6 @@ struct CopyupRequest<librbd::MockTestImageCtx> : public CopyupRequest<librbd::Mo
 
 CopyupRequest<librbd::MockTestImageCtx>* CopyupRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
 
-template <>
-struct ImageListSnapsRequest<librbd::MockTestImageCtx> {
-  static ImageListSnapsRequest* s_instance;
-
-  AioCompletion* aio_comp;
-  Extents image_extents;
-  SnapshotDelta* snapshot_delta;
-
-  ImageListSnapsRequest() {
-    s_instance = this;
-  }
-  ImageListSnapsRequest(
-      librbd::MockImageCtx& image_ctx, AioCompletion* aio_comp,
-      Extents&& image_extents, ImageArea area, SnapIds&& snap_ids,
-      int list_snaps_flags, SnapshotDelta* snapshot_delta,
-      const ZTracer::Trace& parent_trace) {
-    ceph_assert(s_instance != nullptr);
-    s_instance->aio_comp = aio_comp;
-    s_instance->image_extents = image_extents;
-    s_instance->snapshot_delta = snapshot_delta;
-  }
-
-
-  MOCK_METHOD0(execute_send, void());
-  void send() {
-    ceph_assert(s_instance != nullptr);
-    s_instance->execute_send();
-  }
-};
-
-ImageListSnapsRequest<librbd::MockTestImageCtx>* ImageListSnapsRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
-
 namespace util {
 
 template <>
@@ -167,7 +135,6 @@ struct TestMockIoObjectRequest : public TestMockFixture {
   typedef ObjectListSnapsRequest<librbd::MockTestImageCtx> MockObjectListSnapsRequest;
   typedef AbstractObjectWriteRequest<librbd::MockTestImageCtx> MockAbstractObjectWriteRequest;
   typedef CopyupRequest<librbd::MockTestImageCtx> MockCopyupRequest;
-  typedef ImageListSnapsRequest<librbd::MockTestImageCtx> MockImageListSnapsRequest;
   typedef util::Mock MockUtils;
 
   void expect_object_may_exist(MockTestImageCtx &mock_image_ctx,
@@ -406,21 +373,24 @@ struct TestMockIoObjectRequest : public TestMockFixture {
         })));
   }
 
-  void expect_image_list_snaps(MockImageListSnapsRequest& req,
+  void expect_image_list_snaps(MockTestImageCtx &mock_image_ctx,
                                const Extents& image_extents,
                                const SnapshotDelta& image_snapshot_delta,
                                int r) {
-    EXPECT_CALL(req, execute_send())
-      .WillOnce(Invoke(
-        [&req, image_extents, image_snapshot_delta, r]() {
-          ASSERT_EQ(image_extents, req.image_extents);
-          *req.snapshot_delta = image_snapshot_delta;
+    EXPECT_CALL(*mock_image_ctx.io_image_dispatcher, send(_)).WillOnce(
+            Invoke([image_extents, image_snapshot_delta, r](
+                    io::ImageDispatchSpec* spec) {
+              auto* req = boost::get<io::ImageDispatchSpec::ListSnaps>(
+                      &spec->request);
+              ASSERT_TRUE(req != nullptr);
 
-          auto aio_comp = req.aio_comp;
-          aio_comp->set_request_count(1);
-          aio_comp->add_request();
-          aio_comp->complete_request(r);
-        }));
+              ASSERT_EQ(image_extents, spec->image_extents);
+              *req->snapshot_delta = image_snapshot_delta;
+              spec->dispatch_result = io::DISPATCH_RESULT_COMPLETE;
+              spec->aio_comp->set_request_count(1);
+              spec->aio_comp->add_request();
+              spec->aio_comp->complete_request(r);
+            }));
   }
 };
 
@@ -1899,12 +1869,10 @@ TEST_F(TestMockIoObjectRequest, ListSnapsParent) {
   expect_get_parent_overlap(mock_image_ctx, CEPH_NOSNAP, 4096, 0);
   expect_prune_parent_extents(mock_image_ctx, {{0, 4096}}, 4096, 4096);
 
-  MockImageListSnapsRequest mock_image_list_snaps_request;
   SnapshotDelta image_snapshot_delta;
   image_snapshot_delta[{1,6}].insert(
     0, 1024, {SPARSE_EXTENT_STATE_DATA, 1024});
-  expect_image_list_snaps(mock_image_list_snaps_request,
-                          {{0, 4096}}, image_snapshot_delta, 0);
+  expect_image_list_snaps(mock_image_ctx, {{0, 4096}}, image_snapshot_delta, 0);
 
   SnapshotDelta snapshot_delta;
   C_SaferCond ctx;


### PR DESCRIPTION
This fixes a bug crashing `rbd diff` when run on image being migrated from non native source.

See: https://tracker.ceph.com/issues/53786

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
