### PR TITLE
rgw: reopen ops log file on sighup

### DIFF
--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -174,6 +174,8 @@ class OpsLogFile : public JsonOpsLogSink, public Thread, public DoutPrefixProvid
   bool stopped;
   uint64_t data_size;
   uint64_t max_data_size;
+  std::string path;
+  std::atomic_bool need_reopen;
 
   void flush();
 protected:
@@ -185,6 +187,7 @@ public:
   CephContext *get_cct() const override { return cct; }
   unsigned get_subsys() const override { return dout_subsys; }
   std::ostream& gen_prefix(std::ostream& out) const override { return out << "rgw OpsLogFile: "; }
+  void reopen();
   void start();
   void stop();
 };

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -130,6 +130,15 @@ static void handle_sigterm(int signum)
 
 }
 
+static OpsLogFile* ops_log_file = nullptr;
+
+static void rgw_sighup_handler(int signum) {
+    if (ops_log_file != nullptr) {
+        ops_log_file->reopen();
+    }
+    sighup_handler(signum);
+}
+
 static void godown_alarm(int signum)
 {
   _exit(0);
@@ -314,7 +323,6 @@ int radosgw_Main(int argc, const char **argv)
   common_init_finish(g_ceph_context);
 
   init_async_signal_handler();
-  register_async_signal_handler(SIGHUP, sighup_handler);
 
   TracepointProvider::initialize<rgw_rados_tracepoint_traits>(g_ceph_context);
   TracepointProvider::initialize<rgw_op_tracepoint_traits>(g_ceph_context);
@@ -541,12 +549,12 @@ int radosgw_Main(int argc, const char **argv)
     olog_socket->init(g_conf()->rgw_ops_log_socket_path);
     olog->add_sink(olog_socket);
   }
-  OpsLogFile* ops_log_file;
   if (!g_conf()->rgw_ops_log_file_path.empty()) {
     ops_log_file = new OpsLogFile(g_ceph_context, g_conf()->rgw_ops_log_file_path, g_conf()->rgw_ops_log_data_backlog);
     ops_log_file->start();
     olog->add_sink(ops_log_file);
   }
+  register_async_signal_handler(SIGHUP, rgw_sighup_handler);
   olog->add_sink(new OpsLogRados(store));
 
   r = signal_fd_init();
@@ -688,7 +696,7 @@ int radosgw_Main(int argc, const char **argv)
     delete fec;
   }
 
-  unregister_async_signal_handler(SIGHUP, sighup_handler);
+  unregister_async_signal_handler(SIGHUP, rgw_sighup_handler);
   unregister_async_signal_handler(SIGTERM, handle_sigterm);
   unregister_async_signal_handler(SIGINT, handle_sigterm);
   unregister_async_signal_handler(SIGUSR1, handle_sigterm);


### PR DESCRIPTION
Handles radosgw SIGHUP such that ops log file is reopened if applicable.

Fixes: https://tracker.ceph.com/issues/53788
Signed-off-by: Cory Snyder <csnyder@iland.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests