### PR TITLE
qa/suites: Crimson flavor configuration fix 

### DIFF
--- a/qa/suites/crimson-rados/basic/deploy/ceph.yaml
+++ b/qa/suites/crimson-rados/basic/deploy/ceph.yaml
@@ -1,6 +1,13 @@
 overrides:
-  ceph:
+  install:
+    ceph:
+      flavor: crimson
+tasks:
+- install:
+- ceph:
     conf:
+      osd:
+        debug monc: 20
       mon:
         mon min osdmap epochs: 50
         paxos service trim min: 10
@@ -8,9 +15,4 @@ overrides:
         mon osdmap full prune min: 15
         mon osdmap full prune interval: 2
         mon osdmap full prune txsize: 2
-tasks:
-- install:
-    ceph:
-      flavor: crimson
-- ceph:
     flavor: crimson

--- a/qa/suites/crimson-rados/basic/deploy/cephadm.yaml.disabled
+++ b/qa/suites/crimson-rados/basic/deploy/cephadm.yaml.disabled
@@ -1,0 +1,16 @@
+# no need to verify os + flavor + sha1
+verify_ceph_hash: false
+tasks:
+- cephadm:
+    conf:
+      mgr:
+        debug ms: 1
+        debug mgr: 20
+        debug osd: 10
+- cephadm.shell:
+    mon.a:
+      - ceph orch status
+      - ceph orch ps
+      - ceph orch ls
+      - ceph orch host ls
+      - ceph orch device ls

--- a/qa/suites/crimson-rados/rbd/deploy/ceph.yaml
+++ b/qa/suites/crimson-rados/rbd/deploy/ceph.yaml
@@ -1,6 +1,13 @@
 overrides:
-  ceph:
+  install:
+    ceph:
+      flavor: crimson
+tasks:
+- install:
+- ceph:
     conf:
+      osd:
+        debug monc: 20
       mon:
         mon min osdmap epochs: 50
         paxos service trim min: 10
@@ -8,9 +15,4 @@ overrides:
         mon osdmap full prune min: 15
         mon osdmap full prune interval: 2
         mon osdmap full prune txsize: 2
-tasks:
-- install:
-    ceph:
-      flavor: crimson
-- ceph:
     flavor: crimson

--- a/qa/suites/crimson-rados/rbd/deploy/cephadm.yaml.disabled
+++ b/qa/suites/crimson-rados/rbd/deploy/cephadm.yaml.disabled
@@ -1,0 +1,16 @@
+# no need to verify os + flavor + sha1
+verify_ceph_hash: false
+tasks:
+- cephadm:
+    conf:
+      mgr:
+        debug ms: 1
+        debug mgr: 20
+        debug osd: 10
+- cephadm.shell:
+    mon.a:
+      - ceph orch status
+      - ceph orch ps
+      - ceph orch ls
+      - ceph orch host ls
+      - ceph orch device ls


### PR DESCRIPTION
The current configurations of `crimson-rados` suite queries for **default** Shaman builds instead of a **crimson** build.

Before this change, test logs were the following:

https://pulpito.ceph.com/teuthology-2022-01-02_01:01:03-crimson-rados-master-distro-default-smithi/

```
2022-01-02T01:06:41.121 INFO:teuthology.task.internal:Checking packages for os_type 'centos', flavor 'default' and ceph hash 'a2f5a3c1dbfa4dce41e25da4f029a8fdb8c8d864'

2022-01-02T01:06:41.123 DEBUG:teuthology.packaging:Querying https://shaman.ceph.com/api/search?status=ready&project=ceph&flavor=default&distros=centos%2F8%2Fx86_64&ref=master

2022-01-02T01:18:16.128 DEBUG:teuthology.packaging:Querying https://shaman.ceph.com/api/search?status=ready&project=ceph&flavor=default&distros=centos%2F8%2Fx86_64&sha1=a2f5a3c1dbfa4dce41e25da4f029a8fdb8c8d864
2022-01-02T01:18:16.336 INFO:teuthology.task.install.rpm:Pulling from https://4.chacra.ceph.com/r/ceph/master/a2f5a3c1dbfa4dce41e25da4f029a8fdb8c8d864/centos/8/flavors/default/
```

After this change:

https://pulpito.ceph.com/matan-2022-01-06_15:18:08-crimson-rados-master-distro-basic-smithi/
```
2022-01-06T15:28:02.571 INFO:teuthology.task.internal:Checking packages for os_type 'centos', flavor 'crimson' and ceph hash '24df4a2e83c57788f5638aad0e88a738d80878ef'

2022-01-06T15:28:02.573 DEBUG:teuthology.packaging:Querying https://shaman.ceph.com/api/search?status=ready&project=ceph&flavor=crimson&distros=centos%2F8%2Fx86_64&ref=master

2022-01-06T15:37:21.394 DEBUG:teuthology.packaging:Querying https://shaman.ceph.com/api/search?status=ready&project=ceph&flavor=crimson&distros=centos%2F8%2Fx86_64&sha1=24df4a2e83c57788f5638aad0e88a738d80878ef
2022-01-06T15:37:21.638 INFO:teuthology.task.install.rpm:Pulling from https://1.chacra.ceph.com/r/ceph/master/24df4a2e83c57788f5638aad0e88a738d80878ef/centos/8/flavors/crimson/
```


* Applying this change will make all of the suite's tests to fail (except [one](https://pulpito.ceph.com/matan-2022-01-06_15:18:08-crimson-rados-master-distro-basic-smithi/)).
* The issue most likely occurred due to a bug in the install task itself, this change can be used as a workaround for now in order to run the right tests.


Signed-off-by: Matan Breizman <mbreizma@redhat.com>
