### PR TITLE
mgr/cephadm: add simple pytest for cephadm's agent.py

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_agent.py
+++ b/src/pybind/mgr/cephadm/tests/test_agent.py
@@ -1,0 +1,56 @@
+import json
+from unittest.mock import Mock
+
+import cherrypy
+import pytest
+from cherrypy.test.helper import CPWebCase
+from cephadm.agent import Root
+from cephadm.tests.fixtures import with_cephadm_module
+
+
+class TestAgent(CPWebCase):
+
+    @pytest.fixture(autouse=True)
+    def _cephadm_module(self):
+        with with_cephadm_module({}) as m:
+            self.cephadm_module = m
+            cherrypy.tree.apps['']._mock_wraps = self.cephadm_module
+            yield m
+
+    def _request(self, url, method='GET', data=None, headers=None):
+        b = None
+        h = None
+        if data:
+            b = json.dumps(data)
+            h = [('Content-Type', 'application/json'),
+                 ('Content-Length', str(len(b)))]
+        if headers:
+            h = headers
+        self.getPage(url, method=method, body=b, headers=h)
+
+    def assertJsonBody(self, data, msg=None):
+        """Fail if value != self.body."""
+        json_body = self.json_body()
+        if data != json_body:
+            if msg is None:
+                msg = 'expected body:\n%r\n\nactual body:\n%r' % (
+                    data, json_body)
+            self._handlewebError(msg)
+
+    def json_body(self):
+        body_str = self.body.decode('utf-8') if isinstance(self.body, bytes) else self.body
+        return json.loads(body_str)
+
+    @classmethod
+    def setup_server(cls):
+        root_conf = {'/': {'request.dispatch': cherrypy.dispatch.MethodDispatcher(),
+                           'tools.response_headers.on': True}}
+        cherrypy.tree.mount(Root(Mock(wraps=None)), '/', root_conf)
+
+    def test_slash(self):
+        self._request('/')
+        assert b'Cephadm HTTP Endpoint is up and running' in self.body
+
+    def test_post_empty(self):
+        self._request('/data/', 'POST', data='{}')
+        self.assertJsonBody({"result": "Bad metadata: 'str' object has no attribute 'keys'"})


### PR DESCRIPTION
Increasing testing coverage by a tiny bit.

Signed-off-by: Sebastian Wagner <sewagner@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
