### PR TITLE
mon/MDSMonitor: fix standby-replay mds being removed from MDSMap unexpectedly

### DIFF
--- a/doc/cephfs/.gitignore
+++ b/doc/cephfs/.gitignore
@@ -1,1 +1,0 @@
-mds-state-diagram.svg

--- a/doc/cephfs/mds-state-diagram.dot
+++ b/doc/cephfs/mds-state-diagram.dot
@@ -57,6 +57,7 @@ D0 -> N3 [color=red,penwidth=2.0];
 // terminal (but not "in")
 node [shape=polygon,sides=6,color=black,peripheries=1];
 D1 [label="down:damaged"]
+S2 -> D1 [color=black,penwidth=2.0];
 N3 -> D1 [color=black,penwidth=2.0];
 N4 -> D1 [color=black,penwidth=2.0];
 N5 -> D1 [color=black,penwidth=2.0];
@@ -69,5 +70,6 @@ D1 -> D0 [color=red,penwidth=2.0]
 node [shape=polygon,sides=6,color=purple,peripheries=1];
 D3 [label="down:stopped"]
 S3 -> D3 [color=purple,penwidth=2.0];
+N6 -> D3 [color=purple,penwidth=2.0];
 
 }

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -999,28 +999,44 @@ MDSMap::availability_t MDSMap::is_cluster_available() const
 
 bool MDSMap::state_transition_valid(DaemonState prev, DaemonState next)
 {
-  bool state_valid = true;
-  if (next != prev) {
-    if (prev == MDSMap::STATE_REPLAY) {
-      if (next != MDSMap::STATE_RESOLVE && next != MDSMap::STATE_RECONNECT) {
-        state_valid = false;
-      }
-    } else if (prev == MDSMap::STATE_REJOIN) {
-      if (next != MDSMap::STATE_ACTIVE &&
-	  next != MDSMap::STATE_CLIENTREPLAY &&
-	  next != MDSMap::STATE_STOPPED) {
-        state_valid = false;
-      }
-    } else if (prev >= MDSMap::STATE_RESOLVE && prev < MDSMap::STATE_ACTIVE) {
-      // Once I have entered replay, the only allowable transitions are to
-      // the next next along in the sequence.
-      if (next != prev + 1) {
-        state_valid = false;
-      }
-    }
-  }
+  if (next == prev)
+    return true;
+  if (next == MDSMap::STATE_DAMAGED)
+    return true;
 
-  return state_valid;
+  if (prev == MDSMap::STATE_BOOT) {
+    return next == MDSMap::STATE_STANDBY;
+  } else if (prev == MDSMap::STATE_STANDBY) {
+    return next == MDSMap::STATE_STANDBY_REPLAY ||
+           next == MDSMap::STATE_REPLAY ||
+           next == MDSMap::STATE_CREATING ||
+           next == MDSMap::STATE_STARTING;
+  } else if (prev == MDSMap::STATE_CREATING || prev == MDSMap::STATE_STARTING) {
+    return next == MDSMap::STATE_ACTIVE;
+  } else if (prev == MDSMap::STATE_STANDBY_REPLAY) {
+    return next == MDSMap::STATE_REPLAY;
+  } else if (prev == MDSMap::STATE_REPLAY) {
+    return next == MDSMap::STATE_RESOLVE ||
+           next == MDSMap::STATE_RECONNECT;
+  } else if (prev >= MDSMap::STATE_RESOLVE && prev < MDSMap::STATE_ACTIVE) {
+    // Once I have entered replay, the only allowable transitions are to
+    // the next next along in the sequence.
+    // Except...
+    if (prev == MDSMap::STATE_REJOIN &&
+        (next == MDSMap::STATE_ACTIVE ||    // No need to do client replay
+         next == MDSMap::STATE_STOPPED)) {  // no subtrees
+      return true;         
+    }
+    return next == prev + 1;
+  } else if (prev == MDSMap::STATE_ACTIVE) {
+    return next == MDSMap::STATE_STOPPING;
+  } else if (prev == MDSMap::STATE_STOPPING) {
+    return next == MDSMap::STATE_STOPPED;
+  } else {
+    derr << __func__ << ": Unknown prev state "
+         << ceph_mds_state_name(prev) << "(" << prev << ")" << dendl;
+    return false;
+  }
 }
 
 bool MDSMap::check_health(mds_rank_t standby_daemon_count)

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -56,9 +56,8 @@ class MDSMap {
 public:
   /* These states are the union of the set of possible states of an MDS daemon,
    * and the set of possible states of an MDS rank. See
-   * doc/cephfs/mds-states.rst for state descriptions,
-   * doc/cephfs/mds-state-diagram.svg for a visual state diagram, and
-   * doc/cephfs/mds-state-diagram.dot to update mds-state-diagram.svg.
+   * doc/cephfs/mds-states.rst for state descriptions and a visual state diagram, and
+   * doc/cephfs/mds-state-diagram.dot to update the diagram.
    */
   typedef enum {
     // States of an MDS daemon not currently holding a rank

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2238,8 +2238,15 @@ void MDSRankDispatcher::handle_mds_map(
   // I am only to be passed MDSMaps in which I hold a rank
   ceph_assert(whoami != MDS_RANK_NONE);
 
-  MDSMap::DaemonState oldstate = state;
   mds_gid_t mds_gid = mds_gid_t(monc->get_global_id());
+  MDSMap::DaemonState oldstate = oldmap.get_state_gid(mds_gid);
+  if (oldstate == MDSMap::STATE_NULL) {
+    // monitor may skip sending me the STANDBY map (e.g. if paxos_propose_interval is high)
+    // Assuming I have passed STANDBY state if I got a rank in the first map.
+    oldstate = MDSMap::STATE_STANDBY;
+  }
+  // I should not miss map update
+  ceph_assert(state == oldstate);
   state = mdsmap->get_state_gid(mds_gid);
   if (state != oldstate) {
     last_state = oldstate;

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -414,7 +414,7 @@ class MDSRank {
     // The last different state I held before current
     MDSMap::DaemonState last_state = MDSMap::STATE_BOOT;
     // The state assigned to me by the MDSMap
-    MDSMap::DaemonState state = MDSMap::STATE_BOOT;
+    MDSMap::DaemonState state = MDSMap::STATE_STANDBY;
 
     bool cluster_degraded = false;
 


### PR DESCRIPTION
mds/FSMap: stricter state_transition_valid

Reject any unknown transitions.

mon/MDSMonitor: remove redundant state change check

There are two sets of checks to state change in prepare_beacon. Since the last commit, the first set is all covered by
`MDSMap::state_transition_valid`. So remove the first set and move the second set to its place.

And some misc fixes.

Fixes: https://tracker.ceph.com/issues/53811

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
