### PR TITLE
pacific: qa/suites/fs: add prefetch_dirfrags false to thrasher suite

### DIFF
--- a/qa/suites/fs/thrash/workloads/overrides/prefetch_dirfrags/no.yaml
+++ b/qa/suites/fs/thrash/workloads/overrides/prefetch_dirfrags/no.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      mds:
+        mds oft prefetch dirfrags: false

--- a/qa/suites/fs/thrash/workloads/overrides/prefetch_dirfrags/yes.yaml
+++ b/qa/suites/fs/thrash/workloads/overrides/prefetch_dirfrags/yes.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      mds:
+        mds oft prefetch dirfrags: true


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53761

---

backport of https://github.com/ceph/ceph/pull/44067
parent tracker: https://tracker.ceph.com/issues/52591

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh