### PR TITLE
mgr/dashboard: NFS pages shows 'Page not found'

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nfs.py
+++ b/src/pybind/mgr/dashboard/controllers/nfs.py
@@ -96,7 +96,7 @@ class NFSGanesha(RESTController):
         status = {'available': True, 'message': None}
         try:
             mgr.remote('nfs', 'cluster_ls')
-        except ImportError as error:
+        except (ImportError, RuntimeError) as error:
             logger.exception(error)
             status['available'] = False
             status['message'] = str(error)  # type: ignore

--- a/src/pybind/mgr/dashboard/tests/test_nfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_nfs.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 
 from .. import mgr
 from ..controllers._version import APIVersion
-from ..controllers.nfs import NFSGaneshaExports, NFSGaneshaUi
+from ..controllers.nfs import NFSGanesha, NFSGaneshaExports, NFSGaneshaUi
 from ..tests import ControllerTestCase
 from ..tools import NotificationQueue, TaskManager
 
@@ -227,3 +227,20 @@ class NFSGaneshaUiControllerTest(ControllerTestCase):
         cephfs_class.return_value.ls_dir.assert_called_once_with('/foo', 3)
         self.assertStatus(200)
         self.assertJsonBody({'paths': []})
+
+
+class NFSGaneshaControllerTest(ControllerTestCase):
+    @classmethod
+    def setup_server(cls):
+        cls.setup_controllers([NFSGanesha])
+
+    def test_status_available(self):
+        self._get('/api/nfs-ganesha/status')
+        self.assertStatus(200)
+        self.assertJsonBody({'available': True, 'message': None})
+
+    def test_status_not_available(self):
+        mgr.remote = Mock(side_effect=RuntimeError('Test'))
+        self._get('/api/nfs-ganesha/status')
+        self.assertStatus(200)
+        self.assertJsonBody({'available': False, 'message': 'Test'})


### PR DESCRIPTION
If no orchestrator is configured, the NFS page in the Dashboard shows 'Page not found'.

Fixes: https://tracker.ceph.com/issues/53813

Old behaviour:
![Bildschirmfoto vom 2022-01-10 11-29-28](https://user-images.githubusercontent.com/1897962/148758672-2529e7ef-9ec5-4ee0-a416-7ace75ae1f15.png)

![Bildschirmfoto von 2022-01-10 11-27-00](https://user-images.githubusercontent.com/1897962/148758778-55fa9667-b0ec-4040-b5a0-713ab9bc9bcc.png)

New (expected) behaviour:
![Bildschirmfoto vom 2022-01-10 11-27-50](https://user-images.githubusercontent.com/1897962/148758718-aae7ed4e-510e-48f1-bd84-8de4807cb81a.png)

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
