### PR TITLE
crush: fix upmap bucket replacement for some crush rule

### DIFF
--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -1454,6 +1454,33 @@ TEST_F(CrushWrapperTest, try_remap_rule) {
     ASSERT_EQ(5, out[1]);
     ASSERT_EQ(16, out[2]);
   }
+
+  {
+    cout << "take + choose + chooseleaf + emit" << std::endl;
+    int rule = c.add_rule(3, 4, 0);
+    ASSERT_EQ(3, rule);
+    c.set_rule_step_take(rule, 0, bno);
+    c.set_rule_step_choose_firstn(rule, 1, 3, 2);
+    c.set_rule_step_choose_leaf_firstn(rule, 2, 1, 1);
+    c.set_rule_step_emit(rule, 3);
+
+    // a:(foo | bar): 0 1 2 | 3 4 5
+    // b:(baz | qux): 6 7 8 | 9 10 11
+    // c:(bif | pop): 12 13 14 | 15 16 17
+    vector<int> orig = {0, 6, 12};
+    set<int> overfull = {0, 6, 12};
+    vector<int> underfull = {3, 4, 5, 7, 8, 9, 10, 11, 15, 16, 17};
+    vector<int> more_underfull = {};
+    vector<int> out;
+    int r = c.try_remap_rule(cct, rule, 3, overfull, underfull, more_underfull,
+                             orig, &out);
+    cout << orig << " -> r = " << (int)r << " out " << out << std::endl;
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(3u, out.size());
+    ASSERT_EQ(3, out[0]);  // 0 -> 3 (from diff host)
+    ASSERT_EQ(7, out[1]);  // 6 -> 7 (from same host)
+    ASSERT_EQ(15, out[2]); // 12 -> 15 (from diff host)
+  }
 }
 
 // Local Variables:


### PR DESCRIPTION
I didn't find a ticket on tracker and if one should be created, please tell me.
Since it's the first time I make a pr to ceph, just tell me if I did something wrong that go against the guideline.

## Problem
For some crush rule, current `CrushWrapper::_choose_type_stack` will **only** replace bucket (if current bucket have overfull leaf but no underfull) for the first fanout number of bucket. It should be able to replace for other bucket.
https://github.com/ceph/ceph/blob/7e035110784fba02ba81944e444be9a36932c6a3/src/crush/CrushWrapper.cc#L4000-L4003
## example
Just as is showed in the test.
for tree like:
```
rack a -> host foo | bar -> 0 1 2 | 3 4 5
rack b -> host baz | qux -> 6 7 8 | 9 10 11
rack c -> host bif | pop -> 12 13 14 | 15 16 17
```
If a rule looks like this
```
choose 3 rack
chooseleaf 1 host

type_stack: [<rack, 3>, <host, 1>, <osd, 1>]
```
> Of course this rule can be replaced by chooseleaf 3 rack, but it's valid. And a complex rule might have more than two choose like choose datacenter than rack than host.

For the three picked hosts, only the first host can be replaced when it has overfull osd and has no underfull osd.
The for loop iters on first n(fanout) buckets everytime.
So if we have orig `{0, 6, 12}`，and `osd.12` is overfull, bucket `bif` should be able to replace to bucket `pop` when `osd.13` and `osd.14` is not underfull.

**But there is still another problem.**
If the rule is somewhat like `choose 2 host ; choose 2 osd`, then each host will pick two osd. But if one of two is upmapped to another osd that belongs to a different host, the rule might be broken.
I currently didn't fix this. Only replace while the rule choose only one osd from above bucket? Do you have better way to solve this.

## performance
It seems useless to do bucket replace on bucket above host (rack, for example rule above). Because the build process of vector `o` has nothing to do with vector `w`. The result of replacement on rack will be cover by `w.swap(o)`.
And so underfull_buckets can just be generated for host. The `subtree_contains` is really time consume as no parent info on bucket.
This might refactor this function a lot so I want your advise.

There is still another bug for `CrushWrapper::verify_upmap`. The logic is a little bit complex......I'm reading the code.

Fixes: https://tracker.ceph.com/issues/54305
Signed-off-by: wangnengjie <wangnengjie@sensetime.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
