### PR TITLE
mon: add monstore-tool fix-paxos-counters repair routine

### DIFF
--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -741,6 +741,13 @@ options:
   services:
   - mon
   with_legacy: true
+- name: paxos_warn_table_size
+  type: uint
+  level: advanced
+  default: 10000
+  services:
+  - mon
+  fmt_desc: The maximum amount of versions before warning
 - name: mon_auth_validate_all_caps
   type: bool
   level: advanced

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -237,16 +237,16 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
 
   paxos = std::make_unique<Paxos>(*this, "paxos");
 
-  paxos_service[PAXOS_MDSMAP].reset(new MDSMonitor(*this, *paxos, "mdsmap"));
-  paxos_service[PAXOS_MONMAP].reset(new MonmapMonitor(*this, *paxos, "monmap"));
-  paxos_service[PAXOS_OSDMAP].reset(new OSDMonitor(cct, *this, *paxos, "osdmap"));
-  paxos_service[PAXOS_LOG].reset(new LogMonitor(*this, *paxos, "logm"));
-  paxos_service[PAXOS_AUTH].reset(new AuthMonitor(*this, *paxos, "auth"));
-  paxos_service[PAXOS_MGR].reset(new MgrMonitor(*this, *paxos, "mgr"));
-  paxos_service[PAXOS_MGRSTAT].reset(new MgrStatMonitor(*this, *paxos, "mgrstat"));
-  paxos_service[PAXOS_HEALTH].reset(new HealthMonitor(*this, *paxos, "health"));
-  paxos_service[PAXOS_CONFIG].reset(new ConfigMonitor(*this, *paxos, "config"));
-  paxos_service[PAXOS_KV].reset(new KVMonitor(*this, *paxos, "kv"));
+  paxos_service[PAXOS_MDSMAP].reset(new MDSMonitor(*this, *paxos, get_paxos_name(PAXOS_MDSMAP)));
+  paxos_service[PAXOS_MONMAP].reset(new MonmapMonitor(*this, *paxos, get_paxos_name(PAXOS_MONMAP)));
+  paxos_service[PAXOS_OSDMAP].reset(new OSDMonitor(cct, *this, *paxos, get_paxos_name(PAXOS_OSDMAP)));
+  paxos_service[PAXOS_LOG].reset(new LogMonitor(*this, *paxos, get_paxos_name(PAXOS_LOG)));
+  paxos_service[PAXOS_AUTH].reset(new AuthMonitor(*this, *paxos, get_paxos_name(PAXOS_AUTH)));
+  paxos_service[PAXOS_MGR].reset(new MgrMonitor(*this, *paxos, get_paxos_name(PAXOS_MGR)));
+  paxos_service[PAXOS_MGRSTAT].reset(new MgrStatMonitor(*this, *paxos, get_paxos_name(PAXOS_MGRSTAT)));
+  paxos_service[PAXOS_HEALTH].reset(new HealthMonitor(*this, *paxos, get_paxos_name(PAXOS_HEALTH)));
+  paxos_service[PAXOS_CONFIG].reset(new ConfigMonitor(*this, *paxos, get_paxos_name(PAXOS_CONFIG)));
+  paxos_service[PAXOS_KV].reset(new KVMonitor(*this, *paxos, get_paxos_name(PAXOS_KV)));
 
   bool r = mon_caps.parse("allow *", NULL);
   ceph_assert(r);

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -461,6 +461,13 @@ void Paxos::_sanity_check_store()
 {
   version_t lc = get_store()->get(get_name(), "last_committed");
   ceph_assert(lc == last_committed);
+  if (last_committed < first_committed) {
+    mon.clog->warn() << "sanity_check_store violation in " << get_name() << ". first_commited: " << first_committed << " last_commited: " << last_committed <<
+     ". Run ceph-monstore-tool fix-paxos-counters";
+  }
+  if ((last_committed - first_committed) > g_conf().get_val<uint64_t>("paxos_warn_table_size")) {
+    mon.clog->warn() << "sanity_check_store violation in " << get_name() << ". Number of versions reached warning level, maybe table corrupted or garbable collection broken. first_commited: " << first_committed << " last_commited: " << last_committed;
+  }
 }
 
 

--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -20,6 +20,11 @@
 #include "Monitor.h"
 #include "MonitorDBStore.h"
 
+const std::string kPaxosKeyLastCommited = "last_committed";
+const std::string kPaxosKeyFirstCommited = "first_committed";
+const std::string kPaxosFullPrefix = "full";
+const std::string kPaxosFullLatest = "latest";
+
 /**
  * A Paxos Service is an abstraction that easily allows one to obtain an
  * association between a Monitor and a Paxos class, in order to implement any
@@ -149,9 +154,9 @@ public:
       proposing(false),
       service_version(0), proposal_timer(0), have_pending(false),
       format_version(0),
-      last_committed_name("last_committed"),
-      first_committed_name("first_committed"),
-      full_prefix_name("full"), full_latest_name("latest"),
+      last_committed_name(kPaxosKeyLastCommited),
+      first_committed_name(kPaxosKeyFirstCommited),
+      full_prefix_name(kPaxosFullPrefix), full_latest_name(kPaxosFullLatest),
       cached_first_committed(0), cached_last_committed(0)
   {
   }

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -39,6 +39,21 @@ enum {
   PAXOS_NUM
 };
 
+inline const char *get_paxos_name(int p) {
+  switch (p) {
+  case PAXOS_MDSMAP: return "mdsmap";
+  case PAXOS_MONMAP: return "monmap";
+  case PAXOS_OSDMAP: return "osdmap";
+  case PAXOS_LOG: return "logm";
+  case PAXOS_AUTH: return "auth";
+  case PAXOS_MGR: return "mgr";
+  case PAXOS_MGRSTAT: return "mgrstat";
+  case PAXOS_HEALTH: return "health";
+  case PAXOS_CONFIG: return "config";
+  default: ceph_abort(); return 0;
+  }
+}
+
 #define CEPH_MON_ONDISK_MAGIC "ceph mon volume v012"
 
 // map of entity_type -> features -> count

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -50,6 +50,7 @@ inline const char *get_paxos_name(int p) {
   case PAXOS_MGRSTAT: return "mgrstat";
   case PAXOS_HEALTH: return "health";
   case PAXOS_CONFIG: return "config";
+  case PAXOS_KV: return "kv";
   default: ceph_abort(); return 0;
   }
 }


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->
We experienced constant monstore growth without reason. Invetigation showed that the first_commited counter was much larger then the last_commited counter on serveral paxos tables. This causes the garbage collector to malfunction and ever more problems on other subsystems.

This PR adds a repair command 'monstore-tool [path] fix-paxos-counters' to fix such corruptions as well as a sanity check to compain if the counters have illogical values at runtime.

The repair routine scans the paxos tables for versions and adjusts the last_commited and first_commited counts to the longest, continuus chain from the last version commited. Older versions or ones that can't be decoded correctly are deleted.
This should fix any case where the mon does not start due corrupted versions.

Our monstore grow to 140gb over the course of some weeks, mostly logm and mgrstat versions. After fixing the counters, the database shrunk to ~100 MB.

We don't know how the corruption started, but after asking on the ceph-users mailinglist, another user experienced a similar grow of the mon database, in his case over 700GB. So, this kind of corruption seems to happen once in a while, maybe on a power outage.

Fixes: https://tracker.ceph.com/issues/53485
Signed-off-by:  Daniel Poelzleithner <poelzleithner@b1-systems.de>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
