### PR TITLE
test/crimson/seastar_runner: set begin_signaled before eventfd_write

### DIFF
--- a/src/test/crimson/seastar_runner.h
+++ b/src/test/crimson/seastar_runner.h
@@ -69,9 +69,9 @@ struct SeastarRunner {
     auto ret = app.run(argc, argv, [this] {
       on_end.reset(new seastar::readable_eventfd);
       return seastar::now().then([this] {
+	begin_signaled = true;
 	auto r = ::eventfd_write(begin_fd.get(), APP_RUNNING);
 	assert(r == 0);
-	begin_signaled = true;
 	return seastar::now();
       }).then([this] {
 	return on_end->wait().then([](size_t){});
@@ -85,8 +85,8 @@ struct SeastarRunner {
       std::cerr << "Seastar app returns " << ret << std::endl;
     }
     if (!begin_signaled) {
-      ::eventfd_write(begin_fd.get(), APP_NOT_RUN);
       begin_signaled = true;
+      ::eventfd_write(begin_fd.get(), APP_NOT_RUN);
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Yingxin Cheng <yingxin.cheng@intel.com>

Fix the observed test failure from https://github.com/ceph/ceph/pull/44478#issuecomment-1009527392 and https://github.com/ceph/ceph/pull/44490#issuecomment-1007185559



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
