### PR TITLE
rgw: clean bucket info object only if removing bucket index shards clean success

### DIFF
--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -763,15 +763,15 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
     ldpp_dout(dpp, -1) << "Error: " << __func__ <<
       " failed to clean up old shards; " <<
       "RGWRados::clean_bucket_index returned " << ret << dendl;
-  }
-
-  ret = store->ctl()->bucket->remove_bucket_instance_info(bucket_info.bucket,
-                                                       bucket_info, null_yield, dpp);
-  if (ret < 0) {
-    ldpp_dout(dpp, -1) << "Error: " << __func__ <<
-      " failed to clean old bucket info object \"" <<
-      bucket_info.bucket.get_key() <<
-      "\"created after successful resharding with error " << ret << dendl;
+  } else {
+    ret = store->ctl()->bucket->remove_bucket_instance_info(bucket_info.bucket,
+                                                        bucket_info, null_yield, dpp);
+    if (ret < 0) {
+      ldpp_dout(dpp, -1) << "Error: " << __func__ <<
+        " failed to clean old bucket info object \"" <<
+        bucket_info.bucket.get_key() <<
+        "\"created after successful resharding with error " << ret << dendl;
+    }
   }
 
   ldpp_dout(dpp, 1) << __func__ <<
@@ -793,16 +793,16 @@ error_out:
     ldpp_dout(dpp, -1) << "Error: " << __func__ <<
       " failed to clean up shards from failed incomplete resharding; " <<
       "RGWRados::clean_bucket_index returned " << ret2 << dendl;
-  }
-
-  ret2 = store->ctl()->bucket->remove_bucket_instance_info(new_bucket_info.bucket,
-                                                        new_bucket_info,
-							null_yield, dpp);
-  if (ret2 < 0) {
-    ldpp_dout(dpp, -1) << "Error: " << __func__ <<
-      " failed to clean bucket info object \"" <<
-      new_bucket_info.bucket.get_key() <<
-      "\"created during incomplete resharding with error " << ret2 << dendl;
+  } else {
+    ret2 = store->ctl()->bucket->remove_bucket_instance_info(new_bucket_info.bucket,
+                                                          new_bucket_info,
+                null_yield, dpp);
+    if (ret2 < 0) {
+      ldpp_dout(dpp, -1) << "Error: " << __func__ <<
+        " failed to clean bucket info object \"" <<
+        new_bucket_info.bucket.get_key() <<
+        "\"created during incomplete resharding with error " << ret2 << dendl;
+    }
   }
 
   return ret;


### PR DESCRIPTION
radosgw-admin reshard stale-instances rm will cleanup stale-instances and stale-index from bucket resharding, but some stale-index can't be removed which have no corresponding stale-instances, so after resharding, radosgw should remove bucket info object after  succeeding in removing bucket index shards.


Signed-off-by: Huber-ming <zhangsm01@inspur.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
