### PR TITLE
[DNM] mgr/nfs: add interface to update a cephfs export's

### DIFF
--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -474,6 +474,48 @@ fragment.  For example,::
        transports = "TCP";
    }
 
+Update CephFS export's clients dynamically
+------------------------------------------
+
+A CephFS export's client access control list can be replaced without
+restarting the ganesha server(s) by using the following command.
+
+::
+
+    $ ceph nfs export clients update cephfs <cluster_id> <pseudo_path> --clients <json_list_of_clients>
+
+The 'clients' arguments should be a list of python dictionaries in JSON format.
+Each dictionary represents a ganesha export's client block. A client block
+dictionary should have the following keys 'addresses', 'access_type', 'squash'.
+
+Possible values of 'access_type' are 'ro', 'rw', 'none'
+
+Possible values of 'squash' are "root", "root_squash", "rootsquash", "rootid",
+"root_id_squash", "rootidsquash", "all", "all_squash", "allsquash", "all_anomnymous",
+"allanonymous", "no_root_squash", "none", "noidsquash"
+
+For example, to update clients of a CephFS export in cluster 'mynfs' with
+pseudopath '/cephfs'
+
+::
+
+  $ read -d '' CLIENTS_JSON << EOF
+  > [
+  >   {
+  >     "addresses": ["10.0.2.15", "10.0.2.16"],
+  >     "access_type": "rw",
+  >     "squash": "none"
+  >   },
+  >   {
+  >     "addresses": ["10.0.2.17"],
+  >     "access_type": "ro",
+  >     "squash": "none"
+  >   }
+  > ]
+  > EOF
+
+  $ ceph nfs export clients update cephfs mynfs /cephfs --clients "$CLIENTS_JSON"
+
 
 Mounting
 ========

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -41,6 +41,18 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                              read_only=readonly, path=path,
                                              squash=squash, addr=client_addr)
 
+    @CLICommand('nfs export clients update cephfs', perm='rw')
+    def _cmd_nfs_export_clients_update_cephfs(
+            self,
+            cluster_id: str,
+            pseudo_path: str,
+            clients: str
+    ) -> Tuple[int, str, str]:
+        """Update a CephFS export's clients by `-i <json list of ganesha client blocks>`"""
+        return self.export_mgr.update_cephfs_export_clients(
+            cluster_id=cluster_id, pseudo_path=pseudo_path,
+            clients_json=clients)
+
     @CLICommand('nfs export create rgw', perm='rw')
     def _cmd_nfs_export_create_rgw(
             self,


### PR DESCRIPTION
... clients dynamically without restarting the ganesha server(s).

The CLI is as follows,
$ ceph nfs export update clients cephfs --clients \<json-list-of-ganesha-exports\>

Signed-off-by: Ramana Raja <rraja@redhat.com>
Fixes: https://tracker.ceph.com/issues/53055





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
