### PR TITLE
mgr/dashboard/telemetry: reduce telemetry dashboard preview size

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -274,7 +274,8 @@
                      for="report"
                      class="cd-col-form-label">Report preview
                 <cd-helper i18n-html
-                           html="The actual telemetry data that will be submitted.">
+                           html="The actual telemetry data that will be submitted."><em>Note: Please select 'Download' to
+                                   view the full report, including metrics from the perf channel.</em>
                 </cd-helper>
               </label>
               <div class="cd-col-form-input">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -268,6 +268,41 @@ describe('TelemetryComponent', () => {
       });
     });
 
+    it('should remove perf channel fields from a report', () => {
+      expect(
+        JSON.parse(
+          component.formatReportTest({
+            perf_counters: {},
+            stats_per_pool: {},
+            stats_per_pg: {},
+            io_rate: {},
+            osd_perf_histograms: {},
+            mempool: {},
+            heap_stats: {},
+            rocksdb_stats: {}
+          })
+        )
+      ).toStrictEqual({});
+
+      expect(
+        JSON.parse(
+          component.formatReportTest({
+            perf_counters: {},
+            stats_per_pool: {},
+            stats_per_pg: {},
+            io_rate: {},
+            osd_perf_histograms: {},
+            mempool: {},
+            heap_stats: {},
+            rocksdb_stats: {},
+            other: {}
+          })
+        )
+      ).toStrictEqual({
+        other: {}
+      });
+    });
+
     it('should submit', () => {
       component.onSubmit();
       const req = httpTesting.expectOne('api/telemetry');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -128,6 +128,28 @@ export class TelemetryComponent extends CdForm implements OnInit {
     return JSON.stringify(copy, null, 2);
   }
 
+  formatReportTest(report: object) {
+    let copy = {};
+    copy = JSON.parse(JSON.stringify(report));
+    const perf_keys = [
+      'perf_counters',
+      'stats_per_pool',
+      'stats_per_pg',
+      'io_rate',
+      'osd_perf_histograms',
+      'mempool',
+      'heap_stats',
+      'rocksdb_stats'
+    ];
+    for (let i = 0; i < perf_keys.length; i++) {
+      const key = perf_keys[i];
+      if (key in copy) {
+        delete copy[key];
+      }
+    }
+    return JSON.stringify(copy, null, 2);
+  }
+
   private createPreviewForm() {
     const controls = {
       report: this.formatReport(),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -106,9 +106,31 @@ export class TelemetryComponent extends CdForm implements OnInit {
     return JSON.stringify(report, this.replacer, 2);
   }
 
+  private formatReport() {
+    let copy = {};
+    copy = JSON.parse(JSON.stringify(this.report));
+    const perf_keys = [
+      'perf_counters',
+      'stats_per_pool',
+      'stats_per_pg',
+      'io_rate',
+      'osd_perf_histograms',
+      'mempool',
+      'heap_stats',
+      'rocksdb_stats'
+    ];
+    for (let i = 0; i < perf_keys.length; i++) {
+      const key = perf_keys[i];
+      if (key in copy['report']) {
+        delete copy['report'][key];
+      }
+    }
+    return JSON.stringify(copy, null, 2);
+  }
+
   private createPreviewForm() {
     const controls = {
-      report: JSON.stringify(this.report, this.replacer, 2),
+      report: this.formatReport(),
       reportId: this.reportId,
       licenseAgrmt: [this.licenseAgrmt, Validators.requiredTrue]
     };


### PR DESCRIPTION
Keeping perf channel metrics on the telemetry preview form may cause
laggy loading times and slow behavior in the text box if the report
is particularly long. As a workaround, we can remove performance metrics
from the preview form and notify the users that they may still download
a full report upon selecting the "Download" button.

For the future, it might be good to implement this so telemetry sends
a compressed report to the server.

Fixes: https://tracker.ceph.com/issues/53831
Signed-off-by: Laura Flores <lflores@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
