### PR TITLE
pacific: cephadm: make extract_uid_gid errors more readable

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1464,6 +1464,9 @@ def call_throws(
         **kwargs: Any) -> Tuple[str, str, int]:
     out, err, ret = call(ctx, command, desc, verbosity, timeout, **kwargs)
     if ret:
+        for s in (out, err):
+            if s.strip() and len(s.splitlines()) <= 2:  # readable message?
+                raise RuntimeError(f'Failed command: {" ".join(command)}: {s}')
         raise RuntimeError('Failed command: %s' % ' '.join(command))
     return out, err, ret
 
@@ -2580,6 +2583,8 @@ def extract_uid_gid(ctx, img='', file_path='/var/lib/ceph'):
     else:
         paths = file_path
 
+    ex: Optional[Tuple[str, RuntimeError]] = None
+
     for fp in paths:
         try:
             out = CephContainer(
@@ -2590,8 +2595,11 @@ def extract_uid_gid(ctx, img='', file_path='/var/lib/ceph'):
             ).run()
             uid, gid = out.split(' ')
             return int(uid), int(gid)
-        except RuntimeError:
-            pass
+        except RuntimeError as e:
+            ex = (fp, e)
+    if ex:
+        raise Error(f'Failed to extract uid/gid for path {ex[0]}: {ex[1]}')
+
     raise RuntimeError('uid/gid not found')
 
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -524,6 +524,16 @@ docker.io/ceph/daemon-base:octopus
             infer_config(ctx)
             assert ctx.config == result
 
+    @mock.patch('cephadm.call')
+    def test_extract_uid_gid_fail(self, _call):
+        err = """Error: container_linux.go:370: starting container process caused: process_linux.go:459: container init caused: process_linux.go:422: setting cgroup config for procHooks process caused: Unit libpod-056038e1126191fba41d8a037275136f2d7aeec9710b9ee
+ff792c06d8544b983.scope not found.: OCI runtime error"""
+        _call.return_value = ('', err, 127)
+        ctx = cd.CephadmContext()
+        ctx.container_engine = mock_podman()
+        with pytest.raises(cd.Error, match='OCI'):
+            cd.extract_uid_gid(ctx)
+
 
 class TestCustomContainer(unittest.TestCase):
     cc: cd.CustomContainer


### PR DESCRIPTION
Backport of #44293