### PR TITLE
test/crimson: fix a race condition in SeastarRunner

### DIFF
--- a/src/test/crimson/seastar_runner.h
+++ b/src/test/crimson/seastar_runner.h
@@ -69,9 +69,9 @@ struct SeastarRunner {
     auto ret = app.run(argc, argv, [this] {
       on_end.reset(new seastar::readable_eventfd);
       return seastar::now().then([this] {
+	begin_signaled = true;
 	auto r = ::eventfd_write(begin_fd.get(), APP_RUNNING);
 	assert(r == 0);
-	begin_signaled = true;
 	return seastar::now();
       }).then([this] {
 	return on_end->wait().then([](size_t){});
@@ -85,8 +85,8 @@ struct SeastarRunner {
       std::cerr << "Seastar app returns " << ret << std::endl;
     }
     if (!begin_signaled) {
-      ::eventfd_write(begin_fd.get(), APP_NOT_RUN);
       begin_signaled = true;
+      ::eventfd_write(begin_fd.get(), APP_NOT_RUN);
     }
   }
 


### PR DESCRIPTION
This patch is supposed to fix the following problem:

```
        Start 234: unittest-seastar-errorator
216/258 Test #234: unittest-seastar-errorator ................Child aborted***Exception:   0.95 sec
WARNING: debug mode. Not for benchmarking or production
WARN  2022-01-11 10:01:32,973 [shard 0] seastar - Creation of perf_event based stall detector failed, falling back to posix timer: std::system_error (error system:13, perf_event_open() failed: Permission denied)
unittest-seastar-errorator: ../src/test/crimson/seastar_runner.h:45: int SeastarRunner::init(int, char **): Assertion `begin_signaled == true' failed.
Aborting.
Backtrace:
  0xb3397a
  0x1d19430
  0x1d1905d
  0x1b72332
  0x1b9dd95
  0x1c75fe9
  0x1c76231
  0x1c7605a
  0x7f20b7aee3bf
  /lib/x86_64-linux-gnu/libc.so.6+0x4618a
  /lib/x86_64-linux-gnu/libc.so.6+0x25858
  /lib/x86_64-linux-gnu/libc.so.6+0x25728
  /lib/x86_64-linux-gnu/libc.so.6+0x36f35
  0xc8bb88
  0xc7ec71
  /lib/x86_64-linux-gnu/libc.so.6+0x270b2
  0xafc95d
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
