### PR TITLE
pacific: mgr/dashboard: add test coverage for API docs (SwaggerUI) 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/api-docs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/api-docs.e2e-spec.ts
@@ -1,0 +1,15 @@
+import { ApiDocsPageHelper } from 'cypress/integration/ui/api-docs.po';
+
+describe('Api Docs Page', () => {
+  const apiDocs = new ApiDocsPageHelper();
+
+  beforeEach(() => {
+    cy.login();
+    Cypress.Cookies.preserveOnce('token');
+    apiDocs.navigateTo();
+  });
+
+  it('should show the API Docs description', () => {
+    cy.get('.renderedMarkdown').first().contains('This is the official Ceph REST API');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/api-docs.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/api-docs.po.ts
@@ -1,0 +1,5 @@
+import { PageHelper } from '../page-helper.po';
+
+export class ApiDocsPageHelper extends PageHelper {
+  pages = { index: { url: '#/api-docs', id: 'cd-api-docs' } };
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53825

---

backport of https://github.com/ceph/ceph/pull/44449
parent tracker: https://tracker.ceph.com/issues/53756

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh