### PR TITLE
pacific: mgr/cephadm: avoid repeated calls to get_module_option

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -409,6 +409,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.autotune_interval = 0
             self.apply_spec_fails: List[Tuple[str, str]] = []
             self.max_osd_draining_count = 10
+            self.device_enhanced_scan = False
 
         self._cons: Dict[str, Tuple[remoto.backends.BaseConnection,
                                     remoto.backends.LegacyModuleExecute]] = {}

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -439,8 +439,7 @@ class CephadmServe:
         return None
 
     def _refresh_host_devices(self, host: str) -> Optional[str]:
-
-        with_lsm = self.mgr.get_module_option('device_enhanced_scan')
+        with_lsm = self.mgr.device_enhanced_scan
         inventory_args = ['--', 'inventory',
                           '--format=json-pretty',
                           '--filter-for-batch']


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/44134

Some of the changes were to agent specific code which is not yet in pacific so they were left out.