### PR TITLE
octopus: osd/OSDMapMapping: fix spurious threadpool timeout errors

### DIFF
--- a/src/common/WorkQueue.cc
+++ b/src/common/WorkQueue.cc
@@ -99,7 +99,9 @@ void ThreadPool::worker(WorkThread *wt)
       break;
     }
 
-    if (!_pause && !work_queues.empty()) {
+    if (work_queues.empty()) {
+      ldout(cct, 10) << "worker no work queues" << dendl;
+    } else if (!_pause) {
       WorkQueue_* wq;
       int tries = 2 * work_queues.size();
       bool did = false;

--- a/src/osd/OSDMapMapping.h
+++ b/src/osd/OSDMapMapping.h
@@ -115,7 +115,11 @@ protected:
     ParallelPGMapper *m;
 
     WQ(ParallelPGMapper *m_, ThreadPool *tp)
-      : ThreadPool::WorkQueue<Item>("ParallelPGMapper::WQ", 0, 0, tp),
+      : ThreadPool::WorkQueue<Item>(
+	"ParallelPGMapper::WQ",
+	ceph::make_timespan(m_->cct->_conf->threadpool_default_timeout),
+	ceph::timespan::zero(),
+	tp),
         m(m_) {}
 
     bool _enqueue(Item *i) override {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53719

---

backport of https://github.com/ceph/ceph/pull/44225
parent tracker: https://tracker.ceph.com/issues/53506

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh