### PR TITLE
pacific: librbd: diff-iterate reports incorrect offsets in fast-diff mode

### DIFF
--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -300,9 +300,12 @@ int DiffIterate<I>::execute() {
                    diff_state == object_map::DIFF_STATE_DATA_UPDATED) {
           bool updated = (diff_state == object_map::DIFF_STATE_DATA_UPDATED);
           for (auto& oe : extents) {
-            r = m_callback(off + oe.offset, oe.length, updated, m_callback_arg);
-            if (r < 0) {
-              return r;
+            for (auto& be : oe.buffer_extents) {
+              r = m_callback(off + be.first, be.second, updated,
+                             m_callback_arg);
+              if (r < 0) {
+                return r;
+              }
             }
           }
         }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53839

---

backport of https://github.com/ceph/ceph/pull/44483
parent tracker: https://tracker.ceph.com/issues/53784

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh