### PR TITLE
mgr/cephadm/iscsi: use `mon_command` in `post_remove` instead of `check_mon_command`

### DIFF
--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -156,17 +156,17 @@ class IscsiService(CephService):
         """
         logger.debug(f'Post remove daemon {self.TYPE}.{daemon.daemon_id}')
 
-        if 'dashboard' in self.mgr.get('mgr_map')['modules']:
-            # remove config for dashboard iscsi gateways
-            ret, out, err = self.mgr.check_mon_command({
-                'prefix': 'dashboard iscsi-gateway-rm',
-                'name': daemon.hostname,
-            })
+        # remove config for dashboard iscsi gateways
+        ret, out, err = self.mgr.mon_command({
+            'prefix': 'dashboard iscsi-gateway-rm',
+            'name': daemon.hostname,
+        })
+        if not ret:
             logger.info(f'{daemon.hostname} removed from iscsi gateways dashboard config')
 
         # needed to know if we have ssl stuff for iscsi in ceph config
         iscsi_config_dict = {}
-        ret, iscsi_config, err = self.mgr.check_mon_command({
+        ret, iscsi_config, err = self.mgr.mon_command({
             'prefix': 'config-key dump',
             'key': 'iscsi',
         })
@@ -176,7 +176,7 @@ class IscsiService(CephService):
         # remove iscsi cert and key from ceph config
         for iscsi_key, value in iscsi_config_dict.items():
             if f'iscsi/client.{daemon.name()}/' in iscsi_key:
-                ret, out, err = self.mgr.check_mon_command({
+                ret, out, err = self.mgr.mon_command({
                     'prefix': 'config-key rm',
                     'key': iscsi_key,
                 })


### PR DESCRIPTION
Use `mon_command` instead of `check_mon_command` in `post_remove` to avoid errors such as if iscsi service is removed before the iscsi gateway list is updated, cluster will enter error state and iscsi removal gets stuck.

The error `Module 'cephadm' has failed: dashboard iscsi-gateway-rm failed: iSCSI gateway 'vm-00' does not exist retval: -2` doesn't occur all the time; it only occurs if the iscsi service is removed before the iscsi gateway list is updated with the deployed daemons. If the iscsi service is removed by the time the iscsi gateway list is already updated, then no error occurs

Fixes: https://tracker.ceph.com/issues/53706
Signed-off-by: Melissa Li <melissali@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
