### PR TITLE
doc/releases: remove outdated info and versions; mark nautilus eol

### DIFF
--- a/doc/_ext/ceph_releases.py
+++ b/doc/_ext/ceph_releases.py
@@ -116,7 +116,7 @@ class CephReleases(Directive):
 
 class CephTimeline(Directive):
     has_content = False
-    required_arguments = 7
+    required_arguments = 4
     optional_arguments = 0
     option_spec = {}
 

--- a/doc/releases/general.rst
+++ b/doc/releases/general.rst
@@ -21,33 +21,9 @@ name, since the latin names are harder to remember or pronounce).
 Version numbers have three components, *x.y.z*.  *x* identifies the release
 cycle (e.g., 13 for Mimic).  *y* identifies the release type:
 
-* x.0.z - development releases (for early testers and the brave at heart)
+* x.0.z - development versions
 * x.1.z - release candidates (for test clusters, brave users)
 * x.2.z - stable/bugfix releases (for users)
-
-This versioning convention started with the 9.y.z Infernalis cycle.  Prior to
-that, versions looked with 0.y for development releases and 0.y.z for stable
-series.
-
-Development releases (x.0.z)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Each development release (x.0.z) freezes the master development branch
-and applies `integration and upgrade tests
-<https://github.com/ceph/ceph/tree/master/qa/suites/>`_ before it is released.  Once
-released, there is no effort to backport fixes; developer focus is on
-the next development release which is usually only a few weeks away.
-
-* Development release every 8 to 12 weeks
-* Intended for testing, not production deployments
-* Full integration testing
-* Upgrade testing from the last stable release(s)
-* Every effort is made to allow *offline* upgrades from previous
-  development releases (meaning you can stop all daemons, upgrade, and
-  restart).  No attempt is made to support online rolling upgrades
-  between development releases.  This facilitates deployment of
-  development releases on non-production test clusters without
-  repopulating them with data.
 
 Release candidates (x.1.z)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -97,10 +73,6 @@ months (i.e., two 12 month release cycles) after the month of the first release.
 For example, Mimic (13.2.z) will reach end of life (EOL) shortly after Octopus
 (15.2.0) is released. The lifetime of a release may vary because it depends on
 how quickly the stable releases are published.
-
-In the case of Jewel and Kraken, the lifetime was slightly different than
-described above. Prior to Luminous, only every other stable release was an "LTS"
-release.
 
 Detailed information on all releases, past and present, can be found at :ref:`ceph-releases-index`
 

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -21,7 +21,6 @@ security fixes.
 
    Pacific (v16.2.*) <pacific>
    Octopus (v15.2.*) <octopus>
-   Nautilus (v14.2.*) <nautilus>
 
 .. ceph_releases:: releases.yml current
 
@@ -38,6 +37,7 @@ receive bug fixes or backports).
    :maxdepth: 1
    :hidden:
 
+   Nautilus (v14.2.*) <nautilus>
    Mimic (v13.2.*) <mimic>
    Luminous (v12.2.*) <luminous>
    Kraken (v11.2.*) <kraken>

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -55,7 +55,7 @@ receive bug fixes or backports).
 Release timeline
 ----------------
 
-.. ceph_timeline:: releases.yml dev pacific octopus nautilus mimic luminous
+.. ceph_timeline:: releases.yml pacific octopus nautilus
 
 
 .. _Pacific: pacific

--- a/doc/releases/releases.yml
+++ b/doc/releases/releases.yml
@@ -70,6 +70,7 @@ releases:
 
   nautilus:
     target_eol: 2021-06-01
+    actual_eol: 2021-06-30
     releases:
       - version: 14.2.22
         released: 2021-06-30


### PR DESCRIPTION

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
