### PR TITLE
crimson/os/seastore: consolidate seastore_journal logs with cleanup and validations

### DIFF
--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -439,7 +439,7 @@ Journal::RecordBatch::add_pending(
   assert(state != state_t::SUBMITTING);
   assert(can_batch(record, block_size).value() == new_size);
 
-  auto dlength_offset = pending.current_dlength;
+  auto dlength_offset = pending.size.dlength;
   pending.push_back(
       std::move(record), block_size);
   assert(pending.size == new_size);

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -13,6 +13,15 @@
 #include "crimson/os/seastore/segment_cleaner.h"
 
 SET_SUBSYS(seastore_journal);
+/*
+ * format:
+ * - H<handle-addr> information
+ *
+ * levels:
+ * - INFO:  major initiation, closing, rolling and replay operations
+ * - DEBUG: INFO details, major submit operations
+ * - TRACE: DEBUG details
+ */
 
 namespace crimson::os::seastore {
 
@@ -44,13 +53,28 @@ Journal::Journal(
   register_metrics();
 }
 
+Journal::open_for_write_ret Journal::open_for_write()
+{
+  LOG_PREFIX(Journal::open_for_write);
+  INFO("device_id={}", journal_segment_manager.get_device_id());
+  return journal_segment_manager.open();
+}
+
+Journal::close_ertr::future<> Journal::close()
+{
+  LOG_PREFIX(Journal::close);
+  INFO("closing");
+  metrics.clear();
+  return journal_segment_manager.close();
+}
+
 Journal::prep_replay_segments_fut
 Journal::prep_replay_segments(
   std::vector<std::pair<segment_id_t, segment_header_t>> segments)
 {
   LOG_PREFIX(Journal::prep_replay_segments);
-  DEBUG("{} segments", segments.size());
   if (segments.empty()) {
+    ERROR("no journal segments for replay");
     return crimson::ct_error::input_output_error::make();
   }
   std::sort(
@@ -83,7 +107,6 @@ Journal::prep_replay_segments(
   auto journal_tail = segments.rbegin()->second.journal_tail;
   segment_provider->update_journal_tail_committed(journal_tail);
   auto replay_from = journal_tail.offset;
-  DEBUG("journal_tail={}", journal_tail);
   auto from = segments.begin();
   if (replay_from != P_ADDR_NULL) {
     from = std::find_if(
@@ -103,17 +126,20 @@ Journal::prep_replay_segments(
       from->first,
       journal_segment_manager.get_block_size());
   }
-  auto ret = replay_segments_t(segments.end() - from);
+
+  auto num_segments = segments.end() - from;
+  INFO("{} segments to replay, from {}",
+       num_segments, replay_from);
+  auto ret = replay_segments_t(num_segments);
   std::transform(
     from, segments.end(), ret.begin(),
-    [this, FNAME](const auto &p) {
+    [this](const auto &p) {
       auto ret = journal_seq_t{
 	p.second.journal_segment_seq,
 	paddr_t::make_seg_paddr(
 	  p.first,
 	  journal_segment_manager.get_block_size())
       };
-      DEBUG("replaying from {}", ret);
       return std::make_pair(ret, p.second);
     });
   ret[0].first.offset = replay_from;
@@ -129,7 +155,7 @@ Journal::replay_segment(
   delta_handler_t &handler)
 {
   LOG_PREFIX(Journal::replay_segment);
-  DEBUG("starting at {}", seq);
+  INFO("starting at {} -- {}", seq, header);
   return seastar::do_with(
     scan_valid_records_cursor(seq),
     ExtentReader::found_record_handler_t([=, &handler](
@@ -138,12 +164,12 @@ Journal::replay_segment(
       const bufferlist& mdbuf)
       -> ExtentReader::scan_valid_records_ertr::future<>
     {
-      DEBUG("decoding {} records", header.records);
       auto maybe_record_deltas_list = try_decode_deltas(
           header, mdbuf, locator.record_block_base);
       if (!maybe_record_deltas_list) {
         // This should be impossible, we did check the crc on the mdbuf
-        ERROR("unable to decode deltas for record {}", locator.record_block_base);
+        ERROR("unable to decode deltas for record {} at {}",
+              header, locator);
         return crimson::ct_error::input_output_error::make();
       }
 
@@ -161,13 +187,13 @@ Journal::replay_segment(
            FNAME,
            &handler](record_deltas_t& record_deltas)
         {
-          DEBUG("decoded {} deltas at block_base {}",
-                record_deltas.deltas.size(),
-                record_deltas.record_block_base);
           auto locator = record_locator_t{
             record_deltas.record_block_base,
             write_result
           };
+          DEBUG("processing {} deltas at block_base {}",
+                record_deltas.deltas.size(),
+                locator);
           return crimson::do_for_each(
             record_deltas.deltas,
             [locator,
@@ -216,6 +242,8 @@ Journal::replay_ret Journal::replay(
   std::vector<std::pair<segment_id_t, segment_header_t>>&& segment_headers,
   delta_handler_t &&delta_handler)
 {
+  LOG_PREFIX(Journal::replay);
+  INFO("got {} segments", segment_headers.size());
   return seastar::do_with(
     std::move(delta_handler), replay_segments_t(),
     [this, segment_headers=std::move(segment_headers)]
@@ -223,8 +251,6 @@ Journal::replay_ret Journal::replay(
   {
     return prep_replay_segments(std::move(segment_headers)
     ).safe_then([this, &handler, &segments](auto replay_segs) mutable {
-      LOG_PREFIX(Journal::replay);
-      DEBUG("found {} segments", replay_segs.size());
       segments = std::move(replay_segs);
       return crimson::do_for_each(segments, [this, &handler](auto i) mutable {
         return replay_segment(i.first, i.second, handler);
@@ -235,6 +261,8 @@ Journal::replay_ret Journal::replay(
 
 void Journal::register_metrics()
 {
+  LOG_PREFIX(Journal::register_metrics);
+  DEBUG("");
   record_submitter.reset_stats();
   namespace sm = seastar::metrics;
   metrics.add_group(
@@ -300,9 +328,30 @@ Journal::JournalSegmentManager::JournalSegmentManager(
   reset();
 }
 
+Journal::JournalSegmentManager::open_ret
+Journal::JournalSegmentManager::open()
+{
+  return roll().safe_then([this] {
+    return get_current_write_seq();
+  });
+}
+
 Journal::JournalSegmentManager::close_ertr::future<>
 Journal::JournalSegmentManager::close()
 {
+  LOG_PREFIX(JournalSegmentManager::close);
+  if (current_journal_segment) {
+    INFO("segment_id={}, seq={}, "
+         "written_to={}, committed_to={}, nonce={}",
+         current_journal_segment->get_segment_id(),
+         get_segment_seq(),
+         written_to,
+         committed_to,
+         current_segment_nonce);
+  } else {
+    INFO("no current journal segment");
+  }
+
   return (
     current_journal_segment ?
     current_journal_segment->close() :
@@ -320,16 +369,26 @@ Journal::JournalSegmentManager::close()
 Journal::JournalSegmentManager::roll_ertr::future<>
 Journal::JournalSegmentManager::roll()
 {
+  LOG_PREFIX(JournalSegmentManager::roll);
   auto old_segment_id = current_journal_segment ?
     current_journal_segment->get_segment_id() :
     NULL_SEG_ID;
+  if (current_journal_segment) {
+    INFO("closing segment {}, seq={}, "
+         "written_to={}, committed_to={}, nonce={}",
+         old_segment_id,
+         get_segment_seq(),
+         written_to,
+         committed_to,
+         current_segment_nonce);
+  }
 
   return (
     current_journal_segment ?
     current_journal_segment->close() :
     Segment::close_ertr::now()
   ).safe_then([this] {
-    return segment_provider->get_segment(segment_manager.get_device_id());
+    return segment_provider->get_segment(get_device_id());
   }).safe_then([this](auto segment) {
     return segment_manager.open(segment);
   }).safe_then([this](auto sref) {
@@ -356,10 +415,7 @@ Journal::JournalSegmentManager::write(ceph::bufferlist to_write)
   LOG_PREFIX(JournalSegmentManager::write);
   auto write_length = to_write.length();
   auto write_start_seq = get_current_write_seq();
-  DEBUG("write_start {} => {}, length={}",
-        write_start_seq,
-        write_start_seq.offset.as_seg_paddr().get_segment_off() + write_length,
-        write_length);
+  TRACE("{}~{}", write_start_seq, write_length);
   assert(write_length > 0);
   assert((write_length % segment_manager.get_block_size()) == 0);
   assert(!needs_roll(write_length));
@@ -386,8 +442,7 @@ void Journal::JournalSegmentManager::mark_committed(
   const journal_seq_t& new_committed_to)
 {
   LOG_PREFIX(JournalSegmentManager::mark_committed);
-  DEBUG("committed_to {} => {}",
-        committed_to, new_committed_to);
+  TRACE("{} => {}", committed_to, new_committed_to);
   assert(committed_to == journal_seq_t() ||
          committed_to <= new_committed_to);
   committed_to = new_committed_to;
@@ -411,10 +466,7 @@ Journal::JournalSegmentManager::initialize_segment(Segment& segment)
     new_tail,
     current_segment_nonce,
     false};
-  DEBUG("segment_id {} journal_tail_target {}, header {}",
-        segment.get_segment_id(),
-        new_tail,
-        header);
+  INFO("writing {} ...", header);
   encode(header, bl);
 
   bufferptr bp(
@@ -436,17 +488,20 @@ Journal::JournalSegmentManager::initialize_segment(Segment& segment)
 Journal::RecordBatch::add_pending_ret
 Journal::RecordBatch::add_pending(
   record_t&& record,
+  OrderingHandle& handle,
   extent_len_t block_size)
 {
   LOG_PREFIX(RecordBatch::add_pending);
   auto new_size = get_encoded_length_after(record, block_size);
-  DEBUG("batches={}, write_size={}",
+  auto dlength_offset = pending.size.dlength;
+  TRACE("H{} batches={}, write_size={}, dlength_offset={} ...",
+        (void*)&handle,
         pending.get_size() + 1,
-        new_size.get_encoded_length());
+        new_size.get_encoded_length(),
+        dlength_offset);
   assert(state != state_t::SUBMITTING);
   assert(can_batch(record, block_size).value() == new_size);
 
-  auto dlength_offset = pending.size.dlength;
   pending.push_back(
       std::move(record), block_size);
   assert(pending.size == new_size);
@@ -459,9 +514,10 @@ Journal::RecordBatch::add_pending(
   state = state_t::PENDING;
 
   return io_promise->get_shared_future(
-  ).then([dlength_offset
+  ).then([dlength_offset, FNAME, &handle
          ](auto maybe_promise_result) -> add_pending_ret {
     if (!maybe_promise_result.has_value()) {
+      ERROR("H{} write failed", (void*)&handle);
       return crimson::ct_error::input_output_error::make();
     }
     auto write_result = maybe_promise_result->write_result;
@@ -470,6 +526,7 @@ Journal::RecordBatch::add_pending(
           maybe_promise_result->mdlength + dlength_offset),
       write_result
     };
+    TRACE("H{} write finish with {}", (void*)&handle, submit_result);
     return add_pending_ret(
       add_pending_ertr::ready_future_marker{},
       submit_result);
@@ -481,10 +538,6 @@ Journal::RecordBatch::encode_batch(
   const journal_seq_t& committed_to,
   segment_nonce_t segment_nonce)
 {
-  LOG_PREFIX(RecordBatch::encode_batch);
-  DEBUG("batches={}, committed_to={}",
-        pending.get_size(),
-        committed_to);
   assert(state == state_t::PENDING);
   assert(pending.get_size() > 0);
   assert(io_promise.has_value());
@@ -503,20 +556,13 @@ Journal::RecordBatch::encode_batch(
 void Journal::RecordBatch::set_result(
   maybe_result_t maybe_write_result)
 {
-  LOG_PREFIX(RecordBatch::set_result);
   maybe_promise_result_t result;
   if (maybe_write_result.has_value()) {
-    DEBUG("batches={}, write_start {} + {}",
-          submitting_size,
-          maybe_write_result->start_seq,
-          maybe_write_result->length);
     assert(maybe_write_result->length == submitting_length);
     result = promise_result_t{
       *maybe_write_result,
       submitting_mdlength
     };
-  } else {
-    ERROR("batches={}, write is failed!", submitting_size);
   }
   assert(state == state_t::SUBMITTING);
   assert(io_promise.has_value());
@@ -536,9 +582,8 @@ Journal::RecordBatch::submit_pending_fast(
   const journal_seq_t& committed_to,
   segment_nonce_t segment_nonce)
 {
-  LOG_PREFIX(RecordBatch::submit_pending_fast);
   auto new_size = get_encoded_length_after(record, block_size);
-  DEBUG("write_size={}", new_size.get_encoded_length());
+  std::ignore = new_size;
   assert(state == state_t::EMPTY);
   assert(can_batch(record, block_size).value() == new_size);
 
@@ -585,6 +630,7 @@ Journal::RecordSubmitter::submit(
   OrderingHandle& handle)
 {
   LOG_PREFIX(RecordSubmitter::submit);
+  DEBUG("H{} {} start ...", (void*)&handle, record);
   assert(write_pipeline);
   auto expected_size = record_group_size_t(
       record.size,
@@ -592,10 +638,8 @@ Journal::RecordSubmitter::submit(
   ).get_encoded_length();
   auto max_record_length = journal_segment_manager.get_max_write_length();
   if (expected_size > max_record_length) {
-    ERROR("record size {} exceeds max {}",
-          expected_size,
-          max_record_length
-    );
+    ERROR("H{} {} exceeds max record size {}",
+          (void*)&handle, record, max_record_length);
     return crimson::ct_error::erange::make();
   }
 
@@ -615,18 +659,33 @@ void Journal::RecordSubmitter::update_state()
   }
 }
 
+void Journal::RecordSubmitter::decrement_io_with_flush()
+{
+  LOG_PREFIX(RecordSubmitter::decrement_io_with_flush);
+  assert(num_outstanding_io > 0);
+  --num_outstanding_io;
+#ifndef NDEBUG
+  auto prv_state = state;
+#endif
+  update_state();
+
+  if (wait_submit_promise.has_value()) {
+    DEBUG("wait resolved");
+    assert(prv_state == state_t::FULL);
+    wait_submit_promise->set_value();
+    wait_submit_promise.reset();
+  }
+
+  if (!p_current_batch->is_empty()) {
+    TRACE("flush");
+    flush_current_batch();
+  }
+}
+
 void Journal::RecordSubmitter::account_submission(
   std::size_t num,
   const record_group_size_t& size)
 {
-  LOG_PREFIX(RecordSubmitter::account_submission);
-  DEBUG("Journal::RecordSubmitter: submitting {} records, "
-        "mdsize={}, dsize={}, fillness={}",
-        num,
-        size.get_raw_mdlength(),
-        size.dlength,
-        ((double)(size.get_raw_mdlength() + size.dlength) /
-        (size.get_mdlength() + size.dlength)));
   stats.record_group_padding_bytes +=
     (size.get_mdlength() - size.get_raw_mdlength());
   stats.record_group_metadata_bytes += size.get_raw_mdlength();
@@ -653,20 +712,23 @@ void Journal::RecordSubmitter::flush_current_batch()
 
   increment_io();
   auto num = p_batch->get_num_records();
+  auto committed_to = journal_segment_manager.get_committed_to();
   auto [to_write, sizes] = p_batch->encode_batch(
-    journal_segment_manager.get_committed_to(),
-    journal_segment_manager.get_nonce());
+    committed_to, journal_segment_manager.get_nonce());
+  DEBUG("{} records, {}, committed_to={}, outstanding_io={} ...",
+        num, sizes, committed_to, num_outstanding_io);
   account_submission(num, sizes);
   std::ignore = journal_segment_manager.write(to_write
-  ).safe_then([this, p_batch](auto write_result) {
+  ).safe_then([this, p_batch, FNAME, num, sizes=sizes](auto write_result) {
+    TRACE("{} records, {}, write done with {}", num, sizes, write_result);
     finish_submit_batch(p_batch, write_result);
   }).handle_error(
-    crimson::ct_error::all_same_way([this, p_batch, FNAME](auto e) {
-      ERROR("got error {}", e);
+    crimson::ct_error::all_same_way([this, p_batch, FNAME, num, sizes=sizes](auto e) {
+      ERROR("{} records, {}, got error {}", num, sizes, e);
       finish_submit_batch(p_batch, std::nullopt);
     })
-  ).handle_exception([this, p_batch, FNAME](auto e) {
-    ERROR("got exception {}", e);
+  ).handle_exception([this, p_batch, FNAME, num, sizes=sizes](auto e) {
+    ERROR("{} records, {}, got exception {}", num, sizes, e);
     finish_submit_batch(p_batch, std::nullopt);
   });
 }
@@ -677,19 +739,23 @@ Journal::RecordSubmitter::submit_pending(
   OrderingHandle& handle,
   bool flush)
 {
+  LOG_PREFIX(RecordSubmitter::submit_pending);
   assert(!p_current_batch->is_submitting());
   stats.record_batch_stats.increment(
       p_current_batch->get_num_records() + 1);
   bool do_flush = (flush || state == state_t::IDLE);
-  auto write_fut = [this, do_flush, record=std::move(record)]() mutable {
+  auto write_fut = [this, do_flush, FNAME, record=std::move(record), &handle]() mutable {
     if (do_flush && p_current_batch->is_empty()) {
       // fast path with direct write
       increment_io();
+      auto committed_to = journal_segment_manager.get_committed_to();
       auto [to_write, sizes] = p_current_batch->submit_pending_fast(
         std::move(record),
         journal_segment_manager.get_block_size(),
-        journal_segment_manager.get_committed_to(),
+        committed_to,
         journal_segment_manager.get_nonce());
+      DEBUG("H{} fast submit {}, committed_to={}, outstanding_io={} ...",
+            (void*)&handle, sizes, committed_to, num_outstanding_io);
       account_submission(1, sizes);
       return journal_segment_manager.write(to_write
       ).safe_then([mdlength = sizes.get_mdlength()](auto write_result) {
@@ -703,9 +769,15 @@ Journal::RecordSubmitter::submit_pending(
     } else {
       // indirect write with or without the existing pending records
       auto write_fut = p_current_batch->add_pending(
-        std::move(record), journal_segment_manager.get_block_size());
+        std::move(record),
+        handle,
+        journal_segment_manager.get_block_size());
       if (do_flush) {
+        DEBUG("H{} added pending and flush", (void*)&handle);
         flush_current_batch();
+      } else {
+        DEBUG("H{} added with {} pending",
+              (void*)&handle, p_current_batch->get_num_records());
       }
       return write_fut;
     }
@@ -713,9 +785,10 @@ Journal::RecordSubmitter::submit_pending(
   return handle.enter(write_pipeline->device_submission
   ).then([write_fut=std::move(write_fut)]() mutable {
     return std::move(write_fut);
-  }).safe_then([this, &handle](auto submit_result) {
+  }).safe_then([this, FNAME, &handle](auto submit_result) {
     return handle.enter(write_pipeline->finalize
-    ).then([this, submit_result] {
+    ).then([this, FNAME, submit_result, &handle] {
+      DEBUG("H{} finish with {}", (void*)&handle, submit_result);
       journal_segment_manager.mark_committed(
           submit_result.write_result.get_end_seq());
       return submit_result;
@@ -728,6 +801,9 @@ Journal::RecordSubmitter::do_submit(
   record_t&& record,
   OrderingHandle& handle)
 {
+  LOG_PREFIX(RecordSubmitter::do_submit);
+  TRACE("H{} outstanding_io={}/{} ...",
+        (void*)&handle, num_outstanding_io, io_depth_limit);
   assert(!p_current_batch->is_submitting());
   if (state <= state_t::PENDING) {
     // can increment io depth
@@ -737,13 +813,17 @@ Journal::RecordSubmitter::do_submit(
     if (!maybe_new_size.has_value() ||
         (maybe_new_size->get_encoded_length() >
          journal_segment_manager.get_max_write_length())) {
+      TRACE("H{} flush", (void*)&handle);
       assert(p_current_batch->is_pending());
       flush_current_batch();
       return do_submit(std::move(record), handle);
     } else if (journal_segment_manager.needs_roll(
           maybe_new_size->get_encoded_length())) {
       if (p_current_batch->is_pending()) {
+        TRACE("H{} flush and roll", (void*)&handle);
         flush_current_batch();
+      } else {
+        TRACE("H{} roll", (void*)&handle);
       }
       return journal_segment_manager.roll(
       ).safe_then([this, record=std::move(record), &handle]() mutable {
@@ -768,6 +848,7 @@ Journal::RecordSubmitter::do_submit(
     if (!wait_submit_promise.has_value()) {
       wait_submit_promise = seastar::promise<>();
     }
+    DEBUG("H{} wait ...", (void*)&handle);
     return wait_submit_promise->get_future(
     ).then([this, record=std::move(record), &handle]() mutable {
       return do_submit(std::move(record), handle);

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -15,7 +15,6 @@
 #include "include/buffer.h"
 #include "include/denc.h"
 
-#include "crimson/common/log.h"
 #include "crimson/os/seastore/extent_reader.h"
 #include "crimson/os/seastore/segment_manager.h"
 #include "crimson/os/seastore/ordering_handle.h"

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -6,8 +6,8 @@
 
 namespace {
 
-seastar::logger& logger() {
-  return crimson::get_logger(ceph_subsys_seastore_tm);
+seastar::logger& journal_logger() {
+  return crimson::get_logger(ceph_subsys_seastore_journal);
 }
 
 }
@@ -297,14 +297,14 @@ try_decode_records_header(
   try {
     decode(header, bp);
   } catch (ceph::buffer::error &e) {
-    logger().debug(
+    journal_logger().debug(
         "try_decode_records_header: failed, "
         "cannot decode record_group_header_t, got {}.",
         e);
     return std::nullopt;
   }
   if (header.segment_nonce != expected_nonce) {
-    logger().debug(
+    journal_logger().debug(
         "try_decode_records_header: failed, record_group_header nonce mismatch, "
         "read {}, expected {}!",
         header.segment_nonce,
@@ -329,7 +329,8 @@ bool validate_records_metadata(
     test_crc);
   bool success = (test_crc == recorded_crc);
   if (!success) {
-    logger().debug("validate_records_metadata: failed, metadata crc mismatch.");
+    journal_logger().debug(
+        "validate_records_metadata: failed, metadata crc mismatch.");
   }
   return success;
 }
@@ -340,7 +341,8 @@ bool validate_records_data(
 {
   bool success = (data_bl.crc32c(-1) == header.data_crc);
   if (!success) {
-    logger().debug("validate_records_data: failed, data crc mismatch!");
+    journal_logger().debug(
+        "validate_records_data: failed, data crc mismatch!");
   }
   return success;
 }
@@ -360,7 +362,7 @@ try_decode_record_headers(
     try {
       decode(i, bliter);
     } catch (ceph::buffer::error &e) {
-      logger().debug(
+      journal_logger().debug(
           "try_decode_record_headers: failed, "
           "cannot decode record_header_t, got {}.",
           e);
@@ -379,7 +381,7 @@ try_decode_extent_infos(
 {
   auto maybe_headers = try_decode_record_headers(header, md_bl);
   if (!maybe_headers) {
-    logger().debug(
+    journal_logger().debug(
         "try_decode_extent_infos: failed, cannot decode record headers.");
     return std::nullopt;
   }
@@ -400,7 +402,7 @@ try_decode_extent_infos(
       try {
         decode(i, bliter);
       } catch (ceph::buffer::error &e) {
-        logger().debug(
+        journal_logger().debug(
             "try_decode_extent_infos: failed, "
             "cannot decode extent_info_t, got {}.",
             e);
@@ -420,7 +422,7 @@ try_decode_deltas(
 {
   auto maybe_record_extent_infos = try_decode_extent_infos(header, md_bl);
   if (!maybe_record_extent_infos) {
-    logger().debug(
+    journal_logger().debug(
         "try_decode_deltas: failed, cannot decode extent_infos.");
     return std::nullopt;
   }
@@ -445,7 +447,7 @@ try_decode_deltas(
       try {
         decode(i, bliter);
       } catch (ceph::buffer::error &e) {
-        logger().debug(
+        journal_logger().debug(
             "try_decode_deltas: failed, "
             "cannot decode delta_info_t, got {}.",
             e);

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -69,10 +69,10 @@ std::ostream &operator<<(std::ostream &out, const paddr_t &rhs)
 
 std::ostream &operator<<(std::ostream &out, const journal_seq_t &seq)
 {
-  return out << "journal_seq_t(segment_seq="
-	     << seq.segment_seq << ", offset="
-	     << seq.offset
-	     << ")";
+  return out << "journal_seq_t("
+             << "segment_seq=" << seq.segment_seq
+             << ", offset=" << seq.offset
+             << ")";
 }
 
 std::ostream &operator<<(std::ostream &out, extent_types_t t)
@@ -152,7 +152,7 @@ std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
 {
   return out << "segment_header_t("
 	     << "segment_seq=" << header.journal_segment_seq
-	     << ", physical_segment_id=" << header.physical_segment_id
+	     << ", segment_id=" << header.physical_segment_id
 	     << ", journal_tail=" << header.journal_tail
 	     << ", segment_nonce=" << header.segment_nonce
 	     << ", out-of-line=" << header.out_of_line
@@ -179,6 +179,34 @@ void record_size_t::account(const delta_info_t& delta)
   plain_mdlength += ceph::encoded_sizeof(delta);
 }
 
+std::ostream &operator<<(std::ostream& out, const record_size_t& rsize)
+{
+  return out << "record_size_t("
+             << "raw_md=" << rsize.get_raw_mdlength()
+             << ", data=" << rsize.dlength
+             << ")";
+}
+
+std::ostream &operator<<(std::ostream& out, const record_t& r)
+{
+  return out << "record_t("
+             << "num_extents=" << r.extents.size()
+             << ", num_deltas=" << r.deltas.size()
+             << ")";
+}
+
+std::ostream& operator<<(std::ostream& out, const record_group_header_t& h)
+{
+  return out << "record_group_header_t("
+             << "num_records=" << h.records
+             << ", mdlength=" << h.mdlength
+             << ", dlength=" << h.dlength
+             << ", nonce=" << h.segment_nonce
+             << ", committed_to=" << h.committed_to
+             << ", data_crc=" << h.data_crc
+             << ")";
+}
+
 extent_len_t record_group_size_t::get_raw_mdlength() const
 {
   return plain_mdlength +
@@ -197,6 +225,24 @@ void record_group_size_t::account(
   plain_mdlength += rsize.get_raw_mdlength();
   dlength += rsize.dlength;
   block_size = _block_size;
+}
+
+std::ostream& operator<<(std::ostream& out, const record_group_size_t& size)
+{
+  return out << "record_group_size_t("
+             << "raw_md=" << size.get_raw_mdlength()
+             << ", data=" << size.dlength
+             << ", block_size=" << size.block_size
+             << ", fullness=" << size.get_fullness()
+             << ")";
+}
+
+std::ostream& operator<<(std::ostream& out, const record_group_t& rg)
+{
+  return out << "record_group_t("
+             << "num_records=" << rg.records.size()
+             << ", " << rg.size
+             << ")";
 }
 
 ceph::bufferlist encode_record(
@@ -516,6 +562,22 @@ blk_paddr_t convert_paddr_to_blk_paddr(paddr_t addr, size_t block_size,
 	  (block_size * blocks_per_segment) + s.get_segment_off());
 }
 
+std::ostream& operator<<(std::ostream& out, const write_result_t& w)
+{
+  return out << "write_result_t("
+             << "start=" << w.start_seq
+             << ", length=" << w.length
+             << ")";
+}
+
+std::ostream& operator<<(std::ostream& out, const record_locator_t& l)
+{
+  return out << "record_locator_t("
+             << "block_base=" << l.record_block_base
+             << ", " << l.write_result
+             << ")";
+}
+
 void scan_valid_records_cursor::emplace_record_group(
     const record_group_header_t& header, ceph::bufferlist&& md_bl)
 {
@@ -530,6 +592,16 @@ void scan_valid_records_cursor::emplace_record_group(
   increment_seq(header.dlength + header.mdlength);
   ceph_assert(new_committed_to == journal_seq_t() ||
               new_committed_to < seq);
+}
+
+std::ostream& operator<<(std::ostream& out, const scan_valid_records_cursor& c)
+{
+  return out << "cursor(last_valid_header_found=" << c.last_valid_header_found
+             << ", seq=" << c.seq
+             << ", last_committed=" << c.last_committed
+             << ", pending_record_groups=" << c.pending_record_groups.size()
+             << ", num_consumed_records=" << c.num_consumed_records
+             << ")";
 }
 
 }

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -516,5 +516,20 @@ blk_paddr_t convert_paddr_to_blk_paddr(paddr_t addr, size_t block_size,
 	  (block_size * blocks_per_segment) + s.get_segment_off());
 }
 
+void scan_valid_records_cursor::emplace_record_group(
+    const record_group_header_t& header, ceph::bufferlist&& md_bl)
+{
+  auto new_committed_to = header.committed_to;
+  ceph_assert(last_committed == journal_seq_t() ||
+              last_committed <= new_committed_to);
+  last_committed = new_committed_to;
+  pending_record_groups.emplace_back(
+    seq.offset,
+    header,
+    std::move(md_bl));
+  increment_seq(header.dlength + header.mdlength);
+  ceph_assert(new_committed_to == journal_seq_t() ||
+              new_committed_to < seq);
+}
 
 }

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -427,8 +427,6 @@ try_decode_extent_infos(
 {
   auto maybe_headers = try_decode_record_headers(header, md_bl);
   if (!maybe_headers) {
-    journal_logger().debug(
-        "try_decode_extent_infos: failed, cannot decode record headers.");
     return std::nullopt;
   }
 
@@ -468,8 +466,6 @@ try_decode_deltas(
 {
   auto maybe_record_extent_infos = try_decode_extent_infos(header, md_bl);
   if (!maybe_record_extent_infos) {
-    journal_logger().debug(
-        "try_decode_deltas: failed, cannot decode extent_infos.");
     return std::nullopt;
   }
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1230,6 +1230,7 @@ struct record_size_t {
   void account(const delta_info_t& delta);
 };
 WRITE_EQ_OPERATORS_2(record_size_t, plain_mdlength, dlength);
+std::ostream &operator<<(std::ostream&, const record_size_t&);
 
 struct record_t {
   std::vector<extent_t> extents;
@@ -1272,6 +1273,7 @@ struct record_t {
     deltas.push_back(std::move(delta));
   }
 };
+std::ostream &operator<<(std::ostream&, const record_t&);
 
 struct record_header_t {
   uint32_t deltas;              // number of deltas
@@ -1307,6 +1309,7 @@ struct record_group_header_t {
     DENC_FINISH(p);
   }
 };
+std::ostream& operator<<(std::ostream&, const record_group_header_t&);
 
 struct record_group_size_t {
   extent_len_t plain_mdlength = 0; // mdlength without the group header
@@ -1351,6 +1354,7 @@ struct record_group_size_t {
                extent_len_t block_size);
 };
 WRITE_EQ_OPERATORS_3(record_group_size_t, plain_mdlength, dlength, block_size);
+std::ostream& operator<<(std::ostream&, const record_group_size_t&);
 
 struct record_group_t {
   std::vector<record_t> records;
@@ -1384,6 +1388,7 @@ struct record_group_t {
     size = {};
   }
 };
+std::ostream& operator<<(std::ostream&, const record_group_t&);
 
 ceph::bufferlist encode_record(
   record_t&& record,
@@ -1435,11 +1440,13 @@ struct write_result_t {
     return start_seq.add_offset(length);
   }
 };
+std::ostream& operator<<(std::ostream&, const write_result_t&);
 
 struct record_locator_t {
   paddr_t record_block_base;
   write_result_t write_result;
 };
+std::ostream& operator<<(std::ostream&, const record_locator_t&);
 
 /// scan segment for end incrementally
 struct scan_valid_records_cursor {
@@ -1491,6 +1498,7 @@ struct scan_valid_records_cursor {
     journal_seq_t seq)
     : seq(seq) {}
 };
+std::ostream& operator<<(std::ostream&, const scan_valid_records_cursor&);
 
 inline const seg_paddr_t& paddr_t::as_seg_paddr() const {
   assert(get_addr_type() == addr_types_t::SEGMENT);

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1446,6 +1446,7 @@ struct scan_valid_records_cursor {
   bool last_valid_header_found = false;
   journal_seq_t seq;
   journal_seq_t last_committed;
+  std::size_t num_consumed_records = 0;
 
   struct found_record_group_t {
     paddr_t offset;
@@ -1472,10 +1473,18 @@ struct scan_valid_records_cursor {
     return seq.offset.as_seg_paddr().get_segment_off();
   }
 
-  void increment(segment_off_t off) {
+  void increment_seq(segment_off_t off) {
     auto& seg_addr = seq.offset.as_seg_paddr();
     seg_addr.set_segment_off(
       seg_addr.get_segment_off() + off);
+  }
+
+  void emplace_record_group(const record_group_header_t&, ceph::bufferlist&&);
+
+  void pop_record_group() {
+    assert(!pending_record_groups.empty());
+    ++num_consumed_records;
+    pending_record_groups.pop_front();
   }
 
   scan_valid_records_cursor(

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1355,7 +1355,6 @@ WRITE_EQ_OPERATORS_3(record_group_size_t, plain_mdlength, dlength, block_size);
 struct record_group_t {
   std::vector<record_t> records;
   record_group_size_t size;
-  extent_len_t current_dlength = 0;
 
   record_group_t() = default;
   record_group_t(
@@ -1372,7 +1371,6 @@ struct record_group_t {
       record_t&& record,
       extent_len_t block_size) {
     size.account(record.size, block_size);
-    current_dlength += record.size.dlength;
     records.push_back(std::move(record));
     assert(size.get_encoded_length() < MAX_SEG_OFF);
   }
@@ -1384,7 +1382,6 @@ struct record_group_t {
   void clear() {
     records.clear();
     size = {};
-    current_dlength = 0;
   }
 };
 


### PR DESCRIPTION

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
