### PR TITLE
cmake/modules/BuildSPDK.cmake: link whole-archive

### DIFF
--- a/cmake/modules/BuildSPDK.cmake
+++ b/cmake/modules/BuildSPDK.cmake
@@ -68,12 +68,14 @@ macro(build_spdk)
     add_dependencies(${spdk_lib} spdk-ext)
   endforeach()
 
-  set_target_properties(spdk::env_dpdk PROPERTIES
-    INTERFACE_LINK_LIBRARIES "dpdk::dpdk;rt")
-  set_target_properties(spdk::lvol PROPERTIES
-    INTERFACE_LINK_LIBRARIES spdk::util)
-  set_target_properties(spdk::util PROPERTIES
-    INTERFACE_LINK_LIBRARIES ${UUID_LIBRARIES})
   set(SPDK_INCLUDE_DIR "${source_dir}/include")
+  add_library(spdk::spdk INTERFACE IMPORTED)
+  add_dependencies(spdk::spdk
+    ${SPDK_LIBRARIES})
+  # workaround for https://review.spdk.io/gerrit/c/spdk/spdk/+/6798
+  set_target_properties(spdk::spdk PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${SPDK_INCLUDE_DIR}
+    INTERFACE_LINK_LIBRARIES
+    "-Wl,--whole-archive $<JOIN:${spdk_libs}, > -Wl,--no-whole-archive;dpdk::dpdk;rt;${UUID_LIBRARIES}")
   unset(source_dir)
 endmacro()

--- a/src/blk/CMakeLists.txt
+++ b/src/blk/CMakeLists.txt
@@ -35,7 +35,8 @@ if(HAVE_LIBAIO)
 endif(HAVE_LIBAIO)
 
 if(WITH_SPDK)
-  target_link_libraries(blk PRIVATE ${SPDK_LIBRARIES})
+  target_link_libraries(blk
+    PRIVATE spdk::spdk)
 endif()
 
 if(WITH_ZBD)


### PR DESCRIPTION
We build spdk as static library, linking against them requires the
use of `-Wl,--whole-archive` as argument, otherwise we will have error
`nvme.c: nvme_probe_internal: *ERROR*: NVMe trtype 256 not available`.
This is due to the use of constructor functions in spdk to register
NVMe transports. So we need to do so to ensure we call all the
constructors.

Signed-off-by: Tongliang Deng <dengtongliang@sensetime.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
