### PR TITLE
mgr/dashboard: fix: get SMART data from single-daemon device

### DIFF
--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -8,7 +8,6 @@ from mgr_module import CommandResult
 from mgr_util import get_most_recent_rate, get_time_series_rates
 
 from .. import mgr
-from ..exceptions import DashboardException
 
 try:
     from typing import Any, Dict, Optional, Union
@@ -235,11 +234,7 @@ class CephService(object):
         # type: (dict) -> Dict[str, dict]
         # Check whether the device is associated with daemons.
         if 'daemons' in device and device['daemons']:
-            dev_smart_data = None
-
-            # The daemons associated with the device. Note, the list may
-            # contain daemons that are 'down' or 'destroyed'.
-            daemons = device.get('daemons')
+            dev_smart_data: Dict[str, Any] = {}
 
             # Get a list of all OSD daemons on all hosts that are 'up'
             # because SMART data can not be retrieved from daemons that
@@ -250,26 +245,27 @@ class CephService(object):
                 if node.get('status') == 'up'
             ]
 
-            # Finally get the daemons on the host of the given device
-            # that are 'up'. All daemons on the same host can deliver
-            # SMART data, thus it is not relevant for us which daemon
-            # we are using.
-            daemons = list(set(daemons) & set(osd_daemons_up))  # type: ignore
-
-            for daemon in daemons:
+            # All daemons on the same host can deliver SMART data,
+            # thus it is not relevant for us which daemon we are using.
+            # NOTE: the list may contain daemons that are 'down' or 'destroyed'.
+            for daemon in device['daemons']:
                 svc_type, svc_id = daemon.split('.')
                 if 'osd' in svc_type:
+                    if daemon not in osd_daemons_up:
+                        continue
                     try:
                         dev_smart_data = CephService.send_command(
                             svc_type, 'smart', svc_id, devid=device['devid'])
-                    except SendCommandError:
+                    except SendCommandError as error:
+                        logger.warning(str(error))
                         # Try to retrieve SMART data from another daemon.
                         continue
                 elif 'mon' in svc_type:
                     try:
                         dev_smart_data = CephService.send_command(
                             svc_type, 'device query-daemon-health-metrics', who=daemon)
-                    except SendCommandError:
+                    except SendCommandError as error:
+                        logger.warning(str(error))
                         # Try to retrieve SMART data from another daemon.
                         continue
                 else:
@@ -280,10 +276,7 @@ class CephService(object):
                             '[SMART] Error retrieving smartctl data for device ID "%s": %s',
                             dev_id, dev_data)
                 break
-            if dev_smart_data is None:
-                raise DashboardException(
-                    'Failed to retrieve SMART data for device ID "{}"'.format(
-                        device['devid']))
+
             return dev_smart_data
         logger.warning('[SMART] No daemons associated with device ID "%s"',
                        device['devid'])


### PR DESCRIPTION
Return SMART data even when a device is only associated with a single daemon.

Fixes: https://tracker.ceph.com/issues/53858
Signed-off-by: Alfonso Martínez <almartin@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
