### PR TITLE
rgw: "bucket check --fix" should delete damaged multipart uploads fro…

### DIFF
--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -561,6 +561,21 @@ public:
     CLSRGWConcurrentIO(io_ctx, _bucket_objs, max_aio) {}
 };
 
+class CLSRGWIssueBucketBIDirSuggest : public CLSRGWConcurrentIO {
+  std::map<int, bufferlist>& updates;
+protected:
+  virtual int issue_op(int shard_id, const string& oid);
+public:
+  CLSRGWIssueBucketBIDirSuggest(librados::IoCtx& io_ctx,
+				std::map<int, std::string>& _bucket_objs,
+				std::map<int, bufferlist>& _updates,
+				uint32_t max_aio)
+  : CLSRGWConcurrentIO(io_ctx, _bucket_objs, max_aio),
+    updates(_updates)
+  {/* empty */ }
+};
+
+
 int cls_rgw_get_dir_header_async(librados::IoCtx& io_ctx, std::string& oid, RGWGetDirHeader_CB *ctx);
 
 void cls_rgw_encode_suggestion(char op, rgw_bucket_dir_entry& dirent, ceph::buffer::list& updates);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9062,33 +9062,55 @@ int RGWRados::cls_obj_usage_log_clear(const DoutPrefixProvider *dpp, string& oid
 }
 
 
-int RGWRados::remove_objs_from_index(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, list<rgw_obj_index_key>& oid_list)
+int RGWRados::remove_objs_from_index(const DoutPrefixProvider *dpp,
+				     RGWBucketInfo& bucket_info,
+				     const std::list<rgw_obj_index_key>& entry_key_list)
 {
   RGWSI_RADOS::Pool index_pool;
-  string dir_oid;
+  const auto& latest_log = bucket_info.layout.logs.back();
+  const rgw::bucket_index_layout_generation& current_index =
+    rgw::log_to_index_layout(latest_log);
+
+  const uint32_t num_shards = current_index.layout.normal.num_shards;
 
   uint8_t suggest_flag = (svc.zone->get_zone().log_data ? CEPH_RGW_DIR_SUGGEST_LOG_OP : 0);
+  std::map<int, std::string> index_oids;
 
-  int r = svc.bi_rados->open_bucket_index(dpp, bucket_info, &index_pool, &dir_oid);
-  if (r < 0)
+  int r = svc.bi_rados->open_bucket_index(dpp, bucket_info, std::nullopt,
+					  current_index, &index_pool,
+					  &index_oids, nullptr);
+  if (r < 0) {
     return r;
+  }
 
-  bufferlist updates;
+  // needed so objclass won't skip req
+  constexpr uint64_t highest_epoch = uint64_t(-1);
 
-  for (auto iter = oid_list.begin(); iter != oid_list.end(); ++iter) {
+  // split up removals by shard
+  std::map<int, bufferlist> sharded_updates;
+  for (const auto& entry_key : entry_key_list) {
+    const rgw_obj_key obj_key(entry_key);
+    const uint32_t shard = rgw_bucket_shard_index(obj_key, num_shards);
+    bufferlist& updates = sharded_updates[shard];
+
     rgw_bucket_dir_entry entry;
-    entry.key = *iter;
-    ldpp_dout(dpp, 2) << "RGWRados::remove_objs_from_index bucket=" << bucket_info.bucket << " obj=" << entry.key.name << ":" << entry.key.instance << dendl;
-    entry.ver.epoch = (uint64_t)-1; // ULLONG_MAX, needed to that objclass doesn't skip out request
+    entry.key = entry_key;
+    entry.ver.epoch = highest_epoch;
+
+    ldpp_dout(dpp, 5) << __func__ << "bucket=" << bucket_info.bucket <<
+      " shard=" << shard <<
+      " obj=" << entry.key.name << ":" << entry.key.instance << dendl;
+
     updates.append(CEPH_RGW_REMOVE | suggest_flag);
     encode(entry, updates);
   }
 
-  bufferlist out;
-
-  r = index_pool.ioctx().exec(dir_oid, RGW_CLASS, RGW_DIR_SUGGEST_CHANGES, updates, out);
-
-  return r;
+  // this operation ignores shards for which there's not an update, so
+  // we can send the complete list of bucket index shard oids
+  return CLSRGWIssueBucketBIDirSuggest(index_pool.ioctx(),
+				       index_oids,
+				       sharded_updates,
+				       cct->_conf->rgw_bucket_index_max_aio)();
 }
 
 int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1465,7 +1465,8 @@ public:
                          std::map<RGWObjCategory, RGWStorageStats> *calculated_stats);
   int bucket_rebuild_index(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info);
   int bucket_set_reshard(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const cls_rgw_bucket_instance_entry& entry);
-  int remove_objs_from_index(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, std::list<rgw_obj_index_key>& oid_list);
+  int remove_objs_from_index(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info,
+			     const std::list<rgw_obj_index_key>& oid_list);
   int move_rados_obj(const DoutPrefixProvider *dpp,
                      librados::IoCtx& src_ioctx,
 		     const std::string& src_oid, const std::string& src_locator,

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -53,6 +53,9 @@ static inline int rgw_shards_mod(unsigned hval, int max_shards)
   return hval % RGW_SHARDS_PRIME_1 % max_shards;
 }
 
+uint32_t rgw_bucket_shard_index(const rgw_obj_key& obj_key,
+				int num_shards);
+
 // used for logging and tagging
 inline int rgw_shard_id(const std::string& key, int max_shards)
 {


### PR DESCRIPTION
…m bi

As one of the steps in `radosgw-admin bucket check --fix ...` it looks
for bucket index entries for incomplete multipart uploads that do not
have a corresponding ".meta" entry in the same bucket index. It then
intends to delete those entries, however the function that it calls
to perform the bucket index deletions was flawed and did not direct
the removals to the appropriate shard(s), but instead a non-existant
oid.

This commit determines the appropriate shard for each of the entries
to be removed and asynchronously issues "dir suggest changes" to each
of the shards to remove the entries.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
