### PR TITLE
rgw/dbstore: hide dbstore_log.h from rgw_main.cc

### DIFF
--- a/src/rgw/store/dbstore/common/dbstore.cc
+++ b/src/rgw/store/dbstore/common/dbstore.cc
@@ -24,7 +24,7 @@ int DB::Initialize(string logfile, int loglevel)
   }
 
   if (loglevel > 0) {
-    cct->_conf->subsys.set_log_level(dout_subsys, loglevel);
+    cct->_conf->subsys.set_log_level(ceph_subsys_rgw, loglevel);
   }
   if (!logfile.empty()) {
     cct->_log->set_log_file(logfile);

--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -15,7 +15,6 @@
 #define FMT_HEADER_ONLY 1
 #include "fmt/format.h"
 #include <map>
-#include "dbstore_log.h"
 #include "rgw/rgw_sal.h"
 #include "rgw/rgw_common.h"
 #include "rgw/rgw_bucket.h"
@@ -650,7 +649,7 @@ class DBOp {
             params->lc_entry_table.c_str(),
             params->bucket_table.c_str());
 
-      ldout(params->cct, 0) << "Incorrect table type("<<type<<") specified" << dendl;
+      lsubdout(params->cct, rgw, 0) << "rgw dbstore: Incorrect table type("<<type<<") specified" << dendl;
 
       return NULL;
     }
@@ -1396,7 +1395,7 @@ class DB {
     lc_head_table(db_name+".lc_head.table"),
     lc_entry_table(db_name+".lc_entry.table"),
     cct(_cct),
-    dp(_cct, dout_subsys, "rgw DBStore backend: ")
+    dp(_cct, ceph_subsys_rgw, "rgw DBStore backend: ")
   {}
     /*	DB() {}*/
 
@@ -1407,7 +1406,7 @@ class DB {
     lc_head_table(db_name+".lc_head.table"),
     lc_entry_table(db_name+".lc_entry.table"),
     cct(_cct),
-    dp(_cct, dout_subsys, "rgw DBStore backend: ")
+    dp(_cct, ceph_subsys_rgw, "rgw DBStore backend: ")
   {}
     virtual	~DB() {}
 

--- a/src/rgw/store/dbstore/dbstore_mgr.cc
+++ b/src/rgw/store/dbstore/dbstore_mgr.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "dbstore_mgr.h"
+#include "common/dbstore_log.h"
 
 /* Given a tenant, find and return the DBStore handle.
  * If not found and 'create' set to true, create one

--- a/src/rgw/store/dbstore/dbstore_mgr.h
+++ b/src/rgw/store/dbstore/dbstore_mgr.h
@@ -40,7 +40,7 @@ public:
                       CODE_ENVIRONMENT_DAEMON, CINIT_FLAG_NO_MON_CONFIG, 1)->get();
     cct->_log->set_log_file(logfile);
     cct->_log->reopen_log_file();
-    cct->_conf->subsys.set_log_level(dout_subsys, loglevel);
+    cct->_conf->subsys.set_log_level(ceph_subsys_rgw, loglevel);
   };
   ~DBStoreManager() { destroyAllHandles(); };
 


### PR DESCRIPTION
dbstore_log.h sets global dout_subsys/dout_prefix macros, and was leaking into rgw_main.cc through the common/dbstore.h. this caused all of rgw_main's log output to start with the wrong prefix "rgw dbstore: "

Fixes: https://tracker.ceph.com/issues/53177

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
