### PR TITLE
cephfs: Suppor "entry_timeout" and "attr_timeout" options for improve performance.

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -240,8 +240,8 @@ static void fuse_ll_lookup(fuse_req_t req, fuse_ino_t parent, const char *name)
   if (r >= 0) {
     fe.ino = cfuse->make_fake_ino(fe.attr.st_ino, fe.attr.st_dev);
     fe.attr.st_rdev = new_encode_dev(fe.attr.st_rdev);
-	fe.entry_timeout = cfuse->entry_timeout;
-	fe.attr_timeout = cfuse->attr_timeout;
+    fe.entry_timeout = cfuse->entry_timeout;
+    fe.attr_timeout = cfuse->attr_timeout;
     fuse_reply_entry(req, &fe);
   } else {
     fuse_reply_err(req, get_sys_errno(-r));

--- a/src/common/options/mds-client.yaml.in
+++ b/src/common/options/mds-client.yaml.in
@@ -390,6 +390,20 @@ options:
   default: true
   services:
   - mds_client
+ - name: fuse_entry_timeout
+  type: int
+  level: advanced
+  desc: timeout for entry in kernel
+  default: 0
+  services:
+  - mds_client
+ - name: fuse_attr_timeout
+  type: int
+  level: advanced
+  desc: timeout for attr in kernel
+  default: 0
+  services:
+  - mds_client
 - name: fuse_max_write
   type: size
   level: advanced


### PR DESCRIPTION
Fuse provides the ability to cache the entry and attr, but cephfs is not used, so I add it to improve performance.

Thank lxbsz fix consistency problem: #44432

The following Fixed contains the test data before and after modification:
Fixes: https://tracker.ceph.com/issues/53730
Signed-off-by: Sheng Xie <1204488658@qq.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
