### PR TITLE
octopus: qa/run_xfstests_qemu.sh: stop reporting success without actually running any tests

### DIFF
--- a/qa/run_xfstests_qemu.sh
+++ b/qa/run_xfstests_qemu.sh
@@ -13,7 +13,11 @@ SCRIPT="run_xfstests-obsolete.sh"
 cd "${TESTDIR}"
 
 wget -O "${SCRIPT}" "${URL_BASE}/${SCRIPT}"
-chmod +x "${SCRIPT}"
+# mark executable only if the file isn't empty since ./"${SCRIPT}"
+# on an empty file would succeed
+if [[ -s "${SCRIPT}" ]]; then
+    chmod +x "${SCRIPT}"
+fi
 
 # tests excluded fail in the current testing vm regardless of whether
 # rbd is used

--- a/qa/tasks/userdata_setup.yaml
+++ b/qa/tasks/userdata_setup.yaml
@@ -17,6 +17,15 @@
   sed -i 's/archive.ubuntu.com/old-releases.ubuntu.com/' /etc/apt/sources.list
   sed -i 's/security.ubuntu.com/old-releases.ubuntu.com/' /etc/apt/sources.list
   apt-get update
+
+  # DST Root CA X3 certificate expired on Sep 30, 2021.  It was used by
+  # Let's Encrypt, which is what git.ceph.com relies on for HTTPS.  Get the
+  # new Let's Encrypt root certificate in place and deactivate the old one
+  # (lines that begin with "!" are deselected).
+  apt-get install --only-upgrade ca-certificates libssl1.0.0
+  sed -i 's/mozilla\/DST_Root_CA_X3\.crt/!mozilla\/DST_Root_CA_X3\.crt/' /etc/ca-certificates.conf
+  update-ca-certificates
+
   apt-get -y install nfs-common
   mkdir /mnt/log
   # 10.0.2.2 is the host


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53879

---

backport of https://github.com/ceph/ceph/pull/44571
parent tracker: https://tracker.ceph.com/issues/53841