### PR TITLE
rgw/swift: fix up underscores in swift user metadata

### DIFF
--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -816,3 +816,5 @@ extern int dump_body(struct req_state* s, const char* buf, size_t len);
 extern int dump_body(struct req_state* s, /* const */ ceph::buffer::list& bl);
 extern int dump_body(struct req_state* s, const std::string& str);
 extern int recv_body(struct req_state* s, char* buf, size_t max);
+
+std::string lowercase_underscore_http_attr(const std::string& orig);

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -667,7 +667,7 @@ static void get_rmattrs_from_headers(const req_state * const s,
 
     if (prefix_len > 0) {
       string name(RGW_ATTR_META_PREFIX);
-      name.append(lowercase_dash_http_attr(p + prefix_len));
+      name.append(lowercase_underscore_http_attr(p + prefix_len));
       rmattr_names.insert(name);
     }
   }


### PR DESCRIPTION
in 8cd8fc40d538229a33ca159e59b5202809bd0e7b, a fix for userscores in s3 user metadata changed the xattr format of these metadata names. this updates swift's metadata-removal path to match that underscore format. however, this breaks the ability for swift to remove any pre-existing user metadata with underscores :(

Fixes: https://tracker.ceph.com/issues/51772

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
