### PR TITLE
rgw: disable parquet by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,7 @@ option(WITH_RADOSGW_AMQP_ENDPOINT "Rados Gateway's pubsub support for AMQP push 
 option(WITH_RADOSGW_KAFKA_ENDPOINT "Rados Gateway's pubsub support for Kafka push endpoint" ON)
 option(WITH_RADOSGW_LUA_PACKAGES "Rados Gateway's support for dynamically adding lua packagess" ON)
 option(WITH_RADOSGW_DBSTORE "DBStore backend for Rados Gateway" ON)
+option(WITH_RADOSGW_SELECT_PARQUET "Support for s3 select on parquet objects" OFF)
 
 if(WITH_RADOSGW)
   find_package(EXPAT REQUIRED)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -24,7 +24,6 @@
 %bcond_with zbd
 %bcond_with cmake_verbose_logging
 %bcond_without ceph_test_package
-%bcond_without arrow_parquet
 %ifarch s390
 %bcond_with tcmalloc
 %else
@@ -233,10 +232,6 @@ BuildRequires:	xfsprogs-devel
 BuildRequires:	xmlstarlet
 BuildRequires:	nasm
 BuildRequires:	lua-devel
-%if 0%{with arrow_parquet}
-BuildRequires:	arrow-devel >= 4.0.0
-BuildRequires:	parquet-devel
-%endif
 %if 0%{with seastar} || 0%{with jaeger}
 BuildRequires:  yaml-cpp-devel >= 0.6
 %endif

--- a/debian/control
+++ b/debian/control
@@ -108,8 +108,6 @@ Build-Depends: automake,
                xmlstarlet <pkg.ceph.check>,
                nasm [amd64],
                zlib1g-dev,
-	       libarrow-dev (>= 4.0.0),
-	       libparquet-dev (>= 4.0.0),
 Standards-Version: 4.4.0
 
 Package: ceph

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -356,28 +356,12 @@ else
 	    build_profiles+=",pkg.ceph.jaeger"
 	fi
 
-	if [ "$(arch)" == "x86_64" ]; then
-		ARCH="amd64"
-	elif [ "$(arch)" == "aarch64" ]; then
-		ARCH="arm64"
-	fi
-
-	if [ -z ${ARCH+x} ]; then
-		echo "WARNING: $(arch) is not yet a supported architecture.  Can't install arrow."
-	else
-		wget -qO - https://dist.apache.org/repos/dist/dev/arrow/KEYS | $SUDO apt-key add -
-		echo "deb [arch=$ARCH] https://apache.jfrog.io/artifactory/arrow/ubuntu $(lsb_release -sc) main" | $SUDO tee /etc/apt/sources.list.d/arrow.list
-		$SUDO apt update
-	fi
-
 	$SUDO env DEBIAN_FRONTEND=noninteractive mk-build-deps \
 	      --build-profiles "${build_profiles#,}" \
 	      --install --remove \
 	      --tool="apt-get -y --no-install-recommends $backports" $control || exit 1
 	$SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y remove ceph-build-deps
 	if [ "$control" != "debian/control" ] ; then rm $control; fi
-	$SUDO rm -f /etc/apt/sources.list.d/arrow.list
-
         ;;
     centos|fedora|rhel|ol|virtuozzo)
         builddepcmd="dnf -y builddep --allowerasing"

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -3,12 +3,12 @@ if(NOT GPERF)
   message(FATAL_ERROR "Can't find gperf")
 endif()
 
-find_package(Arrow QUIET)
-if(Arrow_FOUND)
+if(WITH_RADOSGW_SELECT_PARQUET)
+  find_package(Arrow QUIET REQUIRED)
   set(ARROW_LIBRARIES "-larrow -lparquet")
   add_definitions(-D_ARROW_EXIST)
   message("-- arrow is installed, radosgw/s3select-op is able to process parquet objects")
-endif()
+endif(WITH_RADOSGW_SELECT_PARQUET)
 
 function(gperf_generate input output)
   add_custom_command(


### PR DESCRIPTION
adds a cmake option `WITH_RADOSGW_SELECT_PARQUET` that defaults to OFF, because we can't yet satisfy its dependencies. also reverts the packaging and repository changes

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
