### PR TITLE
rgw/swift: don't crash on nonexistent bucket in BulkUpload

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7389,9 +7389,10 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   ACLOwner bowner;
 
   op_ret = store->get_bucket(this, s->user.get(), rgw_bucket(rgw_bucket_key(s->user->get_tenant(), bucket_name)), &bucket, y);
-  if (op_ret == -ENOENT) {
-    ldpp_dout(this, 20) << "non existent directory=" << bucket_name << dendl;
-  } else if (op_ret < 0) {
+  if (op_ret < 0) {
+    if (op_ret == -ENOENT) {
+      ldpp_dout(this, 20) << "non existent directory=" << bucket_name << dendl;
+    }
     return op_ret;
   }
 


### PR DESCRIPTION
i hit this crash in the tempest suite while testing https://github.com/ceph/ceph/pull/38319. a call to `RGWBulkUploadOp::handle_file()` crashed right after logging `non existent directory=tmpfw8o9et0`. the original creation of this directory failed with `user cannot create a bucket in a different tenant`

i'm not sure how this behaved before the zipper changes, but this early return should cause the bulk_upload reponse to include a 404 error for each file that it tries to upload in buckets we're unable to create

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
