### PR TITLE
rgw: fix "bucket radoslist" with indexless buckets

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6860,7 +6860,9 @@ int main(int argc, const char **argv)
     }
 
     if (bucket_name.empty()) {
-      ret = lister.run(dpp());
+      // yes_i_really_mean_it means continue with listing even if
+      // there are indexless buckets
+      ret = lister.run(dpp(), yes_i_really_mean_it);
     } else {
       ret = lister.run(dpp(), bucket_name);
     }

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1076,23 +1076,13 @@ static int bucket_stats(rgw::sal::Store* store,
     return ret;
   }
 
-  if (bucket->get_info().layout.current_index.layout.type ==
-      rgw::BucketIndexType::Indexless) {
+  if (bucket->get_info().is_indexless()) {
     cerr << "error, indexless buckets do not maintain stats; bucket=" <<
       bucket->get_name() << std::endl;
     return -EINVAL;
   }
 
-  if (bucket->get_info().layout.logs.empty()) {
-    // this check may be redundant with the previous check of
-    // layout.type; calling back() on an empty vector produces
-    // undefined behavior
-    cerr << "error, layout log list is empty; bucket=" << bucket->get_name() <<
-      std::endl;
-    return -EINVAL;
-  }
-  const auto& latest_log = bucket->get_info().layout.logs.back();
-  const auto& index = log_to_index_layout(latest_log);
+  const auto& index = bucket->get_info().get_current_index();
   std::string bucket_ver, master_ver;
   std::string max_marker;
   ret = bucket->read_stats(dpp, index, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, &max_marker);

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -202,5 +202,8 @@ inline uint32_t num_shards(const bucket_index_layout_generation& index) {
 inline uint32_t current_num_shards(const BucketLayout& layout) {
   return num_shards(layout.current_index);
 }
+inline bool is_layout_indexless(const bucket_index_layout_generation& layout) {
+  return layout.layout.type == BucketIndexType::Indexless;
+}
 
 } // namespace rgw

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1117,6 +1117,16 @@ struct RGWBucketInfo {
 
   bool empty_sync_policy() const;
 
+  bool is_indexless() const {
+    return rgw::is_layout_indexless(layout.current_index);
+  }
+  const rgw::bucket_index_layout_generation& get_current_index() const {
+    return layout.current_index;
+  }
+  rgw::bucket_index_layout_generation& get_current_index() {
+    return layout.current_index;
+  }
+
   RGWBucketInfo();
   ~RGWBucketInfo();
 };

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -1319,7 +1319,8 @@ int RGWRadosList::process_bucket(
 }
 
 
-int RGWRadosList::run(const DoutPrefixProvider *dpp)
+int RGWRadosList::run(const DoutPrefixProvider *dpp,
+		      const bool yes_i_really_mean_it)
 {
   int ret;
   void* handle = nullptr;
@@ -1332,16 +1333,35 @@ int RGWRadosList::run(const DoutPrefixProvider *dpp)
     return ret;
   }
 
-  const int max_keys = 1000;
+  constexpr int max_keys = 1000;
   bool truncated = true;
+  bool warned_indexless = false;
 
   do {
     std::list<std::string> buckets;
     ret = store->meta_list_keys_next(dpp, handle, max_keys, buckets, &truncated);
 
     for (std::string& bucket_id : buckets) {
-      ret = run(dpp, bucket_id);
+      ret = run(dpp, bucket_id, true);
       if (ret == -ENOENT) {
+	continue;
+      } else if (ret == -EINVAL) {
+	if (! warned_indexless) {
+	  if (yes_i_really_mean_it) {
+	    std::cerr <<
+	      "WARNING: because there is at least one indexless bucket (" <<
+	      bucket_id <<
+	      ") the results of radoslist are *incomplete*; continuing due to --yes-i-really-mean-it" <<
+	      std::endl;
+	    warned_indexless = true;
+	  } else {
+	    std::cerr << "ERROR: because there is at least one indexless bucket (" <<
+	      bucket_id <<
+	      ") the results of radoslist are *incomplete*; use --yes-i-really-mean-it to bypass error" <<
+	      std::endl;
+	    return ret;
+	  }
+	}
 	continue;
       } else if (ret < 0) {
 	return ret;
@@ -1350,13 +1370,13 @@ int RGWRadosList::run(const DoutPrefixProvider *dpp)
   } while (truncated);
 
   return 0;
-} // RGWRadosList::run()
+} // RGWRadosList::run(DoutPrefixProvider, bool)
 
 
-int RGWRadosList::run(const DoutPrefixProvider *dpp, const std::string& start_bucket_name)
+int RGWRadosList::run(const DoutPrefixProvider *dpp,
+		      const std::string& start_bucket_name,
+		      const bool silent_indexless)
 {
-  RGWObjectCtx obj_ctx(store);
-  std::unique_ptr<rgw::sal::Bucket> bucket;
   int ret;
 
   add_bucket_entire(start_bucket_name);
@@ -1380,6 +1400,12 @@ int RGWRadosList::run(const DoutPrefixProvider *dpp, const std::string& start_bu
       std::cerr << "ERROR: could not get info for bucket " << bucket_name <<
 	" -- " << cpp_strerror(-ret) << std::endl;
       return ret;
+    } else if (bucket->get_info().is_indexless()) {
+      if (! silent_indexless) {
+	std::cerr << "ERROR: unable to run radoslist on indexless bucket " <<
+	  bucket_name << std::endl;
+      }
+      return -EINVAL;
     }
 
     const std::string bucket_id = bucket->get_key().get_key();
@@ -1428,12 +1454,13 @@ int RGWRadosList::run(const DoutPrefixProvider *dpp, const std::string& start_bu
   } // while (! bucket_process_map.empty())
 
   if (include_rgw_obj_name) {
-    goto done;
+    return 0;
   }
 
   // now handle incomplete multipart uploads by going back to the
   // initial bucket
 
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   ret = store->get_bucket(dpp, nullptr, tenant_name, start_bucket_name, &bucket, null_yield);
   if (ret == -ENOENT) {
     // bucket deletion race?
@@ -1451,10 +1478,8 @@ int RGWRadosList::run(const DoutPrefixProvider *dpp, const std::string& start_bu
     return ret;
   }
 
-done:
-
   return 0;
-} // RGWRadosList::run(string)
+} // RGWRadosList::run(DoutPrefixProvider, string, bool)
 
 
 int RGWRadosList::do_incomplete_multipart(const DoutPrefixProvider *dpp,

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -291,8 +291,11 @@ public:
 
   int build_linked_oids_index();
 
-  int run(const DoutPrefixProvider *dpp, const std::string& bucket_id);
-  int run(const DoutPrefixProvider *dpp);
+  int run(const DoutPrefixProvider *dpp,
+	  const std::string& bucket_id,
+	  const bool silent_indexless = false);
+  int run(const DoutPrefixProvider *dpp,
+	  const bool yes_i_really_mean_it = false);
 
   // if there's a non-empty field separator, that means we'll display
   // bucket and object names


### PR DESCRIPTION
Determining whether a bucket is indexless starting with an RGWBucketInfo object requires traversing multiple data structures and "inside knowledge".  This allows it to be determined directly from the RGWBucketInfo object.

Additionally, multiple code paths traverse these data structures to access the final bucket log generation. But that won't exist for indexless buckets, and calling back() on an empty std::vector results in undefined behavior. So this is designed to avoid the currently widely distributed structure traversals and simply return a nullptr to indicate an indexless bucket.

Ideally this commit will enable further streamlining and improved correctness.

The "bucket radoslist" sub-command of radosgw-admin is supposed to list all rados objects tied to one or all directories and thereby provide a way to determine orphaned rados objects.

But indexless buckets don't provide an index to employ for this purpose. So warnings or errors should be provided depending on the circumstances.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
