### PR TITLE
mds: kill session state are open when mds do ms_handle_remote_reset

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1037,6 +1037,9 @@ void MDSDaemon::ms_handle_remote_reset(Connection *con)
       dout(3) << "ms_handle_remote_reset closing connection for session " << session->info.inst << dendl;
       con->mark_down();
       con->set_priv(nullptr);
+    } else if (session->is_open()) {
+      dout(3) << "ms_handle_remote_reset kill session " << session->info.inst << dendl;
+      mds_rank->server->kill_session(session, nullptr);
     }
   }
 }


### PR DESCRIPTION
if the mds decide to reuse the old connection it will
do reset_session and should  also kill the session
which are open state in MDSDaemon::ms_handle_remote_reset
to prevent the situation client session is stuck in
opening state and never has chance to becaome open.

the root cause is client missed the request_open
reply but the mds session has become open already.
so we should kill the session in mds side and let
mds recreate the session when received the connect
request from client.

Fixes: http://tracker.ceph.com/issues/53911
Signed-off-by: YunfeiGuan <yunfeiguan@xtaotech.com>