### PR TITLE
quincy: rgw: first batch of quincy backports

### DIFF
--- a/qa/suites/rgw/multisite/notify.yaml
+++ b/qa/suites/rgw/multisite/notify.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      client.0: # disable notifications on one zone per cluster
+        rgw data notify interval msec: 0

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2801,9 +2801,13 @@ options:
   type: int
   level: advanced
   desc: data changes notification interval to followers
+  long_desc: In multisite, radosgw will occasionally broadcast new entries in its
+    data changes log to peer zones, so they can prioritize sync of some
+    of the most recent changes. Can be disabled with 0.
   default: 200
   services:
   - rgw
+  with_legacy: true
 - name: rgw_torrent_origin
   type: str
   level: advanced
@@ -2822,7 +2826,7 @@ options:
   type: bool
   level: basic
   desc: Enable dynamic resharding
-  long_desc: If true, RGW will dynamicall increase the number of shards in buckets
+  long_desc: If true, RGW will dynamically increase the number of shards in buckets
     that have a high number of objects per shard.
   default: true
   services:

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1626,6 +1626,12 @@ public:
         drain_all();
         return set_cr_error(retcode);
       }
+      // clean up full sync index
+      yield {
+        const auto& pool = sync_env->svc->zone->get_zone_params().log_pool;
+        auto oid = full_data_sync_index_shard_oid(sc->source_zone.id, shard_id);
+        call(new RGWRadosRemoveCR(sync_env->store, {pool, oid}));
+      }
       // keep lease and transition to incremental_sync()
     }
     return 0;

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -990,6 +990,10 @@ void RGWDataChangesLog::renew_stop()
 
 void RGWDataChangesLog::mark_modified(int shard_id, const rgw_bucket_shard& bs)
 {
+  if (!cct->_conf->rgw_data_notify_interval_msec) {
+    return;
+  }
+
   auto key = bs.get_key();
   {
     std::shared_lock rl{modified_lock}; // read lock to check for existence

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7389,9 +7389,10 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   ACLOwner bowner;
 
   op_ret = store->get_bucket(this, s->user.get(), rgw_bucket(rgw_bucket_key(s->user->get_tenant(), bucket_name)), &bucket, y);
-  if (op_ret == -ENOENT) {
-    ldpp_dout(this, 20) << "non existent directory=" << bucket_name << dendl;
-  } else if (op_ret < 0) {
+  if (op_ret < 0) {
+    if (op_ret == -ENOENT) {
+      ldpp_dout(this, 20) << "non existent directory=" << bucket_name << dendl;
+    }
     return op_ret;
   }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1311,8 +1311,10 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp)
       sync_log_trimmer->start();
     }
   }
-  data_notifier = new RGWDataNotifier(this);
-  data_notifier->start();
+  if (cct->_conf->rgw_data_notify_interval_msec) {
+    data_notifier = new RGWDataNotifier(this);
+    data_notifier->start();
+  }
 
   binfo_cache = new RGWChainedCacheImpl<bucket_info_entry>;
   binfo_cache->init(svc.cache);

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -225,6 +225,9 @@ void RGWOp_Bucket_Remove::execute(optional_yield y)
   op_ret = store->get_bucket(s, s->user.get(), string(), bucket_name, &bucket, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "get_bucket returned ret=" << op_ret << dendl;
+    if (op_ret == -ENOENT) {
+      op_ret = -ERR_NO_SUCH_BUCKET;
+    }
     return;
   }
 
@@ -405,4 +408,3 @@ RGWOp *RGWHandler_Bucket::op_delete()
 
   return new RGWOp_Bucket_Remove;
 }
-

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1666,6 +1666,11 @@ public:
           drain_all();
           return retcode;
         }
+        // clean up full sync index
+        yield {
+          auto oid = full_sync_index_shard_oid(shard_id);
+          call(new RGWRadosRemoveCR(sync_env->store, {pool, oid}));
+        }
       }
 
       /* 

--- a/src/rgw/services/svc_bucket_sobj.cc
+++ b/src/rgw/services/svc_bucket_sobj.cc
@@ -642,4 +642,3 @@ int RGWSI_Bucket_SObj::read_buckets_stats(RGWSI_Bucket_X_Ctx& ctx,
 
   return m.size();
 }
-

--- a/src/rgw/store/dbstore/common/dbstore.cc
+++ b/src/rgw/store/dbstore/common/dbstore.cc
@@ -24,7 +24,7 @@ int DB::Initialize(string logfile, int loglevel)
   }
 
   if (loglevel > 0) {
-    cct->_conf->subsys.set_log_level(dout_subsys, loglevel);
+    cct->_conf->subsys.set_log_level(ceph_subsys_rgw, loglevel);
   }
   if (!logfile.empty()) {
     cct->_log->set_log_file(logfile);

--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -15,7 +15,6 @@
 #define FMT_HEADER_ONLY 1
 #include "fmt/format.h"
 #include <map>
-#include "dbstore_log.h"
 #include "rgw/rgw_sal.h"
 #include "rgw/rgw_common.h"
 #include "rgw/rgw_bucket.h"
@@ -651,7 +650,7 @@ class DBOp {
             params->lc_entry_table.c_str(),
             params->bucket_table.c_str());
 
-      ldout(params->cct, 0) << "Incorrect table type("<<type<<") specified" << dendl;
+      lsubdout(params->cct, rgw, 0) << "rgw dbstore: Incorrect table type("<<type<<") specified" << dendl;
 
       return NULL;
     }
@@ -1395,7 +1394,7 @@ class DB {
     lc_head_table(db_name+".lc_head.table"),
     lc_entry_table(db_name+".lc_entry.table"),
     cct(_cct),
-    dp(_cct, dout_subsys, "rgw DBStore backend: ")
+    dp(_cct, ceph_subsys_rgw, "rgw DBStore backend: ")
   {}
     /*	DB() {}*/
 
@@ -1406,7 +1405,7 @@ class DB {
     lc_head_table(db_name+".lc_head.table"),
     lc_entry_table(db_name+".lc_entry.table"),
     cct(_cct),
-    dp(_cct, dout_subsys, "rgw DBStore backend: ")
+    dp(_cct, ceph_subsys_rgw, "rgw DBStore backend: ")
   {}
     virtual	~DB() {}
 

--- a/src/rgw/store/dbstore/dbstore_mgr.cc
+++ b/src/rgw/store/dbstore/dbstore_mgr.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "dbstore_mgr.h"
+#include "common/dbstore_log.h"
 
 /* Given a tenant, find and return the DBStore handle.
  * If not found and 'create' set to true, create one

--- a/src/rgw/store/dbstore/dbstore_mgr.h
+++ b/src/rgw/store/dbstore/dbstore_mgr.h
@@ -40,7 +40,7 @@ public:
                       CODE_ENVIRONMENT_DAEMON, CINIT_FLAG_NO_MON_CONFIG, 1)->get();
     cct->_log->set_log_file(logfile);
     cct->_log->reopen_log_file();
-    cct->_conf->subsys.set_log_level(dout_subsys, loglevel);
+    cct->_conf->subsys.set_log_level(ceph_subsys_rgw, loglevel);
   };
   ~DBStoreManager() { destroyAllHandles(); };
 


### PR DESCRIPTION
includes the following prs:

https://github.com/ceph/ceph/pull/44078  meta sync retries
https://github.com/ceph/ceph/pull/44413  remove bucket admin api
https://github.com/ceph/ceph/pull/44581  dbstore logging
https://github.com/ceph/ceph/pull/40011  datalog notify interval
https://github.com/ceph/ceph/pull/44617  swift bulk upload
https://github.com/ceph/ceph/pull/33934  delete full sync index

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
