### PR TITLE
script: backport updates for quincy

### DIFF
--- a/src/script/backport-create-issue
+++ b/src/script/backport-create-issue
@@ -122,7 +122,7 @@ def connect_to_redmine(a):
 def releases():
     return ('argonaut', 'bobtail', 'cuttlefish', 'dumpling', 'emperor',
             'firefly', 'giant', 'hammer', 'infernalis', 'jewel', 'kraken',
-            'luminous', 'mimic', 'nautilus', 'octopus', 'pacific')
+            'luminous', 'mimic', 'nautilus', 'octopus', 'pacific', 'quincy')
 
 def populate_status_dict(r):
     for status in r.issue_status.all():

--- a/src/script/backport-resolve-issue
+++ b/src/script/backport-resolve-issue
@@ -324,7 +324,7 @@ def read_from_file(fs):
 def releases():
     return ('argonaut', 'bobtail', 'cuttlefish', 'dumpling', 'emperor',
             'firefly', 'giant', 'hammer', 'infernalis', 'jewel', 'kraken',
-            'luminous', 'mimic', 'nautilus', 'octopus', 'pacific')
+            'luminous', 'mimic', 'nautilus', 'octopus', 'pacific', 'quincy')
 
 def report_params(a):
     global dry_run
@@ -352,7 +352,7 @@ def ver_to_release():
     return {'v9.2': 'infernalis', 'v10.2': 'jewel', 'v11.2': 'kraken',
             'v12.2': 'luminous', 'v13.2': 'mimic', 'v14.2': 'nautilus',
             'v15.2': 'octopus', 'v16.0': 'pacific', 'v16.1': 'pacific',
-            'v16.2': 'pacific'}
+            'v16.2': 'pacific', 'v17.0': 'quincy'}
 
 def usage():
     logging.error("Redmine credentials are required to perform this operation. "

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -1084,6 +1084,7 @@ function try_known_milestones {
         nautilus) mn="12" ;;
         octopus) mn="13" ;;
         pacific) mn="14" ;;
+        quincy) mn="15" ;;
     esac
     echo "$mn"
 }


### PR DESCRIPTION
Signed-off-by: Neha Ojha <nojha@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
