### PR TITLE
doc/cephadm: remove duplicate deployment scenario section

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -229,49 +229,6 @@ available options.
 
 .. _cephadm-enable-cli:
 
-Different deployment scenarios
-==============================
-
-Single host
------------
-
-To configure a Ceph cluster to run on a single host, use the ``--single-host-defaults`` flag when bootstrapping.
-
-Deployment in an isolated environment
--------------------------------------
-
-You can install Cephadm in an isolated environment by using a custom container registry and configuring Docker to use an insecure registry. Ensure your container image is inside the registry and that you have access to all hosts you wish to add to the cluster. Currently, to add multiple hosts to a Ceph cluster in an isolated environment, you must use Docker. This may require you to uninstall Podman if it's present on your host as Cephadm prefers to use Podman over Docker.
-
-Run a local container registry:
-
-.. prompt:: bash #
-
-   docker run --privileged -d --name registry -p 5000:5000 -v /var/lib/registry:/var/lib/registry --restart=always registry:2
-
-Edit the ``/etc/docker/daemon.json`` file with the hostname and port where the registry is running:
-
-.. code-block:: bash
-
-   { "insecure-registries":["*<hostname>*:5000"] }
-
-.. note:: For every host which accesses the local registry, you will need to repeat this step and edit the ``/etc/docker/daemon.json`` file on the host.
-
-Restart docker:
-
-.. prompt:: bash #
-
-   systemctl daemon-reload
-   systemctl restart docker
-   
-Next, push your container image to your local registry.
-
-Then run bootstrap using the ``--image`` flag with your container image. For example:
-
-.. prompt:: bash #
-
-   cephadm --image *<hostname>*:5000/ceph/ceph bootstrap --mon-ip *<mon-ip>*
-
-
 Enable Ceph CLI
 ===============
 


### PR DESCRIPTION
Noticed there were two "Different deployment scenarios" sections in the docs.

Signed-off-by: Melissa Li <melissali@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
