### PR TITLE
crimson/os/seastore: consolidate seastore_t and seastore_cache logs

### DIFF
--- a/src/common/subsys.h
+++ b/src/common/subsys.h
@@ -88,6 +88,7 @@ SUBSYS(seastore_onode, 0, 5)
 SUBSYS(seastore_odata, 0, 5)
 SUBSYS(seastore_omap, 0, 5)
 SUBSYS(seastore_tm, 0, 5)    // logs below seastore tm
+SUBSYS(seastore_t, 0, 5)
 SUBSYS(seastore_cleaner, 0, 5)
 SUBSYS(seastore_lba, 0, 5)
 SUBSYS(seastore_cache, 0, 5)

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -336,13 +336,6 @@ public:
     return get_extent<T>(t, offset, length, [](T &){});
   }
 
-
-  /**
-   * get_extent_by_type
-   *
-   * Based on type, instantiate the correct concrete type
-   * and read in the extent at location offset~length.
-   */
 private:
   // This is a workaround std::move_only_function not being available,
   // not really worth generalizing at this time.
@@ -419,6 +412,12 @@ private:
   }
 
 public:
+  /**
+   * get_extent_by_type
+   *
+   * Based on type, instantiate the correct concrete type
+   * and read in the extent at location offset~length.
+   */
   template <typename Func>
   get_extent_by_type_ret get_extent_by_type(
     Transaction &t,         ///< [in] transaction
@@ -464,10 +463,6 @@ public:
     t.add_fresh_extent(ret, delayed);
     ret->state = CachedExtent::extent_state_t::INITIAL_WRITE_PENDING;
     return ret;
-  }
-
-  void clear_lru() {
-    lru.clear();
   }
 
   void mark_delayed_extent_inline(
@@ -590,13 +585,13 @@ public:
     // journal replay should has been finished at this point,
     // Cache::root should have been inserted to the dirty list
     assert(root->is_dirty());
-    std::vector<CachedExtentRef> dirty;
+    std::vector<CachedExtentRef> _dirty;
     for (auto &e : extents) {
-      dirty.push_back(CachedExtentRef(&e));
+      _dirty.push_back(CachedExtentRef(&e));
     }
     return seastar::do_with(
       std::forward<F>(f),
-      std::move(dirty),
+      std::move(_dirty),
       [this, &t](auto &f, auto &refs) mutable
     {
       return trans_intr::do_for_each(

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -88,6 +88,9 @@ namespace crimson::os::seastore {
  * Cache logs
  *
  * levels:
+ * - INFO: major initiation, closing operations
+ * - DEBUG: major extent related operations, INFO details
+ * - TRACE: DEBUG details
  * - seastore_t logs
  */
 class Cache {
@@ -134,6 +137,8 @@ public:
 
   /// Declare ref retired in t
   void retire_extent(Transaction &t, CachedExtentRef ref) {
+    LOG_PREFIX(Cache::retire_extent);
+    SUBDEBUGT(seastore_cache, "retire extent -- {}", t, *ref);
     t.add_to_retired_set(ref);
   }
 
@@ -158,6 +163,8 @@ public:
    * returns t.root and assume it is already present/read in t
    */
   RootBlockRef get_root_fast(Transaction &t) {
+    LOG_PREFIX(Cache::get_root_fast);
+    SUBTRACET(seastore_cache, "root already on t -- {}", t, *t.root);
     assert(t.root);
     return t.root;
   }
@@ -180,8 +187,11 @@ public:
     const src_ext_t* p_metric_key, ///< [in] cache query metric key
     Func &&extent_init_func        ///< [in] init func for extent
   ) {
+    LOG_PREFIX(Cache::get_extent);
     auto cached = query_cache(offset, p_metric_key);
     if (!cached) {
+      SUBDEBUG(seastore_cache,
+          "{} {}~{} is absent, reading ...", T::TYPE, offset, length);
       auto ret = CachedExtent::make_cached_extent_ref<T>(
         alloc_cache_buf(length));
       ret->set_paddr(offset);
@@ -194,6 +204,9 @@ public:
 
     // extent PRESENT in cache
     if (cached->get_type() == extent_types_t::RETIRED_PLACEHOLDER) {
+      SUBDEBUG(seastore_cache,
+          "{} {}~{} is absent(placeholder), reading ...",
+          T::TYPE, offset, length);
       auto ret = CachedExtent::make_cached_extent_ref<T>(
         alloc_cache_buf(length));
       ret->set_paddr(offset);
@@ -211,6 +224,9 @@ public:
       return read_extent<T>(
 	std::move(ret));
     } else {
+      SUBTRACE(seastore_cache,
+          "{} {}~{} is present in cache -- {}",
+          T::TYPE, offset, length, *cached);
       auto ret = TCachedExtentRef<T>(static_cast<T*>(cached.get()));
       return ret->wait_io(
       ).then([ret=std::move(ret)]() mutable
@@ -248,11 +264,14 @@ public:
     CachedExtentRef ret;
     LOG_PREFIX(Cache::get_extent_if_cached);
     auto result = t.get_extent(offset, &ret);
-    if (result != Transaction::get_extent_ret::ABSENT) {
-      // including get_extent_ret::RETIRED
-      SUBDEBUGT(seastore_cache,
-	"Found extent at offset {} on transaction: {}",
-	t, offset, *ret);
+    if (result == Transaction::get_extent_ret::RETIRED) {
+      SUBDEBUGT(seastore_cache, "{} {} is retired on t -- {}",
+          t, type, offset, *ret);
+      return get_extent_if_cached_iertr::make_ready_future<
+        CachedExtentRef>(ret);
+    } else if (result == Transaction::get_extent_ret::PRESENT) {
+      SUBTRACET(seastore_cache, "{} {} is present on t -- {}",
+          t, type, offset, *ret);
       return get_extent_if_cached_iertr::make_ready_future<
         CachedExtentRef>(ret);
     }
@@ -263,17 +282,15 @@ public:
     if (!ret ||
         // retired_placeholder is not really cached yet
         ret->get_type() == extent_types_t::RETIRED_PLACEHOLDER) {
-      SUBDEBUGT(seastore_cache,
-	"No extent at offset {}, retired_placeholder: {}",
-	t, offset, !!ret);
+      SUBDEBUGT(seastore_cache, "{} {} is absent{}",
+                t, type, offset, !!ret ? "(placeholder)" : "");
       return get_extent_if_cached_iertr::make_ready_future<
         CachedExtentRef>();
     }
 
     // present in cache and is not a retired_placeholder
-    SUBDEBUGT(seastore_cache,
-      "Found extent at offset {} in cache: {}",
-      t, offset, *ret);
+    SUBDEBUGT(seastore_cache, "{} {} is present in cache -- {}",
+              t, type, offset, *ret);
     t.add_to_read_set(ret);
     touch_extent(*ret);
     return ret->wait_io().then([ret] {
@@ -303,29 +320,33 @@ public:
     LOG_PREFIX(Cache::get_extent);
     auto result = t.get_extent(offset, &ret);
     if (result != Transaction::get_extent_ret::ABSENT) {
+      SUBTRACET(seastore_cache, "{} {}~{} is {} on t -- {}",
+          t,
+          T::TYPE,
+          offset,
+          length,
+          result == Transaction::get_extent_ret::PRESENT ? "present" : "retired",
+          *ret);
       assert(result != Transaction::get_extent_ret::RETIRED);
-      SUBDEBUGT(seastore_cache,
-	"Found extent at offset {} on transaction: {}",
-	t, offset, *ret);
       return seastar::make_ready_future<TCachedExtentRef<T>>(
 	ret->cast<T>());
     } else {
+      SUBTRACET(seastore_cache, "{} {}~{} is absent on t, query cache ...",
+                t, T::TYPE, offset, length);
       auto metric_key = std::make_pair(t.get_src(), T::TYPE);
       return trans_intr::make_interruptible(
 	get_extent<T>(
 	  offset, length, &metric_key,
 	  std::forward<Func>(extent_init_func))
-      ).si_then([this, FNAME, offset, &t](auto ref) {
+      ).si_then([this, FNAME, offset, length, &t](auto ref) {
 	(void)this; // silence incorrect clang warning about capture
 	if (!ref->is_valid()) {
-	  SUBDEBUGT(seastore_cache, "got invalid extent: {}", t, ref);
+	  SUBDEBUGT(seastore_cache, "{} {}~{} is invalid -- {}",
+	            t, T::TYPE, offset, length, *ref);
 	  ++(get_by_src(stats.trans_conflicts_by_unknown, t.get_src()));
 	  mark_transaction_conflicted(t, *ref);
 	  return get_extent_iertr::make_ready_future<TCachedExtentRef<T>>();
 	} else {
-	  SUBDEBUGT(seastore_cache,
-	    "Read extent at offset {} in cache: {}",
-	    t, offset, *ref);
 	  touch_extent(*ref);
 	  t.add_to_read_set(ref);
 	  return get_extent_iertr::make_ready_future<TCachedExtentRef<T>>(
@@ -387,14 +408,22 @@ private:
     paddr_t offset,
     laddr_t laddr,
     seastore_off_t length,
-    extent_init_func_t &&extent_init_func) {
+    extent_init_func_t &&extent_init_func
+  ) {
+    LOG_PREFIX(Cache::get_extent_by_type);
     CachedExtentRef ret;
     auto status = t.get_extent(offset, &ret);
     if (status == Transaction::get_extent_ret::RETIRED) {
+      SUBDEBUGT(seastore_cache, "{} {}~{} {} is retired on t -- {}",
+                t, type, offset, length, laddr, *ret);
       return seastar::make_ready_future<CachedExtentRef>();
     } else if (status == Transaction::get_extent_ret::PRESENT) {
+      SUBTRACET(seastore_cache, "{} {}~{} {} is present on t -- {}",
+                t, type, offset, length, laddr, *ret);
       return seastar::make_ready_future<CachedExtentRef>(ret);
     } else {
+      SUBTRACET(seastore_cache, "{} {}~{} {} is absent on t, query cache ...",
+                t, type, offset, length, laddr);
       auto src = t.get_src();
       return trans_intr::make_interruptible(
 	_get_extent_by_type(
@@ -402,8 +431,8 @@ private:
 	  std::move(extent_init_func))
       ).si_then([=, &t](CachedExtentRef ret) {
         if (!ret->is_valid()) {
-          LOG_PREFIX(Cache::get_extent_by_type);
-          SUBDEBUGT(seastore_cache, "got invalid extent: {}", t, ret);
+          SUBDEBUGT(seastore_cache, "{} {}~{} {} is invalid -- {}",
+                    t, type, offset, length, laddr, *ret);
           ++(get_by_src(stats.trans_conflicts_by_unknown, t.get_src()));
           mark_transaction_conflicted(t, *ret.get());
           return get_extent_ertr::make_ready_future<CachedExtentRef>();
@@ -464,6 +493,9 @@ public:
     seastore_off_t length, ///< [in] length
     bool delayed = false  ///< [in] whether the paddr allocation of extent is delayed
   ) {
+    LOG_PREFIX(Cache::alloc_new_extent);
+    SUBDEBUGT(seastore_cache, "allocate {} {}B, delay={}",
+              t, T::TYPE, length, delayed);
     auto ret = CachedExtent::make_cached_extent_ref<T>(
       alloc_cache_buf(length));
     t.add_fresh_extent(ret, delayed);
@@ -473,14 +505,21 @@ public:
 
   void mark_delayed_extent_inline(
     Transaction& t,
-    LogicalCachedExtentRef& ref) {
+    LogicalCachedExtentRef& ref
+  ) {
+    LOG_PREFIX(Cache::mark_delayed_extent_inline);
+    SUBDEBUGT(seastore_cache, "-- {}", t, *ref);
     t.mark_delayed_extent_inline(ref);
   }
 
   void mark_delayed_extent_ool(
     Transaction& t,
     LogicalCachedExtentRef& ref,
-    paddr_t final_addr) {
+    paddr_t final_addr
+  ) {
+    LOG_PREFIX(Cache::mark_delayed_extent_ool);
+    SUBDEBUGT(seastore_cache, "final_addr={} -- {}",
+              t, final_addr, *ref);
     t.mark_delayed_extent_ool(ref, final_addr);
   }
 
@@ -588,6 +627,15 @@ public:
     Transaction &t,
     F &&f)
   {
+    LOG_PREFIX(Cache::init_cached_extents);
+    SUBINFOT(seastore_cache,
+        "start with {}({}B) extents, {} dirty, from {}",
+        t,
+        extents.size(),
+        extents.get_bytes(),
+        dirty.size(),
+        get_oldest_dirty_from().value_or(journal_seq_t{}));
+
     // journal replay should has been finished at this point,
     // Cache::root should have been inserted to the dirty list
     assert(root->is_dirty());
@@ -598,16 +646,20 @@ public:
     return seastar::do_with(
       std::forward<F>(f),
       std::move(_dirty),
-      [this, &t](auto &f, auto &refs) mutable
+      [this, FNAME, &t](auto &f, auto &refs) mutable
     {
       return trans_intr::do_for_each(
         refs,
-        [this, &t, &f](auto &e)
+        [this, FNAME, &t, &f](auto &e)
       {
+        SUBTRACET(seastore_cache, "inspecting extent ... -- {}", t, *e);
         return f(t, e
-        ).si_then([this, &t, e](bool is_alive) {
+        ).si_then([this, FNAME, &t, e](bool is_alive) {
           if (!is_alive) {
+            SUBDEBUGT(seastore_cache, "extent is not alive, remove -- {}", t, *e);
             remove_extent(e);
+          } else {
+            SUBDEBUGT(seastore_cache, "extent is alive -- {}", t, *e);
           }
         });
       });
@@ -616,7 +668,15 @@ public:
       crimson::ct_error::assert_all{
         "Invalid error in Cache::init_cached_extents"
       }
-    );
+    ).si_then([this, FNAME, &t] {
+      SUBINFOT(seastore_cache,
+          "finish with {}({}B) extents, {} dirty, from {}",
+          t,
+          extents.size(),
+          extents.get_bytes(),
+          dirty.size(),
+          get_oldest_dirty_from().value_or(journal_seq_t{}));
+    });
   }
 
   /**
@@ -741,6 +801,10 @@ private:
 
   public:
     LRU(size_t capacity) : capacity(capacity) {}
+
+    size_t get_capacity() const {
+      return capacity;
+    }
 
     size_t get_current_contents_bytes() const {
       return contents;
@@ -974,12 +1038,14 @@ private:
       extent->get_bptr()
     ).safe_then(
       [extent=std::move(extent)]() mutable {
+        LOG_PREFIX(Cache::read_extent);
         extent->state = CachedExtent::extent_state_t::CLEAN;
         /* TODO: crc should be checked against LBA manager */
         extent->last_committed_crc = extent->get_crc32c();
 
         extent->on_clean_read();
         extent->complete_io();
+        SUBDEBUG(seastore_cache, "read extent done -- {}", *extent);
         return get_extent_ertr::make_ready_future<TCachedExtentRef<T>>(
           std::move(extent));
       },

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -795,49 +795,29 @@ private:
     uint64_t hit = 0;
   };
 
-  /**
-   * effort_t
-   *
-   * Count the number of extents involved in the effort and the total bytes of
-   * them.
-   *
-   * Each effort_t represents the effort of a set of extents involved in the
-   * transaction, classified by read, mutate, retire and allocate behaviors,
-   * see XXX_trans_efforts_t.
-   */
-  struct effort_t {
-    uint64_t extents = 0;
-    uint64_t bytes = 0;
-
-    void increment(uint64_t extent_len) {
-      ++extents;
-      bytes += extent_len;
-    }
-  };
-
   template <typename CounterT>
   using counter_by_extent_t = std::array<CounterT, EXTENT_TYPES_MAX>;
 
   struct invalid_trans_efforts_t {
-    effort_t read;
-    effort_t mutate;
+    io_stat_t read;
+    io_stat_t mutate;
     uint64_t mutate_delta_bytes = 0;
-    effort_t retire;
-    effort_t fresh;
-    effort_t fresh_ool_written;
+    io_stat_t retire;
+    io_stat_t fresh;
+    io_stat_t fresh_ool_written;
     counter_by_extent_t<uint64_t> num_trans_invalidated;
     uint64_t num_ool_records = 0;
     uint64_t ool_record_bytes = 0;
   };
 
   struct commit_trans_efforts_t {
-    counter_by_extent_t<effort_t> read_by_ext;
-    counter_by_extent_t<effort_t> mutate_by_ext;
+    counter_by_extent_t<io_stat_t> read_by_ext;
+    counter_by_extent_t<io_stat_t> mutate_by_ext;
     counter_by_extent_t<uint64_t> delta_bytes_by_ext;
-    counter_by_extent_t<effort_t> retire_by_ext;
-    counter_by_extent_t<effort_t> fresh_invalid_by_ext; // inline but is already invalid (retired)
-    counter_by_extent_t<effort_t> fresh_inline_by_ext;
-    counter_by_extent_t<effort_t> fresh_ool_by_ext;
+    counter_by_extent_t<io_stat_t> retire_by_ext;
+    counter_by_extent_t<io_stat_t> fresh_invalid_by_ext; // inline but is already invalid (retired)
+    counter_by_extent_t<io_stat_t> fresh_inline_by_ext;
+    counter_by_extent_t<io_stat_t> fresh_ool_by_ext;
     uint64_t num_trans = 0; // the number of inline records
     uint64_t num_ool_records = 0;
     uint64_t ool_record_padding_bytes = 0;
@@ -847,7 +827,7 @@ private:
   };
 
   struct success_read_trans_efforts_t {
-    effort_t read;
+    io_stat_t read;
     uint64_t num_trans = 0;
   };
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -83,6 +83,12 @@ namespace crimson::os::seastore {
  *   CachedExtent::delta_written(paddr_t) with the address of the start
  *   of the record
  * - Complete all promises with the final record start paddr_t
+ *
+ *
+ * Cache logs
+ *
+ * levels:
+ * - seastore_t logs
  */
 class Cache {
 public:
@@ -111,8 +117,8 @@ public:
         return on_transaction_destruct(t);
       }
     );
-    SUBDEBUGT(seastore_cache, "created name={}, source={}, is_weak={}",
-              *ret, name, src, is_weak);
+    SUBDEBUGT(seastore_t, "created name={}, source={}, is_weak={}",
+             *ret, name, src, is_weak);
     return ret;
   }
 
@@ -120,10 +126,10 @@ public:
   void reset_transaction_preserve_handle(Transaction &t) {
     LOG_PREFIX(Cache::reset_transaction_preserve_handle);
     if (t.did_reset()) {
+      SUBTRACET(seastore_t, "reset", t);
       ++(get_by_src(stats.trans_created_by_src, t.get_src()));
     }
     t.reset_preserve_handle(last_commit);
-    SUBDEBUGT(seastore_cache, "reset", t);
   }
 
   /// Declare ref retired in t

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -648,9 +648,13 @@ Journal::RecordSubmitter::submit(
 
 seastar::future<> Journal::RecordSubmitter::flush(OrderingHandle &handle)
 {
+  LOG_PREFIX(RecordSubmitter::flush);
+  DEBUG("H{} flush", (void*)&handle);
   return handle.enter(write_pipeline->device_submission
   ).then([this, &handle] {
     return handle.enter(write_pipeline->finalize);
+  }).then([FNAME, &handle] {
+    DEBUG("H{} flush done", (void*)&handle);
   });
 }
 

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -118,9 +118,11 @@ public:
    * Implementation must initialize the LBAPin on any
    * LogicalCachedExtent's and may also read in any dependent
    * structures, etc.
+   *
+   * @return returns whether the extent is alive
    */
   using init_cached_extent_iertr = base_iertr;
-  using init_cached_extent_ret = init_cached_extent_iertr::future<>;
+  using init_cached_extent_ret = init_cached_extent_iertr::future<bool>;
   virtual init_cached_extent_ret init_cached_extent(
     Transaction &t,
     CachedExtentRef e) = 0;

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
@@ -286,12 +286,11 @@ LBABtree::init_cached_extent_ret LBABtree::init_cached_extent(
 	  c.pins->add_pin(
 	    static_cast<BtreeLBAPin&>(logn->get_pin()).pin);
 	}
-	DEBUGT("logical extent {} live, initialized", c.trans, *logn);
-	return e;
+	DEBUGT("logical extent {} live", c.trans, *logn);
+	return true;
       } else {
-	DEBUGT("logical extent {} not live, dropping", c.trans, *logn);
-	c.cache.drop_from_cache(logn);
-	return CachedExtentRef();
+	DEBUGT("logical extent {} not live", c.trans, *logn);
+	return false;
       }
     });
   } else if (e->get_type() == extent_types_t::LADDR_INTERNAL) {
@@ -304,11 +303,10 @@ LBABtree::init_cached_extent_ret LBABtree::init_cached_extent(
       if (cand_depth <= iter.get_depth() &&
 	  &*iter.get_internal(cand_depth).node == &*eint) {
 	DEBUGT("extent {} is live", c.trans, *eint);
-	return e;
+	return true;
       } else {
 	DEBUGT("extent {} is not live", c.trans, *eint);
-	c.cache.drop_from_cache(eint);
-	return CachedExtentRef();
+	return false;
       }
     });
   } else if (e->get_type() == extent_types_t::LADDR_LEAF) {
@@ -319,11 +317,10 @@ LBABtree::init_cached_extent_ret LBABtree::init_cached_extent(
       // Note, this check is valid even if iter.is_end()
       if (iter.leaf.node == &*eleaf) {
 	DEBUGT("extent {} is live", c.trans, *eleaf);
-	return e;
+	return true;
       } else {
 	DEBUGT("extent {} is not live", c.trans, *eleaf);
-	c.cache.drop_from_cache(eleaf);
-	return CachedExtentRef();
+	return false;
       }
     });
   } else {
@@ -334,7 +331,7 @@ LBABtree::init_cached_extent_ret LBABtree::init_cached_extent(
       e->get_type());
     return init_cached_extent_ret(
       interruptible::ready_future_marker{},
-      e);
+      true);
   }
 }
 

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
@@ -378,10 +378,10 @@ public:
    * Checks whether e is live (reachable from lba tree) and drops or initializes
    * accordingly.
    *
-   * Returns e if live and a null CachedExtentRef otherwise.
+   * Returns if e is live.
    */
   using init_cached_extent_iertr = base_iertr;
-  using init_cached_extent_ret = init_cached_extent_iertr::future<CachedExtentRef>;
+  using init_cached_extent_ret = init_cached_extent_iertr::future<bool>;
   init_cached_extent_ret init_cached_extent(op_context_t c, CachedExtentRef e);
 
   /// get_leaf_if_live: get leaf node at laddr/addr if still live

--- a/src/crimson/os/seastore/logging.h
+++ b/src/crimson/os/seastore/logging.h
@@ -17,11 +17,11 @@
 #define LOG(level_, MSG, ...) \
   LOCAL_LOGGER.log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
 #define LOGT(level_, MSG, t, ...) \
-  LOCAL_LOGGER.log(level_, "{}({}): " MSG, FNAME, (void*)&t , ##__VA_ARGS__)
+  LOCAL_LOGGER.log(level_, "{} {}: " MSG, (void*)&t, FNAME , ##__VA_ARGS__)
 #define SUBLOG(subname_, level_, MSG, ...) \
   LOGGER(subname_).log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
 #define SUBLOGT(subname_, level_, MSG, t, ...) \
-  LOGGER(subname_).log(level_, "{}({}): " MSG, FNAME, (void*)&t , ##__VA_ARGS__)
+  LOGGER(subname_).log(level_, "{} {}: " MSG, (void*)&t, FNAME , ##__VA_ARGS__)
 
 #else
 
@@ -35,11 +35,11 @@ void _LOG(seastar::logger& logger, std::string_view info) {
 #define LOG(level_, MSG, ...) \
   _LOG<level_>(LOCAL_LOGGER, "{}: " MSG ## _format(FNAME , ##__VA_ARGS__))
 #define LOGT(level_, MSG, t_, ...) \
-  _LOG<level_>(LOCAL_LOGGER, "{}({}): " MSG ## _format(FNAME, (void*)&t_ , ##__VA_ARGS__))
+  _LOG<level_>(LOCAL_LOGGER, "{} {}: " MSG ## _format((void*)&t_, FNAME , ##__VA_ARGS__))
 #define SUBLOG(subname_, level_, MSG, ...) \
   _LOG<level_>(LOGGER(subname_), "{}: " MSG ## _format(FNAME , ##__VA_ARGS__))
 #define SUBLOGT(subname_, level_, MSG, t_, ...) \
-  _LOG<level_>(LOGGER(subname_), "{}({}): " MSG ## _format(FNAME, (void*)&t_ , ##__VA_ARGS__))
+  _LOG<level_>(LOGGER(subname_), "{} {}: " MSG ## _format((void*)&t_, FNAME , ##__VA_ARGS__))
 
 #endif
 

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -45,6 +45,11 @@ inline std::ostream& operator<<(std::ostream& out, const io_stat_t& stat) {
  * Transaction
  *
  * Representation of in-progress mutation. Used exclusively through Cache methods.
+ *
+ * Transaction log levels:
+ * seastore_t
+ * - DEBUG: transaction create, conflict, commit events
+ * - TRACE: DEBUG details
  */
 class Transaction {
 public:

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -50,6 +50,7 @@ inline std::ostream& operator<<(std::ostream& out, const io_stat_t& stat) {
  * seastore_t
  * - DEBUG: transaction create, conflict, commit events
  * - TRACE: DEBUG details
+ * - seastore_cache logs
  */
 class Transaction {
 public:
@@ -68,7 +69,8 @@ public:
 	iter != write_set.end()) {
       if (out)
 	*out = CachedExtentRef(&*iter);
-      SUBTRACET(seastore_tm, "Found offset {} in write_set: {}", *this, addr, *iter);
+      SUBTRACET(seastore_cache, "{} is present in write_set -- {}",
+                *this, addr, *iter);
       return get_extent_ret::PRESENT;
     } else if (
       auto iter = read_set.find(addr);
@@ -78,7 +80,8 @@ public:
       assert(iter->ref->get_type() != extent_types_t::RETIRED_PLACEHOLDER);
       if (out)
 	*out = iter->ref;
-      SUBTRACET(seastore_tm, "Found offset {} in read_set: {}", *this, addr, *(iter->ref));
+      SUBTRACET(seastore_cache, "{} is present in read_set -- {}",
+                *this, addr, *(iter->ref));
       return get_extent_ret::PRESENT;
     } else {
       return get_extent_ret::ABSENT;
@@ -115,7 +118,6 @@ public:
   void add_fresh_extent(
     CachedExtentRef ref,
     bool delayed = false) {
-    LOG_PREFIX(Transaction::add_fresh_extent);
     ceph_assert(!is_weak());
     if (delayed) {
       assert(ref->is_logical());
@@ -128,39 +130,30 @@ public:
       inline_block_list.push_back(ref);
     }
     fresh_block_stats.increment(ref->get_length());
-    SUBTRACET(seastore_tm, "adding {} to write_set", *this, *ref);
     write_set.insert(*ref);
   }
 
   void mark_delayed_extent_inline(LogicalCachedExtentRef& ref) {
-    LOG_PREFIX(Transaction::mark_delayed_extent_inline);
-    SUBTRACET(seastore_tm, "removing {} from write_set", *this, *ref);
     write_set.erase(*ref);
     ref->set_paddr(make_record_relative_paddr(offset));
     offset += ref->get_length();
     inline_block_list.push_back(ref);
-    SUBTRACET(seastore_tm, "adding {} to write_set", *this, *ref);
     write_set.insert(*ref);
   }
 
   void mark_delayed_extent_ool(LogicalCachedExtentRef& ref, paddr_t final_addr) {
-    LOG_PREFIX(Transaction::mark_delayed_extent_ool);
-    SUBTRACET(seastore_tm, "removing {} from write_set", *this, *ref);
     write_set.erase(*ref);
     ref->set_paddr(final_addr);
     assert(!ref->get_paddr().is_null());
     assert(!ref->is_inline());
     ool_block_list.push_back(ref);
-    SUBTRACET(seastore_tm, "adding {} to write_set", *this, *ref);
     write_set.insert(*ref);
   }
 
   void add_mutated_extent(CachedExtentRef ref) {
-    LOG_PREFIX(Transaction::add_mutated_extent);
     ceph_assert(!is_weak());
     assert(read_set.count(ref->prior_instance->get_paddr()));
     mutated_block_list.push_back(ref);
-    SUBTRACET(seastore_tm, "adding {} to write_set", *this, *ref);
     write_set.insert(*ref);
   }
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
