### PR TITLE
octopus: mds: trigger stray reintegration when loading dentry

### DIFF
--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -1032,8 +1032,13 @@ class Filesystem(MDSCluster):
         return self.json_asok(command, 'mds', info['name'], timeout=timeout)
 
     def rank_tell(self, command, rank=0, status=None):
-        info = self.get_rank(rank=rank, status=status)
-        return json.loads(self.mon_manager.raw_cluster_cmd("tell", 'mds.{0}'.format(info['name']), *command))
+        try:
+            info = self.get_rank(rank=rank, status=status)
+            out = self.mon_manager.raw_cluster_cmd("tell", 'mds.{0}'.format(info['name']), *command)
+            return json.loads(out)
+        except json.decoder.JSONDecodeError:
+            log.error("could not decode: {}".format(out))
+            raise
 
     def ranks_tell(self, command, status=None):
         if status is None:

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -248,6 +248,9 @@ void CDentry::link_remote(CDentry::linkage_t *dnl, CInode *in)
 
   if (dnl == &linkage)
     in->add_remote_parent(this);
+
+  // check for reintegration
+  dir->cache->eval_remote(this);
 }
 
 void CDentry::unlink_remote(CDentry::linkage_t *dnl)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53735

---

backport of https://github.com/ceph/ceph/pull/44342
parent tracker: https://tracker.ceph.com/issues/53641

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh