### PR TITLE
cephadm: add shared_ceph_folder opt to ceph-volume subcommand

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -8095,6 +8095,10 @@ def _get_parser():
         'ceph-volume', help='run ceph-volume inside a container')
     parser_ceph_volume.set_defaults(func=command_ceph_volume)
     parser_ceph_volume.add_argument(
+        '--shared_ceph_folder',
+        metavar='CEPH_SOURCE_FOLDER',
+        help='Development mode. Several folders in containers are volumes mapped to different sub-folders in the ceph source folder')
+    parser_ceph_volume.add_argument(
         '--fsid',
         help='cluster FSID')
     parser_ceph_volume.add_argument(


### PR DESCRIPTION
This commit adds the `--shared_ceph_folder` option to `ceph-volume`
subcommand, just like `shell` and `bootstrap` subcommands.

Fixes: https://tracker.ceph.com/issues/53931

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>