### PR TITLE
rgw multisite reshard: check for empty logs and indexless layouts

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -674,39 +674,12 @@ int RGWBucket::sync(RGWBucketAdminOpState& op_state, const DoutPrefixProvider *d
     bucket->get_info().flags |= BUCKET_DATASYNC_DISABLED;
   }
 
+  // when writing this metadata, RGWSI_BucketIndex_RADOS::handle_overwrite()
+  // will write the corresponding datalog and bilog entries
   int r = bucket->put_info(dpp, false, real_time());
   if (r < 0) {
     set_err_msg(err_msg, "ERROR: failed writing bucket instance info:" + cpp_strerror(-r));
     return r;
-  }
-
-  int shards_num = bucket->get_info().layout.current_index.layout.normal.num_shards? bucket->get_info().layout.current_index.layout.normal.num_shards : 1;
-  int shard_id = bucket->get_info().layout.current_index.layout.normal.num_shards? 0 : -1;
-  const auto& log_layout = bucket->get_info().layout.logs.back();
-
-  if (!sync) {
-    r = static_cast<rgw::sal::RadosStore*>(store)->svc()->bilog_rados->log_stop(dpp, bucket->get_info(), log_layout, -1);
-    if (r < 0) {
-      set_err_msg(err_msg, "ERROR: failed writing stop bilog:" + cpp_strerror(-r));
-      return r;
-    }
-  } else {
-    r = static_cast<rgw::sal::RadosStore*>(store)->svc()->bilog_rados->log_start(dpp, bucket->get_info(), log_layout, -1);
-    if (r < 0) {
-      set_err_msg(err_msg, "ERROR: failed writing resync bilog:" + cpp_strerror(-r));
-      return r;
-    }
-  }
-
-  for (int i = 0; i < shards_num; ++i, ++shard_id) {
-    r = static_cast<rgw::sal::RadosStore*>(store)
-      ->svc()->datalog_rados->add_entry(dpp, bucket->get_info(),
-					bucket->get_info().layout.logs.back(),
-					shard_id);
-    if (r < 0) {
-      set_err_msg(err_msg, "ERROR: failed writing data log:" + cpp_strerror(-r));
-      return r;
-    }
   }
 
   return 0;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1076,13 +1076,13 @@ static int bucket_stats(rgw::sal::Store* store,
     return ret;
   }
 
-  if (bucket->get_info().is_indexless()) {
+  const auto& index = bucket->get_info().get_current_index();
+  if (is_layout_indexless(index)) {
     cerr << "error, indexless buckets do not maintain stats; bucket=" <<
       bucket->get_name() << std::endl;
     return -EINVAL;
   }
 
-  const auto& index = bucket->get_info().get_current_index();
   std::string bucket_ver, master_ver;
   std::string max_marker;
   ret = bucket->read_stats(dpp, index, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, &max_marker);
@@ -1178,7 +1178,6 @@ int RGWBucketAdminOp::limit_check(rgw::sal::Store* store,
 
       for (const auto& iter : m_buckets) {
 	auto& bucket = iter.second;
-	uint32_t num_shards = 1;
 	uint64_t num_objects = 0;
 
 	marker = bucket->get_name(); /* Casey's location for marker update,
@@ -1189,11 +1188,14 @@ int RGWBucketAdminOp::limit_check(rgw::sal::Store* store,
 	if (ret < 0)
 	  continue;
 
+	const auto& index = bucket->get_info().get_current_index();
+	if (is_layout_indexless(index)) {
+	  continue; // indexless buckets don't have stats
+	}
+
 	/* need stats for num_entries */
 	string bucket_ver, master_ver;
 	std::map<RGWObjCategory, RGWStorageStats> stats;
-	const auto& latest_log = bucket->get_info().layout.logs.back();
-	const auto& index = log_to_index_layout(latest_log);
 	ret = bucket->read_stats(dpp, index, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, nullptr);
 
 	if (ret < 0)
@@ -1203,7 +1205,7 @@ int RGWBucketAdminOp::limit_check(rgw::sal::Store* store,
 	  num_objects += s.second.num_objects;
 	}
 
-	num_shards = bucket->get_info().layout.current_index.layout.normal.num_shards;
+	const uint32_t num_shards = rgw::num_shards(index.layout.normal);
 	uint64_t objs_per_shard =
 	  (num_shards) ? num_objects/num_shards : num_objects;
 	{

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3159,12 +3159,12 @@ public:
 	if (check_compat) {
 	  // use shard count from our log gen=0
 	  // try to convert existing per-shard incremental status for backward compatibility
-	  if (source_info.layout.logs.front().gen > 0) {
+	  if (source_info.layout.logs.empty() ||
+	      source_info.layout.logs.front().gen > 0) {
 	    ldpp_dout(dpp, 20) << "no generation zero when checking compatibility" << dendl;
 	    no_zero = true;
-	  }
-	  if (auto& log = source_info.layout.logs.front();
-	      log.layout.type != rgw::BucketLogType::InIndex) {
+	  } else if (auto& log = source_info.layout.logs.front();
+                     log.layout.type != rgw::BucketLogType::InIndex) {
 	    ldpp_dout(dpp, 20) << "unrecognized log layout type when checking compatibility " << log.layout.type << dendl;
 	    no_zero = true;
 	  }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -791,6 +791,21 @@ int RGWRados::get_max_chunk_size(const rgw_placement_rule& placement_rule, const
   return get_max_chunk_size(pool, max_chunk_size, dpp, palignment);
 }
 
+void add_datalog_entry(const DoutPrefixProvider* dpp,
+                       RGWDataChangesLog* datalog,
+                       const RGWBucketInfo& bucket_info,
+                       uint32_t shard_id)
+{
+  const auto& logs = bucket_info.layout.logs;
+  if (logs.empty()) {
+    return;
+  }
+  int r = datalog->add_entry(dpp, bucket_info, logs.back(), shard_id);
+  if (r < 0) {
+    ldpp_dout(dpp, -1) << "ERROR: failed writing data log" << dendl;
+  } // datalog error is not fatal
+}
+
 class RGWIndexCompletionManager;
 
 struct complete_op_data {
@@ -888,12 +903,8 @@ int RGWIndexCompletionThread::process(const DoutPrefixProvider *dpp)
       /* ignoring error, can't do anything about it */
       continue;
     }
-    r = store->svc.datalog_rados->add_entry(this, bucket_info,
-					    bucket_info.layout.logs.back(),
-					    bs.shard_id);
-    if (r < 0) {
-      ldpp_dout(this, -1) << "ERROR: failed writing data log" << dendl;
-    }
+
+    add_datalog_entry(this, store->svc.datalog_rados, bucket_info, bs.shard_id);
   }
 
   return 0;
@@ -5228,13 +5239,8 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y, const DoutPrefixProvi
       return r;
     }
 
-    r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info,
-					    target->bucket_info.layout.logs.back(),
-					    bs->shard_id);
-    if (r < 0) {
-      ldpp_dout(dpp, -1) << "ERROR: failed writing data log" << dendl;
-      return r;
-    }
+    add_datalog_entry(dpp, store->svc.datalog_rados,
+                      target->bucket_info, bs->shard_id);
 
     return 0;
   }
@@ -6304,12 +6310,8 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
 
   ret = store->cls_obj_complete_add(*bs, obj, optag, poolid, epoch, ent, category, remove_objs, bilog_flags, zones_trace);
 
-  int r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info,
-					      target->bucket_info.layout.logs.back(),
-					      bs->shard_id);
-  if (r < 0) {
-    ldpp_dout(dpp, -1) << "ERROR: failed writing data log" << dendl;
-  }
+  add_datalog_entry(dpp, store->svc.datalog_rados,
+                    target->bucket_info, bs->shard_id);
 
   return ret;
 }
@@ -6333,12 +6335,8 @@ int RGWRados::Bucket::UpdateIndex::complete_del(const DoutPrefixProvider *dpp,
 
   ret = store->cls_obj_complete_del(*bs, optag, poolid, epoch, obj, removed_mtime, remove_objs, bilog_flags, zones_trace);
 
-  int r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info,
-					      target->bucket_info.layout.logs.back(),
-					      bs->shard_id);
-  if (r < 0) {
-    ldpp_dout(dpp, -1) << "ERROR: failed writing data log" << dendl;
-  }
+  add_datalog_entry(dpp, store->svc.datalog_rados,
+                    target->bucket_info, bs->shard_id);
 
   return ret;
 }
@@ -6362,12 +6360,8 @@ int RGWRados::Bucket::UpdateIndex::cancel(const DoutPrefixProvider *dpp,
    * for following the specific bucket shard log. Otherwise they end up staying behind, and users
    * have no way to tell that they're all caught up
    */
-  int r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info,
-					      target->bucket_info.layout.logs.back(),
-					      bs->shard_id);
-  if (r < 0) {
-    ldpp_dout(dpp, -1) << "ERROR: failed writing data log" << dendl;
-  }
+  add_datalog_entry(dpp, store->svc.datalog_rados,
+                    target->bucket_info, bs->shard_id);
 
   return ret;
 }
@@ -6996,12 +6990,7 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
     return r;
   }
 
-  r = svc.datalog_rados->add_entry(dpp, bucket_info,
-				   bucket_info.layout.logs.back(),
-				   bs.shard_id);
-  if (r < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: failed writing data log" << dendl;
-  }
+  add_datalog_entry(dpp, svc.datalog_rados, bucket_info, bs.shard_id);
 
   return 0;
 }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9108,10 +9108,10 @@ int RGWRados::remove_objs_from_index(const DoutPrefixProvider *dpp,
 				     const std::list<rgw_obj_index_key>& entry_key_list)
 {
   RGWSI_RADOS::Pool index_pool;
-  const auto& latest_log = bucket_info.layout.logs.back();
-  const rgw::bucket_index_layout_generation& current_index =
-    rgw::log_to_index_layout(latest_log);
-
+  const auto& current_index = bucket_info.get_current_index();
+  if (is_layout_indexless(current_index)) {
+    return 0;
+  }
   const uint32_t num_shards = current_index.layout.normal.num_shards;
 
   uint8_t suggest_flag = (svc.zone->get_zone().log_data ? CEPH_RGW_DIR_SUGGEST_LOG_OP : 0);

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -421,6 +421,12 @@ void RGWOp_BILog_List::execute(optional_yield y) {
   }
 
   const auto& logs = bucket->get_info().layout.logs;
+  if (logs.empty()) {
+    ldpp_dout(s, 5) << "ERROR: bucket=" << bucket_name << " has no log layouts" << dendl;
+    op_ret = -ENOENT;
+    return;
+  }
+
   auto log = std::prev(logs.end());
   if (gen) {
     log = std::find_if(logs.begin(), logs.end(), rgw::matches_gen(*gen));
@@ -541,9 +547,15 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
     return;
   }
 
+  const auto& logs = bucket->get_info().layout.logs;
+  if (logs.empty()) {
+    ldpp_dout(s, 5) << "ERROR: bucket=" << bucket_name << " has no log layouts" << dendl;
+    op_ret = -ENOENT;
+    return;
+  }
+
   map<RGWObjCategory, RGWStorageStats> stats;
-  const auto& latest_log = bucket->get_info().layout.logs.back();
-  const auto& index = log_to_index_layout(latest_log);
+  const auto& index = log_to_index_layout(logs.back());
 
   int ret =  bucket->read_stats(s, index, shard_id, &bucket_ver, &master_ver, stats, &max_marker, &syncstopped);
   if (ret < 0 && ret != -ENOENT) {
@@ -551,8 +563,8 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
     return;
   }
 
-  oldest_gen = bucket->get_info().layout.logs.front().gen;
-  latest_gen = latest_log.gen;
+  oldest_gen = logs.front().gen;
+  latest_gen = logs.back().gen;
 }
 
 void RGWOp_BILog_Info::send_response() {

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -466,9 +466,7 @@ int RadosBucket::remove_bucket_bypass_gc(int concurrent_max, bool
   if (ret < 0)
     return ret;
 
-  const auto& latest_log = info.layout.logs.back();
-  const auto& index = log_to_index_layout(latest_log);
-
+  const auto& index = info.get_current_index();
   ret = read_stats(dpp, index, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, NULL);
   if (ret < 0)
     return ret;

--- a/src/rgw/rgw_trim_bilog.cc
+++ b/src/rgw/rgw_trim_bilog.cc
@@ -648,6 +648,10 @@ int BucketTrimInstanceCR::operate(const DoutPrefixProvider *dpp)
       return set_cr_error(-ENOENT);
     }
 
+    if (pbucket_info->layout.logs.empty()) {
+      return set_cr_done(); // no bilogs to trim
+    }
+
     // query peers for sync status
     set_status("fetching sync status from relevant peers");
     yield {


### PR DESCRIPTION
always verify that logs is not empty before calling `logs.back()` or `logs.front()`

several places were getting the current index layout indirectly with `layout.logs.back()` and `rgw::log_to_index_layout()`. use `layout.current_index` instead so we don't rely on `layout.logs`, which may be empty for indexless buckets

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
