### PR TITLE
pacific: osd: PeeringState: fix selection order in calc_replicated_acting_stretch

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1891,8 +1891,8 @@ public:
   }
   osd_id_t pop_osd() {
     ceph_assert(!is_empty());
-    auto ret = osds.back();
-    osds.pop_back();
+    auto ret = osds.front();
+    osds.pop_front();
     return ret.second;
   }
 
@@ -1901,7 +1901,7 @@ public:
 
   osd_ord_t get_ord() const {
     return osds.empty() ? std::make_tuple(false, eversion_t())
-      : osds.back().first;
+      : osds.front().first;
   }
 
   bool is_empty() const { return osds.empty(); }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53933

---

backport of https://github.com/ceph/ceph/pull/44518
parent tracker: https://tracker.ceph.com/issues/53824

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh