### PR TITLE
ceph-volume: don't use MultiLogger in find_executable_on_host()

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -34,6 +34,7 @@ changedir=
 commands=
   git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch {env:CEPH_ANSIBLE_CLONE:"https://github.com/ceph/ceph-ansible.git"} {envdir}/tmp/ceph-ansible
   python -m pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
+  ansible-galaxy install -r {envdir}/tmp/ceph-ansible/requirements.yml -v
 
   # bash {toxinidir}/../scripts/vagrant_up.sh {env:VAGRANT_UP_FLAGS:""} {posargs:--provider=virtualbox}
   bash {toxinidir}/../scripts/vagrant_up.sh {posargs:--provider=virtualbox}

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -32,6 +32,7 @@ changedir=
 commands=
   git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch {env:CEPH_ANSIBLE_CLONE:"https://github.com/ceph/ceph-ansible.git"} {envdir}/tmp/ceph-ansible
   pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
+  ansible-galaxy install -r {envdir}/tmp/ceph-ansible/requirements.yml -v
 
   bash {toxinidir}/../scripts/vagrant_up.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
   bash {toxinidir}/../scripts/generate_ssh_config.sh {changedir}

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -28,6 +28,7 @@ changedir=
 commands=
   git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
   pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
+  ansible-galaxy install -r {envdir}/tmp/ceph-ansible/requirements.yml -v
 
   bash {toxinidir}/../scripts/vagrant_up.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
   bash {toxinidir}/../scripts/generate_ssh_config.sh {changedir}

--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -59,10 +59,10 @@ def find_executable_on_host(locations=[], executable='', binary_check='/bin/ls')
     stdout = as_string(process.stdout.read())
     if stdout:
         executable_on_host = stdout.split('\n')[0]
-        mlogger.info('Executable {} found on the host, will use {}'.format(executable, executable_on_host))
+        logger.info('Executable {} found on the host, will use {}'.format(executable, executable_on_host))
         return executable_on_host
     else:
-        mlogger.warning('Executable {} not found on the host, will return {} as-is'.format(executable, executable))
+        logger.warning('Executable {} not found on the host, will return {} as-is'.format(executable, executable))
         return executable
 
 def which(executable, run_on_host=False):


### PR DESCRIPTION
This generates a lot of unnecessary messages on the terminal.

Fixes: https://tracker.ceph.com/issues/53934

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
