### PR TITLE
doc/mgr/prometheus: correct metric name

### DIFF
--- a/doc/mgr/prometheus.rst
+++ b/doc/mgr/prometheus.rst
@@ -253,7 +253,7 @@ The goal is to run a query like
 
 ::
 
-    rate(node_disk_bytes_written[30s]) and
+    rate(node_disk_written_bytes_total[30s]) and
     on (device,instance) ceph_disk_occupation_human{ceph_daemon="osd.0"}
 
 Out of the box the above query will not return any metrics since the ``instance`` labels of
@@ -284,7 +284,7 @@ To correlate an OSD and its disks write rate, the following query can be used:
 ::
 
     label_replace(
-        rate(node_disk_bytes_written[30s]),
+        rate(node_disk_written_bytes_total[30s]),
         "exported_instance",
         "$1",
         "instance",


### PR DESCRIPTION
Replace the metric name `node_disk_bytes_written` by `node_disk_written_bytes_total` to reflect changes made in node exporter version 0.16.0 https://github.com/prometheus/node_exporter/releases/tag/v0.16.0 / https://github.com/prometheus/node_exporter/blob/v0.16.0/docs/example-16-compatibility-rules.yml .

Fixes: https://tracker.ceph.com/issues/53932
Signed-off-by: Tatjana Dehler <tdehler@suse.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
