### PR TITLE
qa: fill the test_file before trying to read it

### DIFF
--- a/qa/tasks/cephfs/test_pool_perm.py
+++ b/qa/tasks/cephfs/test_pool_perm.py
@@ -6,9 +6,12 @@ import os
 
 class TestPoolPerm(CephFSTestCase):
     def test_pool_perm(self):
-        self.mount_a.run_shell(["touch", "test_file"])
+        self.mount_a.run_shell(["touch", "test_pool_perm_file"])
 
-        file_path = os.path.join(self.mount_a.mountpoint, "test_file")
+        # write 1MB data to the file before testing r perm
+        self.mount_a.write_n_mb("test_pool_perm_file", 1)
+
+        file_path = os.path.join(self.mount_a.mountpoint, "test_pool_perm_file")
 
         remote_script = dedent("""
             import os
@@ -25,6 +28,8 @@ class TestPoolPerm(CephFSTestCase):
                     raise
             else:
                 raise RuntimeError("client does not check permission of data pool")
+            fininaly:
+                os.close(fd)
             """)
 
         client_name = "client.{0}".format(self.mount_a.client_id)

--- a/qa/tasks/cephfs/test_pool_perm.py
+++ b/qa/tasks/cephfs/test_pool_perm.py
@@ -17,7 +17,7 @@ class TestPoolPerm(CephFSTestCase):
             import os
             import errno
 
-            fd = os.open("{path}", os.O_RDWR)
+            fd = os.open("{path}", os.O_RDWR | os.O_DIRECT)
             try:
                 if {check_read}:
                     ret = os.read(fd, 1024)


### PR DESCRIPTION
When the file is empty the kernel will trigger a getattr request
to libcephfs to get the file size, and then if the read offset is
larger or equal to the file size it will just return without firing
real read to libcephfs.

This will fill the file with some contents and reopen the file to
flush the buffer and reset the file offset to 0.

More detail please see:
https://tracker.ceph.com/issues/53859?issue_count=49&issue_position=2&next_issue_id=53908&prev_issue_id=43960#note-5


Fixes: https://tracker.ceph.com/issues/53859
Signed-off-by: Xiubo Li <xiubli@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
