### PR TITLE
mgr/dashboard: remove feedback module as always-on

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -106,7 +106,6 @@ const static std::map<uint32_t, std::set<std::string>> always_on_modules = {
       "progress",
       "balancer",
       "devicehealth",
-      "feedback",
       "orchestrator",
       "rbd_support",
       "volumes",
@@ -462,7 +461,7 @@ public:
     mm(a), op(c) {}
   void finish(int r) override {
     if (r >= 0) {
-      // Success 
+      // Success
     } else if (r == -ECANCELED) {
       mm->mon.no_reply(op);
     } else {

--- a/src/pybind/mgr/dashboard/controllers/feedback.py
+++ b/src/pybind/mgr/dashboard/controllers/feedback.py
@@ -8,7 +8,7 @@ from ._version import APIVersion
 
 
 @APIRouter('/feedback', Scope.CONFIG_OPT)
-@APIDoc("Feedback", "Report")
+@APIDoc("Feedback API", "Report")
 class FeedbackController(RESTController):
 
     @RESTController.MethodMap(version=APIVersion.EXPERIMENTAL)
@@ -52,7 +52,7 @@ class FeedbackController(RESTController):
 
 
 @APIRouter('/feedback/api_key', Scope.CONFIG_OPT)
-@APIDoc("Feedback API", "Report")
+@APIDoc(group="Report")
 class FeedbackApiController(RESTController):
 
     @RESTController.MethodMap(version=APIVersion.EXPERIMENTAL)

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -10517,7 +10517,7 @@ tags:
   name: RbdSnapshot
 - description: RBD Trash Management API
   name: RbdTrash
-- description: Feedback
+- description: Feedback API
   name: Report
 - description: RGW Management API
   name: Rgw


### PR DESCRIPTION
It was mistakenly left as always-on

Fixes: https://tracker.ceph.com/issues/53950
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
