### PR TITLE
octopus: cls/journal: skip disconnected clients when calculating min_commit_position

### DIFF
--- a/src/cls/journal/cls_journal.cc
+++ b/src/cls/journal/cls_journal.cc
@@ -265,11 +265,12 @@ int find_min_commit_position(cls_method_context_t hctx,
     }
 
     start_after = batch.rbegin()->id;
-
     // update the (minimum) commit position from this batch of clients
-    for(std::set<cls::journal::Client>::iterator it = batch.begin();
-        it != batch.end(); ++it) {
-      cls::journal::ObjectSetPosition object_set_position = (*it).commit_position;
+    for (const auto &client : batch) {
+      if (client.state == cls::journal::CLIENT_STATE_DISCONNECTED) {
+        continue;
+      }
+      const auto &object_set_position = client.commit_position;
       if (object_set_position.object_positions.empty()) {
 	*minset = cls::journal::ObjectSetPosition();
 	break;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53937

---

backport of https://github.com/ceph/ceph/pull/44601
parent tracker: https://tracker.ceph.com/issues/53888

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh