### PR TITLE
mgr/dashboard: navigation page e2e fix 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/navigation.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/navigation.e2e-spec.ts
@@ -10,12 +10,12 @@ describe('Shared pages', () => {
   });
 
   it('should display the vertical menu by default', () => {
-    shared.getVerticalMenu().should('be.visible');
+    shared.getVerticalMenu().should('not.have.class', 'active');
   });
 
   it('should hide the vertical menu', () => {
     shared.getMenuToggler().click();
-    shared.getVerticalMenu().should('not.be.visible');
+    shared.getVerticalMenu().should('have.class', 'active');
   });
 
   it('should navigate to the correct page', () => {

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/navigation.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/navigation.po.ts
@@ -44,11 +44,11 @@ export class NavigationPageHelper extends PageHelper {
   ];
 
   getVerticalMenu() {
-    return cy.get('ul.cd-navbar-primary');
+    return cy.get('nav[id=sidebar]');
   }
 
   getMenuToggler() {
-    return cy.get('cd-navigation > div.cd-navbar-top button.btn.btn-link');
+    return cy.get('[aria-label="toggle sidebar visibility"]');
   }
 
   checkNavigations(navs: any) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -6,7 +6,8 @@
   <div class="cd-navbar-top">
     <nav class="navbar navbar-expand-md navbar-dark cd-navbar-brand">
       <button class="btn btn-link py-0"
-              (click)="showMenuSidebar = !showMenuSidebar">
+              (click)="showMenuSidebar = !showMenuSidebar"
+              aria-label="toggle sidebar visibility">
         <i class="fa fa-bars fa-2x"
            aria-hidden="true"></i>
       </button>


### PR DESCRIPTION
Fixing the e2e failure introduced by https://github.com/ceph/ceph/pull/44238

Looks like the newly added relative position for the sidebar is
causing cypress to verify that the sidebar is hidden from the user view.

Original Error
```
1) Shared pages
       should hide the vertical menu:
     AssertionError: Timed out retrying after 120000ms: Expected to find element: `cd-navigation > div.cd-navbar-top button.btn.btn-link`, but never found it.
      at NavigationPageHelper.getMenuToggler (https://172.21.2.16:41083/__cypress/tests?p=cypress/integration/ui/navigation.e2e-spec.ts:440:19)
      at Context.eval (https://172.21.2.16:41083/__cypress/tests?p=cypress/integration/ui/navigation.e2e-spec.ts:369:16)
  ```

Fixes: https://tracker.ceph.com/issues/53960
Signed-off-by: Nizamudeen A <nia@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
