### PR TITLE
pybind/mgr/mgr_util: fix to_pretty_timedelta()

### DIFF
--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -768,18 +768,18 @@ def _pairwise(iterable: Iterable[T]) -> Generator[Tuple[Optional[T], T], None, N
 
 def to_pretty_timedelta(n: datetime.timedelta) -> str:
     if n < datetime.timedelta(seconds=120):
-        return str(n.seconds) + 's'
+        return str(int(n.total_seconds())) + 's'
     if n < datetime.timedelta(minutes=120):
-        return str(n.seconds // 60) + 'm'
+        return str(int(n.total_seconds()) // 60) + 'm'
     if n < datetime.timedelta(hours=48):
-        return str(n.seconds // 3600) + 'h'
+        return str(int(n.total_seconds()) // 3600) + 'h'
     if n < datetime.timedelta(days=14):
-        return str(n.days) + 'd'
+        return str(int(n.total_seconds()) // (3600*24)) + 'd'
     if n < datetime.timedelta(days=7*12):
-        return str(n.days // 7) + 'w'
+        return str(int(n.total_seconds()) // (3600*24*7)) + 'w'
     if n < datetime.timedelta(days=365*2):
-        return str(n.days // 30) + 'M'
-    return str(n.days // 365) + 'y'
+        return str(int(n.total_seconds()) // (3600*24*30)) + 'M'
+    return str(int(n.total_seconds()) // (3600*24*365)) + 'y'
 
 
 def profile_method(skip_attribute: bool = False) -> Callable[[Callable[..., T]], Callable[..., T]]:

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -62,7 +62,7 @@ if 'UNITTEST' in os.environ:
         def _ceph_get_store_prefix(self, prefix):
             return self.mock_store_prefix('store', prefix)
 
-        def _ceph_get_module_option(self, module, key, localized_prefix= None):
+        def _ceph_get_module_option(self, module, key, localized_prefix=None):
             try:
                 _, val, _ = self.check_mon_command({
                     'prefix': 'config get',
@@ -108,7 +108,7 @@ if 'UNITTEST' in os.environ:
             # Mocking the config store is handy sometimes:
             def config_get():
                 who = cmd['who'].split('.')
-                whos = ['global'] + ['.'.join(who[:i+1]) for i in range(len(who))]
+                whos = ['global'] + ['.'.join(who[:i + 1]) for i in range(len(who))]
                 for attepmt in reversed(whos):
                     val = self.mock_store_get('config', f'{attepmt}/{cmd["key"]}', None)
                     if val is not None:
@@ -151,7 +151,7 @@ if 'UNITTEST' in os.environ:
 
         def _ceph_get_foreign_option(self, entity, name):
             who = entity.split('.')
-            whos = ['global'] + ['.'.join(who[:i+1]) for i in range(len(who))]
+            whos = ['global'] + ['.'.join(who[:i + 1]) for i in range(len(who))]
             for attepmt in reversed(whos):
                 val = self.mock_store_get('config', f'{attepmt}/{name}', None)
                 if val is not None:
@@ -174,7 +174,6 @@ if 'UNITTEST' in os.environ:
             if not hasattr(self, '_store'):
                 self._store = {}
 
-
             if self.__class__ not in M_classes:
                 # call those only once.
                 self._register_commands('')
@@ -193,7 +192,6 @@ if 'UNITTEST' in os.environ:
             self._ceph_log = mock.MagicMock()
             self._ceph_dispatch_remote = lambda *_: None
             self._ceph_get_mgr_id = mock.MagicMock()
-
 
     cm = mock.Mock()
     cm.BaseMgrModule = M

--- a/src/pybind/mgr/tests/test_mgr_util.py
+++ b/src/pybind/mgr/tests/test_mgr_util.py
@@ -1,0 +1,19 @@
+import datetime
+import mgr_util
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "delta, out",
+    [
+        (datetime.timedelta(minutes=90), '90m'),
+        (datetime.timedelta(minutes=190), '3h'),
+        (datetime.timedelta(days=3), '3d'),
+        (datetime.timedelta(hours=3), '3h'),
+        (datetime.timedelta(days=365 * 3.1), '3y'),
+        (datetime.timedelta(minutes=90), '90m'),
+    ]
+)
+def test_pretty_timedelta(delta: datetime.timedelta, out: str):
+    assert mgr_util.to_pretty_timedelta(delta) == out

--- a/src/pybind/mgr/tests/test_tls.py
+++ b/src/pybind/mgr/tests/test_tls.py
@@ -15,7 +15,8 @@ class TLSchecks(unittest.TestCase):
         verify_tls(crt, key)
 
     def test_invalid_RDN(self):
-        self.assertRaises(ValueError, create_self_signed_cert, dname={'O': 'Ceph', 'Bogus': 'testsuite'})
+        self.assertRaises(ValueError, create_self_signed_cert,
+                          dname={'O': 'Ceph', 'Bogus': 'testsuite'})
 
     def test_invalid_key(self):
         crt, key = create_self_signed_cert()


### PR DESCRIPTION
https://tracker.ceph.com/issues/53953






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>