### PR TITLE
test/bufferlist: ensure rebuild_aligned_size_and_memory() always rebuilds.

### DIFF
--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1853,13 +1853,14 @@ TEST(BufferList, rebuild_aligned_size_and_memory) {
      * scenario where the first bptr is both size and memory aligned and
      * the second is 0-length */
     bl.clear();
-    bufferptr ptr1(buffer::create_aligned(4096, 4096));
-    bl.append(ptr1);
-    bufferptr ptr(10);
-    /* bl.back().length() must be 0 */
-    bl.append(ptr, 0, 0);
+    bl.append(bufferptr{buffer::create_aligned(4096, 4096)});
+    bufferptr ptr(buffer::create_aligned(42, 4096));
+    /* bl.back().length() must be 0. offset set to 42 guarantees
+     * the entire list is unaligned. */
+    bl.append(ptr, 42, 0);
     EXPECT_EQ(bl.get_num_buffers(), 2);
     EXPECT_EQ(bl.back().length(), 0);
+    EXPECT_FALSE(bl.is_aligned(4096));
     /* rebuild_aligned() calls rebuild_aligned_size_and_memory().
      * we assume the rebuild always happens. */
     EXPECT_TRUE(bl.rebuild_aligned(4096));


### PR DESCRIPTION
Before the patch the test case was showing an unreliable behaviour dependent on the underlying memory allocator. It was because the bufferlist rebuild can be skipped, resulting in unchanged number of buffers, if all of them begin at aligned addressees.

The commit fixes that by allocating a 4 KiB-aligned buffer and offsetting it by a small constant (42) to ensure the memory added to the bufferlist begins at non-4 KiB address.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
