### PR TITLE
octopus: ceph-volume: show RBD devices as not available

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -331,6 +331,15 @@ class TestGetDevices(object):
         result = disk.get_devices(_sys_block_path=block_path)
         assert result[sda_path]['rotational'] == '1'
 
+    def test_is_ceph_rbd(self, tmpfile, tmpdir, patched_get_block_devs_lsblk):
+        rbd_path = '/dev/rbd0'
+        patched_get_block_devs_lsblk.return_value = [[rbd_path, rbd_path, 'disk']]
+        block_path = self.setup_path(tmpdir)
+        block_rbd_path = os.path.join(block_path, 'rbd0')
+        os.makedirs(block_rbd_path)
+        result = disk.get_devices(_sys_block_path=block_path)
+        assert rbd_path not in result
+
 
 class TestSizeCalculations(object):
 

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -361,6 +361,13 @@ def is_partition(dev):
     return False
 
 
+def is_ceph_rbd(dev):
+    """
+    Boolean to determine if a given device is a ceph RBD device, like /dev/rbd0
+    """
+    return dev.startswith(('/dev/rbd'))
+
+
 class BaseFloatUnit(float):
     """
     Base class to support float representations of size values. Suffix is
@@ -763,6 +770,10 @@ def get_devices(_sys_block_path='/sys/block'):
             continue
         sysdir = os.path.join(_sys_block_path, devname)
         metadata = {}
+
+        # If the device is ceph rbd it gets excluded
+        if is_ceph_rbd(diskname):
+            continue
 
         # If the mapper device is a logical volume it gets excluded
         if is_mapper_device(diskname):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53961

---

backport of https://github.com/ceph/ceph/pull/44604
parent tracker: https://tracker.ceph.com/issues/53846

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh