### PR TITLE
mds: dump recent log events for extraordinary events

### DIFF
--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -62,3 +62,4 @@
 .. confval:: mds_skip_ino
 .. confval:: mds_min_caps_per_client
 .. confval:: mds_symlink_recovery
+.. confval:: mds_extraordinary_events_dump_interval

--- a/doc/cephfs/troubleshooting.rst
+++ b/doc/cephfs/troubleshooting.rst
@@ -188,6 +188,40 @@ You can enable dynamic debug against the CephFS module.
 
 Please see: https://github.com/ceph/ceph/blob/master/src/script/kcon_all.sh
 
+In-memory Log Dump
+==================
+
+In-memory logs can be dumped by setting ``mds_extraordinary_events_dump_interval``
+during a lower level debugging (log level < 10). ``mds_extraordinary_events_dump_interval``
+is the interval in seconds for dumping the recent in-memory logs when there is an Extra-Ordinary event.
+
+The Extra-Ordinary events are classified as:
+
+* Client Eviction
+* Missed Beacon ACK from the monitors
+* Missed Internal Heartbeats
+
+In-memory Log Dump is disabled by default to prevent log file bloat in a production environment.
+The below commands consecutively enables it::
+
+  $ ceph config set mds debug_mds <log_level>/<gather_level>
+  $ ceph config set mds mds_extraordinary_events_dump_interval <seconds>
+
+The ``log_level`` should be < 10 and ``gather_level`` should be >= 10 to enable in-memory log dump.
+When it is enabled, the MDS checks for the extra-ordinary events every
+``mds_extraordinary_events_dump_interval`` seconds and if any of them occurs, MDS dumps the
+in-memory logs containing the relevant event details in ceph-mds log.
+
+.. note:: For higher log levels (log_level >= 10) there is no reason to dump the In-memory Logs and a
+          lower gather level (gather_level < 10) is insufficient to gather In-memory Logs. Thus a
+          log level >=10 or a gather level < 10 in debug_mds would prevent enabling the In-memory Log Dump.
+          In such cases, when there is a failure it's required to reset the value of
+          mds_extraordinary_events_dump_interval to 0 before enabling using the above commands.
+
+The In-memory Log Dump can be disabled using::
+
+  $ ceph config set mds mds_extraordinary_events_dump_interval 0
+
 Reporting Issues
 ================
 

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1458,3 +1458,17 @@ options:
   - mds
   flags:
   - runtime
+- name: mds_extraordinary_events_dump_interval
+  type: secs
+  level: advanced
+  desc: Interval in seconds for dumping the recent in-memory logs when there is an extra-ordinary event.
+  long_desc: Interval in seconds for dumping the recent in-memory logs when there is an extra-ordinary
+    event. The default is ``0`` (disabled). The log level should be ``< 10`` and the gather level
+    should be ``>=10`` in debug_mds for enabling this option.
+  default: 0
+  min: 0
+  max: 60
+  services:
+  - mds
+  flags:
+  - runtime

--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -73,20 +73,30 @@ void Beacon::init(const MDSMap &mdsmap)
 
   sender = std::thread([this]() {
     std::unique_lock<std::mutex> lock(mutex);
-    std::condition_variable c; // no one wakes us
+    bool sent;
     while (!finished) {
       auto now = clock::now();
       auto since = std::chrono::duration<double>(now-last_send).count();
       auto interval = beacon_interval;
+      sent = false;
       if (since >= interval*.90) {
         if (!_send()) {
           interval = 0.5; /* 500ms */
+        }
+        else {
+          sent = true;
         }
       } else {
         interval -= since;
       }
       dout(20) << "sender thread waiting interval " << interval << "s" << dendl;
-      c.wait_for(lock, interval*1s);
+      if (cvar.wait_for(lock, interval*1s) == std::cv_status::timeout) {
+        if (sent) {
+          //missed beacon ack because we timedout after a beacon send
+          dout(0) << "missed beacon ack from the monitors" << dendl;
+          missed_beacon_ack_dump = true;
+        }
+      }
     }
   });
 }
@@ -173,7 +183,11 @@ void Beacon::send_and_wait(const double duration)
   while (!seq_stamp.empty() && seq_stamp.begin()->first <= awaiting_seq) {
     auto now = clock::now();
     auto s = duration*.95-std::chrono::duration<double>(now-start).count();
-    if (s < 0) break;
+    if (s < 0) {
+      //missed beacon ACKs
+      missed_beacon_ack_dump = true;
+      break;
+    }
     cvar.wait_for(lock, s*1s);
   }
 }
@@ -191,6 +205,8 @@ bool Beacon::_send()
     /* If anything isn't progressing, let avoid sending a beacon so that
      * the MDS will consider us laggy */
     dout(0) << "Skipping beacon heartbeat to monitors (last acked " << since << "s ago); MDS internal heartbeat is not healthy!" << dendl;
+    //missed internal heartbeat
+    missed_internal_heartbeat_dump = true;
     return false;
   }
 

--- a/src/mds/Beacon.h
+++ b/src/mds/Beacon.h
@@ -44,6 +44,8 @@ class Beacon : public Dispatcher
 public:
   using clock = ceph::coarse_mono_clock;
   using time = ceph::coarse_mono_time;
+  bool missed_beacon_ack_dump = false;
+  bool missed_internal_heartbeat_dump = false;
 
   Beacon(CephContext *cct, MonClient *monc, std::string_view name);
   ~Beacon() override;

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -373,6 +373,7 @@ class MDSRank {
     int config_client(int64_t session_id, bool remove,
 		      const std::string& option, const std::string& value,
 		      std::ostream& ss);
+    void schedule_inmemory_logger();
 
     // Reference to global MDS::mds_lock, so that users of MDSRank don't
     // carry around references to the outer MDS, and we can substitute
@@ -558,6 +559,8 @@ class MDSRank {
     // with the provided epoch.
     void apply_blocklist(const std::set<entity_addr_t> &addrs, epoch_t epoch);
 
+    void reset_event_flags();
+
     // Incarnation as seen in MDSMap at the point where a rank is
     // assigned.
     int incarnation = 0;
@@ -614,6 +617,7 @@ class MDSRank {
     Context *suicide_hook;
 
     bool standby_replaying = false;  // true if current replay pass is in standby-replay mode
+    uint64_t extraordinary_events_dump_interval = 0;
 private:
     bool send_status = true;
 
@@ -624,10 +628,13 @@ private:
     // "task" string that gets displayed in ceph status
     inline static const std::string SCRUB_STATUS_KEY = "scrub status";
 
+    bool client_eviction_dump = false;
+
     void get_task_status(std::map<std::string, std::string> *status);
     void schedule_update_timer_task();
     void send_task_status();
 
+    void inmemory_logger();
     bool is_rank0() const {
       return whoami == (mds_rank_t)0;
     }


### PR DESCRIPTION
This PR addresses dumping in-memory logs for the extra-ordinary events:
[1] evicts a client.
[2] misses beacon ACKs from monitors.
[3] misses internal heartbeats.

Fixes: https://tracker.ceph.com/issues/40633