### PR TITLE
src/rados: rewrite bs cache autotune instructions

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4695,10 +4695,10 @@ options:
   level: dev
   desc: The number of seconds to wait between rebalances when cache autotune is enabled.
   fmt_desc: |
-    The number of seconds to wait between rebalances when cache autotune
-    is enabled.  This setting changes how quickly the allocation ratios of
-    various caches are recomputed.  Note:  Setting this interval too small
-    can result in high CPU usage and lower performance.
+    The number of seconds to wait between rebalances when cache autotune is
+    enabled.  `bluestore_cache_autotune_interval` sets the speed at which Ceph
+    recomputes the allocation ratios of various caches. Note: Setting this
+    interval too small can result in high CPU usage and lower performance.
   default: 5
   see_also:
   - bluestore_cache_autotune


### PR DESCRIPTION
This commit rewrites one sentence in the "Bluestore
Config Reference". The sentence does not itself appear
in the directory structure under /docs/rados/, but is
instead in /src/common/options/global.yaml.in and is
included in the Bluestore Config Reference by means of
a confval directive.

The rewritten sentence has been rewritten from the passive
voice to the active voice, and a "how"-formation has been
removed. The removal of the "how"-formation, in my opinion,
makes the sentence go down much smoother for the first-time
reader.

Signed-off-by: Zac Dover <zac.dover@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
