### PR TITLE
octopus: mon/MgrStatMonitor: do not spam subscribers (mgr) with service_map

### DIFF
--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -305,10 +305,9 @@ bool MgrStatMonitor::preprocess_statfs(MonOpRequestRef op)
 
 void MgrStatMonitor::check_sub(Subscription *sub)
 {
-  const auto epoch = mon->monmap->get_epoch();
   dout(10) << __func__
 	   << " next " << sub->next
-	   << " have " << epoch << dendl;
+	   << " vs service_map.epoch " << service_map.epoch << dendl;
   if (sub->next <= service_map.epoch) {
     auto m = new MServiceMap(service_map);
     sub->session->con->send_message(m);
@@ -317,7 +316,7 @@ void MgrStatMonitor::check_sub(Subscription *sub)
 	  session_map.remove_sub(sub);
 	});
     } else {
-      sub->next = epoch + 1;
+      sub->next = service_map.epoch + 1;
     }
   }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53534

---

backport of https://github.com/ceph/ceph/pull/44196
parent tracker: https://tracker.ceph.com/issues/53479

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh