### PR TITLE
octopus: os/bluestore: avoid premature onode release.

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1058,6 +1058,7 @@ public:
     MEMPOOL_CLASS_HELPERS();
 
     std::atomic_int nref;  ///< reference count
+    std::atomic_int put_nref = {0};
     Collection *c;
     ghobject_t oid;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53609

---

backport of https://github.com/ceph/ceph/pull/43770
parent tracker: https://tracker.ceph.com/issues/53002

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh