### PR TITLE
octopus: osdc: add set_error in BufferHead, when split set_error to right

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -107,6 +107,7 @@ ObjectCacher::BufferHead *ObjectCacher::Object::split(BufferHead *left,
   right->last_write_tid = left->last_write_tid;
   right->last_read_tid = left->last_read_tid;
   right->set_state(left->get_state());
+  right->set_error(left->error);
   right->snapc = left->snapc;
   right->set_journal_tid(left->journal_tid);
 

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -161,6 +161,13 @@ class ObjectCacher {
     }
     int get_state() const { return state; }
 
+    inline int get_error() const {
+      return error;
+    }
+    inline void set_error(int _error) {
+      error = _error;
+    }
+
     inline ceph_tid_t get_journal_tid() const {
       return journal_tid;
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53704

---

backport of https://github.com/ceph/ceph/pull/43881
parent tracker: https://tracker.ceph.com/issues/53227

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh