### PR TITLE
octopus: qa/run-tox-mgr-dashboard: Do not write to /tmp/test_sanitize_password…

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 import errno
 import json
+import tempfile
 import time
 import unittest
 
@@ -588,7 +589,7 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
     def test_sanitize_password(self):
         self.test_create_user()
         password = 'myPass\\n\\r\\n'
-        with open('/tmp/test_sanitize_password.txt', 'w+') as pwd_file:
+        with tempfile.TemporaryFile(mode='w+') as pwd_file:
             # Add new line separators (like some text editors when a file is saved).
             pwd_file.write('{}{}'.format(password, '\n\r\n\n'))
             pwd_file.seek(0)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51826

---

backport of https://github.com/ceph/ceph/pull/42449
parent tracker: https://tracker.ceph.com/issues/51792

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh