### PR TITLE
pacific: rgwlc:  remove lc entry on bucket delete

### DIFF
--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -30,6 +30,8 @@
 
 #include "rgw_zone.h"
 #include "rgw_rest_conn.h"
+#include "rgw_service.h"
+#include "rgw_lc.h"
 #include "services/svc_sys_obj.h"
 #include "services/svc_zone.h"
 #include "services/svc_tier_rados.h"
@@ -131,6 +133,10 @@ int RGWRadosBucket::remove_bucket(const DoutPrefixProvider *dpp,
   if (ret < 0) {
     return ret;
   }
+
+  // remove lifecycle config, if any (XXX note could be made generic)
+  (void) store->getRados()->get_lc()->remove_bucket_config(
+    this->info, get_attrs());
 
   ret = store->ctl()->bucket->sync_user_stats(dpp, info.owner, info, y);
   if (ret < 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53849

---

backport of https://github.com/ceph/ceph/pull/36308
parent tracker: https://tracker.ceph.com/issues/46728

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh