### PR TITLE
pacific: qa/vstart_runner: align interfaces of different run_python()

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -741,13 +741,14 @@ class LocalKernelMount(KernelMount):
         if self.using_namespace:
             super(type(self), self).cleanup_netns()
 
-    def _run_python(self, pyscript, py_version='python'):
+    def _run_python(self, pyscript, py_version='python', sudo=False):
         """
         Override this to remove the daemon-helper prefix that is used otherwise
         to make the process killable.
         """
         return self.client_remote.run(args=[py_version, '-c', pyscript],
-                                      wait=False, stdout=StringIO())
+                                      wait=False, stdout=StringIO(),
+                                      omit_sudo=(not sudo))
 
 class LocalFuseMount(FuseMount):
     def __init__(self, ctx, test_dir, client_id, client_keyring_path=None,
@@ -937,13 +938,14 @@ class LocalFuseMount(FuseMount):
         if self.using_namespace:
             super(type(self), self).cleanup_netns()
 
-    def _run_python(self, pyscript, py_version='python'):
+    def _run_python(self, pyscript, py_version='python', sudo=False):
         """
         Override this to remove the daemon-helper prefix that is used otherwise
         to make the process killable.
         """
         return self.client_remote.run(args=[py_version, '-c', pyscript],
-                                      wait=False, stdout=StringIO())
+                                      wait=False, stdout=StringIO(),
+                                      omit_sudo=(not sudo))
 
 # XXX: this class has nothing to do with the Ceph daemon (ceph-mgr) of
 # the same name.


### PR DESCRIPTION
At pacific branch, run_python() in qa/tasks/cephfs/vstart_runner.py
accepts one parameter less compared to run_python() in
qa/tasks/cephfs/mount.py and qa/tasks/vstart_runner.py at main branch.
This inconsistency in interface in pacific branch causes crashes for
some tests located in qa/tasks/cephfs when executed using
vstart_runner.py.

Fixes: https://tracker.ceph.com/issues/53970
Signed-off-by: Rishabh Dave <ridave@redhat.com>



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>