### PR TITLE
octopus: rbd: add missing switch arguments for recognition by get_command_spec()

### DIFF
--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -84,7 +84,9 @@ static const std::string NO_ERROR("no-error");
 static const std::string LIMIT("limit");
 
 static const std::set<std::string> SWITCH_ARGUMENTS = {
-  WHOLE_OBJECT, NO_PROGRESS, PRETTY_FORMAT, VERBOSE, NO_ERROR};
+  WHOLE_OBJECT, IMAGE_SHARED, IMAGE_THICK_PROVISION, IMAGE_FLATTEN,
+  NO_PROGRESS, PRETTY_FORMAT, VERBOSE, NO_ERROR
+};
 
 struct ImageSize {};
 struct ImageOrder {};

--- a/src/tools/rbd/action/Children.cc
+++ b/src/tools/rbd/action/Children.cc
@@ -157,6 +157,7 @@ int execute(const po::variables_map &vm,
   return 0;
 }
 
+Shell::SwitchArguments switched_arguments({"all", "a", "descendants"});
 Shell::Action action(
   {"children"}, {}, "Display children of an image or its snapshot.", "",
   &get_arguments, &execute);

--- a/src/tools/rbd/action/Device.cc
+++ b/src/tools/rbd/action/Device.cc
@@ -163,7 +163,8 @@ int execute_unmap(const po::variables_map &vm,
   return (*get_device_operations(vm)->execute_unmap)(vm, ceph_global_init_args);
 }
 
-Shell::SwitchArguments switched_arguments({"read-only", "exclusive"});
+Shell::SwitchArguments switched_arguments({"exclusive", "force", "read-only"});
+
 Shell::Action action_list(
   {"device", "list"}, {"showmapped"}, "List mapped rbd images.", "",
   &get_list_arguments, &execute_list);

--- a/src/tools/rbd/action/Diff.cc
+++ b/src/tools/rbd/action/Diff.cc
@@ -132,7 +132,6 @@ int execute(const po::variables_map &vm,
   return 0;
 }
 
-Shell::SwitchArguments switched_arguments({at::WHOLE_OBJECT});
 Shell::Action action(
   {"diff"}, {},
   "Print extents that differ since a previous snap, or image creation.", "",

--- a/src/tools/rbd/action/Export.cc
+++ b/src/tools/rbd/action/Export.cc
@@ -308,7 +308,6 @@ int execute_diff(const po::variables_map &vm,
   return 0;
 }
 
-Shell::SwitchArguments switched_arguments({at::WHOLE_OBJECT});
 Shell::Action action_diff(
   {"export-diff"}, {}, "Export incremental diff to file.", "",
   &get_arguments_diff, &execute_diff);

--- a/src/tools/rbd/action/Nbd.cc
+++ b/src/tools/rbd/action/Nbd.cc
@@ -267,8 +267,6 @@ int execute_unmap_deprecated(const po::variables_map &vm,
   return execute_unmap(vm, ceph_global_args);
 }
 
-Shell::SwitchArguments switched_arguments({"read-only", "exclusive"});
-
 Shell::Action action_show_deprecated(
   {"nbd", "list"}, {"nbd", "ls"}, "List the nbd devices already used.", "",
   &get_list_arguments_deprecated, &execute_list_deprecated, false);

--- a/src/tools/rbd/action/Trash.cc
+++ b/src/tools/rbd/action/Trash.cc
@@ -514,7 +514,6 @@ int execute_restore(const po::variables_map &vm,
   return r;
 }
 
-
 Shell::Action action_move(
   {"trash", "move"}, {"trash", "mv"}, "Move an image to the trash.", "",
   &get_move_arguments, &execute_move);
@@ -527,7 +526,6 @@ Shell::Action action_purge(
   {"trash", "purge"}, {}, "Remove all expired images from trash.", "",
   &get_purge_arguments, &execute_purge);
 
-Shell::SwitchArguments switched_arguments({"long", "l"});
 Shell::Action action_list(
   {"trash", "list"}, {"trash", "ls"}, "List trash images.", "",
   &get_list_arguments, &execute_list);

--- a/src/tools/rbd/action/TrashPurgeSchedule.cc
+++ b/src/tools/rbd/action/TrashPurgeSchedule.cc
@@ -332,6 +332,8 @@ int execute_status(const po::variables_map &vm,
   return 0;
 }
 
+Shell::SwitchArguments switched_arguments({"recursive", "R"});
+
 Shell::Action add_action(
   {"trash", "purge", "schedule", "add"}, {}, "Add trash purge schedule.", "",
   &get_arguments_add, &execute_add);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53982

---

backport of https://github.com/ceph/ceph/pull/44669
parent tracker: https://tracker.ceph.com/issues/53935