### PR TITLE
rgwlc: fix compat-decoding of cls_rgw_lc_get_entry_ret

### DIFF
--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -83,7 +83,6 @@ void cls_rgw_gc_list_ret::generate_test_instances(list<cls_rgw_gc_list_ret*>& ls
   ls.back()->truncated = true;
 }
 
-
 void cls_rgw_gc_remove_op::dump(Formatter *f) const
 {
   encode_json("tags", tags, f);
@@ -95,6 +94,18 @@ void cls_rgw_gc_remove_op::generate_test_instances(list<cls_rgw_gc_remove_op*>& 
   ls.push_back(new cls_rgw_gc_remove_op);
   ls.back()->tags.push_back("tag1");
   ls.back()->tags.push_back("tag2");
+}
+
+void cls_rgw_lc_get_entry_ret::dump(Formatter *f) const
+{
+  encode_json("entry", entry, f);
+}
+
+void cls_rgw_lc_get_entry_ret::generate_test_instances(list<cls_rgw_lc_get_entry_ret*>& ls)
+{
+  cls_rgw_lc_entry entry("bucket1", 6000, 0);
+  ls.push_back(new cls_rgw_lc_get_entry_ret);
+  ls.back()->entry = entry;
 }
 
 void rgw_cls_obj_prepare_op::generate_test_instances(list<rgw_cls_obj_prepare_op*>& o)

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1118,6 +1118,8 @@ struct cls_rgw_lc_get_entry_ret {
     }
     DECODE_FINISH(bl);
   }
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<cls_rgw_lc_get_entry_ret*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_get_entry_ret)
 

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1092,17 +1092,32 @@ struct cls_rgw_lc_get_entry_ret {
     : entry(std::move(_entry)) {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 2, bl);
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
-    decode(entry, bl);
+    DECODE_START(2, bl);
+    if (struct_v < 2) {
+      /* there was an unmarked change in the encoding during v1, so
+       * if the sender version is v1, try decoding both ways (sorry) */
+      ceph::buffer::list::const_iterator save_bl = bl;
+      try {
+	decode(entry, bl);
+      } catch (ceph::buffer::error& e) {
+	std::pair<std::string, int> oe;
+	bl = save_bl;
+	decode(oe, bl);
+	entry.bucket = oe.first;
+	entry.start_time = 0;
+	entry.status = oe.second;
+      }
+    } else {
+      decode(entry, bl);
+    }
     DECODE_FINISH(bl);
   }
-
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_get_entry_ret)
 

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -754,7 +754,18 @@ void cls_rgw_bucket_instance_entry::generate_test_instances(
   ls.back()->reshard_status = RESHARD_STATUS::IN_PROGRESS;
   ls.back()->new_bucket_instance_id = "new_instance_id";
 }
-  
+
+void cls_rgw_lc_entry::dump(Formatter *f) const
+{
+  encode_json("bucket", bucket, f);
+  encode_json("start_time", start_time, f);
+  encode_json("status", status, f);
+}
+
+void generate_test_instances(list<cls_rgw_lc_entry*>& ls)
+{
+}
+
 void cls_rgw_lc_obj_head::dump(Formatter *f) const 
 {
   encode_json("start_date", start_date, f);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+#include <list>
 #include <boost/container/flat_map.hpp>
 #include "common/ceph_time.h"
 #include "common/Formatter.h"
@@ -1291,6 +1292,8 @@ struct cls_rgw_lc_entry {
     decode(status, bl);
     DECODE_FINISH(bl);
   }
+  void dump(Formatter *f) const;
+  void generate_test_instances(std::list<cls_rgw_lc_entry*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_entry);
 

--- a/src/tools/ceph-dencoder/rgw_types.h
+++ b/src/tools/ceph-dencoder/rgw_types.h
@@ -44,6 +44,7 @@ TYPE(rgw_bucket_olh_log_entry)
 TYPE(rgw_usage_log_entry)
 
 #include "cls/rgw/cls_rgw_ops.h"
+TYPE(cls_rgw_lc_get_entry_ret)
 TYPE(rgw_cls_obj_prepare_op)
 TYPE(rgw_cls_obj_complete_op)
 TYPE(rgw_cls_list_op)


### PR DESCRIPTION
Fix compat-decode of cls_rgw_lc_get_entry_ret, which had changed
earlier in 394750597.  While not initially a problem, the more
recent change to allow radosgw-admin lc process to operate on a single
bucket created a way to decode an un-upgraded structure.

Fixes: https://tracker.ceph.com/issues/53927

Reported by Jeegn Chen <jeegnchen@gmail.com>.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
