### PR TITLE
scrub/osd: add a missing 'publish stats to osd'

### DIFF
--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2162,6 +2162,7 @@ void PgScrubber::cleanup_on_finish()
   requeue_waiting();
 
   reset_internal_state();
+  m_pg->publish_stats_to_osd();
   m_flags = scrub_flags_t{};
 
   // type-specific state clear
@@ -2200,6 +2201,7 @@ void PgScrubber::clear_pgscrub_state()
 
   // type-specific state clear
   _scrub_clear_state();
+  m_pg->publish_stats_to_osd();
 }
 
 void PgScrubber::replica_handling_done()


### PR DESCRIPTION

... to publish the last scrub status report.
The change is needed following the merge of
PR #42735.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

