### PR TITLE
mgr/progress: 0 affected PG doesn't break test case

### DIFF
--- a/src/pybind/mgr/progress/test_progress.py
+++ b/src/pybind/mgr/progress/test_progress.py
@@ -1,23 +1,20 @@
-#python unit test
-import unittest
 import os
 import sys
 from tests import mock
-
-import pytest
-import json
+from progress import module
 os.environ['UNITTEST'] = "1"
 sys.path.insert(0, "../../pybind/mgr")
-from progress import module
+
 
 class TestPgRecoveryEvent(object):
-    # Testing PgRecoveryEvent class
 
     def setup(self):
-        # Creating the class and Mocking 
+
+        # Creating the class and Mocking
         # a bunch of attributes for testing
-        module._module = mock.Mock() # just so Event._refresh() works
-        self.test_event = module.PgRecoveryEvent(None, None, [module.PgId(1,i) for i in range(3)], [0], 30, False)
+
+        module._module = mock.Mock()  # just so Event._refresh() works
+        self.test_event = module.PgRecoveryEvent(None, None, [module.PgId(1, i) for i in range(3)], [0], 30, False)
 
     def test_pg_update(self):
         # Test for a completed event when the pg states show active+clean
@@ -48,10 +45,10 @@ class TestPgRecoveryEvent(object):
         assert self.test_event._progress == 1.0
 
 
-class OSDMap: 
-    
+class OSDMap:
+
     # This is an artificial class to help
-    # _osd_in_out function have all the 
+    # _osd_in_out function have all the
     # necessary characteristics, some
     # of the funcitons are copied from
     # mgr_module
@@ -59,17 +56,17 @@ class OSDMap:
     def __init__(self, dump, pg_stats):
         self._dump = dump
         self._pg_stats = pg_stats
-        
+
     def _pg_to_up_acting_osds(self, pool_id, ps):
-        pg_id = str(pool_id) + "." + str(ps)
-        for pg in self._pg_stats["pg_stats"]:
-            if pg["pg_id"] == pg_id:
+        pg_id = str(pool_id) + '.' + str(ps)
+        for pg in self._pg_stats['pg_stats']:
+            if pg['pg_id'] == pg_id:
                 ret = {
-                        "up_primary": pg["up_primary"],
-                        "acting_primary": pg["acting_primary"],
-                        "up": pg["up"],
-                        "acting": pg["acting"]
-                        }
+                    'up_primary': pg['up_primary'],
+                    'acting_primary': pg['acting_primary'],
+                    'up': pg['up'],
+                    'acting': pg['acting'],
+                    }
                 return ret
 
     def dump(self):
@@ -88,8 +85,9 @@ class OSDMap:
 
 
 class TestModule(object):
+
     # Testing Module Class
-    
+
     def setup(self):
         # Creating the class and Mocking a
         # bunch of attributes for testing
@@ -98,72 +96,40 @@ class TestModule(object):
         module.Module._ceph_get_option = mock.Mock()  # .__init__
         module.Module._configure_logging = lambda *args: ...  # .__init__
         self.test_module = module.Module('module_name', 0, 0)  # so we can see if an event gets created
-        self.test_module.get = mock.Mock() # so we can call pg_update
-        self.test_module._complete = mock.Mock() # we want just to see if this event gets called
-        self.test_module.get_osdmap = mock.Mock() # so that self.get_osdmap().get_epoch() works
-        module._module = mock.Mock() # so that Event.refresh() works
+        self.test_module.get = mock.Mock()  # so we can call pg_update
+        self.test_module._complete = mock.Mock()  # we just want to see if this function gets called
+        self.test_module._prune_completed_events = mock.Mock()  # we just want to see if this function gets called
+        self.test_module.get_osdmap = mock.Mock()  # so that self.get_osdmap().get_epoch() works
+        module._module = mock.Mock()  # so that Event.refresh() works
 
     def test_osd_in_out(self):
-        # test for the correct event being
+
+        # Test for the correct event being
         # triggered and completed.
 
-        old_pg_stats = {
-            "pg_stats":[
-                {
-                "pg_id": "1.0",
-                "up_primary": 3,
-                "acting_primary": 3,
-                "up": [
-                    3,
-                    0
-                    ],
-                "acting": [
-                    3,
-                    0
-                    ]
-        
-                },
+        old_pg_stats = {'pg_stats': [{
+            'pg_id': '1.0',
+            'up_primary': 3,
+            'acting_primary': 3,
+            'up': [3, 0],
+            'acting': [3, 0],
+            }]}
 
-                ]
-            }
-        new_pg_stats = {
-            "pg_stats":[
-                {
-              "pg_id": "1.0",
-              "up_primary": 0,
-              "acting_primary": 0,
-              "up": [
-                0,
-                2
-              ],
-              "acting": [
-                0,
-                2
-              ]
-            },
-                ]
-            }
+        new_pg_stats = {'pg_stats': [{
+            'pg_id': '1.0',
+            'up_primary': 0,
+            'acting_primary': 0,
+            'up': [0, 2],
+            'acting': [0, 2],
+            }]}
 
-        old_dump ={ 
-            "pools": [
-                {
-                    "pool": 1,
-                    "pg_num": 1
-                    }
-                ]
-            }
+        old_dump = {'pools': [{'pool': 1, 'pg_num': 1}]}
 
-        new_dump = {
-                "pools": [
-                    {
-                        "pool": 1,
-                        "pg_num": 1
-                        }
-                    ]
-                }
+        new_dump = {'pools': [{'pool': 1, 'pg_num': 1}]}
 
         new_map = OSDMap(new_dump, new_pg_stats)
         old_map = OSDMap(old_dump, old_pg_stats)
+
         self.test_module._osd_in_out(old_map, old_dump, new_map, 3, "out")
         # check if only one event is created
         assert len(self.test_module._events) == 1
@@ -172,3 +138,40 @@ class TestModule(object):
         assert self.test_module._complete.call_count == 1
         # check if a PgRecovery Event was created and pg_update gets triggered
         assert module.PgRecoveryEvent.pg_update.call_count == 2
+
+    def test_no_pgs_affected_osd_marked_in_out(self):
+        # Test to for the case where osd marked in out
+        # didn't create an event due to 0 PGs being affected.
+
+        old_pg_stats = {'pg_stats': [{
+            'pg_id': '1.0',
+            'up_primary': 1,
+            'acting_primary': 1,
+            'up': [1, 0],
+            'acting': [1, 0],
+            }]}
+
+        new_pg_stats = {'pg_stats': [{
+            'pg_id': '1.0',
+            'up_primary': 0,
+            'acting_primary': 0,
+            'up': [0, 2],
+            'acting': [0, 2],
+            }]}
+
+        old_dump = {'pools': [{'pool': 1, 'pg_num': 1}]}
+
+        new_dump = {'pools': [{'pool': 1, 'pg_num': 1}]}
+
+        new_map = OSDMap(new_dump, new_pg_stats)
+        old_map = OSDMap(old_dump, old_pg_stats)
+        self.test_module._osd_in_out(old_map, old_dump, new_map, 3, "out")
+        # check if no event is created in this scenario
+        assert len(self.test_module._events) == 0
+        completed_events = self.test_module._completed_events
+        # check if _completed_event has 1 event
+        assert len(completed_events) == 1
+        # check if the only completed event has a message: 0 PGs affected by ...
+        assert "0 PGs affected by osd.3 being marked out" in completed_events[0].message
+        # check if _prune_completed_events was called
+        assert self.test_module._prune_completed_events.call_count == 1


### PR DESCRIPTION
Currently in qa/tasks/mgr/test_progress.py
we don't have a case where PG recovery event
doesn't get triggered when osd is marked in/out
due to the osd not being in any of the PGs acting
sets in both old osd map and new osd map.

Fixes: https://tracker.ceph.com/issues/53984

Signed-off-by: Kamoltat <ksirivad@redhat.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
