### PR TITLE
osd/scrub: use separate chunk size configuration for shallow scrubs

### DIFF
--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -207,8 +207,18 @@ function TEST_scrub_snaps() {
     do
       activate_osd $dir $osd || return 1
     done
+    ceph tell osd.* config set osd_shallow_scrub_chunk_max 25
+    ceph tell osd.* config set osd_shallow_scrub_chunk_min 5
+    ceph tell osd.* config set osd_pg_stat_report_interval_max 1
+
 
     wait_for_clean || return 1
+
+    ceph tell osd.* config get osd_shallow_scrub_chunk_max
+    ceph tell osd.* config get osd_shallow_scrub_chunk_min
+    ceph tell osd.* config get osd_pg_stat_report_interval_max
+    ceph tell osd.* config get osd_scrub_chunk_max
+    ceph tell osd.* config get osd_scrub_chunk_min
 
     local pgid="${poolid}.0"
     if ! pg_scrub "$pgid" ; then
@@ -759,6 +769,10 @@ function _scrub_snaps_multi() {
       activate_osd $dir $osd || return 1
     done
 
+    ceph tell osd.* config set osd_shallow_scrub_chunk_max 3
+    ceph tell osd.* config set osd_shallow_scrub_chunk_min 3
+    ceph tell osd.* config set osd_scrub_chunk_min 3
+    ceph tell osd.* config set osd_pg_stat_report_interval_max 1
     wait_for_clean || return 1
 
     local pgid="${poolid}.0"
@@ -1149,7 +1163,7 @@ fi
 function TEST_scrub_snaps_replica() {
     local dir=$1
     ORIG_ARGS=$CEPH_ARGS
-    CEPH_ARGS+=" --osd_scrub_chunk_min=3 --osd_scrub_chunk_max=3"
+    CEPH_ARGS+=" --osd_scrub_chunk_min=3 --osd_scrub_chunk_max=20 --osd_shallow_scrub_chunk_min=3 --osd_shallow_scrub_chunk_max=3 --osd_pg_stat_report_interval_max=1"
     _scrub_snaps_multi $dir replica
     err=$?
     CEPH_ARGS=$ORIG_ARGS
@@ -1159,7 +1173,7 @@ function TEST_scrub_snaps_replica() {
 function TEST_scrub_snaps_primary() {
     local dir=$1
     ORIG_ARGS=$CEPH_ARGS
-    CEPH_ARGS+=" --osd_scrub_chunk_min=3 --osd_scrub_chunk_max=3"
+    CEPH_ARGS+=" --osd_scrub_chunk_min=3 --osd_scrub_chunk_max=20 --osd_shallow_scrub_chunk_min=3 --osd_shallow_scrub_chunk_max=3 --osd_pg_stat_report_interval_max=1"
     _scrub_snaps_multi $dir primary
     err=$?
     CEPH_ARGS=$ORIG_ARGS

--- a/qa/standalone/scrub/scrub-helpers.sh
+++ b/qa/standalone/scrub/scrub-helpers.sh
@@ -239,6 +239,7 @@ function standard_scrub_cluster() {
             --osd_scrub_interval_randomize_ratio=0 \
             --osd_scrub_backoff_ratio=0.0 \
             --osd_pool_default_pg_autoscale_mode=off \
+            --osd_pg_stat_report_interval_max=1 \
             $extra_pars"
 
     for osd in $(seq 0 $(expr $OSDS - 1))

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -333,7 +333,7 @@ options:
 - name: osd_scrub_chunk_min
   type: int
   level: advanced
-  desc: Minimum number of objects to scrub in a single chunk
+  desc: Minimum number of objects to deep-scrub in a single chunk
   fmt_desc: The minimal number of object store chunks to scrub during single operation.
     Ceph blocks writes to single chunk during scrub.
   default: 5
@@ -343,11 +343,34 @@ options:
 - name: osd_scrub_chunk_max
   type: int
   level: advanced
-  desc: Maximum number of objects to scrub in a single chunk
+  desc: Maximum number of objects to deep-scrub in a single chunk
   fmt_desc: The maximum number of object store chunks to scrub during single operation.
   default: 25
   see_also:
   - osd_scrub_chunk_min
+  with_legacy: true
+- name: osd_shallow_scrub_chunk_min
+  type: int
+  level: advanced
+  desc: Minimum number of objects to scrub in a single chunk
+  fmt_desc: The minimum number of object store chunks to scrub during single operation.
+    Not applicable to deep scrubs.
+    Ceph blocks writes to single chunk during scrub.
+  default: 50
+  see_also:
+  - osd_shallow_scrub_chunk_max
+  - osd_scrub_chunk_min
+  with_legacy: true
+- name: osd_shallow_scrub_chunk_max
+  type: int
+  level: advanced
+  desc: Maximum number of objects to scrub in a single chunk
+  fmt_desc: The maximum number of object store chunks to scrub during single operation.
+    Not applicable to deep scrubs.
+  default: 100
+  see_also:
+  - osd_shallow_scrub_chunk_min
+  - osd_scrub_chunk_max
   with_legacy: true
 # sleep between [deep]scrub ops
 - name: osd_scrub_sleep

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-pg-scrub-modal/osd-pg-scrub-modal.options.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-pg-scrub-modal/osd-pg-scrub-modal.options.ts
@@ -31,6 +31,8 @@ export class OsdPgScrubModalOptions {
     'osd_scrub_interval_randomize_ratio',
     'osd_scrub_invalid_stats',
     'osd_scrub_load_threshold',
-    'osd_scrub_max_preemptions'
+    'osd_scrub_max_preemptions',
+    'osd_shallow_scrub_chunk_max',
+    'osd_shallow_scrub_chunk_min'
   ];
 }


### PR DESCRIPTION
Using the existing common default chunk size for scrubs that are
not deep-scrubs is wasteful: a high ratio of inter-OSD messages
per chunk, while the actual OSD work per chunk is minimal.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
