### PR TITLE
octopus: rbd-mirror: fix races in snapshot-based mirroring deletion propagation

### DIFF
--- a/src/test/rbd_mirror/image_replayer/test_mock_PrepareRemoteImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_PrepareRemoteImageRequest.cc
@@ -331,7 +331,6 @@ TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, SuccessJournal) {
 }
 
 TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, SuccessSnapshot) {
-  ::journal::MockJournaler mock_remote_journaler;
   MockThreads mock_threads(m_threads);
 
   InSequence seq;
@@ -434,8 +433,7 @@ TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, SuccessNotRegistered) {
             mock_journal_state_builder.remote_client_state);
 }
 
-TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, MirrorImageIdError) {
-  ::journal::MockJournaler mock_remote_journaler;
+TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, GetMirrorImageIdError) {
   MockThreads mock_threads(m_threads);
 
   InSequence seq;
@@ -461,7 +459,6 @@ TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, MirrorImageIdError) {
 }
 
 TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, GetMirrorInfoError) {
-  ::journal::MockJournaler mock_remote_journaler;
   MockThreads mock_threads(m_threads);
 
   InSequence seq;

--- a/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.cc
@@ -37,6 +37,10 @@ template <typename I>
 void PrepareRemoteImageRequest<I>::send() {
   if (*m_state_builder != nullptr) {
     (*m_state_builder)->remote_mirror_uuid = m_remote_pool_meta.mirror_uuid;
+    auto state_builder = dynamic_cast<snapshot::StateBuilder<I>*>(*m_state_builder);
+    if (state_builder) {
+      state_builder->remote_mirror_peer_uuid = m_remote_pool_meta.mirror_peer_uuid;
+    }
   }
 
   get_remote_image_id();
@@ -61,7 +65,6 @@ void PrepareRemoteImageRequest<I>::handle_get_remote_image_id(int r) {
            << "remote_image_id=" << m_remote_image_id << dendl;
 
   if (r == -ENOENT) {
-    finalize_snapshot_state_builder(r);
     finish(r);
     return;
   } else if (r < 0) {
@@ -92,7 +95,6 @@ void PrepareRemoteImageRequest<I>::handle_get_mirror_info(int r) {
 
   if (r == -ENOENT) {
     dout(10) << "image " << m_global_image_id << " not mirrored" << dendl;
-    finalize_snapshot_state_builder(r);
     finish(r);
     return;
   } else if (r < 0) {
@@ -129,7 +131,7 @@ void PrepareRemoteImageRequest<I>::handle_get_mirror_info(int r) {
     get_client();
     break;
   case cls::rbd::MIRROR_IMAGE_MODE_SNAPSHOT:
-    finalize_snapshot_state_builder(0);
+    finalize_snapshot_state_builder();
     finish(0);
     break;
   default:
@@ -247,18 +249,14 @@ void PrepareRemoteImageRequest<I>::finalize_journal_state_builder(
 }
 
 template <typename I>
-void PrepareRemoteImageRequest<I>::finalize_snapshot_state_builder(int r) {
+void PrepareRemoteImageRequest<I>::finalize_snapshot_state_builder() {
   snapshot::StateBuilder<I>* state_builder = nullptr;
   if (*m_state_builder != nullptr) {
     state_builder = dynamic_cast<snapshot::StateBuilder<I>*>(*m_state_builder);
-  } else if (r >= 0) {
+    ceph_assert(state_builder != nullptr);
+  } else {
     state_builder = snapshot::StateBuilder<I>::create(m_global_image_id);
     *m_state_builder = state_builder;
-  }
-
-  if (state_builder == nullptr) {
-    // local image prepare failed or is using journal-based mirroring
-    return;
   }
 
   dout(10) << "remote_mirror_uuid=" << m_remote_pool_meta.mirror_uuid << ", "
@@ -266,7 +264,6 @@ void PrepareRemoteImageRequest<I>::finalize_snapshot_state_builder(int r) {
            << m_remote_pool_meta.mirror_peer_uuid << ", "
            << "remote_image_id=" << m_remote_image_id << ", "
            << "remote_promotion_state=" << m_promotion_state << dendl;
-  ceph_assert(state_builder != nullptr);
   state_builder->remote_mirror_uuid = m_remote_pool_meta.mirror_uuid;
   state_builder->remote_mirror_peer_uuid = m_remote_pool_meta.mirror_peer_uuid;
   state_builder->remote_image_id = m_remote_image_id;

--- a/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.h
@@ -140,7 +140,7 @@ private:
 
   void finalize_journal_state_builder(cls::journal::ClientState client_state,
                                       const MirrorPeerClientMeta& client_meta);
-  void finalize_snapshot_state_builder(int r);
+  void finalize_snapshot_state_builder();
 
   void finish(int r);
 };

--- a/src/tools/rbd_mirror/image_replayer/StateBuilder.cc
+++ b/src/tools/rbd_mirror/image_replayer/StateBuilder.cc
@@ -43,8 +43,9 @@ bool StateBuilder<I>::is_local_primary() const  {
 
 template <typename I>
 bool StateBuilder<I>::is_linked() const {
-  return (local_promotion_state ==
-            librbd::mirror::PROMOTION_STATE_NON_PRIMARY);
+  return ((local_promotion_state ==
+             librbd::mirror::PROMOTION_STATE_NON_PRIMARY) &&
+          is_linked_impl());
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_replayer/StateBuilder.h
+++ b/src/tools/rbd_mirror/image_replayer/StateBuilder.h
@@ -44,7 +44,7 @@ public:
   virtual bool is_disconnected() const = 0;
 
   bool is_local_primary() const;
-  virtual bool is_linked() const;
+  bool is_linked() const;
 
   virtual cls::rbd::MirrorImageMode get_mirror_image_mode() const = 0;
 
@@ -100,6 +100,8 @@ protected:
   void close_local_image(Context* on_finish);
 
 private:
+  virtual bool is_linked_impl() const = 0;
+
   void handle_close_local_image(int r, Context* on_finish);
   void handle_close_remote_image(int r, Context* on_finish);
 };

--- a/src/tools/rbd_mirror/image_replayer/StateBuilder.h
+++ b/src/tools/rbd_mirror/image_replayer/StateBuilder.h
@@ -51,9 +51,7 @@ public:
   virtual image_sync::SyncPointHandler* create_sync_point_handler() = 0;
   void destroy_sync_point_handler();
 
-  virtual bool replay_requires_remote_image() const {
-    return false;
-  }
+  virtual bool replay_requires_remote_image() const = 0;
 
   void close_remote_image(Context* on_finish);
 

--- a/src/tools/rbd_mirror/image_replayer/StateBuilder.h
+++ b/src/tools/rbd_mirror/image_replayer/StateBuilder.h
@@ -81,13 +81,13 @@ public:
 
   std::string global_image_id;
 
-  std::string local_image_id{};
+  std::string local_image_id;
   librbd::mirror::PromotionState local_promotion_state =
     librbd::mirror::PROMOTION_STATE_PRIMARY;
   ImageCtxT* local_image_ctx = nullptr;
 
   std::string remote_mirror_uuid;
-  std::string remote_image_id{};
+  std::string remote_image_id;
   librbd::mirror::PromotionState remote_promotion_state =
     librbd::mirror::PROMOTION_STATE_NON_PRIMARY;
   ImageCtxT* remote_image_ctx = nullptr;

--- a/src/tools/rbd_mirror/image_replayer/journal/StateBuilder.cc
+++ b/src/tools/rbd_mirror/image_replayer/journal/StateBuilder.cc
@@ -58,10 +58,9 @@ bool StateBuilder<I>::is_disconnected() const {
 }
 
 template <typename I>
-bool StateBuilder<I>::is_linked() const {
+bool StateBuilder<I>::is_linked_impl() const {
   ceph_assert(!this->remote_mirror_uuid.empty());
-  return (image_replayer::StateBuilder<I>::is_linked() &&
-          local_primary_mirror_uuid == this->remote_mirror_uuid);
+  return (local_primary_mirror_uuid == this->remote_mirror_uuid);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_replayer/journal/StateBuilder.h
+++ b/src/tools/rbd_mirror/image_replayer/journal/StateBuilder.h
@@ -42,6 +42,10 @@ public:
 
   image_sync::SyncPointHandler* create_sync_point_handler() override;
 
+  bool replay_requires_remote_image() const override {
+    return false;
+  }
+
   BaseRequest* create_local_image_request(
       Threads<ImageCtxT>* threads,
       librados::IoCtx& local_io_ctx,

--- a/src/tools/rbd_mirror/image_replayer/journal/StateBuilder.h
+++ b/src/tools/rbd_mirror/image_replayer/journal/StateBuilder.h
@@ -37,7 +37,6 @@ public:
   void close(Context* on_finish) override;
 
   bool is_disconnected() const override;
-  bool is_linked() const override;
 
   cls::rbd::MirrorImageMode get_mirror_image_mode() const override;
 
@@ -75,6 +74,7 @@ public:
   SyncPointHandler<ImageCtxT>* sync_point_handler = nullptr;
 
 private:
+  bool is_linked_impl() const override;
 
   void shut_down_remote_journaler(Context* on_finish);
   void handle_shut_down_remote_journaler(int r, Context* on_finish);

--- a/src/tools/rbd_mirror/image_replayer/snapshot/StateBuilder.cc
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/StateBuilder.cc
@@ -56,10 +56,9 @@ bool StateBuilder<I>::is_disconnected() const {
 }
 
 template <typename I>
-bool StateBuilder<I>::is_linked() const {
+bool StateBuilder<I>::is_linked_impl() const {
   // the remote has to have us registered as a peer
-  return (image_replayer::StateBuilder<I>::is_linked() &&
-          !remote_mirror_peer_uuid.empty());
+  return !remote_mirror_peer_uuid.empty();
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_replayer/snapshot/StateBuilder.h
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/StateBuilder.h
@@ -42,7 +42,6 @@ public:
   void close(Context* on_finish) override;
 
   bool is_disconnected() const override;
-  bool is_linked() const override;
 
   cls::rbd::MirrorImageMode get_mirror_image_mode() const override;
 
@@ -79,6 +78,9 @@ public:
   std::string remote_mirror_peer_uuid;
 
   librbd::mirror::snapshot::ImageMeta<ImageCtxT>* local_image_meta = nullptr;
+
+private:
+  bool is_linked_impl() const override;
 };
 
 } // namespace snapshot


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53988

---

backport of https://github.com/ceph/ceph/pull/44714
parent tracker: https://tracker.ceph.com/issues/53963