### PR TITLE
osd/scrub: fix ceph::mutex usage

### DIFF
--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2113,7 +2113,7 @@ PgScrubber::preemption_data_t::preemption_data_t(PG* pg) : m_pg{pg}
 
 void PgScrubber::preemption_data_t::reset()
 {
-  std::lock_guard<std::mutex> lk{m_preemption_lock};
+  std::lock_guard<ceph::mutex> lk{m_preemption_lock};
 
   m_preemptable = false;
   m_preempted = false;

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -846,12 +846,15 @@ private:
 
     [[nodiscard]] bool is_preemptable() const final { return m_preemptable; }
 
+    preemption_data_t(const preemption_data_t&) = delete;
+    preemption_data_t(preemption_data_t&&) = delete;
+
     bool do_preempt() final
     {
       if (m_preempted || !m_preemptable)
 	return false;
 
-      std::lock_guard<std::mutex> lk{m_preemption_lock};
+      std::lock_guard<ceph::mutex> lk{m_preemption_lock};
       if (!m_preemptable)
 	return false;
 
@@ -865,7 +868,7 @@ private:
 
     void enable_preemption()
     {
-      std::lock_guard<std::mutex> lk{m_preemption_lock};
+      std::lock_guard<ceph::mutex> lk{m_preemption_lock};
       if (are_preemptions_left() && !m_preempted) {
 	m_preemptable = true;
       }
@@ -881,7 +884,7 @@ private:
 
     bool disable_and_test() final
     {
-      std::lock_guard<std::mutex> lk{m_preemption_lock};
+      std::lock_guard<ceph::mutex> lk{m_preemption_lock};
       m_preemptable = false;
       return m_preempted;
     }
@@ -894,7 +897,7 @@ private:
 
     void adjust_parameters() final
     {
-      std::lock_guard<std::mutex> lk{m_preemption_lock};
+      std::lock_guard<ceph::mutex> lk{m_preemption_lock};
 
       if (m_preempted) {
 	m_preempted = false;
@@ -906,7 +909,7 @@ private:
 
    private:
     PG* m_pg;
-    mutable ceph::mutex m_preemption_lock;
+    mutable ceph::mutex m_preemption_lock = ceph::make_mutex("preemption_lock");
     bool m_preemptable{false};
     bool m_preempted{false};
     int m_left;

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -20,6 +20,10 @@ struct preemption_t {
 
   virtual ~preemption_t() = default;
 
+  preemption_t() = default;
+  preemption_t(const preemption_t&) = delete;
+  preemption_t(preemption_t&&) = delete;
+
   [[nodiscard]] virtual bool is_preemptable() const = 0;
 
   [[nodiscard]] virtual bool was_preempted() const = 0;


### PR DESCRIPTION
Fixing a bogus usage pattern of ceph::mutex, introduced
in the scrub-backend refactoring PR.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
