### PR TITLE
build: add --help and --crimson to install-deps.sh

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -234,6 +234,19 @@ function version_lt {
     test $1 != $(echo -e "$1\n$2" | sort -rV | head -n 1)
 }
 
+function usage_exit() {
+    printf "usage: [ENV VAR]... $0 [option]... \nex: WITH_JAEGER=1 $0 --crimson\n"
+    printf "options:\n"
+    printf "  --crimson: install pkgs specific to crimson-osd. Alias for WITH_SEASTAR\n"
+    printf "environment variables:\n"
+    printf "  FOR_MAKE_CHECK\n"
+    printf "  WITH_SEASTAR: alias for --crimson\n"
+    printf "  WITH_JAEGER\n"
+    printf "  WITH_ZBD\n"
+    printf "  WITH_PMEM\n"
+    exit
+}
+
 for_make_check=false
 if tty -s; then
     # interactive
@@ -302,6 +315,18 @@ if [ x$(uname)x = xFreeBSDx ]; then
 
     exit
 else
+    while [ $# -ge 1 ]; do
+    case $1 in
+        --crimson)
+            ceph_osd=crimson-osd
+            nodaemon=1
+            msgr=2
+            ;;
+        *)
+            usage_exit
+    esac
+    shift
+    done
     [ $WITH_SEASTAR ] && with_seastar=true || with_seastar=false
     [ $WITH_JAEGER ] && with_jaeger=true || with_jaeger=false
     [ $WITH_ZBD ] && with_zbd=true || with_zbd=false


### PR DESCRIPTION
We already have the `WITH_SEASTAR` env. variable support. However, the inconsistency with `vstart.sh` (which offers the `--crimson` switch) could be misleading, especially as the env-based approach makes sanity checks impossible. This allows e.g. a typo to sneak in undetected and surprise a developer.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
