### PR TITLE
octopus: ceph-volume: don't use MultiLogger in find_executable_on_host()

### DIFF
--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -59,10 +59,10 @@ def find_executable_on_host(locations=[], executable='', binary_check='/bin/ls')
     stdout = as_string(process.stdout.read())
     if stdout:
         executable_on_host = stdout.split('\n')[0]
-        mlogger.info('Executable {} found on the host, will use {}'.format(executable, executable_on_host))
+        logger.info('Executable {} found on the host, will use {}'.format(executable, executable_on_host))
         return executable_on_host
     else:
-        mlogger.warning('Executable {} not found on the host, will return {} as-is'.format(executable, executable))
+        logger.warning('Executable {} not found on the host, will return {} as-is'.format(executable, executable))
         return executable
 
 def which(executable, run_on_host=False):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53954

---

backport of https://github.com/ceph/ceph/pull/44665
parent tracker: https://tracker.ceph.com/issues/53934

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh