### PR TITLE
qa/ceph_manager: clean up CephManager.do_rados()

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -22,6 +22,7 @@ from teuthology import misc as teuthology
 from tasks.scrub import Scrubber
 from tasks.util.rados import cmd_erasure_code_profile
 from tasks.util import get_remote
+
 from teuthology.contextutil import safe_while
 from teuthology.orchestra.remote import Remote
 from teuthology.orchestra import run
@@ -1534,10 +1535,12 @@ class CephManager:
         self.rook = rook
         self.cephadm = cephadm
         self.testdir = teuthology.get_testdir(self.ctx)
-        self.run_cluster_cmd_prefix = [
-            'sudo', 'adjust-ulimits', 'ceph-coverage',
-            f'{self.testdir}/archive/coverage', 'timeout', '120', 'ceph',
-            '--cluster', self.cluster]
+        # prefix args for ceph cmds to be executed
+        pre = ['adjust-ulimits', 'ceph-coverage',
+               f'{self.testdir}/archive/coverage']
+        self.CEPH_CMD = ['sudo'] + pre + ['timeout', '120', 'ceph',
+                                          '--cluster', self.cluster]
+        self.RADOS_CMD = pre + ['rados', '--cluster', self.cluster]
         self.run_ceph_w_prefix = ['sudo', 'daemon-helper', 'kill', 'ceph',
                                   '--cluster', self.cluster]
 
@@ -1584,7 +1587,7 @@ class CephManager:
                            stdout=StringIO(),
                            check_status=kwargs.get('check_status', True))
 
-        kwargs['args'] = self.run_cluster_cmd_prefix + kwargs['args']
+        kwargs['args'] = self.CEPH_CMD + kwargs['args']
         return self.controller.run(**kwargs)
 
     def raw_cluster_cmd(self, *args, **kwargs) -> str:
@@ -1719,14 +1722,7 @@ class CephManager:
         if remote is None:
             remote = self.controller
 
-        pre = [
-            'adjust-ulimits',
-            'ceph-coverage',
-           f'{self.testdir}/archive/coverage',
-            'rados',
-            '--cluster',
-            self.cluster,
-            ]
+        pre = self.RADOS_CMD + [] # deep-copying!
         if pool is not None:
             pre += ['--pool', pool]
         if namespace is not None:

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -191,6 +191,7 @@ else:
     SRC_PREFIX = "./"
 
 CEPH_CMD = os.path.join(BIN_PREFIX, 'ceph')
+RADOS_CMD = os.path.join(BIN_PREFIX, 'rados')
 
 
 def rm_nonascii_chars(var):
@@ -754,6 +755,8 @@ class LocalCephManager(CephManager):
         self.rook = False
         self.testdir = None
         self.run_ceph_w_prefix = self.run_cluster_cmd_prefix = [CEPH_CMD]
+        self.CEPH_CMD = [CEPH_CMD]
+        self.RADOS_CMD = [RADOS_CMD]
 
     def find_remote(self, daemon_type, daemon_id):
         """


### PR DESCRIPTION
do_rados() prefixes extra arguments to every command because they are
helpful during execution of tests with teuthology. This patch
eliminates these extra arguments entirely (through overriding) for test
executions with vstart_runner.py.

Note: "timeout 120" is now prefixed to rados commands too. AFAIS, it
shouldn't have any side-effects on anything.

Similar to commit: https://github.com/ceph/ceph/pull/38481/commits/93677576c1fd6d0e4e2991a9ba6be6d222ea98ea







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>