### PR TITLE
rgw: maintain bucket instance xattrs during successful & cancelled reshard

### DIFF
--- a/qa/workunits/rgw/test_rgw_reshard.py
+++ b/qa/workunits/rgw/test_rgw_reshard.py
@@ -98,7 +98,10 @@ def run_bucket_reshard_cmd(bucket_name, num_shards, **kwargs):
     return exec_cmd(cmd, **kwargs)
 
 def test_bucket_reshard(conn, name, **fault):
-    bucket = conn.create_bucket(Bucket=name)
+    # create a bucket with non-default ACLs to verify that reshard preserves them
+    bucket = conn.create_bucket(Bucket=name, ACL='authenticated-read')
+    grants = bucket.Acl().grants
+
     objs = []
     try:
         # create objs
@@ -119,6 +122,8 @@ def test_bucket_reshard(conn, name, **fault):
         # verify that the bucket is writeable by deleting an object
         objs.pop().delete()
 
+        assert grants == bucket.Acl().grants # recheck grants after cancel
+
         # retry reshard without fault injection. if radosgw-admin aborted,
         # we'll have to retry until the reshard lock expires
         while True:
@@ -133,6 +138,8 @@ def test_bucket_reshard(conn, name, **fault):
         # recheck shard count
         final_shard_count = get_bucket_stats(name).num_shards
         assert(final_shard_count == num_shards_expected)
+
+        assert grants == bucket.Acl().grants # recheck grants after commit
     finally:
         # cleanup on resharded bucket must succeed
         bucket.delete_objects(Delete={'Objects':[{'Key':o.key} for o in objs]})

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7683,7 +7683,9 @@ next:
       return -EINVAL;
     }
 
-    RGWBucketReshard br(static_cast<rgw::sal::RadosStore*>(store), bucket->get_info(), nullptr /* no callback */);
+    RGWBucketReshard br(static_cast<rgw::sal::RadosStore*>(store),
+			bucket->get_info(), bucket->get_attrs(),
+			nullptr /* no callback */);
 
 #define DEFAULT_RESHARD_MAX_ENTRIES 1000
     if (max_entries < 1) {
@@ -7783,7 +7785,9 @@ next:
       return -ret;
     }
 
-    RGWBucketReshard br(static_cast<rgw::sal::RadosStore*>(store), bucket->get_info(), nullptr /* no callback */);
+    RGWBucketReshard br(static_cast<rgw::sal::RadosStore*>(store),
+			bucket->get_info(), bucket->get_attrs(),
+			nullptr /* no callback */);
     list<cls_rgw_bucket_instance_entry> status;
     int r = br.get_status(dpp(), &status);
     if (r < 0) {
@@ -7826,7 +7830,9 @@ next:
 
     if (bucket_initable) {
       // we did not encounter an error, so let's work with the bucket
-      RGWBucketReshard br(static_cast<rgw::sal::RadosStore*>(store), bucket->get_info(), nullptr /* no callback */);
+	RGWBucketReshard br(static_cast<rgw::sal::RadosStore*>(store),
+			    bucket->get_info(), bucket->get_attrs(),
+			    nullptr /* no callback */);
       int ret = br.cancel(dpp());
       if (ret < 0) {
         if (ret == -EBUSY) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6844,14 +6844,18 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
   int ret = 0;
   cls_rgw_bucket_instance_entry entry;
 
+  // gets loaded by fetch_new_bucket_info; can be used by
+  // clear_resharding
+  std::map<std::string, bufferlist> bucket_attrs;
+
   // since we want to run this recovery code from two distinct places,
   // let's just put it in a lambda so we can easily re-use; if the
   // lambda successfully fetches a new bucket id, it sets
   // new_bucket_id and returns 0, otherwise it returns a negative
   // error code
   auto fetch_new_bucket_info =
-    [this, &bucket_info, dpp](const std::string& log_tag) -> int {
-      int ret = try_refresh_bucket_info(bucket_info, nullptr, dpp);
+    [this, &bucket_info, &bucket_attrs, dpp](const std::string& log_tag) -> int {
+      int ret = try_refresh_bucket_info(bucket_info, nullptr, dpp, &bucket_attrs);
       if (ret < 0) {
 	ldpp_dout(dpp, 0) << __func__ <<
 	  " ERROR: failed to refresh bucket info after reshard at " <<
@@ -6906,7 +6910,9 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
 	ldpp_dout(dpp, 10) << __PRETTY_FUNCTION__ <<
 	  ": was able to take reshard lock for bucket " <<
 	  bucket_id << dendl;
-        // the reshard may have finished, so call clear_resharding() with its current bucket info
+        // the reshard may have finished, so call clear_resharding()
+        // with its current bucket info; ALSO this will load
+        // bucket_attrs for call to clear_resharding below
         ret = fetch_new_bucket_info("trying_to_clear_resharding");
         if (ret < 0) {
 	  reshard_lock.unlock();
@@ -6915,7 +6921,7 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
 	    bucket_id << dendl;
           continue; // try again
         }
-	ret = RGWBucketReshard::clear_resharding(this->store, bucket_info, dpp);
+	ret = RGWBucketReshard::clear_resharding(this->store, bucket_info, bucket_attrs, dpp);
 	if (ret < 0) {
 	  reshard_lock.unlock();
 	  ldpp_dout(dpp, 0) << __PRETTY_FUNCTION__ <<

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -248,8 +248,9 @@ public:
 
 RGWBucketReshard::RGWBucketReshard(rgw::sal::RadosStore* _store,
 				   const RGWBucketInfo& _bucket_info,
+				   const std::map<std::string, bufferlist>& _bucket_attrs,
 				   RGWBucketReshardLock* _outer_reshard_lock) :
-  store(_store), bucket_info(_bucket_info),
+  store(_store), bucket_info(_bucket_info), bucket_attrs(_bucket_attrs),
   reshard_lock(store, bucket_info, true),
   outer_reshard_lock(_outer_reshard_lock)
 { }
@@ -323,6 +324,7 @@ static int init_target_index(rgw::sal::RadosStore* store,
 // write the target layout to the bucket instance metadata
 static int init_target_layout(rgw::sal::RadosStore* store,
                               RGWBucketInfo& bucket_info,
+			      std::map<std::string, bufferlist>& bucket_attrs,
                               const ReshardFaultInjector& fault,
                               uint32_t new_num_shards,
                               const DoutPrefixProvider* dpp)
@@ -371,7 +373,7 @@ static int init_target_layout(rgw::sal::RadosStore* store,
   if (ret = fault.check("set_target_layout");
       ret == 0) { // no fault injected, write the bucket instance metadata
     ret = store->getRados()->put_bucket_instance_info(bucket_info, false,
-                                                      real_time(), nullptr, dpp);
+                                                      real_time(), &bucket_attrs, dpp);
   }
 
   if (ret < 0) {
@@ -424,11 +426,12 @@ static int revert_target_layout(rgw::sal::RadosStore* store,
 
 static int init_reshard(rgw::sal::RadosStore* store,
                         RGWBucketInfo& bucket_info,
+			std::map<std::string, bufferlist>& bucket_attrs,
                         const ReshardFaultInjector& fault,
                         uint32_t new_num_shards,
                         const DoutPrefixProvider *dpp)
 {
-  int ret = init_target_layout(store, bucket_info, fault, new_num_shards, dpp);
+  int ret = init_target_layout(store, bucket_info, bucket_attrs, fault, new_num_shards, dpp);
   if (ret < 0) {
     return ret;
   }
@@ -472,6 +475,7 @@ static int cancel_reshard(rgw::sal::RadosStore* store,
 
 static int commit_reshard(rgw::sal::RadosStore* store,
                           RGWBucketInfo& bucket_info,
+			  std::map<std::string, bufferlist>& bucket_attrs,
                           const ReshardFaultInjector& fault,
                           const DoutPrefixProvider *dpp)
 {
@@ -506,7 +510,10 @@ static int commit_reshard(rgw::sal::RadosStore* store,
 
   int ret = fault.check("commit_target_layout");
   if (ret == 0) { // no fault injected, write the bucket instance metadata
-    ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), nullptr, dpp);
+    ret =
+      store->getRados()->put_bucket_instance_info(bucket_info, false,
+						  real_time(),
+						  &bucket_attrs, dpp);
   }
 
   if (ret < 0) {
@@ -817,7 +824,7 @@ int RGWBucketReshard::execute(int num_shards,
   }
 
   // prepare the target index and add its layout the bucket info
-  ret = init_reshard(store, bucket_info, fault, num_shards, dpp);
+  ret = init_reshard(store, bucket_info, bucket_attrs, fault, num_shards, dpp);
   if (ret < 0) {
     return ret;
   }
@@ -837,7 +844,7 @@ int RGWBucketReshard::execute(int num_shards,
     return ret;
   }
 
-  ret = commit_reshard(store, bucket_info, fault, dpp);
+  ret = commit_reshard(store, bucket_info, bucket_attrs, fault, dpp);
   if (ret < 0) {
     return ret;
   }
@@ -1051,11 +1058,14 @@ int RGWReshard::process_entry(const cls_rgw_reshard_entry& entry,
 
   rgw_bucket bucket;
   RGWBucketInfo bucket_info;
+  std::map<std::string, bufferlist> bucket_attrs;
 
   int ret = store->getRados()->get_bucket_info(store->svc(),
-                                               entry.tenant, entry.bucket_name,
+                                               entry.tenant,
+					       entry.bucket_name,
                                                bucket_info, nullptr,
-                                               null_yield, dpp, nullptr);
+                                               null_yield, dpp,
+					       &bucket_attrs);
   if (ret < 0 || bucket_info.bucket.bucket_id != entry.bucket_id) {
     if (ret < 0) {
       ldpp_dout(dpp, 0) <<  __func__ <<
@@ -1097,7 +1107,7 @@ int RGWReshard::process_entry(const cls_rgw_reshard_entry& entry,
     return remove(dpp, entry);
   }
 
-  RGWBucketReshard br(store, bucket_info, nullptr);
+  RGWBucketReshard br(store, bucket_info, bucket_attrs, nullptr);
 
   ReshardFaultInjector f; // no fault injected
   ret = br.execute(entry.new_num_shards, f, max_entries, dpp,

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -74,6 +74,7 @@ class RGWBucketReshard {
  private:
   rgw::sal::RadosStore *store;
   RGWBucketInfo bucket_info;
+  std::map<std::string, bufferlist> bucket_attrs;
 
   RGWBucketReshardLock reshard_lock;
   RGWBucketReshardLock* outer_reshard_lock;
@@ -95,6 +96,7 @@ public:
   // manage
   RGWBucketReshard(rgw::sal::RadosStore* _store,
 		   const RGWBucketInfo& _bucket_info,
+		   const std::map<std::string, bufferlist>& _bucket_attrs,
 		   RGWBucketReshardLock* _outer_reshard_lock);
   int execute(int num_shards, const ReshardFaultInjector& f,
               int max_op_entries, const DoutPrefixProvider *dpp,
@@ -162,6 +164,10 @@ public:
       std::min(prime_ish_num_shards, absolute_max);
 
     return final_num_shards;
+  }
+
+  const std::map<std::string, bufferlist>& get_bucket_attrs() const {
+    return bucket_attrs;
   }
 
   // for multisite, the RGWBucketInfo keeps a history of old log generations

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -108,6 +108,7 @@ public:
 
   static int clear_resharding(rgw::sal::RadosStore* store,
 			      RGWBucketInfo& bucket_info,
+			      std::map<std::string, bufferlist>& bucket_attrs,
                               const DoutPrefixProvider* dpp);
 
   static uint32_t get_max_prime_shards() {


### PR DESCRIPTION
With the new resharding code, some bucket metadata that is stored as xattrs (e.g., ACLs, life-cycle policies) were not sent with the updated bucket instance data when resharding completed. As a result, resharding has a regression where that metadata is lost after a successful reshard.
    
The first commit restores the variable in the RGWBucketReshard class that maintains the bucket attributes, so they can be saved when the bucket instance object is updated.

There appears to be a long-standing bug in RGW such that when resharding is cancelled and the bucket instance is updated to reflect the new resharding status, the xattrs were lost. The xattrs are used to store metadata such as ACLs and LifeCycle policies.
    
The second commit makes sure that all call paths that lead to a cancelled reshard provide the xattrs, so they can be included when the bucket instance info is updated.

Additionally, @cbodley contributed tests.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
