### PR TITLE
common: fix compilation warnings in numa.cc

### DIFF
--- a/src/common/numa.cc
+++ b/src/common/numa.cc
@@ -156,6 +156,7 @@ static int easy_readdir(const std::string& dir, std::set<std::string> *out)
   return 0;
 }
 
+#ifdef HAVE_DPDK
 static std::string get_task_comm(pid_t tid)
 {
   static const char* comm_fmt = "/proc/self/task/%d/comm";
@@ -173,7 +174,7 @@ static std::string get_task_comm(pid_t tid)
   if (n < 0) {
     return "";
   }
-  assert(n <= sizeof(name));
+  assert(static_cast<size_t>(n) <= sizeof(name));
   if (name[n - 1] == '\n') {
     name[n - 1] = '\0';
   } else {
@@ -181,6 +182,7 @@ static std::string get_task_comm(pid_t tid)
   }
   return name;
 }
+#endif
 
 int set_cpu_affinity_all_threads(size_t cpu_set_size, cpu_set_t *cpu_set)
 {


### PR DESCRIPTION
```
[141/1591] Building CXX object src/common/CMakeFiles/common-common-objs.dir/numa.cc.o
In file included from ../src/include/types.h:63,
                 from ../src/include/stringify.h:7,
                 from ../src/common/numa.cc:10:
../src/common/numa.cc: In function ‘std::string get_task_comm(pid_t)’:
../src/common/numa.cc:176:12: warning: comparison of integer expressions of different signedness: ‘ssize_t’ {aka ‘long int’} and ‘long unsigned int’ [-Wsign-compare]
  176 |   assert(n <= sizeof(name));
      |          ~~^~~~~~~~~~~~~~~
../src/common/numa.cc: At global scope:
../src/common/numa.cc:159:20: warning: ‘std::string get_task_comm(pid_t)’ defined but not used [-Wunused-function]
  159 | static std::string get_task_comm(pid_t tid)
      |                    ^~~~~~~~~~~~~

```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
