### PR TITLE
fix the file system takes a long time to build with iscsi disk of rbd

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7524,6 +7524,10 @@ static std::vector<Option> get_rbd_options() {
     .set_min(1)
     .set_description("minimum schedule tick (in milliseconds) for QoS"),
 
+    Option("rbd_discard_with_qos", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("discard and writesame don't use qos"),
+
     Option("rbd_discard_on_zeroed_write_same", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description("discard data on zeroed write same instead of writing zero"),

--- a/src/librbd/io/ImageDispatchSpec.cc
+++ b/src/librbd/io/ImageDispatchSpec.cc
@@ -98,6 +98,20 @@ struct ImageDispatchSpec<I>::TokenRequestedVisitor
     return true;
   }
 
+  uint64_t operator()(const Discard&) const {
+    if (spec->m_image_ctx.cct->_conf.template get_val<bool>("rbd_discard_with_qos")) {
+      if (flag & RBD_QOS_READ_MASK) {
+        *tokens = 0;
+        return false;
+      }
+      *tokens = (flag & RBD_QOS_BPS_MASK) ? spec->extents_length() : 1;
+      return true;
+    }
+
+    *tokens = 0;
+    return true;
+  }
+
   template <typename T>
   uint64_t operator()(const T&) const {
     if (flag & RBD_QOS_READ_MASK) {


### PR DESCRIPTION
Set the BPS QoS of RBD image to 150MB/s and the size of RBD to 100G, and then use the iSCSI disk of the image to make the file system. It takes 15 minutes, which is not allowed in the production environment. 

So I added a parameter to enable discard to bypass QoS



Fixes :https://tracker.ceph.com/issues/54027
Signed-off-by: pkulijiawei <lijiawei1@chinatelecom.cn>
Review-by: wuxuehan <wuxuehan@chinatelecom.cn>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
