### PR TITLE
Allow containers to access files labeled as cert_t

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -16,6 +16,8 @@ require {
 	type targetd_etc_rw_t;
 	type amqp_port_t;
 	type soundd_port_t;
+	type container_t;
+	type cert_t;
 	class sock_file unlink;
 	class tcp_socket name_connect_t;
 	class lnk_file { create getattr read unlink };
@@ -161,3 +163,10 @@ fsadm_manage_pid(ceph_t)
 
 #============= setfiles_t ==============
 allow setfiles_t ceph_var_lib_t:file write;
+
+#============= container_t ==============
+allow container_t cert_t:file read;
+allow container_t cert_t:file open;
+allow container_t cert_t:file getattr;
+allow container_t cert_t:dir read;
+allow container_t cert_t:dir search;


### PR DESCRIPTION
Initially binding `/etc/pki/ca-trust/extracted:z` to mon/rgw containers
was done to solve an OSP TripleO issue on RHEL (ceph#3638) but by using the z flag it brought other issues like https://bugzilla.redhat.com/show_bug.cgi?id=2026953
The z flag prevents local services (like sssd) running on the host accessing the certificates/files in that folder.

Solving this requires to modify the ceph-selinux package to allow
container_t flagged processes to have access to files/folders labelled with
cert_t and use ro instead of z flag.

2 PR are created to solve this issue. One for ceph-selinux and another one for
ceph-ansible (https://github.com/ceph/ceph-ansible/pull/7061)

Signed-off-by: Teoman ONAY <tonay@redhat.com>