### PR TITLE
crimson/os/seastore: allow EPM to make decisions on the general allocation path

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1017,13 +1017,17 @@ record_t Cache::prepare_record(Transaction &t)
                i->get_type()).increment(i->get_length());
     retire_stat.increment(i->get_length());
     commit_retire_extent(t, i);
-    if (i->backend_type == device_type_t::RANDOM_BLOCK) {
+    // FIXME: whether the extent belongs to RBM should be available through its
+    // device-id from its paddr after RBM is properly integrated.
+    /*
+    if (i belongs to RBM) {
       paddr_t paddr = i->get_paddr();
       rbm_alloc_delta_t delta;
       delta.op = rbm_alloc_delta_t::op_types_t::CLEAR;
       delta.alloc_blk_ranges.push_back(std::make_pair(paddr, i->get_length()));
       t.add_rbm_alloc_info_blocks(delta);
     }
+    */
   }
 
   record.extents.reserve(t.inline_block_list.size());

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -25,8 +25,10 @@ SET_SUBSYS(seastore_cache);
 namespace crimson::os::seastore {
 
 Cache::Cache(
-  ExtentReader &reader)
+  ExtentReader &reader,
+  ExtentPlacementManager &epm)
   : reader(reader),
+    epm(epm),
     lru(crimson::common::get_conf<Option::size_t>(
 	  "seastore_cache_lru_size"))
 {

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -855,37 +855,37 @@ CachedExtentRef Cache::alloc_new_extent_by_type(
   Transaction &t,       ///< [in, out] current transaction
   extent_types_t type,  ///< [in] type tag
   seastore_off_t length, ///< [in] length
-  bool delay 		///< [in] whether to delay paddr alloc
+  placement_hint_t hint
 )
 {
   LOG_PREFIX(Cache::alloc_new_extent_by_type);
-  SUBDEBUGT(seastore_cache, "allocate {} {}B, delay={}",
-            t, type, length, delay);
+  SUBDEBUGT(seastore_cache, "allocate {} {}B, hint={}",
+            t, type, length, hint);
   switch (type) {
   case extent_types_t::ROOT:
     ceph_assert(0 == "ROOT is never directly alloc'd");
     return CachedExtentRef();
   case extent_types_t::LADDR_INTERNAL:
-    return alloc_new_extent<lba_manager::btree::LBAInternalNode>(t, length, delay);
+    return alloc_new_extent<lba_manager::btree::LBAInternalNode>(t, length, hint);
   case extent_types_t::LADDR_LEAF:
-    return alloc_new_extent<lba_manager::btree::LBALeafNode>(t, length, delay);
+    return alloc_new_extent<lba_manager::btree::LBALeafNode>(t, length, hint);
   case extent_types_t::ONODE_BLOCK_STAGED:
-    return alloc_new_extent<onode::SeastoreNodeExtent>(t, length, delay);
+    return alloc_new_extent<onode::SeastoreNodeExtent>(t, length, hint);
   case extent_types_t::OMAP_INNER:
-    return alloc_new_extent<omap_manager::OMapInnerNode>(t, length, delay);
+    return alloc_new_extent<omap_manager::OMapInnerNode>(t, length, hint);
   case extent_types_t::OMAP_LEAF:
-    return alloc_new_extent<omap_manager::OMapLeafNode>(t, length, delay);
+    return alloc_new_extent<omap_manager::OMapLeafNode>(t, length, hint);
   case extent_types_t::COLL_BLOCK:
-    return alloc_new_extent<collection_manager::CollectionNode>(t, length, delay);
+    return alloc_new_extent<collection_manager::CollectionNode>(t, length, hint);
   case extent_types_t::OBJECT_DATA_BLOCK:
-    return alloc_new_extent<ObjectDataBlock>(t, length, delay);
+    return alloc_new_extent<ObjectDataBlock>(t, length, hint);
   case extent_types_t::RETIRED_PLACEHOLDER:
     ceph_assert(0 == "impossible");
     return CachedExtentRef();
   case extent_types_t::TEST_BLOCK:
-    return alloc_new_extent<TestBlock>(t, length, delay);
+    return alloc_new_extent<TestBlock>(t, length, hint);
   case extent_types_t::TEST_BLOCK_PHYSICAL:
-    return alloc_new_extent<TestBlockPhysical>(t, length, delay);
+    return alloc_new_extent<TestBlockPhysical>(t, length, hint);
   case extent_types_t::NONE: {
     ceph_assert(0 == "NONE is an invalid extent type");
     return CachedExtentRef();

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -100,12 +100,8 @@ public:
     crimson::ct_error::input_output_error>;
   using base_iertr = trans_iertr<base_ertr>;
 
-  Cache(ExtentReader &reader);
+  Cache(ExtentReader &reader, ExtentPlacementManager &epm);
   ~Cache();
-
-  void set_epm(ExtentPlacementManager& epm) {
-    p_epm = &epm;
-  }
 
   /// Creates empty transaction by source
   TransactionRef create_transaction(
@@ -501,7 +497,7 @@ public:
     LOG_PREFIX(Cache::alloc_new_extent);
     SUBTRACET(seastore_cache, "allocate {} {}B, hint={}",
               t, T::TYPE, length, hint);
-    auto result = p_epm->alloc_new_extent(t, T::TYPE, length, hint);
+    auto result = epm.alloc_new_extent(t, T::TYPE, length, hint);
     auto ret = CachedExtent::make_cached_extent_ref<T>(std::move(result.bp));
     ret->set_paddr(result.paddr);
     t.add_fresh_extent(ret);
@@ -740,7 +736,7 @@ public:
 
 private:
   ExtentReader &reader;	   	   ///< ref to extent reader
-  ExtentPlacementManager* p_epm = nullptr;
+  ExtentPlacementManager& epm;
   RootBlockRef root;               ///< ref to current root
   ExtentIndex extents;             ///< set of live extents
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -503,26 +503,6 @@ public:
     return ret;
   }
 
-  void mark_delayed_extent_inline(
-    Transaction& t,
-    LogicalCachedExtentRef& ref
-  ) {
-    LOG_PREFIX(Cache::mark_delayed_extent_inline);
-    SUBDEBUGT(seastore_cache, "-- {}", t, *ref);
-    t.mark_delayed_extent_inline(ref);
-  }
-
-  void mark_delayed_extent_ool(
-    Transaction& t,
-    LogicalCachedExtentRef& ref,
-    paddr_t final_addr
-  ) {
-    LOG_PREFIX(Cache::mark_delayed_extent_ool);
-    SUBDEBUGT(seastore_cache, "final_addr={} -- {}",
-              t, final_addr, *ref);
-    t.mark_delayed_extent_ool(ref, final_addr);
-  }
-
   /**
    * alloc_new_extent
    *

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -335,9 +335,6 @@ public:
 
   virtual ~CachedExtent();
 
-  /// type of the backend device that will hold this extent
-  device_type_t backend_type = device_type_t::NONE;
-
   /// hint for allocators
   placement_hint_t hint = placement_hint_t::NUM_HINTS;
 

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -17,11 +17,9 @@ namespace crimson::os::seastore {
 
 SegmentedAllocator::SegmentedAllocator(
   SegmentProvider& sp,
-  SegmentManager& sm,
-  Journal& journal)
+  SegmentManager& sm)
   : segment_provider(sp),
-    segment_manager(sm),
-    journal(journal)
+    segment_manager(sm)
 {
   std::generate_n(
     std::back_inserter(writers),
@@ -30,8 +28,7 @@ SegmentedAllocator::SegmentedAllocator(
     [&] {
       return Writer{
 	segment_provider,
-	segment_manager,
-	journal};
+	segment_manager};
       });
 }
 
@@ -201,7 +198,7 @@ SegmentedAllocator::Writer::init_segment(Segment& segment) {
       segment_manager.get_block_size()));
   bp.zero();
   auto header =segment_header_t{
-    journal.get_segment_seq(),
+    OOL_SEG_SEQ,
     segment.get_segment_id(),
     NO_DELTAS, 0, true};
   logger().debug("SegmentedAllocator::Writer::init_segment: initting {}, {}",

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -1,8 +1,10 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 smarttab expandtab
 
-#include "crimson/os/seastore/journal.h"
 #include "crimson/os/seastore/extent_placement_manager.h"
+
+#include "crimson/os/seastore/lba_manager.h"
+#include "crimson/os/seastore/segment_cleaner.h"
 
 namespace {
   seastar::logger& logger() {
@@ -18,13 +20,11 @@ SegmentedAllocator::SegmentedAllocator(
   SegmentProvider& sp,
   SegmentManager& sm,
   LBAManager& lba_manager,
-  Journal& journal,
-  Cache& cache)
+  Journal& journal)
   : segment_provider(sp),
     segment_manager(sm),
     lba_manager(lba_manager),
-    journal(journal),
-    cache(cache)
+    journal(journal)
 {
   std::generate_n(
     std::back_inserter(writers),
@@ -35,8 +35,7 @@ SegmentedAllocator::SegmentedAllocator(
 	segment_provider,
 	segment_manager,
 	lba_manager,
-	journal,
-        cache};
+	journal};
       });
 }
 

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -200,7 +200,7 @@ SegmentedAllocator::Writer::init_segment(Segment& segment) {
   auto header =segment_header_t{
     OOL_SEG_SEQ,
     segment.get_segment_id(),
-    NO_DELTAS, 0, true};
+    NO_DELTAS, 0};
   logger().debug("SegmentedAllocator::Writer::init_segment: initting {}, {}",
     segment.get_segment_id(),
     header);

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -57,10 +57,11 @@ SegmentedAllocator::Writer::finish_write(
       lextent->get_laddr(),
       lextent->get_paddr(),
       ool_extent.get_ool_paddr()
-    ).si_then([&ool_extent, &t, &lextent, this] {
+    ).si_then([&ool_extent, &t, &lextent, this, FNAME] {
       lextent->backend_type = device_type_t::NONE;
       lextent->hint = {};
-      cache.mark_delayed_extent_ool(t, lextent, ool_extent.get_ool_paddr());
+      TRACET("mark extent as ool at {} -- {}", t, ool_extent.get_ool_paddr(), *lextent);
+      t.mark_delayed_extent_ool(lextent, ool_extent.get_ool_paddr());
       return finish_record_iertr::now();
     });
   }).si_then([&record] {

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -58,7 +58,6 @@ SegmentedAllocator::Writer::finish_write(
       lextent->get_paddr(),
       ool_extent.get_ool_paddr()
     ).si_then([&ool_extent, &t, &lextent, this, FNAME] {
-      lextent->backend_type = device_type_t::NONE;
       lextent->hint = {};
       TRACET("mark extent as ool at {} -- {}", t, ool_extent.get_ool_paddr(), *lextent);
       t.mark_delayed_extent_ool(lextent, ool_extent.get_ool_paddr());

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -252,7 +252,7 @@ SegmentedAllocator::Writer::roll_segment(bool set_rolling) {
   }
 
   return segment_provider.get_segment(
-    segment_manager.get_device_id()
+    segment_manager.get_device_id(), OOL_SEG_SEQ
   ).safe_then([this](auto segment) {
     return segment_manager.open(segment);
   }).safe_then([this](auto segref) {

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -163,7 +163,6 @@ struct open_segment_wrapper_t : public boost::intrusive_ref_counter<
 using open_segment_wrapper_ref =
   boost::intrusive_ptr<open_segment_wrapper_t>;
 
-class LBAManager;
 class SegmentProvider;
 
 /**
@@ -185,11 +184,9 @@ class SegmentedAllocator : public ExtentAllocator {
     Writer(
       SegmentProvider& sp,
       SegmentManager& sm,
-      LBAManager& lba_manager,
       Journal& journal)
       : segment_provider(sp),
         segment_manager(sm),
-        lba_manager(lba_manager),
         journal(journal)
     {}
     Writer(Writer &&) = default;
@@ -205,13 +202,6 @@ class SegmentedAllocator : public ExtentAllocator {
       });
     }
   private:
-    using finish_record_ertr = crimson::errorator<
-      crimson::ct_error::input_output_error>;
-    using finish_record_iertr = trans_iertr<finish_record_ertr>;
-    using finish_record_ret = finish_record_iertr::future<>;
-    finish_record_ret finish_write(
-      Transaction& t,
-      ool_record_t& record);
     bool _needs_roll(seastore_off_t length) const;
 
     write_iertr::future<> _write(
@@ -235,7 +225,6 @@ class SegmentedAllocator : public ExtentAllocator {
     open_segment_wrapper_ref current_segment;
     std::list<open_segment_wrapper_ref> open_segments;
     seastore_off_t allocated_to = 0;
-    LBAManager& lba_manager;
     Journal& journal;
     crimson::condition_variable segment_rotation_guard;
     seastar::gate writer_guard;
@@ -245,7 +234,6 @@ public:
   SegmentedAllocator(
     SegmentProvider& sp,
     SegmentManager& sm,
-    LBAManager& lba_manager,
     Journal& journal);
 
   Writer &get_writer(placement_hint_t hint) {
@@ -281,15 +269,12 @@ private:
   SegmentProvider& segment_provider;
   SegmentManager& segment_manager;
   std::vector<Writer> writers;
-  LBAManager& lba_manager;
   Journal& journal;
 };
 
 class ExtentPlacementManager {
 public:
-  ExtentPlacementManager(
-    LBAManager& lba_manager
-  ) : lba_manager(lba_manager) {}
+  ExtentPlacementManager() = default;
 
   struct alloc_result_t {
     paddr_t paddr;
@@ -332,34 +317,25 @@ public:
   /**
    * delayed_alloc_or_ool_write
    *
-   * Performs any outstanding ool writes and updates pending lba updates
-   * accordingly
+   * Performs delayed allocation and do writes for out-of-line extents.
    */
   using alloc_paddr_iertr = ExtentOolWriter::write_iertr;
   alloc_paddr_iertr::future<> delayed_alloc_or_ool_write(
-    Transaction& t) {
+    Transaction& t,
+    const std::list<LogicalCachedExtentRef>& delayed_extents) {
     LOG_PREFIX(ExtentPlacementManager::delayed_alloc_or_ool_write);
-    SUBDEBUGT(seastore_tm, "start", t);
+    SUBDEBUGT(seastore_tm, "start with {} delayed extents",
+              t, delayed_extents.size());
     return seastar::do_with(
         std::map<ExtentAllocator*, std::list<LogicalCachedExtentRef>>(),
-        [this, &t](auto& alloc_map) {
-      LOG_PREFIX(ExtentPlacementManager::delayed_alloc_or_ool_write);
-      auto& alloc_list = t.get_delayed_alloc_list();
-      uint64_t num_ool_extents = 0;
-      for (auto& extent : alloc_list) {
-        // extents may be invalidated
-        if (!extent->is_valid()) {
-          t.increment_delayed_invalid_extents();
-          continue;
-        }
+        [this, &t, &delayed_extents](auto& alloc_map) {
+      for (auto& extent : delayed_extents) {
         // For now, just do ool allocation for any delayed extent
         auto& allocator_ptr = get_allocator(
           get_allocator_type(extent->hint), extent->hint
         );
         alloc_map[allocator_ptr.get()].emplace_back(extent);
-        num_ool_extents++;
       }
-      SUBDEBUGT(seastore_tm, "{} ool extents", t, num_ool_extents);
       return trans_intr::do_for_each(alloc_map, [&t](auto& p) {
         auto allocator = p.first;
         auto& extents = p.second;
@@ -388,7 +364,6 @@ private:
     return devices[std::rand() % devices.size()];
   }
 
-  LBAManager& lba_manager;
   std::map<device_type_t, std::vector<ExtentAllocatorRef>> allocators;
 };
 using ExtentPlacementManagerRef = std::unique_ptr<ExtentPlacementManager>;

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -7,7 +7,6 @@
 
 #include "crimson/common/condition_variable.h"
 #include "crimson/os/seastore/cached_extent.h"
-#include "crimson/os/seastore/journal.h"
 #include "crimson/os/seastore/logging.h"
 #include "crimson/os/seastore/segment_manager.h"
 #include "crimson/os/seastore/transaction.h"
@@ -183,11 +182,9 @@ class SegmentedAllocator : public ExtentAllocator {
   public:
     Writer(
       SegmentProvider& sp,
-      SegmentManager& sm,
-      Journal& journal)
+      SegmentManager& sm)
       : segment_provider(sp),
-        segment_manager(sm),
-        journal(journal)
+        segment_manager(sm)
     {}
     Writer(Writer &&) = default;
 
@@ -225,7 +222,6 @@ class SegmentedAllocator : public ExtentAllocator {
     open_segment_wrapper_ref current_segment;
     std::list<open_segment_wrapper_ref> open_segments;
     seastore_off_t allocated_to = 0;
-    Journal& journal;
     crimson::condition_variable segment_rotation_guard;
     seastar::gate writer_guard;
     bool rolling_segment = false;
@@ -233,8 +229,7 @@ class SegmentedAllocator : public ExtentAllocator {
 public:
   SegmentedAllocator(
     SegmentProvider& sp,
-    SegmentManager& sm,
-    Journal& journal);
+    SegmentManager& sm);
 
   Writer &get_writer(placement_hint_t hint) {
     return writers[std::rand() % writers.size()];
@@ -269,7 +264,6 @@ private:
   SegmentProvider& segment_provider;
   SegmentManager& segment_manager;
   std::vector<Writer> writers;
-  Journal& journal;
 };
 
 class ExtentPlacementManager {

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -312,7 +312,6 @@ public:
                   can_delay_allocation(dtype));
     CachedExtentRef extent = cache.alloc_new_extent_by_type(
         t, type, length, delay);
-    extent->backend_type = dtype;
     extent->hint = hint;
     return extent;
   }
@@ -333,7 +332,6 @@ public:
                   can_delay_allocation(dtype));
     TCachedExtentRef<T> extent = cache.alloc_new_extent<T>(
         t, length, delay);
-    extent->backend_type = dtype;
     extent->hint = hint;
     return extent;
   }
@@ -363,7 +361,7 @@ public:
         }
         // For now, just do ool allocation for any delayed extent
         auto& allocator_ptr = get_allocator(
-          extent->backend_type, extent->hint
+          get_allocator_type(extent->hint), extent->hint
         );
         alloc_map[allocator_ptr.get()].emplace_back(extent);
         num_ool_extents++;

--- a/src/crimson/os/seastore/extent_reader.cc
+++ b/src/crimson/os/seastore/extent_reader.cc
@@ -114,6 +114,7 @@ ExtentReader::scan_valid_records_ret ExtentReader::scan_valid_records(
   auto& segment_manager =
     *segment_managers[cursor.get_segment_id().device_id()];
   if (cursor.get_segment_offset() == 0) {
+    INFO("start to scan segment {}", cursor.get_segment_id());
     cursor.increment_seq(segment_manager.get_block_size());
   }
   DEBUG("starting at {}, budget={}", cursor, budget);

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -194,6 +194,7 @@ Journal::replay_segment(
             record_deltas.deltas,
             [locator,
              this,
+             FNAME,
              &handler](delta_info_t& delta)
           {
             /* The journal may validly contain deltas for extents in
@@ -211,6 +212,11 @@ Journal::replay_segment(
               if (delta_paddr_segment_type == segment_type_t::NULL_SEG ||
                   (delta_paddr_segment_type == segment_type_t::JOURNAL &&
                    delta_paddr_segment_seq > locator_segment_seq)) {
+                SUBDEBUG(seastore_cache,
+                         "delta is obsolete, delta_paddr_segment_seq={}, locator_segment_seq={} -- {}",
+                         segment_seq_printer_t{delta_paddr_segment_seq},
+                         segment_seq_printer_t{locator_segment_seq},
+                         delta);
                 return replay_ertr::now();
               }
             }

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -385,7 +385,8 @@ Journal::JournalSegmentManager::roll()
     current_journal_segment->close() :
     Segment::close_ertr::now()
   ).safe_then([this] {
-    return segment_provider->get_segment(get_device_id());
+    return segment_provider->get_segment(
+        get_device_id(), next_journal_segment_seq);
   }).safe_then([this](auto segment) {
     return segment_manager.open(segment);
   }).safe_then([this](auto sref) {
@@ -395,9 +396,6 @@ Journal::JournalSegmentManager::roll()
     if (old_segment_id != NULL_SEG_ID) {
       segment_provider->close_segment(old_segment_id);
     }
-    segment_provider->set_journal_segment(
-      current_journal_segment->get_segment_id(),
-      get_segment_seq());
   }).handle_error(
     roll_ertr::pass_further{},
     crimson::ct_error::assert_all{

--- a/src/crimson/os/seastore/lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager.cc
@@ -6,9 +6,43 @@
 #include "crimson/os/seastore/lba_manager.h"
 #include "crimson/os/seastore/lba_manager/btree/btree_lba_manager.h"
 
-namespace crimson::os::seastore::lba_manager {
+namespace crimson::os::seastore {
 
-LBAManagerRef create_lba_manager(
+LBAManager::update_mappings_ret
+LBAManager::update_mappings(
+  Transaction& t,
+  const std::list<LogicalCachedExtentRef>& extents,
+  const std::vector<paddr_t>& original_paddrs)
+{
+  assert(extents.size() == original_paddrs.size());
+  auto extents_end = extents.end();
+  return seastar::do_with(
+      extents.begin(),
+      original_paddrs.begin(),
+      [this, extents_end, &t](auto& iter_extents,
+                              auto& iter_original_paddrs) {
+    return trans_intr::repeat(
+      [this, extents_end, &t, &iter_extents, &iter_original_paddrs]
+    {
+      if (extents_end == iter_extents) {
+        return update_mappings_iertr::make_ready_future<
+          seastar::stop_iteration>(seastar::stop_iteration::yes);
+      }
+      return update_mapping(
+          t,
+          (*iter_extents)->get_laddr(),
+          *iter_original_paddrs,
+          (*iter_extents)->get_paddr()
+      ).si_then([&iter_extents, &iter_original_paddrs] {
+        ++iter_extents;
+        ++iter_original_paddrs;
+        return seastar::stop_iteration::no;
+      });
+    });
+  });
+}
+
+LBAManagerRef lba_manager::create_lba_manager(
   SegmentManager &segment_manager,
   Cache &cache) {
   return LBAManagerRef(new btree::BtreeLBAManager(segment_manager, cache));

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -164,13 +164,13 @@ public:
     CachedExtentRef extent) = 0;
 
   /**
-   * delayed_update_mapping
+   * update_mapping
    *
-   * update lba mapping for delayed allocated extents
+   * update lba mapping for a delayed allocated extent
    */
-  using update_le_mapping_iertr = base_iertr;
-  using update_le_mapping_ret = base_iertr::future<>;
-  virtual update_le_mapping_ret update_mapping(
+  using update_mapping_iertr = base_iertr;
+  using update_mapping_ret = base_iertr::future<>;
+  virtual update_mapping_ret update_mapping(
     Transaction& t,
     laddr_t laddr,
     paddr_t prev_addr,

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -175,6 +175,19 @@ public:
     laddr_t laddr,
     paddr_t prev_addr,
     paddr_t paddr) = 0;
+
+  /**
+   * update_mappings
+   *
+   * update lba mappings for delayed allocated extents
+   */
+  using update_mappings_iertr = update_mapping_iertr;
+  using update_mappings_ret = update_mapping_ret;
+  update_mappings_ret update_mappings(
+    Transaction& t,
+    const std::list<LogicalCachedExtentRef>& extents,
+    const std::vector<paddr_t>& original_paddrs);
+
   /**
    * get_physical_extent_if_live
    *

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -102,7 +102,7 @@ public:
     Transaction &t,
     CachedExtentRef extent) final;
 
-  update_le_mapping_ret update_mapping(
+  update_mapping_ret update_mapping(
     Transaction& t,
     laddr_t laddr,
     paddr_t prev_addr,
@@ -217,16 +217,16 @@ private:
     int delta);
 
   /**
-   * update_mapping
+   * _update_mapping
    *
    * Updates mapping, removes if f returns nullopt
    */
-  using update_mapping_iertr = ref_iertr;
-  using update_mapping_ret = ref_iertr::future<lba_map_val_t>;
+  using _update_mapping_iertr = ref_iertr;
+  using _update_mapping_ret = ref_iertr::future<lba_map_val_t>;
   using update_func_t = std::function<
     lba_map_val_t(const lba_map_val_t &v)
     >;
-  update_mapping_ret update_mapping(
+  _update_mapping_ret _update_mapping(
     Transaction &t,
     laddr_t addr,
     update_func_t &&f);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1418,7 +1418,8 @@ seastar::future<std::unique_ptr<SeaStore>> make_seastore(
     auto cache = std::make_unique<Cache>(scanner_ref);
     auto lba_manager = lba_manager::create_lba_manager(*sm, *cache);
 
-    auto epm = std::make_unique<ExtentPlacementManager>(*cache, *lba_manager);
+    auto epm = std::make_unique<ExtentPlacementManager>(*lba_manager);
+    cache->set_epm(*epm);
 
     journal->set_segment_provider(&*segment_cleaner);
 

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1415,11 +1415,9 @@ seastar::future<std::unique_ptr<SeaStore>> make_seastore(
       false /* detailed */);
 
     auto journal = std::make_unique<Journal>(*sm, scanner_ref);
-    auto cache = std::make_unique<Cache>(scanner_ref);
+    auto epm = std::make_unique<ExtentPlacementManager>();
+    auto cache = std::make_unique<Cache>(scanner_ref, *epm);
     auto lba_manager = lba_manager::create_lba_manager(*sm, *cache);
-
-    auto epm = std::make_unique<ExtentPlacementManager>(*lba_manager);
-    cache->set_epm(*epm);
 
     journal->set_segment_provider(&*segment_cleaner);
 

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -64,7 +64,7 @@ std::ostream &operator<<(std::ostream &out, const paddr_t &rhs)
     out << "BLOCK_REG";
   } else if (rhs.is_record_relative()) {
     out << "RECORD_REG";
-  } else if (rhs.get_device_id() == DEVICE_ID_DELAYED) {
+  } else if (rhs.is_delayed()) {
     out << "DELAYED_TEMP";
   } else if (rhs.get_addr_type() == addr_types_t::SEGMENT) {
     const seg_paddr_t& s = rhs.as_seg_paddr();

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -42,6 +42,43 @@ std::ostream &offset_to_stream(std::ostream &out, const seastore_off_t &t)
     return out << t;
 }
 
+std::ostream& operator<<(std::ostream& out, segment_type_t t)
+{
+  switch(t) {
+  case segment_type_t::JOURNAL:
+    return out << "JOURNAL";
+  case segment_type_t::OOL:
+    return out << "OOL";
+  case segment_type_t::NULL_SEG:
+    return out << "NULL_SEG";
+  default:
+    return out << "INVALID_SEGMENT_TYPE!";
+  }
+}
+
+segment_type_t segment_seq_to_type(segment_seq_t seq)
+{
+  if (seq <= MAX_VALID_SEG_SEQ) {
+    return segment_type_t::JOURNAL;
+  } else if (seq == OOL_SEG_SEQ) {
+    return segment_type_t::OOL;
+  } else {
+    assert(seq == NULL_SEG_SEQ);
+    return segment_type_t::NULL_SEG;
+  }
+}
+
+std::ostream& operator<<(std::ostream& out, segment_seq_printer_t seq)
+{
+  auto type = segment_seq_to_type(seq.seq);
+  switch(type) {
+  case segment_type_t::JOURNAL:
+    return out << seq.seq;
+  default:
+    return out << type;
+  }
+}
+
 std::ostream &operator<<(std::ostream &out, const segment_id_t& segment)
 {
   return out << "[" << (uint64_t)segment.device_id() << ","
@@ -83,7 +120,7 @@ std::ostream &operator<<(std::ostream &out, const paddr_t &rhs)
 std::ostream &operator<<(std::ostream &out, const journal_seq_t &seq)
 {
   return out << "journal_seq_t("
-             << "segment_seq=" << seq.segment_seq
+             << "segment_seq=" << segment_seq_printer_t{seq.segment_seq}
              << ", offset=" << seq.offset
              << ")";
 }
@@ -164,11 +201,10 @@ std::ostream &operator<<(std::ostream &out, const extent_info_t &info)
 std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
 {
   return out << "segment_header_t("
-	     << "segment_seq=" << header.journal_segment_seq
+	     << "segment_seq=" << segment_seq_printer_t{header.journal_segment_seq}
 	     << ", segment_id=" << header.physical_segment_id
 	     << ", journal_tail=" << header.journal_tail
 	     << ", segment_nonce=" << header.segment_nonce
-	     << ", out-of-line=" << header.out_of_line
 	     << ")";
 }
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -482,6 +482,9 @@ public:
 
   paddr_t operator-(paddr_t rhs) const;
 
+  bool is_delayed() const {
+    return get_device_id() == DEVICE_ID_DELAYED;
+  }
   bool is_block_relative() const {
     return get_device_id() == DEVICE_ID_BLOCK_RELATIVE;
   }
@@ -667,7 +670,7 @@ constexpr paddr_t make_block_relative_paddr(seastore_off_t off) {
 constexpr paddr_t make_fake_paddr(seastore_off_t off) {
   return paddr_t::make_seg_paddr(FAKE_SEG_ID, off);
 }
-constexpr paddr_t delayed_temp_paddr(seastore_off_t off) {
+constexpr paddr_t make_delayed_temp_paddr(seastore_off_t off) {
   return paddr_t::make_seg_paddr(
     segment_id_t{DEVICE_ID_DELAYED, 0},
     off);

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -191,10 +191,11 @@ std::ostream &offset_to_stream(std::ostream &, const seastore_off_t &t);
 /* Monotonically increasing segment seq, uniquely identifies
  * the incarnation of a segment */
 using segment_seq_t = uint32_t;
-static constexpr segment_seq_t NULL_SEG_SEQ =
-  std::numeric_limits<segment_seq_t>::max();
 static constexpr segment_seq_t MAX_SEG_SEQ =
   std::numeric_limits<segment_seq_t>::max();
+static constexpr segment_seq_t NULL_SEG_SEQ = MAX_SEG_SEQ;
+static constexpr segment_seq_t OOL_SEG_SEQ = MAX_SEG_SEQ - 1;
+static constexpr segment_seq_t MAX_VALID_SEG_SEQ = MAX_SEG_SEQ - 2;
 
 // Offset of delta within a record
 using record_delta_idx_t = uint32_t;

--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -283,6 +283,7 @@ SegmentCleaner::rewrite_dirty_ret SegmentCleaner::rewrite_dirty(
     limit,
     config.journal_rewrite_per_cycle
   ).si_then([=, &t](auto dirty_list) {
+    DEBUGT("rewrite {} dirty extents", t, dirty_list.size());
     return seastar::do_with(
       std::move(dirty_list),
       [FNAME, this, &t](auto &dirty_list) {

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -61,7 +61,7 @@ class segment_info_set_t {
       return segment_seq_to_type(journal_segment_seq);
     }
 
-    void set_open();
+    void set_open(segment_seq_t);
     void set_empty();
     void set_closed();
 
@@ -275,15 +275,13 @@ public:
   using get_segment_ertr = crimson::errorator<
     crimson::ct_error::input_output_error>;
   using get_segment_ret = get_segment_ertr::future<segment_id_t>;
-  virtual get_segment_ret get_segment(device_id_t id) = 0;
+  virtual get_segment_ret get_segment(
+      device_id_t id, segment_seq_t seq) = 0;
 
   virtual void close_segment(segment_id_t) {}
 
-  virtual void set_journal_segment(
-    segment_id_t segment,
-    segment_seq_t seq) {}
-
   virtual journal_seq_t get_journal_tail_target() const = 0;
+
   virtual void update_journal_tail_committed(journal_seq_t tail_committed) = 0;
 
   virtual segment_seq_t get_seq(segment_id_t id) { return 0; }
@@ -717,21 +715,10 @@ public:
   using init_segments_ret = init_segments_ertr::future<init_segments_ret_bare>;
   init_segments_ret init_segments();
 
-  get_segment_ret get_segment(device_id_t id) final;
+  get_segment_ret get_segment(
+      device_id_t id, segment_seq_t seq) final;
 
   void close_segment(segment_id_t segment) final;
-
-  void set_journal_segment(
-    segment_id_t segment, segment_seq_t seq) final {
-    assert(segment.device_id() ==
-      segments[segment.device_id()]->device_id);
-    assert(segment.device_segment_id() <
-      segments[segment.device_id()]->num_segments);
-    segments[segment].journal_segment_seq = seq;
-    segments[segment].out_of_line = false;
-    segments.new_journal_segment();
-    assert(segments[segment].is_open());
-  }
 
   journal_seq_t get_journal_tail_target() const final {
     return journal_tail_target;
@@ -1263,6 +1250,7 @@ private:
       "SegmentCleaner::init_mark_segment_closed: segment {}, seq {}",
       segment,
       segment_seq_printer_t{seq});
+    ceph_assert(segment_seq_to_type(seq) != segment_type_t::NULL_SEG);
     mark_closed(segment);
     segments[segment].journal_segment_seq = seq;
     auto s_type = segments[segment].get_type();
@@ -1311,6 +1299,7 @@ private:
       space_tracker->dump_usage(segment);
       assert(space_tracker->get_usage(segment) == 0);
     }
+    auto s_type = segment_info.get_type();
     segment_info.set_empty();
     stats.empty_segments++;
     crimson::get_logger(ceph_subsys_seastore_cleaner
@@ -1323,7 +1312,6 @@ private:
 	should_block_on_gc(),
 	get_projected_available_ratio(),
 	get_projected_reclaim_ratio());
-    auto s_type = segment_info.get_type();
     ceph_assert(s_type != segment_type_t::NULL_SEG);
     if (s_type == segment_type_t::JOURNAL) {
       segments.journal_segment_emptied();
@@ -1331,7 +1319,7 @@ private:
     maybe_wake_gc_blocked_io();
   }
 
-  void mark_open(segment_id_t segment) {
+  void mark_open(segment_id_t segment, segment_seq_t seq) {
     assert(segment.device_id() ==
       segments[segment.device_id()]->device_id);
     assert(segment.device_segment_id() <
@@ -1339,14 +1327,22 @@ private:
     assert(segments[segment].is_empty());
     assert(segments.get_empty_segments(segment.device_id()) > 0);
     segments.segment_opened(segment);
-    segments[segment].set_open();
+    auto& segment_info = segments[segment];
+    segment_info.set_open(seq);
+
+    auto s_type = segment_info.get_type();
+    ceph_assert(s_type != segment_type_t::NULL_SEG);
+    if (s_type == segment_type_t::JOURNAL) {
+      segments.new_journal_segment();
+    }
     assert(stats.empty_segments > 0);
     stats.empty_segments--;
     crimson::get_logger(ceph_subsys_seastore_cleaner
-      ).info("mark open: {}, empty_segments {}"
+      ).info("mark open: {} {}, empty_segments {}"
 	", opened_segments {}, should_block_on_gc {}"
 	", projected_avail_ratio {}, projected_reclaim_ratio {}",
 	segment,
+	segment_seq_printer_t{seq},
 	stats.empty_segments,
 	segments.get_opened_segments(),
 	should_block_on_gc(),

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -116,15 +116,16 @@ public:
   }
 
   void add_fresh_extent(
-    CachedExtentRef ref,
-    bool delayed = false) {
+    CachedExtentRef ref) {
     ceph_assert(!is_weak());
-    if (delayed) {
+    if (ref->get_paddr().is_delayed()) {
+      assert(ref->get_paddr() == make_delayed_temp_paddr(0));
       assert(ref->is_logical());
       ref->set_paddr(make_delayed_temp_paddr(delayed_temp_offset));
       delayed_temp_offset += ref->get_length();
       delayed_alloc_list.emplace_back(ref->cast<LogicalCachedExtent>());
     } else {
+      assert(ref->get_paddr() == make_record_relative_paddr(0));
       ref->set_paddr(make_record_relative_paddr(offset));
       offset += ref->get_length();
       inline_block_list.push_back(ref);

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -190,8 +190,18 @@ public:
     return to_release;
   }
 
-  auto& get_delayed_alloc_list() {
-    return delayed_alloc_list;
+  auto get_delayed_alloc_list() {
+    std::list<LogicalCachedExtentRef> ret;
+    for (auto& extent : delayed_alloc_list) {
+      // delayed extents may be invalidated
+      if (extent->is_valid()) {
+        ret.push_back(std::move(extent));
+      } else {
+        ++num_delayed_invalid_extents;
+      }
+    }
+    delayed_alloc_list.clear();
+    return ret;
   }
 
   const auto &get_mutated_block_list() {
@@ -346,10 +356,6 @@ public:
   };
   ool_write_stats_t& get_ool_write_stats() {
     return ool_write_stats;
-  }
-
-  void increment_delayed_invalid_extents() {
-    ++num_delayed_invalid_extents;
   }
 
 private:

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -121,7 +121,7 @@ public:
     ceph_assert(!is_weak());
     if (delayed) {
       assert(ref->is_logical());
-      ref->set_paddr(delayed_temp_paddr(delayed_temp_offset));
+      ref->set_paddr(make_delayed_temp_paddr(delayed_temp_offset));
       delayed_temp_offset += ref->get_length();
       delayed_alloc_list.emplace_back(ref->cast<LogicalCachedExtent>());
     } else {

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -381,7 +381,7 @@ TransactionManager::rewrite_logical_extent(
 
   auto lextent = extent->cast<LogicalCachedExtent>();
   cache->retire_extent(t, extent);
-  auto nlextent = epm->alloc_new_extent_by_type(
+  auto nlextent = cache->alloc_new_extent_by_type(
     t,
     lextent->get_type(),
     lextent->get_length(),

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -304,7 +304,7 @@ public:
     LOG_PREFIX(TransactionManager::alloc_extent);
     SUBTRACET(seastore_tm, "{} len={}, placement_hint={}, laddr_hint={}",
               t, T::TYPE, len, placement_hint, laddr_hint);
-    auto ext = epm->alloc_new_extent<T>(
+    auto ext = cache->alloc_new_extent<T>(
       t,
       len,
       placement_hint);
@@ -551,8 +551,7 @@ public:
 	*segment_cleaner,
 	*sm,
 	*lba_manager,
-	*journal,
-	*cache));
+	*journal));
   }
 
   ~TransactionManager();

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -550,7 +550,6 @@ public:
       std::make_unique<SegmentedAllocator>(
 	*segment_cleaner,
 	*sm,
-	*lba_manager,
 	*journal));
   }
 

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -549,8 +549,7 @@ public:
       device_type_t::SEGMENTED,
       std::make_unique<SegmentedAllocator>(
 	*segment_cleaner,
-	*sm,
-	*journal));
+	*sm));
   }
 
   ~TransactionManager();

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -140,20 +140,17 @@ void TMDriver::init()
     false /* detailed */);
   std::vector<SegmentManager*> sms;
   segment_cleaner->mount(segment_manager->get_device_id(), sms);
-  auto journal = std::make_unique<Journal>(*segment_manager, scanner_ref);
-  auto cache = std::make_unique<Cache>(scanner_ref);
+  auto journal = std::make_unique<Journal>(*segment_manager, *scanner);
+  auto epm = std::make_unique<ExtentPlacementManager>();
+  auto cache = std::make_unique<Cache>(scanner_ref, *epm);
   auto lba_manager = lba_manager::create_lba_manager(*segment_manager, *cache);
-
-  auto epm = std::make_unique<ExtentPlacementManager>(*cache, *lba_manager);
 
   epm->add_allocator(
     device_type_t::SEGMENTED,
     std::make_unique<SegmentedAllocator>(
       *segment_cleaner,
       *segment_manager,
-      *lba_manager,
-      *journal,
-      *cache));
+      *journal));
 
   journal->set_segment_provider(&*segment_cleaner);
 

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -149,8 +149,7 @@ void TMDriver::init()
     device_type_t::SEGMENTED,
     std::make_unique<SegmentedAllocator>(
       *segment_cleaner,
-      *segment_manager,
-      *journal));
+      *segment_manager));
 
   journal->set_segment_provider(&*segment_cleaner);
 

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -43,7 +43,7 @@ struct btree_test_base :
 
   void update_segment_avail_bytes(paddr_t offset) final {}
 
-  get_segment_ret get_segment(device_id_t id) final {
+  get_segment_ret get_segment(device_id_t id, segment_seq_t seq) final {
     auto ret = next;
     next = segment_id_t{
       next.device_id(),

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -30,6 +30,7 @@ struct btree_test_base :
   segment_manager::EphemeralSegmentManagerRef segment_manager;
   ExtentReaderRef scanner;
   JournalRef journal;
+  ExtentPlacementManagerRef epm;
   CacheRef cache;
 
   size_t block_size;
@@ -74,7 +75,8 @@ struct btree_test_base :
     segment_manager = segment_manager::create_test_ephemeral();
     scanner.reset(new ExtentReader());
     journal.reset(new Journal(*segment_manager, *scanner));
-    cache.reset(new Cache(*scanner));
+    epm.reset(new ExtentPlacementManager());
+    cache.reset(new Cache(*scanner, *epm));
 
     block_size = segment_manager->get_block_size();
     next = segment_id_t{segment_manager->get_device_id(), 0};
@@ -117,6 +119,7 @@ struct btree_test_base :
       segment_manager.reset();
       scanner.reset();
       journal.reset();
+      epm.reset();
       cache.reset();
     }).handle_error(
       crimson::ct_error::all_same_way([] {

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -22,6 +22,7 @@ namespace {
 struct cache_test_t : public seastar_test_suite_t {
   segment_manager::EphemeralSegmentManagerRef segment_manager;
   ExtentReaderRef reader;
+  ExtentPlacementManagerRef epm;
   CacheRef cache;
   paddr_t current;
   journal_seq_t seq;
@@ -84,7 +85,8 @@ struct cache_test_t : public seastar_test_suite_t {
   seastar::future<> set_up_fut() final {
     segment_manager = segment_manager::create_test_ephemeral();
     reader.reset(new ExtentReader());
-    cache.reset(new Cache(*reader));
+    epm.reset(new ExtentPlacementManager());
+    cache.reset(new Cache(*reader, *epm));
     current = paddr_t::make_seg_paddr(segment_id_t(segment_manager->get_device_id(), 0), 0);
     reader->add_segment_manager(segment_manager.get());
     return segment_manager->init(
@@ -112,6 +114,7 @@ struct cache_test_t : public seastar_test_suite_t {
     ).safe_then([this] {
       segment_manager.reset();
       reader.reset();
+      epm.reset();
       cache.reset();
     }).handle_error(
       Cache::close_ertr::assert_all{}

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -84,7 +84,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
 
   void update_segment_avail_bytes(paddr_t offset) final {}
 
-  get_segment_ret get_segment(device_id_t id) final {
+  get_segment_ret get_segment(device_id_t id, segment_seq_t seq) final {
     auto ret = next;
     next = segment_id_t{
       next.device_id(),

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -147,7 +147,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
 	  [this, &segments](auto segment_id) {
 	  return scanner->read_segment_header(segment_id_t{0, segment_id})
 	  .safe_then([&segments, segment_id](auto header) {
-	    if (!header.out_of_line) {
+	    if (header.get_type() == segment_type_t::JOURNAL) {
 	      segments.emplace_back(
 		std::make_pair(
 		  segment_id_t{0, segment_id},

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -88,8 +88,7 @@ auto get_transaction_manager(
     device_type_t::SEGMENTED,
     std::make_unique<SegmentedAllocator>(
       *segment_cleaner,
-      segment_manager,
-      *journal));
+      segment_manager));
 
   journal->set_segment_provider(&*segment_cleaner);
 

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -80,19 +80,16 @@ auto get_transaction_manager(
     std::move(scanner),
     true);
   auto journal = std::make_unique<Journal>(segment_manager, scanner_ref);
-  auto cache = std::make_unique<Cache>(scanner_ref);
+  auto epm = std::make_unique<ExtentPlacementManager>();
+  auto cache = std::make_unique<Cache>(scanner_ref, *epm);
   auto lba_manager = lba_manager::create_lba_manager(segment_manager, *cache);
-
-  auto epm = std::make_unique<ExtentPlacementManager>(*cache, *lba_manager);
 
   epm->add_allocator(
     device_type_t::SEGMENTED,
     std::make_unique<SegmentedAllocator>(
       *segment_cleaner,
       segment_manager,
-      *lba_manager,
-      *journal,
-      *cache));
+      *journal));
 
   journal->set_segment_provider(&*segment_cleaner);
 


### PR DESCRIPTION
With related refactors to move epm below cache and above device, simplifing its dependencies to Cache, LBAManager, Journal components, with related fixes.

~~TODO: Seems EPM doesn't need to depend on the Journal either.~~ Done.

Verified with rados bench running 400 seconds under the release build.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
