### PR TITLE
rgw/dbstore: Use Object ID to handle I/O concurrency

### DIFF
--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -922,6 +922,7 @@ namespace rgw::sal {
 			       obj->get_obj());
     DB::Object::Write obj_op(&op_target);
 
+    /* Create meta object */
     obj_op.meta.owner = owner.get_id();
     obj_op.meta.category = RGWObjCategory::MultiMeta;
     obj_op.meta.flags = PUT_OBJ_CREATE_EXCL;
@@ -1098,17 +1099,9 @@ namespace rgw::sal {
     /* Original head object */
     DB::Object op_target(store->getDB(),
 			     target_obj->get_bucket()->get_info(),
-			     target_obj->get_obj());
+			     target_obj->get_obj(), get_upload_id());
     DB::Object::Write obj_op(&op_target);
-    obj_op.prepare(NULL);
-
-    /* Meta object */
-    std::unique_ptr<rgw::sal::Object> meta_obj = get_meta_obj();
-    DB::Object meta_op_target(store->getDB(),
-			     meta_obj->get_bucket()->get_info(),
-			     meta_obj->get_obj());
-    DB::Object::Write mp_op(&meta_op_target);
-    mp_op.update_mp_parts(dpp, target_obj->get_obj().key);
+    ret = obj_op.prepare(dpp);
 
     obj_op.meta.owner = owner.get_id();
     obj_op.meta.flags = PUT_OBJ_CREATE;
@@ -1226,12 +1219,13 @@ namespace rgw::sal {
                 oid(head_obj->get_name() + "." + upload_id +
                     "." + std::to_string(part_num)),
                 meta_obj(((DBMultipartUpload*)upload)->get_meta_obj()),
-                op_target(_store->getDB(), meta_obj->get_bucket()->get_info(), meta_obj->get_obj()),
+                op_target(_store->getDB(), head_obj->get_bucket()->get_info(), head_obj->get_obj(), upload_id),
                 parent_op(&op_target), part_num(_part_num),
-                part_num_str(_part_num_str) { parent_op.prepare(NULL);}
+                part_num_str(_part_num_str) {}
 
   int DBMultipartWriter::prepare(optional_yield y)
   {
+    parent_op.prepare(NULL);
     parent_op.set_mp_part_str(upload_id + "." + std::to_string(part_num));
     // XXX: do we need to handle part_num_str??
     return 0;

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -41,7 +41,7 @@ namespace rgw::sal {
     int ret;
 
     buckets.clear();
-    ret = store->getDB()->list_buckets(dpp, info.user_id, marker, end_marker, max,
+    ret = store->getDB()->list_buckets(dpp, "", info.user_id, marker, end_marker, max,
         need_stats, &ulist, &is_truncated);
     if (ret < 0)
       return ret;
@@ -1899,6 +1899,11 @@ namespace rgw::sal {
     if (use_lc_thread) {
       ret = db->createLCTables(dpp);
       lc->start_processor();
+    }
+
+    ret = db->createGC(dpp);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) <<"GC thread creation failed: ret = " << ret << dendl;
     }
 
     return ret;

--- a/src/rgw/store/dbstore/dbstore_main.cc
+++ b/src/rgw/store/dbstore/dbstore_main.cc
@@ -146,7 +146,10 @@ int main(int argc, char *argv[])
 	cout << "loglevel set to " << loglevel << "\n";
   }
 
-  dbsm = new DBStoreManager(logfile, loglevel);
+  vector<const char*> args;
+  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+                CODE_ENVIRONMENT_DAEMON, CINIT_FLAG_NO_MON_CONFIG, 1);
+  dbsm = new DBStoreManager(cct.get(), logfile, loglevel);
   dbs = dbsm->getDB(tenant, true);
 
   cout<<"No. of threads being created = "<<num_thr<<"\n";

--- a/src/rgw/store/dbstore/dbstore_mgr.h
+++ b/src/rgw/store/dbstore/dbstore_mgr.h
@@ -32,11 +32,9 @@ public:
     cct = _cct;
 	default_db = createDB(default_tenant);
   };
-  DBStoreManager(std::string logfile, int loglevel): DBStoreHandles() {
+  DBStoreManager(CephContext *_cct, std::string logfile, int loglevel): DBStoreHandles() {
     /* No ceph context. Create one with log args provided */
-    std::vector<const char*> args;
-    cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
-                      CODE_ENVIRONMENT_DAEMON, CINIT_FLAG_NO_MON_CONFIG, 1)->get();
+    cct = _cct;
     cct->_log->set_log_file(logfile);
     cct->_log->reopen_log_file();
     cct->_conf->subsys.set_log_level(ceph_subsys_rgw, loglevel);

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.h
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.h
@@ -25,10 +25,8 @@ class SQLiteDB : public DB, virtual public DBOp {
 
     SQLiteDB(sqlite3 *dbi, std::string db_name, CephContext *_cct) : DB(db_name, _cct), cct(_cct) {
       db = (void*)dbi;
-      InitPrepareParams(get_def_dpp(), PrepareParams);
     }
     SQLiteDB(std::string db_name, CephContext *_cct) : DB(db_name, _cct), cct(_cct) {
-      InitPrepareParams(get_def_dpp(), PrepareParams);
     }
     ~SQLiteDB() {}
 
@@ -38,7 +36,8 @@ class SQLiteDB : public DB, virtual public DBOp {
     int InitializeDBOps(const DoutPrefixProvider *dpp) override;
     int FreeDBOps(const DoutPrefixProvider *dpp) override;
 
-    int InitPrepareParams(const DoutPrefixProvider *dpp, DBOpPrepareParams &params) override { return 0; }
+    int InitPrepareParams(const DoutPrefixProvider *dpp, DBOpPrepareParams &p_params,
+                          DBOpParams* params) override;
 
     int exec(const DoutPrefixProvider *dpp, const char *schema,
         int (*callback)(void*,int,char**,char**));
@@ -52,7 +51,11 @@ class SQLiteDB : public DB, virtual public DBOp {
     int createUserTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int createObjectTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int createObjectDataTable(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int createObjectView(const DoutPrefixProvider *dpp, DBOpParams *params);
     int createQuotaTable(const DoutPrefixProvider *dpp, DBOpParams *params);
+    void populate_object_params(const DoutPrefixProvider *dpp,
+                                struct DBOpPrepareParams& p_params,
+                                struct DBOpParams* params, bool data);
 
     int createLCTables(const DoutPrefixProvider *dpp) override;
 

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.h
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.h
@@ -213,12 +213,15 @@ class SQLListUserBuckets : public SQLiteDB, public ListUserBucketsOp {
   private:
     sqlite3 **sdb = NULL;
     sqlite3_stmt *stmt = NULL; // Prepared statement
+    sqlite3_stmt *all_stmt = NULL; // Prepared statement
 
   public:
     SQLListUserBuckets(void **db, std::string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
     ~SQLListUserBuckets() {
       if (stmt)
         sqlite3_finalize(stmt);
+      if (all_stmt)
+        sqlite3_finalize(all_stmt);
     }
     int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
     int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
@@ -387,6 +390,24 @@ class SQLDeleteObjectData : public SQLiteDB, public DeleteObjectDataOp {
     SQLDeleteObjectData(sqlite3 **sdbi, std::string db_name, CephContext *cct) : SQLiteDB(*sdbi, db_name, cct), sdb(sdbi) {}
 
     ~SQLDeleteObjectData() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
+};
+
+class SQLDeleteStaleObjectData : public SQLiteDB, public DeleteStaleObjectDataOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+
+  public:
+    SQLDeleteStaleObjectData(void **db, std::string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
+    SQLDeleteStaleObjectData(sqlite3 **sdbi, std::string db_name, CephContext *cct) : SQLiteDB(*sdbi, db_name, cct), sdb(sdbi) {}
+
+    ~SQLDeleteStaleObjectData() {
       if (stmt)
         sqlite3_finalize(stmt);
     }

--- a/src/rgw/store/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/store/dbstore/tests/dbstore_tests.cc
@@ -98,6 +98,7 @@ namespace {
         GlobalParams.op.obj.state.obj.bucket = GlobalParams.op.bucket.info.bucket;
         GlobalParams.op.obj.state.obj.key.name = object1;
         GlobalParams.op.obj.state.obj.key.instance = "inst1";
+        GlobalParams.op.obj.obj_id = "obj_id1";
         GlobalParams.op.obj_data.part_num = 0;
 
         /* As of now InitializeParams doesnt do anything
@@ -1006,6 +1007,7 @@ TEST_F(DBStoreTest, PutObjectData) {
   encode("HELLO WORLD", b1);
   params.op.obj_data.data = b1;
   params.op.obj_data.size = 12;
+  params.op.obj.state.mtime = real_clock::now();
   ret = db->ProcessOp(dpp, "PutObjectData", &params);
   ASSERT_EQ(ret, 0);
 }
@@ -1014,8 +1016,7 @@ TEST_F(DBStoreTest, UpdateObjectData) {
   struct DBOpParams params = GlobalParams;
   int ret = -1;
 
-  params.op.obj.new_obj_key.name = "object3";
-  params.op.obj.new_obj_key.instance = "inst3";
+  params.op.obj.state.mtime = bucket_mtime;
   ret = db->ProcessOp(dpp, "UpdateObjectData", &params);
   ASSERT_EQ(ret, 0);
 }
@@ -1024,15 +1025,16 @@ TEST_F(DBStoreTest, GetObjectData) {
   struct DBOpParams params = GlobalParams;
   int ret = -1;
 
-  params.op.obj.state.obj.key.instance = "inst3";
-  params.op.obj.state.obj.key.name = "object3";
+  params.op.obj.state.obj.key.instance = "inst1";
+  params.op.obj.state.obj.key.name = "object1";
   ret = db->ProcessOp(dpp, "GetObjectData", &params);
   ASSERT_EQ(ret, 0);
   ASSERT_EQ(params.op.obj_data.part_num, 1);
   ASSERT_EQ(params.op.obj_data.offset, 10);
   ASSERT_EQ(params.op.obj_data.multipart_part_str, "2");
-  ASSERT_EQ(params.op.obj.state.obj.key.instance, "inst3");
-  ASSERT_EQ(params.op.obj.state.obj.key.name, "object3");
+  ASSERT_EQ(params.op.obj.state.obj.key.instance, "inst1");
+  ASSERT_EQ(params.op.obj.state.obj.key.name, "object1");
+  ASSERT_EQ(params.op.obj.state.mtime, bucket_mtime);
   string data;
   decode(data, params.op.obj_data.data);
   ASSERT_EQ(data, "HELLO WORLD");

--- a/src/rgw/store/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/store/dbstore/tests/dbstore_tests.cc
@@ -390,19 +390,6 @@ TEST_F(DBStoreTest, UpdateBucketAttrs) {
   ASSERT_EQ(objv.read_version.ver, 2);
 }
 
-TEST_F(DBStoreTest, BucketChown) {
-  int ret = -1;
-  RGWBucketInfo info;
-  rgw_user user;
-  user.id = "user_id2";
-
-  info.bucket.name = "bucket1";
-
-  ret = db->update_bucket(dpp, "owner", info, false, &user, nullptr, &bucket_mtime, nullptr);
-  ASSERT_EQ(ret, 0);
-  ASSERT_EQ(info.objv_tracker.read_version.ver, 3);
-}
-
 TEST_F(DBStoreTest, UpdateBucketInfo) {
   struct DBOpParams params = GlobalParams;
   int ret = -1;
@@ -418,13 +405,14 @@ TEST_F(DBStoreTest, UpdateBucketInfo) {
   info.bucket.marker = "marker2";
   ret = db->update_bucket(dpp, "info", info, false, nullptr, nullptr, &bucket_mtime, nullptr);
   ASSERT_EQ(ret, 0);
-  ASSERT_EQ(info.objv_tracker.read_version.ver, 4);
+  ASSERT_EQ(info.objv_tracker.read_version.ver, 3);
 }
 
 TEST_F(DBStoreTest, GetBucket) {
   struct DBOpParams params = GlobalParams;
   int ret = -1;
 
+  params.op.bucket.info.bucket.name = "bucket1";
   ret = db->ProcessOp(dpp, "GetBucket", &params);
   ASSERT_EQ(ret, 0);
   ASSERT_EQ(params.op.bucket.info.bucket.name, "bucket1");
@@ -434,10 +422,10 @@ TEST_F(DBStoreTest, GetBucket) {
   ASSERT_EQ(params.op.bucket.ent.bucket.name, "bucket1");
   ASSERT_EQ(params.op.bucket.ent.bucket.tenant, "tenant");
   ASSERT_EQ(params.op.bucket.info.has_instance_obj, false);
-  ASSERT_EQ(params.op.bucket.info.objv_tracker.read_version.ver, 4);
+  ASSERT_EQ(params.op.bucket.info.objv_tracker.read_version.ver, 3);
   ASSERT_EQ(params.op.bucket.info.objv_tracker.read_version.tag, "read_tag");
   ASSERT_EQ(params.op.bucket.mtime, bucket_mtime);
-  ASSERT_EQ(params.op.bucket.info.owner.id, "user_id2");
+  ASSERT_EQ(params.op.bucket.info.owner.id, "user_id1");
   bufferlist k, k2;
   string acl;
   map<std::string, bufferlist>::iterator it2 = params.op.bucket.bucket_attrs.begin();
@@ -448,35 +436,6 @@ TEST_F(DBStoreTest, GetBucket) {
   k2 = it2->second;
   decode(acl, k2);
   ASSERT_EQ(acl, "attrs2");
-}
-
-TEST_F(DBStoreTest, RemoveBucketAPI) {
-  int ret = -1;
-  RGWBucketInfo info;
-
-  info.bucket.name = "bucket1";
-
-  ret = db->remove_bucket(dpp, info);
-  ASSERT_EQ(ret, 0);
-}
-
-TEST_F(DBStoreTest, RemoveUserAPI) {
-  int ret = -1;
-  RGWUserInfo uinfo;
-  RGWObjVersionTracker objv;
-
-  uinfo.user_id.tenant = "tenant";
-  uinfo.user_id.id = "user_id2";
-
-  /* invalid version number...should fail */
-  objv.read_version.ver = 4;
-  ret = db->remove_user(dpp, uinfo, &objv);
-  ASSERT_EQ(ret, -125);
-
-  /* invalid version number...should fail */
-  objv.read_version.ver = 2;
-  ret = db->remove_user(dpp, uinfo, &objv);
-  ASSERT_EQ(ret, 0);
 }
 
 TEST_F(DBStoreTest, CreateBucket) {
@@ -564,7 +523,8 @@ TEST_F(DBStoreTest, ListUserBuckets) {
   marker1 = "";
   do {
     is_truncated = false;
-    ret = db->list_buckets(dpp, owner, marker1, "", max, need_stats, &ulist, &is_truncated);
+    ret = db->list_buckets(dpp, "", owner, marker1, "", max, need_stats, &ulist,
+          &is_truncated);
     ASSERT_EQ(ret, 0);
 
     cout << "marker1 :" << marker1 << "\n";
@@ -586,11 +546,90 @@ TEST_F(DBStoreTest, ListUserBuckets) {
   } while(is_truncated);
 }
 
+TEST_F(DBStoreTest, BucketChown) {
+  int ret = -1;
+  RGWBucketInfo info;
+  rgw_user user;
+  user.id = "user_id2";
+
+  info.bucket.name = "bucket5";
+
+  ret = db->update_bucket(dpp, "owner", info, false, &user, nullptr, &bucket_mtime, nullptr);
+  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(info.objv_tracker.read_version.ver, 3);
+}
+
 TEST_F(DBStoreTest, ListAllBuckets) {
   struct DBOpParams params = GlobalParams;
   int ret = -1;
 
   ret = db->ListAllBuckets(dpp, &params);
+  ASSERT_EQ(ret, 0);
+}
+
+TEST_F(DBStoreTest, ListAllBuckets2) {
+  struct DBOpParams params = GlobalParams;
+  int ret = -1;
+  rgw_user owner;
+  int max = 2;
+  bool need_stats = true;
+  bool is_truncated = false;
+  RGWUserBuckets ulist;
+
+  marker1 = "";
+  do {
+    is_truncated = false;
+    ret = db->list_buckets(dpp, "all", owner, marker1, "", max, need_stats, &ulist,
+          &is_truncated);
+    ASSERT_EQ(ret, 0);
+
+    cout << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ \n";
+    cout << "ownerID : " << owner.id << "\n";
+    cout << "marker1 :" << marker1 << "\n";
+
+    cout << "is_truncated :" << is_truncated << "\n";
+
+    for (const auto& ent: ulist.get_buckets()) {
+      RGWBucketEnt e = ent.second;
+      cout << "###################### \n";
+      cout << "ent.bucket.id : " << e.bucket.name << "\n";
+      cout << "ent.bucket.marker : " << e.bucket.marker << "\n";
+      cout << "ent.bucket.bucket_id : " << e.bucket.bucket_id << "\n";
+      cout << "ent.size : " << e.size << "\n";
+      cout << "ent.rule.name : " << e.placement_rule.name << "\n";
+
+      marker1 = e.bucket.name;
+    }
+    ulist.clear();
+  } while(is_truncated);
+}
+
+TEST_F(DBStoreTest, RemoveBucketAPI) {
+  int ret = -1;
+  RGWBucketInfo info;
+
+  info.bucket.name = "bucket5";
+
+  ret = db->remove_bucket(dpp, info);
+  ASSERT_EQ(ret, 0);
+}
+
+TEST_F(DBStoreTest, RemoveUserAPI) {
+  int ret = -1;
+  RGWUserInfo uinfo;
+  RGWObjVersionTracker objv;
+
+  uinfo.user_id.tenant = "tenant";
+  uinfo.user_id.id = "user_id2";
+
+  /* invalid version number...should fail */
+  objv.read_version.ver = 4;
+  ret = db->remove_user(dpp, uinfo, &objv);
+  ASSERT_EQ(ret, -125);
+
+  /* invalid version number...should fail */
+  objv.read_version.ver = 2;
+  ret = db->remove_user(dpp, uinfo, &objv);
   ASSERT_EQ(ret, 0);
 }
 

--- a/src/rgw/store/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/store/dbstore/tests/dbstore_tests.cc
@@ -29,9 +29,9 @@ namespace gtest {
 
       void SetUp() override {
         cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
-            CODE_ENVIRONMENT_DAEMON, CINIT_FLAG_NO_MON_CONFIG, 1)->get();
+            CODE_ENVIRONMENT_DAEMON, CINIT_FLAG_NO_MON_CONFIG, 1);
         if (!db_type.compare("SQLite")) {
-          db = new SQLiteDB(tenant, cct);
+          db = new SQLiteDB(tenant, cct.get());
           ASSERT_TRUE(db != nullptr);
           ret = db->Initialize(logfile, loglevel);
           ASSERT_GE(ret, 0);
@@ -51,7 +51,7 @@ namespace gtest {
       int ret;
       string logfile = "rgw_dbstore_tests.log";
       int loglevel = 30;
-      CephContext *cct;
+      boost::intrusive_ptr<CephContext> cct;
   };
 }
 


### PR DESCRIPTION
The approach taken here is similar to Rados.

Generate unique ID for each object upload which will be atomically updated in the head object at the end of the operation. This is to prevent data corruption during concurrent writes. In the case of MultipartUploads, <upload_id> is used as ObjectID.

The stale or obsolete tail data will be deleted by GC thread.

Now that the tail objects are associated with objectID, they are not deleted as part of the DeleteObj operation. Such tail objects (with no head object in *.object.table are cleaned up later by GC thread.

To avoid races between writes/reads & GC delete, mtime is maintained for each tail object. This mtime is updated when tail object is written and also when its corresponding head object is deleted.

GC waits for minimum of gc_wait_time before deleting any stale tail object data.

cleanup: Also addressed invalid usage of CephContext in dbstore tests.