### PR TITLE
quincy: mgr/cephadm: require asyncssh 2.8

### DIFF
--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -1,3 +1,3 @@
 -rrequirements-required.txt
-asyncssh
+asyncssh==2.8
 kubernetes==11.0.0


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/44761

This is also in https://github.com/ceph/ceph/pull/44773 but we don't want to merge that yet and this not being in quincy is causing make check failures on PRs against that branch
