### PR TITLE
OSD: move the warning to the cluster log when osd hitting the pg hard limit

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5051,8 +5051,8 @@ bool OSD::maybe_wait_for_max_pg(const OSDMapRef& osdmap,
     bool is_primary = osdmap->get_pg_acting_role(pgid, whoami) == 0;
     pending_creates_from_osd.emplace(pgid, is_primary);
   }
-  dout(1) << __func__ << " withhold creation of pg " << pgid
-	  << ": " << num_pgs << " >= "<< max_pgs_per_osd << dendl;
+  clog->warn() << "withhold creation of pg " << pgid
+               << ": " << num_pgs << " >= " << max_pgs_per_osd;
   return true;
 }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/54050

Signed-off-by: dongdong tao <dongdong.tao@canonical.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
