### PR TITLE
qa/orch/cephadm: test_orch_cli_mon.yaml

### DIFF
--- a/qa/suites/orch/cephadm/workunits/task/test_orch_cli_mon.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_orch_cli_mon.yaml
@@ -4,18 +4,36 @@ roles:
   - osd.1
   - osd.2
   - mon.a
-  - mon.c
-  - mon.d
   - mgr.a
   - client.0
 - - host.b
   - osd.3
   - osd.4
+  - osd.5
   - mon.b
-  - mon.e
   - mgr.b
-  - mgr.c
   - client.1
+- - host.c
+  - osd.6
+  - osd.7
+  - osd.8
+  - mon.c
+  - mgr.c
+  - client.2
+- - host.d
+  - osd.9
+  - osd.10
+  - osd.11
+  - mon.d
+  - mgr.d
+  - client.3
+- - host.e
+  - osd.12
+  - osd.13
+  - osd.14
+  - mon.e
+  - mgr.e
+  - client.4
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/workunits/task/test_orch_cli_mon.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_orch_cli_mon.yaml
@@ -1,0 +1,18 @@
+roles:
+- - host.a
+  - osd.0
+  - osd.1
+  - osd.2
+  - mon.a
+  - mon.b
+  - mon.c
+  - mon.d
+  - mon.e
+  - mgr.a
+  - client.0
+tasks:
+- install:
+- cephadm:
+- cephadm.shell:
+    host.a:
+      - ceph orch apply mon 3

--- a/qa/suites/orch/cephadm/workunits/task/test_orch_cli_mon.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_orch_cli_mon.yaml
@@ -4,15 +4,24 @@ roles:
   - osd.1
   - osd.2
   - mon.a
-  - mon.b
   - mon.c
   - mon.d
-  - mon.e
   - mgr.a
   - client.0
+- - host.b
+  - osd.3
+  - osd.4
+  - mon.b
+  - mon.e
+  - mgr.b
+  - mgr.c
+  - client.1
 tasks:
 - install:
 - cephadm:
 - cephadm.shell:
     host.a:
-      - ceph orch apply mon 3
+      - ceph orch apply mds a
+- cephfs_test_runner:
+    modules:
+      - tasks.cephadm_cases.test_cli_mon

--- a/qa/tasks/cephadm_cases/test_cli_mon.py
+++ b/qa/tasks/cephadm_cases/test_cli_mon.py
@@ -27,28 +27,14 @@ class TestCephadmCLI(MgrTestCase):
 
     def test_apply_mon(self):
         retstr = self._cmd('quorum_status') 
-        log.warning("test_apply_mon: monstatus returns %s" % json.dumps(retstr, indent=2))
+        log.warning("test_apply_mon: monstatus before reduce returns %s" % json.dumps(retstr, indent=2))
         self._orch_cmd('apply', 'mon', '3')
-        self.wait_for_health_clear(90)
-        time.sleep(30)
+        time.sleep(10)
+        retstr = self._cmd('quorum_status')
+        log.warning("test_apply_mon: monstatus ~10s after reduce returns %s" % json.dumps(retstr, indent=2))
         self._create_and_write_pool('test_pool1')
-        time.sleep(10)
         retstr = self._cmd('quorum_status') 
-        log.warning("test_apply_mon: monstatus returns %s" % json.dumps(retstr, indent=2))
-        retstr = self.mgr_cluster.mon_manager.raw_cluster_cmd(
-            'crash', 'ls',
-        )
-        log.warning("test_apply_mon: crash ls returns %s" % retstr)
-        self.assertEqual(0, len(retstr))
-        retstr = self._cmd('quorum_status') 
-        log.warning("test_apply_mon: monstatus returns %s" % json.dumps(retstr, indent=2))
-        self._orch_cmd('apply', 'mon', '5')
-        self.wait_for_health_clear(90)
-        time.sleep(30)
-        self._create_and_write_pool('test_pool2')
-        time.sleep(10)
-        retstr = self._cmd('quorum_status') 
-        log.warning("test_apply_mon: monstatus returns %s" % json.dumps(retstr, indent=2))
+        log.warning("test_apply_mon: monstatus ~26s after reduce returns %s" % json.dumps(retstr, indent=2))
         retstr = self.mgr_cluster.mon_manager.raw_cluster_cmd(
             'crash', 'ls',
         )

--- a/qa/tasks/cephadm_cases/test_cli_mon.py
+++ b/qa/tasks/cephadm_cases/test_cli_mon.py
@@ -1,0 +1,38 @@
+import json
+import logging
+import time
+
+from tasks.mgr.mgr_test_case import MgrTestCase
+
+log = logging.getLogger(__name__)
+
+
+class TestCephadmCLI(MgrTestCase):
+    def _cmd(self, *args) -> str:
+        assert self.mgr_cluster is not None
+        return self.mgr_cluster.mon_manager.raw_cluster_cmd(*args)
+
+    def _orch_cmd(self, *args) -> str:
+        return self._cmd("orch", *args)
+
+    def setUp(self):
+        super(TestCephadmCLI, self).setUp()
+    
+    def _create_and_write_pool(self):
+        "Simulate some writes"
+        self.mgr_cluster.mon_manager.create_pool("test_pool")
+        args = [
+            "rados", "-p", "test_pool", "bench", "30", "write", "-t", "16"]
+        self.mgr_cluster.admin_remote.run(args=args, wait=True)
+
+    def test_apply_mon(self):
+        self._orch_cmd('apply', 'mon', '3')
+        self.wait_for_health_clear(90)
+        time.sleep(30)
+        self._create_and_write_pool()
+        time.sleep(10)
+        retstr = self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'crash', 'ls',
+        )
+        log.warning("test_apply_mon: crash ls returns %s" % retstr)
+        self.assertEqual(0, len(retstr))

--- a/qa/tasks/cephadm_cases/test_cli_mon.py
+++ b/qa/tasks/cephadm_cases/test_cli_mon.py
@@ -26,21 +26,29 @@ class TestCephadmCLI(MgrTestCase):
         self.mgr_cluster.admin_remote.run(args=args, wait=True)
 
     def test_apply_mon(self):
+        retstr = self._cmd('quorum_status') 
+        log.warning("test_apply_mon: monstatus returns %s" % json.dumps(retstr, indent=2))
         self._orch_cmd('apply', 'mon', '3')
         self.wait_for_health_clear(90)
         time.sleep(30)
         self._create_and_write_pool('test_pool1')
         time.sleep(10)
+        retstr = self._cmd('quorum_status') 
+        log.warning("test_apply_mon: monstatus returns %s" % json.dumps(retstr, indent=2))
         retstr = self.mgr_cluster.mon_manager.raw_cluster_cmd(
             'crash', 'ls',
         )
         log.warning("test_apply_mon: crash ls returns %s" % retstr)
         self.assertEqual(0, len(retstr))
+        retstr = self._cmd('quorum_status') 
+        log.warning("test_apply_mon: monstatus returns %s" % json.dumps(retstr, indent=2))
         self._orch_cmd('apply', 'mon', '5')
         self.wait_for_health_clear(90)
         time.sleep(30)
         self._create_and_write_pool('test_pool2')
         time.sleep(10)
+        retstr = self._cmd('quorum_status') 
+        log.warning("test_apply_mon: monstatus returns %s" % json.dumps(retstr, indent=2))
         retstr = self.mgr_cluster.mon_manager.raw_cluster_cmd(
             'crash', 'ls',
         )


### PR DESCRIPTION
Added test_orch_cli_mon.yaml to recreate
the bug in https://tracker.ceph.com/issues/50089.
basically test how `ceph orch apply mon 3` reduces
the number of monitors from 5 to 3, and see if we
can get a crash to occur.

Fixes:  https://tracker.ceph.com/issues/50088,
https://tracker.ceph.com/issues/50089

Signed-off-by: Kamoltat <ksirivad@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
