### PR TITLE
[WIP] mgr/cephadm: provide container resources usage using cAdvisor

### DIFF
--- a/src/cephadm/box/Dockerfile
+++ b/src/cephadm/box/Dockerfile
@@ -2,6 +2,11 @@
 FROM centos:8 as centos-systemd
 ENV container docker
 ENV CEPHADM_PATH=/usr/local/sbin/cephadm
+
+# Centos met EOL and the content of the CentOS 8 repos has been moved to vault.centos.org
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 RUN dnf -y install chrony firewalld lvm2 \
   openssh-server openssh-clients python3 \
   yum-utils sudo which && dnf clean all
@@ -23,7 +28,5 @@ EXPOSE 22
 
 FROM centos-systemd-docker
 WORKDIR /root
-# VOLUME /var/run/docker.sock
-COPY start /usr/local/bin
 
 CMD [ "/usr/sbin/init" ]

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -52,6 +52,7 @@ DEFAULT_PROMETHEUS_IMAGE = 'quay.io/prometheus/prometheus:v2.18.1'
 DEFAULT_NODE_EXPORTER_IMAGE = 'quay.io/prometheus/node-exporter:v0.18.1'
 DEFAULT_ALERT_MANAGER_IMAGE = 'quay.io/prometheus/alertmanager:v0.20.0'
 DEFAULT_GRAFANA_IMAGE = 'quay.io/ceph/ceph-grafana:6.7.4'
+DEFAULT_CADVISOR_IMAGE = 'gcr.io/cadvisor/cadvisor'
 DEFAULT_HAPROXY_IMAGE = 'docker.io/library/haproxy:2.3'
 DEFAULT_KEEPALIVED_IMAGE = 'docker.io/arcts/keepalived'
 DEFAULT_SNMP_GATEWAY_IMAGE = 'docker.io/maxwo/snmp-notifier:v1.2.1'
@@ -426,6 +427,7 @@ class Monitoring(object):
         'node-exporter': [9100],
         'grafana': [3000],
         'alertmanager': [9093, 9094],
+        'cAdvisor': [8080]
     }
 
     components = {
@@ -475,6 +477,11 @@ class Monitoring(object):
                 'peers',
             ],
         },
+        'cAdvisor': {
+            'image': DEFAULT_CADVISOR_IMAGE,
+            'cpus': '1',
+            'memory': '1GB'
+        },
     }  # type: ignore
 
     @staticmethod
@@ -483,7 +490,7 @@ class Monitoring(object):
         """
         :param: daemon_type Either "prometheus", "alertmanager" or "node-exporter"
         """
-        assert daemon_type in ('prometheus', 'alertmanager', 'node-exporter')
+        assert daemon_type in ('prometheus', 'alertmanager', 'node-exporter', 'cAdvisor')
         cmd = daemon_type.replace('-', '_')
         code = -1
         err = ''
@@ -2333,7 +2340,7 @@ def get_daemon_args(ctx, fsid, daemon_type, daemon_id):
         metadata = Monitoring.components[daemon_type]
         r += metadata.get('args', list())
         # set ip and port to bind to for nodeexporter,alertmanager,prometheus
-        if daemon_type != 'grafana':
+        if daemon_type != 'grafana' and daemon_type != 'cAdvisor':
             ip = ''
             port = Monitoring.port_map[daemon_type][0]
             if 'meta_json' in ctx and ctx.meta_json:
@@ -2609,6 +2616,11 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
         elif daemon_type == 'node-exporter':
             mounts['/proc'] = '/host/proc:ro'
             mounts['/sys'] = '/host/sys:ro'
+            mounts['/'] = '/rootfs:ro'
+        elif daemon_type == 'cAdvisor':
+            mounts['/var/run'] = '/var/run:rw'
+            mounts['/var/lib/docker/'] = '/var/lib/docker:ro'
+            mounts['/sys'] = '/sys:ro'
             mounts['/'] = '/rootfs:ro'
         elif daemon_type == 'grafana':
             mounts[os.path.join(data_dir, 'etc/grafana/grafana.ini')] = '/etc/grafana/grafana.ini:Z'
@@ -4699,7 +4711,7 @@ def prepare_ssh(
         cli(['orch', 'apply', 'crash'])
 
     if not ctx.skip_monitoring_stack:
-        for t in ['prometheus', 'grafana', 'node-exporter', 'alertmanager']:
+        for t in ['prometheus', 'grafana', 'node-exporter', 'alertmanager', 'cAdvisor']:
             logger.info('Deploying %s service with default placement...' % t)
             cli(['orch', 'apply', t])
 
@@ -5219,6 +5231,8 @@ def extract_uid_gid_monitoring(ctx, daemon_type):
         uid, gid = extract_uid_gid(ctx, file_path='/etc/prometheus')
     elif daemon_type == 'node-exporter':
         uid, gid = 65534, 65534
+    elif daemon_type == 'node-exporter':
+        uid, gid = 7007, 7007
     elif daemon_type == 'grafana':
         uid, gid = extract_uid_gid(ctx, file_path='/var/lib/grafana')
     elif daemon_type == 'alertmanager':
@@ -5866,7 +5880,8 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                         seen_versions[image_id] = version
                                 elif daemon_type in ['prometheus',
                                                      'alertmanager',
-                                                     'node-exporter']:
+                                                     'node-exporter',
+                                                     'cAdvisor']:
                                     version = Monitoring.get_version(ctx, container_id, daemon_type)
                                     seen_versions[image_id] = version
                                 elif daemon_type == 'haproxy':
@@ -6015,7 +6030,7 @@ def command_adopt(ctx):
         command_adopt_prometheus(ctx, daemon_id, fsid)
     elif daemon_type == 'grafana':
         command_adopt_grafana(ctx, daemon_id, fsid)
-    elif daemon_type == 'node-exporter':
+    elif daemon_type == 'node-exporter' or daemon_type == 'cAdvisor':
         raise Error('adoption of node-exporter not implemented')
     elif daemon_type == 'alertmanager':
         command_adopt_alertmanager(ctx, daemon_id, fsid)
@@ -8326,7 +8341,7 @@ def _get_parser():
     parser_bootstrap.add_argument(
         '--skip-monitoring-stack',
         action='store_true',
-        help='Do not automatically provision monitoring stack (prometheus, grafana, alertmanager, node-exporter)')
+        help='Do not automatically provision monitoring stack (prometheus, grafana, alertmanager, node-exporter, cAdvisor)')
     parser_bootstrap.add_argument(
         '--apply-spec',
         help='Apply cluster spec after bootstrap (copy ssh key, add hosts and apply services)')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -427,7 +427,7 @@ class Monitoring(object):
         'node-exporter': [9100],
         'grafana': [3000],
         'alertmanager': [9093, 9094],
-        'cAdvisor': [8080]
+        'cadvisor': [8080]
     }
 
     components = {
@@ -477,7 +477,7 @@ class Monitoring(object):
                 'peers',
             ],
         },
-        'cAdvisor': {
+        'cadvisor': {
             'image': DEFAULT_CADVISOR_IMAGE,
             'cpus': '1',
             'memory': '1GB'
@@ -490,7 +490,7 @@ class Monitoring(object):
         """
         :param: daemon_type Either "prometheus", "alertmanager" or "node-exporter"
         """
-        assert daemon_type in ('prometheus', 'alertmanager', 'node-exporter', 'cAdvisor')
+        assert daemon_type in ('prometheus', 'alertmanager', 'node-exporter', 'cadvisor')
         cmd = daemon_type.replace('-', '_')
         code = -1
         err = ''
@@ -2340,7 +2340,7 @@ def get_daemon_args(ctx, fsid, daemon_type, daemon_id):
         metadata = Monitoring.components[daemon_type]
         r += metadata.get('args', list())
         # set ip and port to bind to for nodeexporter,alertmanager,prometheus
-        if daemon_type != 'grafana' and daemon_type != 'cAdvisor':
+        if daemon_type != 'grafana' and daemon_type != 'cadvisor':
             ip = ''
             port = Monitoring.port_map[daemon_type][0]
             if 'meta_json' in ctx and ctx.meta_json:
@@ -2617,7 +2617,7 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
             mounts['/proc'] = '/host/proc:ro'
             mounts['/sys'] = '/host/sys:ro'
             mounts['/'] = '/rootfs:ro'
-        elif daemon_type == 'cAdvisor':
+        elif daemon_type == 'cadvisor':
             mounts['/var/run'] = '/var/run:rw'
             mounts['/var/lib/docker/'] = '/var/lib/docker:ro'
             mounts['/sys'] = '/sys:ro'
@@ -4711,7 +4711,7 @@ def prepare_ssh(
         cli(['orch', 'apply', 'crash'])
 
     if not ctx.skip_monitoring_stack:
-        for t in ['prometheus', 'grafana', 'node-exporter', 'alertmanager', 'cAdvisor']:
+        for t in ['prometheus', 'grafana', 'node-exporter', 'alertmanager', 'cadvisor']:
             logger.info('Deploying %s service with default placement...' % t)
             cli(['orch', 'apply', t])
 
@@ -5881,7 +5881,7 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                 elif daemon_type in ['prometheus',
                                                      'alertmanager',
                                                      'node-exporter',
-                                                     'cAdvisor']:
+                                                     'cadvisor']:
                                     version = Monitoring.get_version(ctx, container_id, daemon_type)
                                     seen_versions[image_id] = version
                                 elif daemon_type == 'haproxy':
@@ -6030,7 +6030,7 @@ def command_adopt(ctx):
         command_adopt_prometheus(ctx, daemon_id, fsid)
     elif daemon_type == 'grafana':
         command_adopt_grafana(ctx, daemon_id, fsid)
-    elif daemon_type == 'node-exporter' or daemon_type == 'cAdvisor':
+    elif daemon_type == 'node-exporter' or daemon_type == 'cadvisor':
         raise Error('adoption of node-exporter not implemented')
     elif daemon_type == 'alertmanager':
         command_adopt_alertmanager(ctx, daemon_id, fsid)
@@ -8341,7 +8341,7 @@ def _get_parser():
     parser_bootstrap.add_argument(
         '--skip-monitoring-stack',
         action='store_true',
-        help='Do not automatically provision monitoring stack (prometheus, grafana, alertmanager, node-exporter, cAdvisor)')
+        help='Do not automatically provision monitoring stack (prometheus, grafana, alertmanager, node-exporter, cadvisor)')
     parser_bootstrap.add_argument(
         '--apply-spec',
         help='Apply cluster spec after bootstrap (copy ssh key, add hosts and apply services)')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -199,7 +199,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Prometheus container image',
         ),
         Option(
-            'container_image_cAdvisor',
+            'container_image_cadvisor',
             default=DEFAULT_CADVISOR_IMAGE,
             desc='Cadvisor container image',
         ),
@@ -416,6 +416,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.container_image_grafana = ''
             self.container_image_alertmanager = ''
             self.container_image_node_exporter = ''
+            self.container_image_cadvisor = ''
             self.container_image_haproxy = ''
             self.container_image_keepalived = ''
             self.container_image_snmp_gateway = ''
@@ -663,7 +664,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         suffix = daemon_type not in [
             'mon', 'crash',
             'prometheus', 'node-exporter', 'grafana', 'alertmanager',
-            'container', 'agent', 'snmp-gateway', 'cAdvisor'
+            'container', 'agent', 'snmp-gateway', 'cadvisor'
         ]
         if forcename:
             if len([d for d in existing if d.daemon_id == forcename]):
@@ -1299,7 +1300,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             image = self.container_image_alertmanager
         elif daemon_type == 'node-exporter':
             image = self.container_image_node_exporter
-        elif daemon_type == 'cAdvisor':
+        elif daemon_type == 'cadvisor':
             image = self.container_image_cadvisor
         elif daemon_type == 'haproxy':
             image = self.container_image_haproxy
@@ -2453,7 +2454,7 @@ Then run the following:
                 'alertmanager': PlacementSpec(count=1),
                 'prometheus': PlacementSpec(count=1),
                 'node-exporter': PlacementSpec(host_pattern='*'),
-                'cAdvisor': PlacementSpec(host_pattern='*'),
+                'cadvisor': PlacementSpec(host_pattern='*'),
                 'crash': PlacementSpec(host_pattern='*'),
                 'container': PlacementSpec(count=1),
                 'snmp-gateway': PlacementSpec(count=1),

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -378,6 +378,19 @@ class NodeExporterService(CephadmService):
         return HandleCommandResult(0, out, '')
 
 
+class CadvisorService(CephadmService):
+    TYPE = 'cAdvisor'
+
+    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
+        assert self.TYPE == daemon_spec.daemon_type
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+        return daemon_spec
+
+    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+        assert self.TYPE == daemon_spec.daemon_type
+        return {}, []
+
+
 class SNMPGatewayService(CephadmService):
     TYPE = 'snmp-gateway'
 

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -379,7 +379,7 @@ class NodeExporterService(CephadmService):
 
 
 class CadvisorService(CephadmService):
-    TYPE = 'cAdvisor'
+    TYPE = 'cadvisor'
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -466,6 +466,7 @@ class Orchestrator(object):
             'node-exporter': self.apply_node_exporter,
             'osd': lambda dg: self.apply_drivegroups([dg]),  # type: ignore
             'prometheus': self.apply_prometheus,
+            'cAdvisor': self.apply_cadvisor,
             'rbd-mirror': self.apply_rbd_mirror,
             'rgw': self.apply_rgw,
             'ingress': self.apply_ingress,
@@ -636,6 +637,10 @@ class Orchestrator(object):
         """Update prometheus cluster"""
         raise NotImplementedError()
 
+    def apply_cadvisor(self, spec: ServiceSpec) -> OrchResult[str]:
+        """Update cadvisor cluster"""
+        raise NotImplementedError()
+
     def apply_node_exporter(self, spec: ServiceSpec) -> OrchResult[str]:
         """Update existing a Node-Exporter daemon(s)"""
         raise NotImplementedError()
@@ -719,6 +724,7 @@ def daemon_type_to_service(dtype: str) -> str:
         'grafana': 'grafana',
         'alertmanager': 'alertmanager',
         'prometheus': 'prometheus',
+        'cAdvisor': 'cAdvisor', 
         'node-exporter': 'node-exporter',
         'crash': 'crash',
         'crashcollector': 'crash',  # Specific Rook Daemon
@@ -745,6 +751,7 @@ def service_to_daemon_types(stype: str) -> List[str]:
         'alertmanager': ['alertmanager'],
         'prometheus': ['prometheus'],
         'node-exporter': ['node-exporter'],
+        'cAdvisor': ['cAdvisor'], 
         'crash': ['crash'],
         'container': ['container'],
         'agent': ['agent'],

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -466,7 +466,7 @@ class Orchestrator(object):
             'node-exporter': self.apply_node_exporter,
             'osd': lambda dg: self.apply_drivegroups([dg]),  # type: ignore
             'prometheus': self.apply_prometheus,
-            'cAdvisor': self.apply_cadvisor,
+            'cadvisor': self.apply_cadvisor,
             'rbd-mirror': self.apply_rbd_mirror,
             'rgw': self.apply_rgw,
             'ingress': self.apply_ingress,
@@ -724,7 +724,7 @@ def daemon_type_to_service(dtype: str) -> str:
         'grafana': 'grafana',
         'alertmanager': 'alertmanager',
         'prometheus': 'prometheus',
-        'cAdvisor': 'cAdvisor', 
+        'cadvisor': 'cadvisor', 
         'node-exporter': 'node-exporter',
         'crash': 'crash',
         'crashcollector': 'crash',  # Specific Rook Daemon
@@ -751,7 +751,7 @@ def service_to_daemon_types(stype: str) -> List[str]:
         'alertmanager': ['alertmanager'],
         'prometheus': ['prometheus'],
         'node-exporter': ['node-exporter'],
-        'cAdvisor': ['cAdvisor'], 
+        'cadvisor': ['cadvisor'], 
         'crash': ['crash'],
         'container': ['container'],
         'agent': ['agent'],

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -56,7 +56,7 @@ class ServiceType(enum.Enum):
     grafana = 'grafana'
     node_exporter = 'node-exporter'
     prometheus = 'prometheus'
-    cAdvisor = 'cAdvisor', 
+    cadvisor = 'cadvisor', 
     mds = 'mds'
     rgw = 'rgw'
     nfs = 'nfs'

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -56,6 +56,7 @@ class ServiceType(enum.Enum):
     grafana = 'grafana'
     node_exporter = 'node-exporter'
     prometheus = 'prometheus'
+    cAdvisor = 'cAdvisor', 
     mds = 'mds'
     rgw = 'rgw'
     nfs = 'nfs'

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -438,7 +438,7 @@ class ServiceSpec(object):
     start the services.
     """
     KNOWN_SERVICE_TYPES = 'alertmanager crash grafana iscsi mds mgr mon nfs ' \
-                          'node-exporter osd prometheus rbd-mirror rgw agent ' \
+                          'node-exporter cAdvisor osd prometheus rbd-mirror rgw agent ' \
                           'container ingress cephfs-mirror snmp-gateway'.split()
     REQUIRES_SERVICE_ID = 'iscsi mds nfs rgw container ingress '.split()
     MANAGED_CONFIG_OPTIONS = [
@@ -459,6 +459,7 @@ class ServiceSpec(object):
             'container': CustomContainerSpec,
             'grafana': GrafanaSpec,
             'node-exporter': MonitoringSpec,
+            'cAdvisor': MonitoringSpec,
             'prometheus': MonitoringSpec,
             'snmp-gateway': SNMPGatewaySpec,
         }.get(service_type, cls)
@@ -1054,7 +1055,7 @@ class MonitoringSpec(ServiceSpec):
                  preview_only: bool = False,
                  port: Optional[int] = None,
                  ):
-        assert service_type in ['grafana', 'node-exporter', 'prometheus', 'alertmanager']
+        assert service_type in ['grafana', 'node-exporter', 'prometheus', 'alertmanager', 'cAdvisor']
 
         super(MonitoringSpec, self).__init__(
             service_type, service_id,
@@ -1075,7 +1076,8 @@ class MonitoringSpec(ServiceSpec):
             return {'prometheus': 9095,
                     'node-exporter': 9100,
                     'alertmanager': 9093,
-                    'grafana': 3000}[self.service_type]
+                    'grafana': 3000,
+                    'cAdvisor': 8080}[self.service_type]
 
 
 yaml.add_representer(MonitoringSpec, ServiceSpec.yaml_representer)

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -438,7 +438,7 @@ class ServiceSpec(object):
     start the services.
     """
     KNOWN_SERVICE_TYPES = 'alertmanager crash grafana iscsi mds mgr mon nfs ' \
-                          'node-exporter cAdvisor osd prometheus rbd-mirror rgw agent ' \
+                          'node-exporter cadvisor osd prometheus rbd-mirror rgw agent ' \
                           'container ingress cephfs-mirror snmp-gateway'.split()
     REQUIRES_SERVICE_ID = 'iscsi mds nfs rgw container ingress '.split()
     MANAGED_CONFIG_OPTIONS = [
@@ -459,7 +459,7 @@ class ServiceSpec(object):
             'container': CustomContainerSpec,
             'grafana': GrafanaSpec,
             'node-exporter': MonitoringSpec,
-            'cAdvisor': MonitoringSpec,
+            'cadvisor': MonitoringSpec,
             'prometheus': MonitoringSpec,
             'snmp-gateway': SNMPGatewaySpec,
         }.get(service_type, cls)
@@ -1055,7 +1055,7 @@ class MonitoringSpec(ServiceSpec):
                  preview_only: bool = False,
                  port: Optional[int] = None,
                  ):
-        assert service_type in ['grafana', 'node-exporter', 'prometheus', 'alertmanager', 'cAdvisor']
+        assert service_type in ['grafana', 'node-exporter', 'prometheus', 'alertmanager', 'cadvisor']
 
         super(MonitoringSpec, self).__init__(
             service_type, service_id,
@@ -1077,7 +1077,7 @@ class MonitoringSpec(ServiceSpec):
                     'node-exporter': 9100,
                     'alertmanager': 9093,
                     'grafana': 3000,
-                    'cAdvisor': 8080}[self.service_type]
+                    'cadvisor': 8080}[self.service_type]
 
 
 yaml.add_representer(MonitoringSpec, ServiceSpec.yaml_representer)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/53399
Signed-off-by: Avan Thakkar <athakkar@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
