### PR TITLE
mgr/dashboard: fix columns in host table  with NaN Undefined

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -203,6 +203,37 @@ describe('HostsComponent', () => {
     expect(spans[7].textContent).toBe('N/A');
   });
 
+  it('should test if memory/raw capacity columns shows N/A if facts are available but in fetching state', () => {
+    const features = [OrchestratorFeature.HOST_FACTS];
+    let hostPayload: any[];
+    hostPayload = [
+      {
+        hostname: 'host_test',
+        services: [
+          {
+            type: 'osd',
+            id: '0'
+          }
+        ],
+        cpu_count: 2,
+        cpu_cores: 1,
+        memory_total_kb: undefined,
+        hdd_count: 4,
+        hdd_capacity_bytes: undefined,
+        flash_count: 4,
+        flash_capacity_bytes: undefined,
+        nic_count: 1
+      }
+    ];
+    OrchestratorHelper.mockStatus(true, features);
+    hostListSpy.and.callFake(() => of(hostPayload));
+    fixture.detectChanges();
+
+    component.getHosts(new CdTableFetchDataContext(() => undefined));
+    expect(component.hosts[0]['memory_total_bytes']).toEqual('N/A');
+    expect(component.hosts[0]['raw_capacity']).toEqual('N/A');
+  });
+
   it('should show force maintenance modal when it is safe to stop host', () => {
     const errorMsg = `WARNING: Stopping 1 out of 1 daemons in Grafana service.
                     Service will not be operational with no daemons left. At

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -27,6 +27,7 @@ import { OrchestratorFeature } from '~/app/shared/models/orchestrator.enum';
 import { OrchestratorStatus } from '~/app/shared/models/orchestrator.interface';
 import { Permissions } from '~/app/shared/models/permissions';
 import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
+import { EmptyPipe } from '~/app/shared/pipes/empty.pipe';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { ModalService } from '~/app/shared/services/modal.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
@@ -109,6 +110,7 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
   constructor(
     private authStorageService: AuthStorageService,
     private dimlessBinary: DimlessBinaryPipe,
+    private emptyPipe: EmptyPipe,
     private hostService: HostService,
     private actionLabels: ActionLabelsI18n,
     private modalService: ModalService,
@@ -464,8 +466,10 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
   transformHostsData() {
     if (this.checkHostsFactsAvailable()) {
       _.forEach(this.hosts, (hostKey) => {
-        hostKey['memory_total_bytes'] = hostKey['memory_total_kb'] * 1024;
-        hostKey['raw_capacity'] = hostKey['hdd_capacity_bytes'] + hostKey['flash_capacity_bytes'];
+        hostKey['memory_total_bytes'] = this.emptyPipe.transform(hostKey['memory_total_kb'] * 1024);
+        hostKey['raw_capacity'] = this.emptyPipe.transform(
+          hostKey['hdd_capacity_bytes'] + hostKey['flash_capacity_bytes']
+        );
       });
     } else {
       // mark host facts columns unavailable

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/empty.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/empty.pipe.ts
@@ -7,6 +7,11 @@ import _ from 'lodash';
 })
 export class EmptyPipe implements PipeTransform {
   transform(value: any): any {
-    return _.isUndefined(value) || _.isNull(value) ? '-' : value;
+    if (_.isUndefined(value) || _.isNull(value)) {
+      return '-';
+    } else if (_.isNaN(value)) {
+      return 'N/A';
+    }
+    return value;
   }
 }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/54068
Signed-off-by: Avan Thakkar <athakkar@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
