### PR TITLE
qa: remove centos8 from supported distros

### DIFF
--- a/qa/distros/all/centos_8.yaml
+++ b/qa/distros/all/centos_8.yaml
@@ -1,1 +1,1 @@
-centos_8.3.yaml
+centos_8.stream.yaml

--- a/qa/distros/supported-all-distro/centos_8.stream.yaml
+++ b/qa/distros/supported-all-distro/centos_8.stream.yaml
@@ -1,1 +1,0 @@
-../all/centos_8.stream.yaml

--- a/qa/distros/supported-random-distro$/centos_8.stream.yaml
+++ b/qa/distros/supported-random-distro$/centos_8.stream.yaml
@@ -1,1 +1,0 @@
-../all/centos_8.stream.yaml

--- a/qa/distros/supported/centos_8.stream.yaml
+++ b/qa/distros/supported/centos_8.stream.yaml
@@ -1,1 +1,0 @@
-../all/centos_8.stream.yaml


### PR DESCRIPTION
centos 8 is eol and its package repos no longer exist. centos8.yaml now means centos 8 stream

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
