### PR TITLE
quincy: rgw: fix bucket index list minor calculation bug

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2984,7 +2984,7 @@ static int rgw_bi_list_op(cls_method_context_t hctx,
   }
 
   if (!more) {
-    ret = list_plain_entries(hctx, op.name_filter, op.marker, max,
+    ret = list_plain_entries(hctx, op.name_filter, op.marker, max - count,
 			     &op_ret.entries, &more, PlainEntriesRegion::High);
     if (ret < 0) {
       CLS_LOG(0, "ERROR: %s: list_plain_entries (high) returned ret=%d, marker=\"%s\", filter=\"%s\", max=%d",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54073

---

backport of https://github.com/ceph/ceph/pull/44562
parent tracker: https://tracker.ceph.com/issues/53856

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh