### PR TITLE
qa/rgw: install s3cmd with extra_system_packages

### DIFF
--- a/qa/suites/rgw/verify/0-install.yaml
+++ b/qa/suites/rgw/verify/0-install.yaml
@@ -1,7 +1,7 @@
 tasks:
 - install:
       # extra packages added for the rgw-datacache task
-      extra_packages:
+      extra_system_packages:
         deb: ['s3cmd']
         rpm: ['s3cmd']
 - ceph:


### PR DESCRIPTION
this was preventing installation on ubuntu because of https://tracker.ceph.com/issues/25026

Fixes: https://tracker.ceph.com/issues/54103

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
