### PR TITLE
rgw: fix segfault in UserAsyncRefreshHandler::init_fetch

### DIFF
--- a/src/rgw/services/svc_user_rados.cc
+++ b/src/rgw/services/svc_user_rados.cc
@@ -973,7 +973,6 @@ int RGWSI_User_RADOS::read_stats_async(const DoutPrefixProvider *dpp, RGWSI_Meta
   RGWGetUserStatsContext *cb = new RGWGetUserStatsContext(_cb);
   int r = cls_user_get_header_async(dpp, user_str, cb);
   if (r < 0) {
-    _cb->put();
     delete cb;
     return r;
   }


### PR DESCRIPTION
Fixes a segfault that was occuring in error handling code of UserAsyncRefreshHandler::init_fetch.
When ruser->read_stats_async returned an error code, the instance of UserAsyncRefreshHandler had
already been deallocated in RGWSI_User_RADOS::read_stats_async and a segmentation fault occurs
when attempting to print a member variable in error logs. This commit removes the extra ref count
drop since the ref is properly dropped upstream in RGWQuotaCache::async_refresh error handling
logic.

Fixes: https://tracker.ceph.com/issues/54112
Signed-off-by: Cory Snyder <csnyder@iland.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests