### PR TITLE
doc/dev: Debuggging with gdb

### DIFF
--- a/doc/dev/developer_guide/debugging-gdb.rst
+++ b/doc/dev/developer_guide/debugging-gdb.rst
@@ -1,0 +1,43 @@
+GDB - The GNU Project Debugger
+==============================
+
+`The GNU Project Debugger (GDB) <https://www.sourceware.org/gdb>`_ is
+a powerful tool that allows you to analyze the execution flow
+of a process.
+GDB can help to find bugs, uncover crash errors or track the
+source code during execution of a development cluster.
+It can also be used to debug Teuthology tests runs.
+
+GET STARTED WITH GDB
+--------------------
+
+Basic usage with examples can be found `here. <https://geeksforgeeks.org/gdb-command-in-linux-with-examples>`_
+GDB can be attached to a running process. For instance, after deploying a
+development cluster, the process number (PID) of a ``ceph-osd`` daemon can be found in::
+
+    $ cd build
+    $ cat out/osd.0.pid
+
+Attaching gdb to the process::
+
+    $ gdb ./bin/ceph-osd -p <pid>
+
+.. note::
+    It is recommended to compile without any optimizations (``-O0`` gcc flag)
+    in order to avoid elimintaion of intermediate values.
+
+Stopping for breakpoints while debugging may cause timeouts, so the following
+configuration options are suggested::
+
+        [osd]
+        osd_op_thread_timeout = 1500
+        osd_op_thread_suicide_timeout = 1500
+
+Debugging Teuthology Tests
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``src/script/ceph-debug-docker.sh`` can be used to analyze Teuthology failures::
+
+    $ ./ceph-debug-docker.sh <branch-name>
+
+Refer to the script header for more information.

--- a/doc/dev/developer_guide/index.rst
+++ b/doc/dev/developer_guide/index.rst
@@ -22,3 +22,4 @@ Contributing to Ceph: A Guide for Developers
    Ceph Dashboard Developer Documentation (formerly HACKING.rst) <dash-devel>
    Tracing Developer Documentation <jaegertracing>
    Cephadm Developer Documentation  <../cephadm/index>
+   Debugging with GDB <debugging-gdb>


### PR DESCRIPTION
Initial version for the documentation of gdb usage with Ceph.


Signed-off-by: Matan Breizman <mbreizma@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
