### PR TITLE
ceph-fuse: perform cleanup if test_dentry_handling failed

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -204,7 +204,9 @@ int main(int argc, const char **argv, const char *envp[]) {
           "client_try_dentry_invalidate");
 	bool can_invalidate_dentries =
           client_try_dentry_invalidate && ver < KERNEL_VERSION(3, 18, 0);
-	int tr = client->test_dentry_handling(can_invalidate_dentries);
+	auto test_result = client->test_dentry_handling(can_invalidate_dentries);
+	int tr = test_result.first;
+	bool abort_on_failure = test_result.second;
         bool client_die_on_failed_dentry_invalidate = g_conf().get_val<bool>(
           "client_die_on_failed_dentry_invalidate");
 	if (tr != 0 && client_die_on_failed_dentry_invalidate) {
@@ -229,6 +231,9 @@ int main(int argc, const char **argv, const char *envp[]) {
 	      cerr << "system() invocation failed during remount test" << std::endl;
 	    }
 	  }
+	}
+	if(abort_on_failure) {
+	  ceph_abort();
 	}
 	return reinterpret_cast<void*>(tr);
 #else

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -655,7 +655,7 @@ public:
   void _ll_register_callbacks(struct ceph_client_callback_args *args);
   void ll_register_callbacks(struct ceph_client_callback_args *args); // deprecated
   int ll_register_callbacks2(struct ceph_client_callback_args *args);
-  int test_dentry_handling(bool can_invalidate);
+  std::pair<int, bool> test_dentry_handling(bool can_invalidate);
 
   const char** get_tracked_conf_keys() const override;
   void handle_conf_change(const ConfigProxy& conf,
@@ -1290,7 +1290,7 @@ private:
   int _release_fh(Fh *fh);
   void _put_fh(Fh *fh);
 
-  int _do_remount(bool retry_on_error);
+  std::pair<int, bool> _do_remount(bool retry_on_error);
 
   int _read_sync(Fh *f, uint64_t off, uint64_t len, bufferlist *bl, bool *checkeof);
   int _read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl);


### PR DESCRIPTION
If remount failed due to some reason then `ceph_abort()` is
getting called which causes child process termination
without cleanup.
To fix this issue, `ceph_abort()` call moved after
performing cleanup.

Fixes: https://tracker.ceph.com/issues/54049
Signed-off-by: Nikhilkumar Shelke <nshelke@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
