### PR TITLE
quincy: qa/rgw: tests run against ceph-quincy branch

### DIFF
--- a/qa/suites/rgw/crypt/4-tests/s3tests.yaml
+++ b/qa/suites/rgw/crypt/4-tests/s3tests.yaml
@@ -1,7 +1,7 @@
 tasks:
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-quincy
       barbican:
         kms_key: my-key-1
         kms_key2: my-key-2

--- a/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
@@ -4,12 +4,12 @@ tasks:
 - rgw: [client.0]
 - ragweed:
     client.0:
-      default-branch: ceph-master
+      default-branch: ceph-quincy
       rgw_server: client.0
       stages: prepare
 - ragweed:
     client.0:
-      default-branch: ceph-master
+      default-branch: ceph-quincy
       rgw_server: client.0
       stages: check
 overrides:

--- a/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
@@ -4,7 +4,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-quincy
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/rgw/sts/tasks/first.yaml
+++ b/qa/suites/rgw/sts/tasks/first.yaml
@@ -6,7 +6,7 @@ tasks:
 - s3tests:
     client.0:
       sts_tests: True
-      force-branch: ceph-master
+      force-branch: ceph-quincy
       rgw_server: client.0
       extra_attrs: ['webidentity_test']
 overrides:

--- a/qa/suites/rgw/sts/tasks/ststests.yaml
+++ b/qa/suites/rgw/sts/tasks/ststests.yaml
@@ -3,7 +3,7 @@ tasks:
     client.0:
       sts_tests: True
       extra_attrs: ["test_of_sts"]
-      force-branch: ceph-master
+      force-branch: ceph-quincy
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
@@ -1,7 +1,7 @@
 tasks:
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-quincy
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/rgw/verify/tasks/ragweed.yaml
+++ b/qa/suites/rgw/verify/tasks/ragweed.yaml
@@ -1,6 +1,6 @@
 tasks:
 - ragweed:
     client.0:
-      default-branch: ceph-master
+      default-branch: ceph-quincy
       rgw_server: client.0
       stages: prepare,check

--- a/qa/suites/rgw/verify/tasks/s3tests-java.yaml
+++ b/qa/suites/rgw/verify/tasks/s3tests-java.yaml
@@ -1,6 +1,6 @@
 tasks:
 - s3tests-java:
     client.0:
-        force-branch: ceph-master
+        force-branch: ceph-quincy
         force-repo: https://github.com/ceph/java_s3tests.git 
 

--- a/qa/suites/rgw/verify/tasks/s3tests.yaml
+++ b/qa/suites/rgw/verify/tasks/s3tests.yaml
@@ -1,5 +1,5 @@
 tasks:
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-quincy
       rgw_server: client.0

--- a/qa/suites/rgw/website/tasks/s3tests-website.yaml
+++ b/qa/suites/rgw/website/tasks/s3tests-website.yaml
@@ -12,6 +12,6 @@ tasks:
       dns-s3website-name: s3-website.
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-quincy
       rgw_server: client.0
       rgw_website_server: client.1


### PR DESCRIPTION
target the ceph-quincy branch of s3tests, ragweed, and java_s3tests. this commit targets the quincy branch specifically, rather than merging to master and backporting

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
