### PR TITLE
mgr/nfs: support managing exports without orchestration enabled 

### DIFF
--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -533,20 +533,26 @@ The NFS log level can be adjusted using `nfs cluster config set` command (see :r
 Manual Ganesha deployment
 =========================
 
-It may be possible to deploy and manage the NFS ganesha daemons manually
-instead of allowing cephadm or rook to do so.
+It may be possible to deploy and manage the NFS ganesha daemons without
+orchestration frameworks such as cephadm or rook.
 
 .. note:: Manual configuration is not tested or fully documented; your
           mileage may vary. If you make this work, please help us by
           updating this documentation.
 
-Known issues
+Limitations
 ------------
 
-* The ``mgr/nfs`` module enumerates NFS clusters via the orchestrator API; if NFS is
-  not managed by the orchestrator (e.g., cephadm or rook) then this will not work.  It
-  may be possible to create the cluster, mark the cephadm service as 'unmanaged', but this
-  is awkward and not ideal.
+If no orchestrator module is enabled for the Ceph Manager the NFS cluster
+management commands, such as those starting with ``ceph nfs cluster``, will not
+function. However, commands that manage NFS exports, like those prefixed with
+``ceph nfs export`` are expected to work as long as the necessary RADOS objects
+have already been created. The exact RADOS objects required are not documented
+at this time as support for this feature is incomplete. A curious reader can
+find some details about the object by reading the source code for the
+``mgr/nfs`` module (found in the ceph source tree under
+``src/pybind/mgr/nfs``).
+
 
 Requirements
 ------------

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -93,11 +93,11 @@ class NFSCluster:
 
     def create_empty_rados_obj(self, cluster_id: str) -> None:
         common_conf = self._get_common_conf_obj_name(cluster_id)
-        NFSRados(self.mgr, cluster_id).write_obj('', self._get_common_conf_obj_name(cluster_id))
+        self._rados(cluster_id).write_obj('', self._get_common_conf_obj_name(cluster_id))
         log.info("Created empty object:%s", common_conf)
 
     def delete_config_obj(self, cluster_id: str) -> None:
-        NFSRados(self.mgr, cluster_id).remove_all_obj()
+        self._rados(cluster_id).remove_all_obj()
         log.info("Deleted %s object and all objects in %s",
                  self._get_common_conf_obj_name(cluster_id), cluster_id)
 
@@ -217,7 +217,7 @@ class NFSCluster:
     def get_nfs_cluster_config(self, cluster_id: str) -> Tuple[int, str, str]:
         try:
             if cluster_id in available_clusters(self.mgr):
-                rados_obj = NFSRados(self.mgr, cluster_id)
+                rados_obj = self._rados(cluster_id)
                 conf = rados_obj.read_obj(self._get_user_conf_obj_name(cluster_id))
                 return 0, conf or "", ""
             raise ClusterNotFound()
@@ -227,7 +227,7 @@ class NFSCluster:
     def set_nfs_cluster_config(self, cluster_id: str, nfs_config: str) -> Tuple[int, str, str]:
         try:
             if cluster_id in available_clusters(self.mgr):
-                rados_obj = NFSRados(self.mgr, cluster_id)
+                rados_obj = self._rados(cluster_id)
                 if rados_obj.check_user_config():
                     return 0, "", "NFS-Ganesha User Config already exists"
                 rados_obj.write_obj(nfs_config, self._get_user_conf_obj_name(cluster_id),
@@ -245,7 +245,7 @@ class NFSCluster:
     def reset_nfs_cluster_config(self, cluster_id: str) -> Tuple[int, str, str]:
         try:
             if cluster_id in available_clusters(self.mgr):
-                rados_obj = NFSRados(self.mgr, cluster_id)
+                rados_obj = self._rados(cluster_id)
                 if not rados_obj.check_user_config():
                     return 0, "", "NFS-Ganesha User Config does not exist"
                 rados_obj.remove_obj(self._get_user_conf_obj_name(cluster_id),
@@ -258,3 +258,7 @@ class NFSCluster:
                 "(Manual Restart of NFS PODS required)", ""
         except Exception as e:
             return exception_handler(e, f"Resetting NFS-Ganesha Config failed for {cluster_id}")
+
+    def _rados(self, cluster_id: str) -> NFSRados:
+        """Return a new NFSRados object for the given cluster id."""
+        return NFSRados(self.mgr.rados, cluster_id)

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -10,7 +10,8 @@ from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec, IngressS
 import orchestrator
 
 from .exception import NFSInvalidOperation, ClusterNotFound
-from .utils import available_clusters, restart_nfs_service
+from .utils import (available_clusters, restart_nfs_service, conf_obj_name,
+                    user_conf_obj_name)
 from .export import NFSRados, exception_handler
 
 if TYPE_CHECKING:
@@ -50,12 +51,6 @@ class NFSCluster:
     def __init__(self, mgr: 'Module') -> None:
         self.mgr = mgr
 
-    def _get_common_conf_obj_name(self, cluster_id: str) -> str:
-        return f'conf-nfs.{cluster_id}'
-
-    def _get_user_conf_obj_name(self, cluster_id: str) -> str:
-        return f'userconf-nfs.{cluster_id}'
-
     def _call_orch_apply_nfs(
             self,
             cluster_id: str,
@@ -89,17 +84,18 @@ class NFSCluster:
                                   port=port)
             completion = self.mgr.apply_nfs(spec)
             orchestrator.raise_if_exception(completion)
-        log.debug("Successfully deployed nfs daemons with cluster id %s and placement %s", cluster_id, placement)
+        log.debug("Successfully deployed nfs daemons with cluster id %s and placement %s",
+                  cluster_id, placement)
 
     def create_empty_rados_obj(self, cluster_id: str) -> None:
-        common_conf = self._get_common_conf_obj_name(cluster_id)
-        self._rados(cluster_id).write_obj('', self._get_common_conf_obj_name(cluster_id))
+        common_conf = conf_obj_name(cluster_id)
+        self._rados(cluster_id).write_obj('', conf_obj_name(cluster_id))
         log.info("Created empty object:%s", common_conf)
 
     def delete_config_obj(self, cluster_id: str) -> None:
         self._rados(cluster_id).remove_all_obj()
         log.info("Deleted %s object and all objects in %s",
-                 self._get_common_conf_obj_name(cluster_id), cluster_id)
+                 conf_obj_name(cluster_id), cluster_id)
 
     def create_nfs_cluster(
             self,
@@ -218,7 +214,7 @@ class NFSCluster:
         try:
             if cluster_id in available_clusters(self.mgr):
                 rados_obj = self._rados(cluster_id)
-                conf = rados_obj.read_obj(self._get_user_conf_obj_name(cluster_id))
+                conf = rados_obj.read_obj(user_conf_obj_name(cluster_id))
                 return 0, conf or "", ""
             raise ClusterNotFound()
         except Exception as e:
@@ -230,8 +226,8 @@ class NFSCluster:
                 rados_obj = self._rados(cluster_id)
                 if rados_obj.check_user_config():
                     return 0, "", "NFS-Ganesha User Config already exists"
-                rados_obj.write_obj(nfs_config, self._get_user_conf_obj_name(cluster_id),
-                                    self._get_common_conf_obj_name(cluster_id))
+                rados_obj.write_obj(nfs_config, user_conf_obj_name(cluster_id),
+                                    conf_obj_name(cluster_id))
                 log.debug("Successfully saved %s's user config: \n %s", cluster_id, nfs_config)
                 restart_nfs_service(self.mgr, cluster_id)
                 return 0, "NFS-Ganesha Config Set Successfully", ""
@@ -248,8 +244,8 @@ class NFSCluster:
                 rados_obj = self._rados(cluster_id)
                 if not rados_obj.check_user_config():
                     return 0, "", "NFS-Ganesha User Config does not exist"
-                rados_obj.remove_obj(self._get_user_conf_obj_name(cluster_id),
-                                     self._get_common_conf_obj_name(cluster_id))
+                rados_obj.remove_obj(user_conf_obj_name(cluster_id),
+                                     conf_obj_name(cluster_id))
                 restart_nfs_service(self.mgr, cluster_id)
                 return 0, "NFS-Ganesha Config Reset Successfully", ""
             raise ClusterNotFound()

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -38,7 +38,7 @@ def export_cluster_checker(func: FuncT) -> FuncT:
         This method checks if cluster exists
         """
         if kwargs['cluster_id'] not in available_clusters(export.mgr):
-            return -errno.ENOENT, "", "Cluster does not exists"
+            return -errno.ENOENT, "", "Cluster does not exist"
         return func(export, *args, **kwargs)
     return cast(FuncT, cluster_check)
 

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -12,7 +12,7 @@ from rados import ObjectNotFound
 
 from ceph.deployment.service_spec import NFSServiceSpec
 from nfs import Module
-from nfs.export import ExportMgr
+from nfs.export import ExportMgr, normalize_path
 from nfs.export_utils import GaneshaConfParser, Export, RawBlock
 from nfs.cluster import NFSCluster
 from orchestrator import ServiceDescription, DaemonDescription, OrchResult
@@ -1018,3 +1018,19 @@ NFS_CORE_PARAM {
 
     def test_cluster_config(self):
         self._do_mock_test(self._do_test_cluster_config)
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/foo/bar/baz", "/foo/bar/baz"),
+        ("/foo/bar/baz/", "/foo/bar/baz"),
+        ("/foo/bar/baz ", "/foo/bar/baz"),
+        ("/foo/./bar/baz", "/foo/bar/baz"),
+        ("/foo/bar/baz/..", "/foo/bar"),
+        ("//foo/bar/baz", "/foo/bar/baz"),
+        ("", ""),
+    ]
+)
+def test_normalize_path(path, expected):
+    assert normalize_path(path) == expected

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -5,6 +5,25 @@ import orchestrator
 if TYPE_CHECKING:
     from nfs.module import Module
 
+EXPORT_PREFIX: str = "export-"
+CONF_PREFIX: str = "conf-nfs."
+USER_CONF_PREFIX: str = "userconf-nfs."
+
+
+def export_obj_name(export_id: int) -> str:
+    """Return a rados object name for the export."""
+    return f"{EXPORT_PREFIX}{export_id}"
+
+
+def conf_obj_name(cluster_id: str) -> str:
+    """Return a rados object name for the config."""
+    return f"{CONF_PREFIX}{cluster_id}"
+
+
+def user_conf_obj_name(cluster_id: str) -> str:
+    """Returna a rados object name for the user config."""
+    return f"{USER_CONF_PREFIX}{cluster_id}"
+
 
 def available_clusters(mgr: 'Module') -> List[str]:
     '''


### PR DESCRIPTION
This PR includes changes present in #44845 

This change allows the `ceph nfs export ...` commands to function
without the entire mgr/nfs subsystem requiring orchestration to be
enabled.  When there's no orchestration available, the code falls back
to examining the namespaces in the ".nfs" rados pool to determine what
cluster_id values are valid.

This change does not add support for creating the rados objects and
namespace needed to manage a nfs cluster. As discussed with the
orchestration group on 2022-01-22, rook does not need the mgr module to
establish the namespace. So, for now, we'll defer the work needed to
create the namespace/objects when orchestration is disabled.

Fixes: https://tracker.ceph.com/issues/54043




## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
