### PR TITLE
rgw: Don't erase bucket attributes on trim

### DIFF
--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -175,6 +175,11 @@ int rgw_parse_list_of_flags(struct rgw_name_to_flag *mapping,
   return 0;
 }
 
+map<string, bufferlist>* no_change_attrs() {
+  static map<string, bufferlist> no_change;
+  return &no_change;
+}
+
 int rgw_put_system_obj(const DoutPrefixProvider *dpp, 
                        RGWSysObjectCtx& obj_ctx, const rgw_pool& pool, const string& oid, bufferlist& data, bool exclusive,
                        RGWObjVersionTracker *objv_tracker, real_time set_mtime, optional_yield y, map<string, bufferlist> *pattrs)
@@ -187,12 +192,22 @@ int rgw_put_system_obj(const DoutPrefixProvider *dpp,
   rgw_raw_obj obj(pool, oid);
 
   auto sysobj = obj_ctx.get_obj(obj);
-  int ret = sysobj.wop()
-                  .set_objv_tracker(objv_tracker)
-                  .set_exclusive(exclusive)
-                  .set_mtime(set_mtime)
-                  .set_attrs(*pattrs)
-                  .write(dpp, data, y);
+  int ret;
+
+  if (pattrs != no_change_attrs()) {
+    ret = sysobj.wop()
+      .set_objv_tracker(objv_tracker)
+      .set_exclusive(exclusive)
+      .set_mtime(set_mtime)
+      .set_attrs(*pattrs)
+      .write(dpp, data, y);
+  } else {
+    ret = sysobj.wop()
+      .set_objv_tracker(objv_tracker)
+      .set_exclusive(exclusive)
+      .set_mtime(set_mtime)
+      .write_data(dpp, data, y);
+  }
 
   return ret;
 }

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -268,4 +268,11 @@ using RGWDataAccessRef = std::shared_ptr<RGWDataAccess>;
 /// calls and error handling.
 void rgw_complete_aio_completion(librados::AioCompletion* c, int r);
 
+/// This returns a static, non-NULL pointer, recognized only by
+/// rgw_put_system_obj(). When supplied instead of the attributes, the
+/// attributes will be unmodified.
+///
+// (Currently providing nullptr will wipe all attributes.)
+
+std::map<std::string, ceph::buffer::list>* no_change_attrs();
 #endif

--- a/src/rgw/rgw_trim_bilog.cc
+++ b/src/rgw/rgw_trim_bilog.cc
@@ -729,7 +729,7 @@ int BucketTrimInstanceCR::operate(const DoutPrefixProvider *dpp)
 	yield call(new RGWPutBucketInstanceInfoCR(
 		     store->svc()->rados->get_async_processor(),
 		     store, clean_info->first, false, {},
-		     nullptr, dpp));
+		     no_change_attrs(), dpp));
 
 	// Raced, try again.
 	if (retcode == -ECANCELED) {


### PR DESCRIPTION
Writing bucket instance info is surprising, as if you pass a null
pointer for the attributes, it just erases all the attributes.

To avoid disturbing users and other 'system objects', make a special
case that we can pass in explicitly.