### PR TITLE
pacific: ceph-volume: fix error 'KeyError' with inventory

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -8,7 +8,7 @@ import os
 import uuid
 from itertools import repeat
 from math import floor
-from ceph_volume import process, util
+from ceph_volume import process, util, conf
 from ceph_volume.exceptions import SizeAllocationError
 
 logger = logging.getLogger(__name__)
@@ -839,7 +839,7 @@ class Volume(object):
             report = {
                 'name': self.lv_name,
                 'osd_id': self.tags['ceph.osd_id'],
-                'cluster_name': self.tags['ceph.cluster_name'],
+                'cluster_name': self.tags.get('ceph.cluster_name', conf.cluster),
                 'type': type_,
                 'osd_fsid': self.tags['ceph.osd_fsid'],
                 'cluster_fsid': self.tags['ceph.cluster_fsid'],


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54127

---

backport of https://github.com/ceph/ceph/pull/44218
parent tracker: https://tracker.ceph.com/issues/44356

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh