### PR TITLE
crimson/os/seastore: change segment_off_t to seastore_off_t in ZNSSegmentManager

### DIFF
--- a/src/crimson/os/seastore/segment_manager/zns.cc
+++ b/src/crimson/os/seastore/segment_manager/zns.cc
@@ -490,7 +490,7 @@ SegmentManager::read_ertr::future<> ZNSSegmentManager::read(
 }
 
 Segment::close_ertr::future<> ZNSSegmentManager::segment_close(
-  segment_id_t id, segment_off_t write_pointer)
+  segment_id_t id, seastore_off_t write_pointer)
 {
   return seastar::do_with(
     blk_zone_range{},
@@ -558,7 +558,7 @@ magic_t ZNSSegmentManager::get_magic() const
   return metadata.magic;
 };
 
-segment_off_t ZNSSegment::get_write_capacity() const
+seastore_off_t ZNSSegment::get_write_capacity() const
 {
   return manager.get_segment_size();
 }
@@ -577,7 +577,7 @@ Segment::close_ertr::future<> ZNSSegment::close()
 }
 
 Segment::write_ertr::future<> ZNSSegment::write(
-  segment_off_t offset, ceph::bufferlist bl)
+  seastore_off_t offset, ceph::bufferlist bl)
 {
   if (offset < write_pointer || offset % manager.metadata.block_size != 0) {
     logger().error(

--- a/src/crimson/os/seastore/segment_manager/zns.h
+++ b/src/crimson/os/seastore/segment_manager/zns.h
@@ -68,17 +68,17 @@ namespace crimson::os::seastore::segment_manager::zns {
     ZNSSegment(ZNSSegmentManager &man, segment_id_t i) : manager(man), id(i){};
 
     segment_id_t get_segment_id() const final { return id; }
-    segment_off_t get_write_capacity() const final;
-    segment_off_t get_write_ptr() const final { return write_pointer; }
+    seastore_off_t get_write_capacity() const final;
+    seastore_off_t get_write_ptr() const final { return write_pointer; }
     close_ertr::future<> close() final;
-    write_ertr::future<> write(segment_off_t offset, ceph::bufferlist bl) final;
+    write_ertr::future<> write(seastore_off_t offset, ceph::bufferlist bl) final;
 
     ~ZNSSegment() {}
   private:
     friend class ZNSSegmentManager;
     ZNSSegmentManager &manager;
     const segment_id_t id;
-    segment_off_t write_pointer = 0;
+    seastore_off_t write_pointer = 0;
   };
 
   class ZNSSegmentManager final : public SegmentManager{
@@ -99,11 +99,11 @@ namespace crimson::os::seastore::segment_manager::zns {
       return metadata.size;
     };
 
-    segment_off_t get_block_size() const final {
+    seastore_off_t get_block_size() const final {
       return metadata.block_size;
     };
 
-    segment_off_t get_segment_size() const final {
+    seastore_off_t get_segment_size() const final {
       return metadata.segment_size;
     };
 
@@ -162,7 +162,7 @@ namespace crimson::os::seastore::segment_manager::zns {
     seastar::metrics::metric_group metrics;
 
     Segment::close_ertr::future<> segment_close(
-      segment_id_t id, segment_off_t write_pointer);
+      segment_id_t id, seastore_off_t write_pointer);
 
     uint64_t get_offset(paddr_t addr) {
       auto& seg_addr = addr.as_seg_paddr();


### PR DESCRIPTION
Patching ZNSSegmentManager to work after commit c93d0b7b1e7be2e3879ec384a951edb247a9f775.

Signed-off-by: Joseph Sawaya <josephsawaya938@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
