### PR TITLE
rgw: fix segfault in OpsLogRados::log when realm is reloaded

### DIFF
--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -472,7 +472,7 @@ int OpsLogSocket::log_json(struct req_state* s, bufferlist& bl)
   return 0;
 }
 
-OpsLogRados::OpsLogRados(rgw::sal::Store* store): store(store)
+OpsLogRados::OpsLogRados(rgw::sal::Store* const& store): store(store)
 {
 }
 

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -199,9 +199,11 @@ public:
 };
 
 class OpsLogRados : public OpsLogSink {
-  rgw::sal::Store* store;
+  // main()'s Store pointer as a reference, possibly modified by RGWRealmReloader
+  rgw::sal::Store* const& store;
+
 public:
-  OpsLogRados(rgw::sal::Store* store);
+  OpsLogRados(rgw::sal::Store* const& store);
   int log(struct req_state* s, struct rgw_log_entry& entry) override;
 };
 


### PR DESCRIPTION
We weren't previously handling the deallocation of the store when a realm was reloaded. Now passing a const reference to the pointer.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
