### PR TITLE
pacific: crush: Fix segfault in update_from_hook

### DIFF
--- a/src/common/entity_name.cc
+++ b/src/common/entity_name.cc
@@ -106,7 +106,7 @@ void EntityName::set_name(entity_name_t n)
   set(n.type(), s);
 }
 
-std::string_view EntityName::
+const char* EntityName::
 get_type_str() const
 {
   return ceph_entity_type_name(type);

--- a/src/common/entity_name.h
+++ b/src/common/entity_name.h
@@ -52,7 +52,7 @@ struct EntityName
   void set_id(std::string_view id_);
   void set_name(entity_name_t n);
 
-  std::string_view get_type_str() const;
+  const char* get_type_str() const;
 
   uint32_t get_type() const { return type; }
   bool is_osd() const { return get_type() == CEPH_ENTITY_TYPE_OSD; }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53480

---

backport of https://github.com/ceph/ceph/pull/43944
parent tracker: https://tracker.ceph.com/issues/50659

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh