### PR TITLE
mds: lower dout message levels when dropping cap flushes on the floor

### DIFF
--- a/src/common/debug.h
+++ b/src/common/debug.h
@@ -22,6 +22,8 @@
 
 #define dout(v) ldout((dout_context), (v))
 
+#define dout_once(v) ldout_once((dout_context), (v))
+
 #define pdout(v, p) lpdout((dout_context), (v), (p))
 
 #define dlog_p(sub, v) ldlog_p1((dout_context), (sub), (v))

--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -175,6 +175,18 @@ struct is_dynamic<dynamic_marker_t<T>> : public std::true_type {};
 #define ldout(cct, v)  dout_impl(cct, dout_subsys, v) dout_prefix
 #define lderr(cct) dout_impl(cct, ceph_subsys_, -1) dout_prefix
 
+// like ldout, but first occurrence will also be logged to cluster log
+#define ldout_once(cct, v)						\
+  do {									\
+    static bool logged = false;						\
+									\
+    if (!logged) {							\
+      clog << sub;							\
+      logged = true;							\
+    }									\
+    ldout(cct, v)							\
+  } while (0)
+
 #define ldpp_subdout(dpp, sub, v) 						\
   if (decltype(auto) pdpp = (dpp); pdpp) /* workaround -Wnonnull-compare for 'this' */ \
     dout_impl(pdpp->get_cct(), ceph_subsys_##sub, v) \

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -3193,7 +3193,7 @@ void Locker::handle_client_caps(const cref_t<MClientCaps> &m)
      *   - mds trim its cache
      *   - mds receives cap messages from client
      */
-    dout(7) << "handle_client_caps on unknown ino " << m->get_ino() << ", dropping" << dendl;
+    dout_once(7) << "handle_client_caps tid " << m->get_client_tid() << " on unknown ino " << m->get_ino() << ", dropping" << dendl;
     return;
   }
 
@@ -3212,9 +3212,9 @@ void Locker::handle_client_caps(const cref_t<MClientCaps> &m)
   Capability *cap = 0;
   cap = head_in->get_client_cap(client);
   if (!cap) {
-    dout(7) << "handle_client_caps no cap for client." << client << " on " << *head_in << dendl;
+    dout_once(7) << "handle_client_caps tid " << m->get_client_tid() << " no cap for client." << client << " on " << *head_in << dendl;
     return;
-  }  
+  }
   ceph_assert(cap);
 
   // freezing|frozen?
@@ -3224,7 +3224,7 @@ void Locker::handle_client_caps(const cref_t<MClientCaps> &m)
     return;
   }
   if (ceph_seq_cmp(m->get_mseq(), cap->get_mseq()) < 0) {
-    dout(7) << "handle_client_caps mseq " << m->get_mseq() << " < " << cap->get_mseq()
+    dout_once(7) << "handle_client_caps tid " << m->get_client_tid() << " mseq " << m->get_mseq() << " < " << cap->get_mseq()
 	    << ", dropping" << dendl;
     return;
   }
@@ -3292,7 +3292,7 @@ void Locker::handle_client_caps(const cref_t<MClientCaps> &m)
   }
 
   if (cap->get_cap_id() != m->get_cap_id()) {
-    dout(7) << " ignoring client capid " << m->get_cap_id() << " != my " << cap->get_cap_id() << dendl;
+    dout_once(7) << "handle_client_caps tid " << m->get_client_tid() << " ignoring client capid " << m->get_cap_id() << " != my " << cap->get_cap_id() << dendl;
   } else {
     CInode *in = head_in;
     if (follows > 0) {


### PR DESCRIPTION
In some cases, the MDS can ignore a cap flush from the client and never
send a FLUSH_ACK. Lower the debug levels for some of the dout messages
in handle_client_caps to 0, to make it so that they are always printed.

Fixes: https://tracker.ceph.com/issues/54107
Signed-off-by: Jeff Layton <jlayton@redhat.com>

Marking this draft for now, so consider it to be an RFC for the moment. Is there a better way to gather more info as to why we aren't always getting a FLUSH_ACK like we should?



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
