### PR TITLE
qa/orch: use hwe kernel in rook/smoke tests (ubuntu 20.04)

### DIFF
--- a/qa/suites/orch/rook/smoke/0-distro/ubuntu_20.04.yaml
+++ b/qa/suites/orch/rook/smoke/0-distro/ubuntu_20.04.yaml
@@ -1,2 +1,1 @@
-os_type: ubuntu
-os_version: "20.04"
+.qa/distros/container-hosts/ubuntu_20.04.yaml


### PR DESCRIPTION
Use the override in ./src/qa/distros/container-hosts/ubuntu_20.04.yaml
in order to use hwe kernel for Ubuntu 20.04

This is because the ubuntu 20.04 kernel (5.4) has a bug that prevents
from using nvme-loop.

see https://lkml.org/lkml/2020/9/21/1456

Fixes: https://tracker.ceph.com/issues/54094

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
