### PR TITLE
cephadm: update mounts for shared_ceph_folder

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2592,7 +2592,7 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
                 mounts[ceph_folder + '/src/cephadm/cephadm'] = '/usr/sbin/cephadm'
                 mounts[ceph_folder + '/src/pybind/mgr'] = '/usr/share/ceph/mgr'
                 mounts[ceph_folder + '/src/python-common/ceph'] = '/usr/lib/python3.6/site-packages/ceph'
-                mounts[ceph_folder + '/monitoring/grafana/dashboards'] = '/etc/grafana/dashboards/ceph-dashboard'
+                mounts[ceph_folder + '/monitoring/ceph-mixin/dashboards_out'] = '/etc/grafana/dashboards/ceph-dashboard'
                 mounts[ceph_folder + '/monitoring/prometheus/alerts'] = '/etc/prometheus/ceph'
             else:
                 logger.error('{}{}{}'.format(termcolor.red,


### PR DESCRIPTION
ceph/ceph#44059 introduced a refactor that breaks `--shared_ceph_folder` option
in cephadm.
Let's update cephadm and mount the new path.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
