### PR TITLE
crimson/os/seastore/lba_manager: consolidate logs 

### DIFF
--- a/src/common/subsys.h
+++ b/src/common/subsys.h
@@ -91,6 +91,7 @@ SUBSYS(seastore_tm, 0, 5)    // logs below seastore tm
 SUBSYS(seastore_t, 0, 5)
 SUBSYS(seastore_cleaner, 0, 5)
 SUBSYS(seastore_lba, 0, 5)
+SUBSYS(seastore_lba_details, 0, 5)
 SUBSYS(seastore_cache, 0, 5)
 SUBSYS(seastore_journal, 0, 5)
 SUBSYS(seastore_device, 0, 5)

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -11,12 +11,20 @@
 #include "crimson/os/seastore/logging.h"
 
 SET_SUBSYS(seastore_lba);
+/*
+ * levels:
+ * - INFO:  mkfs
+ * - DEBUG: modification operations
+ * - TRACE: read operations, DEBUG details
+ */
 
 namespace crimson::os::seastore::lba_manager::btree {
 
 BtreeLBAManager::mkfs_ret BtreeLBAManager::mkfs(
   Transaction &t)
 {
+  LOG_PREFIX(BtreeLBAManager::mkfs);
+  INFOT("start", t);
   return cache.get_root(t).si_then([this, &t](auto croot) {
     croot->get_root().lba_root = LBABtree::mkfs(get_context(t));
     return mkfs_iertr::now();
@@ -34,20 +42,24 @@ BtreeLBAManager::get_mappings(
   laddr_t offset, extent_len_t length)
 {
   LOG_PREFIX(BtreeLBAManager::get_mappings);
-  DEBUGT("offset: {}, length{}", t, offset, length);
+  TRACET("{}~{}", t, offset, length);
   auto c = get_context(t);
   return with_btree_state<lba_pin_list_t>(
     c,
-    [c, offset, length](auto &btree, auto &ret) {
+    [c, offset, length, FNAME](auto &btree, auto &ret) {
       return LBABtree::iterate_repeat(
 	c,
 	btree.upper_bound_right(c, offset),
-	[&ret, offset, length](auto &pos) {
+	[&ret, offset, length, c, FNAME](auto &pos) {
 	  if (pos.is_end() || pos.get_key() >= (offset + length)) {
+	    TRACET("{}~{} done with {} results",
+	           c.trans, offset, length, ret.size());
 	    return LBABtree::iterate_repeat_ret_inner(
 	      interruptible::ready_future_marker{},
 	      seastar::stop_iteration::yes);
 	  }
+	  TRACET("{}~{} got {}, {}, repeat ...",
+	         c.trans, offset, length, pos.get_key(), pos.get_val());
 	  ceph_assert((pos.get_key() + pos.get_val().len) > offset);
 	  ret.push_back(pos.get_pin());
 	  return LBABtree::iterate_repeat_ret_inner(
@@ -64,7 +76,7 @@ BtreeLBAManager::get_mappings(
   laddr_list_t &&list)
 {
   LOG_PREFIX(BtreeLBAManager::get_mappings);
-  DEBUGT("{}", t, list);
+  TRACET("{}", t, list);
   auto l = std::make_unique<laddr_list_t>(std::move(list));
   auto retptr = std::make_unique<lba_pin_list_t>();
   auto &ret = *retptr;
@@ -88,7 +100,7 @@ BtreeLBAManager::get_mapping(
   laddr_t offset)
 {
   LOG_PREFIX(BtreeLBAManager::get_mapping);
-  DEBUGT("{}", t, offset);
+  TRACET("{}", t, offset);
   auto c = get_context(t);
   return with_btree_ret<LBAPinRef>(
     c,
@@ -97,10 +109,12 @@ BtreeLBAManager::get_mapping(
 	c, offset
       ).si_then([FNAME, offset, c](auto iter) -> get_mapping_ret {
 	if (iter.is_end() || iter.get_key() != offset) {
+	  DEBUGT("{} doesn't exist", c.trans, offset);
 	  return crimson::ct_error::enoent::make();
 	} else {
+	  TRACET("{} got {}, {}",
+	         c.trans, offset, iter.get_key(), iter.get_val());
 	  auto e = iter.get_pin();
-	  DEBUGT("got mapping {}", c.trans, *e);
 	  return get_mapping_ret(
 	    interruptible::ready_future_marker{},
 	    std::move(e));
@@ -127,47 +141,59 @@ BtreeLBAManager::alloc_extent(
   };
 
   LOG_PREFIX(BtreeLBAManager::alloc_extent);
-  DEBUGT("hint: {}, length: {}", t, hint, len);
+  TRACET("{}~{}, hint={}", t, addr, len, hint);
   auto c = get_context(t);
   ++stats.num_alloc_extents;
+  auto lookup_attempts = stats.num_alloc_extents_iter_nexts;
   return with_btree_state<state_t>(
     c,
     hint,
-    [this, FNAME, c, hint, len, addr, &t](auto &btree, auto &state) {
+    [this, FNAME, c, hint, len, addr, lookup_attempts, &t](auto &btree, auto &state) {
       return LBABtree::iterate_repeat(
 	c,
 	btree.upper_bound_right(c, hint),
-	[this, &state, len, &t, hint, FNAME](auto &pos) {
+	[this, &state, len, addr, &t, hint, FNAME, lookup_attempts](auto &pos) {
 	  ++stats.num_alloc_extents_iter_nexts;
-	  if (!pos.is_end()) {
-	    DEBUGT("iterate_repeat: pos: {}~{}, state: {}~{}, hint: {}",
-                   t,
-                   pos.get_key(),
-                   pos.get_val().len,
+	  if (pos.is_end()) {
+	    DEBUGT("{}~{}, hint={}, state: end, done with {} attempts, insert at {}",
+                   t, addr, len, hint,
+                   stats.num_alloc_extents_iter_nexts - lookup_attempts,
+                   state.last_end);
+	    state.insert_iter = pos;
+	    return LBABtree::iterate_repeat_ret_inner(
+	      interruptible::ready_future_marker{},
+	      seastar::stop_iteration::yes);
+	  } else if (pos.get_key() >= (state.last_end + len)) {
+	    DEBUGT("{}~{}, hint={}, state: {}~{}, done with {} attempts, insert at {} -- {}",
+                   t, addr, len, hint,
+                   pos.get_key(), pos.get_val().len,
+                   stats.num_alloc_extents_iter_nexts - lookup_attempts,
                    state.last_end,
-                   len,
-                   hint);
-	  }
-	  if (pos.is_end() || pos.get_key() >= (state.last_end + len)) {
+                   pos.get_val());
 	    state.insert_iter = pos;
 	    return LBABtree::iterate_repeat_ret_inner(
 	      interruptible::ready_future_marker{},
 	      seastar::stop_iteration::yes);
 	  } else {
 	    state.last_end = pos.get_key() + pos.get_val().len;
+	    TRACET("{}~{}, hint={}, state: {}~{}, repeat ... -- {}",
+                   t, addr, len, hint,
+                   pos.get_key(), pos.get_val().len,
+                   pos.get_val());
 	    return LBABtree::iterate_repeat_ret_inner(
 	      interruptible::ready_future_marker{},
 	      seastar::stop_iteration::no);
 	  }
-	}).si_then([FNAME, c, addr, len, &btree, &state] {
-	  DEBUGT("about to insert at addr {}~{}", c.trans, state.last_end, len);
+	}).si_then([FNAME, c, addr, len, hint, &btree, &state] {
 	  return btree.insert(
 	    c,
 	    *state.insert_iter,
 	    state.last_end,
 	    lba_map_val_t{len, addr, 1, 0}
-	  ).si_then([&state](auto &&p) {
+	  ).si_then([&state, FNAME, c, addr, len, hint](auto &&p) {
 	    auto [iter, inserted] = std::move(p);
+	    TRACET("{}~{}, hint={}, inserted at {}",
+	           c.trans, addr, len, hint, state.last_end);
 	    ceph_assert(inserted);
 	    state.ret = iter;
 	  });
@@ -210,6 +236,7 @@ void BtreeLBAManager::complete_transaction(
   Transaction &t)
 {
   LOG_PREFIX(BtreeLBAManager::complete_transaction);
+  DEBUGT("start", t);
   std::vector<CachedExtentRef> to_clear;
   to_clear.reserve(t.get_retired_set().size());
   for (auto &e: t.get_retired_set()) {
@@ -223,7 +250,7 @@ void BtreeLBAManager::complete_transaction(
 
   for (auto &e: to_clear) {
     auto &pin = get_pin(*e);
-    DEBUGT("retiring {}, {}", t, *e, pin);
+    DEBUGT("retiring extent {} -- {}", t, pin, *e);
     pin_set.retire(pin);
   }
 
@@ -240,13 +267,13 @@ void BtreeLBAManager::complete_transaction(
     [](auto &l, auto &r) -> bool { return get_depth(*l) > get_depth(*r); });
 
   for (auto &e : to_link) {
-    DEBUGT("linking {}", t, *e);
+    DEBUGT("linking extent -- {}", t, *e);
     pin_set.add_pin(get_pin(*e));
   }
 
   for (auto &e: to_clear) {
     auto &pin = get_pin(*e);
-    DEBUGT("checking {}, {}", t, *e, pin);
+    TRACET("checking extent {} -- {}", t, pin, *e);
     pin_set.check_parent(pin);
   }
 }
@@ -256,15 +283,16 @@ BtreeLBAManager::init_cached_extent_ret BtreeLBAManager::init_cached_extent(
   CachedExtentRef e)
 {
   LOG_PREFIX(BtreeLBAManager::init_cached_extent);
-  DEBUGT("extent {}", t, *e);
-  return seastar::do_with(bool(), [this, e, &t](bool& ret) {
+  TRACET("{}", t, *e);
+  return seastar::do_with(bool(), [this, e, FNAME, &t](bool& ret) {
     auto c = get_context(t);
     return with_btree(c, [c, e, &ret](auto &btree) {
       return btree.init_cached_extent(c, e
       ).si_then([&ret](bool is_alive) {
         ret = is_alive;
       });
-    }).si_then([&ret] {
+    }).si_then([&ret, e, FNAME, c] {
+      DEBUGT("is_alive={} -- {}", c.trans, ret, *e);
       return ret;
     });
   });
@@ -306,7 +334,7 @@ BtreeLBAManager::scan_mapped_space_ret BtreeLBAManager::scan_mapped_space(
     scan_mapped_space_func_t &&f)
 {
   LOG_PREFIX(BtreeLBAManager::scan_mapped_space);
-  DEBUGT("", t);
+  DEBUGT("start", t);
   auto c = get_context(t);
   return seastar::do_with(
     std::move(f),
@@ -339,14 +367,13 @@ BtreeLBAManager::rewrite_extent_ret BtreeLBAManager::rewrite_extent(
 {
   LOG_PREFIX(BtreeLBAManager::rewrite_extent);
   if (extent->has_been_invalidated()) {
-    ERRORT("{} has been invalidated", t, *extent);
+    ERRORT("extent has been invalidated -- {}", t, *extent);
+    ceph_abort();
   }
-  assert(!extent->has_been_invalidated());
   assert(!extent->is_logical());
 
-  DEBUGT("rewriting {}", t, *extent);
-
   if (is_lba_node(*extent)) {
+    DEBUGT("rewriting lba extent -- {}", t, *extent);
     auto c = get_context(t);
     return with_btree(
       c,
@@ -354,6 +381,7 @@ BtreeLBAManager::rewrite_extent_ret BtreeLBAManager::rewrite_extent(
 	return btree.rewrite_lba_extent(c, extent);
       });
   } else {
+    DEBUGT("skip non lba extent -- {}", t, *extent);
     return rewrite_extent_iertr::now();
   }
 }
@@ -365,6 +393,8 @@ BtreeLBAManager::update_mapping(
   paddr_t prev_addr,
   paddr_t addr)
 {
+  LOG_PREFIX(BtreeLBAManager::update_mapping);
+  TRACET("laddr={}, paddr {} => {}", t, laddr, prev_addr, addr);
   return update_mapping(
     t,
     laddr,
@@ -375,14 +405,17 @@ BtreeLBAManager::update_mapping(
       ceph_assert(in.paddr == prev_addr);
       ret.paddr = addr;
       return ret;
-    }).si_then(
-      [](auto) {},
-      update_le_mapping_iertr::pass_further{},
-      /* ENOENT in particular should be impossible */
-      crimson::ct_error::assert_all{
-	"Invalid error in BtreeLBAManager::rewrite_extent after update_mapping"
-      }
-    );
+    }
+  ).si_then([&t, laddr, prev_addr, addr, FNAME](auto result) {
+      DEBUGT("laddr={}, paddr {} => {} done -- {}",
+             t, laddr, prev_addr, addr, result);
+    },
+    update_le_mapping_iertr::pass_further{},
+    /* ENOENT in particular should be impossible */
+    crimson::ct_error::assert_all{
+      "Invalid error in BtreeLBAManager::rewrite_extent after update_mapping"
+    }
+  );
 }
 
 BtreeLBAManager::get_physical_extent_if_live_ret
@@ -393,6 +426,9 @@ BtreeLBAManager::get_physical_extent_if_live(
   laddr_t laddr,
   seastore_off_t len)
 {
+  LOG_PREFIX(BtreeLBAManager::get_physical_extent_if_live);
+  DEBUGT("{}, laddr={}, paddr={}, length={}",
+         t, type, laddr, addr, len);
   ceph_assert(is_lba_node(type));
   auto c = get_context(t);
   return with_btree_ret<CachedExtentRef>(
@@ -418,6 +454,8 @@ BtreeLBAManager::BtreeLBAManager(
 
 void BtreeLBAManager::register_metrics()
 {
+  LOG_PREFIX(BtreeLBAManager::register_metrics);
+  DEBUG("start");
   stats = {};
   namespace sm = seastar::metrics;
   metrics.add_group(
@@ -443,7 +481,7 @@ BtreeLBAManager::update_refcount_ret BtreeLBAManager::update_refcount(
   int delta)
 {
   LOG_PREFIX(BtreeLBAManager::update_refcount);
-  DEBUGT("addr {}, delta {}", t, addr, delta);
+  TRACET("laddr={}, delta={}", t, addr, delta);
   return update_mapping(
     t,
     addr,
@@ -452,13 +490,15 @@ BtreeLBAManager::update_refcount_ret BtreeLBAManager::update_refcount(
       ceph_assert((int)out.refcount + delta >= 0);
       out.refcount += delta;
       return out;
-    }).si_then([](auto result) {
-      return ref_update_result_t{
-	result.refcount,
-	result.paddr,
-	result.len
-       };
-    });
+    }
+  ).si_then([&t, addr, delta, FNAME](auto result) {
+    DEBUGT("laddr={}, delta={} done -- {}", t, addr, delta, result);
+    return ref_update_result_t{
+      result.refcount,
+      result.paddr,
+      result.len
+     };
+  });
 }
 
 BtreeLBAManager::update_mapping_ret BtreeLBAManager::update_mapping(
@@ -466,8 +506,6 @@ BtreeLBAManager::update_mapping_ret BtreeLBAManager::update_mapping(
   laddr_t addr,
   update_func_t &&f)
 {
-  LOG_PREFIX(BtreeLBAManager::update_mapping);
-  DEBUGT("addr {}", t, addr);
   auto c = get_context(t);
   return with_btree_ret<lba_map_val_t>(
     c,
@@ -477,6 +515,8 @@ BtreeLBAManager::update_mapping_ret BtreeLBAManager::update_mapping(
       ).si_then([&btree, f=std::move(f), c, addr](auto iter)
 		-> update_mapping_ret {
 	if (iter.is_end() || iter.get_key() != addr) {
+	  LOG_PREFIX(BtreeLBAManager::update_mapping);
+	  DEBUGT("laddr={} doesn't exist", c.trans, addr);
 	  return crimson::ct_error::enoent::make();
 	}
 
@@ -505,7 +545,8 @@ BtreeLBAManager::~BtreeLBAManager()
 {
   pin_set.scan([](auto &i) {
     LOG_PREFIX(BtreeLBAManager::~BtreeLBAManager);
-    ERROR("Found {} {} has_ref={}", i, i.get_extent(), i.has_ref());
+    ERROR("Found {}, has_ref={} -- {}",
+          i, i.has_ref(), i.get_extent());
   });
 }
 

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -128,6 +128,11 @@ private:
 
   btree_pin_set_t pin_set;
 
+  struct {
+    uint64_t num_alloc_extents = 0;
+    uint64_t num_alloc_extents_iter_nexts = 0;
+  } stats;
+
   op_context_t get_context(Transaction &t) {
     return op_context_t{cache, t, &pin_set};
   }

--- a/src/crimson/os/seastore/lba_manager/btree/btree_range_pin.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_range_pin.cc
@@ -29,7 +29,7 @@ btree_range_pin_t::~btree_range_pin_t()
   ceph_assert(!pins == !is_linked());
   ceph_assert(!ref);
   if (pins) {
-    DEBUG("removing {}", *this);
+    TRACE("removing {}", *this);
     pins->remove_pin(*this, true);
   }
   extent = nullptr;
@@ -43,7 +43,7 @@ void btree_pin_set_t::replace_pin(btree_range_pin_t &to, btree_range_pin_t &from
 void btree_pin_set_t::remove_pin(btree_range_pin_t &pin, bool do_check_parent)
 {
   LOG_PREFIX(btree_pin_set_t::remove_pin);
-  DEBUG("{}", pin);
+  TRACE("{}", pin);
   ceph_assert(pin.is_linked());
   ceph_assert(pin.pins);
   ceph_assert(!pin.ref);
@@ -124,14 +124,14 @@ void btree_pin_set_t::add_pin(btree_range_pin_t &pin)
     auto *parent = maybe_get_parent(pin.range);
     ceph_assert(parent);
     if (!parent->has_ref()) {
-      DEBUG("acquiring parent {}", static_cast<void*>(parent));
+      TRACE("acquiring parent {}", static_cast<void*>(parent));
       parent->acquire_ref();
     } else {
-      DEBUG("parent has ref {}", static_cast<void*>(parent));
+      TRACE("parent has ref {}", static_cast<void*>(parent));
     }
   }
   if (maybe_get_first_child(pin.range) != nullptr) {
-    DEBUG("acquiring self {}", pin);
+    TRACE("acquiring self {}", pin);
     pin.acquire_ref();
   }
 }
@@ -147,7 +147,7 @@ void btree_pin_set_t::check_parent(btree_range_pin_t &pin)
   LOG_PREFIX(btree_pin_set_t::check_parent);
   auto parent = maybe_get_parent(pin.range);
   if (parent) {
-    DEBUG("releasing parent {}", *parent);
+    TRACE("releasing parent {}", *parent);
     release_if_no_children(*parent);
   }
 }

--- a/src/crimson/os/seastore/lba_manager/btree/btree_range_pin.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_range_pin.cc
@@ -1,15 +1,10 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "crimson/common/log.h"
-
 #include "crimson/os/seastore/lba_manager/btree/btree_range_pin.h"
+#include "crimson/os/seastore/logging.h"
 
-namespace {
-  seastar::logger& logger() {
-    return crimson::get_logger(ceph_subsys_seastore_lba);
-  }
-}
+SET_SUBSYS(seastore_lba);
 
 namespace crimson::os::seastore::lba_manager::btree {
 
@@ -30,10 +25,11 @@ void btree_range_pin_t::take_pin(btree_range_pin_t &other)
 
 btree_range_pin_t::~btree_range_pin_t()
 {
+  LOG_PREFIX(btree_range_pin_t::~btree_range_pin_t);
   ceph_assert(!pins == !is_linked());
   ceph_assert(!ref);
   if (pins) {
-    logger().debug("{}: removing {}", __func__, *this);
+    DEBUG("removing {}", *this);
     pins->remove_pin(*this, true);
   }
   extent = nullptr;
@@ -46,7 +42,8 @@ void btree_pin_set_t::replace_pin(btree_range_pin_t &to, btree_range_pin_t &from
 
 void btree_pin_set_t::remove_pin(btree_range_pin_t &pin, bool do_check_parent)
 {
-  logger().debug("{}: {}", __func__, pin);
+  LOG_PREFIX(btree_pin_set_t::remove_pin);
+  DEBUG("{}", pin);
   ceph_assert(pin.is_linked());
   ceph_assert(pin.pins);
   ceph_assert(!pin.ref);
@@ -107,15 +104,14 @@ void btree_pin_set_t::release_if_no_children(btree_range_pin_t &pin)
 
 void btree_pin_set_t::add_pin(btree_range_pin_t &pin)
 {
+  LOG_PREFIX(btree_pin_set_t::add_pin);
   ceph_assert(!pin.is_linked());
   ceph_assert(!pin.pins);
   ceph_assert(!pin.ref);
 
   auto [prev, inserted] = pins.insert(pin);
   if (!inserted) {
-    logger().error(
-      "{}: unable to add {} ({}), found {} ({})",
-      __func__,
+    ERROR("unable to add {} ({}), found {} ({})",
       pin,
       *(pin.extent),
       *prev,
@@ -128,16 +124,14 @@ void btree_pin_set_t::add_pin(btree_range_pin_t &pin)
     auto *parent = maybe_get_parent(pin.range);
     ceph_assert(parent);
     if (!parent->has_ref()) {
-      logger().debug("{}: acquiring parent {}", __func__,
-		     static_cast<void*>(parent));
+      DEBUG("acquiring parent {}", static_cast<void*>(parent));
       parent->acquire_ref();
     } else {
-      logger().debug("{}: parent has ref {}", __func__,
-		     static_cast<void*>(parent));
+      DEBUG("parent has ref {}", static_cast<void*>(parent));
     }
   }
   if (maybe_get_first_child(pin.range) != nullptr) {
-    logger().debug("{}: acquiring self {}", __func__, pin);
+    DEBUG("acquiring self {}", pin);
     pin.acquire_ref();
   }
 }
@@ -150,9 +144,10 @@ void btree_pin_set_t::retire(btree_range_pin_t &pin)
 
 void btree_pin_set_t::check_parent(btree_range_pin_t &pin)
 {
+  LOG_PREFIX(btree_pin_set_t::check_parent);
   auto parent = maybe_get_parent(pin.range);
   if (parent) {
-    logger().debug("{}: releasing parent {}", __func__, *parent);
+    DEBUG("releasing parent {}", *parent);
     release_if_no_children(*parent);
   }
 }

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
@@ -1,9 +1,6 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "crimson/common/log.h"
-#include "crimson/os/seastore/logging.h"
-
 #include "crimson/os/seastore/lba_manager/btree/lba_btree.h"
 
 SET_SUBSYS(seastore_lba);
@@ -342,7 +339,7 @@ LBABtree::get_internal_if_live(
   laddr_t laddr,
   seastore_off_t len)
 {
-  LOG_PREFIX(BtreeLBAManager::get_leaf_if_live);
+  LOG_PREFIX(LBABtree::get_internal_if_live);
   return lower_bound(
     c, laddr
   ).si_then([FNAME, c, addr, laddr, len](auto iter) {
@@ -378,7 +375,7 @@ LBABtree::get_leaf_if_live(
   laddr_t laddr,
   seastore_off_t len)
 {
-  LOG_PREFIX(BtreeLBAManager::get_leaf_if_live);
+  LOG_PREFIX(LBABtree::get_leaf_if_live);
   return lower_bound(
     c, laddr
   ).si_then([FNAME, c, addr, laddr, len](auto iter) {
@@ -637,8 +634,7 @@ LBABtree::handle_split_ret LBABtree::handle_split(
 
   /* pos may be either node_position_t<LBALeafNode> or
    * node_position_t<LBAInternalNode> */
-  auto split_level = [&](auto &parent_pos, auto &pos) {
-    LOG_PREFIX(LBATree::handle_split);
+  auto split_level = [&, FNAME](auto &parent_pos, auto &pos) {
     auto [left, right, pivot] = pos.node->make_split_children(c);
 
     auto parent_node = parent_pos.node;
@@ -777,9 +773,8 @@ LBABtree::handle_merge_ret merge_level(
     donor_iter.get_val().maybe_relative_to(parent_pos.node->get_paddr()),
     begin,
     end
-  ).si_then([c, iter, donor_iter, donor_is_left, &parent_pos, &pos](
+  ).si_then([FNAME, c, iter, donor_iter, donor_is_left, &parent_pos, &pos](
 	      typename NodeType::Ref donor) {
-    LOG_PREFIX(LBABtree::merge_level);
     auto [l, r] = donor_is_left ?
       std::make_pair(donor, pos.node) : std::make_pair(pos.node, donor);
 
@@ -804,7 +799,6 @@ LBABtree::handle_merge_ret merge_level(
       c.cache.retire_extent(c.trans, l);
       c.cache.retire_extent(c.trans, r);
     } else {
-      LOG_PREFIX(LBABtree::merge_level);
       auto [replacement_l, replacement_r, pivot] =
 	l->make_balanced(
 	  c,

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
@@ -3,7 +3,7 @@
 
 #include "crimson/os/seastore/lba_manager/btree/lba_btree.h"
 
-SET_SUBSYS(seastore_lba);
+SET_SUBSYS(seastore_lba_details);
 
 namespace crimson::os::seastore::lba_manager::btree {
 

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
@@ -8,9 +8,8 @@
 #include <memory>
 #include <string.h>
 
-#include "crimson/common/log.h"
-
 #include "crimson/os/seastore/lba_manager.h"
+#include "crimson/os/seastore/logging.h"
 #include "crimson/os/seastore/seastore_types.h"
 #include "crimson/os/seastore/lba_manager/btree/lba_btree_node.h"
 

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.h
@@ -545,7 +545,7 @@ private:
     mapped_space_visitor_t *visitor ///< [in] mapped space visitor
   ) {
     LOG_PREFIX(LBATree::lookup_depth_range);
-    SUBDEBUGT(seastore_lba, "{} -> {}", c.trans, from, to);
+    SUBDEBUGT(seastore_lba_details, "{} -> {}", c.trans, from, to);
     return seastar::do_with(
       from,
       [c, to, visitor, &iter, &li, &ll](auto &d) {
@@ -609,7 +609,7 @@ private:
 	    auto riter = ll(*(root_entry.node));
 	    root_entry.pos = riter->get_offset();
 	  }
-	  SUBDEBUGT(seastore_lba, "got root, depth {}", c.trans, root.get_depth());
+	  SUBDEBUGT(seastore_lba_details, "got root, depth {}", c.trans, root.get_depth());
 	  return lookup_depth_range(
 	    c,
 	    iter,

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
@@ -11,12 +11,9 @@
 #include "include/byteorder.h"
 
 #include "crimson/os/seastore/lba_manager/btree/lba_btree_node.h"
+#include "crimson/os/seastore/logging.h"
 
-namespace {
-  seastar::logger& logger() {
-    return crimson::get_logger(ceph_subsys_seastore_lba);
-  }
-}
+SET_SUBSYS(seastore_lba);
 
 namespace crimson::os::seastore::lba_manager::btree {
 
@@ -28,13 +25,11 @@ std::ostream &LBAInternalNode::print_detail(std::ostream &out) const
 
 void LBAInternalNode::resolve_relative_addrs(paddr_t base)
 {
+  LOG_PREFIX(LBAInternalNode::resolve_relative_addrs);
   for (auto i: *this) {
     if (i->get_val().is_relative()) {
       auto updated = base.add_relative(i->get_val());
-      logger().debug(
-	"LBAInternalNode::resolve_relative_addrs {} -> {}",
-	i->get_val(),
-	updated);
+      DEBUG("{} -> {}", i->get_val(), updated);
       i->set_val(updated);
     }
   }
@@ -48,14 +43,12 @@ std::ostream &LBALeafNode::print_detail(std::ostream &out) const
 
 void LBALeafNode::resolve_relative_addrs(paddr_t base)
 {
+  LOG_PREFIX(LBALeafNode::resolve_relative_addrs);
   for (auto i: *this) {
     if (i->get_val().paddr.is_relative()) {
       auto val = i->get_val();
       val.paddr = base.add_relative(val.paddr);
-      logger().debug(
-	"LBALeafNode::resolve_relative_addrs {} -> {}",
-	i->get_val().paddr,
-	val.paddr);
+      DEBUG("{} -> {}", i->get_val().paddr, val.paddr);
       i->set_val(val);
     }
   }

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
@@ -17,6 +17,16 @@ SET_SUBSYS(seastore_lba);
 
 namespace crimson::os::seastore::lba_manager::btree {
 
+std::ostream& operator<<(std::ostream& out, const lba_map_val_t& v)
+{
+  return out << "lba_map_val_t("
+             << v.paddr
+             << "~" << v.len
+             << ", refcount=" << v.refcount
+             << ", checksum=" << v.checksum
+             << ")";
+}
+
 std::ostream &LBAInternalNode::print_detail(std::ostream &out) const
 {
   return out << ", size=" << get_size()
@@ -29,7 +39,7 @@ void LBAInternalNode::resolve_relative_addrs(paddr_t base)
   for (auto i: *this) {
     if (i->get_val().is_relative()) {
       auto updated = base.add_relative(i->get_val());
-      DEBUG("{} -> {}", i->get_val(), updated);
+      TRACE("{} -> {}", i->get_val(), updated);
       i->set_val(updated);
     }
   }
@@ -48,7 +58,7 @@ void LBALeafNode::resolve_relative_addrs(paddr_t base)
     if (i->get_val().paddr.is_relative()) {
       auto val = i->get_val();
       val.paddr = base.add_relative(val.paddr);
-      DEBUG("{} -> {}", i->get_val().paddr, val.paddr);
+      TRACE("{} -> {}", i->get_val().paddr, val.paddr);
       i->set_val(val);
     }
   }

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -55,6 +55,8 @@ WRITE_EQ_OPERATORS_4(
   refcount,
   checksum);
 
+std::ostream& operator<<(std::ostream& out, const lba_map_val_t&);
+
 class BtreeLBAPin;
 using BtreeLBAPinRef = std::unique_ptr<BtreeLBAPin>;
 


### PR DESCRIPTION
This PR won't adjust logs in `lba_btree` in order to minimize potential conflicts to the ongoing work https://github.com/ceph/ceph/pull/44912. Note there is still a minor cleanup to `lba_tree`, see commit "move lba_tree_inner_stats into LBAManager".

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
