### PR TITLE
balancer: Improve performance in rare cases

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -2382,6 +2382,14 @@ options:
   default: true
   flags:
   - runtime
+- name: osd_calc_pg_upmaps_aggressively_fast
+  type: bool
+  level: advanced
+  desc: Prevent very long (>10 minutes) calculations in some extreme cases (applicable
+    only to aggressive mode)
+  default: true
+  flags:
+  - runtime
 - name: osd_calc_pg_upmaps_local_fallback_retries
   type: uint
   level: advanced

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4735,7 +4735,7 @@ int OSDMap::calc_pg_upmaps(
       int osd = p->second;
       float deviation = p->first;
       if (fast_aggressive && osd_to_skip.count(osd)) {
-	ldout(cct, 20) << " Skipping osd " << osd 
+	ldout(cct, 20) << " Fast aggressive mode: skipping osd " << osd 
 	               << " osd_to_skip size = " << osd_to_skip.size() << dendl;
 	continue;
       }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4714,6 +4714,11 @@ int OSDMap::calc_pg_upmaps(
     set<pg_t> to_skip;
     uint64_t local_fallback_retried = 0;
 
+    // Used to prevent some of the unsuccessful loop iterations (save runtime)
+    // If we can't find a change per OSD we skip further iterations for this OSD
+    uint n_changes = 0, prev_n_changes = 0;
+    set<int> osd_to_skip;
+
   retry:
 
     set<pg_t> to_unmap;
@@ -4727,6 +4732,12 @@ int OSDMap::calc_pg_upmaps(
       }
       int osd = p->second;
       float deviation = p->first;
+      if (osd_to_skip.count(osd)) {
+	ldout(cct, 20) << " Skipping osd " << osd 
+	               << " osd_to_skip size = " << osd_to_skip.size() << dendl;
+	continue;
+      }
+
       if (deviation < 0) {
         ldout(cct, 10) << " hitting underfull osds now"
                        << " when trying to remap overfull osds"
@@ -4824,6 +4835,13 @@ int OSDMap::calc_pg_upmaps(
           goto test_change;
 	}
       }
+      if (prev_n_changes == n_changes) {  // no changes for prev OSD
+	osd_to_skip.insert(osd);
+      }
+      else {
+	prev_n_changes = n_changes;
+      }
+
     }
 
     ceph_assert(!(to_unmap.size() || to_upmap.size()));
@@ -4917,6 +4935,8 @@ int OSDMap::calc_pg_upmaps(
     pgs_by_osd = temp_pgs_by_osd;
     osd_deviation = temp_osd_deviation;
     deviation_osd = temp_deviation_osd;
+    n_changes++;
+
 
     num_changed += pack_upmap_results(cct, to_unmap, to_upmap, tmp_osd_map, pending_inc);
 


### PR DESCRIPTION
In some cases calc_pg_upmaps can work for extemly long time (> 10 minutes)
This change improves the performance in these cases to single digit
seconds.

Fixes: https://tracker.ceph.com/issues/54180

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
