### PR TITLE
mgr/dashboard: set appropriate baseline branch for applitools 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/applitools.config.js
+++ b/src/pybind/mgr/dashboard/frontend/applitools.config.js
@@ -1,3 +1,12 @@
+const fs = require('fs')
+var branch = new String();
+
+// Read the contents of the ceph_release file to retrieve
+// the branch
+fs.readFile('../../../../ceph_release', (_, data) => {
+    branch = data.toString().split('\n')[1];
+});
+
 module.exports = {
   appName: 'Ceph Dashboard',
   batchId: process.env.APPLITOOLS_BATCH_ID, 
@@ -8,8 +17,9 @@ module.exports = {
     { width: 800, height: 600, name: 'chrome' },
     { width: 800, height: 600, name: 'firefox' }
   ],
-  showLogs: true,
+  showLogs: false,
   saveDebugData: true,
   failCypressOnDiff: true,
-  concurrency: 4
+  concurrency: 4,
+  baselineBranchName: branch
 };


### PR DESCRIPTION
All the dashboard PRs are checked against a baseline branch called
'default' in the visual regresstion testing. This will cause issues when
testing PRs in different branches. For eg: currently our master and
pacific has to save two different screenshots since the two of them
differ slightly.

Fixes: https://tracker.ceph.com/issues/54190
Signed-off-by: Nizamudeen A <nia@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
