### PR TITLE
cmake: add dependency compress->common

### DIFF
--- a/src/compressor/CMakeLists.txt
+++ b/src/compressor/CMakeLists.txt
@@ -5,6 +5,7 @@ if (HAVE_QATZIP)
   list(APPEND compressor_srcs QatAccel.cc)
 endif()
 add_library(compressor_objs OBJECT ${compressor_srcs})
+add_dependencies(compressor_objs common-objs)
 if(HAVE_QATZIP AND HAVE_QATDRV)
   target_link_libraries(compressor_objs PRIVATE
                         QatDrv::qat_s


### PR DESCRIPTION
The compression code depends on headers generated during the build
of the common code for ceph.

Ensure that CMake understands this dependency, avoiding a race
between generation of header files and compilation of the
compression module.

Signed-off-by: James Page <james.page@ubuntu.com>
