### PR TITLE
rgw/dbstore: Add dbstore-tests to `make check`

### DIFF
--- a/src/rgw/store/dbstore/tests/CMakeLists.txt
+++ b/src/rgw/store/dbstore/tests/CMakeLists.txt
@@ -8,5 +8,6 @@ set(dbstore_tests_srcs
 
 include_directories(${CMAKE_INCLUDE_DIR})
 
-add_executable(dbstore-tests ${dbstore_tests_srcs})
-target_link_libraries(dbstore-tests ${CMAKE_LINK_LIBRARIES})
+add_executable(unittest_dbstore_tests ${dbstore_tests_srcs})
+target_link_libraries(unittest_dbstore_tests ${CMAKE_LINK_LIBRARIES})
+add_ceph_unittest(unittest_dbstore_tests)

--- a/src/rgw/store/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/store/dbstore/tests/dbstore_tests.cc
@@ -29,7 +29,8 @@ namespace gtest {
 
       void SetUp() override {
         cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
-            CODE_ENVIRONMENT_DAEMON, CINIT_FLAG_NO_MON_CONFIG, 1);
+            CODE_ENVIRONMENT_DAEMON,
+            CINIT_FLAG_NO_DEFAULT_CONFIG_FILE | CINIT_FLAG_NO_MON_CONFIG | CINIT_FLAG_NO_DAEMON_ACTIONS);
         if (!db_type.compare("SQLite")) {
           db = new SQLiteDB(tenant, cct.get());
           ASSERT_TRUE(db != nullptr);


### PR DESCRIPTION
Include and run dbstore-tests as part of `make check` target

Fixes: https://tracker.ceph.com/issues/54193
Signed-off-by: Soumya Koduri <skoduri@redhat.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
