### PR TITLE
osd/scrub: limiting scrubber-backend external interfaces

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -306,12 +306,12 @@ public:
     stats.objects_scrubbed = 0;
   }
 
-  void reset_objects_scrubbed() {
-    recovery_state.update_stats(
-      [=](auto &history, auto &stats) {
-  reset_objects_scrubbed(stats);
-  return true;
-      });
+  void reset_objects_scrubbed()
+  {
+    recovery_state.update_stats([=](auto& history, auto& stats) {
+      reset_objects_scrubbed(stats);
+      return true;
+    });
   }
 
   bool is_deleting() const {

--- a/src/osd/scrubber/ScrubStore.cc
+++ b/src/osd/scrubber/ScrubStore.cc
@@ -124,11 +124,21 @@ Store::~Store()
   ceph_assert(results.empty());
 }
 
+void Store::add_error(int64_t pool, const inconsistent_obj_wrapper& e)
+{
+  add_object_error(pool, e);
+}
+
 void Store::add_object_error(int64_t pool, const inconsistent_obj_wrapper& e)
 {
   bufferlist bl;
   e.encode(bl);
   results[to_object_key(pool, e.object)] = bl;
+}
+
+void Store::add_error(int64_t pool, const inconsistent_snapset_wrapper& e)
+{
+  add_snap_error(pool, e);
 }
 
 void Store::add_snap_error(int64_t pool, const inconsistent_snapset_wrapper& e)

--- a/src/osd/scrubber/ScrubStore.h
+++ b/src/osd/scrubber/ScrubStore.h
@@ -25,6 +25,11 @@ public:
 		       const coll_t& coll);
   void add_object_error(int64_t pool, const inconsistent_obj_wrapper& e);
   void add_snap_error(int64_t pool, const inconsistent_snapset_wrapper& e);
+
+  // and a variant-friendly interface:
+  void add_error(int64_t pool, const inconsistent_obj_wrapper& e);
+  void add_error(int64_t pool, const inconsistent_snapset_wrapper& e);
+
   bool empty() const;
   void flush(ObjectStore::Transaction *);
   void cleanup(ObjectStore::Transaction *);

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -25,7 +25,6 @@
 
 using std::list;
 using std::pair;
-using std::set;
 using std::stringstream;
 using std::vector;
 using namespace Scrub;
@@ -1039,13 +1038,16 @@ int PgScrubber::build_replica_map_chunk()
     case 0: {
       // finished!
 
-      m_be->replica_clean_meta(replica_scrubmap, m_end.is_max(), m_start);
+      auto required_fixes = m_be->replica_clean_meta(
+        replica_scrubmap, m_end.is_max(), m_start, *this);
+      // actuate snap-mapper changes:
+      apply_snap_mapper_fixes(required_fixes);
 
       // the local map has been created. Send it to the primary.
       // Note: once the message reaches the Primary, it may ask us for another
-      // chunk - and we better be done with the current scrub. Thus - the preparation of
-      // the reply message is separate, and we clear the scrub state before actually
-      // sending it.
+      // chunk - and we better be done with the current scrub. Thus - the
+      // preparation of the reply message is separate, and we clear the scrub
+      // state before actually sending it.
 
       auto reply = prep_replica_map_msg(PreemptionNoted::no_preemption);
       replica_handling_done();
@@ -1129,10 +1131,107 @@ void PgScrubber::run_callbacks()
   }
 }
 
+void PgScrubber::persist_scrub_results(inconsistent_objs_t&& all_errors)
+{
+  dout(10) << __func__ << " " << all_errors.size() << " errors" << dendl;
+
+  for (auto& e : all_errors) {
+    std::visit([this](auto& e) { m_store->add_error(m_pg->pool.id, e); }, e);
+  }
+
+  ObjectStore::Transaction t;
+  m_store->flush(&t);
+  m_osds->store->queue_transaction(m_pg->ch, std::move(t), nullptr);
+}
+
+void PgScrubber::apply_snap_mapper_fixes(
+  const std::vector<snap_mapper_fix_t>& fix_list)
+{
+  dout(15) << __func__ << " " << fix_list.size() << " fixes" << dendl;
+
+  if (fix_list.empty()) {
+    return;
+  }
+
+  ObjectStore::Transaction t;
+  OSDriver::OSTransaction t_drv(m_pg->osdriver.get_transaction(&t));
+
+  for (auto& [fix_op, hoid, snaps, bogus_snaps] : fix_list) {
+
+    if (fix_op == snap_mapper_op_t::update) {
+
+      // must remove the existing snap-set before inserting the correct one
+      if (auto r = m_pg->snap_mapper.remove_oid(hoid, &t_drv); r < 0) {
+
+        derr << __func__ << ": remove_oid returned " << cpp_strerror(r)
+             << dendl;
+        ceph_abort();
+      }
+
+      m_osds->clog->error() << fmt::format(
+        "osd.{} found snap mapper error on pg {} oid {} snaps in mapper: {}, "
+        "oi: "
+        "{} ...repaired",
+        m_pg_whoami, m_pg_id, hoid, bogus_snaps, snaps);
+
+    } else {
+
+      m_osds->clog->error() << fmt::format(
+        "osd.{} found snap mapper error on pg {} oid {} snaps missing in "
+        "mapper, should be: {} ...repaired",
+        m_pg_whoami, m_pg_id, hoid, snaps);
+    }
+
+    // now - insert the correct snap-set
+
+    m_pg->snap_mapper.add_oid(hoid, snaps, &t_drv);
+  }
+
+  // wait for repair to apply to avoid confusing other bits of the system.
+  {
+    dout(15) << __func__ << " wait on repair!" << dendl;
+
+    ceph::condition_variable my_cond;
+    ceph::mutex my_lock = ceph::make_mutex("PG::_scan_snaps my_lock");
+    int e = 0;
+    bool done{false};
+
+    t.register_on_applied_sync(new C_SafeCond(my_lock, my_cond, &done, &e));
+
+    if (e = m_pg->osd->store->queue_transaction(m_pg->ch, std::move(t));
+        e != 0) {
+      derr << __func__ << ": queue_transaction got " << cpp_strerror(e)
+           << dendl;
+    } else {
+      std::unique_lock l{my_lock};
+      my_cond.wait(l, [&done] { return done; });
+      ceph_assert(m_pg->osd->store);  // RRR why?
+    }
+    dout(15) << __func__ << " wait on repair - done" << dendl;
+  }
+}
+
 void PgScrubber::maps_compare_n_cleanup()
 {
   m_pg->add_objects_scrubbed_count(m_be->get_primary_scrubmap().objects.size());
-  m_be->scrub_compare_maps(m_end.is_max());
+
+  auto required_fixes = m_be->scrub_compare_maps(m_end.is_max(), *this);
+  if (!required_fixes.inconsistent_objs.empty()) {
+    if (state_test(PG_STATE_REPAIR)) {
+      dout(10) << __func__ << ": discarding scrub results (repairing)" << dendl;
+    } else {
+      // perform the ordered scrub-store I/O:
+      persist_scrub_results(std::move(required_fixes.inconsistent_objs));
+    }
+  }
+
+  // actuate snap-mapper changes:
+  apply_snap_mapper_fixes(required_fixes.snap_fix_list);
+
+  auto chunk_err_counts = m_be->get_error_counts();
+  m_shallow_errors += chunk_err_counts.shallow_errors;
+  m_deep_errors += chunk_err_counts.deep_errors;
+
   m_start = m_end;
   run_callbacks();
   requeue_waiting();

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1630,7 +1630,7 @@ void PgScrubber::scrub_finish()
         static_cast<int>(m_pg->cct->_conf->osd_scrub_auto_repair_num_errors)) {
 
     dout(10) << __func__ << " undoing the repair" << dendl;
-    state_clear(PG_STATE_REPAIR); // not expected to be set, anyway
+    state_clear(PG_STATE_REPAIR);  // not expected to be set, anyway
     m_is_repair = false;
     update_op_mode_text();
   }

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1626,7 +1626,8 @@ void PgScrubber::scrub_finish()
   // if the repair request comes from auto-repair and large number of errors,
   // we would like to cancel auto-repair
   if (m_is_repair && m_flags.auto_repair &&
-      m_authoritative.size() > m_pg->cct->_conf->osd_scrub_auto_repair_num_errors) {
+      m_be->authoritative_peers_count() >
+        static_cast<int>(m_pg->cct->_conf->osd_scrub_auto_repair_num_errors)) {
 
     dout(10) << __func__ << " undoing the repair" << dendl;
     state_clear(PG_STATE_REPAIR); // not expected to be set, anyway
@@ -1636,10 +1637,12 @@ void PgScrubber::scrub_finish()
 
   m_be->update_repair_status(m_is_repair);
 
-  // if a regular scrub had errors within the limit, do a deep scrub to auto repair
+  // if a regular scrub had errors within the limit, do a deep scrub to auto
+  // repair
   bool do_auto_scrub = false;
-  if (m_flags.deep_scrub_on_error && !m_authoritative.empty() &&
-      m_authoritative.size() <= m_pg->cct->_conf->osd_scrub_auto_repair_num_errors) {
+  if (m_flags.deep_scrub_on_error && m_be->authoritative_peers_count() &&
+      m_be->authoritative_peers_count() <=
+        static_cast<int>(m_pg->cct->_conf->osd_scrub_auto_repair_num_errors)) {
     ceph_assert(!m_is_deep);
     do_auto_scrub = true;
     dout(15) << __func__ << " Try to auto repair after scrub errors" << dendl;
@@ -1650,9 +1653,34 @@ void PgScrubber::scrub_finish()
   // type-specific finish (can tally more errors)
   _scrub_finish();
 
+  /// \todo fix the relevant scrub test so that we would not need the extra log
+  /// line here (even if the following 'if' is false)
+
+  if (m_be->authoritative_peers_count()) {
+
+    auto err_msg = fmt::format("{} {} {} missing, {} inconsistent objects",
+                               m_pg->info.pgid,
+                               m_mode_desc,
+                               m_be->m_missing.size(),
+                               m_be->m_inconsistent.size());
+
+    dout(2) << err_msg << dendl;
+    m_osds->clog->error() << fmt::to_string(err_msg);
+  }
+
   // note that the PG_STATE_REPAIR might have changed above
-  m_fixed_count += m_be->scrub_process_inconsistent();
-  bool has_error = !m_authoritative.empty() && m_is_repair;
+  if (m_be->authoritative_peers_count() && m_is_repair) {
+
+    state_clear(PG_STATE_CLEAN);
+    // we know we have a problem, so it's OK to set the user-visible flag
+    // even if we only reached here via auto-repair
+    state_set(PG_STATE_REPAIR);
+    update_op_mode_text();
+    m_be->update_repair_status(true);
+    m_fixed_count += m_be->scrub_process_inconsistent();
+  }
+
+  bool has_error = (m_be->authoritative_peers_count() > 0) && m_is_repair;
 
   {
     stringstream oss;
@@ -2103,7 +2131,6 @@ void PgScrubber::reset_internal_state()
 
   run_callbacks();
 
-  m_authoritative.clear();
   num_digest_updates_pending = 0;
   m_primary_scrubmap_pos.reset();
   replica_scrubmap = ScrubMap{};

--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -98,6 +98,11 @@ ScrubBackend::ScrubBackend(PgScrubber& scrubber,
               : (m_depth == scrub_level_t::deep ? "deep-scrub"sv : "scrub"sv));
 }
 
+uint64_t ScrubBackend::logical_to_ondisk_size(uint64_t logical_size) const
+{
+  return m_pgbe.be_get_ondisk_size(logical_size);
+}
+
 void ScrubBackend::update_repair_status(bool should_repair)
 {
   dout(15) << __func__
@@ -771,12 +776,12 @@ shard_as_auth_t ScrubBackend::possible_auth_shard(const hobject_t& obj,
   // This is automatically corrected in repair_oinfo_oid()
   ceph_assert(oi.soid == obj);
 
-  if (test_error_cond(smap_obj.size != m_pgbe.be_get_ondisk_size(oi.size),
+  if (test_error_cond(smap_obj.size != logical_to_ondisk_size(oi.size),
                       shard_info,
                       &shard_info_wrapper::set_obj_size_info_mismatch)) {
 
     errstream << sep(err) << "candidate size " << smap_obj.size << " info size "
-              << m_pgbe.be_get_ondisk_size(oi.size) << " mismatch";
+              << logical_to_ondisk_size(oi.size) << " mismatch";
   }
 
   std::optional<uint32_t> digest;
@@ -1325,7 +1330,7 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
 
   // sizes:
 
-  uint64_t oi_size = m_pgbe.be_get_ondisk_size(auth_oi.size);
+  uint64_t oi_size = logical_to_ondisk_size(auth_oi.size);
   if (oi_size != candidate.size) {
     format_to(out,
               "{}size {} != size {} from auth oi {}",
@@ -1494,12 +1499,12 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
     }
 
     if (oi) {
-      if (m_pgbe.be_get_ondisk_size(oi->size) != p->second.size) {
-        clog->error() << m_mode_desc << " " << info.pgid << " " << soid
+      if (logical_to_ondisk_size(oi->size) != p->second.size) {
+        clog->error() << m_mode_desc << " " << m_pg_id << " " << soid
                       << " : on disk size (" << p->second.size
                       << ") does not match object info size (" << oi->size
                       << ") adjusted for ondisk to ("
-                      << m_pgbe.be_get_ondisk_size(oi->size) << ")";
+                      << logical_to_ondisk_size(oi->size) << ")";
         soid_error.set_size_mismatch();
         this_chunk->m_error_counts.shallow_errors++;
       }

--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -17,8 +17,6 @@
 
 #include "pg_scrubber.h"
 
-using std::list;
-using std::pair;
 using std::set;
 using std::stringstream;
 using std::vector;
@@ -56,6 +54,8 @@ ScrubBackend::ScrubBackend(PgScrubber& scrubber,
     , m_repair{repair}
     , m_depth{shallow_or_deep}
     , m_pg_id{scrubber.m_pg_id}
+    , m_pool{m_pg.get_pool()}
+    , m_incomplete_clones_allowed{m_pool.info.allow_incomplete_clones()}
     , m_conf{m_scrubber.get_pg_cct()->_conf}
     , clog{m_scrubber.m_osds->clog}
 {
@@ -67,7 +67,7 @@ ScrubBackend::ScrubBackend(PgScrubber& scrubber,
                std::back_inserter(m_acting_but_me),
                [i_am](const pg_shard_t& shard) { return shard != i_am; });
 
-  m_is_replicated = m_pg.get_pool().info.is_replicated();
+  m_is_replicated = m_pool.info.is_replicated();
   m_mode_desc =
     (m_repair ? "repair"sv
               : (m_depth == scrub_level_t::deep ? "deep-scrub"sv : "scrub"sv));
@@ -87,11 +87,12 @@ ScrubBackend::ScrubBackend(PgScrubber& scrubber,
     , m_repair{repair}
     , m_depth{shallow_or_deep}
     , m_pg_id{scrubber.m_pg_id}
+    , m_pool{m_pg.get_pool()}
     , m_conf{m_scrubber.get_pg_cct()->_conf}
     , clog{m_scrubber.m_osds->clog}
 {
   m_formatted_id = m_pg_id.calc_name_sring();
-  m_is_replicated = m_pg.get_pool().info.is_replicated();
+  m_is_replicated = m_pool.info.is_replicated();
   m_mode_desc =
     (m_repair ? "repair"sv
               : (m_depth == scrub_level_t::deep ? "deep-scrub"sv : "scrub"sv));
@@ -122,7 +123,7 @@ ScrubMap& ScrubBackend::get_primary_scrubmap()
 void ScrubBackend::merge_to_authoritative_set()
 {
   dout(15) << __func__ << dendl;
-  ceph_assert(m_pg.is_primary());
+  ceph_assert(m_scrubber.is_primary());
   ceph_assert(this_chunk->authoritative_set.empty() &&
               "the scrubber-backend should be empty");
 
@@ -155,7 +156,7 @@ void ScrubBackend::decode_received_map(pg_shard_t from,
                                        const MOSDRepScrubMap& msg)
 {
   auto p = const_cast<bufferlist&>(msg.get_data()).cbegin();
-  this_chunk->received_maps[from].decode(p, m_pg.pool.id);
+  this_chunk->received_maps[from].decode(p, m_pool.id);
 
   dout(15) << __func__ << ": decoded map from : " << from
            << ": versions: " << this_chunk->received_maps[from].valid_through
@@ -190,7 +191,7 @@ objs_fix_list_t ScrubBackend::scrub_compare_maps(
   SnapMapperAccessor& snaps_getter)
 {
   dout(10) << __func__ << " has maps, analyzing" << dendl;
-  ceph_assert(m_pg.is_primary());
+  ceph_assert(m_scrubber.is_primary());
 
   // construct authoritative scrub map for type-specific scrubbing
 
@@ -231,7 +232,7 @@ void ScrubBackend::omap_checks()
   for (const auto& ho : this_chunk->authoritative_set) {
 
     for (const auto& [srd, smap] : this_chunk->received_maps) {
-      if (srd != m_pg.get_primary()) {
+      if (srd != m_pg_whoami) {
         // Only set omap stats for the primary
         continue;
       }
@@ -245,7 +246,7 @@ void ScrubBackend::omap_checks()
       m_omap_stats.omap_bytes += smap_obj.object_omap_bytes;
       m_omap_stats.omap_keys += smap_obj.object_omap_keys;
       if (smap_obj.large_omap_object_found) {
-        auto osdmap = m_pg.get_osdmap();
+        auto osdmap = m_scrubber.get_osdmap();
         pg_t pg;
         osdmap->map_to_pg(ho.pool, ho.oid.name, ho.get_key(), ho.nspace, &pg);
         pg_t mpg = osdmap->raw_pg_to_pg(pg);
@@ -329,7 +330,7 @@ void ScrubBackend::repair_oinfo_oid(ScrubMap& smap)
       OSDriver::OSTransaction _t(m_pg.osdriver.get_transaction(&t));
 
       clog->error() << "osd." << m_pg_whoami
-                    << " found object info error on pg " << m_pg.info.pgid
+                    << " found object info error on pg " << m_pg_id
                     << " oid " << hoid << " oid in object info: " << oi.soid
                     << "...repaired";
       // Fix object info
@@ -830,20 +831,17 @@ std::optional<std::string> ScrubBackend::compare_obj_in_maps(const hobject_t& ho
   if (!auth_res.is_auth_available) {
     // no auth selected
     object_error.set_version(0);
-    object_error.set_auth_missing(ho,
-                                  this_chunk->received_maps,
-                                  auth_res.shard_map,
-                                  m_scrubber.m_shallow_errors,
-                                  m_scrubber.m_deep_errors,
-                                  m_pg_whoami);
+    object_error.set_auth_missing(
+      ho, this_chunk->received_maps, auth_res.shard_map,
+      this_chunk->m_error_counts.shallow_errors,
+      this_chunk->m_error_counts.deep_errors, m_pg_whoami);
 
     if (object_error.has_deep_errors()) {
-      ++m_scrubber.m_deep_errors;
+      this_chunk->m_error_counts.deep_errors++;
     } else if (object_error.has_shallow_errors()) {
-      ++m_scrubber.m_shallow_errors;
+      this_chunk->m_error_counts.shallow_errors++;
     }
 
-    //m_scrubber.m_store->add_object_error(ho.pool, object_error);
     this_chunk->m_inconsistent_objs.push_back(std::move(object_error));
     return fmt::format("{} soid {} : failed to pick suitable object info\n",
                        m_scrubber.m_pg_id.pgid,
@@ -882,9 +880,9 @@ std::optional<std::string> ScrubBackend::compare_obj_in_maps(const hobject_t& ho
   }
 
   if (object_error.has_deep_errors()) {
-    ++m_scrubber.m_deep_errors;
+    this_chunk->m_error_counts.deep_errors++;
   } else if (object_error.has_shallow_errors()) {
-    ++m_scrubber.m_shallow_errors;
+    this_chunk->m_error_counts.shallow_errors++;
   }
 
   if (object_error.errors || object_error.union_shards.errors) {
@@ -994,8 +992,7 @@ void ScrubBackend::inconsistents(const hobject_t& ho,
         utime_t age = this_chunk->started - auth_oi.local_mtime;
 
         // \todo find out 'age_limit' only once
-        const auto age_limit =
-          m_scrubber.get_pg_cct()->_conf->osd_deep_scrub_update_digest_min_age;
+        const auto age_limit = m_conf->osd_deep_scrub_update_digest_min_age;
 
         if (age <= age_limit) {
           dout(20) << __func__ << ": missing digest but age (" << age
@@ -1136,9 +1133,9 @@ ScrubBackend::auth_and_obj_errs_t ScrubBackend::match_in_shards(
 
         this_chunk->cur_inconsistent.insert(srd);
         if (auth_sel.shard_map[srd].has_deep_errors()) {
-          ++m_scrubber.m_deep_errors;
+          this_chunk->m_error_counts.deep_errors++;
         } else {
-          ++m_scrubber.m_shallow_errors;
+          this_chunk->m_error_counts.shallow_errors++;
         }
 
         if (discrep_found) {
@@ -1170,12 +1167,12 @@ ScrubBackend::auth_and_obj_errs_t ScrubBackend::match_in_shards(
       auth_sel.shard_map[srd].primary = (srd == m_pg_whoami);
 
       // Can't have any other errors if there is no information available
-      ++m_scrubber.m_shallow_errors;
+      this_chunk->m_error_counts.shallow_errors++;
       errstream << m_pg_id << " shard " << srd << " " << ho << " : missing\n";
     }
     obj_result.add_shard(srd, auth_sel.shard_map[srd]);
 
-    dout(30) << __func__ << ": soid " << ho << " : " << errstream.str()
+    dout(20) << __func__ << ": (debug) soid " << ho << " : " << errstream.str()
              << dendl;
   }
 
@@ -1444,10 +1441,6 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
   dout(10) << __func__ << " num stat obj "
            << m_pg.info.stats.stats.sum.num_objects << dendl;
 
-  auto& info = m_pg.info;
-  const PGPool& pool = m_pg.pool;
-  bool allow_incomplete_clones = pool.info.allow_incomplete_clones();
-
   std::optional<snapid_t> all_clones;  // Unspecified snapid_t or std::nullopt
 
   // traverse in reverse order.
@@ -1480,9 +1473,9 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
     std::optional<object_info_t> oi;
     if (!p->second.attrs.count(OI_ATTR)) {
       oi = std::nullopt;
-      clog->error() << m_mode_desc << " " << info.pgid << " " << soid
+      clog->error() << m_mode_desc << " " << m_pg_id << " " << soid
                     << " : no '" << OI_ATTR << "' attr";
-      ++m_scrubber.m_shallow_errors;
+      this_chunk->m_error_counts.shallow_errors++;
       soid_error.set_info_missing();
     } else {
       bufferlist bv;
@@ -1491,10 +1484,10 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
         oi = object_info_t(bv);
       } catch (ceph::buffer::error& e) {
         oi = std::nullopt;
-        clog->error() << m_mode_desc << " " << info.pgid << " " << soid
+        clog->error() << m_mode_desc << " " << m_pg_id << " " << soid
                       << " : can't decode '" << OI_ATTR << "' attr "
                       << e.what();
-        ++m_scrubber.m_shallow_errors;
+        this_chunk->m_error_counts.shallow_errors++;
         soid_error.set_info_corrupted();
         soid_error.set_info_missing();  // Not available too
       }
@@ -1508,7 +1501,7 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
                       << ") adjusted for ondisk to ("
                       << m_pgbe.be_get_ondisk_size(oi->size) << ")";
         soid_error.set_size_mismatch();
-        ++m_scrubber.m_shallow_errors;
+        this_chunk->m_error_counts.shallow_errors++;
       }
 
       dout(20) << m_mode_desc << "  " << soid << " " << *oi << dendl;
@@ -1538,7 +1531,7 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
       // Expecting an object with snap for current head
       if (soid.has_snapset() || soid.get_head() != head->get_head()) {
 
-        dout(10) << __func__ << " " << m_mode_desc << " " << info.pgid
+        dout(10) << __func__ << " " << m_mode_desc << " " << m_pg_id
                  << " new object " << soid << " while processing " << *head
                  << dendl;
 
@@ -1551,8 +1544,7 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
       // Log any clones we were expecting to be there up to target
       // This will set missing, but will be a no-op if snap.soid == *curclone.
       missing += process_clones_to(head,
-                                   snapset, /*clog, info.pgid, m_mode_desc,*/
-                                   allow_incomplete_clones,
+                                   snapset,
                                    target,
                                    &curclone,
                                    head_error);
@@ -1574,14 +1566,14 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
     if (!expected) {
       // If we couldn't read the head's snapset, just ignore clones
       if (head && !snapset) {
-        clog->error() << m_mode_desc << " " << info.pgid << " TTTTT:" << m_pg_id
+        clog->error() << m_mode_desc << " " << m_pg_id << " TTTTT:" << m_pg_id
                       << " " << soid
                       << " : clone ignored due to missing snapset";
       } else {
-        clog->error() << m_mode_desc << " " << info.pgid << " " << soid
+        clog->error() << m_mode_desc << " " << m_pg_id << " " << soid
                       << " : is an unexpected clone";
       }
-      ++m_scrubber.m_shallow_errors;
+      this_chunk->m_error_counts.shallow_errors++;
       soid_error.set_headless();
       this_chunk->m_inconsistent_objs.push_back(std::move(soid_error));
       ++soid_error_count;
@@ -1596,8 +1588,7 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
       if (missing) {
         log_missing(missing,
                     head,
-                    __func__,
-                    pool.info.allow_incomplete_clones());
+                    __func__);
       }
 
       // Save previous head error information
@@ -1615,9 +1606,9 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
                << dendl;
 
       if (p->second.attrs.count(SS_ATTR) == 0) {
-        clog->error() << m_mode_desc << " " << info.pgid << " " << soid
+        clog->error() << m_mode_desc << " " << m_pg_id << " " << soid
                       << " : no '" << SS_ATTR << "' attr";
-        ++m_scrubber.m_shallow_errors;
+        this_chunk->m_error_counts.shallow_errors++;
         snapset = std::nullopt;
         head_error.set_snapset_missing();
       } else {
@@ -1630,10 +1621,10 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
           head_error.ss_bl.push_back(p->second.attrs[SS_ATTR]);
         } catch (ceph::buffer::error& e) {
           snapset = std::nullopt;
-          clog->error() << m_mode_desc << " " << info.pgid << " " << soid
+          clog->error() << m_mode_desc << " " << m_pg_id << " " << soid
                         << " : can't decode '" << SS_ATTR << "' attr "
                         << e.what();
-          ++m_scrubber.m_shallow_errors;
+          this_chunk->m_error_counts.shallow_errors++;
           head_error.set_snapset_corrupted();
         }
       }
@@ -1645,9 +1636,9 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
         if (!snapset->clones.empty()) {
           dout(20) << "  snapset " << *snapset << dendl;
           if (snapset->seq == 0) {
-            clog->error() << m_mode_desc << " " << info.pgid << " " << soid
+            clog->error() << m_mode_desc << " " << m_pg_id << " " << soid
                           << " : snaps.seq not set";
-            ++m_scrubber.m_shallow_errors;
+            this_chunk->m_error_counts.shallow_errors++;
             head_error.set_snapset_error();
           }
         }
@@ -1662,23 +1653,23 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
                << dendl;
 
       if (snapset->clone_size.count(soid.snap) == 0) {
-        clog->error() << m_mode_desc << " " << info.pgid << " " << soid
+        clog->error() << m_mode_desc << " " << m_pg_id << " " << soid
                       << " : is missing in clone_size";
-        ++m_scrubber.m_shallow_errors;
+        this_chunk->m_error_counts.shallow_errors++;
         soid_error.set_size_mismatch();
       } else {
         if (oi && oi->size != snapset->clone_size[soid.snap]) {
-          clog->error() << m_mode_desc << " " << info.pgid << " " << soid
+          clog->error() << m_mode_desc << " " << m_pg_id << " " << soid
                         << " : size " << oi->size << " != clone_size "
                         << snapset->clone_size[*curclone];
-          ++m_scrubber.m_shallow_errors;
+          this_chunk->m_error_counts.shallow_errors++;
           soid_error.set_size_mismatch();
         }
 
         if (snapset->clone_overlap.count(soid.snap) == 0) {
-          clog->error() << m_mode_desc << " " << info.pgid << " " << soid
+          clog->error() << m_mode_desc << " " << m_pg_id << " " << soid
                         << " : is missing in clone_overlap";
-          ++m_scrubber.m_shallow_errors;
+          this_chunk->m_error_counts.shallow_errors++;
           soid_error.set_size_mismatch();
         } else {
           // This checking is based on get_clone_bytes().  The first 2 asserts
@@ -1700,9 +1691,9 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
           }
 
           if (bad_interval_set) {
-            clog->error() << m_mode_desc << " " << info.pgid << " " << soid
+            clog->error() << m_mode_desc << " " << m_pg_id << " " << soid
                           << " : bad interval_set in clone_overlap";
-            ++m_scrubber.m_shallow_errors;
+            this_chunk->m_error_counts.shallow_errors++;
             soid_error.set_size_mismatch();
           } else {
             stat.num_bytes += snapset->get_clone_bytes(soid.snap);
@@ -1721,12 +1712,11 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
   }
 
   if (doing_clones(snapset, curclone)) {
-    dout(10) << __func__ << " " << m_mode_desc << " " << info.pgid
+    dout(10) << __func__ << " " << m_mode_desc << " " << m_pg_id
              << " No more objects while processing " << *head << dendl;
 
     missing += process_clones_to(head,
                                  snapset,
-                                 allow_incomplete_clones,
                                  all_clones,
                                  &curclone,
                                  head_error);
@@ -1736,7 +1726,7 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
   // before dropping out of the loop for the last head.
 
   if (missing) {
-    log_missing(missing, head, __func__, allow_incomplete_clones);
+    log_missing(missing, head, __func__);
   }
   if (head && (head_error.errors || soid_error_count)) {
     this_chunk->m_inconsistent_objs.push_back(std::move(head_error));
@@ -1751,7 +1741,6 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
 int ScrubBackend::process_clones_to(
   const std::optional<hobject_t>& head,
   const std::optional<SnapSet>& snapset,
-  bool allow_incomplete_clones,
   std::optional<snapid_t> target,
   vector<snapid_t>::reverse_iterator* curclone,
   inconsistent_snapset_wrapper& e)
@@ -1768,12 +1757,12 @@ int ScrubBackend::process_clones_to(
     ++missing_count;
     // it is okay to be missing one or more clones in a cache tier.
     // skip higher-numbered clones in the list.
-    if (!allow_incomplete_clones) {
+    if (!m_incomplete_clones_allowed) {
       next_clone.snap = **curclone;
       clog->error() << m_mode_desc << " " << m_pg_id << " " << *head
                     << " : expected clone " << next_clone << " " << m_missing
                     << " missing";
-      ++m_scrubber.m_shallow_errors;
+      this_chunk->m_error_counts.shallow_errors++;
       e.set_clone_missing(next_clone.snap);
     }
     // Clones are descending
@@ -1784,11 +1773,10 @@ int ScrubBackend::process_clones_to(
 
 void ScrubBackend::log_missing(int missing,
                                const std::optional<hobject_t>& head,
-                               const char* logged_func_name,
-                               bool allow_incomplete_clones)
+                               const char* logged_func_name)
 {
   ceph_assert(head);
-  if (allow_incomplete_clones) {
+  if (m_incomplete_clones_allowed) {
     dout(20) << logged_func_name << " " << m_mode_desc << " " << m_pg_id << " "
              << *head << " skipped " << missing << " clone(s) in cache tier"
              << dendl;

--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -386,25 +386,24 @@ int ScrubBackend::scrub_process_inconsistent()
 
   for (const auto& [hobj, shrd_list] : m_auth_peers) {
 
-      auto missing_entry = m_missing.find(hobj);
+    auto missing_entry = m_missing.find(hobj);
 
-      if (missing_entry != m_missing.end()) {
-        repair_object(hobj, shrd_list, missing_entry->second);
-        fixed_cnt += missing_entry->second.size();
-      }
-
-      if (m_inconsistent.count(hobj)) {
-        repair_object(hobj, shrd_list, m_inconsistent[hobj]);
-        fixed_cnt += m_inconsistent[hobj].size();
-      }
+    if (missing_entry != m_missing.end()) {
+      repair_object(hobj, shrd_list, missing_entry->second);
+      fixed_cnt += missing_entry->second.size();
     }
+
+    if (m_inconsistent.count(hobj)) {
+      repair_object(hobj, shrd_list, m_inconsistent[hobj]);
+      fixed_cnt += m_inconsistent[hobj].size();
+    }
+  }
   return fixed_cnt;
 }
 
-void ScrubBackend::repair_object(
-  const hobject_t& soid,
-  const auth_peers_t& ok_peers,
-  const set<pg_shard_t>& bad_peers)
+void ScrubBackend::repair_object(const hobject_t& soid,
+                                 const auth_peers_t& ok_peers,
+                                 const set<pg_shard_t>& bad_peers)
 {
   if (g_conf()->subsys.should_gather<ceph_subsys_osd, 20>()) {
     // log the good peers
@@ -506,9 +505,9 @@ auth_selection_t ScrubBackend::select_auth_object(const hobject_t& ho,
                << dendl;
     }
 
-    dout(20) << fmt::format(
-                  "{}: {} shard {} got:{:D}", __func__, ho, l, shard_ret)
-             << dendl;
+    dout(20)
+      << fmt::format("{}: {} shard {} got:{:D}", __func__, ho, l, shard_ret)
+      << dendl;
 
     if (shard_ret.possible_auth == shard_as_auth_t::usable_t::not_usable) {
 
@@ -542,11 +541,11 @@ auth_selection_t ScrubBackend::select_auth_object(const hobject_t& ho,
            dcount(shard_ret.oi) > dcount(ret_auth.auth_oi))) {
 
         dout(30) << fmt::format("{}: using {} moved auth oi {:p} <-> {:p}",
-                                      __func__,
-                                      l,
-                                      (void*)&ret_auth.auth_oi,
-                                      (void*)&shard_ret.oi)
-                     << dendl;
+                                __func__,
+                                l,
+                                (void*)&ret_auth.auth_oi,
+                                (void*)&shard_ret.oi)
+                 << dendl;
 
         ret_auth.auth = shard_ret.auth_iter;
         ret_auth.auth_shard = ret_auth.auth->first;
@@ -702,13 +701,13 @@ shard_as_auth_t ScrubBackend::possible_auth_shard(const hobject_t& obj,
       }
     } else {
       // debug@dev only
-      dout(30)
-        << fmt::format("{} missing snap addr: {:p} shard_info: {:p} er: {:x}",
-                       __func__,
-                       (void*)&smap_obj,
-                       (void*)&shard_info,
-                       shard_info.errors)
-        << dendl;
+      dout(30) << fmt::format(
+                    "{} missing snap addr: {:p} shard_info: {:p} er: {:x}",
+                    __func__,
+                    (void*)&smap_obj,
+                    (void*)&shard_info,
+                    shard_info.errors)
+               << dendl;
     }
   }
 
@@ -817,7 +816,8 @@ void ScrubBackend::compare_smaps()
                 });
 }
 
-std::optional<std::string> ScrubBackend::compare_obj_in_maps(const hobject_t& ho)
+std::optional<std::string> ScrubBackend::compare_obj_in_maps(
+  const hobject_t& ho)
 {
   // clear per-object data:
   this_chunk->cur_inconsistent.clear();
@@ -836,10 +836,12 @@ std::optional<std::string> ScrubBackend::compare_obj_in_maps(const hobject_t& ho
   if (!auth_res.is_auth_available) {
     // no auth selected
     object_error.set_version(0);
-    object_error.set_auth_missing(
-      ho, this_chunk->received_maps, auth_res.shard_map,
-      this_chunk->m_error_counts.shallow_errors,
-      this_chunk->m_error_counts.deep_errors, m_pg_whoami);
+    object_error.set_auth_missing(ho,
+                                  this_chunk->received_maps,
+                                  auth_res.shard_map,
+                                  this_chunk->m_error_counts.shallow_errors,
+                                  this_chunk->m_error_counts.deep_errors,
+                                  m_pg_whoami);
 
     if (object_error.has_deep_errors()) {
       this_chunk->m_error_counts.deep_errors++;
@@ -876,8 +878,11 @@ std::optional<std::string> ScrubBackend::compare_obj_in_maps(const hobject_t& ho
 
     // At this point auth_list is populated, so we add the object error
     // shards as inconsistent.
-    inconsistents(
-      ho, auth_object, auth_res.auth_oi, std::move(*opt_ers), errstream);
+    inconsistents(ho,
+                  auth_object,
+                  auth_res.auth_oi,
+                  std::move(*opt_ers),
+                  errstream);
   } else {
 
     // both the auth & errs containers are empty
@@ -1548,11 +1553,8 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
 
       // Log any clones we were expecting to be there up to target
       // This will set missing, but will be a no-op if snap.soid == *curclone.
-      missing += process_clones_to(head,
-                                   snapset,
-                                   target,
-                                   &curclone,
-                                   head_error);
+      missing +=
+        process_clones_to(head, snapset, target, &curclone, head_error);
     }
 
     bool expected;
@@ -1591,9 +1593,7 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
     if (soid.has_snapset()) {
 
       if (missing) {
-        log_missing(missing,
-                    head,
-                    __func__);
+        log_missing(missing, head, __func__);
       }
 
       // Save previous head error information
@@ -1720,11 +1720,8 @@ void ScrubBackend::scrub_snapshot_metadata(ScrubMap& map)
     dout(10) << __func__ << " " << m_mode_desc << " " << m_pg_id
              << " No more objects while processing " << *head << dendl;
 
-    missing += process_clones_to(head,
-                                 snapset,
-                                 all_clones,
-                                 &curclone,
-                                 head_error);
+    missing +=
+      process_clones_to(head, snapset, all_clones, &curclone, head_error);
   }
 
   // There could be missing found by the test above or even
@@ -1846,7 +1843,6 @@ std::vector<snap_mapper_fix_t> ScrubBackend::scan_snaps(
       if (maybe_fix_order) {
         out_orders.push_back(std::move(*maybe_fix_order));
       }
-
     }
   }
 
@@ -1878,7 +1874,7 @@ std::optional<snap_mapper_fix_t> ScrubBackend::scan_object_snaps(
   if (r == -ENOENT || cur_snaps != obj_snaps) {
 
     // add this object to the list of snapsets that needs fixing. Note
-    // that we also collect the existing (bogus) list, as legacy log lines show those
+    // that we also collect the existing (bogus) list, for logging purposes
     snap_mapper_op_t fixing_op =
       (r == -ENOENT ? snap_mapper_op_t::add : snap_mapper_op_t::update);
     return snap_mapper_fix_t{fixing_op, hoid, obj_snaps, cur_snaps};

--- a/src/osd/scrubber/scrub_backend.h
+++ b/src/osd/scrubber/scrub_backend.h
@@ -64,6 +64,11 @@ using digests_fixes_t = std::vector<std::pair<hobject_t, data_omap_digests_t>>;
 using shard_info_map_t = std::map<pg_shard_t, shard_info_wrapper>;
 using shard_to_scrubmap_t = std::map<pg_shard_t, ScrubMap>;
 
+using auth_peers_t = std::vector<std::pair<ScrubMap::object, pg_shard_t>>;
+
+using wrapped_err_t =
+  std::variant<inconsistent_obj_wrapper, inconsistent_snapset_wrapper>;
+using inconsistent_objs_t = std::vector<wrapped_err_t>;
 
 /// omap-specific stats
 struct omap_stat_t {
@@ -72,6 +77,43 @@ struct omap_stat_t {
  int64_t omap_keys{0};
 };
 
+
+/*
+ * snaps-related aux structures:
+ * the scrub-backend scans the snaps associated with each scrubbed object, and
+ * fixes corrupted snap-sets.
+ * The actual access to the PG's snap_mapper, and the actual I/O transactions,
+ * are performed by the main PgScrubber object.
+ * the following aux structures are used to facilitate the required exchanges:
+ * - pre-fix snap-sets are accessed by the scrub-backend, and:
+ * - a list of fix-orders (either insert or replace operations) are returned
+ */
+
+struct SnapMapperAccessor {
+  virtual int get_snaps(const hobject_t& hoid,
+                        std::set<snapid_t>* snaps_set) const = 0;
+  virtual ~SnapMapperAccessor() = default;
+};
+
+enum class snap_mapper_op_t {
+  add,
+  update,
+};
+
+struct snap_mapper_fix_t {
+  snap_mapper_op_t op;
+  hobject_t hoid;
+  std::set<snapid_t> snaps;
+  std::set<snapid_t> wrong_snaps;  // only collected & returned for logging sake
+};
+
+// and - as the main scrub-backend entry point - scrub_compare_maps() - must
+// be able to return both a list of snap fixes and a list of inconsistent
+// objects:
+struct objs_fix_list_t {
+  inconsistent_objs_t inconsistent_objs;
+  std::vector<snap_mapper_fix_t> snap_fix_list;
+};
 
 /**
  * A structure used internally by select_auth_object()
@@ -150,8 +192,9 @@ struct fmt::formatter<shard_as_auth_t> {
       // note: 'if' chain, as hard to consistently (on all compilers) avoid some
       // warnings for a switch plus multiple return paths
       if (as_auth.possible_auth == shard_as_auth_t::usable_t::not_usable) {
-        return format_to(
-          ctx.out(), "{{shard-not-usable:{}}}", as_auth.error_text);
+        return format_to(ctx.out(),
+                         "{{shard-not-usable:{}}}",
+                         as_auth.error_text);
       }
       if (as_auth.possible_auth == shard_as_auth_t::usable_t::not_found) {
         return format_to(ctx.out(), "{{shard-not-found}}");
@@ -231,6 +274,8 @@ struct scrub_chunk_t {
   /// Map from object with errors to good peers
   std::map<hobject_t, std::list<pg_shard_t>> authoritative;
 
+  inconsistent_objs_t m_inconsistent_objs;
+
 
   // these must be reset for each element:
 
@@ -284,9 +329,11 @@ class ScrubBackend {
    */
   void update_repair_status(bool should_repair);
 
-  void replica_clean_meta(ScrubMap& smap,
-                          bool max_reached,
-                          const hobject_t& start);
+  std::vector<snap_mapper_fix_t> replica_clean_meta(
+    ScrubMap& smap,
+    bool max_reached,
+    const hobject_t& start,
+    SnapMapperAccessor& snaps_getter);
 
   /**
    * decode the arriving MOSDRepScrubMap message, placing the replica's
@@ -296,7 +343,8 @@ class ScrubBackend {
    */
   void decode_received_map(pg_shard_t from, const MOSDRepScrubMap& msg);
 
-  void scrub_compare_maps(bool max_reached);
+  objs_fix_list_t scrub_compare_maps(bool max_reached,
+                                     SnapMapperAccessor& snaps_getter);
 
   int scrub_process_inconsistent();
 
@@ -322,15 +370,19 @@ class ScrubBackend {
  /// collecting some scrub-session-wide omap stats
   omap_stat_t m_omap_stats;
 
+  /// Mapping from object with errors to good peers
+  std::map<hobject_t, auth_peers_t> m_auth_peers;
+
   // shorthands:
   ConfigProxy& m_conf;
   LogChannelRef clog;
 
  private:
-  using auth_and_obj_errs_t =
-    std::tuple<std::list<pg_shard_t>,  ///< the auth-list
-               std::set<pg_shard_t>    ///< object_errors
-               >;
+
+  struct auth_and_obj_errs_t {
+    std::list<pg_shard_t> auth_list;
+    std::set<pg_shard_t> object_errors;
+  };
 
   std::optional<scrub_chunk_t> this_chunk;
 
@@ -385,11 +437,9 @@ class ScrubBackend {
                            std::stringstream& errorstream,
                            bool has_snapset);
 
-
-  void repair_object(
-    const hobject_t& soid,
-    const std::list<std::pair<ScrubMap::object, pg_shard_t>>& ok_peers,
-    const std::set<pg_shard_t>& bad_peers);
+  void repair_object(const hobject_t& soid,
+                     const auth_peers_t& ok_peers,
+                     const std::set<pg_shard_t>& bad_peers);
 
   /**
    * An auxiliary used by select_auth_object() to test a specific shard
@@ -452,9 +502,22 @@ class ScrubBackend {
                    const char* logged_func_name,
                    bool allow_incomplete_clones);
 
-  void scan_snaps(ScrubMap& smap);
+  /**
+   * returns a list of snaps "fix orders"
+   */
+  std::vector<snap_mapper_fix_t> scan_snaps(
+    ScrubMap& smap,
+    SnapMapperAccessor& snaps_getter);
 
-  void scan_object_snaps(const hobject_t& hoid,
-                         ScrubMap::object& scrmap_obj,
-                         const SnapSet& snapset);
+  /**
+   * an aux used by scan_snaps(), possibly returning a fix-order
+   * for a specific hobject.
+   */
+  std::optional<snap_mapper_fix_t> scan_object_snaps(
+    const hobject_t& hoid,
+    const SnapSet& snapset,
+    SnapMapperAccessor& snaps_getter);
+
+  // accessing the PG backend for this translation service
+  uint64_t logical_to_ondisk_size(uint64_t logical_size) const;
 };

--- a/src/osd/scrubber/scrub_backend.h
+++ b/src/osd/scrubber/scrub_backend.h
@@ -352,6 +352,8 @@ class ScrubBackend {
 
   const omap_stat_t& this_scrub_omapstats() const { return m_omap_stats; }
 
+  int authoritative_peers_count() const { return m_auth_peers.size(); };
+
   std::ostream& logger_prefix(std::ostream* _dout, const ScrubBackend* t);
 
  private:


### PR DESCRIPTION
Target: improving Scrubber BE testability by reducing the number and
complexity of the external APIs it uses.
    
First step of many. Here:
- removing I/O (i.e. Store) direct access;
- making the backend the sole owner of the authoritative set;
- cleaning the usage of the "size-of-disk" service;
- error counters;
and a few additional minor cleanups.

    