### PR TITLE
qa/suites/orch/cephadm: use "uname -n" rather than "hostname"

### DIFF
--- a/qa/suites/orch/cephadm/osds/2-ops/rmdir-reactivate.yaml
+++ b/qa/suites/orch/cephadm/osds/2-ops/rmdir-reactivate.yaml
@@ -5,7 +5,7 @@ tasks:
         set -e
         set -x
         ceph orch ps
-        HOST=$(hostname -s)
+        HOST=$(uname -n)
         OSD=$(ceph orch ps $HOST | grep osd | head -n 1 | awk '{print $1}')
         echo "host $HOST, osd $OSD"
         ceph orch daemon stop $OSD

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/client-keyring.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/client-keyring.yaml
@@ -1,7 +1,7 @@
 tasks:
 - cephadm.shell:
     host.a:
-      - ceph orch host label add `hostname` foo
+      - ceph orch host label add `uname -n` foo
       - ceph auth get-or-create client.foo mon 'allow r'
       - ceph orch client-keyring set client.foo label:foo --mode 770 --owner 11111:22222
 - exec:
@@ -16,7 +16,7 @@ tasks:
       - test ! -e /etc/ceph/ceph.client.foo.keyring
 - cephadm.shell:
     host.b:
-      - ceph orch host label add `hostname` foo
+      - ceph orch host label add `uname -n` foo
 - exec:
     host.b:
       - while ! test -e /etc/ceph/ceph.client.foo.keyring ; do sleep 1 ; done
@@ -25,7 +25,7 @@ tasks:
       - ls -al /etc/ceph/ceph.client.foo.keyring | grep 22222
 - cephadm.shell:
     host.b:
-      - ceph orch host label rm `hostname` foo
+      - ceph orch host label rm `uname -n` foo
 - exec:
     host.b:
       - while test -e /etc/ceph/ceph.client.foo.keyring ; do sleep 1 ; done


### PR DESCRIPTION
As hostname is not installed in centos 8.stream containers

Fixes: https://tracker.ceph.com/issues/54197

Signed-off-by: Adam King <adking@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
