### PR TITLE
pacific: monitoring: mention PyYAML only once in requirements

### DIFF
--- a/monitoring/prometheus/tests/requirements.txt
+++ b/monitoring/prometheus/tests/requirements.txt
@@ -1,2 +1,2 @@
-pyyaml
+pyyaml==6.0
 bs4


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54204

---

backport of https://github.com/ceph/ceph/pull/44930
parent tracker: https://tracker.ceph.com/issues/54185

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh