### PR TITLE
octopus: rgw: Use 100-continue in OPA requests to reduce latency

### DIFF
--- a/src/rgw/rgw_opa.cc
+++ b/src/rgw/rgw_opa.cc
@@ -31,6 +31,7 @@ int rgw_opa_authorize(RGWOp *& op,
   /* set required headers for OPA request */
   req.append_header("X-Auth-Token", opa_token);
   req.append_header("Content-Type", "application/json");
+  req.append_header("Expect", "100-continue");
 
   /* check if we want to verify OPA server SSL certificate */
   req.set_verify_ssl(s->cct->_conf->rgw_opa_verify_ssl);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52242

---

backport of https://github.com/ceph/ceph/pull/42685
parent tracker: https://tracker.ceph.com/issues/52067

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh