### PR TITLE
mgr/dashboard: "Please expand your cluster first" shouldn't be shown if cluster is already meaningfully running

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -5152,6 +5152,9 @@ def command_bootstrap(ctx):
     logger.info('Enabling autotune for osd_memory_target')
     cli(['config', 'set', 'osd', 'osd_memory_target_autotune', 'true'])
 
+    # Notify the Dashboard to show the 'Expand cluster' page on first log in.
+    cli(['config-key', 'set', 'mgr/dashboard/cluster/status', 'INSTALLED'])
+
     logger.info('You can access the Ceph CLI with:\n\n'
                 '\tsudo %s shell --fsid %s -c %s -k %s\n' % (
                     sys.argv[0],

--- a/src/pybind/mgr/dashboard/services/cluster.py
+++ b/src/pybind/mgr/dashboard/services/cluster.py
@@ -12,7 +12,12 @@ class ClusterModel:
 
     status: Status
 
-    def __init__(self, status=Status.INSTALLED.name):
+    def __init__(self, status=Status.POST_INSTALLED.name):
+        """
+        :param status: The status of the cluster. Assume that the cluster
+            is already functional by default.
+        :type status: str
+        """
         self.status = self.Status[status]
 
     def dict(self):
@@ -23,4 +28,8 @@ class ClusterModel:
 
     @classmethod
     def from_db(cls):
-        return cls(status=mgr.get_store('cluster/status', cls.Status.INSTALLED.name))
+        """
+        Get the stored cluster status from the configuration key/value store.
+        If the status is not set, assume it is already fully functional.
+        """
+        return cls(status=mgr.get_store('cluster/status', cls.Status.POST_INSTALLED.name))


### PR DESCRIPTION
This PR will assume that a cluster is already up and fully running. If this should not be the expected behaviour, deployment tools have to set `INSTALLED` explicitly. Without this assumption it might happen that upgraded and fully running clusters, e.g. Octopus -> Pacific, will show the `Expand Cluster` page on first log in.

cephadm will take care that the bootstrap phase will write the necessary key to show the 'Expand cluster' page.

Fixes: https://tracker.ceph.com/issues/54215

The issue was introduced by https://github.com/ceph/ceph/pull/42557.

Signed-off-by: Volker Theile <vtheile@suse.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
