### PR TITLE
Allow control of tcmalloc thread cache size using ceph configuration

### DIFF
--- a/src/common/PriorityCache.cc
+++ b/src/common/PriorityCache.cc
@@ -91,6 +91,14 @@ namespace PriorityCache
               "aggregate bytes in use by the heap", "h",
               PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
 
+    b.add_u64(MallocStats::M_MAX_THREADCACHE_BYTES, "max_threadcache_bytes",
+              "current tcmalloc.max_total_thread_cache_bytes", "m_tc",
+              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+
+    b.add_u64(MallocStats::M_CURR_THREADCACHE_BYTES, "current_threadcache_bytes",
+              "current tcmalloc.current_total_thread_cache_bytes", "c_tc",
+              PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
+
     b.add_u64(MallocStats::M_CACHE_BYTES, "cache_bytes",
               "current memory available for caches.", "c",
               PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));
@@ -113,10 +121,13 @@ namespace PriorityCache
     size_t heap_size = 0;
     size_t unmapped = 0;
     uint64_t mapped = 0;
-
+    size_t max_threadcache_size = 0;
+    size_t curr_threadcache_size = 0;
     ceph_heap_release_free_memory();
     ceph_heap_get_numeric_property("generic.heap_size", &heap_size);
     ceph_heap_get_numeric_property("tcmalloc.pageheap_unmapped_bytes", &unmapped);
+    ceph_heap_get_numeric_property("tcmalloc.max_total_thread_cache_bytes", &max_threadcache_size);
+    ceph_heap_get_numeric_property("tcmalloc.current_total_thread_cache_bytes", &curr_threadcache_size);
     mapped = heap_size - unmapped;
 
     uint64_t new_size = tuned_mem;
@@ -146,6 +157,8 @@ namespace PriorityCache
     logger->set(MallocStats::M_MAPPED_BYTES, mapped);
     logger->set(MallocStats::M_UNMAPPED_BYTES, unmapped);
     logger->set(MallocStats::M_HEAP_BYTES, heap_size);
+    logger->set(MallocStats::M_MAX_THREADCACHE_BYTES, max_threadcache_size);
+    logger->set(MallocStats::M_CURR_THREADCACHE_BYTES, curr_threadcache_size);
     logger->set(MallocStats::M_CACHE_BYTES, new_size);
   }
 

--- a/src/common/PriorityCache.h
+++ b/src/common/PriorityCache.h
@@ -34,6 +34,8 @@ namespace PriorityCache {
     M_MAPPED_BYTES,
     M_UNMAPPED_BYTES,
     M_HEAP_BYTES,
+    M_MAX_THREADCACHE_BYTES,
+    M_CURR_THREADCACHE_BYTES,
     M_CACHE_BYTES,
     M_LAST,
   };

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -792,6 +792,29 @@ options:
   default: false
   flags:
   - startup
+- name: tcmalloc_thread_cache_bytes
+  type: size
+  level: advanced
+  desc: When tcmalloc is enabled it specifies thread cache size
+  long_desc: Sets tcmalloc.max_total_thread_cache_bytes value.
+    If set this will override settings privided via environment variable
+    TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES.
+    Tcmalloc assigns each thread a thread-local cache.
+    Small allocations are satisfied from the thread-local cache.
+    Objects are moved from central data structures into a thread-local cache as needed,
+    and periodic garbage collections are used to migrate memory back from
+    a thread-local cache into the central data structures.
+    Programs with intensive use of dynamic memory for thread-local, short-lived objects
+    do benefit greately from having large cache.
+    tcmalloc default - 32_M. tcmalloc minimum - 512_K.
+  default: 0
+  see_also:
+  - bluestore_cache_autotune
+  - osd_memory_cache_min
+  - osd_memory_base
+  - osd_memory_target_autotune
+  flags:
+  - startup
 - name: key
   type: str
   level: advanced

--- a/src/global/CMakeLists.txt
+++ b/src/global/CMakeLists.txt
@@ -12,8 +12,8 @@ add_dependencies(libglobal_objs legacy-option-headers)
 
 add_library(global-static STATIC
   $<TARGET_OBJECTS:libglobal_objs>)
-target_link_libraries(global-static common)
+target_link_libraries(global-static heap_profiler common)
 
 add_library(global STATIC
   $<TARGET_OBJECTS:libglobal_objs>)
-target_link_libraries(global ceph-common ${EXTRALIBS})
+target_link_libraries(global heap_profiler ceph-common ${EXTRALIBS})

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -29,6 +29,7 @@
 #include "include/compat.h"
 #include "include/str_list.h"
 #include "mon/MonClient.h"
+#include "perfglue/heap_profiler.h"
 
 #ifndef _WIN32
 #include <pwd.h>
@@ -408,6 +409,7 @@ global_init(const std::map<std::string,std::string> *defaults,
       g_ceph_context->get_set_uid(),
       g_ceph_context->get_set_gid());
   }
+  ceph_heap_track_thread_cache("tcmalloc_thread_cache_bytes");
 
   // Now we're ready to complain about config file parse errors
   g_conf().complain_about_parse_error(g_ceph_context);

--- a/src/perfglue/disabled_heap_profiler.cc
+++ b/src/perfglue/disabled_heap_profiler.cc
@@ -45,3 +45,5 @@ bool ceph_heap_set_numeric_property(const char *property, size_t value)
 
 void ceph_heap_profiler_handle_command(const std::vector<std::string>& cmd,
                                        std::ostream& out) { return; }
+
+void ceph_heap_track_thread_cache(const char* conf_variable_name) { return; }

--- a/src/perfglue/heap_profiler.h
+++ b/src/perfglue/heap_profiler.h
@@ -54,4 +54,5 @@ bool ceph_heap_set_numeric_property(const char *property, size_t value);
 void ceph_heap_profiler_handle_command(const std::vector<std::string> &cmd,
                                        std::ostream& out);
 
+void ceph_heap_track_thread_cache(const char* conf_variable_name);
 #endif /* HEAP_PROFILER_H_ */


### PR DESCRIPTION
This code is a solution to avoid passing `TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES` environment variable to stared process. Now one can pass `tcmalloc_thread_cache_size` to starting ceph process or set it in ceph.conf file.

We now also 2 similar solutions:
#41804
#41817

I prefer this one, because it allows to set thread cache properties in universal way; it will be easier to document.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
