### PR TITLE
rbd/mirror: set replayer status as resync invalid if no remote primary available

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_snapshot.sh
+++ b/qa/workunits/rbd/rbd_mirror_snapshot.sh
@@ -440,6 +440,16 @@ wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
 wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+replaying'
 compare_images ${POOL} ${image}
 
+testlog "TEST: request image resync while no known primary exists"
+demote_image ${CLUSTER1} ${POOL} ${image}
+request_resync_image ${CLUSTER1} ${POOL} ${image} image_id
+wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'present' ${image_id}
+wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'present'
+wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
+wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+stopped'
+compare_images ${POOL} ${image}
+remove_image_retry ${CLUSTER2} ${POOL} ${image}
+
 if [ -z "${RBD_MIRROR_USE_RBD_MIRROR}" ]; then
   testlog "TEST: image resync while replayer is stopped"
   admin_daemons ${CLUSTER1} rbd mirror stop ${POOL}/${image}

--- a/src/test/rbd_mirror/image_replayer/snapshot/test_mock_Replayer.cc
+++ b/src/test/rbd_mirror/image_replayer/snapshot/test_mock_Replayer.cc
@@ -357,6 +357,7 @@ struct StateBuilder<librbd::MockTestImageCtx> {
   librbd::MockTestImageCtx* remote_image_ctx;
 
   std::string remote_mirror_uuid = "remote mirror uuid";
+  librbd::mirror::PromotionState remote_promotion_state;
 
   librbd::mirror::snapshot::ImageMeta<librbd::MockTestImageCtx>*
     local_image_meta = nullptr;

--- a/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
@@ -216,6 +216,7 @@ struct StateBuilder<librbd::MockTestImageCtx> {
   std::string local_image_id;
   std::string remote_mirror_uuid;
   std::string remote_image_id;
+  librbd::mirror::PromotionState remote_promotion_state;
 
   static StateBuilder* create(const std::string&) {
     ceph_assert(s_instance != nullptr);
@@ -748,6 +749,7 @@ TEST_F(TestMockImageReplayerBootstrapRequest, PrepareReplayResyncRequested) {
   // prepare local image
   MockPrepareLocalImageRequest mock_prepare_local_image_request;
   MockStateBuilder mock_state_builder;
+  mock_state_builder.remote_promotion_state = librbd::mirror::PROMOTION_STATE_PRIMARY;
   expect_send(mock_prepare_local_image_request, mock_state_builder,
               m_local_image_ctx->id, m_local_image_ctx->name, 0);
 

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -226,7 +226,7 @@ ImageReplayer<I>::ImageReplayer(
   m_local_image_name(global_image_id),
   m_lock(ceph::make_mutex("rbd::mirror::ImageReplayer " +
       stringify(local_io_ctx.get_id()) + " " + global_image_id)),
-  m_progress_cxt(this),
+  m_progress_ctx(this),
   m_replayer_listener(new ReplayerListener(this))
 {
   // Register asok commands using a temporary "remote_pool_name/global_image_id"
@@ -358,7 +358,7 @@ void ImageReplayer<I>::bootstrap() {
       m_threads, m_local_io_ctx, m_remote_image_peer.io_ctx, m_instance_watcher,
       m_global_image_id, m_local_mirror_uuid,
       m_remote_image_peer.remote_pool_meta, m_cache_manager_handler,
-      m_pool_meta_cache, &m_progress_cxt, &m_state_builder, &m_resync_requested,
+      m_pool_meta_cache, &m_progress_ctx, &m_state_builder, &m_resync_requested,
       ctx);
 
   request->get();

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -398,6 +398,9 @@ void ImageReplayer<I>::handle_bootstrap(int r) {
   } else if (r == -ERESTART) {
     on_start_fail(r, "image in transient state, try again");
     return;
+  } else if (r == -EPERM) {
+    on_start_fail(0, "resync invalid, remote image is non-primary");
+    return;
   } else if (r < 0) {
     on_start_fail(r, "error bootstrapping replay");
     return;

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -201,7 +201,7 @@ private:
     boost::make_optional(false, cls::rbd::MIRROR_IMAGE_STATUS_STATE_UNKNOWN);
   int m_last_r = 0;
 
-  BootstrapProgressContext m_progress_cxt;
+  BootstrapProgressContext m_progress_ctx;
 
   bool m_finished = false;
   bool m_delete_in_progress = false;

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
@@ -322,6 +322,11 @@ void BootstrapRequest<I>::handle_prepare_replay(int r) {
     return;
   } else if (*m_do_resync) {
     dout(10) << "local image resync requested" << dendl;
+    if ((*m_state_builder)->remote_promotion_state != librbd::mirror::PROMOTION_STATE_PRIMARY) {
+      m_ret_val = -EPERM;
+      derr << "remote image is non primary, cannot resync without a known primary" << dendl;
+      *m_do_resync = 0;
+    }
     close_remote_image();
     return;
   } else if ((*m_state_builder)->is_disconnected()) {

--- a/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.cc
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.cc
@@ -356,6 +356,11 @@ void Replayer<I>::handle_load_local_image_meta(int r) {
   }
 
   if (r >= 0 && m_state_builder->local_image_meta->resync_requested) {
+    if (m_state_builder->remote_promotion_state != librbd::mirror::PROMOTION_STATE_PRIMARY) {
+      derr << "remote image is non primary, cannot resync without a known primary"  << dendl;
+      handle_replay_complete(-EPERM, "remote image is non primary, cannot resync without a known primary");
+      return;
+    }
     m_resync_requested = true;
 
     dout(10) << "local image resync requested" << dendl;


### PR DESCRIPTION
this covers the case where the remote is non-primary and we try resync
from it, deleting our local image and having no knowing primary image to
sync from.
Mark such resync as invalid and update replayer status.

fixes: https://tracker.ceph.com/issues/54098

```
a1:
  global_id:   2c25ef7b-448d-451b-80a6-9cc136729c1e
  state:       up+unknown
  description: remote image demoted
  service:     admin on vossi03
  last_update: 2022-02-09 15:41:09
  peer_sites:
    name: secondary
    state: up+stopped
    description: resync invalid, remote image is non-primary
    last_update: 2022-02-09 15:41:09
```


Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
