### PR TITLE
pacific: mon: Abort device health when device not found

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -417,6 +417,11 @@ int Monitor::do_admin_command(
     cmd_getval(cmdmap, "devid", want_devid);
 
     string devname = store->get_devname();
+    if (devname.empty()) {
+      err << "could not determine device name for " << store->get_path();
+      r = -ENOENT;
+      goto abort;
+    }
     set<string> devnames;
     get_raw_devices(devname, &devnames);
     json_spirit::mObject json_map;

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -57,6 +57,10 @@ class MonitorDBStore
     return devname;
   }
 
+  std::string get_path() {
+    return path;
+  }
+
   std::shared_ptr<PriorityCache::PriCache> get_priority_cache() const {
     return db->get_priority_cache();
   }

--- a/systemd/ceph-mon@.service.in
+++ b/systemd/ceph-mon@.service.in
@@ -20,7 +20,10 @@ LockPersonality=true
 MemoryDenyWriteExecute=true
 # Need NewPrivileges via `sudo smartctl`
 NoNewPrivileges=false
-PrivateDevices=yes
+# We need access to block devices to check the health of the disk backing the
+# monitor DB store. It can be set to `true` if you're not interested in that
+# feature.
+PrivateDevices=false
 PrivateTmp=true
 ProtectControlGroups=true
 ProtectHome=true


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54232

---

backport of https://github.com/ceph/ceph/pull/44221
parent tracker: https://tracker.ceph.com/issues/52416

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh