### PR TITLE
mgr, osd: Append withholding pg creation message to PENDING_CREATING_PGS

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -243,6 +243,13 @@ CephFS: Disallow delegating preallocated inode ranges to clients. Config
   now disabled by default. The new file system flag `balance_automate`
   can be used to toggle it on or off. It can be enabled or disabled via
   `ceph fs set <fs_name> balance_automate <bool>`.
+* The ``PENDING_CREATING_PGS`` health check will log an additional warning
+  "(PG creation pending, temporarily increase 'osd_max_pg_per_osd_hard_ratio')"
+  if the number of PGs on an OSD is greater than or equal to
+  ``(osd_max_pg_per_osd_hard_ratio * mon_max_pg_per_osd)``.
+  It is recommended to add OSDs to the cluster to resolve this condition.
+  Increase `osd_max_pg_per_osd_hard_ratio` to mitigate this warning temporarily.
+
 * RGW's default backend for `rgw_enable_ops_log` changed from RADOS to file.
   The default value of `rgw_ops_log_rados` is now false, and `rgw_ops_log_file_path`
   defaults to "/var/log/ceph/ops-log-$cluster-$name.log".

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1353,6 +1353,26 @@ To see the location of a specific OSD, run the following command:
 
    ceph osd find osd.<id>
 
+PENDING_CREATING_PGS
+____________________
+
+One or more OSD have PGs pending creation for reasons that includes a flawed
+CRUSH map or rules and dead OSD. The additional text
+"(PG creation pending, temporarily increase 'osd_max_pg_per_osd_hard_ratio')"
+in the pending PG creation health message indicates that one or more OSDs have
+blocked PG creation due to overdose protection. This means that the number of PGs on
+an OSD is greater than or equal to `mon_max_pg_per_osd * osd_max_pg_per_osd_hard_ratio`.
+
+When PG creation is pending due to overdose protection, it is highly recommended
+to add OSDs to the cluster. This will resolve the problem by spreading PGs across more OSDs,
+with each OSD holding fewer PGs, so long as the new capacity is added appropriately across
+CRUSH failure domains. A temporary solution is to increase osd_max_pg_per_osd_hard_ratio to
+a value that will satisfy the condition of num_pgs < (osd_max_pg_per_osd_hard_ratio * mon_max_pg_per_osd).
+The num_pgs count for a given OSD can be queried via the daemon's admin socket with the
+following command, executed from the daemon's host::
+
+  ceph daemon osd.<id> status
+
 PG_NOT_SCRUBBED
 _______________
 

--- a/qa/standalone/osd/osd-withhold-pg-creation.sh
+++ b/qa/standalone/osd/osd-withhold-pg-creation.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2022 Red Hat <contact@redhat.com>
+#
+# Author: Prashant D <pdhange@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7155" # git grep '\<7155\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+function TEST_withhold_pg_creation() {
+    local dir=$1
+    local WAIT_BEFORE_RESTART=60
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
+    run_osd $dir 3 || return 1
+    run_osd $dir 4 || return 1
+    run_osd $dir 5 || return 1
+
+    for node in `seq 0 5`; do
+      ceph osd crush add-bucket osd-node-$node host
+    done
+
+    for node in `seq 0 5`; do
+      ceph osd crush move osd-node-$node root=default
+    done
+
+    for osd in `seq 0 5`; do
+      ceph osd crush move osd.$osd host=osd-node-$osd
+    done
+
+    host_bucket=$(hostname -s)
+    ceph osd crush remove $host_bucket
+
+    ceph osd erasure-code-profile set myprofile k=4 m=2 crush-failure-domain=host
+    ceph osd pool set noautoscale
+    ceph config set mon mon_max_pg_per_osd 2000
+    ceph osd pool create ecpool 512 512 erasure myprofile
+    ceph osd pool create ecpool1 128 128 erasure myprofile
+    ceph osd pool create ecpool2 512 512 erasure myprofile
+    ceph osd pool create ecpool3 512 512 erasure myprofile
+    ceph osd pool create rbd 32 32
+    sleep 30
+    ERRORS=0
+    if ! ceph status 2>&1 | grep -q "PG creation pending"; then
+      ERRORS="$(expr $ERRORS + 1)"
+    fi
+
+    for osd in  `seq 0 5`; do
+      CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${osd}) config set osd_max_pg_per_osd_hard_ratio 10
+    done
+    WAIT_FOR_CLEAN_TIMEOUT=60 wait_for_clean
+
+    for osd in  `seq 0 5`; do
+      CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${osd}) config set osd_max_pg_per_osd_hard_ratio 1
+    done
+
+    ceph osd out 3
+    kill_daemons $dir TERM osd.3 || return 1
+    activate_osd $dir 3 || return 1
+    if ! ceph status 2>&1 | grep -q "PG creation pending"; then
+      ERRORS="$(expr $ERRORS + 1)"
+    fi
+    ceph osd in 3
+    ceph osd crush move osd.3 host=osd-node-3
+    ceph osd crush remove $host_bucket
+
+    for osd in  `seq 0 5`; do
+      CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${osd}) config set osd_max_pg_per_osd_hard_ratio 10 
+    done
+ 
+    WAIT_FOR_CLEAN_TIMEOUT=60 wait_for_clean
+
+    if [ $ERRORS -gt 0 ]; then
+        echo "TEST FAILED WITH $ERRORS ERRORS"
+        return 1
+    fi
+
+    echo "TEST PASSED"
+    return 0
+}
+
+main osd-withhold-pg-creation "$@"


### PR DESCRIPTION
PGs creation can gets stuck if OSD has reached PG overdose
protection. Report this in PENDING_CREATING_PGS health warn.
Adding more OSDs to the cluster is recommended to unblock
PGs creation. For a temporary solution, increase
'osd_max_pg_per_osd_hard_ratio' value.

Fixes: https://tracker.ceph.com/issues/23117

Signed-off-by: Prashant D <pdhange@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
