### PR TITLE
doc/dev: add section on using the gen_state_diagram.py script

### DIFF
--- a/doc/dev/peering.rst
+++ b/doc/dev/peering.rst
@@ -60,7 +60,8 @@ Concepts
    accepting write operations, and *recovery* can proceed
    in the background.
 
-*PG info* basic metadata about the PG's creation epoch, the version
+*PG info*
+   basic metadata about the PG's creation epoch, the version
    for the most recent write to the PG, *last epoch started*, *last
    epoch clean*, and the beginning of the *current interval*.  Any
    inter-OSD communication about PGs includes the *PG info*, such that
@@ -253,7 +254,17 @@ The high level process is for the current PG primary to:
      old object (all of whose copies disappeared before they could be
      replicated on members of the current *acting set*).
 
-State Model
------------
+Generate a State Model
+----------------------
+
+Use the `gen_state_diagram.py <https://github.com/ceph/ceph/blob/master/doc/scripts/gen_state_diagram.py>`_ script to generate a copy of the latest peering state model::
+
+        $ git clone https://github.com/ceph/ceph.git
+        $ cd ceph
+        $ cat src/osd/PeeringState.h src/osd/PeeringState.cc | doc/scripts/gen_state_diagram.py > doc/dev/peering_graph.generated.dot
+        $ sed -i 's/7,7/1080,1080/' doc/dev/peering_graph.generated.dot
+        $ dot -Tsvg doc/dev/peering_graph.generated.dot > doc/dev/peering_graph.generated.svg
+
+Sample state model:
 
 .. graphviz:: peering_graph.generated.dot

--- a/doc/scripts/README.md
+++ b/doc/scripts/README.md
@@ -1,0 +1,11 @@
+Script Usage
+============
+
+Peering State Model: gen_state_diagram.py
+------------------------------------------
+    $ git clone https://github.com/ceph/ceph.git
+    $ cd ceph
+    $ cat src/osd/PeeringState.h src/osd/PeeringState.cc | doc/scripts/gen_state_diagram.py > doc/dev/peering_graph.generated.dot
+    $ sed -i 's/7,7/1080,1080/' doc/dev/peering_graph.generated.dot
+    $ dot -Tsvg doc/dev/peering_graph.generated.dot > doc/dev/peering_graph.generated.svg
+


### PR DESCRIPTION
Commands sourced from Jianshen Liu's blog post on the Ceph peering state machine: https://jianshenliu.com/blog/development/ceph-peering-state-machine/

Question for reviewers: Should the source listed above be mentioned directly in the docs?

Signed-off-by: Laura Flores <lflores@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
