### PR TITLE
qa/tasks/cephadm_cases: increase timeouts in test_cli.py

### DIFF
--- a/qa/tasks/cephadm_cases/test_cli.py
+++ b/qa/tasks/cephadm_cases/test_cli.py
@@ -44,14 +44,14 @@ class TestCephadmCLI(MgrTestCase):
 
     def test_pause(self):
         self._orch_cmd('pause')
-        self.wait_for_health('CEPHADM_PAUSED', 30)
+        self.wait_for_health('CEPHADM_PAUSED', 60)
         self._orch_cmd('resume')
-        self.wait_for_health_clear(30)
+        self.wait_for_health_clear(60)
 
     def test_daemon_restart(self):
         self._orch_cmd('daemon', 'stop', 'osd.0')
-        self.wait_for_health('OSD_DOWN', 30)
-        with safe_while(sleep=1, tries=30) as proceed:
+        self.wait_for_health('OSD_DOWN', 60)
+        with safe_while(sleep=2, tries=30) as proceed:
             while proceed():
                 j = json.loads(self._orch_cmd('ps', '--format', 'json'))
                 d = {d['daemon_name']: d for d in j}
@@ -59,7 +59,7 @@ class TestCephadmCLI(MgrTestCase):
                     break
         time.sleep(5)
         self._orch_cmd('daemon', 'start', 'osd.0')
-        self.wait_for_health_clear(90)
+        self.wait_for_health_clear(120)
         self._orch_cmd('daemon', 'restart', 'osd.0')
 
     def test_device_ls_wide(self):
@@ -67,7 +67,7 @@ class TestCephadmCLI(MgrTestCase):
 
     def test_cephfs_mirror(self):
         self._orch_cmd('apply', 'cephfs-mirror')
-        self.wait_until_true(lambda: 'cephfs-mirror' in self._orch_cmd('ps'), 30)
-        self.wait_for_health_clear(30)
+        self.wait_until_true(lambda: 'cephfs-mirror' in self._orch_cmd('ps'), 60)
+        self.wait_for_health_clear(60)
         self._orch_cmd('rm', 'cephfs-mirror')
-        self.wait_until_true(lambda: 'cephfs-mirror' not in self._orch_cmd('ps'), 30)
+        self.wait_until_true(lambda: 'cephfs-mirror' not in self._orch_cmd('ps'), 60)


### PR DESCRIPTION
These seem to be failing sometimes but in my testing
sometimes these events are happening a few seconds after
we hit the timeout. Trying to see if this makes the tests
more consistent. No need to mark the test as failed
if we report something up in 34 seconds vs 25 especially
when cephadm works on a cyclic daemon refresh.

Signed-off-by: Adam King <adking@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
