### PR TITLE
octopus: ceph-volume: honour osd_dmcrypt_key_size option

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -153,6 +153,8 @@ def activate_bluestore(osd_lvs, no_systemd=False):
     osd_id = osd_block_lv.tags['ceph.osd_id']
     conf.cluster = osd_block_lv.tags['ceph.cluster_name']
     osd_fsid = osd_block_lv.tags['ceph.osd_fsid']
+    configuration.load_ceph_conf_path(osd_block_lv.tags['ceph.cluster_name'])
+    configuration.load()
 
     # mount on tmpfs the osd directory
     osd_path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
@@ -214,6 +214,7 @@ class TestActivate(object):
         assert fake_start_osd.calls != []
 
     def test_bluestore_no_systemd(self, is_root, monkeypatch, capture):
+        monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         fake_enable = Capture()
         fake_start_osd = Capture()
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda *a, **kw: True)
@@ -236,6 +237,7 @@ class TestActivate(object):
         assert fake_start_osd.calls == []
 
     def test_bluestore_systemd(self, is_root, monkeypatch, capture):
+        monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         fake_enable = Capture()
         fake_start_osd = Capture()
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda *a, **kw: True)
@@ -259,6 +261,7 @@ class TestActivate(object):
         assert fake_start_osd.calls != []
 
     def test_bluestore_no_systemd_autodetect(self, is_root, monkeypatch, capture):
+        monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         fake_enable = Capture()
         fake_start_osd = Capture()
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda *a, **kw: True)
@@ -282,6 +285,7 @@ class TestActivate(object):
         assert fake_start_osd.calls == []
 
     def test_bluestore_systemd_autodetect(self, is_root, monkeypatch, capture):
+        monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         fake_enable = Capture()
         fake_start_osd = Capture()
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted',

--- a/src/ceph-volume/ceph_volume/tests/functional/vagrant_variables.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/vagrant_variables.yml
@@ -39,7 +39,7 @@ eth: 'eth1'
 # For more boxes have a look at:
 #   - https://atlas.hashicorp.com/boxes/search?utf8=✓&sort=&provider=virtualbox&q=
 #   - https://download.gluster.org/pub/gluster/purpleidea/vagrant/
-vagrant_box: centos/8
+vagrant_box: centos/stream8
 # vagrant_box_url: https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-Vagrant-8.1.1911-20200113.3.x86_64.vagrant-libvirt.box
 #ssh_private_key_path: "~/.ssh/id_rsa"
 # The sync directory changes based on vagrant box

--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -9,21 +9,29 @@ from .disk import lsblk, device_family, get_part_entry_type
 
 logger = logging.getLogger(__name__)
 
+def get_key_size_from_conf():
+    """
+    Return the osd dmcrypt key size from config file.
+    Default is 512.
+    """
+    default_key_size = '512'
+    key_size = conf.ceph.get_safe(
+        'osd',
+        'osd_dmcrypt_key_size',
+        default='512')
+
+    if key_size not in ['256', '512']:
+        logger.warning(("Invalid value set for osd_dmcrypt_key_size ({}). "
+                        "Falling back to {}bits".format(key_size, default_key_size)))
+        return default_key_size
+
+    return key_size
 
 def create_dmcrypt_key():
     """
-    Create the secret dm-crypt key used to decrypt a device.
+    Create the secret dm-crypt key (KEK) used to encrypt/decrypt the Volume Key.
     """
-    # get the customizable dmcrypt key size (in bits) from ceph.conf fallback
-    # to the default of 1024
-    dmcrypt_key_size = conf.ceph.get_safe(
-        'osd',
-        'osd_dmcrypt_key_size',
-        default=1024,
-    )
-    # The size of the key is defined in bits, so we must transform that
-    # value to bytes (dividing by 8) because we read in bytes, not bits
-    random_string = os.urandom(int(dmcrypt_key_size / 8))
+    random_string = os.urandom(128)
     key = base64.b64encode(random_string).decode('utf-8')
     return key
 
@@ -38,6 +46,8 @@ def luks_format(key, device):
     command = [
         'cryptsetup',
         '--batch-mode', # do not prompt
+        '--key-size',
+        get_key_size_from_conf(),
         '--key-file', # misnomer, should be key
         '-',          # because we indicate stdin for the key here
         'luksFormat',
@@ -83,6 +93,8 @@ def luks_open(key, device, mapping):
     """
     command = [
         'cryptsetup',
+        '--key-size',
+        get_key_size_from_conf(),
         '--key-file',
         '-',
         '--allow-discards',  # allow discards (aka TRIM) requests for device


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54245

---

backport of https://github.com/ceph/ceph/pull/44765
parent tracker: https://tracker.ceph.com/issues/54006

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh