### PR TITLE
mgr/dashboard: dashboard turns telemetry off when configuring report

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -185,6 +185,19 @@
                        i18n-placeholder>
               </div>
             </div>
+            <div class="form-group row">
+              <label class="cd-col-form-label"
+                     for="organization"
+                     i18n>Organization</label>
+              <div class="cd-col-form-input">
+                <input id="organization"
+                       class="form-control"
+                       type="text"
+                       formControlName="organization"
+                       placeholder="Organization name"
+                       i18n-placeholder>
+              </div>
+            </div>
           </ng-container>
             <legend i18n>Advanced Settings</legend>
             <div class="form-group row">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -120,16 +120,6 @@ describe('TelemetryComponent', () => {
       });
     });
 
-    it('should update the Telemetry configuration', () => {
-      component.updateConfig();
-      const req = httpTesting.expectOne('api/mgr/module/telemetry');
-      expect(req.request.method).toBe('PUT');
-      expect(req.request.body).toEqual({
-        config: {}
-      });
-      req.flush({});
-    });
-
     it('should disable the Telemetry module', () => {
       const message = 'Module disabled message.';
       const followUpFunc = function () {
@@ -303,16 +293,24 @@ describe('TelemetryComponent', () => {
       });
     });
 
-    it('should submit', () => {
+    it('should submit ', () => {
       component.onSubmit();
-      const req = httpTesting.expectOne('api/telemetry');
-      expect(req.request.method).toBe('PUT');
-      expect(req.request.body).toEqual({
+      const req1 = httpTesting.expectOne('api/telemetry');
+      expect(req1.request.method).toBe('PUT');
+      expect(req1.request.body).toEqual({
         enable: true,
         license_name: 'sharing-1-0'
       });
-      req.flush({});
-      expect(router.navigate).toHaveBeenCalledWith(['']);
+      req1.flush({});
+      const req2 = httpTesting.expectOne({
+        url: 'api/mgr/module/telemetry',
+        method: 'PUT'
+      });
+      expect(req2.request.body).toEqual({
+        config: {}
+      });
+      req2.flush({});
+      expect(router.url).toBe('/');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -86,22 +86,28 @@ describe('TelemetryComponent', () => {
         fixture.debugElement.nativeElement.querySelector('input[id=contact]');
       const getDescriptionField = () =>
         fixture.debugElement.nativeElement.querySelector('input[id=description]');
+      const checkVisibility = () => {
+        if (component.showContactInfo) {
+          expect(getContactField()).toBeTruthy();
+          expect(getDescriptionField()).toBeTruthy();
+        } else {
+          expect(getContactField()).toBeFalsy();
+          expect(getDescriptionField()).toBeFalsy();
+        }
+      };
 
-      // Initially hidden.
-      expect(getContactField()).toBeFalsy();
-      expect(getDescriptionField()).toBeFalsy();
+      // Initial check.
+      checkVisibility();
 
-      // Show fields.
+      // toggle fields.
       component.toggleIdent();
       fixture.detectChanges();
-      expect(getContactField()).toBeTruthy();
-      expect(getDescriptionField()).toBeTruthy();
+      checkVisibility();
 
-      // Hide fields.
+      // toggle fields again.
       component.toggleIdent();
       fixture.detectChanges();
-      expect(getContactField()).toBeFalsy();
-      expect(getDescriptionField()).toBeFalsy();
+      checkVisibility();
     });
 
     it('should set module enability to true correctly', () => {
@@ -293,7 +299,7 @@ describe('TelemetryComponent', () => {
       });
     });
 
-    it('should submit ', () => {
+    it('should submit', () => {
       component.onSubmit();
       const req1 = httpTesting.expectOne('api/telemetry');
       expect(req1.request.method).toBe('PUT');


### PR DESCRIPTION
- The wizard should not turn telemetry off, unless the user explicitly clicked the "Deactivate" button.The user should be able to explore the report details without setting any new configuration.
- Contact Information section visibility should correspond to enabling / disabling the Ident channel:
If the Ident channel box is not checked, this section should not be visible. If it is checked - the section should be visible.
- The Organization field was missing (Dashboard displays only Contact and Description).

Fixes: https://tracker.ceph.com/issues/54120, https://tracker.ceph.com/issues/54133
Signed-off-by: Sarthak0702 <sarthak.0702@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
