### PR TITLE
radosgw-admin zone deletion uses zone delete

### DIFF
--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -231,9 +231,9 @@ the default zone group first.
 
 ::
 
-    # radosgw-admin zonegroup remove --rgw-zonegroup=default --rgw-zone=default
+    # radosgw-admin zonegroup delete --rgw-zonegroup=default --rgw-zone=default
     # radosgw-admin period update --commit
-    # radosgw-admin zone rm --rgw-zone=default
+    # radosgw-admin zone delete --rgw-zone=default
     # radosgw-admin period update --commit
     # radosgw-admin zonegroup delete --rgw-zonegroup=default
     # radosgw-admin period update --commit
@@ -410,7 +410,7 @@ Delete the default zone if needed.
 
 ::
 
-    # radosgw-admin zone rm --rgw-zone=default
+    # radosgw-admin zone delete --rgw-zone=default
 
 Finally, delete the default pools in your Ceph storage cluster if
 needed.


### PR DESCRIPTION
doc/radosgw/multisite.rst: zone rm does not work on pacific, zone delete works