### PR TITLE
rgw multisite reshard: retry writes to bucket instance on ECANCELED

### DIFF
--- a/qa/workunits/rgw/test_rgw_reshard.py
+++ b/qa/workunits/rgw/test_rgw_reshard.py
@@ -95,6 +95,8 @@ def run_bucket_reshard_cmd(bucket_name, num_shards, **kwargs):
         cmd += ' --inject-error-at {}'.format(kwargs.pop('error_at'))
     elif 'abort_at' in kwargs:
         cmd += ' --inject-abort-at {}'.format(kwargs.pop('abort_at'))
+    if 'error_code' in kwargs:
+        cmd += ' --inject-error-code {}'.format(kwargs.pop('error_code'))
     return exec_cmd(cmd, **kwargs)
 
 def test_bucket_reshard(conn, name, **fault):
@@ -113,27 +115,31 @@ def test_bucket_reshard(conn, name, **fault):
 
         # try reshard with fault injection
         _, ret = run_bucket_reshard_cmd(name, num_shards_expected, check_retcode=False, **fault)
-        assert(ret != 0 and ret != errno.EBUSY)
 
-        # check shard count
-        cur_shard_count = get_bucket_stats(name).num_shards
-        assert(cur_shard_count == old_shard_count)
+        if fault.get('error_code') == errno.ECANCELED:
+            assert(ret == 0) # expect ECANCELED to retry and succeed
+        else:
+            assert(ret != 0 and ret != errno.EBUSY)
 
-        # verify that the bucket is writeable by deleting an object
-        objs.pop().delete()
+            # check shard count
+            cur_shard_count = get_bucket_stats(name).num_shards
+            assert(cur_shard_count == old_shard_count)
 
-        assert grants == bucket.Acl().grants # recheck grants after cancel
+            # verify that the bucket is writeable by deleting an object
+            objs.pop().delete()
 
-        # retry reshard without fault injection. if radosgw-admin aborted,
-        # we'll have to retry until the reshard lock expires
-        while True:
-            _, ret = run_bucket_reshard_cmd(name, num_shards_expected, check_retcode=False)
-            if ret == errno.EBUSY:
-                log.info('waiting 30 seconds for reshard lock to expire...')
-                time.sleep(30)
-                continue
-            assert(ret == 0)
-            break
+            assert grants == bucket.Acl().grants # recheck grants after cancel
+
+            # retry reshard without fault injection. if radosgw-admin aborted,
+            # we'll have to retry until the reshard lock expires
+            while True:
+                _, ret = run_bucket_reshard_cmd(name, num_shards_expected, check_retcode=False)
+                if ret == errno.EBUSY:
+                    log.info('waiting 30 seconds for reshard lock to expire...')
+                    time.sleep(30)
+                    continue
+                assert(ret == 0)
+                break
 
         # recheck shard count
         final_shard_count = get_bucket_stats(name).num_shards
@@ -234,6 +240,8 @@ def main():
     # TESTCASE 'manual bucket resharding','inject error','fail','check bucket accessibility', 'retry reshard'
     log.debug('TEST: reshard bucket with EIO injected at set_target_layout\n')
     test_bucket_reshard(connection, 'error-at-set-target-layout', error_at='set_target_layout')
+    log.debug('TEST: reshard bucket with ECANCELED injected at set_target_layout\n')
+    test_bucket_reshard(connection, 'error-at-set-target-layout', error_at='set_target_layout', error_code=errno.ECANCELED)
     log.debug('TEST: reshard bucket with abort at set_target_layout\n')
     test_bucket_reshard(connection, 'abort-at-set-target-layout', abort_at='set_target_layout')
 
@@ -244,6 +252,8 @@ def main():
 
     log.debug('TEST: reshard bucket with EIO injected at commit_target_layout\n')
     test_bucket_reshard(connection, 'error-at-commit-target-layout', error_at='commit_target_layout')
+    log.debug('TEST: reshard bucket with ECANCELED injected at commit_target_layout\n')
+    test_bucket_reshard(connection, 'error-at-commit-target-layout', error_at='commit_target_layout', error_code=errno.ECANCELED)
     log.debug('TEST: reshard bucket with abort at commit_target_layout\n')
     test_bucket_reshard(connection, 'abort-at-commit-target-layout', abort_at='commit_target_layout')
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3644,6 +3644,7 @@ int main(int argc, const char **argv)
   ceph::timespan opt_timeout_sec = std::chrono::seconds(60);
 
   std::optional<std::string> inject_error_at;
+  std::optional<int> inject_error_code;
   std::optional<std::string> inject_abort_at;
 
   rgw::zone_features::set enable_features;
@@ -4126,6 +4127,8 @@ int main(int argc, const char **argv)
       opt_timeout_sec = std::chrono::seconds(atoi(val.c_str()));
     } else if (ceph_argparse_witharg(args, i, &val, "--inject-error-at", (char*)NULL)) {
       inject_error_at = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--inject-error-code", (char*)NULL)) {
+      inject_error_code = atoi(val.c_str());
     } else if (ceph_argparse_witharg(args, i, &val, "--inject-abort-at", (char*)NULL)) {
       inject_abort_at = val;
     } else if (ceph_argparse_binary_flag(args, i, &detail, NULL, "--detail", (char*)NULL)) {
@@ -7736,7 +7739,8 @@ next:
 
     ReshardFaultInjector fault;
     if (inject_error_at) {
-      fault.inject(*inject_error_at, InjectError{-EIO, dpp()});
+      const int code = -inject_error_code.value_or(EIO);
+      fault.inject(*inject_error_at, InjectError{code, dpp()});
     } else if (inject_abort_at) {
       fault.inject(*inject_abort_at, InjectAbort{});
     }

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -52,6 +52,17 @@ struct bucket_index_normal_layout {
   BucketHashType hash_type = BucketHashType::Mod;
 };
 
+
+inline bool operator==(const bucket_index_normal_layout& l,
+                       const bucket_index_normal_layout& r) {
+  return l.num_shards == r.num_shards
+      && l.hash_type == r.hash_type;
+}
+inline bool operator!=(const bucket_index_normal_layout& l,
+                       const bucket_index_normal_layout& r) {
+  return !(l == r);
+}
+
 void encode(const bucket_index_normal_layout& l, bufferlist& bl, uint64_t f=0);
 void decode(bucket_index_normal_layout& l, bufferlist::const_iterator& bl);
 void encode_json_impl(const char *name, const bucket_index_normal_layout& l, ceph::Formatter *f);
@@ -64,6 +75,15 @@ struct bucket_index_layout {
   bucket_index_normal_layout normal;
 };
 
+inline bool operator==(const bucket_index_layout& l,
+                       const bucket_index_layout& r) {
+  return l.type == r.type && l.normal == r.normal;
+}
+inline bool operator!=(const bucket_index_layout& l,
+                       const bucket_index_layout& r) {
+  return !(l == r);
+}
+
 void encode(const bucket_index_layout& l, bufferlist& bl, uint64_t f=0);
 void decode(bucket_index_layout& l, bufferlist::const_iterator& bl);
 void encode_json_impl(const char *name, const bucket_index_layout& l, ceph::Formatter *f);
@@ -73,6 +93,15 @@ struct bucket_index_layout_generation {
   uint64_t gen = 0;
   bucket_index_layout layout;
 };
+
+inline bool operator==(const bucket_index_layout_generation& l,
+                       const bucket_index_layout_generation& r) {
+  return l.gen == r.gen && l.layout == r.layout;
+}
+inline bool operator!=(const bucket_index_layout_generation& l,
+                       const bucket_index_layout_generation& r) {
+  return !(l == r);
+}
 
 void encode(const bucket_index_layout_generation& l, bufferlist& bl, uint64_t f=0);
 void decode(bucket_index_layout_generation& l, bufferlist::const_iterator& bl);

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -325,7 +325,7 @@ static int init_target_index(rgw::sal::RadosStore* store,
 static int init_target_layout(rgw::sal::RadosStore* store,
                               RGWBucketInfo& bucket_info,
 			      std::map<std::string, bufferlist>& bucket_attrs,
-                              const ReshardFaultInjector& fault,
+                              ReshardFaultInjector& fault,
                               uint32_t new_num_shards,
                               const DoutPrefixProvider* dpp)
 {
@@ -391,7 +391,7 @@ static int init_target_layout(rgw::sal::RadosStore* store,
 static int revert_target_layout(rgw::sal::RadosStore* store,
                                 RGWBucketInfo& bucket_info,
 				std::map<std::string, bufferlist>& bucket_attrs,
-                                const ReshardFaultInjector& fault,
+                                ReshardFaultInjector& fault,
                                 const DoutPrefixProvider* dpp)
 {
   auto& layout = bucket_info.layout;
@@ -429,7 +429,7 @@ static int revert_target_layout(rgw::sal::RadosStore* store,
 static int init_reshard(rgw::sal::RadosStore* store,
                         RGWBucketInfo& bucket_info,
 			std::map<std::string, bufferlist>& bucket_attrs,
-                        const ReshardFaultInjector& fault,
+                        ReshardFaultInjector& fault,
                         uint32_t new_num_shards,
                         const DoutPrefixProvider *dpp)
 {
@@ -457,7 +457,7 @@ static int init_reshard(rgw::sal::RadosStore* store,
 static int cancel_reshard(rgw::sal::RadosStore* store,
                           RGWBucketInfo& bucket_info,
 			  std::map<std::string, bufferlist>& bucket_attrs,
-                          const ReshardFaultInjector& fault,
+                          ReshardFaultInjector& fault,
                           const DoutPrefixProvider *dpp)
 {
   static constexpr auto max_retries = 10;
@@ -488,7 +488,7 @@ static int cancel_reshard(rgw::sal::RadosStore* store,
 static int commit_reshard(rgw::sal::RadosStore* store,
                           RGWBucketInfo& bucket_info,
 			  std::map<std::string, bufferlist>& bucket_attrs,
-                          const ReshardFaultInjector& fault,
+                          ReshardFaultInjector& fault,
                           const DoutPrefixProvider *dpp)
 {
   static constexpr auto max_retries = 10;
@@ -579,7 +579,7 @@ int RGWBucketReshard::clear_resharding(rgw::sal::RadosStore* store,
 				       std::map<std::string, bufferlist>& bucket_attrs,
                                        const DoutPrefixProvider* dpp)
 {
-  constexpr ReshardFaultInjector no_fault;
+  ReshardFaultInjector no_fault;
   return cancel_reshard(store, bucket_info, bucket_attrs, no_fault, dpp);
 }
 
@@ -825,7 +825,7 @@ int RGWBucketReshard::get_status(const DoutPrefixProvider *dpp, list<cls_rgw_buc
 }
 
 int RGWBucketReshard::execute(int num_shards,
-                              const ReshardFaultInjector& fault,
+                              ReshardFaultInjector& fault,
                               int max_op_entries,
                               const DoutPrefixProvider *dpp,
                               bool verbose, ostream *out,

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -460,9 +460,18 @@ static int cancel_reshard(rgw::sal::RadosStore* store,
                           const ReshardFaultInjector& fault,
                           const DoutPrefixProvider *dpp)
 {
+  static constexpr auto max_retries = 10;
   // unblock writes to the current index shard objects
-  int ret = set_resharding_status(dpp, static_cast<rgw::sal::RadosStore*>(store), bucket_info,
-                                  cls_rgw_reshard_status::NOT_RESHARDING);
+  int ret = 0;
+  int tries = 0;
+  do {
+    ret = set_resharding_status(dpp, static_cast<rgw::sal::RadosStore*>(store), bucket_info,
+				cls_rgw_reshard_status::NOT_RESHARDING);
+    ++tries;
+    ldpp_dout(dpp, 1) << "WARNING: " << __func__
+		      << " set_resharding_status got -ECANCELED. Retrying."
+		      << dendl;
+  } while (ret == -ECANCELED && tries < max_retries);
   if (ret < 0) {
     ldpp_dout(dpp, 1) << "WARNING: " << __func__ << " failed to unblock "
         "writes to current index objects: " << cpp_strerror(ret) << dendl;
@@ -470,7 +479,15 @@ static int cancel_reshard(rgw::sal::RadosStore* store,
   }
 
   if (bucket_info.layout.target_index) {
-    return revert_target_layout(store, bucket_info, bucket_attrs, fault, dpp);
+    tries = 0;
+    do {
+      ret = revert_target_layout(store, bucket_info, bucket_attrs, fault, dpp);
+      ++tries;
+      ldpp_dout(dpp, 1) << "WARNING: " << __func__
+			<< " revert_target_layout got -ECANCELED. Retrying."
+			<< dendl;
+    } while (ret == -ECANCELED && tries < max_retries);
+    return ret;
   }
   // there is nothing to revert
   return 0;
@@ -482,6 +499,7 @@ static int commit_reshard(rgw::sal::RadosStore* store,
                           const ReshardFaultInjector& fault,
                           const DoutPrefixProvider *dpp)
 {
+  static constexpr auto max_retries = 10;
   auto& layout = bucket_info.layout;
   auto prev = layout; // make a copy for cleanup
   const auto next_log_gen = layout.logs.empty() ? 1 :
@@ -514,10 +532,14 @@ static int commit_reshard(rgw::sal::RadosStore* store,
 
   int ret = fault.check("commit_target_layout");
   if (ret == 0) { // no fault injected, write the bucket instance metadata
-    ret =
-      store->getRados()->put_bucket_instance_info(bucket_info, false,
-						  real_time(),
-						  &bucket_attrs, dpp);
+    int tries = 0;
+    do {
+      ret =
+	store->getRados()->put_bucket_instance_info(bucket_info, false,
+						    real_time(),
+						    &bucket_attrs, dpp);
+      ++tries;
+    } while (ret == -ECANCELED && tries < max_retries);
   }
 
   if (ret < 0) {
@@ -527,8 +549,16 @@ static int commit_reshard(rgw::sal::RadosStore* store,
     bucket_info.layout = std::move(prev); // restore in-memory layout
 
     // unblock writes to the current index shard objects
-    int ret2 = set_resharding_status(dpp, store, bucket_info,
-                                     cls_rgw_reshard_status::NOT_RESHARDING);
+    int tries = 0;
+    int ret2 = 0;
+    do {
+      ret2 = set_resharding_status(dpp, store, bucket_info,
+				   cls_rgw_reshard_status::NOT_RESHARDING);
+      ++tries;
+      ldpp_dout(dpp, 1) << "WARNING: " << __func__
+			<< " set_resharding_status got -ECANCELED. Retrying."
+			<< dendl;
+    } while (ret2 == -ECANCELED && tries < max_retries);
     if (ret2 < 0) {
       ldpp_dout(dpp, 1) << "WARNING: " << __func__ << " failed to unblock "
           "writes to current index objects: " << cpp_strerror(ret2) << dendl;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -440,7 +440,7 @@ static int init_reshard(rgw::sal::RadosStore* store,
 
   if (ret = fault.check("block_writes");
       ret == 0) { // no fault injected, block writes to the current index shards
-    ret = set_resharding_status(dpp, static_cast<rgw::sal::RadosStore*>(store), bucket_info,
+    ret = set_resharding_status(dpp, store, bucket_info,
                                 cls_rgw_reshard_status::IN_PROGRESS);
   }
 
@@ -462,16 +462,8 @@ static int cancel_reshard(rgw::sal::RadosStore* store,
 {
   static constexpr auto max_retries = 10;
   // unblock writes to the current index shard objects
-  int ret = 0;
-  int tries = 0;
-  do {
-    ret = set_resharding_status(dpp, static_cast<rgw::sal::RadosStore*>(store), bucket_info,
-				cls_rgw_reshard_status::NOT_RESHARDING);
-    ++tries;
-    ldpp_dout(dpp, 1) << "WARNING: " << __func__
-		      << " set_resharding_status got -ECANCELED. Retrying."
-		      << dendl;
-  } while (ret == -ECANCELED && tries < max_retries);
+  int ret = set_resharding_status(dpp, store, bucket_info,
+                                  cls_rgw_reshard_status::NOT_RESHARDING);
   if (ret < 0) {
     ldpp_dout(dpp, 1) << "WARNING: " << __func__ << " failed to unblock "
         "writes to current index objects: " << cpp_strerror(ret) << dendl;
@@ -549,16 +541,8 @@ static int commit_reshard(rgw::sal::RadosStore* store,
     bucket_info.layout = std::move(prev); // restore in-memory layout
 
     // unblock writes to the current index shard objects
-    int tries = 0;
-    int ret2 = 0;
-    do {
-      ret2 = set_resharding_status(dpp, store, bucket_info,
-				   cls_rgw_reshard_status::NOT_RESHARDING);
-      ++tries;
-      ldpp_dout(dpp, 1) << "WARNING: " << __func__
-			<< " set_resharding_status got -ECANCELED. Retrying."
-			<< dendl;
-    } while (ret2 == -ECANCELED && tries < max_retries);
+    int ret2 = set_resharding_status(dpp, store, bucket_info,
+                                     cls_rgw_reshard_status::NOT_RESHARDING);
     if (ret2 < 0) {
       ldpp_dout(dpp, 1) << "WARNING: " << __func__ << " failed to unblock "
           "writes to current index objects: " << cpp_strerror(ret2) << dendl;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -432,33 +432,69 @@ static int revert_target_layout(rgw::sal::RadosStore* store,
                                 ReshardFaultInjector& fault,
                                 const DoutPrefixProvider* dpp)
 {
-  auto& layout = bucket_info.layout;
-  auto prev = layout; // make a copy for cleanup
+  auto prev = bucket_info.layout; // make a copy for cleanup
 
   // remove target index shard objects
-  int ret = store->svc()->bi->clean_index(dpp, bucket_info, *layout.target_index);
+  int ret = store->svc()->bi->clean_index(dpp, bucket_info, *prev.target_index);
   if (ret < 0) {
     ldpp_dout(dpp, 1) << "WARNING: " << __func__ << " failed to remove "
         "target index with: " << cpp_strerror(ret) << dendl;
     ret = 0; // non-fatal error
   }
 
-  // clear target_index and resharding state
-  layout.target_index = std::nullopt;
-  layout.resharding = rgw::BucketReshardState::None;
+  // retry in case of racing writes to the bucket instance metadata
+  static constexpr auto max_retries = 10;
+  int tries = 0;
+  do {
+    // clear target_index and resharding state
+    bucket_info.layout.target_index = std::nullopt;
+    bucket_info.layout.resharding = rgw::BucketReshardState::None;
 
-  if (ret = fault.check("revert_target_layout");
-      ret == 0) { // no fault injected, revert the bucket instance metadata
-    ret = store->getRados()->put_bucket_instance_info(bucket_info, false,
-                                                      real_time(),
-						      &bucket_attrs, dpp);
-  }
+    if (ret = fault.check("revert_target_layout");
+        ret == 0) { // no fault injected, revert the bucket instance metadata
+      ret = store->getRados()->put_bucket_instance_info(bucket_info, false,
+                                                        real_time(),
+                                                        &bucket_attrs, dpp);
+    } else if (ret == -ECANCELED) {
+      fault.clear(); // clear the fault so a retry can succeed
+    }
+
+    if (ret == -ECANCELED) {
+      // racing write detected, read the latest bucket info and try again
+      auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
+      int ret2 = store->getRados()->get_bucket_instance_info(
+          obj_ctx, bucket_info.bucket, bucket_info,
+          nullptr, &bucket_attrs, null_yield, dpp);
+      if (ret2 < 0) {
+        ldpp_dout(dpp, 0) << "ERROR: " << __func__ << " failed to read "
+            "bucket info: " << cpp_strerror(ret2) << dendl;
+        ret = ret2;
+        break;
+      }
+
+      // check that we're still in the reshard state we started in
+      if (bucket_info.layout.resharding == rgw::BucketReshardState::None) {
+        ldpp_dout(dpp, 1) << "WARNING: " << __func__ << " raced with "
+            "reshard cancel" << dendl;
+        return -ECANCELED;
+      }
+      if (bucket_info.layout.current_index != prev.current_index ||
+          bucket_info.layout.target_index != prev.target_index) {
+        ldpp_dout(dpp, 1) << "WARNING: " << __func__ << " raced with "
+            "another reshard" << dendl;
+        return -ECANCELED;
+      }
+
+      prev = bucket_info.layout; // update the copy
+    }
+    ++tries;
+  } while (ret == -ECANCELED && tries < max_retries);
 
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: " << __func__ << " failed to clear "
         "target index layout in bucket info: " << cpp_strerror(ret) << dendl;
 
-    bucket_info.layout = std::move(prev); // restore in-memory layout
+    bucket_info.layout = std::move(prev);  // restore in-memory layout
     return ret;
   }
   return 0;
@@ -498,7 +534,6 @@ static int cancel_reshard(rgw::sal::RadosStore* store,
                           ReshardFaultInjector& fault,
                           const DoutPrefixProvider *dpp)
 {
-  static constexpr auto max_retries = 10;
   // unblock writes to the current index shard objects
   int ret = set_resharding_status(dpp, store, bucket_info,
                                   cls_rgw_reshard_status::NOT_RESHARDING);
@@ -509,15 +544,7 @@ static int cancel_reshard(rgw::sal::RadosStore* store,
   }
 
   if (bucket_info.layout.target_index) {
-    tries = 0;
-    do {
-      ret = revert_target_layout(store, bucket_info, bucket_attrs, fault, dpp);
-      ++tries;
-      ldpp_dout(dpp, 1) << "WARNING: " << __func__
-			<< " revert_target_layout got -ECANCELED. Retrying."
-			<< dendl;
-    } while (ret == -ECANCELED && tries < max_retries);
-    return ret;
+    return revert_target_layout(store, bucket_info, bucket_attrs, fault, dpp);
   }
   // there is nothing to revert
   return 0;

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -98,7 +98,7 @@ public:
 		   const RGWBucketInfo& _bucket_info,
 		   const std::map<std::string, bufferlist>& _bucket_attrs,
 		   RGWBucketReshardLock* _outer_reshard_lock);
-  int execute(int num_shards, const ReshardFaultInjector& f,
+  int execute(int num_shards, ReshardFaultInjector& f,
               int max_op_entries, const DoutPrefixProvider *dpp,
               bool verbose = false, std::ostream *out = nullptr,
               ceph::Formatter *formatter = nullptr,


### PR DESCRIPTION
updates the three places in bucket reshard that write to bucket instance metadata: `init_target_layout()`, `revert_target_layout()`, and `commit_reshard()`

`ECANCELED` errors from cls_version are handled with a retry loop similar to `retry_raced_bucket_write()` from `rgw_op.cc`. each time we see `ECANCELED`, we re-read the bucket instance metadata and check for races with other reshards or reshard cancelation, then re-apply the mutation to bucket_info

i chose not to reuse `retry_raced_bucket_write()` here because it requires `rgw::sal::Bucket`, and reshard doesn't use sal interfaces yet - switching that would really complicate backports

`qa/workunits/rgw/test_rgw_reshard.py` has reshard test cases with fault injection to test error paths and crash recovery. i extended the test and radosgw-admin to allow injection of these `ECANCELED` errors. the injected `ECANCELED` errors are special because they're only injected once, so the test expects the retry to succeed

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
