### PR TITLE
octopus: librbd: honor FUA op flag for write_same() in write-around cache

### DIFF
--- a/src/librbd/cache/WriteAroundObjectDispatch.cc
+++ b/src/librbd/cache/WriteAroundObjectDispatch.cc
@@ -108,8 +108,8 @@ bool WriteAroundObjectDispatch<I>::write_same(
   ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
                  << object_off << "~" << object_len << dendl;
 
-  return dispatch_io(object_no, object_off, object_len, 0, dispatch_result,
-                     on_finish, on_dispatched);
+  return dispatch_io(object_no, object_off, object_len, op_flags,
+                     dispatch_result, on_finish, on_dispatched);
 }
 
 template <typename I>

--- a/src/test/librbd/cache/test_mock_WriteAroundObjectDispatch.cc
+++ b/src/test/librbd/cache/test_mock_WriteAroundObjectDispatch.cc
@@ -632,7 +632,7 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOBlockedIO) {
   finish_ctx_ptr2->complete(0);
 }
 
-TEST_F(TestMockCacheWriteAroundObjectDispatch, FUA) {
+TEST_F(TestMockCacheWriteAroundObjectDispatch, WriteFUA) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
@@ -652,6 +652,30 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FUA) {
                                      LIBRADOS_OP_FLAG_FADVISE_FUA, {},
                                      nullptr, nullptr, &dispatch_result,
                                      &finish_ctx_ptr, &dispatch_ctx));
+  ASSERT_EQ(finish_ctx_ptr, &finish_ctx);
+}
+
+TEST_F(TestMockCacheWriteAroundObjectDispatch, WriteSameFUA) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockWriteAroundObjectDispatch object_dispatch(&mock_image_ctx, 16384, false);
+
+  InSequence seq;
+
+  bufferlist data;
+  data.append(std::string(512, '1'));
+
+  io::DispatchResult dispatch_result;
+  MockContext finish_ctx;
+  MockContext dispatch_ctx;
+  Context* finish_ctx_ptr = &finish_ctx;
+  ASSERT_FALSE(object_dispatch.write_same(0, 0, 8192, {{0, 8192}},
+                                          std::move(data), {},
+                                          LIBRADOS_OP_FLAG_FADVISE_FUA, {},
+                                          nullptr, nullptr, &dispatch_result,
+                                          &finish_ctx_ptr, &dispatch_ctx));
   ASSERT_EQ(finish_ctx_ptr, &finish_ctx);
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53015

---

backport of https://github.com/ceph/ceph/pull/43568
parent tracker: https://tracker.ceph.com/issues/52956