### PR TITLE
pacific: librbd: fix use-after-free on ictx in list_descendants()

### DIFF
--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -318,8 +318,8 @@ int Image<I>::list_descendants(
       return 0;
     }
     lderr(cct) << "failed to open descendant " << image_id
-                     << " from pool " << io_ctx.get_pool_name() << ":"
-                     << cpp_strerror(r) << dendl;
+               << " from pool " << io_ctx.get_pool_name() << ":"
+               << cpp_strerror(r) << dendl;
     return r;
   }
 
@@ -328,8 +328,8 @@ int Image<I>::list_descendants(
   int r1 = ictx->state->close();
   if (r1 < 0) {
     lderr(cct) << "error when closing descendant " << image_id
-                     << " from pool " << io_ctx.get_pool_name() << ":"
-                     << cpp_strerror(r) << dendl;
+               << " from pool " << io_ctx.get_pool_name() << ":"
+               << cpp_strerror(r1) << dendl;
   }
 
   return r;

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -311,12 +311,13 @@ int Image<I>::list_descendants(
     std::vector<librbd::linked_image_spec_t> *images) {
   ImageCtx *ictx = new librbd::ImageCtx("", image_id, nullptr,
                                         io_ctx, true);
+  CephContext *cct = ictx->cct;
   int r = ictx->state->open(OPEN_FLAG_SKIP_OPEN_PARENT);
   if (r < 0) {
     if (r == -ENOENT) {
       return 0;
     }
-    lderr(ictx->cct) << "failed to open descendant " << image_id
+    lderr(cct) << "failed to open descendant " << image_id
                      << " from pool " << io_ctx.get_pool_name() << ":"
                      << cpp_strerror(r) << dendl;
     return r;
@@ -326,7 +327,7 @@ int Image<I>::list_descendants(
 
   int r1 = ictx->state->close();
   if (r1 < 0) {
-    lderr(ictx->cct) << "error when closing descendant " << image_id
+    lderr(cct) << "error when closing descendant " << image_id
                      << " from pool " << io_ctx.get_pool_name() << ":"
                      << cpp_strerror(r) << dendl;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52534

---

backport of https://github.com/ceph/ceph/pull/43074
parent tracker: https://tracker.ceph.com/issues/52522