### PR TITLE
pacific: krbd: return error when no initial monitor address found

### DIFF
--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -221,6 +221,11 @@ static int build_map_buf(CephContext *cct, const krbd_spec& spec,
     }
   }
 
+  if (oss.tellp() == 0) {
+    std::cerr << "rbd: failed to get mon address (possible ms_mode mismatch)" << std::endl;
+    return -ENOENT;
+  }
+
   oss << " name=" << cct->_conf->name.get_id();
 
   KeyRing keyring;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54187

---

backport of https://github.com/ceph/ceph/pull/44886
parent tracker: https://tracker.ceph.com/issues/54128