### PR TITLE
octopus: mgr/rbd_support: fix schedule remove

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -1211,7 +1211,16 @@ test_trash_purge_schedule() {
         rbd trash purge schedule rm -p $p 1m
     done
 
+    # Negative tests
+    rbd trash purge schedule add 2m
+    expect_fail rbd trash purge schedule add -p rbd dummy
+    expect_fail rbd trash purge schedule add dummy
+    expect_fail rbd trash purge schedule remove -p rbd dummy
+    expect_fail rbd trash purge schedule remove dummy
+    rbd trash purge schedule ls -p rbd | grep 'every 1d starting at 01:30'
+    rbd trash purge schedule ls | grep 'every 2m'
     rbd trash purge schedule remove -p rbd 1d 01:30
+    rbd trash purge schedule remove 2m
     test "$(rbd trash purge schedule ls -R --format json)" = "[]"
 
     remove_images
@@ -1263,6 +1272,14 @@ test_mirror_snapshot_schedule() {
 
     rbd mirror snapshot schedule add 1h 00:15
     test "$(rbd mirror snapshot schedule ls)" = 'every 1h starting at 00:15:00'
+
+    # Negative tests
+    expect_fail rbd mirror snapshot schedule add dummy
+    expect_fail rbd mirror snapshot schedule add -p rbd2/ns1 --image test1 dummy
+    expect_fail rbd mirror snapshot schedule remove dummy
+    expect_fail rbd mirror snapshot schedule remove -p rbd2/ns1 --image test1 dummy
+    test "$(rbd mirror snapshot schedule ls)" = 'every 1h starting at 00:15:00'
+    test "$(rbd mirror snapshot schedule ls -p rbd2/ns1 --image test1)" = 'every 1m'
 
     rbd rm rbd2/ns1/test1
 

--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -462,10 +462,12 @@ class Schedules:
             if interval is None:
                 schedule = None
             else:
-                schedule.remove(Interval.from_string(interval),
-                                StartTime.from_string(start_time))
-                if schedule:
-                    self.schedules[level_spec.id] = schedule
+                try:
+                    schedule.remove(Interval.from_string(interval),
+                                    StartTime.from_string(start_time))
+                finally:
+                    if schedule:
+                        self.schedules[level_spec.id] = schedule
             if not schedule:
                 del self.level_specs[level_spec.id]
         self.save(level_spec, schedule)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54169

---

backport of https://github.com/ceph/ceph/pull/43910
parent tracker: https://tracker.ceph.com/issues/53250

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh