### PR TITLE
octopus: rbd: mark optional positional arguments as such in help output

### DIFF
--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -1567,7 +1567,7 @@
   rbd help mirror image enable
   usage: rbd mirror image enable [--pool <pool>] [--namespace <namespace>] 
                                  [--image <image>] 
-                                 <image-spec> <mode> 
+                                 <image-spec> [<mode>] 
   
   Enable RBD mirroring for an image.
   
@@ -1842,7 +1842,7 @@
                                         [--pool <pool>] 
                                         [--namespace <namespace>] 
                                         [--image <image>] 
-                                        <interval> <start-time> 
+                                        <interval> [<start-time>] 
   
   Add mirror snapshot schedule.
   
@@ -1877,7 +1877,7 @@
                                         [--pool <pool>] 
                                         [--namespace <namespace>] 
                                         [--image <image>] 
-                                        <interval> <start-time> 
+                                        [<interval>] [<start-time>] 
   
   Remove mirror snapshot schedule.
   
@@ -2409,7 +2409,7 @@
   
   rbd help trash purge schedule add
   usage: rbd trash purge schedule add [--pool <pool>] [--namespace <namespace>] 
-                                      <interval> <start-time> 
+                                      <interval> [<start-time>] 
   
   Add trash purge schedule.
   
@@ -2438,7 +2438,7 @@
   rbd help trash purge schedule remove
   usage: rbd trash purge schedule remove
                                         [--pool <pool>] [--namespace <namespace>] 
-                                        <interval> <start-time> 
+                                        [<interval>] [<start-time>] 
   
   Remove trash purge schedule.
   

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -732,7 +732,7 @@
   rbd help feature disable
   usage: rbd feature disable [--pool <pool>] [--namespace <namespace>] 
                              [--image <image>] 
-                             <image-spec> <features> [<features> ...]
+                             <image-spec> <features> [<features> ...] 
   
   Disable the specified image feature.
   
@@ -753,7 +753,7 @@
                             [--journal-splay-width <journal-splay-width>] 
                             [--journal-object-size <journal-object-size>] 
                             [--journal-pool <journal-pool>] 
-                            <image-spec> <features> [<features> ...]
+                            <image-spec> <features> [<features> ...] 
   
   Enable the specified image feature.
   

--- a/src/tools/rbd/OptionPrinter.cc
+++ b/src/tools/rbd/OptionPrinter.cc
@@ -19,38 +19,63 @@ OptionPrinter::OptionPrinter(const OptionsDescription &positional,
 }
 
 void OptionPrinter::print_short(std::ostream &os, size_t initial_offset) {
-  size_t name_width = std::min(initial_offset, MAX_DESCRIPTION_OFFSET) + 1;
-
-  IndentStream indent_stream(name_width, initial_offset, LINE_WIDTH, os);
-  indent_stream.set_delimiter("[");
+  size_t max_option_width = 0;
+  std::vector<std::string> optionals;
   for (size_t i = 0; i < m_optional.options().size(); ++i) {
+    std::stringstream option;
+
     bool required = m_optional.options()[i]->semantic()->is_required();
     if (!required) {
-      indent_stream << "[";
+      option << "[";
     }
-    indent_stream << "--" << m_optional.options()[i]->long_name();
+    option << "--" << m_optional.options()[i]->long_name();
     if (m_optional.options()[i]->semantic()->max_tokens() != 0) {
-      indent_stream << " <" << m_optional.options()[i]->long_name() << ">";
+      option << " <" << m_optional.options()[i]->long_name() << ">";
     }
     if (!required) {
-      indent_stream << "]";
+      option << "]";
     }
-    indent_stream << " ";
+    max_option_width = std::max(max_option_width, option.str().size());
+    optionals.emplace_back(option.str());
   }
 
-  if (m_optional.options().size() > 0 || m_positional.options().size() == 0) {
+  std::vector<std::string> positionals;
+  for (size_t i = 0; i < m_positional.options().size(); ++i) {
+    std::stringstream option;
+
+    option << "<" << m_positional.options()[i]->long_name() << ">";
+    if (m_positional.options()[i]->semantic()->max_tokens() > 1) {
+      option << " [<" << m_positional.options()[i]->long_name() << "> ...]";
+    }
+
+    max_option_width = std::max(max_option_width, option.str().size());
+    positionals.emplace_back(option.str());
+
+    if (m_positional.options()[i]->semantic()->max_tokens() > 1) {
+      break;
+    }
+  }
+
+  size_t indent = std::min(initial_offset, MAX_DESCRIPTION_OFFSET) + 1;
+  if (indent + max_option_width + 2 > LINE_WIDTH) {
+    // decrease the indent so that we don't wrap past the end of the line
+    indent = LINE_WIDTH - max_option_width - 2;
+  }
+
+  IndentStream indent_stream(indent, initial_offset, LINE_WIDTH, os);
+  indent_stream.set_delimiter("[");
+  for (auto& option : optionals) {
+    indent_stream << option << " ";
+  }
+
+  if (optionals.size() > 0 || positionals.size() == 0) {
     indent_stream << std::endl;
   }
 
-  if (m_positional.options().size() > 0) {
+  if (positionals.size() > 0) {
     indent_stream.set_delimiter(" ");
-    for (size_t i = 0; i < m_positional.options().size(); ++i) {
-      indent_stream << "<" << m_positional.options()[i]->long_name() << "> ";
-      if (m_positional.options()[i]->semantic()->max_tokens() > 1) {
-        indent_stream << "[<" << m_positional.options()[i]->long_name()
-                      << "> ...]";
-        break;
-      }
+    for (auto& option : positionals) {
+      indent_stream << option << " ";
     }
     indent_stream << std::endl;
   }

--- a/src/tools/rbd/Schedule.cc
+++ b/src/tools/rbd/Schedule.cc
@@ -152,11 +152,19 @@ void normalize_level_spec_args(std::map<std::string, std::string> *args) {
   }
 }
 
-void add_schedule_options(po::options_description *positional) {
+void add_schedule_options(po::options_description *positional,
+                          bool mandatory) {
+  if (mandatory) {
+    positional->add_options()
+      ("interval", "schedule interval");
+  } else {
+    positional->add_options()
+      ("interval", po::value<std::string>()->default_value(""),
+       "schedule interval");
+  }
   positional->add_options()
-    ("interval", "schedule interval");
-  positional->add_options()
-    ("start-time", "schedule start time");
+    ("start-time", po::value<std::string>()->default_value(""),
+     "schedule start time");
 }
 
 int get_schedule_args(const po::variables_map &vm, bool mandatory,

--- a/src/tools/rbd/Schedule.h
+++ b/src/tools/rbd/Schedule.h
@@ -23,7 +23,7 @@ int get_level_spec_args(const boost::program_options::variables_map &vm,
 void normalize_level_spec_args(std::map<std::string, std::string> *args);
 
 void add_schedule_options(
-  boost::program_options::options_description *positional);
+  boost::program_options::options_description *positional, bool mandatory);
 int get_schedule_args(const boost::program_options::variables_map &vm,
                       bool mandatory, std::map<std::string, std::string> *args);
 

--- a/src/tools/rbd/action/MirrorImage.cc
+++ b/src/tools/rbd/action/MirrorImage.cc
@@ -77,7 +77,8 @@ void get_arguments_enable(po::options_description *positional,
                           po::options_description *options) {
   at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
   positional->add_options()
-    ("mode", "mirror image mode (journal or snapshot) [default: journal]");
+    ("mode", po::value<std::string>()->default_value(""),
+     "mirror image mode (journal or snapshot) [default: journal]");
 }
 
 void get_arguments_disable(po::options_description *positional,

--- a/src/tools/rbd/action/MirrorSnapshotSchedule.cc
+++ b/src/tools/rbd/action/MirrorSnapshotSchedule.cc
@@ -121,7 +121,7 @@ std::ostream& operator<<(std::ostream& os, ScheduleStatus &s) {
 void get_arguments_add(po::options_description *positional,
                        po::options_description *options) {
   add_level_spec_options(options);
-  add_schedule_options(positional);
+  add_schedule_options(positional, true);
 }
 
 int execute_add(const po::variables_map &vm,
@@ -156,7 +156,7 @@ int execute_add(const po::variables_map &vm,
 void get_arguments_remove(po::options_description *positional,
                           po::options_description *options) {
   add_level_spec_options(options);
-  add_schedule_options(positional);
+  add_schedule_options(positional, false);
 }
 
 int execute_remove(const po::variables_map &vm,

--- a/src/tools/rbd/action/TrashPurgeSchedule.cc
+++ b/src/tools/rbd/action/TrashPurgeSchedule.cc
@@ -151,7 +151,7 @@ std::ostream& operator<<(std::ostream& os, ScheduleStatus &s) {
 void get_arguments_add(po::options_description *positional,
                        po::options_description *options) {
   add_level_spec_options(options, false);
-  add_schedule_options(positional);
+  add_schedule_options(positional, true);
 }
 
 int execute_add(const po::variables_map &vm,
@@ -186,7 +186,7 @@ int execute_add(const po::variables_map &vm,
 void get_arguments_remove(po::options_description *positional,
                           po::options_description *options) {
   add_level_spec_options(options, false);
-  add_schedule_options(positional);
+  add_schedule_options(positional, false);
 }
 
 int execute_remove(const po::variables_map &vm,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54230

---

backport of https://github.com/ceph/ceph/pull/44937
parent tracker: https://tracker.ceph.com/issues/54191