### PR TITLE
cephadm/ingress: make frontend stats bind on localhost

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/ingress/haproxy.cfg.j2
+++ b/src/pybind/mgr/cephadm/templates/services/ingress/haproxy.cfg.j2
@@ -48,6 +48,7 @@ defaults
 frontend stats
     mode http
     bind {{ ip }}:{{ monitor_port }}
+    bind localhost:{{ monitor_port }}
     stats enable
     stats uri /stats
     stats refresh 10s


### PR DESCRIPTION
The current configuration of keepalived makes it do
a curl on `localhost:9999` in order to check the endpoint is alive.
Given the endpoint only binds on the vip addr, that doesn't work.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>