### PR TITLE
pacific: mds: mds_oft_prefetch_dirfrags default to false

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8594,7 +8594,7 @@ std::vector<Option> get_mds_options() {
     .set_description("rate of decay for export targets communicated to clients"),
 
     Option("mds_oft_prefetch_dirfrags", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
+    .set_default(false)
     .set_description("prefetch dirfrags recorded in open file table on startup")
     .set_flag(Option::FLAG_STARTUP),
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54194

---

backport of https://github.com/ceph/ceph/pull/44667
parent tracker: https://tracker.ceph.com/issues/53952

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh