### PR TITLE
quincy: mds: mds_oft_prefetch_dirfrags default to false

### DIFF
--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -834,7 +834,7 @@ options:
   type: bool
   level: advanced
   desc: prefetch dirfrags recorded in open file table on startup
-  default: true
+  default: false
   services:
   - mds
   flags:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54196

---

backport of https://github.com/ceph/ceph/pull/44667
parent tracker: https://tracker.ceph.com/issues/53952

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh