### PR TITLE
admin/doc-requirements: pin breathe to 4.32.0

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,7 +1,7 @@
 Sphinx == 3.5.4
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
 git+https://github.com/vlasovskikh/funcparserlib.git
-breathe >= 4.20.0
+breathe == 4.32.0
 cryptography
 Jinja2
 pyyaml >= 5.1.2


### PR DESCRIPTION
in breathe v4.33, it includes following commit

https://github.com/michaeljones/breathe/commit/2498a437234343503e0087cad793c6f333f1f781

which specfies the app config value of "graphviz_dot". this annoys
sphinx:

WARNING: while setting up extension breathe: node class 'graphviz' is already registered, its visitors will be overridden

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/sphinx/cmd/build.py", line 276, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/sphinx/application.py", line 245, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/sphinx/application.py", line 402, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/sphinx/registry.py", line 430, in load_extension
    metadata = setup(app)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/breathe/__init__.py", line 14, in setup
    renderer_setup(app)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/breathe/renderer/sphinxrenderer.py", line 2613, in setup
    app.add_config_value("graphviz_dot", "dot", "html")
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/sphinx/application.py", line 535, in add_config_value
    self.config.add(name, default, rebuild, types)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/sphinx/config.py", line 282, in add
    raise ExtensionError(__('Config value %r already present') % name)
sphinx.errors.ExtensionError: Config value 'graphviz_dot' already present

Extension error:
Config value 'graphviz_dot' already present

this issue has been reported to upstream, see
https://github.com/michaeljones/breathe/issues/803

before it is fixed upstream, let's stick with 4.32.0
which is known to work.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
