### PR TITLE
mgr/dashboard: change privacy protocol field from required to optional

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
@@ -37,7 +37,13 @@ export class ServicesPageHelper extends PageHelper {
     });
   }
 
-  addService(serviceType: string, exist?: boolean, count = '1', snmpVersion?: string) {
+  addService(
+    serviceType: string,
+    exist?: boolean,
+    count = '1',
+    snmpVersion?: string,
+    snmpPrivProtocol?: boolean
+  ) {
     cy.get(`${this.pages.create.id}`).within(() => {
       this.selectServiceType(serviceType);
       switch (serviceType) {
@@ -67,12 +73,14 @@ export class ServicesPageHelper extends PageHelper {
           } else {
             cy.get('#engine_id').type('800C53F00000');
             this.selectOption('auth_protocol', 'SHA');
-            this.selectOption('privacy_protocol', 'DES');
+            if (snmpPrivProtocol) {
+              this.selectOption('privacy_protocol', 'DES');
+              cy.get('#snmp_v3_priv_password').type('testencrypt');
+            }
 
             // Credentials
             cy.get('#snmp_v3_auth_username').type('test');
             cy.get('#snmp_v3_auth_password').type('testpass');
-            cy.get('#snmp_v3_priv_password').type('testencrypt');
           }
           break;
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/09-services.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/orchestrator/workflow/09-services.e2e-spec.ts
@@ -77,7 +77,20 @@ describe('Services page', () => {
 
   it('should create and delete snmp-gateway service with version V3', () => {
     services.navigateTo('create');
-    services.addService('snmp-gateway', false, '1', 'V3');
+    services.addService('snmp-gateway', false, '1', 'V3', true);
+    services.checkExist('snmp-gateway', true);
+
+    services.clickServiceTab('snmp-gateway', 'Details');
+    cy.get('cd-service-details').within(() => {
+      services.checkServiceStatus('snmp-gateway');
+    });
+
+    services.deleteService('snmp-gateway');
+  });
+
+  it('should create and delete snmp-gateway service with version V3 and w/o privacy protocol', () => {
+    services.navigateTo('create');
+    services.addService('snmp-gateway', false, '1', 'V3', false);
     services.checkExist('snmp-gateway', true);
 
     services.clickServiceTab('snmp-gateway', 'Details');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -84,7 +84,8 @@
         </div>
 
         <!-- unmanaged -->
-        <div class="form-group row">
+        <div class="form-group row"
+             *ngIf="serviceForm.controls.service_type.value !== 'snmp-gateway'">
           <div class="cd-col-form-offset">
             <div class="custom-control custom-checkbox">
               <input class="custom-control-input"
@@ -487,6 +488,9 @@
               <span class="invalid-feedback"
                     *ngIf="serviceForm.showError('engine_id', frm, 'required')"
                     i18n>This field is required.</span>
+              <span class="invalid-feedback"
+                    *ngIf="serviceForm.showError('engine_id', frm, 'snmpEngineIdPattern')"
+                    i18n>The value does not match the pattern: <strong>Must be in hexadecimal and length must be multiple of 2 with min value = 10 amd max value = 64.</strong></span>
             </div>
           </div>
           <!-- Auth protocol for snmp V3 -->

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -63,7 +63,8 @@
           </div>
 
         <!-- Service id -->
-        <div class="form-group row">
+        <div class="form-group row"
+             *ngIf="serviceForm.controls.service_type.value !== 'snmp-gateway'">
           <label i18n
                  class="cd-col-form-label"
                  [ngClass]="{'required': ['mds', 'rgw', 'nfs', 'iscsi', 'ingress'].includes(serviceForm.controls.service_type.value)}"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
@@ -459,6 +459,7 @@ x4Ea7kGVgx9kWh5XjWz9wjZvY49UKIT5ppIAWPMbLl3UpfckiuNhTA==
           }
         });
       });
+
       it('should test snmp-gateway service with V3', () => {
         formHelper.setValue('snmp_version', 'V3');
         formHelper.setValue('engine_id', '800C53F00000');
@@ -484,11 +485,24 @@ x4Ea7kGVgx9kWh5XjWz9wjZvY49UKIT5ppIAWPMbLl3UpfckiuNhTA==
           }
         });
       });
+
       it('should submit invalid snmp destination', () => {
         formHelper.setValue('snmp_version', 'V2c');
         formHelper.setValue('snmp_destination', '192.168.20.1');
         formHelper.setValue('snmp_community', 'public');
         formHelper.expectError('snmp_destination', 'snmpDestinationPattern');
+      });
+
+      it('should submit invalid snmp engine id', () => {
+        formHelper.setValue('snmp_version', 'V3');
+        formHelper.setValue('snmp_destination', '192.168.20.1');
+        formHelper.setValue('engine_id', 'AABBCCDDE');
+        formHelper.setValue('auth_protocol', 'SHA');
+        formHelper.setValue('privacy_protocol', 'DES');
+        formHelper.setValue('snmp_v3_auth_username', 'testuser');
+        formHelper.setValue('snmp_v3_auth_password', 'testpass');
+
+        formHelper.expectError('engine_id', 'snmpEngineIdPattern');
       });
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -245,7 +245,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         null,
         [
           CdValidators.requiredIf({
-            service_type: 'snmp-gateway',
+            snmp_version: 'V3',
             unmanaged: false
           })
         ]
@@ -254,25 +254,17 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         'SHA',
         [
           CdValidators.requiredIf({
-            service_type: 'snmp-gateway',
+            snmp_version: 'V3',
             unmanaged: false
           })
         ]
       ],
-      privacy_protocol: [
-        null,
-        [
-          CdValidators.requiredIf({
-            service_type: 'snmp-gateway',
-            unmanaged: false
-          })
-        ]
-      ],
+      privacy_protocol: [null],
       snmp_community: [
         null,
         [
           CdValidators.requiredIf({
-            service_type: 'snmp-gateway',
+            snmp_version: 'V2c',
             unmanaged: false
           })
         ]
@@ -281,7 +273,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         null,
         [
           CdValidators.requiredIf({
-            service_type: 'snmp-gateway',
+            snmp_version: 'V3',
             unmanaged: false
           })
         ]
@@ -290,7 +282,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         null,
         [
           CdValidators.requiredIf({
-            service_type: 'snmp-gateway',
+            snmp_version: 'V3',
             unmanaged: false
           })
         ]
@@ -299,7 +291,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         null,
         [
           CdValidators.requiredIf({
-            service_type: 'snmp-gateway',
+            privacy_protocol: { op: '!empty' },
             unmanaged: false
           })
         ]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -29,6 +29,7 @@ import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 export class ServiceFormComponent extends CdForm implements OnInit {
   readonly RGW_SVC_ID_PATTERN = /^([^.]+)(\.([^.]+)\.([^.]+))?$/;
   readonly SNMP_DESTINATION_PATTERN = /^[^\:]+:[0-9]/;
+  readonly SNMP_ENGINE_ID_PATTERN = /^[0-9A-Fa-f]{10,64}/g;
   @ViewChild(NgbTypeahead, { static: false })
   typeahead: NgbTypeahead;
 
@@ -219,8 +220,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         null,
         [
           CdValidators.requiredIf({
-            service_type: 'snmp-gateway',
-            unmanaged: false
+            service_type: 'snmp-gateway'
           })
         ]
       ],
@@ -229,8 +229,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         {
           validators: [
             CdValidators.requiredIf({
-              service_type: 'snmp-gateway',
-              unmanaged: false
+              service_type: 'snmp-gateway'
             }),
             CdValidators.custom('snmpDestinationPattern', (value: string) => {
               if (_.isEmpty(value)) {
@@ -245,8 +244,13 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         null,
         [
           CdValidators.requiredIf({
-            snmp_version: 'V3',
-            unmanaged: false
+            service_type: 'snmp-gateway'
+          }),
+          CdValidators.custom('snmpEngineIdPattern', (value: string) => {
+            if (_.isEmpty(value)) {
+              return false;
+            }
+            return !this.SNMP_ENGINE_ID_PATTERN.test(value);
           })
         ]
       ],
@@ -254,8 +258,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         'SHA',
         [
           CdValidators.requiredIf({
-            snmp_version: 'V3',
-            unmanaged: false
+            service_type: 'snmp-gateway'
           })
         ]
       ],
@@ -264,8 +267,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         null,
         [
           CdValidators.requiredIf({
-            snmp_version: 'V2c',
-            unmanaged: false
+            snmp_version: 'V2c'
           })
         ]
       ],
@@ -273,8 +275,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         null,
         [
           CdValidators.requiredIf({
-            snmp_version: 'V3',
-            unmanaged: false
+            service_type: 'snmp-gateway'
           })
         ]
       ],
@@ -282,8 +283,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         null,
         [
           CdValidators.requiredIf({
-            snmp_version: 'V3',
-            unmanaged: false
+            service_type: 'snmp-gateway'
           })
         ]
       ],
@@ -291,8 +291,7 @@ export class ServiceFormComponent extends CdForm implements OnInit {
         null,
         [
           CdValidators.requiredIf({
-            privacy_protocol: { op: '!empty' },
-            unmanaged: false
+            privacy_protocol: { op: '!empty' }
           })
         ]
       ]


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/54270
Signed-off-by: Avan Thakkar <athakkar@redhat.com>

Privacy protocol field must be optional and adding validation for snmp v3 engine id along with some cleanups.

Before:
![Screenshot from 2022-02-14 20-02-20](https://user-images.githubusercontent.com/23611106/153883579-d389fc88-5f25-46f3-a7ad-621214ac12ef.png)

After:
![Screenshot from 2022-02-14 20-03-00](https://user-images.githubusercontent.com/23611106/153883616-6d732e9d-daec-4bdc-b4a4-c60ba3043aac.png)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
