### PR TITLE
rgw: cmake configure error on fedora-37/rawhide

### DIFF
--- a/src/rgw/store/dbstore/CMakeLists.txt
+++ b/src/rgw/store/dbstore/CMakeLists.txt
@@ -47,7 +47,7 @@ else()
 endif()
 
 include_directories(${CMAKE_INCLUDE_DIR})
-add_library(dbstore ${dbstore_mgr_srcs})
+add_library(dbstore STATIC ${dbstore_mgr_srcs})
 target_link_libraries(dbstore ${CMAKE_LINK_LIBRARIES})
 
 # testing purpose

--- a/src/rgw/store/dbstore/sqlite/CMakeLists.txt
+++ b/src/rgw/store/dbstore/sqlite/CMakeLists.txt
@@ -12,5 +12,5 @@ include_directories(${CMAKE_INCLUDE_DIR})
 set(SQLITE_COMPILE_FLAGS "-DSQLITE_THREADSAFE=1")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SQLITE_COMPILE_FLAGS}")
 
-add_library(sqlite_db ${sqlite_db_srcs})
+add_library(sqlite_db STATIC ${sqlite_db_srcs})
 target_link_libraries(sqlite_db sqlite3 dbstore_lib rgw_common)


### PR DESCRIPTION
see
https://kojipkgs.fedoraproject.org//work/tasks/6624/82706624/build.log,
excerpted below

...
CMake Error: The inter-target dependency graph contains the following
strongly connected component (cycle): "rgw_common" of type
STATIC_LIBRARY depends on "dbstore" (weak) depends on "sqlite_db" (weak)
"dbstore" of type SHARED_LIBRARY depends on "rgw_common" (weak) depends
on "sqlite_db" (weak) "sqlite_db" of type SHARED_LIBRARY depends on
"rgw_common" (weak) depends on "dbstore" (weak) At least one of these
targets is not a STATIC_LIBRARY. Cyclic dependencies are allowed only
among static libraries. CMake Generate step failed. Build files cannot
be regenerated correctly.
...

https://tracker.ceph.com/issues/54266

Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
