### PR TITLE
admin/doc-requirements: pin breathe to 4.32.0

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,11 +1,18 @@
 Sphinx == 3.5.4
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
-breathe >= 4.20.0
+git+https://github.com/vlasovskikh/funcparserlib.git
+breathe == 4.32.0
+cryptography
+Jinja2
 pyyaml >= 5.1.2
 Cython
+pcpp
 prettytable
 sphinx-autodoc-typehints
 sphinx-prompt
+sphinx_rtd_theme == 0.5.2
 Sphinx-Substitution-Extensions
 typed-ast
+sphinxcontrib-openapi
+sphinxcontrib-seqdiag
 mistune < 2.0.0


### PR DESCRIPTION
in breathe v4.33, it includes following commit

https://github.com/michaeljones/breathe/commit/2498a437234343503e0087cad793c6f333f1f781

which specfies the app config value of "graphviz_dot". this annoys
sphinx:

WARNING: while setting up extension breathe: node class 'graphviz' is already registered, its visitors will be overridden

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/sphinx/cmd/build.py", line 276, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/sphinx/application.py", line 245, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/sphinx/application.py", line 402, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/sphinx/registry.py", line 430, in load_extension
    metadata = setup(app)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/breathe/__init__.py", line 14, in setup
    renderer_setup(app)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/breathe/renderer/sphinxrenderer.py", line 2613, in setup
    app.add_config_value("graphviz_dot", "dot", "html")
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/sphinx/application.py", line 535, in add_config_value
    self.config.add(name, default, rebuild, types)
  File "/home/docs/checkouts/readthedocs.org/user_builds/ceph/envs/44951/lib/python3.8/site-packages/sphinx/config.py", line 282, in add
    raise ExtensionError(__('Config value %r already present') % name)
sphinx.errors.ExtensionError: Config value 'graphviz_dot' already present

Extension error:
Config value 'graphviz_dot' already present

this issue has been reported to upstream, see
https://github.com/michaeljones/breathe/issues/803

before it is fixed upstream, let's stick with 4.32.0
which is known to work.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>
(cherry picked from commit d020d07be97c56db88fadd9921e7b3eff11c0802)