### PR TITLE
quincy: mgr/telemetry: add basic_pool_usage and basic_usage_by_class collections to the telemetry module

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -187,6 +187,7 @@ List all collections with::
   basic_base            REPORTING                                            Basic information about the cluster (capacity, number and type of daemons, version, etc.)
   basic_mds_metadata    NOT REPORTING: NOT OPTED-IN                          MDS metadata
   basic_pool_usage      NOT REPORTING: NOT OPTED-IN                          Default pool application and usage statistics
+  basic_usage_by_class  NOT REPORTING: NOT OPTED-IN                          Default device class usage statistics
   crash_base            REPORTING                                            Information about daemon crashes (daemon type and version, backtrace, etc.)
   device_base           REPORTING                                            Information about device health metrics
   ident_base            NOT REPORTING: CHANNEL ident IS OFF                  User-provided identifying information about the cluster

--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -186,6 +186,7 @@ List all collections with::
   NAME                  STATUS                                               DESC
   basic_base            REPORTING                                            Basic information about the cluster (capacity, number and type of daemons, version, etc.)
   basic_mds_metadata    NOT REPORTING: NOT OPTED-IN                          MDS metadata
+  basic_pool_usage      NOT REPORTING: NOT OPTED-IN                          Pool application and data usage metrics
   crash_base            REPORTING                                            Information about daemon crashes (daemon type and version, backtrace, etc.)
   device_base           REPORTING                                            Information about device health metrics
   ident_base            NOT REPORTING: CHANNEL ident IS OFF                  User-provided identifying information about the cluster

--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -186,7 +186,7 @@ List all collections with::
   NAME                  STATUS                                               DESC
   basic_base            REPORTING                                            Basic information about the cluster (capacity, number and type of daemons, version, etc.)
   basic_mds_metadata    NOT REPORTING: NOT OPTED-IN                          MDS metadata
-  basic_pool_usage      NOT REPORTING: NOT OPTED-IN                          Pool application and data usage metrics
+  basic_pool_usage      NOT REPORTING: NOT OPTED-IN                          Default pool application and usage statistics
   crash_base            REPORTING                                            Information about daemon crashes (daemon type and version, backtrace, etc.)
   device_base           REPORTING                                            Information about device health metrics
   ident_base            NOT REPORTING: CHANNEL ident IS OFF                  User-provided identifying information about the cluster

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -66,6 +66,7 @@ class Collection(str, enum.Enum):
     perf_perf = 'perf_perf'
     basic_mds_metadata = 'basic_mds_metadata'
     basic_pool_usage = 'basic_pool_usage'
+    basic_usage_by_class = 'basic_usage_by_class'
 
 MODULE_COLLECTION : List[Dict] = [
     {
@@ -107,6 +108,12 @@ MODULE_COLLECTION : List[Dict] = [
     {
         "name": Collection.basic_pool_usage,
         "description": "Default pool application and usage statistics",
+        "channel": "basic",
+        "nag": False
+    },
+    {
+        "name": Collection.basic_usage_by_class,
+        "description": "Default device class usage statistics",
         "channel": "basic",
         "nag": False
     }
@@ -1062,8 +1069,8 @@ class Module(MgrModule):
                 'total_bytes': df['stats']['total_bytes'],
                 'total_avail_bytes': df['stats']['total_avail_bytes']
             }
-            # basic_pool_usage collection (2/2)
-            if self.is_enabled_collection(Collection.basic_pool_usage):
+            # basic_usage_by_class collection
+            if self.is_enabled_collection(Collection.basic_usage_by_class):
                 report['usage']['stats_by_class'] = {} # type: ignore
                 for device_class in df['stats_by_class']:
                     if device_class in ['hdd', 'ssd', 'nvme']:

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -598,19 +598,15 @@ class Module(MgrModule):
 
         # collect application metadata from osd_map
         osd_map = self.get('osd_map')
-        app_dict = {}
-        for pool in osd_map['pools']:
-            app_dict[pool['pool']] = pool['application_metadata']
+        application_metadata = {pool['pool']: pool['application_metadata'] for pool in osd_map['pools']}
 
         # add application to each pool from pg_dump
         for pool in result:
-            poolid = pool['poolid']
-            # Check that the pool has an application. If it does not,
-            # the application dict will be empty.
-            if app_dict[poolid]:
-                pool['application'] = list(app_dict[poolid].keys())[0]
-            else:
-                pool['application'] = ""
+            pool['application'] = []
+            # Only include default applications
+            for application in application_metadata[pool['poolid']]:
+                if application in ['cephfs', 'mgr', 'rbd', 'rgw']:
+                    pool['application'].append(application)
 
         return result
 

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -106,7 +106,7 @@ MODULE_COLLECTION : List[Dict] = [
     },
     {
         "name": Collection.basic_pool_usage,
-        "description": "Pool application and data usage metrics",
+        "description": "Default pool application and usage statistics",
         "channel": "basic",
         "nag": False
     }
@@ -910,7 +910,7 @@ class Module(MgrModule):
                         'cache_mode': pool['cache_mode'],
                     }
 
-                # basic_pool_usage collection (1/2)
+                # basic_pool_usage collection
                 if self.is_enabled_collection(Collection.basic_pool_usage):
                     pool_data['application'] = []
                     for application in pool['application_metadata']:

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -851,6 +851,7 @@ class Module(MgrModule):
             service_map = self.get('service_map')
             fs_map = self.get('fs_map')
             df = self.get('df')
+            df_pools = {pool['id']: pool for pool in df['pools']}
 
             report['created'] = mon_map['created']
 
@@ -920,6 +921,30 @@ class Module(MgrModule):
                         # Only include default applications
                         if application in ['cephfs', 'mgr', 'rbd', 'rgw']:
                             pool_data['application'].append(application)
+                    pool_stats = df_pools[pool['pool']]['stats']
+                    pool_data['stats'] = { # filter out kb_used
+                                            'avail_raw': pool_stats['avail_raw'],
+                                            'bytes_used': pool_stats['bytes_used'],
+                                            'compress_bytes_used': pool_stats['compress_bytes_used'],
+                                            'compress_under_bytes': pool_stats['compress_under_bytes'],
+                                            'data_bytes_used': pool_stats['data_bytes_used'],
+                                            'dirty': pool_stats['dirty'],
+                                            'max_avail': pool_stats['max_avail'],
+                                            'objects': pool_stats['objects'],
+                                            'omap_bytes_used': pool_stats['omap_bytes_used'],
+                                            'percent_used': pool_stats['percent_used'],
+                                            'quota_bytes': pool_stats['quota_bytes'],
+                                            'quota_objects': pool_stats['quota_objects'],
+                                            'rd': pool_stats['rd'],
+                                            'rd_bytes': pool_stats['rd_bytes'],
+                                            'stored': pool_stats['stored'],
+                                            'stored_data': pool_stats['stored_data'],
+                                            'stored_omap': pool_stats['stored_omap'],
+                                            'stored_raw': pool_stats['stored_raw'],
+                                            'wr': pool_stats['wr'],
+                                            'wr_bytes': pool_stats['wr_bytes']
+                        }
+
                 cast(List[Dict[str, Any]], report['pools']).append(pool_data)
                 if 'rbd' in pool['application_metadata']:
                     rbd_num_pools += 1

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1066,6 +1066,12 @@ class Module(MgrModule):
                 'total_bytes': df['stats']['total_bytes'],
                 'total_avail_bytes': df['stats']['total_avail_bytes']
             }
+            # basic_pool_usage collection (2/2)
+            if self.is_enabled_collection(Collection.basic_pool_usage):
+                report['usage']['stats_by_class'] = {} # type: ignore
+                for device_class in df['stats_by_class']:
+                    if device_class in ['hdd', 'ssd', 'nvme']:
+                        report['usage']['stats_by_class'][device_class] = df['stats_by_class'][device_class] # type: ignore
 
             services: DefaultDict[str, int] = defaultdict(int)
             for key, value in service_map['services'].items():


### PR DESCRIPTION
Backport:
- https://github.com/ceph/ceph/pull/44781

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
