### PR TITLE
Revert "admin/doc-requirements: pin breathe to 4.32.0"

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,7 +1,7 @@
 Sphinx == 3.5.4
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
 git+https://github.com/vlasovskikh/funcparserlib.git
-breathe >= 4.20.0
+breathe >= 4.20.0,!=4.33
 cryptography
 Jinja2
 pyyaml >= 5.1.2

--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,7 +1,7 @@
 Sphinx == 3.5.4
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
 git+https://github.com/vlasovskikh/funcparserlib.git
-breathe == 4.32.0
+breathe >= 4.20.0
 cryptography
 Jinja2
 pyyaml >= 5.1.2


### PR DESCRIPTION
This reverts commit d020d07be97c56db88fadd9921e7b3eff11c0802.

Fixed upstream https://github.com/michaeljones/breathe/issues/803#issuecomment-1039341857

Signed-off-by: David Galloway <dgalloway@redhat.com>