### PR TITLE
qa/cephfs: upgrade is_mounted() in mount.py

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -71,8 +71,6 @@ class FuseMount(CephFSMount):
 
         self.gather_mount_info()
 
-        self.mounted = True
-
     def _run_mount_cmd(self, mntopts, check_status):
         mount_cmd = self._get_mount_cmd(mntopts)
         mountcmd_stdout, mountcmd_stderr = StringIO(), StringIO()
@@ -281,8 +279,6 @@ class FuseMount(CephFSMount):
 
             time.sleep(5)
 
-        self.mounted = True
-
         # Now that we're mounted, set permissions so that the rest of the test
         # will have unrestricted access to the filesystem mount.
         for retry in range(10):
@@ -358,7 +354,6 @@ class FuseMount(CephFSMount):
                     if self.is_mounted():
                         raise
 
-        self.mounted = False
         self._fuse_conn = None
         self.id = None
         self.inst = None
@@ -407,7 +402,6 @@ class FuseMount(CephFSMount):
             if require_clean:
                 raise
 
-        self.mounted = False
         self.cleanup()
 
     def teardown(self):
@@ -424,8 +418,6 @@ class FuseMount(CephFSMount):
                 self.fuse_daemon.wait()
             except CommandFailedError:
                 pass
-
-        self.mounted = False
 
     def _asok_path(self):
         return "/var/run/ceph/ceph-client.{0}.*.asok".format(self.client_id)

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -61,8 +61,6 @@ class KernelMount(CephFSMount):
                 self.enable_dynamic_debug()
             self.ctx[f'kmount_count.{self.client_remote.hostname}'] = kmount_count + 1
 
-        self.mounted = True
-
     def _run_mount_cmd(self, mntopts, check_status):
         mount_cmd = self._get_mount_cmd(mntopts)
         mountcmd_stdout, mountcmd_stderr = StringIO(), StringIO()
@@ -154,7 +152,6 @@ class KernelMount(CephFSMount):
                 self.disable_dynamic_debug()
             self.ctx[f'kmount_count.{self.client_remote.hostname}'] = kmount_count - 1
 
-        self.mounted = False
         self.cleanup()
 
     def umount_wait(self, force=False, require_clean=False,
@@ -178,7 +175,6 @@ class KernelMount(CephFSMount):
                                          self.mountpoint], timeout=timeout,
                                    omit_sudo=False)
 
-            self.mounted = False
             self.cleanup()
 
     def wait_until_mounted(self):
@@ -186,11 +182,11 @@ class KernelMount(CephFSMount):
         Unlike the fuse client, the kernel client is up and running as soon
         as the initial mount() function returns.
         """
-        assert self.mounted
+        assert self.is_mounted()
 
     def teardown(self):
         super(KernelMount, self).teardown()
-        if self.mounted:
+        if self.is_mounted():
             self.umount()
 
     def _get_debug_dir(self):
@@ -300,7 +296,7 @@ echo '{fdata}' | sudo tee /sys/kernel/debug/dynamic_debug/control
         Look up the CephFS client ID for this mount, using debugfs.
         """
 
-        assert self.mounted
+        assert self.is_mounted()
 
         return self._get_global_id()
 

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -41,7 +41,6 @@ class CephFSMount(object):
         :param cephfs_mntpt: Path to directory inside Ceph FS that will be
                              mounted as root
         """
-        self.mounted = False
         self.ctx = ctx
         self.test_dir = test_dir
 
@@ -170,7 +169,8 @@ class CephFSMount(object):
                               sudo=True).decode())
 
     def is_mounted(self):
-        return self.mounted
+        return self.hostfs_mntpt in \
+            self.client_remote.read_file('/proc/self/mounts',stdout=StringIO())
 
     def setupfs(self, name=None):
         if name is None and self.fs is not None:
@@ -518,7 +518,7 @@ class CephFSMount(object):
         exception: wait accepted too which can be True or False.
         """
         self.umount_wait()
-        assert not self.mounted
+        assert not self.is_mounted()
 
         mntopts = kwargs.pop('mntopts', [])
         check_status = kwargs.pop('check_status', True)


### PR DESCRIPTION
Related PR - PR #46988

Instead of relying on value of a mutable variable, actually check if the
CephFS is mounted on the system. This will prevent bugs due to stale and
incorrect values.

Fixes: https://tracker.ceph.com/issues/54283






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>