### PR TITLE
quincy: cephadm/ingress: make frontend stat bind on localhost

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/ingress/haproxy.cfg.j2
+++ b/src/pybind/mgr/cephadm/templates/services/ingress/haproxy.cfg.j2
@@ -48,6 +48,7 @@ defaults
 frontend stats
     mode http
     bind {{ ip }}:{{ monitor_port }}
+    bind localhost:{{ monitor_port }}
     stats enable
     stats uri /stats
     stats refresh 10s

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -759,6 +759,7 @@ class TestIngressService:
                                 '\nfrontend stats\n    '
                                 'mode http\n    '
                                 'bind 1.2.3.4:8999\n    '
+                                'bind localhost:8999\n    '
                                 'stats enable\n    '
                                 'stats uri /stats\n    '
                                 'stats refresh 10s\n    '


### PR DESCRIPTION
The current configuration of keepalived makes it do
a curl on localhost:9999 in order to check the endpoint is alive.
Given the endpoint only binds on the vip addr, that doesn't work.

Fixes: https://tracker.ceph.com/issues/53807

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit ff482da6cb3a62b14f3a06e2d558876eabebfe65)
