### PR TITLE
qa/tasks/cephfs: increase timeout in test_nfs.py

### DIFF
--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -79,9 +79,9 @@ class TestNFS(MgrTestCase):
         :param expected_status: Status to be verified
         :param fail_msg: Message to be printed if test failed
         '''
-        # Wait for few seconds as ganesha daemon takes few seconds to be deleted/created
+        # Wait for two minutes as ganesha daemon takes some time to be deleted/created
         wait_time = 10
-        while wait_time <= 60:
+        while wait_time <= 120:
             time.sleep(wait_time)
             if expected_status in self._fetch_nfs_status():
                 return


### PR DESCRIPTION
Originated from #44911, regrading a common failure with `test_nfs`:
```INFO:tasks.cephfs_test_runner:AssertionError: NFS Ganesha cluster deployment failed```
This may be solved by allowing Ganesha daemon more time to be created/deleted.


Before the change:
https://pulpito.ceph.com/matan-2022-02-13_13:18:27-orch-master-distro-basic-smithi/
after:
https://pulpito.ceph.com/matan-2022-02-15_10:48:59-orch-master-distro-basic-smithi/

Signed-off-by: Matan Breizman <mbreizma@redhat.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
