### PR TITLE
Monitor: forward report command to leader

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3656,7 +3656,16 @@ void Monitor::handle_command(MonOpRequestRef op)
     rs = "";
     r = 0;
   } else if (prefix == "report") {
-
+    // some of the report data is only known by leader, e.g. osdmap_clean_epochs
+    if (!is_leader() && !is_peon()) {
+      dout(10) << " waiting for quorum" << dendl;
+      waitfor_quorum.push_back(new C_RetryMessage(this, op));
+      return;
+    }
+    if (!is_leader()) {
+      forward_request_leader(op);
+      return;
+    }
     // this must be formatted, in its current form
     if (!f)
       f.reset(Formatter::create("json-pretty"));


### PR DESCRIPTION
The `ceph report` section on `osdmap_clean_epochs` is empty if a peon
responds. Forward this command to the leader.

Fixes: https://tracker.ceph.com/issues/47273
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>