### PR TITLE
pacific: mgr/dashboard: "Please expand your cluster first" shouldn't be shown if cluster is already meaningfully running 

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4646,6 +4646,9 @@ def command_bootstrap(ctx):
     logger.info('Enabling autotune for osd_memory_target')
     cli(['config', 'set', 'osd', 'osd_memory_target_autotune', 'true'])
 
+    # Notify the Dashboard to show the 'Expand cluster' page on first log in.
+    cli(['config-key', 'set', 'mgr/dashboard/cluster/status', 'INSTALLED'])
+
     logger.info('You can access the Ceph CLI with:\n\n'
                 '\tsudo %s shell --fsid %s -c %s -k %s\n' % (
                     sys.argv[0],

--- a/src/pybind/mgr/dashboard/services/cluster.py
+++ b/src/pybind/mgr/dashboard/services/cluster.py
@@ -12,7 +12,12 @@ class ClusterModel:
 
     status: Status
 
-    def __init__(self, status=Status.INSTALLED.name):
+    def __init__(self, status=Status.POST_INSTALLED.name):
+        """
+        :param status: The status of the cluster. Assume that the cluster
+            is already functional by default.
+        :type status: str
+        """
         self.status = self.Status[status]
 
     def dict(self):
@@ -23,4 +28,8 @@ class ClusterModel:
 
     @classmethod
     def from_db(cls):
-        return cls(status=mgr.get_store('cluster/status', cls.Status.INSTALLED.name))
+        """
+        Get the stored cluster status from the configuration key/value store.
+        If the status is not set, assume it is already fully functional.
+        """
+        return cls(status=mgr.get_store('cluster/status', cls.Status.POST_INSTALLED.name))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54284

---

backport of https://github.com/ceph/ceph/pull/44951
parent tracker: https://tracker.ceph.com/issues/54215

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh