### PR TITLE
qa/tasks/qemu: make sure block-rbd.so is installed

### DIFF
--- a/qa/suites/rbd/singleton/all/qemu-iotests-no-cache.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-no-cache.yaml
@@ -3,6 +3,11 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:
 - install:
+    extra_system_packages:
+      rpm:
+      - qemu-kvm-block-rbd
+      deb:
+      - qemu-block-extra
 - ceph:
     fs: xfs
     conf:

--- a/qa/suites/rbd/singleton/all/qemu-iotests-writearound.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-writearound.yaml
@@ -3,6 +3,11 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:
 - install:
+    extra_system_packages:
+      rpm:
+      - qemu-kvm-block-rbd
+      deb:
+      - qemu-block-extra
 - ceph:
     fs: xfs
     conf:

--- a/qa/suites/rbd/singleton/all/qemu-iotests-writeback.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-writeback.yaml
@@ -3,6 +3,11 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:
 - install:
+    extra_system_packages:
+      rpm:
+      - qemu-kvm-block-rbd
+      deb:
+      - qemu-block-extra
 - ceph:
     fs: xfs
     conf:

--- a/qa/suites/rbd/singleton/all/qemu-iotests-writethrough.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-writethrough.yaml
@@ -3,6 +3,11 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:
 - install:
+    extra_system_packages:
+      rpm:
+      - qemu-kvm-block-rbd
+      deb:
+      - qemu-block-extra
 - ceph:
     fs: xfs
     conf:

--- a/qa/tasks/qemu.py
+++ b/qa/tasks/qemu.py
@@ -14,6 +14,7 @@ from teuthology import contextutil
 from teuthology import misc as teuthology
 from teuthology.config import config as teuth_config
 from teuthology.orchestra import run
+from teuthology.packaging import install_package, remove_package
 
 log = logging.getLogger(__name__)
 
@@ -157,6 +158,25 @@ def create_dirs(ctx, config):
                     'rmdir', '{tdir}/qemu'.format(tdir=testdir), run.Raw('||'), 'true',
                     ]
                 )
+
+@contextlib.contextmanager
+def install_block_rbd_driver(ctx, config):
+    """
+    Make sure qemu rbd block driver (block-rbd.so) is installed
+    """
+    for client, client_config in config.items():
+        (remote,) = ctx.cluster.only(client).remotes.keys()
+        if remote.os.package_type == 'rpm':
+            block_rbd_pkg = 'qemu-kvm-block-rbd'
+        else:
+            block_rbd_pkg = 'qemu-block-extra'
+        install_package(block_rbd_pkg, remote)
+    try:
+        yield
+    finally:
+        for client, client_config in config.items():
+            (remote,) = ctx.cluster.only(client).remotes.keys()
+            remove_package(block_rbd_pkg, remote)
 
 @contextlib.contextmanager
 def generate_iso(ctx, config):
@@ -660,6 +680,7 @@ def task(ctx, config):
     create_images(ctx=ctx, config=config, managers=managers)
     managers.extend([
         lambda: create_dirs(ctx=ctx, config=config),
+        lambda: install_block_rbd_driver(ctx=ctx, config=config),
         lambda: generate_iso(ctx=ctx, config=config),
         lambda: download_image(ctx=ctx, config=config),
         ])


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/54286
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
