### PR TITLE
crimson: eliminate clang build warning in crimson

### DIFF
--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree.cc
@@ -593,6 +593,7 @@ LBABtree::find_insertion_ret LBABtree::find_insertion(
     return iter.prev(
       c
     ).si_then([laddr, &iter](auto p) {
+      boost::ignore_unused(laddr); // avoid clang warning;
       assert(p.leaf.node->get_node_meta().begin <= laddr);
       assert(p.get_key() < laddr);
       // Note, this is specifically allowed to violate the iterator

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -226,6 +226,7 @@ OMapInnerNode::list(
 	      start,
 	      config.with_reduced_max(result.size())
 	    ).si_then([&, config](auto &&child_ret) mutable {
+	      boost::ignore_unused(config);   // avoid clang warning;
 	      auto &[child_complete, child_result] = child_ret;
 	      if (result.size() && child_result.size()) {
 		assert(child_result.begin()->first > result.rbegin()->first);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -570,6 +570,7 @@ class NodeExtentAccessorT {
         })
       );
     }).si_then([this, c] {
+      boost::ignore_unused(c);  // avoid clang warning;
       assert(!c.t.is_conflicted());
       return *mut;
     });

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -309,6 +309,7 @@ class TreeBuilder {
     return tree->insert(
         t, p_kv->key, {p_kv->value.get_payload_size()}
     ).si_then([&t, this, p_kv](auto ret) {
+      boost::ignore_unused(this);  // avoid clang warning;
       auto success = ret.second;
       auto cursor = std::move(ret.first);
       initialize_cursor_from_item(t, p_kv->key, p_kv->value, cursor, success);
@@ -401,6 +402,9 @@ class TreeBuilder {
                    p_kv->value);
     return tree->erase(t, p_kv->key
     ).si_then([&t, this, p_kv] (auto size) {
+      boost::ignore_unused(t);  // avoid clang warning;
+      boost::ignore_unused(this);
+      boost::ignore_unused(p_kv);
       ceph_assert(size == 1);
 #ifndef NDEBUG
       return tree->contains(t, p_kv->key

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -159,7 +159,9 @@ SeaStore::mount_ertr::future<> SeaStore::mount()
       oss << root << "/block." << dtype << "." << std::to_string(id);
       auto sm = std::make_unique<
 	segment_manager::block::BlockSegmentManager>(oss.str());
-      return sm->mount().safe_then([this, sm=std::move(sm), magic]() mutable {
+      return sm->mount().safe_then(
+	[this, sm=std::move(sm), magic]() mutable {
+	boost::ignore_unused(magic);  // avoid clang warning;
 	assert(sm->get_magic() == magic);
 	transaction_manager->add_segment_manager(sm.get());
 	secondaries.emplace_back(std::move(sm));

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <iostream>
 #include <vector>
+#include <boost/core/ignore_unused.hpp>
 
 #include "include/byteorder.h"
 #include "include/denc.h"

--- a/src/crimson/tools/store_nbd/fs_driver.cc
+++ b/src/crimson/tools/store_nbd/fs_driver.cc
@@ -182,7 +182,6 @@ seastar::future<> FSDriver::mkfs()
   return init(    
   ).then([this] {
     assert(fs);
-  }).then([this] {
     return fs->start();
   }).then([this] {
     uuid_d uuid;

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -36,6 +36,7 @@ seastar::future<> TMDriver::write(
           logger().debug("dec_ref complete");
           return tm->alloc_extent<TestBlock>(t, offset, ptr.length());
         }).si_then([this, offset, &t, &ptr](auto ext) {
+          boost::ignore_unused(offset);  // avoid clang warning;
           assert(ext->get_laddr() == (size_t)offset);
           assert(ext->get_bptr().length() == ptr.length());
           ext->get_bptr().swap(ptr);


### PR DESCRIPTION
too many warnings when clang build.

Signed-off-by: chunmei-liu <chunmei.liu@intel.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
