### PR TITLE
master rgw/rgw_rados.cc:fix the bug of null pointer

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6359,11 +6359,12 @@ int RGWRados::Bucket::UpdateIndex::cancel(const DoutPrefixProvider *dpp,
    * for following the specific bucket shard log. Otherwise they end up staying behind, and users
    * have no way to tell that they're all caught up
    */
-  int r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info, bs->shard_id);
-  if (r < 0) {
-    ldpp_dout(dpp, -1) << "ERROR: failed writing data log" << dendl;
+  if(ret == 0) {
+      int r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info, bs->shard_id);
+      if (r < 0) {
+          ldpp_dout(dpp, -1) << "ERROR: failed writing data log" << dendl;
+      }
   }
-
   return ret;
 }
 


### PR DESCRIPTION
 master rgw/rgw_rados.cc:fix the bug of null pointer

  1、For the funtion "RGWRados::Bucket::UpdateIndex::cancel" in rgw_rados.cc，if guard_reshard return an error value， "BucketShard *bs" may be null pointer，and radosgw crashes when the codes runs to "int r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info, bs->shard_id);" in "RGWRados::Bucket::UpdateIndex::cancel"

    Fixes:https://tracker.ceph.com/issues/54293?next_issue_id=54292

    Signed-off-by: liangchengwu <liangchengw@chinatelecom.cn>
