### PR TITLE
cephadm: add comment explaining docker.io grep test

### DIFF
--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -63,3 +63,5 @@ deps =
 commands =
     flake8 --config=tox.ini {posargs:cephadm}
     bash -c "test $(grep 'docker.io' cephadm | wc -l) == 13"
+# Downstream distributions may choose to alter this "docker.io" number,
+# to make sure no new references to docker.io are creeping in unnoticed.


### PR DESCRIPTION
Add a comment explain this `docker.io` grep count test, since it's difficult to understand the purpose from simply reading the code.