### PR TITLE
librbd: avoid get_callback_adapter() for tcp_stream::async_connect()

### DIFF
--- a/src/librbd/migration/HttpClient.cc
+++ b/src/librbd/migration/HttpClient.cc
@@ -603,8 +603,9 @@ protected:
 
     m_stream.async_connect(
       results,
-      asio::util::get_callback_adapter(
-        [on_finish](int r, auto endpoint) { on_finish->complete(r); }));
+      [on_finish](boost::system::error_code ec, const auto& endpoint) {
+        on_finish->complete(-ec.value());
+      });
   }
 
   void disconnect(Context* on_finish) override {
@@ -646,9 +647,9 @@ protected:
 
     boost::beast::get_lowest_layer(m_stream).async_connect(
       results,
-      asio::util::get_callback_adapter(
-        [this, on_finish](int r, auto endpoint) {
-          handle_connect(r, on_finish); }));
+      [this, on_finish](boost::system::error_code ec, const auto& endpoint) {
+        handle_connect(-ec.value(), on_finish);
+      });
   }
 
   void disconnect(Context* on_finish) override {


### PR DESCRIPTION
works around a compilation failure in c++20 (with gcc 11.2 and boost 1.76) when choosing between two overloads of `boost::beast::tcp_stream::async_connect()`

`get_callback_adapter()` returns a variadic lambda that matches the concept for both overloads (`completion_token_for<ConnectHandler>` and `completion_token_for<RangeConnectHandler>`), but compilation of the wrapped lambda fails for the `ConnectHandler` overload because it expects two arguments instead of one

instead of using `get_callback_adapter()` to convert the first argument from `boost::system::error_code` to `int` for the wrapped lambda, do this in the lambda itself

Fixes: https://tracker.ceph.com/issues/54303

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
