### PR TITLE
osd/OSDMap: OSDMap CRC inconsistence with incremental CRC

### DIFF
--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -248,18 +248,22 @@ struct entity_addr_t {
     }
   };
 
-  __u32 type;
-  __u32 nonce;
+  ceph_le32 type;
+  ceph_le32 nonce;
   union {
     sockaddr sa;
     sockaddr_in sin;
     sockaddr_in6 sin6;
   } u;
 
-  entity_addr_t() : type(0), nonce(0) {
+  entity_addr_t() {
+    type = 0;
+    nonce = 0;
     memset(&u, 0, sizeof(u));
   }
-  entity_addr_t(__u32 _type, __u32 _nonce) : type(_type), nonce(_nonce) {
+  entity_addr_t(__u32 _type, __u32 _nonce) {
+    type = init_le32(_type);
+    nonce = init_le32(_nonce);
     memset(&u, 0, sizeof(u));
   }
   explicit entity_addr_t(const ceph_entity_addr &o) {
@@ -272,13 +276,13 @@ struct entity_addr_t {
   }
 
   uint32_t get_type() const { return type; }
-  void set_type(uint32_t t) { type = t; }
+  void set_type(uint32_t t) { type = init_le32(t); }
   bool is_legacy() const { return type == TYPE_LEGACY; }
   bool is_msgr2() const { return type == TYPE_MSGR2; }
   bool is_any() const { return type == TYPE_ANY; }
 
   __u32 get_nonce() const { return nonce; }
-  void set_nonce(__u32 n) { nonce = n; }
+  void set_nonce(__u32 n) { nonce = init_le32(n); }
 
   int get_family() const {
     return u.sa.sa_family;


### PR DESCRIPTION
OSDMap incremental update in OSD::handle_osd_map
can trigger CRC inconsistence given a cluster with big
and little endian nodes. The OSDMap CRC (o->get_crc()) is
incorrect comparing to the OSDMap::Incremental (inc.full_crc).
Fixed by using ceph_le16/32/64 instead of __u16/32/64.

Signed-off-by: Aliaksei Makarau < aliaksei.makarau@ibm.com >

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
