### PR TITLE
cls/rgw : adding missing classes in < #include "cls/rgw/cls_rgw_types.h" >

### DIFF
--- a/src/tools/ceph-dencoder/rgw_types.h
+++ b/src/tools/ceph-dencoder/rgw_types.h
@@ -42,6 +42,12 @@ TYPE(rgw_bucket_entry_ver)
 TYPE(cls_rgw_obj_key)
 TYPE(rgw_bucket_olh_log_entry)
 TYPE(rgw_usage_log_entry)
+TYPE(rgw_cls_bi_entry)
+TYPE(rgw_bucket_olh_entry)
+TYPE(rgw_usage_data)
+TYPE(rgw_usage_log_info)
+TYPE(rgw_user_bucket)
+TYPE(cls_rgw_lc_entry)
 
 #include "cls/rgw/cls_rgw_ops.h"
 TYPE(cls_rgw_lc_get_entry_ret)


### PR DESCRIPTION
New classes are declared in #include "cls/rgw/cls_rgw_ops.h"

Fixes: https://tracker.ceph.com/issues/54054
Signed-off-by: Iqbal Khan <iqkhan@redhat.com>