### PR TITLE
osd/scrub: stop sending bogus digest-update event messages

### DIFF
--- a/src/osd/scrubber/PrimaryLogScrub.cc
+++ b/src/osd/scrubber/PrimaryLogScrub.cc
@@ -87,9 +87,8 @@ void PrimaryLogScrub::submit_digest_fixes(const digests_fixes_t& fixes)
 
 
     ctx->register_on_success([this]() {
-      dout(20) << "updating scrub digest " << num_digest_updates_pending
-               << dendl;
-      if (--num_digest_updates_pending <= 0) {
+      if ((num_digest_updates_pending >= 1) &&
+          (--num_digest_updates_pending == 0)) {
         m_osds->queue_scrub_digest_update(m_pl_pg,
                                           m_pl_pg->is_scrub_blocking_ops());
       }


### PR DESCRIPTION
A minimal change extracted from PR#44050, to facilitate
backporting.

The multitudes of bogus events generated fill up the logs.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
