### PR TITLE
octopus: qa/tasks/qemu: make sure block-rbd.so is installed

### DIFF
--- a/qa/suites/rbd/singleton/all/qemu-iotests-no-cache.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-no-cache.yaml
@@ -3,6 +3,11 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:
 - install:
+    extra_system_packages:
+      rpm:
+      - qemu-kvm-block-rbd
+      deb:
+      - qemu-block-extra
 - ceph:
     fs: xfs
     conf:

--- a/qa/suites/rbd/singleton/all/qemu-iotests-writearound.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-writearound.yaml
@@ -3,6 +3,11 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:
 - install:
+    extra_system_packages:
+      rpm:
+      - qemu-kvm-block-rbd
+      deb:
+      - qemu-block-extra
 - ceph:
     fs: xfs
     conf:

--- a/qa/suites/rbd/singleton/all/qemu-iotests-writeback.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-writeback.yaml
@@ -3,6 +3,11 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:
 - install:
+    extra_system_packages:
+      rpm:
+      - qemu-kvm-block-rbd
+      deb:
+      - qemu-block-extra
 - ceph:
     fs: xfs
     conf:

--- a/qa/suites/rbd/singleton/all/qemu-iotests-writethrough.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-writethrough.yaml
@@ -3,6 +3,11 @@ roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:
 - install:
+    extra_system_packages:
+      rpm:
+      - qemu-kvm-block-rbd
+      deb:
+      - qemu-block-extra
 - ceph:
     fs: xfs
     conf:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54300

---

backport of https://github.com/ceph/ceph/pull/45045
parent tracker: https://tracker.ceph.com/issues/54286