### PR TITLE
mds: add protection from clients without fscrypt support

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8315,9 +8315,37 @@ int MDCache::path_traverse(MDRequestRef& mdr, MDSContextFactory& cf,
   if (flags & MDS_TRAVERSE_CHECK_LOCKCACHE)
     mds->locker->find_and_attach_lock_cache(mdr, cur);
 
-  if (mdr && mdr->lock_cache) {
-    if (flags & MDS_TRAVERSE_WANT_DIRLAYOUT)
+  if (mdr) {
+    if (mdr->lock_cache && (flags & MDS_TRAVERSE_WANT_DIRLAYOUT))
       mdr->dir_layout = mdr->lock_cache->get_dir_layout();
+    const cref_t<MClientRequest> &req = mdr->client_request;
+    Session *session = mds->get_session(req);
+    if (session && !session->info.has_feature(CEPHFS_FEATURE_ALTERNATE_NAME) &&
+	req->get_op() != CEPH_MDS_OP_LOOKUP &&
+	req->get_op() != CEPH_MDS_OP_LOOKUPHASH &&
+	req->get_op() != CEPH_MDS_OP_LOOKUPPARENT &&
+	req->get_op() != CEPH_MDS_OP_LOOKUPINO &&
+	req->get_op() != CEPH_MDS_OP_LOOKUPNAME &&
+	req->get_op() != CEPH_MDS_OP_LOOKUPSNAP &&
+	req->get_op() != CEPH_MDS_OP_RMSNAP &&
+	req->get_op() != CEPH_MDS_OP_LSSNAP &&
+	req->get_op() != CEPH_MDS_OP_GETATTR &&
+	req->get_op() != CEPH_MDS_OP_READDIR &&
+	req->get_op() != CEPH_MDS_OP_UNLINK &&
+	req->get_op() != CEPH_MDS_OP_RMDIR) {
+      MutationImpl::LockOpVec lov;
+      /* We need 'As' caps for the fscrypt context */
+      lov.add_rdlock(&cur->authlock);
+      if (!mds->locker->acquire_locks(mdr, lov)) {
+	dout(10) << "traverse: failed to rdlock" << dendl;
+	return 1; /* XXX */
+      }
+      if (!cur->get_inode()->fscrypt_auth.empty()) {
+	dout(10) << "blocking '" << ceph_mds_op_name(req->get_op())
+		<< "' operation in encrypted node" << dendl;
+        return -CEPHFS_EROFS;
+      }
+    }
   } else if (rdlock_snap) {
     int n = (flags & MDS_TRAVERSE_RDLOCK_SNAP2) ? 1 : 0;
     if ((n == 0 && !(mdr->locking_state & MutationImpl::SNAP_LOCKED)) ||


### PR DESCRIPTION
This is just an RFC, as I don't think this is ready for getting merged.  I'm trying to prevent clients that don't have fscrypt support from breaking encrypted data.  There are several ways a client can currently do that, and this patch tries to fix some of them by preventing a client from executing a certain number of operations.

This patch doesn't try to fix every way a file can be damaged.  For example, a client can still append data to an encrypted file if it has the right permission for doing so.  This could probably be solved by preventing some caps to be given to such clients.  But I'm not sure that's something easily done and I'm not sure if that's really a problem -- clients can corrupt files as long as they can write to them, encrypted or not.

Anyway, this is just my initial attempt to fix the problem.  I've several questions:

- Is this the best approach?
- Are these the Ops to be blocked, or am I missing some? (or maybe some of them should be allowed...?)
- I've no idea if the locking is correct (or needed).

(I've no idea how to explicitly request reviews from some people, so I'll just mention a few github users here: @jtlayton @lxbsz @vshankar )

Signed-off-by: Luís Henriques <lhenriques@suse.de>
