### PR TITLE
octopus: cls/rbd: GroupSnapshotNamespace comparator violates ordering rules

### DIFF
--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -475,14 +475,13 @@ struct GroupSnapshotNamespace {
   }
 
   inline bool operator<(const GroupSnapshotNamespace& gsn) const {
-    if (group_pool < gsn.group_pool) {
-      return true;
-    } else if (group_id < gsn.group_id) {
-      return true;
-    } else {
-      return (group_snapshot_id < gsn.group_snapshot_id);
+    if (group_pool != gsn.group_pool) {
+      return group_pool < gsn.group_pool;
     }
-    return false;
+    if (group_id != gsn.group_id) {
+      return group_id < gsn.group_id;
+    }
+    return group_snapshot_id < gsn.group_snapshot_id;
   }
 };
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54297

---

backport of https://github.com/ceph/ceph/pull/45021
parent tracker: https://tracker.ceph.com/issues/49792

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh