### PR TITLE
quincy: os/bluestore/bluefs: Fix improper vselector tracking in _flush_special()

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1729,6 +1729,7 @@ int BlueFS::device_migrate_to_existing(
     dout(10) << __func__ << " " << ino << " " << file_ref->fnode << dendl;
 
     auto& fnode_extents = file_ref->fnode.extents;
+    vselector->sub_usage(file_ref->vselector_hint, file_ref->fnode);
 
     bool rewrite = std::any_of(
       fnode_extents.begin(),
@@ -1804,6 +1805,7 @@ int BlueFS::device_migrate_to_existing(
 	}
       }
     }
+    vselector->add_usage(file_ref->vselector_hint, file_ref->fnode);
   }
   // new logging device in the current naming scheme
   int new_log_dev_cur = bdev[BDEV_WAL] ?
@@ -2469,6 +2471,7 @@ void BlueFS::_rewrite_log_and_layout_sync_LNF_LD(bool allocate_with_fallback,
 
   bluefs_fnode_t old_fnode;
   int r;
+  vselector->sub_usage(log_file->vselector_hint, log_file->fnode);
   log_file->fnode.swap_extents(old_fnode);
   if (allocate_with_fallback) {
     r = _allocate(log_dev, need, &log_file->fnode);
@@ -2490,13 +2493,11 @@ void BlueFS::_rewrite_log_and_layout_sync_LNF_LD(bool allocate_with_fallback,
   // we will write it to super
   log_file->fnode.reset_delta();
   log_file->fnode.size = bl.length();
-  vselector->sub_usage(log_file->vselector_hint, old_fnode);
-  vselector->add_usage(log_file->vselector_hint, log_file->fnode);
 
   log.writer = _create_writer(log_file);
   log.writer->append(bl);
-  uint64_t new_data = _flush_special(log.writer);
-  vselector->add_usage(log_file->vselector_hint, new_data);
+  _flush_special(log.writer);
+  vselector->add_usage(log_file->vselector_hint, log_file->fnode);
 #ifdef HAVE_LIBAIO
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -427,7 +427,7 @@ private:
   int _flush_range_F(FileWriter *h, uint64_t offset, uint64_t length);
   int _flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool buffered);
   int _flush_F(FileWriter *h, bool force, bool *flushed = nullptr);
-  int _flush_special(FileWriter *h);
+  uint64_t _flush_special(FileWriter *h);
   int _fsync(FileWriter *h);
 
 #ifdef HAVE_LIBAIO


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54318

---

backport of https://github.com/ceph/ceph/pull/44955
parent tracker: https://tracker.ceph.com/issues/54248

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh