### PR TITLE
doc: fix format issues

### DIFF
--- a/doc/ceph-volume/lvm/activate.rst
+++ b/doc/ceph-volume/lvm/activate.rst
@@ -78,16 +78,16 @@ Would start the discovery process for the OSD with an id of ``0`` and a UUID of
 The systemd unit will look for the matching OSD device, and by looking at its
 :term:`LVM tags` will proceed to:
 
-# mount the device in the corresponding location (by convention this is
-  ``/var/lib/ceph/osd/<cluster name>-<osd id>/``)
+#. Mount the device in the corresponding location (by convention this is
+``/var/lib/ceph/osd/<cluster name>-<osd id>/``)
 
-# ensure that all required devices are ready for that OSD. In the case of
+#. Ensure that all required devices are ready for that OSD. In the case of
 a journal (when ``--filestore`` is selected) the device will be queried (with
 ``blkid`` for partitions, and lvm for logical volumes) to ensure that the
 correct device is being linked. The symbolic link will *always* be re-done to
 ensure that the correct device is linked.
 
-# start the ``ceph-osd@0`` systemd unit
+#. Start the ``ceph-osd@0`` systemd unit
 
 .. note:: The system infers the objectstore type (filestore or bluestore) by
           inspecting the LVM tags applied to the OSD devices
@@ -104,18 +104,18 @@ Summary
 -------
 To recap the ``activate`` process for :term:`bluestore`:
 
-#. require both :term:`OSD id` and :term:`OSD uuid`
-#. enable the system unit with matching id and uuid
+#. Require both :term:`OSD id` and :term:`OSD uuid`
+#. Enable the system unit with matching id and uuid
 #. Create the ``tmpfs`` mount at the OSD directory in
    ``/var/lib/ceph/osd/$cluster-$id/``
 #. Recreate all the files needed with ``ceph-bluestore-tool prime-osd-dir`` by
    pointing it to the OSD ``block`` device.
-#. the systemd unit will ensure all devices are ready and linked
-#. the matching ``ceph-osd`` systemd unit will get started
+#. The systemd unit will ensure all devices are ready and linked
+#. The matching ``ceph-osd`` systemd unit will get started
 
 And for :term:`filestore`:
 
-#. require both :term:`OSD id` and :term:`OSD uuid`
-#. enable the system unit with matching id and uuid
-#. the systemd unit will ensure all devices are ready and mounted (if needed)
-#. the matching ``ceph-osd`` systemd unit will get started
+#. Require both :term:`OSD id` and :term:`OSD uuid`
+#. Enable the system unit with matching id and uuid
+#. The systemd unit will ensure all devices are ready and mounted (if needed)
+#. The matching ``ceph-osd`` systemd unit will get started


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
