### PR TITLE
crimson: fixes for compiling with fmtlib v8

### DIFF
--- a/src/crimson/os/seastore/logging.h
+++ b/src/crimson/os/seastore/logging.h
@@ -12,8 +12,6 @@
 #define LOGGER(subname_) crimson::get_logger(ceph_subsys_##subname_)
 #define LOG_PREFIX(x) constexpr auto FNAME = #x
 
-#ifdef NDEBUG
-
 #define LOG(level_, MSG, ...) \
   LOCAL_LOGGER.log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
 #define LOGT(level_, MSG, t, ...) \
@@ -22,26 +20,6 @@
   LOGGER(subname_).log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
 #define SUBLOGT(subname_, level_, MSG, t, ...) \
   LOGGER(subname_).log(level_, "{} {}: " MSG, (void*)&t, FNAME , ##__VA_ARGS__)
-
-#else
-
-// do compile-time format string validation
-using namespace fmt::literals;
-template<seastar::log_level lv>
-void _LOG(seastar::logger& logger, std::string_view info) {
-  logger.log(lv, info.data());
-}
-
-#define LOG(level_, MSG, ...) \
-  _LOG<level_>(LOCAL_LOGGER, "{}: " MSG ## _format(FNAME , ##__VA_ARGS__))
-#define LOGT(level_, MSG, t_, ...) \
-  _LOG<level_>(LOCAL_LOGGER, "{} {}: " MSG ## _format((void*)&t_, FNAME , ##__VA_ARGS__))
-#define SUBLOG(subname_, level_, MSG, ...) \
-  _LOG<level_>(LOGGER(subname_), "{}: " MSG ## _format(FNAME , ##__VA_ARGS__))
-#define SUBLOGT(subname_, level_, MSG, t_, ...) \
-  _LOG<level_>(LOGGER(subname_), "{} {}: " MSG ## _format((void*)&t_, FNAME , ##__VA_ARGS__))
-
-#endif
 
 #define TRACE(...) LOG(seastar::log_level::trace, __VA_ARGS__)
 #define TRACET(...) LOGT(seastar::log_level::trace, __VA_ARGS__)

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
@@ -109,3 +109,37 @@ enum class nextent_state_t : uint8_t {
 };
 
 }
+
+template <> struct fmt::formatter<crimson::os::seastore::onode::node_delta_op_t>
+  : fmt::formatter<std::string_view> {
+  using node_delta_op_t =  crimson::os::seastore::onode::node_delta_op_t;
+  // parse is inherited from formatter<string_view>.
+  template <typename FormatContext>
+  auto format(node_delta_op_t op, FormatContext& ctx) {
+    std::string_view name = "unknown";
+    switch (op) {
+    case node_delta_op_t::INSERT:
+      name = "insert";
+      break;
+    case node_delta_op_t::SPLIT:
+      name = "split";
+      break;
+    case node_delta_op_t::SPLIT_INSERT:
+      name = "split_insert";
+      break;
+    case node_delta_op_t::UPDATE_CHILD_ADDR:
+      name = "update_child_addr";
+      break;
+    case node_delta_op_t::ERASE:
+      name = "erase";
+      break;
+    case node_delta_op_t::MAKE_TAIL:
+      name = "make_tail";
+      break;
+    case node_delta_op_t::SUBOP_UPDATE_VALUE:
+      name = "subop_update_value";
+      break;
+    }
+    return formatter<string_view>::format(name, ctx);
+  }
+};

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -35,6 +35,46 @@
 using std::string;
 using crimson::common::local_conf;
 
+template <> struct fmt::formatter<crimson::os::seastore::SeaStore::op_type_t>
+  : fmt::formatter<std::string_view> {
+  using op_type_t =  crimson::os::seastore::SeaStore::op_type_t;
+  // parse is inherited from formatter<string_view>.
+  template <typename FormatContext>
+  auto format(op_type_t op, FormatContext& ctx) {
+    std::string_view name = "unknown";
+    switch (op) {
+      case op_type_t::TRANSACTION:
+      name = "transaction";
+      break;
+    case op_type_t::READ:
+      name = "read";
+      break;
+    case op_type_t::WRITE:
+      name = "write";
+      break;
+    case op_type_t::GET_ATTR:
+      name = "get_attr";
+      break;
+    case op_type_t::GET_ATTRS:
+      name = "get_attrs";
+      break;
+    case op_type_t::STAT:
+      name = "stat";
+      break;
+    case op_type_t::OMAP_GET_VALUES:
+      name = "omap_get_values";
+      break;
+    case op_type_t::OMAP_LIST:
+      name = "omap_list";
+      break;
+    case op_type_t::MAX:
+      name = "unknown";
+      break;
+    }
+    return formatter<string_view>::format(name, ctx);
+  }
+};
+
 SET_SUBSYS(seastore);
 
 namespace crimson::os::seastore {

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -4,6 +4,8 @@
 #include <sys/mman.h>
 #include <string.h>
 
+#include <fmt/format.h>
+
 #include "include/buffer.h"
 
 #include "crimson/common/config_proxy.h"
@@ -23,6 +25,28 @@ SET_SUBSYS(seastore_device);
  * - DEBUG: INFO details, major read and write operations
  * - TRACE: DEBUG details
  */
+
+using segment_state_t = crimson::os::seastore::Segment::segment_state_t;
+
+template <> struct fmt::formatter<segment_state_t>: fmt::formatter<std::string_view> {
+  // parse is inherited from formatter<string_view>.
+  template <typename FormatContext>
+  auto format(segment_state_t s, FormatContext& ctx) {
+    std::string_view name = "unknown";
+    switch (s) {
+    case segment_state_t::EMPTY:
+      name = "empty";
+      break;
+    case segment_state_t::OPEN:
+      name = "open";
+      break;
+    case segment_state_t::CLOSED:
+      name = "closed";
+      break;
+    }
+    return formatter<string_view>::format(name, ctx);
+  }
+};
 
 namespace crimson::os::seastore::segment_manager::block {
 

--- a/src/test/crimson/seastore/onode_tree/test_value.h
+++ b/src/test/crimson/seastore/onode_tree/test_value.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include "crimson/common/log.h"
 #include "crimson/os/seastore/onode_manager/staged-fltree/value.h"
 
@@ -34,6 +36,22 @@ struct test_item_t {
 };
 inline std::ostream& operator<<(std::ostream& os, const test_item_t& item) {
   return os << "TestItem(#" << item.id << ", " << item.size << "B)";
+}
+
+enum class delta_op_t : uint8_t {
+  UPDATE_ID,
+  UPDATE_TAIL_MAGIC,
+};
+
+inline std::ostream& operator<<(std::ostream& os, const delta_op_t op) {
+  switch (op) {
+  case delta_op_t::UPDATE_ID:
+    return os << "update_id";
+  case delta_op_t::UPDATE_TAIL_MAGIC:
+    return os << "update_tail_magic";
+  default:
+    return os << "unknown";
+  }
 }
 
 template <value_magic_t MAGIC,
@@ -86,10 +104,6 @@ class TestValue final : public Value {
 
  public:
   class Recorder final : public ValueDeltaRecorder {
-    enum class delta_op_t : uint8_t {
-      UPDATE_ID,
-      UPDATE_TAIL_MAGIC,
-    };
 
    public:
     Recorder(ceph::bufferlist& encoded)


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
