### PR TITLE
radosgw-admin:rados object was created when creating mfa when given user does not exist

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -9608,6 +9608,12 @@ next:
     if (totp_window > 0) {
       config.window = totp_window;
     }
+    
+	RGWUserInfo& user_info = user_op.get_user_info();
+	if(!user_op.has_existing_user()) {
+		cerr << "ERROR: user not found, unable to create mfa " << std::endl;
+		return EINVAL;
+	}
 
     real_time mtime = real_clock::now();
     string oid = static_cast<rgw::sal::RadosStore*>(store)->svc()->cls->mfa.get_mfa_oid(user->get_id());
@@ -9624,7 +9630,6 @@ next:
       return -ret;
     }
     
-    RGWUserInfo& user_info = user_op.get_user_info();
     user_info.mfa_ids.insert(totp_serial);
     user_op.set_mfa_ids(user_info.mfa_ids);
     string err;


### PR DESCRIPTION
radosgw-admin:rados object was created when creating mfa when given user does not exist

Fixes:https://tracker.ceph.com/issues/54343

Signed-off-by: liangchengwu <liangchengw@chinatelecom.cn>

