### PR TITLE
osd: allow sparse reads with a non-zero truncate-seq

### DIFF
--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -556,7 +556,9 @@ inline namespace v14_2_0 {
      * see aio_sparse_read()
      */
     void sparse_read(uint64_t off, uint64_t len, std::map<uint64_t,uint64_t> *m,
-                    bufferlist *data_bl, int *prval);
+                     bufferlist *data_bl, int *prval,
+                     uint64_t truncate_size = 0,
+                     uint32_t truncate_seq = 0);
 
     /**
      * omap_get_vals: keys and values from the object omap

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -224,11 +224,13 @@ void librados::ObjectReadOperation::read(size_t off, uint64_t len, bufferlist *p
 
 void librados::ObjectReadOperation::sparse_read(uint64_t off, uint64_t len,
 						std::map<uint64_t,uint64_t> *m,
-						bufferlist *data_bl, int *prval)
+						bufferlist *data_bl, int *prval,
+						uint64_t truncate_size,
+						uint32_t truncate_seq)
 {
   ceph_assert(impl);
   ::ObjectOperation *o = &impl->o;
-  o->sparse_read(off, len, m, data_bl, prval);
+  o->sparse_read(off, len, m, data_bl, prval, truncate_size, truncate_seq);
 }
 
 void librados::ObjectReadOperation::checksum(rados_checksum_type_t type,

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5846,22 +5846,26 @@ int PrimaryLogPG::do_sparse_read(OpContext *ctx, OSDOp& osd_op) {
   auto& op = osd_op.op;
   auto& oi = ctx->new_obs.oi;
   auto& soid = oi.soid;
+  uint64_t size = oi.size;
+  uint64_t offset = op.extent.offset;
+  uint64_t length = op.extent.length;
 
-  if (op.extent.truncate_seq) {
-    dout(0) << "sparse_read does not support truncation sequence " << dendl;
-    return -EINVAL;
+  // are we beyond truncate_size?
+  if ((oi.truncate_seq < op.extent.truncate_seq) &&
+       (op.extent.offset + op.extent.length > op.extent.truncate_size) &&
+       (size > op.extent.truncate_size)) {
+    size = op.extent.truncate_size;
+  }
+
+  if (offset > size) {
+    length = 0;
+  } else if (offset + length > size) {
+    length = size - offset;
   }
 
   ++ctx->num_read;
   if (pool.info.is_erasure()) {
     // translate sparse read to a normal one if not supported
-    uint64_t offset = op.extent.offset;
-    uint64_t length = op.extent.length;
-    if (offset > oi.size) {
-      length = 0;
-    } else if (offset + length > oi.size) {
-      length = oi.size - offset;
-    }
 
     if (length > 0) {
       ctx->pending_async_reads.push_back(
@@ -5885,7 +5889,7 @@ int PrimaryLogPG::do_sparse_read(OpContext *ctx, OSDOp& osd_op) {
     map<uint64_t, uint64_t> m;
     int r = osd->store->fiemap(ch, ghobject_t(soid, ghobject_t::NO_GEN,
 					      info.pgid.shard),
-			       op.extent.offset, op.extent.length, m);
+			       offset, length, m);
     if (r < 0)  {
       return r;
     }

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -519,9 +519,13 @@ struct ObjectOperation {
     }
   };
   void sparse_read(uint64_t off, uint64_t len, std::map<uint64_t, uint64_t>* m,
-		   ceph::buffer::list* data_bl, int* prval) {
+		   ceph::buffer::list* data_bl, int* prval,
+		   uint64_t truncate_size = 0, uint32_t truncate_seq = 0) {
     ceph::buffer::list bl;
     add_data(CEPH_OSD_OP_SPARSE_READ, off, len, bl);
+    OSDOp& o = *ops.rbegin();
+    o.op.extent.truncate_size = truncate_size;
+    o.op.extent.truncate_seq = truncate_seq;
     set_handler(CB_ObjectOperation_sparse_read(data_bl, m, prval, nullptr));
     out_rval.back() = prval;
   }

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -201,6 +201,19 @@ TEST_F(LibRadosIoPP, SparseReadOpPP) {
     ASSERT_EQ(0, rval);
     assert_eq_sparse(bl, extents, read_bl);
   }
+  {
+    bufferlist bl;
+    bl.append(buf, sizeof(buf) / 2);
+
+    std::map<uint64_t, uint64_t> extents;
+    bufferlist read_bl;
+    int rval = -1;
+    ObjectReadOperation op;
+    op.sparse_read(0, sizeof(buf), &extents, &read_bl, &rval, sizeof(buf) / 2, 1);
+    ASSERT_EQ(0, ioctx.operate("foo", &op, nullptr));
+    ASSERT_EQ(0, rval);
+    assert_eq_sparse(bl, extents, read_bl);
+  }
 }
 
 TEST_F(LibRadosIoPP, RoundTripPP) {

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -902,7 +902,9 @@ void ObjectReadOperation::read(size_t off, uint64_t len, bufferlist *pbl,
 
 void ObjectReadOperation::sparse_read(uint64_t off, uint64_t len,
                                       std::map<uint64_t,uint64_t> *m,
-                                      bufferlist *pbl, int *prval) {
+                                      bufferlist *pbl, int *prval,
+                                      uint64_t truncate_size,
+                                      uint32_t truncate_seq) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
 
   ObjectOperationTestImpl op;


### PR DESCRIPTION
do_read() just uses the truncate_seq to tell how to cap the length of
the read. I see no reason that sparse reads should do anything
differently.

Change do_sparse_read() to cap the requested length at the truncate_size
if the truncate_seq in the request is newer than we have in the object.

Fixes: https://tracker.ceph.com/issues/54280
Signed-off-by: Jeff Layton <jlayton@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
