### PR TITLE
Add mapping for ernno:13 and adding path in error msg in opendir()/cephfs.pyx

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -177,7 +177,8 @@ class NotDirectory(OSError):
 
 class DiskQuotaExceeded(OSError):
     pass
-
+class PermissionDenied(OSError):
+    pass
 
 cdef errno_to_exception =  {
     CEPHFS_EPERM      : PermissionError,
@@ -193,6 +194,7 @@ cdef errno_to_exception =  {
     CEPHFS_ENOTEMPTY  : ObjectNotEmpty,
     CEPHFS_ENOTDIR    : NotDirectory,
     CEPHFS_EDQUOT     : DiskQuotaExceeded,
+    CEPHFS_EACCES     : PermissionDenied,
 }
 
 
@@ -938,7 +940,7 @@ cdef class LibCephFS(object):
         with nogil:
             ret = ceph_opendir(self.cluster, _path, &handle);
         if ret < 0:
-            raise make_ex(ret, "opendir failed")
+            raise make_ex(ret, "opendir failed at {}".format(path.decode('utf-8')))
         d = DirResult()
         d.lib = self
         d.handle = handle


### PR DESCRIPTION
CEPHFS_EACCES enum (Ernno:13) mapped to `PermissionDenied`  in `errno_to_exception` in cephfs.pyx.
`opendir()` now shows the path of file/folder in error message in cephfs.pyx.

Fixes: https://tracker.ceph.com/issues/54237
Signed-off-by: Sarthak0702 <sarthak.0702@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
