### PR TITLE
rbd-mirror: synchronize with in-flight stop in ImageReplayer::stop()

### DIFF
--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -840,5 +840,109 @@ TEST_F(TestMockImageReplayer, ReplayerRenamed) {
   ASSERT_EQ(image_spec, m_image_replayer->get_name());
 }
 
+TEST_F(TestMockImageReplayer, StopJoinInterruptedReplayer) {
+  // START
+  create_local_image();
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  MockThreads mock_threads(m_threads);
+  expect_work_queue_repeatedly(mock_threads);
+  expect_add_event_after_repeatedly(mock_threads);
+
+  MockReplayer mock_replayer;
+  expect_get_replay_status(mock_replayer);
+  expect_set_mirror_image_status_repeatedly();
+
+  InSequence seq;
+  MockBootstrapRequest mock_bootstrap_request;
+  MockStateBuilder mock_state_builder;
+  expect_send(mock_bootstrap_request, mock_state_builder, mock_local_image_ctx,
+              false, false, 0);
+
+  expect_create_replayer(mock_state_builder, mock_replayer);
+  expect_init(mock_replayer, 0);
+
+  create_image_replayer(mock_threads);
+
+  C_SaferCond start_ctx;
+  m_image_replayer->start(&start_ctx);
+  ASSERT_EQ(0, start_ctx.wait());
+
+  // NOTIFY
+  EXPECT_CALL(mock_replayer, is_resync_requested())
+    .WillOnce(Return(false));
+  EXPECT_CALL(mock_replayer, is_replaying())
+    .WillOnce(Return(false));
+  EXPECT_CALL(mock_replayer, get_error_code())
+    .WillOnce(Return(-EINVAL));
+  EXPECT_CALL(mock_replayer, get_error_description())
+    .WillOnce(Return("INVALID"));
+  const double DELAY = 10;
+  EXPECT_CALL(mock_replayer, shut_down(_))
+    .WillOnce(Invoke([this, DELAY](Context* ctx) {
+		m_threads->timer->add_event_after(DELAY, ctx);
+              }));
+  EXPECT_CALL(mock_replayer, destroy());
+  expect_close(mock_state_builder, 0);
+  expect_mirror_image_status_exists(false);
+
+  mock_replayer.replayer_listener->handle_notification();
+  ASSERT_FALSE(m_image_replayer->is_running());
+
+  C_SaferCond stop_ctx;
+  m_image_replayer->stop(&stop_ctx);
+  ASSERT_EQ(ETIMEDOUT, stop_ctx.wait_for(DELAY * 3 / 4));
+  ASSERT_EQ(0, stop_ctx.wait_for(DELAY));
+}
+
+TEST_F(TestMockImageReplayer, StopJoinRequestedStop) {
+  // START
+  create_local_image();
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  MockThreads mock_threads(m_threads);
+  expect_work_queue_repeatedly(mock_threads);
+  expect_add_event_after_repeatedly(mock_threads);
+
+  MockReplayer mock_replayer;
+  expect_get_replay_status(mock_replayer);
+  expect_set_mirror_image_status_repeatedly();
+
+  InSequence seq;
+  MockBootstrapRequest mock_bootstrap_request;
+  MockStateBuilder mock_state_builder;
+  expect_send(mock_bootstrap_request, mock_state_builder, mock_local_image_ctx,
+              false, false, 0);
+
+  expect_create_replayer(mock_state_builder, mock_replayer);
+  expect_init(mock_replayer, 0);
+
+  create_image_replayer(mock_threads);
+
+  C_SaferCond start_ctx;
+  m_image_replayer->start(&start_ctx);
+  ASSERT_EQ(0, start_ctx.wait());
+
+  // STOP
+  const double DELAY = 10;
+  EXPECT_CALL(mock_replayer, shut_down(_))
+    .WillOnce(Invoke([this, DELAY](Context* ctx) {
+		m_threads->timer->add_event_after(DELAY, ctx);
+              }));
+  EXPECT_CALL(mock_replayer, destroy());
+  expect_close(mock_state_builder, 0);
+  expect_mirror_image_status_exists(false);
+
+  C_SaferCond stop_ctx1;
+  m_image_replayer->stop(&stop_ctx1);
+
+  C_SaferCond stop_ctx2;
+  m_image_replayer->stop(&stop_ctx2);
+  ASSERT_EQ(ETIMEDOUT, stop_ctx2.wait_for(DELAY * 3 / 4));
+  ASSERT_EQ(0, stop_ctx2.wait_for(DELAY));
+
+  ASSERT_EQ(0, stop_ctx1.wait_for(0));
+}
+
 } // namespace mirror
 } // namespace rbd

--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -608,7 +608,7 @@ TEST_F(TestMockImageReplayer, BootstrapCancel) {
   MockStateBuilder mock_state_builder;
   EXPECT_CALL(mock_bootstrap_request, send())
     .WillOnce(Invoke([this, &mock_bootstrap_request]() {
-        m_image_replayer->stop();
+        m_image_replayer->stop(nullptr);
         mock_bootstrap_request.on_finish->complete(-ECANCELED);
       }));
   EXPECT_CALL(mock_bootstrap_request, cancel());

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -528,6 +528,10 @@ void ImageReplayer<I>::stop(Context *on_finish, bool manual, bool restart)
 
     if (!is_running_()) {
       running = false;
+      if (manual && !m_manual_stop) {
+        dout(10) << "marking manual" << dendl;
+        m_manual_stop = true;
+      }
       if (!restart && m_restart_requested) {
         dout(10) << "canceling restart" << dendl;
         m_restart_requested = false;

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -148,6 +148,7 @@ protected:
 
 private:
   typedef std::set<Peer<ImageCtxT>> Peers;
+  typedef std::list<Context *> Contexts;
 
   enum State {
     STATE_UNKNOWN,
@@ -214,7 +215,7 @@ private:
   ReplayerListener* m_replayer_listener = nullptr;
 
   Context *m_on_start_finish = nullptr;
-  Context *m_on_stop_finish = nullptr;
+  Contexts m_on_stop_contexts;
   bool m_stop_requested = false;
   bool m_manual_stop = false;
 

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -101,10 +101,8 @@ public:
     return m_global_image_id;
   }
 
-  void start(Context *on_finish = nullptr, bool manual = false,
-             bool restart = false);
-  void stop(Context *on_finish = nullptr, bool manual = false,
-            bool restart = false);
+  void start(Context *on_finish, bool manual = false, bool restart = false);
+  void stop(Context *on_finish, bool manual = false, bool restart = false);
   void restart(Context *on_finish = nullptr);
   void flush();
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
