### PR TITLE
mds: reset heartbeat when fetching or committing dentries

### DIFF
--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -206,6 +206,14 @@ options:
   services:
   - mds
   with_legacy: true
+- name: mds_heartbeat_reset_grace
+  type: uint
+  level: advanced
+  desc: the basic unit of tolerance in how many circles in a loop, which will
+    keep running by holding the mds_lock, it must trigger to reset heartbeat
+  default: 1000
+  services:
+  - mds
 - name: mds_heartbeat_grace
   type: float
   level: advanced

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2520,21 +2520,21 @@ void CDir::_omap_commit(int op_prio)
     // fnode.snap_purged_thru = realm->get_last_destroyed();
   }
 
-  size_t count = 0;
+  size_t items_count = 0;
   if (state_test(CDir::STATE_FRAGMENTING) && is_new()) {
-    count = get_num_head_items() + get_num_snap_items();
+    items_count = get_num_head_items() + get_num_snap_items();
   } else {
     for (elist<CDentry*>::iterator it = dirty_dentries.begin(); !it.end(); ++it)
-      ++count;
+      ++items_count;
   }
 
   vector<string> to_remove;
   // reverve enough memories, which maybe larger than the actually needed
-  to_remove.reserve(count);
+  to_remove.reserve(items_count);
 
   vector<dentry_commit_item> to_set;
   // reverve enough memories, which maybe larger than the actually needed
-  to_set.reserve(count);
+  to_set.reserve(items_count);
 
   // for dir fragtrees
   bufferlist dfts(CEPH_PAGE_SIZE);

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2106,6 +2106,8 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
   };
   auto proc_nulls_and_waiters = [&](const string& str_key, const string_snap_t& key) {
     bool touch = false;
+    int count = 0;
+
     while (k_it != keys.rend()) {
       int cmp = k_it->compare(str_key);
       if (cmp < 0)
@@ -2123,10 +2125,14 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
       last_name = std::string_view(k_it->c_str(), n_key.name.length());
       null_keys.emplace_back(std::move(n_key));
       ++k_it;
+
+      if (!(++count % mdcache->mds->heartbeat_reset_grace()))
+        mdcache->mds->heartbeat_reset();
     }
     return touch;
   };
 
+  int count = 0;
   unsigned pos = omap.size() - 1;
   double rand_threshold = get_inode()->get_ephemeral_rand();
   for (auto p = omap.rbegin(); p != omap.rend(); ++p, --pos) {
@@ -2142,6 +2148,9 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
       }
       last_name = std::string_view(p->first.c_str(), key.name.length());
     }
+
+    if (!(++count % mdcache->mds->heartbeat_reset_grace()))
+      mdcache->mds->heartbeat_reset();
 
     CDentry *dn = nullptr;
     try {
@@ -2204,6 +2213,9 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
 	dout(12) << "_fetched got null for key " << key << ", added " << *dn << dendl;
       }
       mdcache->touch_dentry(dn);
+
+      if (!(++count % mdcache->mds->heartbeat_reset_grace(2)))
+        mdcache->mds->heartbeat_reset();
     }
   }
 
@@ -2219,9 +2231,13 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
   // open & force frags
   while (!undef_inodes.empty()) {
     CInode *in = undef_inodes.front();
+
     undef_inodes.pop_front();
     in->state_clear(CInode::STATE_REJOINUNDEF);
     mdcache->opened_undef_inode(in);
+
+    if (!(++count % mdcache->mds->heartbeat_reset_grace()))
+      mdcache->mds->heartbeat_reset();
   }
 
   // dirty myself to remove stale snap dentries
@@ -2451,6 +2467,7 @@ void CDir::_omap_commit_ops(int r, int op_prio, int64_t metapool, version_t vers
     _rm.clear();
   };
 
+  int count = 0;
   for (auto &key : stales) {
     unsigned size = key.length() + sizeof(__u32);
     if (write_size + size > max_write_size)
@@ -2458,6 +2475,9 @@ void CDir::_omap_commit_ops(int r, int op_prio, int64_t metapool, version_t vers
 
     write_size += size;
     _rm.emplace(key);
+
+    if (!(++count % mdcache->mds->heartbeat_reset_grace(2)))
+      mdcache->mds->heartbeat_reset();
   }
 
   for (auto &key : to_remove) {
@@ -2467,6 +2487,9 @@ void CDir::_omap_commit_ops(int r, int op_prio, int64_t metapool, version_t vers
 
     write_size += size;
     _rm.emplace(std::move(key));
+
+    if (!(++count % mdcache->mds->heartbeat_reset_grace(2)))
+      mdcache->mds->heartbeat_reset();
   }
 
   bufferlist bl;
@@ -2492,6 +2515,9 @@ void CDir::_omap_commit_ops(int r, int op_prio, int64_t metapool, version_t vers
 
     write_size += size;
     _set[std::move(item.key)].swap(bl);
+
+    if (!(++count % mdcache->mds->heartbeat_reset_grace()))
+      mdcache->mds->heartbeat_reset();
   }
 
   commit_one(true);
@@ -2570,6 +2596,7 @@ void CDir::_omap_commit(int op_prio)
     }
   };
 
+  int count = 0;
   if (state_test(CDir::STATE_FRAGMENTING) && is_new()) {
     ceph_assert(committed_version == 0);
     for (auto p = items.begin(); p != items.end(); ) {
@@ -2578,12 +2605,18 @@ void CDir::_omap_commit(int op_prio)
       if (dn->get_linkage()->is_null())
 	continue;
       write_one(dn);
+
+      if (!(++count % mdcache->mds->heartbeat_reset_grace()))
+        mdcache->mds->heartbeat_reset();
     }
   } else {
     for (auto p = dirty_dentries.begin(); !p.end(); ) {
       CDentry *dn = *p;
       ++p;
       write_one(dn);
+
+      if (!(++count % mdcache->mds->heartbeat_reset_grace()))
+        mdcache->mds->heartbeat_reset();
     }
   }
 
@@ -2735,6 +2768,8 @@ void CDir::_committed(int r, version_t v)
   if (committed_version == get_version()) 
     mark_clean();
 
+  int count = 0;
+
   // dentries clean?
   for (auto p = dirty_dentries.begin(); !p.end(); ) {
     CDentry *dn = *p;
@@ -2772,11 +2807,14 @@ void CDir::_committed(int r, version_t v)
       dout(15) << " dir " << committed_version << " < dn " << dn->get_version() << " still dirty " << *dn << dendl;
       ceph_assert(dn->is_dirty());
     }
+
+    if (!(++count % mdcache->mds->heartbeat_reset_grace()))
+      mdcache->mds->heartbeat_reset();
   }
 
   // finishers?
   bool were_waiters = !waiting_for_commit.empty();
-  
+
   auto it = waiting_for_commit.begin();
   while (it != waiting_for_commit.end()) {
     auto _it = it;
@@ -2792,7 +2830,10 @@ void CDir::_committed(int r, version_t v)
     mdcache->mds->queue_waiters(t);
     waiting_for_commit.erase(it);
     it = _it;
-  } 
+
+    if (!(++count % mdcache->mds->heartbeat_reset_grace()))
+      mdcache->mds->heartbeat_reset();
+  }
 
   // try drop dentries in this dirfrag if it's about to be purged
   if (!inode->is_base() && get_parent_dir()->inode->is_stray() &&

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -3765,13 +3765,13 @@ void MDCache::trim_unlinked_inodes()
       q.push_back(in);
     }
 
-    if (!(++count % 1000))
+    if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
   for (auto& in : q) {
     remove_inode_recursive(in);
 
-    if (!(++count % 1000))
+    if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
 }
@@ -5417,7 +5417,7 @@ bool MDCache::process_imported_caps()
     } else {
       open_ino(p.first, (int64_t)-1, fin, false);
     }
-    if (!(cap_imports_num_opening % 1000))
+    if (!(cap_imports_num_opening % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
 
@@ -5603,7 +5603,7 @@ void MDCache::choose_lock_states_and_reconnect_caps()
       rejoin_pending_snaprealms.insert(in);
     }
 
-    if (!(++count % 1000))
+    if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
 }
@@ -5772,7 +5772,7 @@ void MDCache::export_remaining_imported_caps()
       }
     }
 
-    if (!(++count % 1000))
+    if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
 
@@ -6246,7 +6246,7 @@ void MDCache::reissue_all_caps()
 	n += mds->locker->issue_caps(in);
     }
 
-    if ((count % 1000) + n >= 1000)
+    if ((count % mds->heartbeat_reset_grace()) + n >= mds->heartbeat_reset_grace())
       mds->heartbeat_reset();
     count += n;
   }
@@ -6367,7 +6367,7 @@ void MDCache::identify_files_to_recover()
       rejoin_check_q.push_back(in);
     }
 
-    if (!(++count % 1000))
+    if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
 }
@@ -6379,13 +6379,13 @@ void MDCache::start_files_to_recover()
     if (in->filelock.get_state() == LOCK_XLOCKSNAP)
       mds->locker->issue_caps(in);
     mds->locker->check_inode_max_size(in);
-    if (!(++count % 1000))
+    if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
   rejoin_check_q.clear();
   for (CInode *in : rejoin_recover_q) {
     mds->locker->file_recover(&in->filelock);
-    if (!(++count % 1000))
+    if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
   if (!rejoin_recover_q.empty()) {
@@ -12457,7 +12457,7 @@ void MDCache::force_readonly()
     CInode *in = p.second;
     if (in->is_head())
       mds->locker->eval(in, CEPH_CAP_LOCKS);
-    if (!(++count % 1000))
+    if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -543,6 +543,7 @@ MDSRank::MDSRank(
   server = new Server(this, &metrics_handler);
   locker = new Locker(this, mdcache);
 
+  _heartbeat_reset_grace = g_conf().get_val<uint64_t>("mds_heartbeat_reset_grace");
   heartbeat_grace = g_conf().get_val<double>("mds_heartbeat_grace");
   op_tracker.set_complaint_and_threshold(cct->_conf->mds_op_complaint_time,
                                          cct->_conf->mds_op_log_threshold);
@@ -3751,6 +3752,7 @@ const char** MDSRankDispatcher::get_tracked_conf_keys() const
     "mds_recall_warning_decay_rate",
     "mds_request_load_average_decay_rate",
     "mds_session_cache_liveness_decay_rate",
+    "mds_heartbeat_reset_grace",
     "mds_heartbeat_grace",
     "mds_session_cap_acquisition_decay_rate",
     "mds_max_caps_per_client",
@@ -3769,6 +3771,9 @@ void MDSRankDispatcher::handle_conf_change(const ConfigProxy& conf, const std::s
 {
   // XXX with or without mds_lock!
 
+  if (changed.count("mds_heartbeat_reset_grace")) {
+    _heartbeat_reset_grace = conf.get_val<uint64_t>("mds_heartbeat_reset_grace");
+  }
   if (changed.count("mds_heartbeat_grace")) {
     heartbeat_grace = conf.get_val<double>("mds_heartbeat_grace");
   }

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -267,6 +267,9 @@ class MDSRank {
      * of code while holding the mds_lock
      */
     void heartbeat_reset();
+    int heartbeat_reset_grace(int count=1) {
+      return count * _heartbeat_reset_grace;
+    }
 
     /**
      * Report state DAMAGED to the mon, and then pass on to respawn().  Call
@@ -576,6 +579,7 @@ class MDSRank {
 
     ceph::heartbeat_handle_d *hb = nullptr;  // Heartbeat for threads using mds_lock
     double heartbeat_grace;
+    int _heartbeat_reset_grace;
 
     std::map<mds_rank_t, version_t> peer_mdsmap_epoch;
 

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -1090,7 +1090,7 @@ void OpenFileTable::_prefetch_dirfrags()
       ceph_assert(dir->get_inode()->dirfragtree.is_leaf(dir->get_frag()));
     dir->fetch(gather.new_sub());
 
-    if (!(++num_opening_dirfrags % 1000))
+    if (!(++num_opening_dirfrags % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
 
@@ -1166,7 +1166,7 @@ void OpenFileTable::_prefetch_inodes()
       mdcache->open_ino(ino, pool, fin, false);
     }
 
-    if (!(num_opening_inodes % 1000))
+    if (!(num_opening_inodes % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
 

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -1362,7 +1362,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
 	in->state_clear(CInode::STATE_AUTH);
       ceph_assert(g_conf()->mds_kill_journal_replay_at != 2);
 
-      if (!(++count % 1000))
+      if (!(++count % mds->heartbeat_reset_grace()))
         mds->heartbeat_reset();
     }
 
@@ -1397,7 +1397,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
       if (lump.is_importing())
 	dn->mark_auth();
 
-      if (!(++count % 1000))
+      if (!(++count % mds->heartbeat_reset_grace()))
         mds->heartbeat_reset();
     }
 
@@ -1435,7 +1435,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
       // Make null dentries the first things we trim
       dout(10) << "EMetaBlob.replay pushing to bottom of lru " << *dn << dendl;
 
-      if (!(++count % 1000))
+      if (!(++count % mds->heartbeat_reset_grace()))
         mds->heartbeat_reset();
     }
   }
@@ -1468,7 +1468,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
 	  else
 	    dir->state_set(CDir::STATE_AUTH);
 
-          if (!(++count % 1000))
+          if (!(++count % mds->heartbeat_reset_grace()))
             mds->heartbeat_reset();
 	}
       }
@@ -1500,7 +1500,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
 	dir->state_clear(CDir::STATE_AUTH);
 	mds->mdcache->adjust_subtree_auth(dir, CDIR_AUTH_UNDEF);
 
-        if (!(++count % 1000))
+        if (!(++count % mds->heartbeat_reset_grace()))
           mds->heartbeat_reset();
       }
     }
@@ -1513,7 +1513,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
       ceph_assert(p->first->is_dir());
       mds->mdcache->adjust_subtree_after_rename(p->first, p->second, false);
 
-      if (!(++count % 1000))
+      if (!(++count % mds->heartbeat_reset_grace()))
         mds->heartbeat_reset();
     }
   }
@@ -1531,7 +1531,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
       } else
 	mds->mdcache->remove_inode_recursive(in);
 
-      if (!(++count % 1000))
+      if (!(++count % mds->heartbeat_reset_grace()))
         mds->heartbeat_reset();
     }
   }
@@ -1544,7 +1544,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
     if (client)
       client->got_journaled_agree(p.second, logseg);
 
-    if (!(++count % 1000))
+    if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
 
@@ -1634,7 +1634,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
     ceph_assert(in);
     mds->mdcache->add_recovered_truncate(in, logseg);
 
-    if (!(++count % 1000))
+    if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
   for (const auto& p : truncate_finish) {
@@ -1645,7 +1645,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
       mds->mdcache->remove_recovered_truncate(in, ls);
     }
 
-    if (!(++count % 1000))
+    if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
 
@@ -1667,7 +1667,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
 	dout(10) << "EMetaBlob.replay destroyed " << *p << ", not in cache" << dendl;
       }
 
-      if (!(++count % 1000))
+      if (!(++count % mds->heartbeat_reset_grace()))
         mds->heartbeat_reset();
     }
     mds->mdcache->open_file_table.note_destroyed_inos(logseg->seq, destroyed_inodes);
@@ -1689,7 +1689,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
       }
     }
 
-    if (!(++count % 1000))
+    if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
 
@@ -1705,7 +1705,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
       }
     }
 
-    if (!(++count % 1000))
+    if (!(++count % mds->heartbeat_reset_grace()))
       mds->heartbeat_reset();
   }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/54345
Signed-off-by: Xiubo Li <xiubli@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
