### PR TITLE
rgw/dbstore: use string_view for string constants

### DIFF
--- a/src/rgw/store/dbstore/common/dbstore.cc
+++ b/src/rgw/store/dbstore/common/dbstore.cc
@@ -218,7 +218,7 @@ int DB::objectmapDelete(const DoutPrefixProvider *dpp, string bucket)
   return 0;
 }
 
-int DB::InitializeParams(const DoutPrefixProvider *dpp, string Op, DBOpParams *params)
+int DB::InitializeParams(const DoutPrefixProvider *dpp, DBOpParams *params)
 {
   int ret = -1;
 
@@ -273,7 +273,7 @@ int DB::get_user(const DoutPrefixProvider *dpp,
   }
 
   DBOpParams params = {};
-  InitializeParams(dpp, "GetUser", &params);
+  InitializeParams(dpp, &params);
 
   params.op.query_str = query_str;
 
@@ -324,7 +324,7 @@ int DB::store_user(const DoutPrefixProvider *dpp,
     RGWObjVersionTracker *pobjv, RGWUserInfo* pold_info)
 {
   DBOpParams params = {};
-  InitializeParams(dpp, "CreateUser", &params);
+  InitializeParams(dpp, &params);
   int ret = 0;
 
   /* Check if the user already exists and return the old info, caller will have a use for it */
@@ -386,7 +386,7 @@ int DB::remove_user(const DoutPrefixProvider *dpp,
     RGWUserInfo& uinfo, RGWObjVersionTracker *pobjv)
 {
   DBOpParams params = {};
-  InitializeParams(dpp, "RemoveUser", &params);
+  InitializeParams(dpp, &params);
   int ret = 0;
 
   RGWUserInfo orig_info;
@@ -434,7 +434,7 @@ int DB::get_bucket_info(const DoutPrefixProvider *dpp, const std::string& query_
 
   DBOpParams params = {};
   DBOpParams params2 = {};
-  InitializeParams(dpp, "GetBucket", &params);
+  InitializeParams(dpp, &params);
 
   if (query_str == "name") {
     params.op.bucket.info.bucket.name = info.bucket.name;
@@ -495,7 +495,7 @@ int DB::create_bucket(const DoutPrefixProvider *dpp,
    */
 
   DBOpParams params = {};
-  InitializeParams(dpp, "CreateBucket", &params);
+  InitializeParams(dpp, &params);
   int ret = 0;
 
   /* Check if the bucket already exists and return the old info, caller will have a use for it */
@@ -563,7 +563,7 @@ int DB::remove_bucket(const DoutPrefixProvider *dpp, const RGWBucketInfo info) {
   int ret = 0;
 
   DBOpParams params = {};
-  InitializeParams(dpp, "RemoveBucket", &params);
+  InitializeParams(dpp, &params);
 
   params.op.bucket.info.bucket.name = info.bucket.name;
 
@@ -590,7 +590,7 @@ int DB::list_buckets(const DoutPrefixProvider *dpp, const std::string& query_str
   int ret = 0;
 
   DBOpParams params = {};
-  InitializeParams(dpp, "ListUserBuckets", &params);
+  InitializeParams(dpp, &params);
 
   params.op.user.uinfo.user_id = user;
   params.op.bucket.min_marker = marker;
@@ -671,7 +671,7 @@ int DB::update_bucket(const DoutPrefixProvider *dpp, const std::string& query_st
     pobjv = &info.objv_tracker;
   }
 
-  InitializeParams(dpp, "UpdateBucket", &params);
+  InitializeParams(dpp, &params);
 
   params.op.bucket.info.bucket.name = info.bucket.name;
 
@@ -731,7 +731,7 @@ int DB::Bucket::List::list_objects(const DoutPrefixProvider *dpp, int64_t max,
   DB *store = target->get_store();
 
   DBOpParams db_params = {};
-  store->InitializeParams(dpp, "ListBucketObjects", &db_params);
+  store->InitializeParams(dpp, &db_params);
 
   db_params.op.bucket.info = target->get_bucket_info(); 
   /* XXX: Handle whole marker? key -> name, instance, ns? */
@@ -812,7 +812,7 @@ int DB::Object::obj_omap_set_val_by_key(const DoutPrefixProvider *dpp,
 
   DBOpParams params = {};
 
-  store->InitializeParams(dpp, "GetObject", &params);
+  store->InitializeParams(dpp, &params);
   InitializeParamsfromObject(dpp, &params);
 
   ret = store->ProcessOp(dpp, "GetObject", &params);
@@ -855,7 +855,7 @@ int DB::Object::obj_omap_get_vals_by_keys(const DoutPrefixProvider *dpp,
   if (!vals)
     return -1;
 
-  store->InitializeParams(dpp, "GetObject", &params);
+  store->InitializeParams(dpp, &params);
   InitializeParamsfromObject(dpp, &params);
 
   ret = store->ProcessOp(dpp, "GetObject", &params);
@@ -887,7 +887,7 @@ int DB::Object::add_mp_part(const DoutPrefixProvider *dpp,
 
   DBOpParams params = {};
 
-  store->InitializeParams(dpp, "GetObject", &params);
+  store->InitializeParams(dpp, &params);
   InitializeParamsfromObject(dpp, &params);
 
   ret = store->ProcessOp(dpp, "GetObject", &params);
@@ -925,7 +925,7 @@ int DB::Object::get_mp_parts_list(const DoutPrefixProvider *dpp,
   DBOpParams params = {};
   std::map<std::string, bufferlist> omap;
 
-  store->InitializeParams(dpp, "GetObject", &params);
+  store->InitializeParams(dpp, &params);
   InitializeParamsfromObject(dpp, &params);
 
   ret = store->ProcessOp(dpp, "GetObject", &params);
@@ -969,7 +969,7 @@ int DB::Object::obj_omap_get_all(const DoutPrefixProvider *dpp,
   if (!m)
     return -1;
 
-  store->InitializeParams(dpp, "GetObject", &params);
+  store->InitializeParams(dpp, &params);
   InitializeParamsfromObject(dpp, &params);
 
   ret = store->ProcessOp(dpp, "GetObject", &params);
@@ -1005,7 +1005,7 @@ int DB::Object::obj_omap_get_vals(const DoutPrefixProvider *dpp,
   if (!m)
     return -1;
 
-  store->InitializeParams(dpp, "GetObject", &params);
+  store->InitializeParams(dpp, &params);
   InitializeParamsfromObject(dpp, &params);
 
   ret = store->ProcessOp(dpp, "GetObject", &params);
@@ -1050,7 +1050,7 @@ int DB::Object::set_attrs(const DoutPrefixProvider *dpp,
   rgw::sal::Attrs *attrs;
   map<string, bufferlist>::iterator iter;
 
-  store->InitializeParams(dpp, "GetObject", &params);
+  store->InitializeParams(dpp, &params);
   InitializeParamsfromObject(dpp, &params);
 
   ret = store->ProcessOp(dpp, "GetObject", &params);
@@ -1099,7 +1099,7 @@ int DB::raw_obj::read(const DoutPrefixProvider *dpp, int64_t ofs,
   int ret = 0;
   DBOpParams params = {};
 
-  db->InitializeParams(dpp, "GetObjectData", &params);
+  db->InitializeParams(dpp, &params);
   InitializeParamsfromRawObj(dpp, &params);
 
   ret = db->ProcessOp(dpp, "GetObjectData", &params);
@@ -1130,7 +1130,7 @@ int DB::raw_obj::write(const DoutPrefixProvider *dpp, int64_t ofs, int64_t write
   int ret = 0;
   DBOpParams params = {};
 
-  db->InitializeParams(dpp, "PutObjectData", &params);
+  db->InitializeParams(dpp, &params);
   InitializeParamsfromRawObj(dpp, &params);
 
   /* XXX: Check for chunk_size ?? */
@@ -1208,7 +1208,7 @@ int DB::Object::get_obj_state(const DoutPrefixProvider *dpp,
 
   DBOpParams params = {};
   RGWObjState* s;
-  store->InitializeParams(dpp, "GetObject", &params);
+  store->InitializeParams(dpp, &params);
   InitializeParamsfromObject(dpp, &params);
 
   ret = store->ProcessOp(dpp, "GetObject", &params);
@@ -1641,7 +1641,7 @@ int DB::Object::Write::_do_write_meta(const DoutPrefixProvider *dpp,
 
   map<string, bufferlist>::iterator iter;
 
-  store->InitializeParams(dpp, "PutObject", &params);
+  store->InitializeParams(dpp, &params);
   target->InitializeParamsfromObject(dpp, &params);
 
   obj_state = params.op.obj.state;
@@ -1782,7 +1782,7 @@ int DB::Object::Delete::delete_obj(const DoutPrefixProvider *dpp) {
   /* XXX: check params conditions */
   DBOpParams del_params = {};
 
-  store->InitializeParams(dpp, "DeleteObject", &del_params);
+  store->InitializeParams(dpp, &del_params);
   target->InitializeParamsfromObject(dpp, &del_params);
 
   ret = store->ProcessOp(dpp, "DeleteObject", &del_params);
@@ -1819,7 +1819,7 @@ int DB::get_entry(const std::string& oid, const std::string& marker,
   const DoutPrefixProvider *dpp = get_def_dpp();
 
   DBOpParams params = {};
-  InitializeParams(dpp, "GetLCEntry", &params);
+  InitializeParams(dpp, &params);
 
   params.op.lc_entry.index = oid;
   params.op.lc_entry.entry.bucket = marker;
@@ -1847,7 +1847,7 @@ int DB::get_next_entry(const std::string& oid, std::string& marker,
   const DoutPrefixProvider *dpp = get_def_dpp();
 
   DBOpParams params = {};
-  InitializeParams(dpp, "GetLCEntry", &params);
+  InitializeParams(dpp, &params);
 
   params.op.lc_entry.index = oid;
   params.op.lc_entry.entry.bucket = marker;
@@ -1874,7 +1874,7 @@ int DB::set_entry(const std::string& oid, const rgw::sal::Lifecycle::LCEntry& en
   const DoutPrefixProvider *dpp = get_def_dpp();
 
   DBOpParams params = {};
-  InitializeParams(dpp, "InsertLCEntry", &params);
+  InitializeParams(dpp, &params);
 
   params.op.lc_entry.index = oid;
   params.op.lc_entry.entry = entry;
@@ -1899,7 +1899,7 @@ int DB::list_entries(const std::string& oid, const std::string& marker,
   entries.clear();
 
   DBOpParams params = {};
-  InitializeParams(dpp, "ListLCEntries", &params);
+  InitializeParams(dpp, &params);
 
   params.op.lc_entry.index = oid;
   params.op.lc_entry.min_marker = marker;
@@ -1926,7 +1926,7 @@ int DB::rm_entry(const std::string& oid, const rgw::sal::Lifecycle::LCEntry& ent
   const DoutPrefixProvider *dpp = get_def_dpp();
 
   DBOpParams params = {};
-  InitializeParams(dpp, "RemoveLCEntry", &params);
+  InitializeParams(dpp, &params);
 
   params.op.lc_entry.index = oid;
   params.op.lc_entry.entry = entry;
@@ -1948,7 +1948,7 @@ int DB::get_head(const std::string& oid, rgw::sal::Lifecycle::LCHead& head)
   const DoutPrefixProvider *dpp = get_def_dpp();
 
   DBOpParams params = {};
-  InitializeParams(dpp, "GetLCHead", &params);
+  InitializeParams(dpp, &params);
 
   params.op.lc_head.index = oid;
 
@@ -1971,7 +1971,7 @@ int DB::put_head(const std::string& oid, const rgw::sal::Lifecycle::LCHead& head
   const DoutPrefixProvider *dpp = get_def_dpp();
 
   DBOpParams params = {};
-  InitializeParams(dpp, "InsertLCHead", &params);
+  InitializeParams(dpp, &params);
 
   params.op.lc_head.index = oid;
   params.op.lc_head.head = head;
@@ -1997,7 +1997,7 @@ int DB::delete_stale_objs(const DoutPrefixProvider *dpp, const std::string& buck
    * XXX: This is needed for now to create objectmap of bucket
    * in SQLGetBucket
    */
-  InitializeParams(dpp, "GetBucket", &params);
+  InitializeParams(dpp, &params);
   ret = ProcessOp(dpp, "GetBucket", &params);
   if (ret) {
     ldpp_dout(dpp, 0) << "In GetBucket failed err:(" <<ret<<")" << dendl;
@@ -2007,7 +2007,7 @@ int DB::delete_stale_objs(const DoutPrefixProvider *dpp, const std::string& buck
   /* XXX: handle reads racing with delete here. Simple approach is maybe
    * to use locks or sqlite transactions.
    */
-  InitializeParams(dpp, "DeleteStaleObjectData", &params);
+  InitializeParams(dpp, &params);
   params.op.obj.state.mtime = (real_clock::now() - make_timespan(min_wait));
   ret = ProcessOp(dpp, "DeleteStaleObjectData", &params);
   if (ret) {

--- a/src/rgw/store/dbstore/common/dbstore.cc
+++ b/src/rgw/store/dbstore/common/dbstore.cc
@@ -89,7 +89,8 @@ int DB::Destroy(const DoutPrefixProvider *dpp)
 }
 
 
-DBOp *DB::getDBOp(const DoutPrefixProvider *dpp, string Op, struct DBOpParams *params)
+DBOp *DB::getDBOp(const DoutPrefixProvider *dpp, std::string_view Op,
+                  const DBOpParams *params)
 {
   if (!Op.compare("InsertUser"))
     return dbops.InsertUser;
@@ -238,7 +239,7 @@ out:
   return ret;
 }
 
-int DB::ProcessOp(const DoutPrefixProvider *dpp, string Op, struct DBOpParams *params) {
+int DB::ProcessOp(const DoutPrefixProvider *dpp, std::string_view Op, DBOpParams *params) {
   int ret = -1;
   class DBOp *db_op;
 
@@ -251,11 +252,9 @@ int DB::ProcessOp(const DoutPrefixProvider *dpp, string Op, struct DBOpParams *p
   ret = db_op->Execute(dpp, params);
 
   if (ret) {
-    ldpp_dout(dpp, 0)<<"In Process op Execute failed for fop(" \
-      <<Op.c_str()<<") " << dendl;
+    ldpp_dout(dpp, 0)<<"In Process op Execute failed for fop(" << Op << ")" << dendl;
   } else {
-    ldpp_dout(dpp, 20)<<"Successfully processed fop(" \
-      <<Op.c_str()<<") " << dendl;
+    ldpp_dout(dpp, 20)<<"Successfully processed fop(" << Op << ")" << dendl;
   }
 
   return ret;

--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -310,7 +310,7 @@ struct DBOpLCHeadPrepareInfo {
 
 struct DBOpPrepareInfo {
   DBOpUserPrepareInfo user;
-  std::string query_str = ":query_str";
+  std::string_view query_str; // view into DBOpInfo::query_str
   DBOpBucketPrepareInfo bucket;
   DBOpObjectPrepareInfo obj;
   DBOpObjectDataPrepareInfo obj_data;

--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -641,8 +641,8 @@ class DBOp {
     virtual ~DBOp() {}
     std::mutex mtx; // to protect prepared stmt
 
-    std::string CreateTableSchema(std::string_view type,
-                                  const DBOpParams *params) {
+    static std::string CreateTableSchema(std::string_view type,
+                                         const DBOpParams *params) {
       if (!type.compare("User"))
         return fmt::format(CreateUserTableQ,
             params->user_table);
@@ -677,10 +677,10 @@ class DBOp {
       ceph_abort_msgf("incorrect table type %.*s", type.size(), type.data());
     }
 
-    std::string DeleteTableSchema(std::string_view table) {
+    static std::string DeleteTableSchema(std::string_view table) {
       return fmt::format(DropQ, table);
     }
-    std::string ListTableSchema(std::string_view table) {
+    static std::string ListTableSchema(std::string_view table) {
       return fmt::format(ListAllQ, table);
     }
 
@@ -715,7 +715,7 @@ class InsertUserOp : virtual public DBOp {
   public:
     virtual ~InsertUserOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query, params.user_table,
           params.op.user.user_id, params.op.user.tenant, params.op.user.ns,
           params.op.user.display_name, params.op.user.user_email,
@@ -742,7 +742,7 @@ class RemoveUserOp: virtual public DBOp {
   public:
     virtual ~RemoveUserOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query, params.user_table,
           params.op.user.user_id);
     }
@@ -788,7 +788,7 @@ class GetUserOp: virtual public DBOp {
   public:
     virtual ~GetUserOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       if (params.op.query_str == "email") {
         return fmt::format(QueryByEmail, params.user_table,
             params.op.user.user_email);
@@ -826,7 +826,7 @@ class InsertBucketOp: virtual public DBOp {
   public:
     virtual ~InsertBucketOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query, params.bucket_table,
           params.op.bucket.bucket_name, params.op.bucket.tenant,
           params.op.bucket.marker, params.op.bucket.bucket_id,
@@ -866,7 +866,7 @@ class UpdateBucketOp: virtual public DBOp {
   public:
     virtual ~UpdateBucketOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       if (params.op.query_str == "info") {
         return fmt::format(InfoQuery, params.bucket_table,
             params.op.bucket.tenant, params.op.bucket.marker, params.op.bucket.bucket_id,
@@ -906,7 +906,7 @@ class RemoveBucketOp: virtual public DBOp {
   public:
     virtual ~RemoveBucketOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query, params.bucket_table,
           params.op.bucket.bucket_name);
     }
@@ -926,7 +926,7 @@ class GetBucketOp: virtual public DBOp {
   public:
     virtual ~GetBucketOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       //return fmt::format(Query, params.op.bucket.bucket_name,
       //          params.bucket_table, params.user_table);
       return fmt::format(Query,
@@ -963,7 +963,7 @@ class ListUserBucketsOp: virtual public DBOp {
   public:
     virtual ~ListUserBucketsOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       if (params.op.query_str == "all") {
         return fmt::format(AllQuery, params.bucket_table,
           params.op.bucket.min_marker,
@@ -996,7 +996,7 @@ class PutObjectOp: virtual public DBOp {
   public:
     virtual ~PutObjectOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query,
           params.object_table, params.op.obj.obj_name,
           params.op.obj.obj_instance, params.op.obj.obj_ns,
@@ -1033,7 +1033,7 @@ class DeleteObjectOp: virtual public DBOp {
   public:
     virtual ~DeleteObjectOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query, params.object_table,
           params.op.bucket.bucket_name,
           params.op.obj.obj_name,
@@ -1059,7 +1059,7 @@ class GetObjectOp: virtual public DBOp {
   public:
     virtual ~GetObjectOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query,
           params.object_table,
           params.op.bucket.bucket_name,
@@ -1087,7 +1087,7 @@ class ListBucketObjectsOp: virtual public DBOp {
   public:
     virtual ~ListBucketObjectsOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       /* XXX: Include obj_id, delim */
       return fmt::format(Query,
           params.object_table,
@@ -1128,7 +1128,7 @@ class UpdateObjectOp: virtual public DBOp {
   public:
     virtual ~UpdateObjectOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       if (params.op.query_str == "omap") {
         return fmt::format(OmapQuery,
             params.object_table, params.op.obj.omap,
@@ -1195,7 +1195,7 @@ class PutObjectDataOp: virtual public DBOp {
   public:
     virtual ~PutObjectDataOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query,
           params.objectdata_table,
           params.op.obj.obj_name, params.op.obj.obj_instance,
@@ -1222,7 +1222,7 @@ class UpdateObjectDataOp: virtual public DBOp {
   public:
     virtual ~UpdateObjectDataOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query,
           params.objectdata_table,
           params.op.obj.mtime,
@@ -1241,7 +1241,7 @@ class GetObjectDataOp: virtual public DBOp {
   public:
     virtual ~GetObjectDataOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query,
           params.objectdata_table,
           params.op.bucket.bucket_name,
@@ -1259,7 +1259,7 @@ class DeleteObjectDataOp: virtual public DBOp {
   public:
     virtual ~DeleteObjectDataOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query,
           params.objectdata_table,
           params.op.bucket.bucket_name,
@@ -1277,7 +1277,7 @@ class DeleteStaleObjectDataOp: virtual public DBOp {
   public:
     virtual ~DeleteStaleObjectDataOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query,
           params.objectdata_table,
           params.objectdata_table,
@@ -1296,7 +1296,7 @@ class InsertLCEntryOp: virtual public DBOp {
   public:
     virtual ~InsertLCEntryOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query, params.lc_entry_table,
           params.op.lc_entry.index, params.op.lc_entry.bucket_name,
           params.op.lc_entry.start_time, params.op.lc_entry.status);
@@ -1311,7 +1311,7 @@ class RemoveLCEntryOp: virtual public DBOp {
   public:
     virtual ~RemoveLCEntryOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query, params.lc_entry_table,
           params.op.lc_entry.index, params.op.lc_entry.bucket_name);
     }
@@ -1329,7 +1329,7 @@ class GetLCEntryOp: virtual public DBOp {
   public:
     virtual ~GetLCEntryOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       if (params.op.query_str == "get_next_entry") {
         return fmt::format(NextQuery, params.lc_entry_table,
             params.op.lc_entry.index, params.op.lc_entry.bucket_name);
@@ -1349,7 +1349,7 @@ class ListLCEntriesOp: virtual public DBOp {
   public:
     virtual ~ListLCEntriesOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query, params.lc_entry_table,
           params.op.lc_entry.index, params.op.lc_entry.min_marker,
           params.op.list_max_count);
@@ -1366,7 +1366,7 @@ class InsertLCHeadOp: virtual public DBOp {
   public:
     virtual ~InsertLCHeadOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query, params.lc_head_table,
           params.op.lc_head.index, params.op.lc_head.marker,
           params.op.lc_head.start_date);
@@ -1381,7 +1381,7 @@ class RemoveLCHeadOp: virtual public DBOp {
   public:
     virtual ~RemoveLCHeadOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query, params.lc_head_table,
           params.op.lc_head.index);
     }
@@ -1396,7 +1396,7 @@ class GetLCHeadOp: virtual public DBOp {
   public:
     virtual ~GetLCHeadOp() {}
 
-    std::string Schema(DBOpPrepareParams &params) {
+    static std::string Schema(DBOpPrepareParams &params) {
       return fmt::format(Query, params.lc_head_table,
           params.op.lc_head.index);
     }

--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -1505,7 +1505,7 @@ class DB {
     int Lock(const DoutPrefixProvider *dpp);
     int Unlock(const DoutPrefixProvider *dpp);
 
-    int InitializeParams(const DoutPrefixProvider *dpp, std::string Op, DBOpParams *params);
+    int InitializeParams(const DoutPrefixProvider *dpp, DBOpParams *params);
     int ProcessOp(const DoutPrefixProvider *dpp, std::string_view Op, DBOpParams *params);
     DBOp* getDBOp(const DoutPrefixProvider *dpp, std::string_view Op, const DBOpParams *params);
     int objectmapInsert(const DoutPrefixProvider *dpp, std::string bucket, class ObjectOp* ptr);

--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -159,11 +159,11 @@ struct DBOpParams {
  * to get the right index of each param.
  */
 struct DBOpUserPrepareInfo {
-  std::string user_id = ":user_id";
-  std::string tenant = ":tenant";
-  std::string ns = ":ns";
-  std::string display_name = ":display_name";
-  std::string user_email = ":user_email";
+  static constexpr const char* user_id = ":user_id";
+  static constexpr const char* tenant = ":tenant";
+  static constexpr const char* ns = ":ns";
+  static constexpr const char* display_name = ":display_name";
+  static constexpr const char* user_email = ":user_email";
   /* Support only single access_key for now. So store
    * it separately as primary access_key_id & secret to
    * be able to query easily.
@@ -171,141 +171,141 @@ struct DBOpUserPrepareInfo {
    * In future, when need to support & query from multiple
    * access keys, better to maintain them in a separate table.
    */
-  std::string access_keys_id = ":access_keys_id";
-  std::string access_keys_secret = ":access_keys_secret";
-  std::string access_keys = ":access_keys";
-  std::string swift_keys = ":swift_keys";
-  std::string subusers = ":subusers";
-  std::string suspended = ":suspended";
-  std::string max_buckets = ":max_buckets";
-  std::string op_mask = ":op_mask";
-  std::string user_caps = ":user_caps";
-  std::string admin = ":admin";
-  std::string system = ":system";
-  std::string placement_name = ":placement_name";
-  std::string placement_storage_class = ":placement_storage_class";
-  std::string placement_tags = ":placement_tags";
-  std::string bucket_quota = ":bucket_quota";
-  std::string temp_url_keys = ":temp_url_keys";
-  std::string user_quota = ":user_quota";
-  std::string type = ":type";
-  std::string mfa_ids = ":mfa_ids";
-  std::string assumed_role_arn = ":assumed_role_arn";
-  std::string user_attrs = ":user_attrs";
-  std::string user_ver = ":user_vers";
-  std::string user_ver_tag = ":user_ver_tag";
+  static constexpr const char* access_keys_id = ":access_keys_id";
+  static constexpr const char* access_keys_secret = ":access_keys_secret";
+  static constexpr const char* access_keys = ":access_keys";
+  static constexpr const char* swift_keys = ":swift_keys";
+  static constexpr const char* subusers = ":subusers";
+  static constexpr const char* suspended = ":suspended";
+  static constexpr const char* max_buckets = ":max_buckets";
+  static constexpr const char* op_mask = ":op_mask";
+  static constexpr const char* user_caps = ":user_caps";
+  static constexpr const char* admin = ":admin";
+  static constexpr const char* system = ":system";
+  static constexpr const char* placement_name = ":placement_name";
+  static constexpr const char* placement_storage_class = ":placement_storage_class";
+  static constexpr const char* placement_tags = ":placement_tags";
+  static constexpr const char* bucket_quota = ":bucket_quota";
+  static constexpr const char* temp_url_keys = ":temp_url_keys";
+  static constexpr const char* user_quota = ":user_quota";
+  static constexpr const char* type = ":type";
+  static constexpr const char* mfa_ids = ":mfa_ids";
+  static constexpr const char* assumed_role_arn = ":assumed_role_arn";
+  static constexpr const char* user_attrs = ":user_attrs";
+  static constexpr const char* user_ver = ":user_vers";
+  static constexpr const char* user_ver_tag = ":user_ver_tag";
 };
 
 struct DBOpBucketPrepareInfo {
-  std::string bucket_name = ":bucket_name";
-  std::string tenant = ":tenant";
-  std::string marker = ":marker";
-  std::string bucket_id = ":bucket_id";
-  std::string size = ":size";
-  std::string size_rounded = ":size_rounded";
-  std::string creation_time = ":creation_time";
-  std::string count = ":count";
-  std::string placement_name = ":placement_name";
-  std::string placement_storage_class = ":placement_storage_class";
+  static constexpr const char* bucket_name = ":bucket_name";
+  static constexpr const char* tenant = ":tenant";
+  static constexpr const char* marker = ":marker";
+  static constexpr const char* bucket_id = ":bucket_id";
+  static constexpr const char* size = ":size";
+  static constexpr const char* size_rounded = ":size_rounded";
+  static constexpr const char* creation_time = ":creation_time";
+  static constexpr const char* count = ":count";
+  static constexpr const char* placement_name = ":placement_name";
+  static constexpr const char* placement_storage_class = ":placement_storage_class";
   /* ownerid - maps to DBOpUserPrepareInfo */
-  std::string flags = ":flags";
-  std::string zonegroup = ":zonegroup";
-  std::string has_instance_obj = ":has_instance_obj";
-  std::string quota = ":quota";
-  std::string requester_pays = ":requester_pays";
-  std::string has_website = ":has_website";
-  std::string website_conf = ":website_conf";
-  std::string swift_versioning = ":swift_versioning";
-  std::string swift_ver_location = ":swift_ver_location";
-  std::string mdsearch_config = ":mdsearch_config";
-  std::string new_bucket_instance_id = ":new_bucket_instance_id";
-  std::string obj_lock = ":obj_lock";
-  std::string sync_policy_info_groups = ":sync_policy_info_groups";
-  std::string bucket_attrs = ":bucket_attrs";
-  std::string bucket_ver = ":bucket_vers";
-  std::string bucket_ver_tag = ":bucket_ver_tag";
-  std::string mtime = ":mtime";
-  std::string min_marker = ":min_marker";
-  std::string max_marker = ":max_marker";
+  static constexpr const char* flags = ":flags";
+  static constexpr const char* zonegroup = ":zonegroup";
+  static constexpr const char* has_instance_obj = ":has_instance_obj";
+  static constexpr const char* quota = ":quota";
+  static constexpr const char* requester_pays = ":requester_pays";
+  static constexpr const char* has_website = ":has_website";
+  static constexpr const char* website_conf = ":website_conf";
+  static constexpr const char* swift_versioning = ":swift_versioning";
+  static constexpr const char* swift_ver_location = ":swift_ver_location";
+  static constexpr const char* mdsearch_config = ":mdsearch_config";
+  static constexpr const char* new_bucket_instance_id = ":new_bucket_instance_id";
+  static constexpr const char* obj_lock = ":obj_lock";
+  static constexpr const char* sync_policy_info_groups = ":sync_policy_info_groups";
+  static constexpr const char* bucket_attrs = ":bucket_attrs";
+  static constexpr const char* bucket_ver = ":bucket_vers";
+  static constexpr const char* bucket_ver_tag = ":bucket_ver_tag";
+  static constexpr const char* mtime = ":mtime";
+  static constexpr const char* min_marker = ":min_marker";
+  static constexpr const char* max_marker = ":max_marker";
 };
 
 struct DBOpObjectPrepareInfo {
-  std::string obj_name = ":obj_name";
-  std::string obj_instance = ":obj_instance";
-  std::string obj_ns  = ":obj_ns";
-  std::string acls = ":acls";
-  std::string index_ver = ":index_ver";
-  std::string tag = ":tag";
-  std::string flags = ":flags";
-  std::string versioned_epoch = ":versioned_epoch";
-  std::string obj_category = ":obj_category";
-  std::string etag = ":etag";
-  std::string owner = ":owner";
-  std::string owner_display_name = ":owner_display_name";
-  std::string storage_class = ":storage_class";
-  std::string appendable = ":appendable";
-  std::string content_type = ":content_type";
-  std::string index_hash_source = ":index_hash_source";
-  std::string obj_size = ":obj_size";
-  std::string accounted_size = ":accounted_size";
-  std::string mtime = ":mtime";
-  std::string epoch = ":epoch";
-  std::string obj_tag = ":obj_tag";
-  std::string tail_tag = ":tail_tag";
-  std::string write_tag = ":write_tag";
-  std::string fake_tag = ":fake_tag";
-  std::string shadow_obj = ":shadow_obj";
-  std::string has_data = ":has_data";
-  std::string is_olh = ":is_ols";
-  std::string olh_tag = ":olh_tag";
-  std::string pg_ver = ":pg_ver";
-  std::string zone_short_id = ":zone_short_id";
-  std::string obj_version = ":obj_version";
-  std::string obj_version_tag = ":obj_version_tag";
-  std::string obj_attrs = ":obj_attrs";
-  std::string head_size = ":head_size";
-  std::string max_head_size = ":max_head_size";
-  std::string obj_id = ":obj_id";
-  std::string tail_instance = ":tail_instance";
-  std::string head_placement_rule_name = ":head_placement_rule_name";
-  std::string head_placement_storage_class  = ":head_placement_storage_class";
-  std::string tail_placement_rule_name = ":tail_placement_rule_name";
-  std::string tail_placement_storage_class  = ":tail_placement_storage_class";
-  std::string manifest_part_objs = ":manifest_part_objs";
-  std::string manifest_part_rules = ":manifest_part_rules";
-  std::string omap = ":omap";
-  std::string is_multipart = ":is_multipart";
-  std::string mp_parts = ":mp_parts";
-  std::string head_data = ":head_data";
-  std::string min_marker = ":min_marker";
-  std::string max_marker = ":max_marker";
+  static constexpr const char* obj_name = ":obj_name";
+  static constexpr const char* obj_instance = ":obj_instance";
+  static constexpr const char* obj_ns  = ":obj_ns";
+  static constexpr const char* acls = ":acls";
+  static constexpr const char* index_ver = ":index_ver";
+  static constexpr const char* tag = ":tag";
+  static constexpr const char* flags = ":flags";
+  static constexpr const char* versioned_epoch = ":versioned_epoch";
+  static constexpr const char* obj_category = ":obj_category";
+  static constexpr const char* etag = ":etag";
+  static constexpr const char* owner = ":owner";
+  static constexpr const char* owner_display_name = ":owner_display_name";
+  static constexpr const char* storage_class = ":storage_class";
+  static constexpr const char* appendable = ":appendable";
+  static constexpr const char* content_type = ":content_type";
+  static constexpr const char* index_hash_source = ":index_hash_source";
+  static constexpr const char* obj_size = ":obj_size";
+  static constexpr const char* accounted_size = ":accounted_size";
+  static constexpr const char* mtime = ":mtime";
+  static constexpr const char* epoch = ":epoch";
+  static constexpr const char* obj_tag = ":obj_tag";
+  static constexpr const char* tail_tag = ":tail_tag";
+  static constexpr const char* write_tag = ":write_tag";
+  static constexpr const char* fake_tag = ":fake_tag";
+  static constexpr const char* shadow_obj = ":shadow_obj";
+  static constexpr const char* has_data = ":has_data";
+  static constexpr const char* is_olh = ":is_ols";
+  static constexpr const char* olh_tag = ":olh_tag";
+  static constexpr const char* pg_ver = ":pg_ver";
+  static constexpr const char* zone_short_id = ":zone_short_id";
+  static constexpr const char* obj_version = ":obj_version";
+  static constexpr const char* obj_version_tag = ":obj_version_tag";
+  static constexpr const char* obj_attrs = ":obj_attrs";
+  static constexpr const char* head_size = ":head_size";
+  static constexpr const char* max_head_size = ":max_head_size";
+  static constexpr const char* obj_id = ":obj_id";
+  static constexpr const char* tail_instance = ":tail_instance";
+  static constexpr const char* head_placement_rule_name = ":head_placement_rule_name";
+  static constexpr const char* head_placement_storage_class  = ":head_placement_storage_class";
+  static constexpr const char* tail_placement_rule_name = ":tail_placement_rule_name";
+  static constexpr const char* tail_placement_storage_class  = ":tail_placement_storage_class";
+  static constexpr const char* manifest_part_objs = ":manifest_part_objs";
+  static constexpr const char* manifest_part_rules = ":manifest_part_rules";
+  static constexpr const char* omap = ":omap";
+  static constexpr const char* is_multipart = ":is_multipart";
+  static constexpr const char* mp_parts = ":mp_parts";
+  static constexpr const char* head_data = ":head_data";
+  static constexpr const char* min_marker = ":min_marker";
+  static constexpr const char* max_marker = ":max_marker";
   /* Below used to update mp_parts obj name
    * from meta object to src object on completion */
-  std::string new_obj_name = ":new_obj_name";
-  std::string new_obj_instance = ":new_obj_instance";
-  std::string new_obj_ns  = ":new_obj_ns";
+  static constexpr const char* new_obj_name = ":new_obj_name";
+  static constexpr const char* new_obj_instance = ":new_obj_instance";
+  static constexpr const char* new_obj_ns  = ":new_obj_ns";
 };
 
 struct DBOpObjectDataPrepareInfo {
-  std::string part_num = ":part_num";
-  std::string offset = ":offset";
-  std::string data = ":data";
-  std::string size = ":size";
-  std::string multipart_part_str = ":multipart_part_str";
+  static constexpr const char* part_num = ":part_num";
+  static constexpr const char* offset = ":offset";
+  static constexpr const char* data = ":data";
+  static constexpr const char* size = ":size";
+  static constexpr const char* multipart_part_str = ":multipart_part_str";
 };
 
 struct DBOpLCEntryPrepareInfo {
-  std::string index = ":index";
-  std::string bucket_name = ":bucket_name";
-  std::string start_time = ":start_time";
-  std::string status = ":status";
-  std::string min_marker = ":min_marker";
+  static constexpr const char* index = ":index";
+  static constexpr const char* bucket_name = ":bucket_name";
+  static constexpr const char* start_time = ":start_time";
+  static constexpr const char* status = ":status";
+  static constexpr const char* min_marker = ":min_marker";
 };
 
 struct DBOpLCHeadPrepareInfo {
-  std::string index = ":index";
-  std::string start_date = ":start_date";
-  std::string marker = ":marker";
+  static constexpr const char* index = ":index";
+  static constexpr const char* start_date = ":start_date";
+  static constexpr const char* marker = ":marker";
 };
 
 struct DBOpPrepareInfo {
@@ -316,7 +316,7 @@ struct DBOpPrepareInfo {
   DBOpObjectDataPrepareInfo obj_data;
   DBOpLCHeadPrepareInfo lc_head;
   DBOpLCEntryPrepareInfo lc_entry;
-  std::string list_max_count = ":list_max_count";
+  static constexpr const char* list_max_count = ":list_max_count";
 };
 
 struct DBOpPrepareParams {

--- a/src/rgw/store/dbstore/dbstore_main.cc
+++ b/src/rgw/store/dbstore/dbstore_main.cc
@@ -43,7 +43,7 @@ void* process(void *arg)
   DBOpParams params = {};
   const DoutPrefixProvider *dpp = db->get_def_dpp();
 
-  db->InitializeParams(dpp, "InsertUser", &params);
+  db->InitializeParams(dpp, &params);
 
   params.op.user.uinfo.display_name = user1;
   params.op.user.uinfo.user_id.tenant = "tenant";
@@ -65,7 +65,7 @@ void* process(void *arg)
   DBOpParams params2 = {};
   params.op.user.uinfo.user_id.tenant = "tenant2";
 
-  db->InitializeParams(dpp, "GetUser", &params2);
+  db->InitializeParams(dpp, &params2);
   params2.op.user.uinfo.display_name = user1;
   ret = db->ProcessOp(dpp, "GetUser", &params2);
 

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.cc
@@ -1114,19 +1114,19 @@ int SQLInsertUser::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.tenant.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.tenant, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.user_id.tenant.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_id.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_id, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.user_id.id.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.ns.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.ns, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.user_id.ns.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.display_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.display_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.display_name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_email.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_email, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.user_email.c_str(), sdb);
 
   if (!params->op.user.uinfo.access_keys.empty()) {
@@ -1138,74 +1138,74 @@ int SQLInsertUser::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params
     access_key = k.id;
     key = k.key;
 
-    SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.access_keys_id.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.access_keys_id, sdb);
     SQL_BIND_TEXT(dpp, stmt, index, access_key.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.access_keys_secret.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.access_keys_secret, sdb);
     SQL_BIND_TEXT(dpp, stmt, index, key.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.access_keys.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.access_keys, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.uinfo.access_keys, sdb);
   }
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.swift_keys.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.swift_keys, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.uinfo.swift_keys, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.subusers.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.subusers, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.uinfo.subusers, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.suspended.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.suspended, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.user.uinfo.suspended, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.max_buckets.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.max_buckets, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.user.uinfo.max_buckets, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.op_mask.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.op_mask, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.user.uinfo.op_mask, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_caps.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_caps, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.uinfo.caps, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.admin.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.admin, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.user.uinfo.admin, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.system.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.system, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.user.uinfo.system, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.placement_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.placement_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.default_placement.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.placement_storage_class.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.placement_storage_class, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.default_placement.storage_class.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.placement_tags.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.placement_tags, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.uinfo.placement_tags, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.bucket_quota.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.bucket_quota, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.uinfo.bucket_quota, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.temp_url_keys.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.temp_url_keys, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.uinfo.temp_url_keys, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_quota.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_quota, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.uinfo.user_quota, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.type.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.type, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.user.uinfo.type, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.mfa_ids.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.mfa_ids, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.uinfo.mfa_ids, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.assumed_role_arn.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.assumed_role_arn, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.assumed_role_arn.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_attrs.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_attrs, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.user_attrs, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_ver.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_ver, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.user.user_version.ver, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_ver_tag.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_ver_tag, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.user.user_version.tag.c_str(), sdb);
 
 out:
@@ -1244,7 +1244,7 @@ int SQLRemoveUser::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_id.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_id, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.user_id.id.c_str(), sdb);
 
 out:
@@ -1292,7 +1292,7 @@ int SQLGetUser::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
   struct DBOpPrepareParams p_params = PrepareParams;
 
   if (params->op.query_str == "email") { 
-    SQL_BIND_INDEX(dpp, email_stmt, index, p_params.op.user.user_email.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, email_stmt, index, p_params.op.user.user_email, sdb);
     SQL_BIND_TEXT(dpp, email_stmt, index, params->op.user.uinfo.user_email.c_str(), sdb);
   } else if (params->op.query_str == "access_key") { 
     if (!params->op.user.uinfo.access_keys.empty()) {
@@ -1302,20 +1302,20 @@ int SQLGetUser::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
       const RGWAccessKey& k = it->second;
       access_key = k.id;
 
-      SQL_BIND_INDEX(dpp, ak_stmt, index, p_params.op.user.access_keys_id.c_str(), sdb);
+      SQL_BIND_INDEX(dpp, ak_stmt, index, p_params.op.user.access_keys_id, sdb);
       SQL_BIND_TEXT(dpp, ak_stmt, index, access_key.c_str(), sdb);
     }
   } else if (params->op.query_str == "user_id") { 
-    SQL_BIND_INDEX(dpp, userid_stmt, index, p_params.op.user.tenant.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, userid_stmt, index, p_params.op.user.tenant, sdb);
     SQL_BIND_TEXT(dpp, userid_stmt, index, params->op.user.uinfo.user_id.tenant.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, userid_stmt, index, p_params.op.user.user_id.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, userid_stmt, index, p_params.op.user.user_id, sdb);
     SQL_BIND_TEXT(dpp, userid_stmt, index, params->op.user.uinfo.user_id.id.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, userid_stmt, index, p_params.op.user.ns.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, userid_stmt, index, p_params.op.user.ns, sdb);
     SQL_BIND_TEXT(dpp, userid_stmt, index, params->op.user.uinfo.user_id.ns.c_str(), sdb);
   } else { // by default by userid
-    SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_id.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_id, sdb);
     SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.user_id.id.c_str(), sdb);
   }
 
@@ -1366,88 +1366,88 @@ int SQLInsertBucket::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *para
   struct DBOpPrepareParams p_params = PrepareParams;
 
   // user_id here is copied as OwnerID in the bucket table.
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_id.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_id, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.user_id.id.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.tenant.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.tenant, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.tenant.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.marker.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.marker, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.marker.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_id.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_id, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.bucket_id.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.size.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.size, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.bucket.ent.size, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.size_rounded.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.size_rounded, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.bucket.ent.size_rounded, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.creation_time.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.creation_time, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.bucket.info.creation_time, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.count.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.count, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.bucket.ent.count, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.placement_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.placement_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.placement_rule.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.placement_storage_class.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.placement_storage_class, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.placement_rule.storage_class.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.flags.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.flags, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.bucket.info.flags, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.zonegroup.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.zonegroup, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.zonegroup.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.has_instance_obj.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.has_instance_obj, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.bucket.info.has_instance_obj, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.quota.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.quota, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.bucket.info.quota, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.requester_pays.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.requester_pays, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.bucket.info.requester_pays, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.has_website.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.has_website, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.bucket.info.has_website, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.website_conf.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.website_conf, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.bucket.info.website_conf, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.swift_versioning.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.swift_versioning, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.bucket.info.swift_versioning, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.swift_ver_location.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.swift_ver_location, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.swift_ver_location.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.mdsearch_config.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.mdsearch_config, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.bucket.info.mdsearch_config, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.new_bucket_instance_id.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.new_bucket_instance_id, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.new_bucket_instance_id.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.obj_lock.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.obj_lock, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.bucket.info.obj_lock, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.sync_policy_info_groups.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.sync_policy_info_groups, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.bucket.info.sync_policy, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_attrs.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_attrs, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.bucket.bucket_attrs, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_ver.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_ver, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.bucket.bucket_version.ver, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_ver_tag.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_ver_tag, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.bucket_version.tag.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.mtime.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.mtime, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.bucket.mtime, sdb);
 
 out:
@@ -1526,83 +1526,83 @@ int SQLUpdateBucket::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *para
   }
 
   if (params->op.query_str == "attrs") { 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.bucket_attrs.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.bucket_attrs, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.bucket.bucket_attrs, sdb);
   } else if (params->op.query_str == "owner") { 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.creation_time.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.creation_time, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.bucket.info.creation_time, sdb);
   } else if (params->op.query_str == "info") { 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.tenant.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.tenant, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.bucket.info.bucket.tenant.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.marker.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.marker, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.bucket.info.bucket.marker.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.bucket_id.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.bucket_id, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.bucket.info.bucket.bucket_id.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.creation_time.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.creation_time, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.bucket.info.creation_time, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.count.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.count, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.bucket.ent.count, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.placement_name.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.placement_name, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.bucket.info.placement_rule.name.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.placement_storage_class.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.placement_storage_class, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.bucket.info.placement_rule.storage_class.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.flags.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.flags, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.bucket.info.flags, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.zonegroup.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.zonegroup, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.bucket.info.zonegroup.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.has_instance_obj.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.has_instance_obj, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.bucket.info.has_instance_obj, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.quota.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.quota, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.bucket.info.quota, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.requester_pays.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.requester_pays, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.bucket.info.requester_pays, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.has_website.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.has_website, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.bucket.info.has_website, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.website_conf.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.website_conf, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.bucket.info.website_conf, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.swift_versioning.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.swift_versioning, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.bucket.info.swift_versioning, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.swift_ver_location.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.swift_ver_location, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.bucket.info.swift_ver_location.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.mdsearch_config.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.mdsearch_config, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.bucket.info.mdsearch_config, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.new_bucket_instance_id.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.new_bucket_instance_id, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.bucket.info.new_bucket_instance_id.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.obj_lock.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.obj_lock, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.bucket.info.obj_lock, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.sync_policy_info_groups.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.sync_policy_info_groups, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.bucket.info.sync_policy, sdb);
   }
 
-  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.user.user_id.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.user.user_id, sdb);
   SQL_BIND_TEXT(dpp, *stmt, index, params->op.user.uinfo.user_id.id.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, *stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.bucket_ver.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.bucket_ver, sdb);
   SQL_BIND_INT(dpp, *stmt, index, params->op.bucket.bucket_version.ver, sdb);
 
-  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.mtime.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.mtime, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.bucket.mtime, sdb);
 
 out:
@@ -1655,7 +1655,7 @@ int SQLRemoveBucket::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *para
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
 
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
@@ -1698,7 +1698,7 @@ int SQLGetBucket::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
 
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
@@ -1758,14 +1758,14 @@ int SQLListUserBuckets::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *p
   }
 
   if (params->op.query_str != "all") { 
-    SQL_BIND_INDEX(dpp, *pstmt, index, p_params.op.user.user_id.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *pstmt, index, p_params.op.user.user_id, sdb);
     SQL_BIND_TEXT(dpp, *pstmt, index, params->op.user.uinfo.user_id.id.c_str(), sdb);
   }
 
-  SQL_BIND_INDEX(dpp, *pstmt, index, p_params.op.bucket.min_marker.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *pstmt, index, p_params.op.bucket.min_marker, sdb);
   SQL_BIND_TEXT(dpp, *pstmt, index, params->op.bucket.min_marker.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, *pstmt, index, p_params.op.list_max_count.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *pstmt, index, p_params.op.list_max_count, sdb);
   SQL_BIND_INT(dpp, *pstmt, index, params->op.list_max_count, sdb);
 
 out:
@@ -1808,148 +1808,148 @@ int SQLPutObject::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.instance.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_ns.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_ns, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.ns.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.acls.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.acls, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.acls, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.index_ver.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.index_ver, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.index_ver, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.tag.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.tag, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.tag.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.flags.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.flags, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.flags, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.versioned_epoch.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.versioned_epoch, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.versioned_epoch, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_category.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_category, sdb);
   SQL_BIND_INT(dpp, stmt, index, (uint8_t)(params->op.obj.category), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.etag.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.etag, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.etag.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.owner.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.owner, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.owner.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.owner_display_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.owner_display_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.owner_display_name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.storage_class.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.storage_class, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.storage_class.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.appendable.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.appendable, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.appendable, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.content_type.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.content_type, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.content_type.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.index_hash_source.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.index_hash_source, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.index_hash_source.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_size.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_size, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.state.size, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.accounted_size.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.accounted_size, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.state.accounted_size, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.mtime.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.mtime, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.state.mtime, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.epoch.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.epoch, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.state.epoch, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_tag.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_tag, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.state.obj_tag, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.tail_tag.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.tail_tag, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.state.tail_tag, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.write_tag.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.write_tag, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.write_tag.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.fake_tag.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.fake_tag, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.state.fake_tag, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.shadow_obj.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.shadow_obj, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.shadow_obj.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.has_data.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.has_data, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.state.has_data, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.is_olh.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.is_olh, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.state.is_olh, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.olh_tag.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.olh_tag, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.state.olh_tag, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.pg_ver.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.pg_ver, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.state.pg_ver, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.zone_short_id.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.zone_short_id, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.state.zone_short_id, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_version.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_version, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.state.objv_tracker.read_version.ver, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_version_tag.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_version_tag, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.objv_tracker.read_version.tag.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_attrs.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_attrs, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.state.attrset, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.head_size.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.head_size, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.head_size, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.max_head_size.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.max_head_size, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.max_head_size, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_id.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_id, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.obj_id.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.tail_instance.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.tail_instance, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.tail_instance.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.head_placement_rule_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.head_placement_rule_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.head_placement_rule.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.head_placement_storage_class.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.head_placement_storage_class, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.head_placement_rule.storage_class.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.tail_placement_rule_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.tail_placement_rule_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.tail_placement.placement_rule.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.tail_placement_storage_class.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.tail_placement_storage_class, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.tail_placement.placement_rule.storage_class.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.manifest_part_objs.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.manifest_part_objs, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.objs, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.manifest_part_rules.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.manifest_part_rules, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.rules, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.omap.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.omap, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.omap, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.is_multipart.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.is_multipart, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.is_multipart, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.mp_parts.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.mp_parts, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.mp_parts, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.head_data.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.head_data, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.head_data, sdb);
 
 
@@ -1989,13 +1989,13 @@ int SQLDeleteObject::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *para
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.instance.c_str(), sdb);
 out:
   return rc;
@@ -2033,13 +2033,13 @@ int SQLGetObject::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.instance.c_str(), sdb);
 
 out:
@@ -2109,161 +2109,161 @@ int SQLUpdateObject::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *para
     goto out;
   }
 
-  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, *stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_name, sdb);
   SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.state.obj.key.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_instance.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_instance, sdb);
   SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.state.obj.key.instance.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.mtime.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.mtime, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.state.mtime, sdb);
 
   if (params->op.query_str == "omap") { 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.omap.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.omap, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.omap, sdb);
   }
   if (params->op.query_str == "attrs") { 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_attrs.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_attrs, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.state.attrset, sdb);
   }
   if (params->op.query_str == "mp") { 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.mp_parts.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.mp_parts, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.mp_parts, sdb);
   }
   if (params->op.query_str == "meta") { 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_ns.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_ns, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.state.obj.key.ns.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.acls.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.acls, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.acls, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.index_ver.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.index_ver, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.index_ver, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.tag.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.tag, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.tag.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.flags.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.flags, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.flags, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.versioned_epoch.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.versioned_epoch, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.versioned_epoch, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_category.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_category, sdb);
     SQL_BIND_INT(dpp, *stmt, index, (uint8_t)(params->op.obj.category), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.etag.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.etag, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.etag.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.owner.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.owner, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.owner.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.owner_display_name.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.owner_display_name, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.owner_display_name.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.storage_class.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.storage_class, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.storage_class.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.appendable.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.appendable, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.appendable, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.content_type.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.content_type, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.content_type.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.index_hash_source.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.index_hash_source, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.state.obj.index_hash_source.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_size.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_size, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.state.size, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.accounted_size.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.accounted_size, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.state.accounted_size, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.epoch.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.epoch, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.state.epoch, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_tag.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_tag, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.state.obj_tag, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.tail_tag.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.tail_tag, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.state.tail_tag, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.write_tag.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.write_tag, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.state.write_tag.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.fake_tag.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.fake_tag, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.state.fake_tag, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.shadow_obj.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.shadow_obj, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.state.shadow_obj.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.has_data.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.has_data, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.state.has_data, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.is_olh.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.is_olh, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.state.is_olh, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.olh_tag.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.olh_tag, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.state.olh_tag, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.pg_ver.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.pg_ver, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.state.pg_ver, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.zone_short_id.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.zone_short_id, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.state.zone_short_id, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_version.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_version, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.state.objv_tracker.read_version.ver, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_version_tag.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_version_tag, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.state.objv_tracker.read_version.tag.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_attrs.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_attrs, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.state.attrset, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.head_size.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.head_size, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.head_size, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.max_head_size.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.max_head_size, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.max_head_size, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_id.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.obj_id, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.obj_id.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.tail_instance.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.tail_instance, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.tail_instance.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.head_placement_rule_name.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.head_placement_rule_name, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.head_placement_rule.name.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.head_placement_storage_class.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.head_placement_storage_class, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.head_placement_rule.storage_class.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.tail_placement_rule_name.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.tail_placement_rule_name, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.tail_placement.placement_rule.name.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.tail_placement_storage_class.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.tail_placement_storage_class, sdb);
     SQL_BIND_TEXT(dpp, *stmt, index, params->op.obj.tail_placement.placement_rule.storage_class.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.manifest_part_objs.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.manifest_part_objs, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.objs, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.manifest_part_rules.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.manifest_part_rules, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.rules, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.omap.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.omap, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.omap, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.is_multipart.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.is_multipart, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.is_multipart, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.mp_parts.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.mp_parts, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.mp_parts, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.head_data.c_str(), sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.head_data, sdb);
     SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.head_data, sdb);
   }
 
@@ -2319,13 +2319,13 @@ int SQLListBucketObjects::Bind(const DoutPrefixProvider *dpp, struct DBOpParams 
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.min_marker.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.min_marker, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.min_marker.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.list_max_count.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.list_max_count, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.list_max_count, sdb);
 
 out:
@@ -2365,45 +2365,45 @@ int SQLPutObjectData::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *par
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name, sdb);
 
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance, sdb);
 
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.instance.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_ns.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_ns, sdb);
 
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.ns.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
 
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_id.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_id, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.obj_id.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj_data.part_num.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj_data.part_num, sdb);
 
   SQL_BIND_INT(dpp, stmt, index, params->op.obj_data.part_num, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj_data.offset.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj_data.offset, sdb);
 
   SQL_BIND_INT(dpp, stmt, index, params->op.obj_data.offset, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj_data.data.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj_data.data, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj_data.data, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj_data.size.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj_data.size, sdb);
 
   SQL_BIND_INT(dpp, stmt, index, params->op.obj_data.size, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj_data.multipart_part_str.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj_data.multipart_part_str, sdb);
 
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj_data.multipart_part_str.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.mtime.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.mtime, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.state.mtime, sdb);
 
 out:
@@ -2442,19 +2442,19 @@ int SQLUpdateObjectData::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.instance.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_id.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_id, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.obj_id.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.mtime.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.mtime, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.state.mtime, sdb);
 
 out:
@@ -2493,16 +2493,16 @@ int SQLGetObjectData::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *par
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.instance.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_id.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_id, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.obj_id.c_str(), sdb);
 
 out:
@@ -2541,16 +2541,16 @@ int SQLDeleteObjectData::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.name.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_instance, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.instance.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_id.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_id, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.obj_id.c_str(), sdb);
 
 out:
@@ -2589,7 +2589,7 @@ int SQLDeleteStaleObjectData::Bind(const DoutPrefixProvider *dpp, struct DBOpPar
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.mtime.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.mtime, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.state.mtime, sdb);
 
 out:
@@ -2629,16 +2629,16 @@ int SQLInsertLCEntry::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *par
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.index.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.index, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_entry.index.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_entry.entry.bucket.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.status.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.status, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.lc_entry.entry.status, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.start_time.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.start_time, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.lc_entry.entry.start_time, sdb);
 
 out:
@@ -2678,10 +2678,10 @@ int SQLRemoveLCEntry::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *par
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.index.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.index, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_entry.index.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_entry.entry.bucket.c_str(), sdb);
 
 out:
@@ -2733,10 +2733,10 @@ int SQLGetLCEntry::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params
   } else {
     pstmt = &stmt;
   }
-  SQL_BIND_INDEX(dpp, *pstmt, index, p_params.op.lc_entry.index.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *pstmt, index, p_params.op.lc_entry.index, sdb);
   SQL_BIND_TEXT(dpp, *pstmt, index, params->op.lc_entry.index.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, *pstmt, index, p_params.op.lc_entry.bucket_name.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, *pstmt, index, p_params.op.lc_entry.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, *pstmt, index, params->op.lc_entry.entry.bucket.c_str(), sdb);
 
 out:
@@ -2783,13 +2783,13 @@ int SQLListLCEntries::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *par
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.index.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.index, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_entry.index.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.min_marker.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_entry.min_marker, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_entry.min_marker.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.list_max_count.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.list_max_count, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.list_max_count, sdb);
 
 out:
@@ -2829,13 +2829,13 @@ int SQLInsertLCHead::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *para
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.index.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.index, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_head.index.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.marker.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.marker, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_head.head.marker.c_str(), sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.start_date.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.start_date, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.lc_head.head.start_date, sdb);
 
 out:
@@ -2875,7 +2875,7 @@ int SQLRemoveLCHead::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *para
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.index.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.index, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_head.index.c_str(), sdb);
 
 out:
@@ -2915,7 +2915,7 @@ int SQLGetLCHead::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.index.c_str(), sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.index, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_head.index.c_str(), sdb);
 
 out:

--- a/src/rgw/store/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/store/dbstore/tests/dbstore_tests.cc
@@ -106,7 +106,7 @@ namespace {
          * special based on fop. Hence its okay to do
          * global initialization once.
          */
-        ret = db->InitializeParams(dpp, "", &GlobalParams);
+        ret = db->InitializeParams(dpp, &GlobalParams);
         ASSERT_EQ(ret, 0);
       }
 


### PR DESCRIPTION
taking this example:
```c++
class DeleteObjectOp: virtual public DBOp {
  private:
    const std::string Query =
      "DELETE from '{}' where BucketName = {} and ObjName = {} and ObjInstance = {}";
```
here, the string literal `"DELETE from ..."` gets stored in the data segment of the executable. but each time a `RemoveUserOp` is constructed, the `std::string` has to allocate memory and make a copy of that string literal

making this a `static const std::string` is a slight improvement, because this allocation/copy only happens once when the process starts up. but when there are a lot of these static strings, it takes time to initialize them all. and because this is linked into radosgw/radosgw-admin, it would initialize them even when we aren't using dbstore

what we really want is a pointer directly to the string literal. so either a raw pointer:
```c++
static const char* const Query =
  "DELETE from '{}' where BucketName = {} and ObjName = {} and ObjInstance = {}";
```
or a `std::string_view`, which is a pointer and length:
```c++
static constexpr std::string_view Query =
  "DELETE from '{}' where BucketName = {} and ObjName = {} and ObjInstance = {}";
```
there are several tradeoffs to consider here. the biggest one is that `std::string_view` (as a pointer+length) does not represent a null-terminated string, so has no `c_str()` function for use with c APIs that take `const char*`. that means it's mostly for use in pure c++

in this PR, i've only replaced the constant `std::string`s that are passed to `fmt::format()`, which understands `std::string_view`. there are still a lot of static strings, especially in the `*PrepareInfo` structs, which are better suited to `const char*` for use in the sqlite3 interfaces

p.s. incidentially, this also resolves lots of compilation failures with c++20 enabled

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
