### PR TITLE
octopus: mgr/dashboard: dashboard turns telemetry off when configuring report

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -169,6 +169,19 @@
                        i18n-placeholder>
               </div>
             </div>
+            <div class="form-group row">
+              <label class="cd-col-form-label"
+                     for="organization"
+                     i18n>Organization</label>
+              <div class="cd-col-form-input">
+                <input id="organization"
+                       class="form-control"
+                       type="text"
+                       formControlName="organization"
+                       placeholder="Organization name"
+                       i18n-placeholder>
+              </div>
+            </div>
           </ng-container>
             <legend i18n>Advanced Settings</legend>
             <div class="form-group row">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -132,12 +132,14 @@
                   <input type="checkbox"
                          class="custom-control-input"
                          id="channel_ident"
-                         formControlName="channel_ident">
+                         formControlName="channel_ident"
+                         (click)="toggleIdent()">
                   <label class="custom-control-label"
                          for="channel_ident"></label>
                 </div>
               </div>
             </div>
+            <ng-container *ngIf="showContactInfo">
             <legend>
               <ng-container i18n>Contact Information</ng-container>
               <cd-helper i18n>Submitting any contact information is completely optional and disabled by default.</cd-helper>
@@ -167,6 +169,7 @@
                        i18n-placeholder>
               </div>
             </div>
+          </ng-container>
             <legend i18n>Advanced Settings</legend>
             <div class="form-group row">
               <label class="cd-col-form-label"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -80,6 +80,29 @@ describe('TelemetryComponent', () => {
       expect(component).toBeTruthy();
     });
 
+    it('should show/hide ident fields on checking/unchecking', () => {
+      const getContactField = () =>
+        fixture.debugElement.nativeElement.querySelector('input[id=contact]');
+      const getDescriptionField = () =>
+        fixture.debugElement.nativeElement.querySelector('input[id=description]');
+
+      // Initially hidden.
+      expect(getContactField()).toBeFalsy();
+      expect(getDescriptionField()).toBeFalsy();
+
+      // Show fields.
+      component.toggleIdent();
+      fixture.detectChanges();
+      expect(getContactField()).toBeTruthy();
+      expect(getDescriptionField()).toBeTruthy();
+
+      // Hide fields.
+      component.toggleIdent();
+      fixture.detectChanges();
+      expect(getContactField()).toBeFalsy();
+      expect(getDescriptionField()).toBeFalsy();
+    });
+
     it('should set module enability to true correctly', () => {
       expect(component.moduleEnabled).toBeTruthy();
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -96,16 +96,6 @@ describe('TelemetryComponent', () => {
       });
     });
 
-    it('should update the Telemetry configuration', () => {
-      component.updateConfig();
-      const req = httpTesting.expectOne('api/mgr/module/telemetry');
-      expect(req.request.method).toBe('PUT');
-      expect(req.request.body).toEqual({
-        config: {}
-      });
-      req.flush({});
-    });
-
     it('should disable the Telemetry module', () => {
       const message = 'Module disabled message.';
       const followUpFunc = function () {
@@ -162,16 +152,24 @@ describe('TelemetryComponent', () => {
       expect(downloadSpy).toHaveBeenCalledWith(JSON.stringify(reportText, null, 2), filename);
     });
 
-    it('should submit', () => {
+    it('should submit ', () => {
       component.onSubmit();
-      const req = httpTesting.expectOne('api/telemetry');
-      expect(req.request.method).toBe('PUT');
-      expect(req.request.body).toEqual({
+      const req1 = httpTesting.expectOne('api/telemetry');
+      expect(req1.request.method).toBe('PUT');
+      expect(req1.request.body).toEqual({
         enable: true,
         license_name: 'sharing-1-0'
       });
-      req.flush({});
-      expect(router.navigate).toHaveBeenCalledWith(['']);
+      req1.flush({});
+      const req2 = httpTesting.expectOne({
+        url: 'api/mgr/module/telemetry',
+        method: 'PUT'
+      });
+      expect(req2.request.body).toEqual({
+        config: {}
+      });
+      req2.flush({});
+      expect(router.url).toBe('/');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -85,22 +85,28 @@ describe('TelemetryComponent', () => {
         fixture.debugElement.nativeElement.querySelector('input[id=contact]');
       const getDescriptionField = () =>
         fixture.debugElement.nativeElement.querySelector('input[id=description]');
+      const checkVisibility = () => {
+        if (component.showContactInfo) {
+          expect(getContactField()).toBeTruthy();
+          expect(getDescriptionField()).toBeTruthy();
+        } else {
+          expect(getContactField()).toBeFalsy();
+          expect(getDescriptionField()).toBeFalsy();
+        }
+      };
 
-      // Initially hidden.
-      expect(getContactField()).toBeFalsy();
-      expect(getDescriptionField()).toBeFalsy();
+      // Initial check.
+      checkVisibility();
 
-      // Show fields.
+      // toggle fields.
       component.toggleIdent();
       fixture.detectChanges();
-      expect(getContactField()).toBeTruthy();
-      expect(getDescriptionField()).toBeTruthy();
+      checkVisibility();
 
-      // Hide fields.
+      // toggle fields again.
       component.toggleIdent();
       fixture.detectChanges();
-      expect(getContactField()).toBeFalsy();
-      expect(getDescriptionField()).toBeFalsy();
+      checkVisibility();
     });
 
     it('should set module enability to true correctly', () => {
@@ -175,7 +181,7 @@ describe('TelemetryComponent', () => {
       expect(downloadSpy).toHaveBeenCalledWith(JSON.stringify(reportText, null, 2), filename);
     });
 
-    it('should submit ', () => {
+    it('should submit', () => {
       component.onSubmit();
       const req1 = httpTesting.expectOne('api/telemetry');
       expect(req1.request.method).toBe('PUT');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -49,6 +49,7 @@ export class TelemetryComponent implements OnInit {
   sendToUrl = '';
   sendToDeviceUrl = '';
   step = 1;
+  showContactInfo = false;
 
   constructor(
     private formBuilder: CdFormBuilder,
@@ -159,6 +160,10 @@ export class TelemetryComponent implements OnInit {
         this.error = true;
       }
     );
+  }
+
+  toggleIdent() {
+    this.showContactInfo = !this.showContactInfo;
   }
 
   updateConfig() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -32,6 +32,7 @@ export class TelemetryComponent implements OnInit {
   loading = false;
   moduleEnabled: boolean;
   options: Object = {};
+  updatedConfig: Object = {};
   previewForm: CdFormGroup;
   requiredFields = [
     'channel_basic',
@@ -126,12 +127,30 @@ export class TelemetryComponent implements OnInit {
     return result;
   }
 
+  private updateChannelsInReport(updatedConfig: Object = {}) {
+    const channels: string[] = this.report['report']['channels'];
+    const availableChannels: string[] = this.report['report']['channels_available'];
+    const updatedChannels = [];
+    for (const channel of availableChannels) {
+      const key = `channel_${channel}`;
+      // channel unchanged or toggled on
+      if (
+        (!updatedConfig.hasOwnProperty(key) && channels.includes(channel)) ||
+        updatedConfig[key]
+      ) {
+        updatedChannels.push(channel);
+      }
+    }
+    this.report['report']['channels'] = updatedChannels;
+  }
+
   private getReport() {
     this.loading = true;
     this.telemetryService.getReport().subscribe(
       (resp: object) => {
         this.report = resp;
         this.reportId = resp['report']['report_id'];
+        this.updateChannelsInReport(this.updatedConfig);
         this.createPreviewForm();
         this.loading = false;
         this.step++;
@@ -143,32 +162,19 @@ export class TelemetryComponent implements OnInit {
   }
 
   updateConfig() {
-    const config = {};
-    _.forEach(Object.values(this.options), (option) => {
+    this.updatedConfig = {};
+    for (const option of Object.values(this.options)) {
       const control = this.configForm.get(option.name);
+      if (!control.valid) {
+        this.configForm.setErrors({ cdSubmitButton: true });
+        return;
+      }
       // Append the option only if the value has been modified.
       if (control.dirty && control.valid) {
-        config[option.name] = control.value;
+        this.updatedConfig[option.name] = control.value;
       }
-    });
-    this.mgrModuleService.updateConfig('telemetry', config).subscribe(
-      () => {
-        this.disableModule(
-          this.i18n(
-            `Your settings have been applied successfully. \
-Due to privacy/legal reasons the Telemetry module is now disabled until you \
-complete the next step and accept the license.`
-          ),
-          () => {
-            this.getReport();
-          }
-        );
-      },
-      () => {
-        // Reset the 'Submit' button.
-        this.configForm.setErrors({ cdSubmitButton: true });
-      }
-    );
+    }
+    this.getReport();
   }
 
   download(report: object, fileName: string) {
@@ -202,13 +208,35 @@ complete the next step and accept the license.`
   }
 
   onSubmit() {
-    this.telemetryService.enable().subscribe(() => {
-      this.telemetryNotificationService.setVisibility(false);
-      this.notificationService.show(
-        NotificationType.success,
-        this.i18n('The Telemetry module has been configured and activated successfully.')
-      );
-      this.router.navigate(['']);
-    });
+    const observables = [
+      this.telemetryService.enable(),
+      this.mgrModuleService.updateConfig('telemetry', this.updatedConfig)
+    ];
+
+    observableForkJoin(observables).subscribe(
+      () => {
+        this.telemetryNotificationService.setVisibility(false);
+        this.notificationService.show(
+          NotificationType.success,
+          this.i18n('The Telemetry module has been configured and activated successfully.')
+        );
+      },
+      () => {
+        this.telemetryNotificationService.setVisibility(false);
+        this.notificationService.show(
+          NotificationType.error,
+          this.i18n(
+            'An Error occurred while updating the Telemetry module configuration.\
+             Please Try again'
+          )
+        );
+        // Reset the 'Update' button.
+        this.previewForm.setErrors({ cdSubmitButton: true });
+      },
+      () => {
+        this.updatedConfig = {};
+        this.router.navigate(['']);
+      }
+    );
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -32,7 +32,8 @@ export class TelemetryComponent implements OnInit {
   loading = false;
   moduleEnabled: boolean;
   options: Object = {};
-  updatedConfig: Object = {};
+  newConfig: Object = {};
+  configResp: object = {};
   previewForm: CdFormGroup;
   requiredFields = [
     'channel_basic',
@@ -42,14 +43,16 @@ export class TelemetryComponent implements OnInit {
     'interval',
     'proxy',
     'contact',
-    'description'
+    'description',
+    'organization'
   ];
+  contactInfofields = ['contact', 'description', 'organization'];
   report: object = undefined;
   reportId: number = undefined;
   sendToUrl = '';
   sendToDeviceUrl = '';
   step = 1;
-  showContactInfo = false;
+  showContactInfo: boolean;
 
   constructor(
     private formBuilder: CdFormBuilder,
@@ -74,10 +77,11 @@ export class TelemetryComponent implements OnInit {
         this.moduleEnabled = configResp['enabled'];
         this.sendToUrl = configResp['url'];
         this.sendToDeviceUrl = configResp['device_url'];
+        this.showContactInfo = configResp['channel_ident'];
         this.options = _.pick(resp[0], this.requiredFields);
-        const configs = _.pick(configResp, this.requiredFields);
+        this.configResp = _.pick(configResp, this.requiredFields);
         this.createConfigForm();
-        this.configForm.setValue(configs);
+        this.configForm.setValue(this.configResp);
         this.loading = false;
       },
       (_error) => {
@@ -128,21 +132,21 @@ export class TelemetryComponent implements OnInit {
     return result;
   }
 
-  private updateChannelsInReport(updatedConfig: Object = {}) {
-    const channels: string[] = this.report['report']['channels'];
+  private updateReportFromConfig(updatedConfig: Object = {}) {
+    // update channels
     const availableChannels: string[] = this.report['report']['channels_available'];
     const updatedChannels = [];
     for (const channel of availableChannels) {
       const key = `channel_${channel}`;
-      // channel unchanged or toggled on
-      if (
-        (!updatedConfig.hasOwnProperty(key) && channels.includes(channel)) ||
-        updatedConfig[key]
-      ) {
+      if (updatedConfig[key]) {
         updatedChannels.push(channel);
       }
     }
     this.report['report']['channels'] = updatedChannels;
+    // update contactInfo
+    for (const contactInfofield of this.contactInfofields) {
+      this.report['report'][contactInfofield] = updatedConfig[contactInfofield];
+    }
   }
 
   private getReport() {
@@ -151,7 +155,7 @@ export class TelemetryComponent implements OnInit {
       (resp: object) => {
         this.report = resp;
         this.reportId = resp['report']['report_id'];
-        this.updateChannelsInReport(this.updatedConfig);
+        this.updateReportFromConfig(this.newConfig);
         this.createPreviewForm();
         this.loading = false;
         this.step++;
@@ -166,17 +170,22 @@ export class TelemetryComponent implements OnInit {
     this.showContactInfo = !this.showContactInfo;
   }
 
-  updateConfig() {
-    this.updatedConfig = {};
+  buildReport() {
+    this.newConfig = {};
     for (const option of Object.values(this.options)) {
       const control = this.configForm.get(option.name);
-      if (!control.valid) {
+      // Append the option only if they are valid
+      if (control.valid) {
+        this.newConfig[option.name] = control.value;
+      } else {
         this.configForm.setErrors({ cdSubmitButton: true });
         return;
       }
-      // Append the option only if the value has been modified.
-      if (control.dirty && control.valid) {
-        this.updatedConfig[option.name] = control.value;
+    }
+    // reset contact info field  if ident channel is off
+    if (!this.newConfig['channel_ident']) {
+      for (const contactInfofield of this.contactInfofields) {
+        this.newConfig[contactInfofield] = '';
       }
     }
     this.getReport();
@@ -201,21 +210,28 @@ export class TelemetryComponent implements OnInit {
   }
 
   next() {
-    if (this.configForm.pristine) {
-      this.getReport();
-    } else {
-      this.updateConfig();
-    }
+    this.buildReport();
   }
 
   back() {
     this.step--;
   }
 
+  getChangedConfig() {
+    const updatedConfig = {};
+    _.forEach(this.requiredFields, (configField) => {
+      if (!_.isEqual(this.configResp[configField], this.newConfig[configField])) {
+        updatedConfig[configField] = this.newConfig[configField];
+      }
+    });
+    return updatedConfig;
+  }
+
   onSubmit() {
+    const updatedConfig = this.getChangedConfig();
     const observables = [
       this.telemetryService.enable(),
-      this.mgrModuleService.updateConfig('telemetry', this.updatedConfig)
+      this.mgrModuleService.updateConfig('telemetry', updatedConfig)
     ];
 
     observableForkJoin(observables).subscribe(
@@ -239,7 +255,7 @@ export class TelemetryComponent implements OnInit {
         this.previewForm.setErrors({ cdSubmitButton: true });
       },
       () => {
-        this.updatedConfig = {};
+        this.newConfig = {};
         this.router.navigate(['']);
       }
     );


### PR DESCRIPTION
backport trackers:
https://tracker.ceph.com/issues/54351
https://tracker.ceph.com/issues/54349
https://tracker.ceph.com/issues/54357

---

backport of https://github.com/ceph/ceph/pull/44985 and https://github.com/ceph/ceph/pull/41721
parent trackers:
https://tracker.ceph.com/issues/54120
https://tracker.ceph.com/issues/54133
https://tracker.ceph.com/issues/51020

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh