### PR TITLE
stop.sh: make do_umountall() unmount the evicted clients

### DIFF
--- a/src/stop.sh
+++ b/src/stop.sh
@@ -104,7 +104,7 @@ do_umountall() {
     done
 
     #Get fuse mounts of the cluster
-    CEPH_FUSE_MNTS=$("${CEPH_BIN}"/ceph -c $conf_fn tell mds.* client ls 2>/dev/null | grep mount_point | tr -d '",' | awk '{print $2}')
+    CEPH_FUSE_MNTS=$(findmnt -t fuse.ceph-fuse -n --raw --output=target)
     [ -n "$CEPH_FUSE_MNTS" ] && sudo umount -f $CEPH_FUSE_MNTS
 }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/54285

This happens with the fuse mount only.
'client ls' doesn't show the evicted clients. Using 'findmnt' to umount all clients. Any better method?