### PR TITLE
qa/workunits/cephtool: test osd and mon smart command

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -2759,9 +2759,16 @@ function test_mgr_tell()
 
 function test_mgr_devices()
 {
-  ceph device ls
+  ceph device ls | grep osd
+  ceph device ls | grep mon
   expect_false ceph device info doesnotexist
   expect_false ceph device get-health-metrics doesnotexist
+}
+
+function test_devices_smart()
+{
+  ceph daemon mon.a smart | jq -e '. | length > 0'
+  ceph daemon osd.0 smart | jq -e '. | length > 0'
 }
 
 function test_per_pool_scrub_status()


### PR DESCRIPTION
Test that the device detection and smart command is fully working
for mon and osd daemons. This has been broken in the past by
systemd units, selinux, etc.

Fixes: https://tracker.ceph.com/issues/54385
Related-to: https://tracker.ceph.com/issues/52416
Related-to: https://tracker.ceph.com/issues/54313
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>