### PR TITLE
rgw,test: Fix build errors in 32 bit platforms

### DIFF
--- a/src/rgw/store/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.cc
@@ -580,10 +580,13 @@ static int list_lc_head(const DoutPrefixProvider *dpp, DBOpInfo &op, sqlite3_stm
   if (!stmt)
     return -1;
 
+  int64_t start_date;
+
   op.lc_head.index = (const char*)sqlite3_column_text(stmt, LCHeadIndex);
   op.lc_head.head.set_marker((const char*)sqlite3_column_text(stmt, LCHeadMarker));
  
-  SQL_DECODE_BLOB_PARAM(dpp, stmt, LCHeadStartDate, op.lc_head.head.get_start_date(), sdb);
+  SQL_DECODE_BLOB_PARAM(dpp, stmt, LCHeadStartDate, start_date, sdb);
+  op.lc_head.head.get_start_date() = start_date;
 
   return 0;
 }
@@ -2803,7 +2806,7 @@ int SQLInsertLCHead::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *para
   SQL_BIND_TEXT(dpp, stmt, index, params->op.lc_head.head.get_marker().c_str(), sdb);
 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.lc_head.start_date, sdb);
-  SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.lc_head.head.get_start_date(), sdb);
+  SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, static_cast<int64_t>(params->op.lc_head.head.start_date), sdb);
 
 out:
   return rc;

--- a/src/test/libcephfs/ceph_pthread_self.h
+++ b/src/test/libcephfs/ceph_pthread_self.h
@@ -25,7 +25,7 @@ static uint64_t ceph_pthread_self() {
   static_assert(std::is_convertible_v<decltype(me), uint64_t> ||
                 std::is_pointer_v<decltype(me)>,
                 "we need to use pthread_self() for the owner parameter");
-  return reinterpret_cast<uint64_t>(me);
+  return static_cast<uint64_t>(me);
 }
 
 #endif


### PR DESCRIPTION
When building on 32 bit platforms (tested on armhf), 2 errors were detected: The first involves the compiler being unable to disambiguate a call to deserialize an integer (apparently because there isn't a specialization for it) and the second, invalid usage of the builtin reinterpret_cast.