### PR TITLE
osd: require osd_pg_max_concurrent_snap_trims > 0

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -2823,6 +2823,7 @@ options:
   type: uint
   level: advanced
   default: 2
+  min: 1
   with_legacy: true
 # max number of trimming pgs
 - name: osd_max_trimming_pgs

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -15595,6 +15595,9 @@ boost::statechart::result PrimaryLogPG::AwaitAsyncWork::react(const DoSnapWork&)
 
   vector<hobject_t> to_trim;
   unsigned max = pg->cct->_conf->osd_pg_max_concurrent_snap_trims;
+  // we need to look for at least 1 snaptrim, otherwise we'll misinterpret
+  // the ENOENT below and erase snap_to_trim.
+  ceph_assert(max > 0);
   to_trim.reserve(max);
   int r = pg->snap_mapper.get_next_objects_to_trim(
     snap_to_trim,

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -322,6 +322,10 @@ int SnapMapper::get_next_objects_to_trim(
 {
   ceph_assert(out);
   ceph_assert(out->empty());
+
+  // if max would be 0, we return ENOENT and the caller would mistakenly
+  // trim the snaptrim queue
+  ceph_assert(max > 0);
   int r = 0;
   for (set<string>::iterator i = prefixes.begin();
        i != prefixes.end() && out->size() < max && r == 0;


### PR DESCRIPTION
If osd_pg_max_concurrent_snap_trims is zero, we mistakenly clear
the snaptrim queue. Require it to be > 0.

Fixes: https://tracker.ceph.com/issues/54396
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>