### PR TITLE
quincy: Combine backport of master PRs 45118 and 45121. 

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3218,7 +3218,7 @@ int OSD::run_osd_bench_test(
   if (osize && onum) {
     bufferlist bl;
     bufferptr bp(osize);
-    bp.zero();
+    memset(bp.c_str(), 'a', bp.length());
     bl.push_back(std::move(bp));
     bl.rebuild_page_aligned();
     for (int i=0; i<onum; ++i) {
@@ -3235,7 +3235,7 @@ int OSD::run_osd_bench_test(
 
   bufferlist bl;
   bufferptr bp(bsize);
-  bp.zero();
+  memset(bp.c_str(), 'a', bp.length());
   bl.push_back(std::move(bp));
   bl.rebuild_page_aligned();
 

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -29,7 +29,7 @@ def get_ata_wear_level(data: Dict[Any, Any]) -> Optional[float]:
     Extract wear level (as float) from smartctl -x --json output for SATA SSD
     """
     for page in data.get("ata_device_statistics", {}).get("pages", []):
-        if page.get("number") != 7:
+        if page is None or page.get("number") != 7:
             continue
         for item in page.get("table", []):
             if item["offset"] == 8:


### PR DESCRIPTION
This backport PR combines the following:

Backport tracker1: https://tracker.ceph.com/issues/54393  (Backport of https://github.com/ceph/ceph/pull/45118)
Parent Tracker: https://tracker.ceph.com/issues/54364

Backport tracker2: https://tracker.ceph.com/issues/54394  (Backport of https://github.com/ceph/ceph/pull/45121)
Parent Tracker: https://tracker.ceph.com/issues/51554


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
