### PR TITLE
Revert "src/ceph-crash.in: remove unused frame in handler()"

### DIFF
--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -18,6 +18,7 @@ auth_names = ['client.crash.%s' % socket.gethostname(),
               'client.crash',
               'client.admin']
 
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -29,7 +30,8 @@ def parse_args():
     )
     parser.add_argument(
         '--name', '-n',
-        help='ceph name to authenticate as (default: try client.crash, client.admin)')
+        help='ceph name to authenticate as '
+             '(default: try client.crash, client.admin)')
     parser.add_argument(
         '--log-level', '-l',
         help='log level output (default: INFO), support INFO or DEBUG')
@@ -79,9 +81,11 @@ def scrape_path(path):
                     (metapath, p, os.path.join('posted/', p))
                 )
 
+
 def handler(signum, frame):
     print('*** Interrupted with signal %d ***' % signum)
     sys.exit(0)
+
 
 def main():
     global auth_names

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -79,7 +79,7 @@ def scrape_path(path):
                     (metapath, p, os.path.join('posted/', p))
                 )
 
-def handler(signum):
+def handler(signum, frame):
     print('*** Interrupted with signal %d ***' % signum)
     sys.exit(0)
 


### PR DESCRIPTION
Revert "src/ceph-crash.in: remove unused frame in handler()"

This reverts commit 432c766a99f70884049bf7a1f268287a5a809777.

unused but required:

```
Traceback (most recent call last):
File "/usr/bin/ceph-crash", line 102, in <module>
main()
File "/usr/bin/ceph-crash", line 98, in main
time.sleep(args.delay * 60)
TypeError: handler() takes exactly 1 argument (2 given)
```

Fixes: https://tracker.ceph.com/issues/54422

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>