### PR TITLE
mgr: add tag to perfcounters

### DIFF
--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -133,7 +133,7 @@ void PerfCountersCollectionImpl::dump_formatted_generic(
     const std::string &counter) const
 {
   f->open_object_section("perfcounter_collection");
-  
+
   for (perf_counters_set_t::iterator l = m_loggers.begin();
        l != m_loggers.end(); ++l) {
     // Optionally filter on logger name, pass through counter filter
@@ -357,7 +357,7 @@ void PerfCounters::dump_formatted_generic(Formatter *f, bool schema,
     bool histograms, const std::string &counter) const
 {
   f->open_object_section(m_name.c_str());
-  
+
   for (perf_counter_data_vec_t::const_iterator d = m_data.begin();
        d != m_data.end(); ++d) {
     if (!counter.empty() && counter != d->name) {
@@ -411,9 +411,11 @@ void PerfCounters::dump_formatted_generic(Formatter *f, bool schema,
         f->dump_string("nick", "");
       }
       f->dump_int("priority", get_adjusted_priority(d->prio));
-      
+
+      f->dump_int("tags", d->tags);
+
       if (d->unit == UNIT_NONE) {
-	f->dump_string("units", "none"); 
+	f->dump_string("units", "none");
       } else if (d->unit == UNIT_BYTES) {
 	f->dump_string("units", "bytes");
       }
@@ -502,56 +504,56 @@ PerfCountersBuilder::~PerfCountersBuilder()
 
 void PerfCountersBuilder::add_u64_counter(
   int idx, const char *name,
-  const char *description, const char *nick, int prio, int unit)
+  const char *description, const char *nick, int prio, int unit, int tags)
 {
   add_impl(idx, name, description, nick, prio,
-	   PERFCOUNTER_U64 | PERFCOUNTER_COUNTER, unit);
+	   PERFCOUNTER_U64 | PERFCOUNTER_COUNTER, unit, tags);
 }
 
 void PerfCountersBuilder::add_u64(
   int idx, const char *name,
-  const char *description, const char *nick, int prio, int unit)
+  const char *description, const char *nick, int prio, int unit, int tags)
 {
-  add_impl(idx, name, description, nick, prio, PERFCOUNTER_U64, unit);
+  add_impl(idx, name, description, nick, prio, PERFCOUNTER_U64, unit, tags);
 }
 
 void PerfCountersBuilder::add_u64_avg(
   int idx, const char *name,
-  const char *description, const char *nick, int prio, int unit)
+  const char *description, const char *nick, int prio, int unit, int tags)
 {
   add_impl(idx, name, description, nick, prio,
-	   PERFCOUNTER_U64 | PERFCOUNTER_LONGRUNAVG, unit);
+	   PERFCOUNTER_U64 | PERFCOUNTER_LONGRUNAVG, unit, tags);
 }
 
 void PerfCountersBuilder::add_time(
   int idx, const char *name,
-  const char *description, const char *nick, int prio)
+  const char *description, const char *nick, int prio, int tags)
 {
-  add_impl(idx, name, description, nick, prio, PERFCOUNTER_TIME);
+  add_impl(idx, name, description, nick, prio, PERFCOUNTER_TIME, tags);
 }
 
 void PerfCountersBuilder::add_time_avg(
   int idx, const char *name,
-  const char *description, const char *nick, int prio)
+  const char *description, const char *nick, int prio, int tags)
 {
   add_impl(idx, name, description, nick, prio,
-	   PERFCOUNTER_TIME | PERFCOUNTER_LONGRUNAVG);
+	   PERFCOUNTER_TIME | PERFCOUNTER_LONGRUNAVG, tags);
 }
 
 void PerfCountersBuilder::add_u64_counter_histogram(
   int idx, const char *name,
   PerfHistogramCommon::axis_config_d x_axis_config,
   PerfHistogramCommon::axis_config_d y_axis_config,
-  const char *description, const char *nick, int prio, int unit)
+  const char *description, const char *nick, int prio, int unit, int tags)
 {
   add_impl(idx, name, description, nick, prio,
-	   PERFCOUNTER_U64 | PERFCOUNTER_HISTOGRAM | PERFCOUNTER_COUNTER, unit,
+	   PERFCOUNTER_U64 | PERFCOUNTER_HISTOGRAM | PERFCOUNTER_COUNTER, unit, tags,
            std::unique_ptr<PerfHistogram<>>{new PerfHistogram<>{x_axis_config, y_axis_config}});
 }
 
 void PerfCountersBuilder::add_impl(
   int idx, const char *name,
-  const char *description, const char *nick, int prio, int ty, int unit,
+  const char *description, const char *nick, int prio, int ty, int unit, int tags,
   std::unique_ptr<PerfHistogram<>> histogram)
 {
   ceph_assert(idx > m_perf_counters->m_lower_bound);
@@ -570,6 +572,7 @@ void PerfCountersBuilder::add_impl(
   data.prio = prio ? prio : prio_default;
   data.type = (enum perfcounter_type_d)ty;
   data.unit = (enum unit_t) unit;
+  data.tags = (enum PerfCountersBuilder::tags_t) tags;
   data.histogram = std::move(histogram);
 }
 

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -8,9 +8,9 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 
@@ -81,32 +81,45 @@ public:
     PRIO_UNINTERESTING = 2,
     PRIO_DEBUGONLY = 0,
   };
+
+  enum tags_t {
+    TAGS_NONE = 0,
+    TAGS_PROMETHEUS = 1 << 0,
+    TAGS_TELEMETRY = 1 << 1,
+  };
+
   void add_u64(int key, const char *name,
 	       const char *description=NULL, const char *nick = NULL,
-	       int prio=0, int unit=UNIT_NONE);
+	       int prio=0, int unit=UNIT_NONE,
+               int tags = TAGS_NONE);
   void add_u64_counter(int key, const char *name,
 		       const char *description=NULL,
 		       const char *nick = NULL,
-		       int prio=0, int unit=UNIT_NONE);
+		       int prio=0, int unit=UNIT_NONE,
+                       int tags = TAGS_NONE);
   void add_u64_avg(int key, const char *name,
 		   const char *description=NULL,
 		   const char *nick = NULL,
-		   int prio=0, int unit=UNIT_NONE);
+		   int prio=0, int unit=UNIT_NONE,
+                   int tags = TAGS_NONE);
   void add_time(int key, const char *name,
 		const char *description=NULL,
 		const char *nick = NULL,
-		int prio=0);
+		int prio=0,
+                int tags = TAGS_NONE);
   void add_time_avg(int key, const char *name,
 		    const char *description=NULL,
 		    const char *nick = NULL,
-		    int prio=0);
+		    int prio=0,
+                    int tags = TAGS_NONE);
   void add_u64_counter_histogram(
     int key, const char* name,
     PerfHistogramCommon::axis_config_d x_axis_config,
     PerfHistogramCommon::axis_config_d y_axis_config,
     const char *description=NULL,
     const char* nick = NULL,
-    int prio=0, int unit=UNIT_NONE);
+    int prio=0, int unit=UNIT_NONE,
+    int tags = TAGS_NONE);
 
   void set_prio_default(int prio_)
   {
@@ -119,6 +132,7 @@ private:
   PerfCountersBuilder& operator=(const PerfCountersBuilder &rhs);
   void add_impl(int idx, const char *name,
                 const char *description, const char *nick, int prio, int ty, int unit=UNIT_NONE,
+                int tags = TAGS_NONE,
                 std::unique_ptr<PerfHistogram<>> histogram = nullptr);
 
   PerfCounters *m_perf_counters;
@@ -129,7 +143,7 @@ private:
 /*
  * A PerfCounters object is usually associated with a single subsystem.
  * It contains counters which we modify to track performance and throughput
- * over time. 
+ * over time.
  *
  * PerfCounters can track several different types of values:
  * 1) integer values & counters
@@ -160,16 +174,18 @@ public:
       : name(NULL),
         description(NULL),
         nick(NULL),
-	 type(PERFCOUNTER_NONE),
-	 unit(UNIT_NONE)
+        type(PERFCOUNTER_NONE),
+        unit(UNIT_NONE),
+        tags(PerfCountersBuilder::TAGS_NONE)
     {}
     perf_counter_data_any_d(const perf_counter_data_any_d& other)
       : name(other.name),
         description(other.description),
         nick(other.nick),
-	 type(other.type),
-	 unit(other.unit),
-	 u64(other.u64.load()) {
+        type(other.type),
+        unit(other.unit),
+        tags(other.tags),
+        u64(other.u64.load()) {
       auto a = other.read_avg();
       u64 = a.first;
       avgcount = a.second;
@@ -185,6 +201,7 @@ public:
     uint8_t prio = 0;
     enum perfcounter_type_d type;
     enum unit_t unit;
+    PerfCountersBuilder::tags_t tags;
     std::atomic<uint64_t> u64 = { 0 };
     std::atomic<uint64_t> avgcount = { 0 };
     std::atomic<uint64_t> avgcount2 = { 0 };
@@ -356,7 +373,7 @@ private:
 
   perf_counters_set_t m_loggers;
 
-  CounterMap by_path; 
+  CounterMap by_path;
 };
 
 

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -265,9 +265,9 @@ void Objecter::init()
 
     pcb.add_u64_counter(l_osdc_op, "op", "Operations");
     pcb.add_u64_counter(l_osdc_op_r, "op_r", "Read operations", "rd",
-			PerfCountersBuilder::PRIO_CRITICAL);
+			PerfCountersBuilder::PRIO_CRITICAL, PerfCountersBuilder::TAGS_PROMETHEUS);
     pcb.add_u64_counter(l_osdc_op_w, "op_w", "Write operations", "wr",
-			PerfCountersBuilder::PRIO_CRITICAL);
+			PerfCountersBuilder::PRIO_CRITICAL, PerfCountersBuilder::TAGS_PROMETHEUS);
     pcb.add_u64_counter(l_osdc_op_rmw, "op_rmw", "Read-modify-write operations",
 			"rdwr", PerfCountersBuilder::PRIO_INTERESTING);
     pcb.add_u64_counter(l_osdc_op_pg, "op_pg", "PG operation");
@@ -661,7 +661,7 @@ bs::error_code Objecter::_normalize_watch_error(bs::error_code ec)
 
 void Objecter::_linger_reconnect(LingerOp *info, bs::error_code ec)
 {
-  ldout(cct, 10) << __func__ << " " << info->linger_id << " = " << ec 
+  ldout(cct, 10) << __func__ << " " << info->linger_id << " = " << ec
 		 << " (last_error " << info->last_error << ")" << dendl;
   std::unique_lock wl(info->watch_lock);
   if (ec) {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/54403
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
