### PR TITLE
pacific: mon: Omit MANY_OBJECTS_PER_PG warning when autoscaler is on

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1031,6 +1031,8 @@ not contain as much data have too many PGs.  See the discussion of
 The threshold can be raised to silence the health warning by adjusting
 the ``mon_pg_warn_max_object_skew`` config option on the managers.
 
+The health warning will be silenced for a particular pool if
+``pg_autoscale_mode`` is set to ``on``.
 
 POOL_APP_NOT_ENABLED
 ____________________

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2996,11 +2996,13 @@ void PGMap::get_health_checks(
 	if (mon_pg_warn_max_object_skew > 0 &&
 	    ratio > mon_pg_warn_max_object_skew) {
 	  ostringstream ss;
-	  ss << "pool " << name << " objects per pg ("
-	     << objects_per_pg << ") is more than " << ratio
-	     << " times cluster average ("
-	     << average_objects_per_pg << ")";
-	  many_detail.push_back(ss.str());
+	  if (pi->pg_autoscale_mode != pg_pool_t::pg_autoscale_mode_t::ON) {
+	      ss << "pool " << name << " objects per pg ("
+		 << objects_per_pg << ") is more than " << ratio
+		 << " times cluster average ("
+		 << average_objects_per_pg << ")";
+	      many_detail.push_back(ss.str());
+	  }
 	}
       }
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53644

---

backport of https://github.com/ceph/ceph/pull/44280
parent tracker: https://tracker.ceph.com/issues/53516

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh