### PR TITLE
octopus: mds: reset the return value for heap command

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -177,6 +177,7 @@ void MDSDaemon::asok_command(
 	heapcmd_vec.push_back(value);
       }
       ceph_heap_profiler_handle_command(heapcmd_vec, ss);
+      r = 0;
     }
   } else if (command == "cpu_profiler") {
     string arg;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50631

---

backport of https://github.com/ceph/ceph/pull/40927
parent tracker: https://tracker.ceph.com/issues/50433

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh