### PR TITLE
octopus: mds: fix possible mds_lock not locked assert

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -961,7 +961,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
 
       // Oh dear, something unreadable in the store for this rank: require
       // operator intervention.
-      mds->damaged();
+      mds->damaged_unlocked();
       ceph_abort();  // damaged should not return
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50847

---

backport of https://github.com/ceph/ceph/pull/41268
parent tracker: https://tracker.ceph.com/issues/50744

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh