### PR TITLE
octopus: mds: progress the recover queue immediately after the inode is enqueued 

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -5415,6 +5415,7 @@ void Locker::file_eval(ScatterLock *lock, bool *need_issue)
   }
   else if (in->state_test(CInode::STATE_NEEDSRECOVER)) {
     mds->mdcache->queue_file_recover(in);
+    mds->mdcache->do_file_recover();
   }
 }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8211,7 +8211,7 @@ int MDCache::path_traverse(MDRequestRef& mdr, MDSContextFactory& cf,
   if (mdr)
     mdr->snapid = snapid;
 
-  client_t client = (mdr && mdr->reqid.name.is_client()) ? mdr->reqid.name.num() : -1;
+  client_t client = mdr ? mdr->get_client() : -1;
 
   if (mds->logger) mds->logger->inc(l_mds_traverse);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51202

---

backport of https://github.com/ceph/ceph/pull/41431
parent tracker: https://tracker.ceph.com/issues/50840

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh