### PR TITLE
octopus: qa: always format the pgid in hex

### DIFF
--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -548,7 +548,7 @@ class TestDataScan(CephFSTestCase):
 
         pg_count = self.fs.pgs_per_fs_pool
         for pg_n in range(0, pg_count):
-            pg_str = "{0}.{1}".format(self.fs.get_data_pool_id(), pg_n)
+            pg_str = "{0}.{1:x}".format(self.fs.get_data_pool_id(), pg_n)
             out = self.fs.data_scan(["pg_files", "mydir", pg_str])
             lines = [l for l in out.split("\n") if l]
             log.info("{0}: {1}".format(pg_str, lines))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51323

---

backport of https://github.com/ceph/ceph/pull/41908
parent tracker: https://tracker.ceph.com/issues/50808

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh