### PR TITLE
[DNM] octopus: mds: update META_POP_READDIR/FETCH/STORE and cache_hit_rate

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -27,6 +27,7 @@
 #include "Locker.h"
 #include "MDLog.h"
 #include "LogSegment.h"
+#include "MDBalancer.h"
 
 #include "common/bloom_filter.hpp"
 #include "include/Context.h"
@@ -1545,6 +1546,8 @@ void CDir::fetch(MDSContext *c, std::string_view want_dn, bool ignore_authpinnab
 
   if (cache->mds->logger) cache->mds->logger->inc(l_mds_dir_fetch);
 
+  mdcache->mds->balancer->hit_dir(this, META_POP_FETCH);
+
   std::set<dentry_key_t> empty;
   _omap_fetch(NULL, empty);
 }
@@ -1569,6 +1572,8 @@ void CDir::fetch(MDSContext *c, const std::set<dentry_key_t>& keys)
 
   auth_pin(this);
   if (cache->mds->logger) cache->mds->logger->inc(l_mds_dir_fetch);
+
+  mdcache->mds->balancer->hit_dir(this, META_POP_FETCH);
 
   _omap_fetch(c, keys);
 }
@@ -2373,6 +2378,8 @@ void CDir::_commit(version_t want, int op_prio)
   }
   
   if (cache->mds->logger) cache->mds->logger->inc(l_mds_dir_commit);
+
+  mdcache->mds->balancer->hit_dir(this, META_POP_STORE);
 
   _omap_commit(op_prio);
 }

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -275,6 +275,8 @@ mds_load_t MDBalancer::get_load()
   }
 
   uint64_t num_requests = mds->get_num_requests();
+  uint64_t num_traverse = mds->logger->get(l_mds_traverse);
+  uint64_t num_traverse_hit = mds->logger->get(l_mds_traverse_hit);
 
   uint64_t cpu_time = 1;
   {
@@ -306,13 +308,17 @@ mds_load_t MDBalancer::get_load()
 	load.req_rate = (num_requests - last_num_requests) / el;
       if (cpu_time > last_cpu_time)
 	load.cpu_load_avg = (cpu_time - last_cpu_time) / el;
+      if (num_traverse > last_num_traverse && num_traverse_hit > last_num_traverse_hit)
+        load.cache_hit_rate = (double)(num_traverse_hit - last_num_traverse_hit) / (num_traverse - last_num_traverse);
     } else {
       auto p = mds_load.find(mds->get_nodeid());
       if (p != mds_load.end()) {
 	load.req_rate = p->second.req_rate;
 	load.cpu_load_avg = p->second.cpu_load_avg;
+	load.cache_hit_rate = p->second.cache_hit_rate;
       }
-      if (num_requests >= last_num_requests && cpu_time >= last_cpu_time)
+      if (num_requests >= last_num_requests && cpu_time >= last_cpu_time &&
+          num_traverse >= last_num_traverse && num_traverse_hit >= last_num_traverse_hit)
 	update_last = false;
     }
   }
@@ -321,6 +327,8 @@ mds_load_t MDBalancer::get_load()
     last_num_requests = num_requests;
     last_cpu_time = cpu_time;
     last_get_load = now;
+    last_num_traverse = num_traverse;
+    last_num_traverse_hit = num_traverse_hit;
   }
 
   dout(15) << load << dendl;

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -134,6 +134,8 @@ private:
   time last_get_load = clock::zero();
   uint64_t last_num_requests = 0;
   uint64_t last_cpu_time = 0;
+  uint64_t last_num_traverse = 0;
+  uint64_t last_num_traverse_hit = 0;
 
   // Dirfrags which are marked to be passed on to MDCache::[split|merge]_dir
   // just as soon as a delayed context comes back and triggers it.

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4711,7 +4711,7 @@ void Server::handle_client_readdir(MDRequestRef& mdr)
   mdr->reply_extra_bl = dirbl;
 
   // bump popularity.  NOTE: this doesn't quite capture it.
-  mds->balancer->hit_dir(dir, META_POP_IRD, -1, numfiles);
+  mds->balancer->hit_dir(dir, META_POP_READDIR, -1, numfiles);
   
   // reply
   mdr->tracei = diri;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51831

---

backport of https://github.com/ceph/ceph/pull/42256
parent tracker: https://tracker.ceph.com/issues/51600

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh