### PR TITLE
octopus: client: do not dump mds twice in Inode::dump()

### DIFF
--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -460,7 +460,6 @@ void Inode::dump(Formatter *f) const
   f->open_array_section("caps");
   for (const auto &pair : caps) {
     f->open_object_section("cap");
-    f->dump_int("mds", pair.first);
     if (&pair.second == auth_cap)
       f->dump_int("auth", 1);
     pair.second.dump(f);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52443

---

backport of https://github.com/ceph/ceph/pull/42899
parent tracker: https://tracker.ceph.com/issues/52386

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh