### PR TITLE
octopus: mds: ensure that we send the btime in cap messages

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4052,6 +4052,7 @@ void CInode::encode_cap_message(const ref_t<MClientCaps> &m, Capability *cap)
   m->mtime = i->mtime;
   m->atime = i->atime;
   m->ctime = i->ctime;
+  m->btime = i->btime;
   m->change_attr = i->change_attr;
   m->time_warp_seq = i->time_warp_seq;
   m->nfiles = i->dirstat.nfiles;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52634

---

backport of https://github.com/ceph/ceph/pull/42737
parent tracker: https://tracker.ceph.com/issues/52123

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh