### PR TITLE
pacific: rbd-mirror: make mirror properly detect pool replayer needs restart

### DIFF
--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -261,7 +261,7 @@ bool PoolReplayer<I>::is_leader() const {
 
 template <typename I>
 bool PoolReplayer<I>::is_running() const {
-  return m_pool_replayer_thread.is_started();
+  return m_pool_replayer_thread.is_started() && !m_stopping;
 }
 
 template <typename I>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54381

---

backport of https://github.com/ceph/ceph/pull/45086
parent tracker: https://tracker.ceph.com/issues/54258

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh