### PR TITLE
mgr: add allowlist to get_all_perf_counters()

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -101,6 +101,7 @@ class NotifyType(str, Enum):
     # perf_schema_update = 'perf_schema_update'
 
 
+
 class CommandResult(object):
     """
     Use with MgrModule.send_command
@@ -1771,7 +1772,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
 
     def _get_module_option(self,
                            key: str,
-                           default: OptionValue,
+                           default: OptionValue = None,
                            localized_prefix: str = "") -> OptionValue:
         r = self._ceph_get_module_option(self.module_name, key,
                                          localized_prefix)
@@ -1950,7 +1951,9 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
     def get_all_perf_counters(self, prio_limit: int = PRIO_USEFUL,
                               services: Sequence[str] = ("mds", "mon", "osd",
                                                          "rbd-mirror", "rgw",
-                                                         "tcmu-runner")) -> Dict[str, dict]:
+                                                         "tcmu-runner"),
+                              allowlist: Sequence[str] = None
+                              ) -> Dict[str, dict]:
         """
         Return the perf counters currently known to this ceph-mgr
         instance, filtered by priority equal to or greater than `prio_limit`.
@@ -1988,6 +1991,10 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
                     # self.log.debug("{0}: {1}".format(
                     #     counter_path, json.dumps(counter_schema)
                     # ))
+
+                    if allowlist is not None and counter_path not in allowlist:
+                        continue
+
                     priority = counter_schema['priority']
                     assert isinstance(priority, int)
                     if priority < prio_limit:


### PR DESCRIPTION
## TODO

- [x] Add `allowlist` parameter to mgr API get_all_perf_counters().
- [x] Provide allowlisted counters for Prometheus exporter based on existing Grafana and Alertmanage queries.
- [x] Add gzip support to the /metrics endpoint (it reduces 98% the size of  the HTTP response, at the expense of halving the max request rate, but that doesn't seem to be the bottleneck here).
- [ ] Review non-perf-counter metrics.
- [ ] Expose metrics in different endpoints (e.g.: `/perf-counters`, `/health`). This would provide horizontal scalability and the scrape interval could be customized based on the data set size vs. data freshness. This could also enable the ["split by use" scaling in Prometheus](https://www.robustperception.io/scaling-and-federating-prometheus).


## Results

For a vstart cluster with 3-mon, 3-mgr, 60-osd, 1 rgw daemon, after this PR:
* **x8 sample reduction**: from 14,312 to 1,773 metrics/scrape,
* **x8.7 payload reduction**: from 978,849 down to 113,537 bytes/scrape,
* **x88 compressed payload reduction**: 11,116 byes/scrape,
* **x11.7 mgr API calls reduction**: from 10,776 to 916 calls/scrape.

## Caveats

From the list of metrics provided by @pereman2, in this environment (vstart-based) I couldn't get the following ones:
```
ceph_daemon not found
ceph_data_sync_from_zone_fetch_bytes_sum not found
ceph_data_sync_from_zone_fetch_bytes_count not found
ceph_data_sync_from_zone_poll_latency_sum not found
ceph_data_sync_from_zone_fetch_errors not found
ceph_rbd_write_ops not found
ceph_rbd_read_ops not found
ceph_rbd_write_bytes not found
ceph_rbd_read_bytes not found
ceph_rbd_write_latency_sum not found
ceph_rbd_write_latency_count not found
ceph_rbd_read_latency_sum not found
ceph_rbd_read_latency_count not found
ceph_pg_undersized not found
ceph_pg_degraded not found
ceph_pg_inconsistent not found
ceph_pg_down not found
ceph_hosts not found
ceph_disk_occupation not found
ceph_disk_occupation_human not found
ceph_disk_latency_read not found
ceph_node_disk_rate not found
ceph_disk_latency_write not found
ceph_bluestore_bluestore_compressed_original not found
ceph_bluestore_bluestore_compressed_allocated not found
ceph_node_down not found
ceph_version not found
ceph_disk_latency not found
ceph_node_disk_irate not found
ceph_pools_iops not found
ceph_pools_iops_bytes not found
ceph_versions_running not found
```

Fixes: https://tracker.ceph.com/issues/54403
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
