### PR TITLE
osd/scrub: stop sending bogus digest-update event messages

### DIFF
--- a/src/osd/scrubber/PrimaryLogScrub.cc
+++ b/src/osd/scrubber/PrimaryLogScrub.cc
@@ -548,7 +548,6 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
 
     ++num_digest_updates_pending;
     ctx->register_on_success([this]() {
-      dout(20) << "updating scrub digest " << num_digest_updates_pending << dendl;
       if ((num_digest_updates_pending >= 1) && (--num_digest_updates_pending == 0)) {
 	m_osds->queue_scrub_digest_update(m_pl_pg, m_pl_pg->is_scrub_blocking_ops());
       }


### PR DESCRIPTION
A minimal change extracted from PR#44050, to facilitate
backporting.

The multitudes of bogus events generated fill up the logs.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
(cherry picked from commit e1b5347b81d17c8a5a1f6e1d4d76d18977ec2b0c)

Conflicts: the logic changes were already part of Quincy. All that's left is
      a removal of an unneeded log message.