### PR TITLE
pacific: osd/scrub: stop sending bogus digest-update events

### DIFF
--- a/src/osd/PrimaryLogScrub.cc
+++ b/src/osd/PrimaryLogScrub.cc
@@ -546,8 +546,8 @@ void PrimaryLogScrub::scrub_snapshot_metadata(ScrubMap& scrubmap,
 
     ++num_digest_updates_pending;
     ctx->register_on_success([this]() {
-      dout(20) << "updating scrub digest " << num_digest_updates_pending << dendl;
-      if (--num_digest_updates_pending <= 0) {
+      if ((num_digest_updates_pending >= 1) && 
+          (--num_digest_updates_pending == 0)) {
 	m_osds->queue_scrub_digest_update(m_pl_pg, m_pl_pg->is_scrub_blocking_ops());
       }
     });


### PR DESCRIPTION
A backport of a fix (PR #45068, commit e1b5347) made in Quincy.
Direct cherry-picking failed, due to the major Scrub code
refactoring in-between.

Fixes: http://tracker.ceph.com/issues/54423

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
