### PR TITLE
mds: fix incorrect can_read judgment of SimpleLock

### DIFF
--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -325,12 +325,14 @@ public:
   bool can_read(client_t client) const {
     return get_sm()->states[state].can_read == ANY ||
       (get_sm()->states[state].can_read == AUTH && parent->is_auth()) ||
-      (get_sm()->states[state].can_read == XCL && client >= 0 && get_xlock_by_client() == client);
+      (get_sm()->states[state].can_read == XCL && client >= 0 && get_xlock_by_client() == client) ||
+      (get_sm()->states[state].can_read == XCL && client >= 0 && (get_xlock_by_client() == -1 && is_rdlocked()));
   }
   bool can_read_projected(client_t client) const {
     return get_sm()->states[state].can_read_projected == ANY ||
       (get_sm()->states[state].can_read_projected == AUTH && parent->is_auth()) ||
-      (get_sm()->states[state].can_read_projected == XCL && client >= 0 && get_xlock_by_client() == client);
+      (get_sm()->states[state].can_read_projected == XCL && client >= 0 && get_xlock_by_client() == client) ||
+      (get_sm()->states[state].can_read == XCL && client >= 0 && (get_xlock_by_client() == -1 && is_rdlocked()));
   }
   bool can_rdlock(client_t client) const {
     return get_sm()->states[state].can_rdlock == ANY ||


### PR DESCRIPTION
when filelock is LOCK_XLOCKDONE, its can_read is XCL but
it doesn't necessarily must have xlocker. we should also
consider it readble if it had been rdlocked.

Fixes: http://tracker.ceph.com/issues/54421
Signed-off-by: YunfeiGuan <yunfeiguan@xtaotech.com>