### PR TITLE
[RFC] rgw/dbstore: virtual InsertUser() instead of class SQLInsertUser

### DIFF
--- a/src/rgw/store/dbstore/CMakeLists.txt
+++ b/src/rgw/store/dbstore/CMakeLists.txt
@@ -18,7 +18,7 @@ set(dbstore_mgr_srcs
 
 add_library(dbstore_lib ${dbstore_srcs})
 target_include_directories(dbstore_lib PUBLIC "${CMAKE_SOURCE_DIR}/src/fmt/include")
-target_include_directories(dbstore_lib PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw")
+target_include_directories(dbstore_lib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 set(link_targets spawn)
 if(WITH_JAEGER)
   list(APPEND link_targets ${jaeger_base})
@@ -29,11 +29,10 @@ set (CMAKE_LINK_LIBRARIES ${CMAKE_LINK_LIBRARIES} dbstore_lib)
 
 IF(USE_SQLITE)
   add_subdirectory(sqlite)
-  set(CMAKE_INCLUDE_DIR ${CMAKE_INCLUDE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/sqlite")
   add_compile_definitions(SQLITE_ENABLED=1)
   set (CMAKE_LINK_LIBRARIES ${CMAKE_LINK_LIBRARIES} rgw_common)
   set (CMAKE_LINK_LIBRARIES ${CMAKE_LINK_LIBRARIES} sqlite_db)
-  add_dependencies(sqlite_db dbstore_lib)
+  target_link_libraries(sqlite_db dbstore_lib)
 ENDIF()
 
 # add pthread library
@@ -46,8 +45,8 @@ else()
 	message(WARNING "Gtest not enabled")
 endif()
 
-include_directories(${CMAKE_INCLUDE_DIR})
 add_library(dbstore STATIC ${dbstore_mgr_srcs})
+target_include_directories(dbstore PUBLIC ${CMAKE_INCLUDE_DIR})
 target_link_libraries(dbstore ${CMAKE_LINK_LIBRARIES})
 
 # testing purpose

--- a/src/rgw/store/dbstore/common/database_exception.h
+++ b/src/rgw/store/dbstore/common/database_exception.h
@@ -1,0 +1,15 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <stdexcept>
+
+namespace rgw::store {
+
+// generic database exception
+struct database_exception : std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+} // namespace rgw::store

--- a/src/rgw/store/dbstore/dbstore_main.cc
+++ b/src/rgw/store/dbstore/dbstore_main.cc
@@ -59,8 +59,14 @@ void* process(void *arg)
   params.op.user.uinfo.access_keys.insert(make_pair("key1", k1));
   params.op.user.uinfo.access_keys.insert(make_pair("key2", k2));
 
-  ret = db->ProcessOp(dpp, "InsertUser", &params);
-  cout << "InsertUser return value: " <<  ret << "\n";
+  try {
+    InsertUser(params.user_table,
+               params.op.user.uinfo,
+               params.op.user.user_version,
+               params.op.user.user_attrs);
+  } catch (const std::exception& e) {
+    cout << "InsertUser failed: " << e.what() << '\n';
+  }
 
   DBOpParams params2 = {};
   params.op.user.uinfo.user_id.tenant = "tenant2";

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.h
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.h
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <string>
 #include <sqlite3.h>
-#include "rgw/store/dbstore/common/dbstore.h"
+#include "common/dbstore.h"
 
 using namespace rgw::store;
 

--- a/src/rgw/store/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/store/dbstore/tests/dbstore_tests.cc
@@ -117,7 +117,6 @@ namespace {
 
 TEST_F(DBStoreTest, InsertUser) {
   struct DBOpParams params = GlobalParams;
-  int ret = -1;
 
   params.op.user.uinfo.user_id.tenant = "tenant";
   params.op.user.uinfo.user_email = "user1@dbstore.com";
@@ -132,8 +131,10 @@ TEST_F(DBStoreTest, InsertUser) {
   params.op.user.user_version.ver = 1;    
   params.op.user.user_version.tag = "UserTAG";    
 
-  ret = db->ProcessOp(dpp, "InsertUser", &params);
-  ASSERT_EQ(ret, 0);
+  ASSERT_NO_THROW(db->InsertUser(params.user_table,
+                                 params.op.user.uinfo,
+                                 params.op.user.user_version,
+                                 params.op.user.user_attrs));
 }
 
 TEST_F(DBStoreTest, GetUser) {
@@ -1182,7 +1183,6 @@ TEST_F(DBStoreTest, RemoveUser) {
 
 TEST_F(DBStoreTest, InsertTestIDUser) {
   struct DBOpParams params = GlobalParams;
-  int ret = -1;
 
   params.op.user.uinfo.user_id.id = "testid";
   params.op.user.uinfo.display_name = "M. Tester";
@@ -1193,8 +1193,10 @@ TEST_F(DBStoreTest, InsertTestIDUser) {
   params.op.user.user_version.ver = 1;    
   params.op.user.user_version.tag = "UserTAG";    
 
-  ret = db->ProcessOp(dpp, "InsertUser", &params);
-  ASSERT_EQ(ret, 0);
+  ASSERT_NO_THROW(db->InsertUser(params.user_table,
+                                 params.op.user.uinfo,
+                                 params.op.user.user_version,
+                                 params.op.user.user_attrs));
 }
 
 int main(int argc, char **argv)

--- a/src/rgw/store/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/store/dbstore/tests/dbstore_tests.cc
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <dbstore.h>
-#include <sqliteDB.h>
+#include <sqlite/sqliteDB.h>
 #include "rgw_common.h"
 
 using namespace std;


### PR DESCRIPTION
replaces the `SQLInsertUser -> InsertUserOp -> DBOp` hierarchy with a virtual `DB::InsertUser()` interface (re: https://tracker.ceph.com/issues/54355)

adds free functions like `bind_text()` to replace the `SQL_*` macros, using exceptions instead of goto for error handling (re: https://tracker.ceph.com/issues/54359)

i only made these changes `SQLInsertUser` as an example for design feedback

this adds `virtual void DB::InsertUser()` as a "low-level interface" that throws exceptions. the "high-level interface", `int DB::store_user()`, hides any exceptions from the application (rgw), by catching them and returning errors as -1

the `InsertUser()` function takes its specific arguments directly, instead of relying on the generic `DBOpParams`, which required copying all arguments into `DBOpParams`

the ownership of `SQLInsertUser`'s prepared statement (`sqlite3_stmt`) has moved to `SQLiteDB`. we still need to find a way to prevent multiple threads from binding/evaluating that statement at the same time

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
