### PR TITLE
BlueFS.cc: avoid unnecessary check of _maybe_compact_log_LNF_NF_LD_D()

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3285,9 +3285,8 @@ void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)/*_WF_L
       }
     }
   }
-  if (flushed_sum) {
-    _maybe_compact_log_LNF_NF_LD_D();
-  }
+  // remove _maybe_compact_log_LNF_NF_LD_D() check since _flush_F()
+  // won't increase log fnode size, there's no need to check.
 }
 
 void BlueFS::flush(FileWriter *h, bool force)/*_WF_LNF_NF_LD_D*/
@@ -3299,9 +3298,8 @@ void BlueFS::flush(FileWriter *h, bool force)/*_WF_LNF_NF_LD_D*/
     r = _flush_F(h, force, &flushed);
     ceph_assert(r == 0);
   }
-  if (r == 0 && flushed) {
-    _maybe_compact_log_LNF_NF_LD_D();
-  }
+  // remove _maybe_compact_log_LNF_NF_LD_D() check since _flush_F()
+  // won't increase log fnode size, there's no need to check.
 }
 
 int BlueFS::_flush_F(FileWriter *h, bool force, bool *flushed)


### PR DESCRIPTION
in append_try_flush() and flush(), log fnode size won't be changed. there's
no need to check _maybe_compact_log_LNF_NF_LD_D().

Signed-off-by: Sheng Qiu <herbert1984106@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
