### PR TITLE
octopus: backport qemu-iotests fixup for centos stream 8

### DIFF
--- a/qa/workunits/rbd/qemu-iotests.sh
+++ b/qa/workunits/rbd/qemu-iotests.sh
@@ -12,7 +12,7 @@ cd qemu
 if lsb_release -da 2>&1 | grep -iqE '(bionic|focal)'; then
     # Bionic requires a matching test harness
     git checkout v2.11.0
-elif lsb_release -da 2>&1 | grep -iqE '(xenial|linux release 8)'; then
+elif lsb_release -da 2>&1 | grep -iqE '(xenial|linux release 8|stream release 8)'; then
     # Xenial requires a recent test harness
     git checkout v2.3.0
 else

--- a/qa/workunits/rbd/qemu-iotests.sh
+++ b/qa/workunits/rbd/qemu-iotests.sh
@@ -9,10 +9,12 @@ testlist='001 002 003 004 005 008 009 010 011 021 025 032 033'
 
 git clone https://github.com/qemu/qemu.git
 cd qemu
-if lsb_release -da 2>&1 | grep -iqE '(bionic|focal)'; then
+
+
+if grep -iqE '(bionic|focal)' /etc/os-release; then
     # Bionic requires a matching test harness
     git checkout v2.11.0
-elif lsb_release -da 2>&1 | grep -iqE '(xenial|linux release 8|stream release 8)'; then
+elif grep -iqE '(xenial|platform:el8)' /etc/os-release; then
     # Xenial requires a recent test harness
     git checkout v2.3.0
 else


### PR DESCRIPTION
Backport commit df96b85b5882 ("qa/workunits/rbd: use xenial version of qemu-iotests for centos stream 8") to octopus.  The octopus backport was missed because initially it wasn't intended to be backported at all -- @ktdreyer backported it to pacific in https://github.com/ceph/ceph/pull/43001 as part of a conflict resolution for a different backport.