### PR TITLE
mds: add long snap name flag in LeaseStat for fscrypt

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -4300,11 +4300,12 @@ void Locker::encode_lease(bufferlist& bl, const session_info_t& info,
 			  const LeaseStat& ls)
 {
   if (info.has_feature(CEPHFS_FEATURE_REPLY_ENCODING)) {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(ls.mask, bl);
     encode(ls.duration_ms, bl);
     encode(ls.seq, bl);
     encode(ls.alternate_name, bl);
+    encode(ls.is_long_snap_name, bl);
     ENCODE_FINISH(bl);
   }
   else {

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -10333,7 +10333,7 @@ void Server::handle_client_lssnap(MDRequestRef& mdr)
 
     encode(snap_name, dnbl);
     //infinite lease
-    LeaseStat e(CEPH_LEASE_VALID, -1, 0);
+    LeaseStat e(CEPH_LEASE_VALID, -1, 0, p->second->ino != diri->ino());
     mds->locker->encode_lease(dnbl, mdr->session->info, e);
     dout(20) << "encode_infinite_lease" << dendl;
 

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -53,19 +53,23 @@ struct LeaseStat {
   __u32 duration_ms = 0;
   __u32 seq = 0;
   std::string alternate_name;
+  __u8 is_long_snap_name = 0;
 
   LeaseStat() = default;
-  LeaseStat(__u16 msk, __u32 dur, __u32 sq) : mask{msk}, duration_ms{dur}, seq{sq} {}
+  LeaseStat(__u16 msk, __u32 dur, __u32 sq, __u8 lsn = 0)
+    : mask{msk}, duration_ms{dur}, seq{sq}, is_long_snap_name(lsn) {}
 
   void decode(ceph::buffer::list::const_iterator &bl, const uint64_t features) {
     using ceph::decode;
     if (features == (uint64_t)-1) {
-      DECODE_START(2, bl);
+      DECODE_START(3, bl);
       decode(mask, bl);
       decode(duration_ms, bl);
       decode(seq, bl);
       if (struct_v >= 2)
         decode(alternate_name, bl);
+      if (struct_v >= 3)
+        decode(is_long_snap_name, bl);
       DECODE_FINISH(bl);
     }
     else {


### PR DESCRIPTION
For the long snapshot names, which are from the parent CInodes,
the format will be "_${ENCRYPTED-NAME}_${PARENT-INO}". In kclient
side we need to base64 decode it to human readable format of
"_${DENCRYPTED-NAME}_${PARENT-INO}" if the encrypt key exists. So
we need to know whether the current snapshot name is a long snap
name.

Signed-off-by: Xiubo Li <xiubli@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
