### PR TITLE
ceph-volume: fix generic activate

### DIFF
--- a/src/ceph-volume/ceph_volume/activate/main.py
+++ b/src/ceph-volume/ceph_volume/activate/main.py
@@ -50,8 +50,6 @@ class Activate(object):
                 start_osd_uuid=self.args.osd_uuid,
                 tmpfs=not self.args.no_tmpfs,
                 systemd=not self.args.no_systemd,
-                block_wal=None,
-                block_db=None,
             )
             return
         except Exception as e:


### PR DESCRIPTION
afd8be7eac5e996c3bd07656601a4534053e2516 broke it.
It has dropped`block_wal` and `block_db` from
`ceph_volume.devices.raw.activate.activate_bluestore` but
`activate.main.Activate.main` still passes those arguments when
calling `RAWActivate([]).activate()`

Fixes: https://tracker.ceph.com/issues/54441

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
