### PR TITLE
mds: support alternate names for snapshots

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -10332,8 +10332,10 @@ void Server::handle_client_lssnap(MDRequestRef& mdr)
       break;
 
     encode(snap_name, dnbl);
+
     //infinite lease
     LeaseStat e(CEPH_LEASE_VALID, -1, 0);
+    e.alternate_name = std::string(p->second->alternate_name);
     mds->locker->encode_lease(dnbl, mdr->session->info, e);
     dout(20) << "encode_infinite_lease" << dendl;
 
@@ -10496,6 +10498,7 @@ void Server::handle_client_mksnap(MDRequestRef& mdr)
   info.ino = diri->ino();
   info.snapid = snapid;
   info.name = snapname;
+  info.alternate_name = req->get_alternate_name();
   info.stamp = mdr->get_op_stamp();
   info.metadata = payload.metadata;
 

--- a/src/mds/snap.cc
+++ b/src/mds/snap.cc
@@ -25,24 +25,28 @@ using namespace std;
 
 void SnapInfo::encode(bufferlist& bl) const
 {
-  ENCODE_START(3, 2, bl);
+  ENCODE_START(4, 2, bl);
   encode(snapid, bl);
   encode(ino, bl);
   encode(stamp, bl);
   encode(name, bl);
   encode(metadata, bl);
+  encode(alternate_name, bl);
   ENCODE_FINISH(bl);
 }
 
 void SnapInfo::decode(bufferlist::const_iterator& bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(3, 2, 2, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(4, 2, 2, bl);
   decode(snapid, bl);
   decode(ino, bl);
   decode(stamp, bl);
   decode(name, bl);
   if (struct_v >= 3) {
     decode(metadata, bl);
+  }
+  if (struct_v >= 4) {
+    decode(alternate_name, bl);
   }
   DECODE_FINISH(bl);
 }

--- a/src/mds/snap.h
+++ b/src/mds/snap.h
@@ -38,6 +38,7 @@ struct SnapInfo {
   inodeno_t ino;
   utime_t stamp;
   std::string name;
+  std::string alternate_name;
 
   mutable std::string long_name; ///< cached _$ino_$name
   std::map<std::string,std::string> metadata;


### PR DESCRIPTION
This PR adds support for alternate_names in snapshots.  It basically stores the alternate_name already received in SnapInfo and later, when doing an LSSNAP, returns it in the Lease.

Signed-off-by: Luís Henriques <lhenriques@suse.de>
