### PR TITLE
quincy: ceph-volume: fix generic activate

### DIFF
--- a/src/ceph-volume/ceph_volume/activate/main.py
+++ b/src/ceph-volume/ceph_volume/activate/main.py
@@ -50,8 +50,6 @@ class Activate(object):
                 start_osd_uuid=self.args.osd_uuid,
                 tmpfs=not self.args.no_tmpfs,
                 systemd=not self.args.no_systemd,
-                block_wal=None,
-                block_db=None,
             )
             return
         except Exception as e:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54454

---

backport of https://github.com/ceph/ceph/pull/45216
parent tracker: https://tracker.ceph.com/issues/54441

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh