### PR TITLE
src/os/bluestore/BlueFS: fix race condition in bluefs log compact flow

### DIFF
--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -125,6 +125,11 @@ public:
     MEMPOOL_CLASS_HELPERS();
 
     bluefs_fnode_t fnode;
+    // use this variable to rack submitted but not completed data flush size
+    // when data are not flushed on disk, fnode's size won't be updated.
+    // so that when compact_log is triggered, we won't dump fnode's size containing
+    // data that are still inflight.
+    uint64_t inflight_flush_size;
     int refs;
     uint64_t dirty_seq;
     bool locked;
@@ -146,6 +151,7 @@ public:
     FRIEND_MAKE_REF(File);
     File()
       :
+	inflight_flush_size(0),
 	refs(0),
 	dirty_seq(0),
 	locked(false),


### PR DESCRIPTION
the issue is currently fnode's size is updated before its data is flushed on disk.
when log compact is triggered, it may dump fnode with a wrong size that contained
inflight flushing data and cause consistency issue.

this patch excludes the unpersistented data from fnode's size during log compact
and avoid the fnode metadata inconsistency.

Signed-off-by: Sheng Qiu <herbert1984106@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
