### PR TITLE
octopus: mgr/prometheus: Added `avail_raw` field for Pools DF Prometheus mgr module

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -66,7 +66,7 @@ def health_status_to_number(status):
 
 DF_CLUSTER = ['total_bytes', 'total_used_bytes', 'total_used_raw_bytes']
 
-DF_POOL = ['max_avail', 'stored', 'stored_raw', 'objects', 'dirty',
+DF_POOL = ['max_avail', 'avail_raw', 'stored', 'stored_raw', 'objects', 'dirty',
            'quota_bytes', 'quota_objects', 'rd', 'rd_bytes', 'wr', 'wr_bytes',
            'compress_bytes_used', 'compress_under_bytes']
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54450

---

backport of https://github.com/ceph/ceph/pull/43058
parent tracker: https://tracker.ceph.com/issues/52512

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh