### PR TITLE
test: osd-scrub-snaps.sh: fix expected 'missing snaps' log string

### DIFF
--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -695,7 +695,7 @@ EOF
     err_strings[19]="log_channel[(]cluster[)] log [[]ERR[]] : scrub [0-9]*[.]0 .*:::obj14:1 : size 1032 != clone_size 1033"
     err_strings[20]="log_channel[(]cluster[)] log [[]ERR[]] : [0-9]*[.]0 scrub 20 errors"
     err_strings[21]="log_channel[(]cluster[)] log [[]ERR[]] : scrub [0-9]*[.]0 .*:::obj15:head : can't decode 'snapset' attr "
-    err_strings[22]="log_channel[(]cluster[)] log [[]ERR[]] : osd[.][0-9]* found snap mapper error on pg 1.0 oid 1:461f8b5e:::obj16:7 snaps missing in mapper, should be: 1,2,3,4,5,6,7 was  r -2...repaired"
+    err_strings[22]="log_channel[(]cluster[)] log [[]ERR[]] : osd[.][0-9]* found snap mapper error on pg 1.0 oid 1:461f8b5e:::obj16:7 snaps missing in mapper, should be: 1,2,3,4,5,6,7 ...repaired"
 
     for err_string in "${err_strings[@]}"
     do
@@ -1126,7 +1126,7 @@ fi
     # Check replica specific messages
     declare -a rep_err_strings
     osd=$(eval echo \$$which)
-    rep_err_strings[0]="log_channel[(]cluster[)] log [[]ERR[]] : osd[.][0-9]* found snap mapper error on pg 1.0 oid 1:461f8b5e:::obj16:7 snaps missing in mapper, should be: 1,2,3,4,5,6,7 was  r -2...repaired"
+    rep_err_strings[0]="log_channel[(]cluster[)] log [[]ERR[]] : osd[.][0-9]* found snap mapper error on pg 1.0 oid 1:461f8b5e:::obj16:7 snaps missing in mapper, should be: 1,2,3,4,5,6,7 ...repaired"
     for err_string in "${rep_err_strings[@]}"
     do
         if ! grep "$err_string" $dir/osd.${osd}.log > /dev/null;


### PR DESCRIPTION
The test expects the following line:
"...found snap mapper error on pg ... oid ... snaps missing in mapper, should be: 1,2,3,4,5,6,7 was r -2...repaired"
while up-to-date scrubber code does not emit the 'was <emptylist> r -2' part. As the list is always empty for missing snaps,
and the r is always '-2' - this part of the message is just confusing.

Fix the expected log message to match the scrub code, by removing the redundant part.

Fixes: https://tracker.ceph.com/issues/54458

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
