### PR TITLE
Fix BlueFS sync compaction

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2507,6 +2507,9 @@ void BlueFS::_rewrite_log_and_layout_sync_LNF_LD(bool allocate_with_fallback,
   }
 #endif
   _flush_bdev();
+  ++log.seq_live;
+  dirty.seq_live = log.seq_live;
+  log.t.seq = log.seq_live;
 
   super.memorized_layout = layout;
   super.log_fnode = log_file->fnode;


### PR DESCRIPTION
BlueFS fine grain locking introduced a critical failure to synchronous compaction of log.

After compaction seq was not incremented. As a result subsequent log entries are off-by-1.
It means that `_replay()` function stops right after first transaction entry, and all subsequent modifications are lost.

```
2022-03-03T07:55:39.765+0000 7ffff7fda840 20 bluefs _replay 0x0:  op_dir_create sharding
2022-03-03T07:55:39.765+0000 7ffff7fda840 20 bluefs _replay 0x0:  op_dir_link  sharding/def to 21
2022-03-03T07:55:39.765+0000 7ffff7fda840 20 bluefs _replay 0x0:  op_jump_seq 1025
2022-03-03T07:55:39.765+0000 7ffff7fda840 10 bluefs _read h 0x555557c46400 0x1000~1000 from file(ino 1 size 0x1000 mtime 0.000000 allocated 410000 alloc_commit 410000 extents [1:0x1540000~410000])
2022-03-03T07:55:39.765+0000 7ffff7fda840 20 bluefs _read left 0xff000 len 0x1000
2022-03-03T07:55:39.765+0000 7ffff7fda840 20 bluefs _read got 4096
2022-03-03T07:55:39.765+0000 7ffff7fda840 10 bluefs _replay 0x1000: stop: seq 1025 != expected 1026
2022-03-03T07:55:39.765+0000 7ffff7fda840 10 bluefs _replay log file size was 0x1000
2022-03-03T07:55:39.765+0000 7ffff7fda840 10 bluefs _replay done
```

Fixes: https://tracker.ceph.com/issues/54465

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
