### PR TITLE
prometheus: Spell check the alert descriptions

### DIFF
--- a/monitoring/ceph-mixin/prometheus_alerts.yml
+++ b/monitoring/ceph-mixin/prometheus_alerts.yml
@@ -397,7 +397,7 @@ groups:
           documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-degraded
           summary: Ceph filesystem is degraded
           description: >
-            One or more metdata daemons (MDS ranks) are failed or in a
+            One or more metadata daemons (MDS ranks) are failed or in a
             damaged state. At best the filesystem is partially available,
             worst case is the filesystem is completely unusable.
       - alert: CephFilesystemMDSRanksLow
@@ -533,7 +533,7 @@ groups:
             During data consistency checks (scrub), at least one PG has been flagged as being
             damaged or inconsistent.
 
-            Check to see which PG is affected, and attempt a manual repair if neccessary. To list
+            Check to see which PG is affected, and attempt a manual repair if necessary. To list
             problematic placement groups, use 'rados list-inconsistent-pg <pool>'. To repair PGs use
             the 'ceph pg repair <pg_num>' command.
       - alert: CephPGRecoveryAtRisk
@@ -561,7 +561,7 @@ groups:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-availability
           summary: Placement group is unavailable, blocking some I/O
           description: >
-            Data availability is reduced impacting the clusters abilty to service I/O to some data. One or
+            Data availability is reduced impacting the clusters ability to service I/O to some data. One or
             more placement groups (PGs) are in a state that blocks IO.
       - alert: CephPGBackfillAtRisk
         expr: ceph_health_detail{name="PG_BACKFILL_FULL"} == 1

--- a/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
+++ b/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
@@ -876,7 +876,7 @@ tests:
           documentation: https://docs.ceph.com/en/latest/cephfs/health-messages/#fs-degraded
           summary: Ceph filesystem is degraded
           description: >
-            One or more metdata daemons (MDS ranks) are failed or in a
+            One or more metadata daemons (MDS ranks) are failed or in a
             damaged state. At best the filesystem is partially available,
             worst case is the filesystem is completely unusable.
  - interval: 1m
@@ -1738,7 +1738,7 @@ tests:
             During data consistency checks (scrub), at least one PG has been flagged as being
             damaged or inconsistent.
 
-            Check to see which PG is affected, and attempt a manual repair if neccessary. To list
+            Check to see which PG is affected, and attempt a manual repair if necessary. To list
             problematic placement groups, use 'rados list-inconsistent-pg <pool>'. To repair PGs use
             the 'ceph pg repair <pg_num>' command.
  - interval: 1m
@@ -1858,7 +1858,7 @@ tests:
           documentation: https://docs.ceph.com/en/latest/rados/operations/health-checks#pg-availability
           summary: Placement group is unavailable, blocking some I/O
           description: >
-            Data availability is reduced impacting the clusters abilty to service I/O to some data. One or
+            Data availability is reduced impacting the clusters ability to service I/O to some data. One or
             more placement groups (PGs) are in a state that blocks IO.
  - interval: 1m
    input_series:


### PR DESCRIPTION
Several prometheus alert descriptions had typos. This was caught by the Rook CI when integrating the latest alerts in https://github.com/rook/rook/pull/9837. See the CI spell check failure [here](https://github.com/rook/rook/runs/5416278702?check_suite_focus=true). 

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
