### PR TITLE
Workaround for bad capture of bluefs allocations

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3265,6 +3265,13 @@ options:
     slow shutdown is primarilyy useful for doing memory leak checking with valgrind.
   default: true
   with_legacy: true
+- name: osd_fast_shutdown_timeout
+  type: int
+  level: advanced
+  desc: timeout in seconds for osd fast-shutdown (0 is unlimited)
+  default: 15
+  with_legacy: true
+  min: 0
 - name: osd_fast_shutdown_notify_mon
   type: bool
   level: advanced
@@ -4936,6 +4943,12 @@ options:
     This setting is used only when OSD is doing ``--mkfs``.
     Next runs of OSD retrieve sharding from disk.
   default: m(3) p(3,0-12) O(3,0-13)=block_cache={type=binned_lru} L P
+- name: bluestore_qfsck_on_mount
+  type: bool
+  level: dev
+  desc: Run quick-fsck at mount comparing allocation-file to RocksDB allocation state
+  default: true
+  with_legacy: true
 - name: bluestore_fsck_on_mount
   type: bool
   level: dev

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -288,7 +288,8 @@ public:
   virtual bool needs_journal() = 0;  //< requires a journal
   virtual bool wants_journal() = 0;  //< prefers a journal
   virtual bool allows_journal() = 0; //< allows a journal
-
+  virtual void prepare_for_fast_shutdown() {}
+  virtual bool has_null_manager() { return false; }
   // return store min allocation size, if applicable
   virtual uint64_t get_min_alloc_size() const {
     return 0;

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -65,6 +65,9 @@ public:
   }
   virtual double get_fragmentation_score();
   virtual void shutdown() = 0;
+  void prepare_for_fast_shutdown() {
+    m_fast_shutdown = true;
+  }
 
   static Allocator *create(
     CephContext* cct,
@@ -91,6 +94,7 @@ private:
   class SocketHook;
   SocketHook* asok_hook = nullptr;
 protected:
+  bool    m_fast_shutdown = false;
   const int64_t device_size = 0;
   const int64_t block_size = 0;
 };

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -65,8 +65,12 @@ public:
   }
   virtual double get_fragmentation_score();
   virtual void shutdown() = 0;
-  void prepare_for_fast_shutdown() {
+  void prepare_for_shutdown() {
     m_fast_shutdown = true;
+  }
+
+  void clear_shutdown() {
+    m_fast_shutdown = false;
   }
 
   static Allocator *create(

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -91,7 +91,7 @@ uint64_t AvlAllocator::_pick_block_fits(uint64_t size,
 void AvlAllocator::_add_to_tree(uint64_t start, uint64_t size)
 {
   ceph_assert(size != 0);
-
+  ceph_assert(m_fast_shutdown == false);
   uint64_t end = start + size;
 
   auto rs_after = range_tree.upper_bound(range_t{start, end},
@@ -160,6 +160,7 @@ void AvlAllocator::_process_range_removal(uint64_t start, uint64_t end,
 
 void AvlAllocator::_remove_from_tree(uint64_t start, uint64_t size)
 {
+  ceph_assert(m_fast_shutdown == false);
   uint64_t end = start + size;
 
   ceph_assert(size != 0);
@@ -180,7 +181,7 @@ void AvlAllocator::_try_remove_from_tree(uint64_t start, uint64_t size,
   uint64_t end = start + size;
 
   ceph_assert(size != 0);
-
+  ceph_assert(m_fast_shutdown == false);
   auto rs = range_tree.find(range_t{ start, end },
     range_tree.key_comp());
 
@@ -217,6 +218,7 @@ int64_t AvlAllocator::_allocate(
   int64_t  hint, // unused, for now!
   PExtentVector* extents)
 {
+  ceph_assert(m_fast_shutdown == false);
   uint64_t allocated = 0;
   while (allocated < want) {
     uint64_t offset, length;
@@ -238,6 +240,7 @@ int AvlAllocator::_allocate(
   uint64_t *offset,
   uint64_t *length)
 {
+  ceph_assert(m_fast_shutdown == false);
   uint64_t max_size = 0;
   if (auto p = range_size_tree.rbegin(); p != range_size_tree.rend()) {
     max_size = p->end - p->start;
@@ -300,6 +303,7 @@ int AvlAllocator::_allocate(
 
 void AvlAllocator::_release(const interval_set<uint64_t>& release_set)
 {
+  ceph_assert(m_fast_shutdown == false);
   for (auto p = release_set.begin(); p != release_set.end(); ++p) {
     const auto offset = p.get_start();
     const auto length = p.get_len();
@@ -313,6 +317,7 @@ void AvlAllocator::_release(const interval_set<uint64_t>& release_set)
 }
 
 void AvlAllocator::_release(const PExtentVector& release_set) {
+  ceph_assert(m_fast_shutdown == false);
   for (auto& e : release_set) {
     ldout(cct, 10) << __func__ << std::hex
       << " offset 0x" << e.offset
@@ -373,7 +378,6 @@ int64_t AvlAllocator::allocate(
                  << std::dec << dendl;
   ceph_assert(isp2(unit));
   ceph_assert(want % unit == 0);
-
   if (max_alloc_size == 0) {
     max_alloc_size = want;
   }
@@ -438,6 +442,7 @@ void AvlAllocator::init_add_free(uint64_t offset, uint64_t length)
 {
   if (!length)
     return;
+  ceph_assert(m_fast_shutdown == false);
   std::lock_guard l(lock);
   ceph_assert(offset + length <= uint64_t(device_size));
   ldout(cct, 10) << __func__ << std::hex
@@ -451,6 +456,7 @@ void AvlAllocator::init_rm_free(uint64_t offset, uint64_t length)
 {
   if (!length)
     return;
+  ceph_assert(m_fast_shutdown == false);
   std::lock_guard l(lock);
   ceph_assert(offset + length <= uint64_t(device_size));
   ldout(cct, 10) << __func__ << std::hex

--- a/src/os/bluestore/BitmapAllocator.cc
+++ b/src/os/bluestore/BitmapAllocator.cc
@@ -29,8 +29,8 @@ int64_t BitmapAllocator::allocate(
   ldout(cct, 10) << __func__ << std::hex << " 0x" << want_size
 		 << "/" << alloc_unit << "," << max_alloc_size << "," << hint
 		 << std::dec << dendl;
-    
-    
+  ceph_assert(m_fast_shutdown == false);
+
   _allocate_l2(want_size, alloc_unit, max_alloc_size, hint,
     &allocated, extents);
   if (!allocated) {
@@ -51,6 +51,7 @@ int64_t BitmapAllocator::allocate(
 void BitmapAllocator::release(
   const interval_set<uint64_t>& release_set)
 {
+  ceph_assert(m_fast_shutdown == false);
   if (cct->_conf->subsys.should_gather<dout_subsys, 10>()) {
     for (auto& [offset, len] : release_set) {
       ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << len
@@ -67,7 +68,7 @@ void BitmapAllocator::init_add_free(uint64_t offset, uint64_t length)
 {
   ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << length
 		  << std::dec << dendl;
-
+  ceph_assert(m_fast_shutdown == false);
   auto mas = get_min_alloc_size();
   uint64_t offs = round_up_to(offset, mas);
   uint64_t l = p2align(offset + length - offs, mas);
@@ -80,6 +81,7 @@ void BitmapAllocator::init_rm_free(uint64_t offset, uint64_t length)
 {
   ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << length
 		 << std::dec << dendl;
+  ceph_assert(m_fast_shutdown == false);
   auto mas = get_min_alloc_size();
   uint64_t offs = round_up_to(offset, mas);
   uint64_t l = p2align(offset + length - offs, mas);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -530,9 +530,9 @@ void BlueFS::dump_block_extents(ostream& out)
   }
 }
 
-int BlueFS::get_block_extents(unsigned id, interval_set<uint64_t> *extents)
+// this function must be called while holding nodes.lock
+void BlueFS::get_block_extents_with_lock(unsigned id, interval_set<uint64_t> *extents)
 {
-  std::lock_guard nl(nodes.lock);
   dout(10) << __func__ << " bdev " << id << dendl;
   ceph_assert(id < alloc.size());
   for (auto& p : nodes.file_map) {
@@ -542,6 +542,12 @@ int BlueFS::get_block_extents(unsigned id, interval_set<uint64_t> *extents)
       }
     }
   }
+}
+
+int BlueFS::get_block_extents(unsigned id, interval_set<uint64_t> *extents)
+{
+  std::lock_guard nl(nodes.lock);
+  get_block_extents_with_lock(id, extents);
   return 0;
 }
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -949,7 +949,7 @@ int BlueFS::maybe_verify_layout(const bluefs_layout_t& layout) const
   return 0;
 }
 
-void BlueFS::umount(bool avoid_compact)
+void BlueFS::umount(bool avoid_compact, unsigned id, interval_set<uint64_t> *extents)
 {
   dout(1) << __func__ << dendl;
 
@@ -963,6 +963,13 @@ void BlueFS::umount(bool avoid_compact)
 
   vselector.reset(nullptr);
   _stop_alloc();
+
+  // store a copy of all allocation
+  if (extents) {
+    dout(1) << __func__ << "::NCB::copying allocation map before umount" << dendl;
+    get_block_extents(id, extents);
+  }
+
   nodes.file_map.clear();
   nodes.dir_map.clear();
   super = bluefs_super_t();

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2520,6 +2520,9 @@ void BlueFS::_rewrite_log_and_layout_sync_LNF_LD(bool allocate_with_fallback,
   }
 #endif
   _flush_bdev();
+  ++log.seq_live;
+  dirty.seq_live = log.seq_live;
+  log.t.seq = log.seq_live;
 
   super.memorized_layout = layout;
   super.log_fnode = log_file->fnode;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -528,7 +528,17 @@ public:
   int mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout);
   int mount();
   int maybe_verify_layout(const bluefs_layout_t& layout) const;
-  void umount(bool avoid_compact = false);
+  void umount(bool avoid_compact = false, unsigned id = -1, interval_set<uint64_t> *extents = nullptr);
+
+  auto lock_allocations() {
+    return new std::lock_guard(nodes.lock);
+  }
+#if 0
+  void unlock_allocations(std::lock_guard* nlp) {
+    delete nlp;
+  }
+#endif
+
   int prepare_new_device(int id, const bluefs_layout_t& layout);
   
   int log_dump();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7709,12 +7709,14 @@ int BlueStore::umount()
     dout(20) << __func__ << " closing" << dendl;
   }
 
-  // raise debug level
+  // stop new allocations and raise debug level
   if (unlikely(m_fast_shutdown)) {
-    cct->_conf.set_val("debug_osd", "20");
-    cct->_conf.set_val("debug_bluestore", "20");
-    cct->_conf.set_val("debug_bluefs", "20");
-    cct->_conf.set_val("debug_rocksdb", "20");
+    alloc->prepare_for_fast_shutdown();
+
+    //cct->_conf.set_val("debug_osd", "20");
+    //cct->_conf.set_val("debug_bluestore", "20");
+    //cct->_conf.set_val("debug_bluefs", "20");
+    //cct->_conf.set_val("debug_rocksdb", "20");
   }
 
   _close_db_and_around();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18376,6 +18376,9 @@ int BlueStore::store_allocator(Allocator* src_allocator)
   ceph_assert(db == nullptr);
   utime_t  start_time = ceph_clock_now();
   int ret = 0;
+  // we need the label when tracing
+  bluestore_bdev_label_t label;
+  _read_bdev_label(cct, path, &label);
 
   // create dir if doesn't exist already
   if (!bluefs->dir_exists(allocator_dir) ) {
@@ -18477,7 +18480,7 @@ int BlueStore::store_allocator(Allocator* src_allocator)
   bluefs->fsync(p_handle);
 
   utime_t duration = ceph_clock_now() - start_time;
-  dout(5) <<"WRITE-extent_count=" << extent_count << ", file_size=" << p_handle->file->fnode.size << ", serial = " << s_serial << dendl;
+  dout(5) <<"WRITE-extent_count=" << extent_count << ", file_size=" << p_handle->file->fnode.size << ", serial=" << s_serial << ", label=" << label << dendl;
   dout(5) <<"p_handle->pos=" << p_handle->pos << " WRITE-duration=" << duration << " seconds" << dendl;
 
   bluefs->close_writer(p_handle);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7672,7 +7672,7 @@ int BlueStore::umount()
 {
   // move bluefs compaction to synchronous mode and force a compaction
   cct->_conf->bluefs_compact_log_sync = true;
-  bluefs->compact_log();
+  //bluefs->compact_log();
 
   ceph_assert(_kv_only || mounted);
   _osr_drain_all();
@@ -18393,7 +18393,7 @@ int BlueStore::store_allocator(Allocator* src_allocator)
   uint64_t allocated = p_handle->file->fnode.get_allocated();
   dout(10) << "file_size=" << file_size << ", allocated=" << allocated << dendl;
 
-#if 1
+#if 0
   bluefs->sync_metadata(false);
 #endif
   unique_ptr<Allocator> allocator(clone_allocator_without_bluefs(src_allocator));

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18399,6 +18399,7 @@ Allocator* BlueStore::create_allocator_snapshot(Allocator* src_allocator)
   if (bluefs) {
     // Get a consistent view of the shared-allocator
     interval_set<uint64_t> bluefs_extents;
+    utime_t  start_time_func = ceph_clock_now();
     bluefs->lock_allocations();
     // The system must be in stable state when we collect allocations map
     alloc->prepare_for_shutdown();
@@ -18408,6 +18409,8 @@ Allocator* BlueStore::create_allocator_snapshot(Allocator* src_allocator)
     // TBD: preallcoate the space and then we can better assert against allocations from new activity
     alloc->clear_shutdown();
     bluefs->unlock_allocations();
+    utime_t end_time = ceph_clock_now();
+    dout(0) << __func__ << "::lock duration:" << end_time - start_time_func << " seconds" << dendl;
   } else {
     allocator = create_bitmap_allocator(bdev->get_size());
     if (allocator) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6393,7 +6393,7 @@ int BlueStore::_open_db_and_around(bool read_only, bool to_repair)
     dout(5) << __func__ << "::NCB::Commit to Null-Manager" << dendl;
     commit_to_null_manager();
     need_to_destage_allocation_file = true;
-    dout(10) << __func__ << "::NCB::need_to_destage_allocation_file was set" << dendl;
+    dout(1) << __func__ << "::NCB::need_to_destage_allocation_file was set" << dendl;
   }
 
   return 0;
@@ -6667,7 +6667,7 @@ void BlueStore::_close_db_leave_bluefs()
 
 void BlueStore::_close_db()
 {
-  dout(10) << __func__ << ":read_only=" << db_was_opened_read_only << " fm=" << fm << " destage_alloc_file=" << need_to_destage_allocation_file << dendl;
+  dout(1) << __func__ << ":read_only=" << db_was_opened_read_only << " fm=" << fm << " destage_alloc_file=" << need_to_destage_allocation_file << dendl;
   _close_db_leave_bluefs();
 
   if (need_to_destage_allocation_file) {
@@ -7524,7 +7524,7 @@ int BlueStore::expand_devices(ostream& out)
     // we grow the allocation range, must reflect it in the allocation file
     alloc->init_add_free(size0, size - size0);
     need_to_destage_allocation_file = true;
-
+    dout(1) << __func__ << "::NCB::need_to_destage_allocation_file was set" << dendl;
     _close_db_and_around();
 
     // mount in read/write to sync expansion changes
@@ -18224,7 +18224,7 @@ int BlueStore::invalidate_allocation_file_on_bluefs()
 {
   // mark that allocation-file was invalidated and we should destage a new copy whne closing db
   need_to_destage_allocation_file = true;
-  dout(10) << "need_to_destage_allocation_file was set" << dendl;
+  dout(1) << "need_to_destage_allocation_file was set" << dendl;
 
   BlueFS::FileWriter *p_handle = nullptr;
   if (!bluefs->dir_exists(allocator_dir)) {
@@ -18431,6 +18431,7 @@ int BlueStore::store_allocator(Allocator* src_allocator)
   int ret = 0;
 
   // Get a consistent view of the shared-allocator
+  dout(1) << " Calling create_allocator_snapshot" << dendl;
   unique_ptr<Allocator> allocator(create_allocator_snapshot(src_allocator));
   if (!allocator) {
     return -1;
@@ -18524,10 +18525,11 @@ int BlueStore::store_allocator(Allocator* src_allocator)
   bluefs->fsync(p_handle);
 
   utime_t duration = ceph_clock_now() - start_time;
-  dout(5) <<"WRITE-extent_count=" << extent_count << ", file_size=" << p_handle->file->fnode.size << ", serial=" << s_serial << dendl;
+  dout(1) <<"WRITE-extent_count=" << extent_count << ", file_size=" << p_handle->file->fnode.size << ", serial=" << s_serial << dendl;
   dout(5) <<"p_handle->pos=" << p_handle->pos << " WRITE-duration=" << duration << " seconds" << dendl;
 
   bluefs->close_writer(p_handle);
+  dout(1) << "::NCB::need_to_destage_allocation_file was cleared" << dendl;
   need_to_destage_allocation_file = false;
   return 0;
 }
@@ -19199,6 +19201,7 @@ int BlueStore::verify_shared_alloc_against_onodes_allocation_info()
   }
 #else
   // Get a consistent view of the shared-allocator
+  dout(1) << " Calling create_allocator_snapshot" << dendl;
   unique_ptr<Allocator> allocator2(create_allocator_snapshot(alloc));
   if (!allocator2) {
     return -1;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7685,6 +7685,8 @@ int BlueStore::_mount()
 
 int BlueStore::umount()
 {
+  // move bluefs compaction to synchronous mode
+  cct->_conf->bluefs_compact_log_sync = true;
   ceph_assert(_kv_only || mounted);
   _osr_drain_all();
 
@@ -7702,7 +7704,7 @@ int BlueStore::umount()
 #endif
     dout(20) << __func__ << " stopping kv thread" << dendl;
     _kv_stop();
-    // skip cache cleanup step on fast shutdown 
+    // skip cache cleanup step on fast shutdown
     if (likely(!m_fast_shutdown)) {
       _shutdown_cache();
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18401,6 +18401,11 @@ int BlueStore::store_allocator(Allocator* src_allocator)
   uint64_t allocated = p_handle->file->fnode.get_allocated();
   dout(10) << "file_size=" << file_size << ", allocated=" << allocated << dendl;
 
+#if 1
+  // remove me - try to prove a point!
+  //cct->_conf->bluefs_compact_log_sync = true;
+  bluefs->compact_log();
+#endif
   unique_ptr<Allocator> allocator(clone_allocator_without_bluefs(src_allocator));
   if (!allocator) {
     bluefs->close_writer(p_handle);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6674,11 +6674,13 @@ void BlueStore::_close_db()
     ceph_assert(fm && fm->is_null_manager());
 #if 1
     // force bluefs sync
+    dout(1) << __func__ << "::NCB::force bluefs sync -- _close_bluefs()" << dendl;
     _close_bluefs();
     // disable BlueFS compaction until after store_allocator()
     auto keep_bluefs_replay_recovery_disable_compact = cct->_conf->bluefs_replay_recovery_disable_compact;
     cct->_conf->bluefs_replay_recovery_disable_compact = true;
     // need bluefs open to store allocation-file
+    dout(1) << __func__ << "::NCB::force bluefs sync -- _open_bluefs()" << dendl;
     _open_bluefs(false, false);
 #endif
     alloc->prepare_for_shutdown();
@@ -19167,7 +19169,7 @@ int BlueStore::verify_shared_alloc_against_onodes_allocation_info()
   uint64_t memory_target = cct->_conf.get_val<Option::size_t>("osd_memory_target");
   ret = compare_allocators(allocator.get(), alloc, stats.insert_count, memory_target);
   if (ret == 0) {
-    dout(5) << "Allocator drive - file integrity check OK" << dendl;
+    dout(1) << "Allocator drive - file integrity check OK" << dendl;
   } else {
     derr << "FAILURE. Allocator from file and allocator from metadata differ::ret=" << ret << dendl;
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7582,7 +7582,7 @@ int BlueStore::_mount()
   {
     static bool perform_bluestore_qfsck = true;
     if (perform_bluestore_qfsck && cct->_conf->bluestore_qfsck_on_mount) {
-      perform_bluestore_qfsck = false;
+      //perform_bluestore_qfsck = false;
       dout(0) << __func__ << "::NCB::bluestore_qfsck_on_mount was initiated ... " << dendl;
       int ret = read_allocation_from_drive_for_bluestore_tool();
       ceph_assert(ret == 0);
@@ -18472,7 +18472,7 @@ int BlueStore::store_allocator(Allocator* src_allocator)
   bluefs->fsync(p_handle);
 
   utime_t duration = ceph_clock_now() - start_time;
-  dout(5) <<"WRITE-extent_count=" << extent_count << ", file_size=" << p_handle->file->fnode.size << dendl;
+  dout(5) <<"WRITE-extent_count=" << extent_count << ", file_size=" << p_handle->file->fnode.size << ", serial = " << s_serial << dendl;
   dout(5) <<"p_handle->pos=" << p_handle->pos << " WRITE-duration=" << duration << " seconds" << dendl;
 
   bluefs->close_writer(p_handle);
@@ -18668,7 +18668,7 @@ int BlueStore::__restore_allocator(Allocator* allocator, uint64_t *num, uint64_t
   utime_t duration = ceph_clock_now() - start_time;
   dout(5) << "READ--extent_count=" << extent_count << ", read_alloc_size=  "
 	    << read_alloc_size << ", file_size=" << file_size << dendl;
-  dout(5) << "READ duration=" << duration << " seconds, s_serial=" << s_serial << dendl;
+  dout(5) << "READ duration=" << duration << " seconds, serial=" << header.serial << dendl;
   *num   = extent_count;
   *bytes = read_alloc_size;
   return 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7670,8 +7670,10 @@ int BlueStore::_mount()
 
 int BlueStore::umount()
 {
-  // move bluefs compaction to synchronous mode
+  // move bluefs compaction to synchronous mode and force a compaction
   cct->_conf->bluefs_compact_log_sync = true;
+  bluefs->compact_log();
+
   ceph_assert(_kv_only || mounted);
   _osr_drain_all();
 
@@ -18362,13 +18364,6 @@ int BlueStore::store_allocator(Allocator* src_allocator)
   // the easiest way to achieve it is to make sure db is closed
   ceph_assert(db == nullptr);
   utime_t  start_time = ceph_clock_now();
-
-#if 1
-  // remove me - try to prove a point!
-  //cct->_conf->bluefs_compact_log_sync = true;
-  bluefs->compact_log();
-#endif
-
   int ret = 0;
   // we need the label when tracing
   bluestore_bdev_label_t label;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18377,6 +18377,13 @@ int BlueStore::store_allocator(Allocator* src_allocator)
   // the easiest way to achieve it is to make sure db is closed
   ceph_assert(db == nullptr);
   utime_t  start_time = ceph_clock_now();
+
+#if 1
+  // remove me - try to prove a point!
+  //cct->_conf->bluefs_compact_log_sync = true;
+  bluefs->compact_log();
+#endif
+
   int ret = 0;
   // we need the label when tracing
   bluestore_bdev_label_t label;
@@ -18407,9 +18414,7 @@ int BlueStore::store_allocator(Allocator* src_allocator)
   dout(10) << "file_size=" << file_size << ", allocated=" << allocated << dendl;
 
 #if 1
-  // remove me - try to prove a point!
-  //cct->_conf->bluefs_compact_log_sync = true;
-  bluefs->compact_log();
+  bluefs->sync_metadata(false);
 #endif
   unique_ptr<Allocator> allocator(clone_allocator_without_bluefs(src_allocator));
   if (!allocator) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18639,6 +18639,16 @@ int BlueStore::store_allocator(Allocator* src_allocator)
   s_serial++;
 
   need_to_destage_allocation_file = false;
+
+#if 1
+  auto temp_allocator = unique_ptr<Allocator>(create_bitmap_allocator(bdev->get_size()));
+  uint64_t num, bytes;
+  ret = __restore_allocator(temp_allocator.get(), &num, &bytes);
+  if (ret != 0) {
+    return ret;
+  }
+#endif
+
   return 0;
 }
 
@@ -18831,9 +18841,9 @@ int BlueStore::__restore_allocator(Allocator* allocator, uint64_t *num, uint64_t
   }
 
   utime_t duration = ceph_clock_now() - start_time;
-  dout(5) << "READ--extent_count=" << extent_count << ", read_alloc_size=  "
+  dout(1) << "READ--extent_count=" << extent_count << ", read_alloc_size=  "
 	    << read_alloc_size << ", file_size=" << file_size << dendl;
-  dout(5) << "READ duration=" << duration << " seconds, serial=" << header.serial << dendl;
+  dout(1) << "READ duration=" << duration << " seconds, serial=" << header.serial << dendl;
   *num   = extent_count;
   *bytes = read_alloc_size;
   return 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18640,7 +18640,7 @@ int BlueStore::store_allocator(Allocator* src_allocator)
 
   need_to_destage_allocation_file = false;
 
-#if 1
+#if 0
   auto temp_allocator = unique_ptr<Allocator>(create_bitmap_allocator(bdev->get_size()));
   uint64_t num, bytes;
   ret = __restore_allocator(temp_allocator.get(), &num, &bytes);
@@ -18873,7 +18873,7 @@ int BlueStore::restore_allocator(Allocator* dest_allocator, uint64_t *num, uint6
   {
     static bool perform_bluestore_qfsck = true;
     if (perform_bluestore_qfsck && cct->_conf->bluestore_qfsck_on_mount) {
-      perform_bluestore_qfsck = false;
+      //perform_bluestore_qfsck = false;
       dout(0) << __func__ << "::NCB::bluestore_qfsck_on_mount was initiated ... " << dendl;
       ceph_assert(verify_shared_alloc_against_onodes_allocation_info() == 0);
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18875,7 +18875,9 @@ int BlueStore::restore_allocator(Allocator* dest_allocator, uint64_t *num, uint6
     if (perform_bluestore_qfsck && cct->_conf->bluestore_qfsck_on_mount) {
       //perform_bluestore_qfsck = false;
       dout(0) << __func__ << "::NCB::bluestore_qfsck_on_mount was initiated ... " << dendl;
-      ceph_assert(verify_shared_alloc_against_onodes_allocation_info() == 0);
+      if (verify_shared_alloc_against_onodes_allocation_info() != 0) {
+	derr << "Failed QFSCK!!" << dendl;
+      }
     }
   }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7672,7 +7672,7 @@ int BlueStore::_mount()
 int BlueStore::umount()
 {
   // move bluefs compaction to synchronous mode and force a compaction
-  cct->_conf->bluefs_compact_log_sync = true;
+  //cct->_conf->bluefs_compact_log_sync = true;
   //bluefs->compact_log();
 
   ceph_assert(_kv_only || mounted);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2764,7 +2764,7 @@ public:
 
 private:
   int32_t ondisk_format = 0;  ///< value detected on mount
-
+  bool    m_fast_shutdown = false;
   int _upgrade_super();  ///< upgrade (called during open_super)
   uint64_t _get_ondisk_reserved() const;
   void _prepare_ondisk_format_super(KeyValueDB::Transaction& t);
@@ -2782,6 +2782,9 @@ public:
   bool needs_journal() override { return false; };
   bool wants_journal() override { return false; };
   bool allows_journal() override { return false; };
+
+  void prepare_for_fast_shutdown() override;
+  virtual bool has_null_manager();
 
   uint64_t get_min_alloc_size() const override {
     return min_alloc_size;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3656,6 +3656,7 @@ public:
 #ifdef CEPH_BLUESTORE_TOOL_RESTORE_ALLOCATION
   int  push_allocation_to_rocksdb();
   int  read_allocation_from_drive_for_bluestore_tool();
+  int  verify_shared_alloc_against_onodes_allocation_info();
 #endif
 private:
 #define MAX_BLOBS_IN_ONODE 128

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3743,6 +3743,8 @@ private:
   int  db_cleanup(int ret);
   int  reset_fm_for_restore();
   int  verify_rocksdb_allocations(Allocator *allocator);
+  Allocator* create_allocator_snapshot(Allocator* src_allocator);
+  Allocator* clone_allocator_without_bluefs_safe(Allocator *src_allocator, interval_set<uint64_t> &bluefs_extents);
   Allocator* clone_allocator_without_bluefs(Allocator *src_allocator);
   Allocator* initialize_allocator_from_freelist(FreelistManager *real_fm);
   void copy_allocator_content_to_fm(Allocator *allocator, FreelistManager *real_fm);

--- a/src/os/bluestore/HybridAllocator.cc
+++ b/src/os/bluestore/HybridAllocator.cc
@@ -29,7 +29,7 @@ int64_t HybridAllocator::allocate(
                  << std::dec << dendl;
   ceph_assert(isp2(unit));
   ceph_assert(want % unit == 0);
-
+  ceph_assert(m_fast_shutdown == false);
   if (max_alloc_size == 0) {
     max_alloc_size = want;
   }
@@ -106,6 +106,7 @@ int64_t HybridAllocator::allocate(
 }
 
 void HybridAllocator::release(const interval_set<uint64_t>& release_set) {
+  ceph_assert(m_fast_shutdown == false);
   std::lock_guard l(lock);
   // this will attempt to put free ranges into AvlAllocator first and
   // fallback to bitmap one via _try_insert_range call
@@ -157,6 +158,7 @@ void HybridAllocator::init_rm_free(uint64_t offset, uint64_t length)
 {
   if (!length)
     return;
+  ceph_assert(m_fast_shutdown == false);
   std::lock_guard l(lock);
   ldout(cct, 10) << __func__ << std::hex
                  << " offset 0x" << offset
@@ -213,6 +215,7 @@ void HybridAllocator::_spillover_range(uint64_t start, uint64_t end)
 
 void HybridAllocator::_add_to_tree(uint64_t start, uint64_t size)
 {
+  ceph_assert(m_fast_shutdown == false);
   if (bmap_alloc) {
     uint64_t head = bmap_alloc->claim_free_to_left(start);
     uint64_t tail = bmap_alloc->claim_free_to_right(start + size);

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -40,6 +40,7 @@ void StupidAllocator::_insert_free(uint64_t off, uint64_t len)
   unsigned bin = _choose_bin(len);
   ldout(cct, 30) << __func__ << " 0x" << std::hex << off << "~" << len
 		 << std::dec << " in bin " << bin << dendl;
+  ceph_assert(m_fast_shutdown == false);
   while (true) {
     free[bin].insert(off, len, &off, &len);
     unsigned newbin = _choose_bin(len);
@@ -75,6 +76,7 @@ int64_t StupidAllocator::allocate_int(
 	   	 << " alloc_unit 0x" << alloc_unit
 	   	 << " hint 0x" << hint << std::dec
 	   	 << dendl;
+  ceph_assert(m_fast_shutdown == false);
   uint64_t want = std::max(alloc_unit, want_size);
   int bin = _choose_bin(want);
   int orig_bin = bin;
@@ -194,7 +196,7 @@ int64_t StupidAllocator::allocate(
   uint64_t offset = 0;
   uint32_t length = 0;
   int res = 0;
-
+  ceph_assert(m_fast_shutdown == false);
   if (max_alloc_size == 0) {
     max_alloc_size = want_size;
   }
@@ -239,6 +241,7 @@ int64_t StupidAllocator::allocate(
 void StupidAllocator::release(
   const interval_set<uint64_t>& release_set)
 {
+  ceph_assert(m_fast_shutdown == false);
   std::lock_guard l(lock);
   for (interval_set<uint64_t>::const_iterator p = release_set.begin();
        p != release_set.end();
@@ -313,6 +316,7 @@ void StupidAllocator::init_add_free(uint64_t offset, uint64_t length)
 {
   if (!length)
     return;
+  ceph_assert(m_fast_shutdown == false);
   std::lock_guard l(lock);
   ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << length
 		 << std::dec << dendl;
@@ -324,6 +328,7 @@ void StupidAllocator::init_rm_free(uint64_t offset, uint64_t length)
 {
   if (!length)
     return;
+  ceph_assert(m_fast_shutdown == false);
   std::lock_guard l(lock);
   ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << length
 	   	 << std::dec << dendl;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4258,33 +4258,89 @@ PerfCounters* OSD::create_recoverystate_perf()
 
 int OSD::shutdown()
 {
+  // vstart overwrites osd_fast_shutdown value in the conf file -> force the value here!
+  //cct->_conf->osd_fast_shutdown = true;
+
+  dout(0) << "Fast Shutdown: - cct->_conf->osd_fast_shutdown = "
+	  << cct->_conf->osd_fast_shutdown
+	  << ", null-fm = " << store->has_null_manager() << dendl;
+
+  utime_t  start_time_func = ceph_clock_now();
+
   if (cct->_conf->osd_fast_shutdown) {
     derr << "*** Immediate shutdown (osd_fast_shutdown=true) ***" << dendl;
     if (cct->_conf->osd_fast_shutdown_notify_mon)
       service.prepare_to_stop();
-    cct->_log->flush();
-    _exit(0);
+
+    // There is no state we need to keep wehn running in NULL-FM moode
+    if (!store->has_null_manager()) {
+      cct->_log->flush();
+      _exit(0);
+    }
+  } else if (!service.prepare_to_stop()) {
+    return 0; // already shutting down
   }
 
-  if (!service.prepare_to_stop())
-    return 0; // already shutting down
   osd_lock.lock();
   if (is_stopping()) {
     osd_lock.unlock();
     return 0;
   }
-  dout(0) << "shutdown" << dendl;
 
+  if (!cct->_conf->osd_fast_shutdown) {
+    dout(0) << "shutdown" << dendl;
+  }
+
+  // don't accept new task for this OSD
   set_state(STATE_STOPPING);
 
-  // Debugging
-  if (cct->_conf.get_val<bool>("osd_debug_shutdown")) {
+  // Disabled debugging during fast-shutdown
+  if (!cct->_conf->osd_fast_shutdown && cct->_conf.get_val<bool>("osd_debug_shutdown")) {
     cct->_conf.set_val("debug_osd", "100");
     cct->_conf.set_val("debug_journal", "100");
     cct->_conf.set_val("debug_filestore", "100");
     cct->_conf.set_val("debug_bluestore", "100");
     cct->_conf.set_val("debug_ms", "100");
     cct->_conf.apply_changes(nullptr);
+  }
+
+  if (cct->_conf->osd_fast_shutdown) {
+    // first, stop new task from being taken from op_shardedwq
+    // and clear all pending tasks
+    op_shardedwq.stop_for_fast_shutdown();
+
+    utime_t  start_time_timer = ceph_clock_now();
+    tick_timer.shutdown();
+    {
+      std::lock_guard l(tick_timer_lock);
+      tick_timer_without_osd_lock.shutdown();
+    }
+
+    osd_lock.unlock();
+    utime_t  start_time_osd_drain = ceph_clock_now();
+
+    // then, wait on osd_op_tp to drain (TBD: should probably add a timeout)
+    osd_op_tp.drain();
+    osd_op_tp.stop();
+
+    utime_t  start_time_umount = ceph_clock_now();
+    store->prepare_for_fast_shutdown();
+    std::lock_guard lock(osd_lock);
+    // TBD: assert in allocator that nothing is being add
+    store->umount();
+
+    utime_t end_time = ceph_clock_now();
+    if (cct->_conf->osd_fast_shutdown_timeout) {
+      ceph_assert(end_time - start_time_func < cct->_conf->osd_fast_shutdown_timeout);
+    }
+    dout(0) <<"Fast Shutdown duration total     :" << end_time              - start_time_func       << " seconds" << dendl;
+    dout(0) <<"Fast Shutdown duration osd_drain :" << start_time_umount     - start_time_osd_drain  << " seconds" << dendl;
+    dout(0) <<"Fast Shutdown duration umount    :" << end_time              - start_time_umount     << " seconds" << dendl;
+    dout(0) <<"Fast Shutdown duration timer     :" << start_time_osd_drain  - start_time_timer      << " seconds" << dendl;
+    cct->_log->flush();
+
+    // now it is safe to exit
+    _exit(0);
   }
 
   // stop MgrClient earlier as it's more like an internal consumer of OSD
@@ -4447,6 +4503,9 @@ int OSD::shutdown()
   objecter_messenger->shutdown();
   hb_front_server_messenger->shutdown();
   hb_back_server_messenger->shutdown();
+
+  utime_t duration = ceph_clock_now() - start_time_func;
+  dout(0) <<"Slow Shutdown duration:" << duration << " seconds" << dendl;
 
   tracing::osd::tracer.shutdown();
 
@@ -11072,6 +11131,11 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
 }
 
 void OSD::ShardedOpWQ::_enqueue(OpSchedulerItem&& item) {
+  if (unlikely(m_fast_shutdown) ) {
+    // stop enqueing when we are in the middle of a fast shutdown
+    return;
+  }
+
   uint32_t shard_index =
     item.get_ordering_token().hash_to_shard(osd->shards.size());
 
@@ -11102,6 +11166,11 @@ void OSD::ShardedOpWQ::_enqueue(OpSchedulerItem&& item) {
 
 void OSD::ShardedOpWQ::_enqueue_front(OpSchedulerItem&& item)
 {
+  if (unlikely(m_fast_shutdown) ) {
+    // stop enqueing when we are in the middle of a fast shutdown
+    return;
+  }
+
   auto shard_index = item.get_ordering_token().hash_to_shard(osd->shards.size());
   auto& sdata = osd->shards[shard_index];
   ceph_assert(sdata);
@@ -11126,6 +11195,24 @@ void OSD::ShardedOpWQ::_enqueue_front(OpSchedulerItem&& item)
   sdata->shard_lock.unlock();
   std::lock_guard l{sdata->sdata_wait_lock};
   sdata->sdata_cond.notify_one();
+}
+
+void OSD::ShardedOpWQ::stop_for_fast_shutdown()
+{
+  uint32_t shard_index = 0;
+  m_fast_shutdown = true;
+
+  for (; shard_index < osd->num_shards; shard_index++) {
+    auto& sdata = osd->shards[shard_index];
+    ceph_assert(sdata);
+    sdata->shard_lock.lock();
+    int work_count = 0;
+    while(! sdata->scheduler->empty() ) {
+      auto work_item = sdata->scheduler->dequeue();
+      work_count++;
+    }
+    sdata->shard_lock.unlock();
+  }
 }
 
 namespace ceph::osd_cmds {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4278,7 +4278,7 @@ int OSD::shutdown()
       _exit(0);
     }
     // disable BlueFS compaction during fast-shutdown
-    cct->_conf->bluefs_replay_recovery_disable_compact;
+    cct->_conf->bluefs_replay_recovery_disable_compact = true;
   } else if (!service.prepare_to_stop()) {
     return 0; // already shutting down
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4277,6 +4277,8 @@ int OSD::shutdown()
       cct->_log->flush();
       _exit(0);
     }
+    // disable BlueFS compaction during fast-shutdown
+    cct->_conf->bluefs_replay_recovery_disable_compact;
   } else if (!service.prepare_to_stop()) {
     return 0; // already shutting down
   }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1592,7 +1592,7 @@ protected:
     : public ShardedThreadPool::ShardedWQ<OpSchedulerItem>
   {
     OSD *osd;
-
+    bool m_fast_shutdown = false;
   public:
     ShardedOpWQ(OSD *o,
 		ceph::timespan ti,
@@ -1609,6 +1609,8 @@ protected:
 
     /// try to do some work
     void _process(uint32_t thread_index, ceph::heartbeat_handle_d *hb) override;
+
+    void stop_for_fast_shutdown();
 
     /// enqueue a new item
     void _enqueue(OpSchedulerItem&& item) override;


### PR DESCRIPTION
Copied from code:
```
// We calculate space used by Bluestore using this formula:
// {bluestore_used_space} = {space_used_by_allocator} \ {space_used_by_bluefs}
// For this formula to be correct, we must make sure that snapshots of
// {space_used_by_allocator} and {space_used_by_bluefs} are in logical sync.
//
// In the first glance snapshot can be taken at any time there is
// no bluefs activity, as space held by bluefs and held by allocator should cancel out.
// There is an implementation detail that disturbs the picture here.
// When we release extents previously used by bluefs we keep them until we properly sync the log.
// Each flush_and_sync_log ends with returning {pending_release} extents to allocator.
// With *one exception*: when flush_and_sync_log triggers compaction of bluefs log,
// then extents of old log are now in {pending_release} state.
// If we capture snapshot now, then our {space_used_by_allocator} will be off by
// the content of {pending_release}.
//
// To make sure above condition does not happen, we do:
// 1) force bluefs log compaction (to clear conditions for compaction soon)
// 2) trigger flush_and_sync_log (to release extents produced by compaction)
//
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
