### PR TITLE
pacific: cmake: pass RTE_DEVEL_BUILD=n when building dpdk

### DIFF
--- a/cmake/modules/BuildDPDK.cmake
+++ b/cmake/modules/BuildDPDK.cmake
@@ -86,7 +86,7 @@ function(do_build_dpdk dpdk_dir)
   ExternalProject_Add(dpdk-ext
     SOURCE_DIR ${dpdk_source_dir}
     CONFIGURE_COMMAND ${make_cmd} config O=${dpdk_dir} T=${target}
-    BUILD_COMMAND ${make_cmd} O=${dpdk_dir} CC=${CMAKE_C_COMPILER} EXTRA_CFLAGS=-fPIC
+    BUILD_COMMAND ${make_cmd} O=${dpdk_dir} CC=${CMAKE_C_COMPILER} EXTRA_CFLAGS=-fPIC RTE_DEVEL_BUILD=n
     BUILD_IN_SOURCE 1
     INSTALL_COMMAND "true")
   if(NUMA_FOUND)


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/45258 to pacific to address "make check" failures (i.e. it's not a mere cleanup for pacific).