### PR TITLE
quincy: cmake: pass RTE_DEVEL_BUILD=n when building dpdk

### DIFF
--- a/cmake/modules/BuildDPDK.cmake
+++ b/cmake/modules/BuildDPDK.cmake
@@ -94,7 +94,7 @@ function(do_build_dpdk dpdk_dir)
   ExternalProject_Add(dpdk-ext
     SOURCE_DIR ${dpdk_source_dir}
     CONFIGURE_COMMAND ${make_cmd} config O=${dpdk_dir} T=${target}
-    BUILD_COMMAND ${make_cmd} O=${dpdk_dir} CC=${CMAKE_C_COMPILER} EXTRA_CFLAGS=${extra_cflags}
+    BUILD_COMMAND ${make_cmd} O=${dpdk_dir} CC=${CMAKE_C_COMPILER} EXTRA_CFLAGS=${extra_cflags} RTE_DEVEL_BUILD=n
     BUILD_IN_SOURCE 1
     INSTALL_COMMAND ""
     LOG_CONFIGURE ON


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/45258 to quincy.  Unlike in octopus and pacific, here it's just a cleanup but let's backport it anyway for consistency across all branches.