### PR TITLE
osd/PGLog: Add PGLog entries length check

### DIFF
--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -81,6 +81,7 @@ struct KeyServerData {
     ls.push_back(new KeyServerData);
     ls.push_back(new KeyServerData);
     ls.back()->version = 1;
+    ls.back()->rotating_ver = 2;
   }
   bool contains(const EntityName& name) const {
     return (secrets.find(name) != secrets.end());

--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -335,9 +335,10 @@ public:
 
   bool parse(const std::string& s);
 
-  void encode(ceph::buffer::list& bl) const;
-  void decode(ceph::bufferlist::const_iterator& bl);
   void decode(json_spirit::Value& v);
+  void bound_encode(size_t& p) const;
+  void encode(ceph::buffer::list::contiguous_appender& p) const;
+  void decode(ceph::buffer::ptr::const_iterator& p);
   void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<hobject_t*>& o);
   friend int cmp(const hobject_t& l, const hobject_t& r);
@@ -364,7 +365,7 @@ public:
   friend struct ghobject_t;
   friend struct test_hobject_fmt_t;
 };
-WRITE_CLASS_ENCODER(hobject_t)
+WRITE_CLASS_DENC(hobject_t)
 
 namespace std {
 template<> struct hash<hobject_t> {

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3833,6 +3833,12 @@ options:
   level: advanced
   default: 100_M
   with_legacy: true
+- name: osd_warn_on_max_pglog_size
+  type: size
+  level: advanced
+  desc: Max pglog entry size that will issue warning message above that
+  default: 4_K
+  with_legacy: true
 - name: osd_bench_max_block_size
   type: size
   level: advanced

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -1310,7 +1310,7 @@ static PG::interruptible_future<> do_pgnls_filtered(
 
   hobject_t lower_bound;
   try {
-    lower_bound.decode(bp);
+    ceph::decode(lower_bound, bp);
   } catch (const buffer::error&) {
     throw std::invalid_argument("unable to decode PGNLS_FILTER description");
   }
@@ -1400,7 +1400,7 @@ static PG::interruptible_future<> do_pgls(
   hobject_t lower_bound;
   auto bp = osd_op.indata.cbegin();
   try {
-    lower_bound.decode(bp);
+    ceph::decode(lower_bound, bp);
   } catch (const buffer::error&) {
     throw std::invalid_argument{"unable to decode PGLS handle"};
   }
@@ -1439,7 +1439,7 @@ static PG::interruptible_future<> do_pgls_filtered(
 
   hobject_t lower_bound;
   try {
-    lower_bound.decode(bp);
+    ceph::decode(lower_bound, bp);
   } catch (const buffer::error&) {
     throw std::invalid_argument("unable to decode PGLS_FILTER description");
   }

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -451,7 +451,7 @@ void PG::prepare_write(pg_info_t &info,
     ceph_assert(ret == 0);
   }
   pglog.write_log_and_missing(
-    t, &km, coll_ref->get_cid(), pgmeta_oid,
+    shard_services.get_cct(), t, &km, coll_ref->get_cid(), pgmeta_oid,
     peering_state.get_pgpool().info.require_rollback());
   if (!km.empty()) {
     t.omap_setkeys(coll_ref->get_cid(), pgmeta_oid, km);

--- a/src/include/object.h
+++ b/src/include/object.h
@@ -54,6 +54,10 @@ struct object_t {
     name.clear();
   }
 
+  DENC(object_t, v, p) {
+    denc(v.name, p);
+  }
+
   void encode(ceph::buffer::list &bl) const {
     using ceph::encode;
     encode(name, bl);
@@ -73,6 +77,7 @@ struct object_t {
   }
 };
 WRITE_CLASS_ENCODER(object_t)
+WRITE_CLASS_DENC_BOUNDED(object_t)
 
 inline std::ostream& operator<<(std::ostream& out, const object_t& o) {
   return out << o.name;
@@ -192,15 +197,9 @@ struct sobject_t {
     o.snap = t;
   }
 
-  void encode(ceph::buffer::list& bl) const {
-    using ceph::encode;
-    encode(oid, bl);
-    encode(snap, bl);
-  }
-  void decode(ceph::buffer::list::const_iterator& bl) {
-    using ceph::decode;
-    decode(oid, bl);
-    decode(snap, bl);
+  DENC(sobject_t, v, p) {
+    denc(v.oid, p);
+    denc(v.snap, p);
   }
   void dump(ceph::Formatter *f) const {
     f->dump_stream("oid") << oid;
@@ -211,7 +210,7 @@ struct sobject_t {
     o.push_back(new sobject_t(object_t("myobject"), 123));
   }
 };
-WRITE_CLASS_ENCODER(sobject_t)
+WRITE_CLASS_DENC_BOUNDED(sobject_t)
 
 inline std::ostream& operator<<(std::ostream& out, const sobject_t &o) {
   return out << o.oid << "/" << o.snap;

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -530,13 +530,8 @@ struct shard_id_t {
 
   const static shard_id_t NO_SHARD;
 
-  void encode(ceph::buffer::list &bl) const {
-    using ceph::encode;
-    encode(id, bl);
-  }
-  void decode(ceph::buffer::list::const_iterator &bl) {
-    using ceph::decode;
-    decode(id, bl);
+  DENC(shard_id_t, v, p) {
+    denc(v.id, p);
   }
   void dump(ceph::Formatter *f) const {
     f->dump_int("id", id);
@@ -548,7 +543,7 @@ struct shard_id_t {
   bool operator==(const shard_id_t&) const = default;
   auto operator<=>(const shard_id_t&) const = default;
 };
-WRITE_CLASS_ENCODER(shard_id_t)
+WRITE_CLASS_DENC(shard_id_t)
 std::ostream &operator<<(std::ostream &lhs, const shard_id_t &rhs);
 
 #if defined(__sun) || defined(_AIX) || defined(__APPLE__) || \

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -179,9 +179,26 @@ public:
 #endif
   }
 
-  DENC(utime_t, v, p) {
-    denc(v.tv.tv_sec, p);
-    denc(v.tv.tv_nsec, p);
+  void bound_encode(size_t& p) const {
+    denc(tv.tv_sec, p);
+    denc(tv.tv_nsec, p);
+  }
+
+  void encode(ceph::buffer::list::contiguous_appender& p) const {
+#if defined(CEPH_LITTLE_ENDIAN)
+    p.append((char *)this, sizeof(__u32) + sizeof(__u32));
+#else
+    denc(tv.tv_sec, p);
+    denc(tv.tv_nsec, p);
+#endif
+  }
+  void decode(ceph::buffer::ptr::const_iterator& p) {
+#if defined(CEPH_LITTLE_ENDIAN)
+    p.get_ptr(sizeof(__u32) + sizeof(__u32)).copy_out(0, sizeof(__u32) + sizeof(__u32), (char *)this);
+#else
+    denc(tv.tv_sec, p);
+    denc(tv.tv_nsec, p);
+#endif
   }
 
   void dump(ceph::Formatter *f) const;

--- a/src/mon/ConnectionTracker.cc
+++ b/src/mon/ConnectionTracker.cc
@@ -344,7 +344,9 @@ void ConnectionReport::generate_test_instances(std::list<ConnectionReport*>& o)
   o.back()->epoch = 2;
   o.back()->epoch_version = 3;
   o.back()->current[0] = true;
+  o.back()->current[1] = false;
   o.back()->history[0] = .4;
+  o.back()->history[1] = 99.9999;
 }
 
 void ConnectionTracker::dump(ceph::Formatter *f) const

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -955,7 +955,7 @@ void PG::prepare_write(
     ceph_assert(ret == 0);
   }
   pglog.write_log_and_missing(
-    t, &km, coll, pgmeta_oid, pool.info.require_rollback());
+    cct, t, &km, coll, pgmeta_oid, pool.info.require_rollback());
   if (!km.empty())
     t.omap_setkeys(coll, pgmeta_oid, km);
   if (!key_to_remove.empty())

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1322,6 +1322,7 @@ public:
   }
 
   void write_log_and_missing(
+    CephContext* cct,
     ObjectStore::Transaction& t,
     std::map<std::string,ceph::buffer::list> *km,
     const coll_t& coll,
@@ -1329,6 +1330,7 @@ public:
     bool require_rollback);
 
   static void write_log_and_missing_wo_missing(
+    CephContext* cct,
     ObjectStore::Transaction& t,
     std::map<std::string,ceph::buffer::list>* km,
     pg_log_t &log,
@@ -1338,6 +1340,7 @@ public:
     const DoutPrefixProvider *dpp = nullptr);
 
   static void write_log_and_missing(
+    CephContext* cct,
     ObjectStore::Transaction& t,
     std::map<std::string,ceph::buffer::list>* km,
     pg_log_t &log,
@@ -1349,6 +1352,7 @@ public:
     const DoutPrefixProvider *dpp = nullptr);
 
   static void _write_log_and_missing_wo_missing(
+    CephContext* cct,
     ObjectStore::Transaction& t,
     std::map<std::string,ceph::buffer::list>* km,
     pg_log_t &log,
@@ -1368,6 +1372,7 @@ public:
     );
 
   static void _write_log_and_missing(
+    CephContext* cct,
     ObjectStore::Transaction& t,
     std::map<std::string,ceph::buffer::list>* km,
     pg_log_t &log,

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -2460,13 +2460,14 @@ public:
   }
 
   void test_disk_roundtrip() {
+    CephContext *cct = g_ceph_context;
     ObjectStore::Transaction t;
     hobject_t hoid;
     hoid.pool = 1;
     hoid.oid = "log";
     ghobject_t log_oid(hoid);
     map<string, bufferlist> km;
-    write_log_and_missing(t, &km, test_coll, log_oid, false);
+    write_log_and_missing(cct, t, &km, test_coll, log_oid, false);
     if (!km.empty()) {
       t.omap_setkeys(test_coll, log_oid, km);
     }

--- a/src/tools/ceph-dencoder/denc_plugin.h
+++ b/src/tools/ceph-dencoder/denc_plugin.h
@@ -29,6 +29,9 @@ public:
       dlclose(mod);
     }
 #endif
+    for (auto& [name, denc] : dencoders) {
+      delete denc;
+    }
   }
   const dencoders_t& register_dencoders() {
     static constexpr std::string_view REGISTER_DENCODERS_FUNCTION = "register_dencoders\0";

--- a/src/tools/ceph_objectstore_tool.h
+++ b/src/tools/ceph_objectstore_tool.h
@@ -25,7 +25,7 @@ class ObjectStoreTool : public RadosDump
     {}
 
     int dump_export(Formatter *formatter, const std::string &dump_data_dir);
-    int do_import(ObjectStore *store, OSDSuperblock& sb, bool force,
+    int do_import(CephContext *cct, ObjectStore *store, OSDSuperblock& sb, bool force,
 		  std::string pgidstr);
     int do_export(CephContext *cct, ObjectStore *fs, coll_t coll, spg_t pgid,
           pg_info_t &info, epoch_t map_epoch, __u8 struct_ver,


### PR DESCRIPTION
while we are writing PG Logs entries we will check the entries that going to be added, if they will exceed the configured length, a warning message will be added to the log.

osd_warn_on_max_pglog_size will be added to the configuration option - when the pg log exceeds that length, we will issue the warning message.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
