### PR TITLE
Fix Windows build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -526,7 +526,14 @@ add_library(common STATIC ${ceph_common_objs})
 target_link_libraries(common ${ceph_common_deps})
 add_dependencies(common legacy-option-headers ${jaeger_base})
 
-add_library(ceph-common ${CEPH_SHARED} ${ceph_common_objs})
+if (WIN32)
+  # Statically building ceph-common on Windows fails. We're temporarily
+  # reverting this: 22fefb2338cfc4fcb03ece3cbf77aa964a7f17f2
+  add_library(ceph-common SHARED ${ceph_common_objs})
+else()
+  add_library(ceph-common ${CEPH_SHARED} ${ceph_common_objs})
+endif()
+
 target_link_libraries(ceph-common ${ceph_common_deps})
 if(ENABLE_COVERAGE)
   target_link_libraries(ceph-common gcov)

--- a/src/include/win32/dlfcn.h
+++ b/src/include/win32/dlfcn.h
@@ -1,0 +1,1 @@
+#include "../dlfcn_compat.h"


### PR DESCRIPTION
Fix Windows build

The Windows build is currently failing because of the following issues:

* missing "dlfcn.h" - we'll define the file and include Ceph's "dlfcn_compat.h"
* libceph-common linking issues - we'll temporarily revert this [1], at least for Windows builds

[1] 22fefb2338cfc4fcb03ece3cbf77aa964a7f17f2

Fixes: https://tracker.ceph.com/issues/54453
Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>