### PR TITLE
crimson, cls: fix the inability to print logs from plugins.

### DIFF
--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -3,6 +3,7 @@
 
 #include <cstdarg>
 #include <cstring>
+#include <boost/container/small_vector.hpp>
 #include "common/ceph_context.h"
 #include "common/ceph_releases.h"
 #include "common/config.h"
@@ -536,16 +537,16 @@ int cls_cxx_get_gathered_data(cls_method_context_t hctx, std::map<std::string, b
 // the classical OSD, it's different b/c of how the dout macro expands.
 int cls_log(int level, const char *format, ...)
 {
-   int size = 256;
+   size_t size = 256;
    va_list ap;
    while (1) {
-     char buf[size];
+     boost::container::small_vector<char, 256> buf(size);
      va_start(ap, format);
-     int n = vsnprintf(buf, size, format, ap);
+     int n = vsnprintf(buf.data(), size, format, ap);
      va_end(ap);
-#define MAX_SIZE 8196
-     if ((n > -1 && n < size) || size > MAX_SIZE) {
-       dout(ceph::dout::need_dynamic(level)) << buf << dendl;
+#define MAX_SIZE 8196UL
+     if ((n > -1 && static_cast<size_t>(n) < size) || size > MAX_SIZE) {
+       dout(ceph::dout::need_dynamic(level)) << buf.data() << dendl;
        return n;
      }
      size *= 2;

--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -15,8 +15,6 @@
 
 #define dout_context ClassHandler::get_instance().cct
 
-static constexpr int dout_subsys = ceph_subsys_objclass;
-
 void *cls_alloc(size_t size)
 {
   return malloc(size);
@@ -146,22 +144,4 @@ void cls_cxx_subop_version(cls_method_context_t hctx, std::string *s)
   snprintf(buf, sizeof(buf), "%lld.%d", (long long)ver, subop_num);
 
   *s = buf;
-}
-
-int cls_log(int level, const char *format, ...)
-{
-   int size = 256;
-   va_list ap;
-   while (1) {
-     char buf[size];
-     va_start(ap, format);
-     int n = vsnprintf(buf, size, format, ap);
-     va_end(ap);
-#define MAX_SIZE 8196
-     if ((n > -1 && n < size) || size > MAX_SIZE) {
-       dout(ceph::dout::need_dynamic(level)) << buf << dendl;
-       return n;
-     }
-     size *= 2;
-   }
 }

--- a/src/osd/objclass.cc
+++ b/src/osd/objclass.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <cstdarg>
+#include <boost/container/small_vector.hpp>
 #include "common/ceph_context.h"
 #include "common/ceph_releases.h"
 #include "common/config.h"
@@ -753,16 +754,16 @@ int cls_cxx_get_gathered_data(cls_method_context_t hctx, std::map<std::string, b
 // crimson-osd, it's different b/c of how the dout macro expands.
 int cls_log(int level, const char *format, ...)
 {
-   int size = 256;
+   size_t size = 256;
    va_list ap;
    while (1) {
-     char buf[size];
+     boost::container::small_vector<char, 256> buf(size);
      va_start(ap, format);
-     int n = vsnprintf(buf, size, format, ap);
+     int n = vsnprintf(buf.data(), size, format, ap);
      va_end(ap);
-#define MAX_SIZE 8196
-     if ((n > -1 && n < size) || size > MAX_SIZE) {
-       dout(ceph::dout::need_dynamic(level)) << buf << dendl;
+#define MAX_SIZE 8196UL
+     if ((n > -1 && static_cast<size_t>(n) < size) || size > MAX_SIZE) {
+       dout(ceph::dout::need_dynamic(level)) << buf.data() << dendl;
        return n;
      }
      size *= 2;


### PR DESCRIPTION
`cls_log()` of the interface between an OSD and a plugin (a Ceph Class) is implemented on top of the `dout` macros and shared between crimson and the classical OSD.

Unfortunately, when a plugin is hosted inside crimson, this causes the inability to send to any in-plugin generated message to the `seastar::logger` for the `objclass` subsystem.

This patch differtiates the implementation of `cls_log()`, and thus allow the `seastar::logger`-based implementation of `dout` to be used.

After the fix:

```
DEBUG 2022-03-07 14:12:14,124 [shard 0] osd - handling op call on object 1:424638ea:::image1:head
DEBUG 2022-03-07 14:12:14,124 [shard 0] osd - calling method rbd.create, num_read=0, num_write=0
DEBUG 2022-03-07 14:12:14,125 [shard 0] objclass - <cls> ../src/cls/rbd/cls_rbd.cc:787: create object_prefix=image1 size=0 order=22 features=0
DEBUG 2022-03-07 14:12:14,125 [shard 0] osd - handling op omap-get-vals-by-keys on object 1:424638ea:::image1:head
DEBUG 2022-03-07 14:12:14,125 [shard 0] osd - omap_get_vals_by_keys: object does not exist: 1:424638ea:::image1:head
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
