### PR TITLE
doc/rados/operations/placement-groups: fix --bulk commands

### DIFF
--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -144,22 +144,22 @@ to OSDs of class `hdd` will each have optimal PG counts that depend on
 the number of those respective device types.
 
 The autoscaler uses the `bulk` flag to determine which pool
-should start out with a full complements of PGs and only
-scales down when the the usage ratio across the pool is not even. 
+should start out with a full complement of PGs and only
+scales down when the the usage ratio across the pool is not even.
 However, if the pool doesn't have the `bulk` flag, the pool will
 start out with minimal PGs and only when there is more usage in the pool.
 
-The autoscaler identifies any overlapping roots and prevents the pools 
+The autoscaler identifies any overlapping roots and prevents the pools
 with such roots from scaling because overlapping roots can cause problems
 with the scaling process.
 
 To create pool with `bulk` flag::
 
-  ceph osd create <pool-name> --bulk
+  ceph osd pool create <pool-name> --bulk
 
 To set/unset `bulk` flag of existing pool::
 
-  ceph osd pool set <pool-name> bulk=true/false/1/0
+  ceph osd pool set <pool-name> bulk <true/false/1/0>
 
 To get `bulk` flag of existing pool::
 


### PR DESCRIPTION
Some parts of the documents regarding
the bulk flag  have typos.

Command for creating a pool

was: `ceph osd create test_pool --bulk`

should be: `ceph osd pool create test_pool --bulk`

Command for setting bulk value in a pool

was: `ceph osd pool set test_pool bulk=<true/false/1/0>`

should be: `ceph osd pool set test_pool bulk <true/false/1/0>`

Also removed a bit of trailing white spaces.

Fixes: https://tracker.ceph.com/issues/54485

Signed-off-by: Kamoltat <ksirivad@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
