### PR TITLE
octopus: rgw: fix leak of RGWBucketList memory (octopus only)

### DIFF
--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -54,10 +54,16 @@ int RGWRadosUser::list_buckets(const string& marker, const string& end_marker,
 
 RGWBucketList::~RGWBucketList()
 {
+  clear();
+}
+
+void RGWBucketList::clear()
+{
   for (auto itr = buckets.begin(); itr != buckets.end(); itr++) {
     delete itr->second;
   }
   buckets.clear();
+  truncated = false;
 }
 
 RGWBucket* RGWRadosUser::add_bucket(rgw_bucket& bucket,

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -154,7 +154,7 @@ public:
     buckets[bucket->ent.bucket.name] = bucket;
   }
   size_t count() const { return buckets.size(); }
-  void clear() { buckets.clear(); truncated = false; }
+  void clear();
 }; // class RGWBucketList
 
 class RGWObject {


### PR DESCRIPTION
this updates an earlier octopus-only fix, 0de02a88be0972c89ed2bb10dc438d080137bd18, to also free the RGWBucket* in each map entry

this issue only exists on octopus, so this fix targets octopus directly instead of cherry-picking from master

Fixes: https://tracker.ceph.com/issues/54482

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
