### PR TITLE
doc: Add alternative memory profiling to doc

### DIFF
--- a/doc/rados/troubleshooting/memory-profiling.rst
+++ b/doc/rados/troubleshooting/memory-profiling.rst
@@ -140,3 +140,32 @@ For example::
 
 .. _Logging and Debugging: ../log-and-debug
 .. _Google Heap Profiler: http://goog-perftools.sourceforge.net/doc/heap_profiler.html
+
+Alternative ways for memory profiling
+-------------------------------------
+
+Running Massif heap profiler with Valgrind
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Massif heap profiler tool can be used with Valgrind to
+measure how much heap memory is used and is good for
+troubleshooting for example Ceph RadosGW.
+
+See the `Massif documentation <https://valgrind.org/docs/manual/ms-manual.html>`_ for
+more information.
+
+Install Valgrind from the package manager for your distribution
+then start the Ceph daemon you want to troubleshoot::
+
+        sudo -u ceph valgrind --max-threads=1024 --tool=massif /usr/bin/radosgw -f --cluster ceph --name NAME --setuser ceph --setgroup ceph
+
+A file similar to ``massif.out.<pid>`` will be saved when it exits
+in your current working directory. The user running the process above
+must have write permissions in the current directory.
+
+You can then run the ``ms_print`` command to get a graph and statistics
+from the collected data in the ``massif.out.<pid>`` file::
+
+        ms_print massif.out.12345
+
+This output is great for inclusion in a bug report.


### PR DESCRIPTION
This adds documentation about alternative
memory profiling options for services such
as RadosGW using the Massif heap memory profiler
with Valgrind.

That was used to produce output like served
in the bug report [1]

[1] https://tracker.ceph.com/issues/54482

Signed-off-by: Tobias Urdin <tobias.urdin@binero.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [X] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests