### PR TITLE
octopus: mgr/devicehealth: fix missing timezone from time delta calculation

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -8,7 +8,7 @@ from mgr_module import MgrModule, CommandResult
 import operator
 import rados
 from threading import Event
-from datetime import datetime, timedelta, date, time
+from datetime import datetime, timedelta, date, time, timezone
 from six import iteritems
 
 TIME_FORMAT = '%Y%m%d-%H%M%S'
@@ -491,7 +491,7 @@ class Module(MgrModule):
         devs = self.get("devices")
         osds_in = {}
         osds_out = {}
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)  # e.g. '2021-09-22 13:18:45.021712+00:00'
         osdmap = self.get("osd_map")
         assert osdmap is not None
         for dev in devs['devices']:
@@ -506,7 +506,7 @@ class Module(MgrModule):
                 continue
             # life_expectancy_(min/max) is in the format of:
             # '%Y-%m-%dT%H:%M:%S.%f%z', e.g.:
-            # '2019-01-20T21:12:12.000000Z'
+            # '2019-01-20 21:12:12.000000+00:00'
             life_expectancy_max = datetime.strptime(
                 dev['life_expectancy_max'],
                 '%Y-%m-%dT%H:%M:%S.%f%z')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53620

-----------------

backport of https://github.com/ceph/ceph/pull/43412
parent tracker: https://tracker.ceph.com/issues/52327





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
