### PR TITLE
rgw/rgw_common: Keyname should not include version_id in case of unversioned bucket.

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1527,6 +1527,18 @@ struct rgw_obj_key {
     snprintf(buf, sizeof(buf), "%s[%s]", name.c_str(), instance.c_str());
     return buf;
   }
+
+  // Helper function to find the key of an object.
+  // This function is for handling the null version if specified in the request.
+  // in case of unversioned bucket object key is returned as is.
+  // in case of versioned bucket object key is key[version_id].
+  std::string get_key_name_string() const{
+    if (have_null_instance()) {
+      return name;
+    }
+
+    return to_str();
+  }
 };
 WRITE_CLASS_ENCODER(rgw_obj_key)
 


### PR DESCRIPTION
**Problem :** If version id parameter is passed as null to delete-object
API in case of unversioned bucket for deletion of simple object,
then object deletion does not happen. This case is valid only when
Motr is used as backend for rgw.

**Implementation :** In case of unversioned bucket the to_str() function
of rgw_obj_key returns key in the following format <obj_key>[null].
To avoid this a new function get_key_name_string() is added which
returns key in the format <obj_key> if instance variable of
rgw_obj_key is set to "null" string.

**Alternate Implementation :** There is one more way to fix this issue by
altering the to_str() function. We can add the "if condition" of the new 
function in the to_str() function.

Other half of this PR (changes in motr_sal layer):
https://github.com/Seagate/cortx-rgw/pull/114

Signed-off-by: Deepak Mahale <deepak.mahale@seagate.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
