### PR TITLE
mgr/alerts: Add Message-Id and Date header to sent emails

### DIFF
--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -4,6 +4,7 @@ A simple cluster health alerting module.
 """
 
 from mgr_module import CLIReadCommand, HandleCommandResult, MgrModule, Option
+from email.utils import make_msgid
 from threading import Event
 from typing import Any, Optional, Dict, List, TYPE_CHECKING, Union
 import json
@@ -203,12 +204,14 @@ class Alerts(MgrModule):
         message = ('From: {from_name} <{sender}>\n'
                    'Subject: {status}\n'
                    'To: {target}\n'
+                   'Message-Id: {message_id}\n'
                    '\n'
                    '{status}\n'.format(
                        sender=self.smtp_sender,
                        from_name=self.smtp_from_name,
                        status=status['status'],
-                       target=self.smtp_destination))
+                       target=self.smtp_destination,
+                       message_id=make_msgid()))
 
         if 'new' in diff:
             message += ('\n--- New ---\n')

--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -4,7 +4,7 @@ A simple cluster health alerting module.
 """
 
 from mgr_module import CLIReadCommand, HandleCommandResult, MgrModule, Option
-from email.utils import make_msgid
+from email.utils import formatdate, make_msgid
 from threading import Event
 from typing import Any, Optional, Dict, List, TYPE_CHECKING, Union
 import json
@@ -205,13 +205,15 @@ class Alerts(MgrModule):
                    'Subject: {status}\n'
                    'To: {target}\n'
                    'Message-Id: {message_id}\n'
+                   'Date: {date}\n'
                    '\n'
                    '{status}\n'.format(
                        sender=self.smtp_sender,
                        from_name=self.smtp_from_name,
                        status=status['status'],
                        target=self.smtp_destination,
-                       message_id=make_msgid()))
+                       message_id=make_msgid(),
+                       date=formatdate()))
 
         if 'new' in diff:
             message += ('\n--- New ---\n')


### PR DESCRIPTION
This adds a `Message-Id:` and `Date:` header to the emails sent by mgr/alerts. According to https://www.ietf.org/rfc/rfc5322.txt the `Message-Id` header "SHOULD" be present ("3.6.4. Identification fields") whereas the `Date` header is required ("3.6.1.  The Origination Date Field").
Absence of both headers also increases the chance of the emails being flagged as spam.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
