### PR TITLE
test/librbd/test_notify.py: effect post object map rebuild assert

### DIFF
--- a/src/test/librbd/test_notify.py
+++ b/src/test/librbd/test_notify.py
@@ -140,11 +140,6 @@ def slave(ioctx):
         assert(not image.is_exclusive_lock_owner())
         assert(list(image.list_snaps()) == [])
 
-        print("rebuild object map")
-        image.rebuild_object_map()
-        assert(not image.is_exclusive_lock_owner())
-        assert((image.flags() & RBD_FLAG_OBJECT_MAP_INVALID) == 0)
-
         if 'RBD_DISABLE_UPDATE_FEATURES' not in os.environ:
             print("update_features")
             assert((image.features() & RBD_FEATURE_OBJECT_MAP) != 0)
@@ -155,6 +150,13 @@ def slave(ioctx):
             assert(not image.is_exclusive_lock_owner())
             assert((image.features() & RBD_FEATURE_OBJECT_MAP) != 0)
             assert((image.flags() & RBD_FLAG_OBJECT_MAP_INVALID) != 0)
+        else:
+            print("skipping update_features")
+
+        print("rebuild object map")
+        image.rebuild_object_map()
+        assert(not image.is_exclusive_lock_owner())
+        assert((image.flags() & RBD_FLAG_OBJECT_MAP_INVALID) == 0)
 
         print("write")
         data = os.urandom(512)


### PR DESCRIPTION
Instead of just optionally skipping update_features test, commit
9c0b239d70cd ("qa/upgrade: conditionally disable update_features
tests") moved it after rebuild_object_map test.  This isn't right
because update_features test invalidates the object map as a side
effect and rebuild_object_map test is what makes it valid again:

  assert((image.flags() & RBD_FLAG_OBJECT_MAP_INVALID) == 0)

Let's make this assert effective, at least when update_features
test isn't skipped.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
