### PR TITLE
[DNM] mon/Elector.cc: Helper PR for fixing bug 50089

### DIFF
--- a/qa/suites/orch/cephadm/workunits/task/test_orch_cli_mon.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_orch_cli_mon.yaml
@@ -1,0 +1,45 @@
+roles:
+- - host.a
+  - osd.0
+  - osd.1
+  - osd.2
+  - mon.a
+  - mgr.a
+  - client.0
+- - host.b
+  - osd.3
+  - osd.4
+  - osd.5
+  - mon.b
+  - mgr.b
+  - client.1
+- - host.c
+  - osd.6
+  - osd.7
+  - osd.8
+  - mon.c
+  - mgr.c
+  - client.2
+- - host.d
+  - osd.9
+  - osd.10
+  - osd.11
+  - mon.d
+  - mgr.d
+  - client.3
+- - host.e
+  - osd.12
+  - osd.13
+  - osd.14
+  - mon.e
+  - mgr.e
+  - client.4
+tasks:
+- install:
+- cephadm:
+- cephadm.shell:
+    host.a:
+      - ceph orch apply mds a
+- cephfs_test_runner:
+    modules:
+      - tasks.cephadm_cases.test_cli_mon

--- a/qa/suites/orch/cephadm/workunits/task/test_orch_cli_mon_same_host.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_orch_cli_mon_same_host.yaml
@@ -1,0 +1,35 @@
+roles:
+- - host.a
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+  - osd.4
+  - osd.5
+  - osd.6
+  - osd.7
+  - osd.8
+  - osd.9
+  - osd.10
+  - osd.11
+  - osd.12
+  - osd.13
+  - osd.14
+  - mon.a
+  - mon.b
+  - mon.c
+  - mon.d
+  - mon.e
+  - mgr.a
+  - mgr.b
+  - mgr.c
+  - client.0
+tasks:
+- install:
+- cephadm:
+- cephadm.shell:
+    host.a:
+      - ceph orch apply mds a
+- cephfs_test_runner:
+    modules:
+      - tasks.cephadm_cases.test_cli_mon

--- a/qa/tasks/cephadm_cases/test_cli_mon.py
+++ b/qa/tasks/cephadm_cases/test_cli_mon.py
@@ -1,0 +1,56 @@
+import json
+import logging
+import time
+
+from tasks.mgr.mgr_test_case import MgrTestCase
+
+log = logging.getLogger(__name__)
+
+
+class TestCephadmCLI(MgrTestCase):
+    def _cmd(self, *args) -> str:
+        assert self.mgr_cluster is not None
+        return self.mgr_cluster.mon_manager.raw_cluster_cmd(*args)
+
+    def _orch_cmd(self, *args) -> str:
+        return self._cmd("orch", *args)
+
+    def setUp(self):
+        super(TestCephadmCLI, self).setUp()
+
+    def _create_and_write_pool(self, pool_name):
+        "Simulate some writes"
+        self.mgr_cluster.mon_manager.create_pool(pool_name)
+        args = [
+            "rados", "-p", pool_name, "bench", "30", "write", "-t", "16"]
+        self.mgr_cluster.admin_remote.run(args=args, wait=True)
+
+    def test_apply_mon_three(self):
+
+        # Evaluating the process of reducing the number of monitors using
+        # the `ceph orch apply mon <num>` command.
+
+        retstr = self._cmd('quorum_status') # log the quorum_status before reducing the monitors
+        log.warning("test_apply_mon: quorum_status before reduce returns %s" % json.dumps(retstr, indent=2))
+
+        self._orch_cmd('apply', 'mon', '3') # reduce the monitors from 5 -> 3
+        time.sleep(10)
+
+        retstr = self._cmd('quorum_status') # log the quorum_status 10s after reducing the monitors
+        log.warning("test_apply_mon: monstatus ~10s after reduce returns %s" % json.dumps(retstr, indent=2))
+
+        self._create_and_write_pool('test_pool1') # Create and write some pools
+
+        retstr = self._cmd('quorum_status') # log the quorum_status 26s after reducing the monitors
+        log.warning("test_apply_mon: monstatus ~26s after reduce returns %s" % json.dumps(retstr, indent=2))
+
+        quorum_size = len(json.loads(retstr)['quorum']) # get quorum size
+        self.assertEqual(quorum_size, 3) # evaluate if quorum size == 3
+
+        time.sleep(5)
+        retstr = self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'crash', 'ls',
+        )
+
+        log.warning("test_apply_mon: crash ls returns %s" % retstr)
+        self.assertEqual(0, len(retstr)) # check if there are no crashes

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -327,6 +327,10 @@ class Elector : public ElectionOwner, RankProvider {
    *
    * @param m A received message
    */
+  
+  void print_live_pinging();
+  void print_dead_pinging();
+
   void dispatch(MonOpRequestRef op);
 
   /**


### PR DESCRIPTION
Added two different workunits:
1. MON=5 in 5 different hosts
2. MON=5 in 1 same host

Additional logging that will give us
information regarding functions in ../src/mon/Elector.cc

Signed-off-by: Kamoltat <ksirivad@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
