### PR TITLE
pacific: mgr/dashboard: fix white screen on Safari 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
@@ -110,7 +110,7 @@ export class HostFormComponent extends CdForm implements OnInit {
     // pattern to replace range [0-5] to [0..5](valid expression for brace expansion)
     // replace any kind of brackets with curly braces
     return hostname
-      .replace(/(?<=\d)\s*-\s*(?=\d)/g, '..')
+      .replace(/(\d)\s*-\s*(\d)/g, '$1..$2')
       .replace(/\(/g, '{')
       .replace(/\)/g, '}')
       .replace(/\[/g, '{')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53700

---

backport of https://github.com/ceph/ceph/pull/44360
parent tracker: https://tracker.ceph.com/issues/53665

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh