### PR TITLE
mds: limit the snapshot names to 240 characters

### DIFF
--- a/doc/dev/cephfs-snapshots.rst
+++ b/doc/dev/cephfs-snapshots.rst
@@ -53,6 +53,17 @@ To create a CephFS snapshot, create a subdirectory under
 ``.snap`` with a name of your choice. For example, to create a snapshot on
 directory "/1/2/3/", invoke ``mkdir /1/2/3/.snap/my-snapshot-name`` .
 
+.. note::
+   Snapshot names can not start with an underscore ('_'), as these names are
+   reserved for internal usage.
+
+.. note::
+   Snapshot names can not exceed 240 characters.  This is because the MDS makes
+   use of long snapshot names internally, which follow the format:
+   `_<SNAPSHOT-NAME>_<INODE-NUMBER>`.  Since filenames in general can't have
+   more than 255 characters, and `<node-id>` takes 13 characters, the long
+   snapshot names can take as much as 255 - 1 - 1 - 13 = 240.
+
 This is transmitted to the MDS Server as a
 CEPH_MDS_OP_MKSNAP-tagged `MClientRequest`, and initially handled in
 Server::handle_client_mksnap(). It allocates a `snapid` from the `SnapServer`,

--- a/qa/workunits/fs/snaps/snaptest-name-limits.sh
+++ b/qa/workunits/fs/snaps/snaptest-name-limits.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# This tests snapshot names limits: names have to be < 240 chars
+#
+
+function cleanup ()
+{
+	rmdir d1/.snap/*
+	rm -rf d1
+}
+
+function fail ()
+{
+	echo $@
+	cleanup
+	exit 1
+}
+
+mkdir d1
+
+longname=$(printf "%.241d" 2)
+mkdir d1/.snap/$longname 2> /dev/null
+[ -d d1/.snap/$longname ] && fail "Invalid snapshot exists: $longname"
+
+cleanup
+
+echo OK

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -10456,6 +10456,7 @@ void Server::handle_client_mksnap(MDRequestRef& mdr)
     return;
   }
   if (snapname.length() == 0 ||
+      snapname.length() > snapshot_name_max ||
       snapname[0] == '_') {
     respond_to_request(mdr, -CEPHFS_EINVAL);
     return;

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -459,6 +459,8 @@ private:
   bool replay_unsafe_with_closed_session = false;
   double cap_revoke_eviction_timeout = 0;
   uint64_t max_snaps_per_dir = 100;
+  // long snapshot names have the following format: "_<SNAPSHOT-NAME>_<INODE-NUMBER>"
+  uint64_t snapshot_name_max = NAME_MAX - 1 - 1 - 13;
   unsigned delegate_inos_pct = 0;
   uint64_t dir_max_entries = 0;
   int64_t bal_fragment_size_max = 0;


### PR DESCRIPTION
This PR comes after [the discussion in this thread](https://lore.kernel.org/all/20220305122527.1102109-1-xiubli@redhat.com/).  Note that this PR requires PR #45192 to be merged as well (probably this dependency can be specified in github...).

Basically, without limting snapshot names, the long snapshot names (those starting with '_') will exceed the maximum allowed file names size.

I'd like to get reviews from, at least, @lxbsz and @jtlayton 

Signed-off-by: Luís Henriques <lhenriques@suse.de>