### PR TITLE
mgr/dashboard: unselect rows in datatables

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/block/mirroring.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/block/mirroring.po.ts
@@ -13,7 +13,7 @@ export class MirroringPageHelper extends PageHelper {
    */
   @PageHelper.restrictTo(pages.index.url)
   editMirror(name: string, option: string) {
-    // Clicks the pool in the table
+    // Select the pool in the table
     this.getFirstTableCell(name).click();
 
     // Clicks the Edit Mode button
@@ -28,5 +28,8 @@ export class MirroringPageHelper extends PageHelper {
     cy.contains('.modal-dialog', 'Edit pool mirror mode').should('not.exist');
     const val = option.toLowerCase(); // used since entries in table are lower case
     this.getFirstTableCell(val).should('be.visible');
+
+    // unselect the pool in the table
+    this.getFirstTableCell(name).click();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
@@ -127,8 +127,8 @@ export class HostsPageHelper extends PageHelper {
   @PageHelper.restrictTo(pages.index.url)
   maintenance(hostname: string, exit = false, force = false) {
     this.clearTableSearchInput();
+    this.getTableCell(this.columnIndex.hostname, hostname).click();
     if (force) {
-      this.getTableCell(this.columnIndex.hostname, hostname).click();
       this.clickActionButton('enter-maintenance');
 
       cy.get('cd-modal').within(() => {
@@ -145,7 +145,6 @@ export class HostsPageHelper extends PageHelper {
     }
     if (exit) {
       this.getTableCell(this.columnIndex.hostname, hostname)
-        .click()
         .parent()
         .find(`datatable-body-cell:nth-child(${this.columnIndex.status})`)
         .then(($ele) => {
@@ -163,7 +162,6 @@ export class HostsPageHelper extends PageHelper {
           expect(status).to.not.include('maintenance');
         });
     } else {
-      this.getTableCell(this.columnIndex.hostname, hostname).click();
       this.clickActionButton('enter-maintenance');
 
       this.getTableCell(this.columnIndex.hostname, hostname)
@@ -187,5 +185,9 @@ export class HostsPageHelper extends PageHelper {
       cy.wait(20000);
       this.expectTableCount('total', 0);
     });
+
+    // unselect it to avoid colliding with any other selection
+    // in different steps
+    this.getTableCell(this.columnIndex.hostname, hostname).click();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
@@ -179,6 +179,10 @@ export class ServicesPageHelper extends PageHelper {
     cy.get('cd-service-daemon-list').within(() => {
       this.getTableRow(daemon).click();
       this.clickActionButton(action);
+
+      // unselect it to avoid colliding with any other selection
+      // in different steps
+      this.getTableRow(daemon).click();
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -568,12 +568,30 @@ describe('TableComponent', () => {
       expect(executingElement.nativeElement.textContent.trim()).toBe(`(${state})`);
     };
 
-    it.only('should display executing template', () => {
+    it('should display executing template', () => {
       testExecutingTemplate();
     });
 
-    it.only('should display executing template with custom classes', () => {
+    it('should display executing template with custom classes', () => {
       testExecutingTemplate({ valueClass: 'a b', executingClass: 'c d' });
+    });
+  });
+
+  describe('test unselect functionality of rows', () => {
+    beforeEach(() => {
+      component.autoReload = -1;
+      component.selectionType = 'single';
+      fixture.detectChanges();
+    });
+
+    it('should unselect row on clicking on it again', () => {
+      const rowCellDebugElement = fixture.debugElement.query(By.css('datatable-body-cell'));
+
+      rowCellDebugElement.triggerEventHandler('click', null);
+      expect(component.selection.selected.length).toEqual(1);
+
+      rowCellDebugElement.triggerEventHandler('click', null);
+      expect(component.selection.selected.length).toEqual(0);
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -308,6 +308,10 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
     } else {
       this.useData();
     }
+
+    if (this.selectionType === 'single') {
+      this.table.selectCheck = this.singleSelectCheck.bind(this);
+    }
   }
 
   initUserConfig() {
@@ -709,6 +713,10 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
       this.selection.selected = $event['selected'];
     }
     this.updateSelection.emit(_.clone(this.selection));
+  }
+
+  private singleSelectCheck(row: any) {
+    return this.selection.selected.indexOf(row) === -1;
   }
 
   toggleColumn(column: CdTableColumn) {


### PR DESCRIPTION
User should be able to unselect a selected row in data-tables.
referred from: https://github.com/swimlane/ngx-datatable/issues/775#issuecomment-304007717

Fixes: https://tracker.ceph.com/issues/53244, https://tracker.ceph.com/issues/54575
Signed-off-by: Sarthak0702 <sarthak.0702@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
