### PR TITLE
pacific: osd: require osd_pg_max_concurrent_snap_trims > 0

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3284,6 +3284,7 @@ std::vector<Option> get_global_options() {
 
     Option("osd_pg_max_concurrent_snap_trims", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(2)
+    .set_min(1)
     .set_description(""),
 
     Option("osd_max_trimming_pgs", Option::TYPE_UINT, Option::LEVEL_ADVANCED)

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -15263,6 +15263,9 @@ boost::statechart::result PrimaryLogPG::AwaitAsyncWork::react(const DoSnapWork&)
 
   vector<hobject_t> to_trim;
   unsigned max = pg->cct->_conf->osd_pg_max_concurrent_snap_trims;
+  // we need to look for at least 1 snaptrim, otherwise we'll misinterpret
+  // the ENOENT below and erase snap_to_trim.
+  ceph_assert(max > 0);
   to_trim.reserve(max);
   int r = pg->snap_mapper.get_next_objects_to_trim(
     snap_to_trim,

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -322,6 +322,10 @@ int SnapMapper::get_next_objects_to_trim(
 {
   ceph_assert(out);
   ceph_assert(out->empty());
+
+  // if max would be 0, we return ENOENT and the caller would mistakenly
+  // trim the snaptrim queue
+  ceph_assert(max > 0);
   int r = 0;
   for (set<string>::iterator i = prefixes.begin();
        i != prefixes.end() && out->size() < max && r == 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54466

---

backport of https://github.com/ceph/ceph/pull/45140
parent tracker: https://tracker.ceph.com/issues/54396

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh