### PR TITLE
mds,client: validate pool against pool ids as well as pool names

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12806,13 +12806,16 @@ int Client::_setxattr_check_data_pool(string& name, string& value, const OSDMap 
     int64_t pool;
     try {
       pool = boost::lexical_cast<unsigned>(tmp);
-      if (!osdmap->have_pg_pool(pool))
-	return -CEPHFS_ENOENT;
-    } catch (boost::bad_lexical_cast const&) {
-      pool = osdmap->lookup_pg_pool_name(tmp);
-      if (pool < 0) {
-	return -CEPHFS_ENOENT;
+      if (osdmap->have_pg_pool(pool)) {
+          return 0;
       }
+    } catch (boost::bad_lexical_cast const&) {
+        // ignore
+    }
+    ldout(cct, 15) << __func__ << ": pool in layout is not a pool id: " << tmp << dendl;
+    pool = osdmap->lookup_pg_pool_name(tmp);
+    if (pool < 0) {
+        return -CEPHFS_ENOENT;
     }
   }
 


### PR DESCRIPTION
Problem:
    If the pool is a numeric string (eg. 23134), the current validation assumes
    that it is a pool id and looks up the list of pool ids and fails validation
    if the pool is not found amongst the list of pool ids.

Solution:
    Since a string of digits can also be used as a pool name, the pool is validated
    against list of pool names as well if it doesn't match any of the pool ids.

Fixes: https://tracker.ceph.com/issues/55165

Signed-off-by: wangxinyu <wangxinyu@inspur.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
