### PR TITLE
quincy: ceph-fuse: perform cleanup if test_dentry_handling failed

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -204,7 +204,9 @@ int main(int argc, const char **argv, const char *envp[]) {
           "client_try_dentry_invalidate");
 	bool can_invalidate_dentries =
           client_try_dentry_invalidate && ver < KERNEL_VERSION(3, 18, 0);
-	int tr = client->test_dentry_handling(can_invalidate_dentries);
+	auto test_result = client->test_dentry_handling(can_invalidate_dentries);
+	int tr = test_result.first;
+	bool abort_on_failure = test_result.second;
         bool client_die_on_failed_dentry_invalidate = g_conf().get_val<bool>(
           "client_die_on_failed_dentry_invalidate");
 	if (tr != 0 && client_die_on_failed_dentry_invalidate) {
@@ -229,6 +231,9 @@ int main(int argc, const char **argv, const char *envp[]) {
 	      cerr << "system() invocation failed during remount test" << std::endl;
 	    }
 	  }
+	}
+	if(abort_on_failure) {
+	  ceph_abort();
 	}
 	return reinterpret_cast<void*>(tr);
 #else

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -655,7 +655,7 @@ public:
   void _ll_register_callbacks(struct ceph_client_callback_args *args);
   void ll_register_callbacks(struct ceph_client_callback_args *args); // deprecated
   int ll_register_callbacks2(struct ceph_client_callback_args *args);
-  int test_dentry_handling(bool can_invalidate);
+  std::pair<int, bool> test_dentry_handling(bool can_invalidate);
 
   const char** get_tracked_conf_keys() const override;
   void handle_conf_change(const ConfigProxy& conf,
@@ -1290,7 +1290,7 @@ private:
   int _release_fh(Fh *fh);
   void _put_fh(Fh *fh);
 
-  int _do_remount(bool retry_on_error);
+  std::pair<int, bool> _do_remount(bool retry_on_error);
 
   int _read_sync(Fh *f, uint64_t off, uint64_t len, bufferlist *bl, bool *checkeof);
   int _read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54477

---

backport of https://github.com/ceph/ceph/pull/44863
parent tracker: https://tracker.ceph.com/issues/54049

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh