### PR TITLE
build: LTO can cause false positives in cmake tests

### DIFF
--- a/cmake/modules/CheckCxxAtomic.cmake
+++ b/cmake/modules/CheckCxxAtomic.cmake
@@ -21,6 +21,7 @@ function(check_cxx_atomics var)
 // We specifically test access via an otherwise unknown pointer here
 // to ensure we get the most complex case.  If this access can be
 // done without libatomic, then all accesses can be done.
+bool atomic16(std::atomic<unsigned __int128> *ptr) __attribute__ ((used));
 bool atomic16(std::atomic<unsigned __int128> *ptr)
 {
   return *ptr != 0;


### PR DESCRIPTION
In particular the cmake/modules/CheckCxxAtomic.cmake test will
report success for HAVE_CXX11_ATOMIC on s390x in Fedora.

Note that the Fedora package builds use the %cmake, %cmake_build, and
%cmake_install macros defined in /usr/lib/rpm/macros.d/macros.cmake
which add -flto=auto -ffat-lto-objects to the CFLAGS and CXXFLAGS.

The HAVE_CXX11_ATOMIC test incorrectly reports success when LTO
determines that atomic16() is unused and optimizes it out, and it
successfully links, even though one might naively think it shouldn't.
Thus the test doesn't perform the subsequent test for HAVE_LIBATOMIC.
The build then proceeds but fails later on when attempts to link
certain programs fail with undefined references to __atomic_load_16,
__atomic_store_16, and __atomic_compare_exchange_16'

https://tracker.ceph.com/issues/54514

Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
