### PR TITLE
pacific: ceph-fuse: perform cleanup if test_dentry_handling failed

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -203,7 +203,9 @@ int main(int argc, const char **argv, const char *envp[]) {
           "client_try_dentry_invalidate");
 	bool can_invalidate_dentries =
           client_try_dentry_invalidate && ver < KERNEL_VERSION(3, 18, 0);
-	int tr = client->test_dentry_handling(can_invalidate_dentries);
+	auto test_result = client->test_dentry_handling(can_invalidate_dentries);
+	int tr = test_result.first;
+	bool abort_on_failure = test_result.second;
         bool client_die_on_failed_dentry_invalidate = g_conf().get_val<bool>(
           "client_die_on_failed_dentry_invalidate");
 	if (tr != 0 && client_die_on_failed_dentry_invalidate) {
@@ -228,6 +230,9 @@ int main(int argc, const char **argv, const char *envp[]) {
 	      cerr << "system() invocation failed during remount test" << std::endl;
 	    }
 	  }
+	}
+	if(abort_on_failure) {
+	  ceph_abort();
 	}
 	return reinterpret_cast<void*>(tr);
 #else

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4395,9 +4395,10 @@ void Client::remove_session_caps(MetaSession *s, int err)
   sync_cond.notify_all();
 }
 
-int Client::_do_remount(bool retry_on_error)
+std::pair<int, bool> Client::_do_remount(bool retry_on_error)
 {
   uint64_t max_retries = cct->_conf.get_val<uint64_t>("mds_max_retries_on_remount_failure");
+  bool abort_on_failure = false;
 
   errno = 0;
   int r = remount_cb(callback_handle);
@@ -4421,10 +4422,10 @@ int Client::_do_remount(bool retry_on_error)
       !(retry_on_error && (++retries_on_invalidate < max_retries));
     if (should_abort && !is_unmounting()) {
       lderr(cct) << "failed to remount for kernel dentry trimming; quitting!" << dendl;
-      ceph_abort();
+      abort_on_failure = true;
     }
   }
-  return r;
+  return std::make_pair(r, abort_on_failure);
 }
 
 class C_Client_Remount : public Context  {
@@ -11312,20 +11313,19 @@ void Client::ll_register_callbacks(struct ceph_client_callback_args *args)
     umask_cb = args->umask_cb;
 }
 
-int Client::test_dentry_handling(bool can_invalidate)
+std::pair<int, bool> Client::test_dentry_handling(bool can_invalidate)
 {
-  int r = 0;
+  std::pair <int, bool> r(0, false);
 
   RWRef_t iref_reader(initialize_state, CLIENT_INITIALIZED);
   if (!iref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return std::make_pair(-CEPHFS_ENOTCONN, false);
 
   can_invalidate_dentries = can_invalidate;
 
   if (can_invalidate_dentries) {
     ceph_assert(dentry_invalidate_cb);
     ldout(cct, 1) << "using dentry_invalidate_cb" << dendl;
-    r = 0;
   } else {
     ceph_assert(remount_cb);
     ldout(cct, 1) << "using remount_cb" << dendl;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -654,7 +654,7 @@ public:
   int ll_osdaddr(int osd, char* buf, size_t size);
 
   void ll_register_callbacks(struct ceph_client_callback_args *args);
-  int test_dentry_handling(bool can_invalidate);
+  std::pair<int, bool> test_dentry_handling(bool can_invalidate);
 
   const char** get_tracked_conf_keys() const override;
   void handle_conf_change(const ConfigProxy& conf,
@@ -1291,7 +1291,7 @@ private:
   int _release_fh(Fh *fh);
   void _put_fh(Fh *fh);
 
-  int _do_remount(bool retry_on_error);
+  std::pair<int, bool> _do_remount(bool retry_on_error);
 
   int _read_sync(Fh *f, uint64_t off, uint64_t len, bufferlist *bl, bool *checkeof);
   int _read_async(Fh *f, uint64_t off, uint64_t len, bufferlist *bl);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54478

---

backport of https://github.com/ceph/ceph/pull/44863
parent tracker: https://tracker.ceph.com/issues/54049

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh