### PR TITLE
rgw: disable RGWDataChangesLog::add_entry() when log_data is off

### DIFF
--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -603,6 +603,10 @@ std::string RGWDataChangesLog::get_oid(uint64_t gen_id, int i) const {
 }
 
 int RGWDataChangesLog::add_entry(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, int shard_id) {
+  if (!zone->log_data) {
+    return 0;
+  }
+
   auto& bucket = bucket_info.bucket;
 
   if (!filter_bucket(dpp, bucket, null_yield)) {


### PR DESCRIPTION
this restores a check for RGWZone::log_data in add_entry(). with per-bucket replication, this check was replaced by a call to `RGWBucketSyncPolicyHandler::bucket_exports_data()`

this call has to consult two rados objects, `bucket.sync-source-hints.<bucketname>` and `bucket.sync-target-hints.<bucketname>`

but if the zone is not configured for multisite, we should avoid these extra object reads and return early

Fixes: https://tracker.ceph.com/issues/54531

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
