### PR TITLE
mgr/dashboard: fix wrong pg status processing

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/pg-category.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/pg-category.service.spec.ts
@@ -35,6 +35,7 @@ describe('PgCategoryService', () => {
 
     it(PgCategory.CATEGORY_WORKING, () => {
       testMethod('clean+scrubbing', PgCategory.CATEGORY_WORKING);
+      testMethod('active+clean+snaptrim_wait', PgCategory.CATEGORY_WORKING);
       testMethod(
         '  8 active+clean+scrubbing+deep, 255 active+clean  ',
         PgCategory.CATEGORY_WORKING

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/pg-category.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/pg-category.service.ts
@@ -54,7 +54,7 @@ export class PgCategoryService {
 
   private getPgStatesFromText(pgStatesText: string) {
     const pgStates = pgStatesText
-      .replace(/[^a-z]+/g, ' ')
+      .replace(/[^a-z_]+/g, ' ')
       .trim()
       .split(' ');
 


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/37327689/157908836-82c42ff6-3f00-4c78-8f40-bd107e8de486.png)

## After
![image](https://user-images.githubusercontent.com/37327689/157908183-643c0c14-0a7f-4583-8a62-6f1af262616a.png)

To reproduce:
1. Create RBD image
1. Run `rbd bench-write <image>` to populate the image
1. Create snapshot from that image
1. Run `rbd bench-write <image>` again
1. Delete the snapshot

That will cause some PGs to become `snaptrim` and `snaptrim_wait`.

Fixes: https://tracker.ceph.com/issues/54481
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
