### PR TITLE
pacific: osd/scrub: only telling the scrubber of awaited-for 'updates' events

### DIFF
--- a/src/messages/MOSDRepScrub.h
+++ b/src/messages/MOSDRepScrub.h
@@ -29,7 +29,7 @@ public:
 
   spg_t pgid;             // PG to scrub
   eversion_t scrub_from; // only scrub log entries after scrub_from
-  eversion_t scrub_to;   // last_update_applied when message sent
+  eversion_t scrub_to;   // last_update_applied when message sent (not used)
   epoch_t map_epoch = 0, min_epoch = 0;
   bool chunky;           // true for chunky scrubs
   hobject_t start;       // lower bound of scrub, inclusive

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10962,8 +10962,10 @@ void PrimaryLogPG::op_applied(const eversion_t &applied_version)
   ceph_assert(applied_version <= info.last_update);
   recovery_state.local_write_applied(applied_version);
 
-  if (is_primary() && m_scrubber->should_requeue_blocked_ops(recovery_state.get_last_update_applied())) {
-    osd->queue_scrub_applied_update(this, is_scrub_blocking_ops());
+  if (is_primary() && m_scrubber) {
+    // if there's a scrub operation waiting for the selected chunk to be fully updated -
+    // allow it to continue
+    m_scrubber->on_applied_when_primary(recovery_state.get_last_update_applied());
   }
 }
 

--- a/src/osd/PrimaryLogScrub.cc
+++ b/src/osd/PrimaryLogScrub.cc
@@ -586,14 +586,3 @@ void PrimaryLogScrub::stats_of_handled_objects(const object_stat_sum_t& delta_st
     }
   }
 }
-
-bool PrimaryLogScrub::should_requeue_blocked_ops(eversion_t last_recovery_applied) const
-{
-  if (!is_scrub_active()) {
-    // just verify that things indeed are quiet
-    ceph_assert(m_start == m_end);
-    return false;
-  }
-
-  return last_recovery_applied >= m_subset_last_update;
-}

--- a/src/osd/PrimaryLogScrub.h
+++ b/src/osd/PrimaryLogScrub.h
@@ -36,15 +36,6 @@ class PrimaryLogScrub : public PgScrubber {
   bool get_store_errors(const scrub_ls_arg_t& arg,
 			scrub_ls_result_t& res_inout) const final;
 
-  /**
-   *  should we requeue blocked ops?
-   *  Yes - if our 'subset_last_applied' is less up-to-date than the
-   *  new recovery_state.get_last_update_applied().
-   *  (used by PrimaryLogPG::op_applied())
-   */
-  [[nodiscard]] bool should_requeue_blocked_ops(
-    eversion_t last_recovery_applied) const final;
-
   void stats_of_handled_objects(const object_stat_sum_t& delta_stats,
 				const hobject_t& soid) final;
 

--- a/src/osd/pg_scrubber.cc
+++ b/src/osd/pg_scrubber.cc
@@ -484,6 +484,17 @@ void PgScrubber::set_subset_last_update(eversion_t e)
   dout(15) << __func__ << " last-update: " << e << dendl;
 }
 
+void PgScrubber::on_applied_when_primary(const eversion_t& applied_version)
+{
+  // we are only interested in updates if we are the Primary, and in state
+  // WaitLastUpdate
+  if (m_fsm->is_accepting_updates() && (applied_version >= m_subset_last_update)) {
+    m_osds->queue_scrub_applied_update(m_pg, m_pg->is_scrub_blocking_ops());
+    dout(15) << __func__ << " update: " << applied_version
+	     << " vs. required: " << m_subset_last_update << dendl;
+  }
+}
+
 /*
  * setting:
  * - m_subset_last_update
@@ -991,7 +1002,7 @@ int PgScrubber::build_scrub_map_chunk(
   // scan objects
   while (!pos.done()) {
     int r = m_pg->get_pgbackend()->be_scan_list(map, pos);
-    dout(10) << __func__ << " be r " << r << dendl;
+    dout(30) << __func__ << " BE returned " << r << dendl;
     if (r == -EINPROGRESS) {
       dout(20) << __func__ << " in progress" << dendl;
       return r;
@@ -1085,7 +1096,6 @@ void PgScrubber::replica_scrub_op(OpRequestRef op)
 
   // are we still processing a previous scrub-map request without noticing that the
   // interval changed? won't see it here, but rather at the reservation stage.
-
 
   if (msg->map_epoch < m_pg->info.history.same_interval_since) {
     dout(10) << "replica_scrub_op discarding old replica_scrub from " << msg->map_epoch
@@ -1336,12 +1346,13 @@ void PgScrubber::handle_scrub_reserve_request(OpRequestRef op)
    *  otherwise the interval would have changed.
    *  Ostensibly we can discard & redo the reservation. But then we
    *  will be temporarily releasing the OSD resource - and might not be able to grab it
-   *  again. Thus we simple treat this as a successful new request.
+   *  again. Thus, we simply treat this as a successful new request.
    */
 
   if (m_remote_osd_resource.has_value() && m_remote_osd_resource->is_stale()) {
     // we are holding a stale reservation from a past epoch
     m_remote_osd_resource.reset();
+    dout(10) << __func__ << " stale reservation request" << dendl;
   }
 
   if (request_ep < m_pg->get_same_interval_since()) {

--- a/src/osd/pg_scrubber.h
+++ b/src/osd/pg_scrubber.h
@@ -290,16 +290,6 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
   /// handle a message carrying a replica map
   void map_from_replica(OpRequestRef op) final;
 
-  /**
-   *  should we requeue blocked ops?
-   *  Applicable to the PrimaryLogScrub derived class.
-   */
-  [[nodiscard]] virtual bool should_requeue_blocked_ops(
-    eversion_t last_recovery_applied) const override
-  {
-    return false;
-  }
-
   void scrub_clear_state() final;
 
   /**
@@ -329,6 +319,8 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
 
   // -------------------------------------------------------------------------------------------
   // the I/F used by the state-machine (i.e. the implementation of ScrubMachineListener)
+
+  [[nodiscard]] bool is_primary() const final { return m_pg->recovery_state.is_primary(); }
 
   bool select_range() final;
 
@@ -397,8 +389,6 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
   bool state_test(uint64_t m) const { return m_pg->state_test(m); }
   void state_set(uint64_t m) { m_pg->state_set(m); }
   void state_clear(uint64_t m) { m_pg->state_clear(m); }
-
-  [[nodiscard]] bool is_primary() const { return m_pg->recovery_state.is_primary(); }
 
   [[nodiscard]] bool is_scrub_registered() const;
 

--- a/src/osd/pg_scrubber.h
+++ b/src/osd/pg_scrubber.h
@@ -212,6 +212,13 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
   void send_sched_replica(epoch_t epoch_queued) final;
 
   void send_replica_pushes_upd(epoch_t epoch_queued) final;
+  /**
+   *  The PG has updated its 'applied version'. It might be that we are waiting for this
+   *  information: after selecting a range of objects to scrub, we've marked the latest
+   *  version of these objects in m_subset_last_update. We will not start the map building
+   *  before we know that the PG has reached this version.
+   */
+  void on_applied_when_primary(const eversion_t& applied_version) final;
 
   /**
    *  we allow some number of preemptions of the scrub, which mean we do

--- a/src/osd/scrub_machine.cc
+++ b/src/osd/scrub_machine.cc
@@ -60,6 +60,14 @@ bool ScrubMachine::is_reserving() const
   return state_cast<const ReservingReplicas*>();
 }
 
+bool ScrubMachine::is_accepting_updates() const
+{
+  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  ceph_assert(scrbr->is_primary());
+
+  return state_cast<const WaitLastUpdate*>();
+}
+
 // for the rest of the code in this file - we know what PG we are dealing with:
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this->context<ScrubMachine>().m_pg)
@@ -236,6 +244,15 @@ WaitLastUpdate::WaitLastUpdate(my_context ctx) : my_base(ctx)
   post_event(UpdatesApplied{});
 }
 
+/**
+ *  Note:
+ *  Updates are locally readable immediately. Thus, on the replicas we do need
+ *  to wait for the update notifications before scrubbing. For the Primary it's
+ *  a bit different: on EC (and only there) rmw operations have an additional
+ *  read roundtrip. That means that on the Primary we need to wait for
+ *  last_update_applied (the replica side, even on EC, is still safe
+ *  since the actual transaction will already be readable by commit time.
+ */
 void WaitLastUpdate::on_new_updates(const UpdatesApplied&)
 {
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases

--- a/src/osd/scrub_machine_lstnr.h
+++ b/src/osd/scrub_machine_lstnr.h
@@ -49,6 +49,8 @@ struct ScrubMachineListener {
 
   virtual ~ScrubMachineListener(){};
 
+  [[nodiscard]] virtual bool is_primary() const = 0;
+
   virtual bool select_range() = 0;
 
   /// walk the log to find the latest update that affects our chunk

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -138,20 +138,6 @@ struct ScrubPgIF {
 
   virtual void send_sched_replica(epoch_t epoch_queued) = 0;
 
-//   virtual void send_full_reset(epoch_t epoch_queued) = 0;
-// 
-//   virtual void send_chunk_free(epoch_t epoch_queued) = 0;
-// 
-//   virtual void send_chunk_busy(epoch_t epoch_queued) = 0;
-// 
-//   virtual void send_local_map_done(epoch_t epoch_queued) = 0;
-// 
-//   virtual void send_get_next_chunk(epoch_t epoch_queued) = 0;
-// 
-//   virtual void send_scrub_is_finished(epoch_t epoch_queued) = 0;
-// 
-//   virtual void send_maps_compared(epoch_t epoch_queued) = 0;
-
   virtual void on_applied_when_primary(const eversion_t &applied_version) = 0;
 
   // --------------------------------------------------
@@ -205,10 +191,6 @@ struct ScrubPgIF {
 					      unsigned int suggested_priority) const = 0;
 
   virtual void add_callback(Context* context) = 0;
-
-  /// should we requeue blocked ops?
-  [[nodiscard]] virtual bool should_requeue_blocked_ops(
-    eversion_t last_recovery_applied) const = 0;
 
   /// add to scrub statistics, but only if the soid is below the scrub start
   virtual void stats_of_handled_objects(const object_stat_sum_t& delta_stats,

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -138,6 +138,22 @@ struct ScrubPgIF {
 
   virtual void send_sched_replica(epoch_t epoch_queued) = 0;
 
+//   virtual void send_full_reset(epoch_t epoch_queued) = 0;
+// 
+//   virtual void send_chunk_free(epoch_t epoch_queued) = 0;
+// 
+//   virtual void send_chunk_busy(epoch_t epoch_queued) = 0;
+// 
+//   virtual void send_local_map_done(epoch_t epoch_queued) = 0;
+// 
+//   virtual void send_get_next_chunk(epoch_t epoch_queued) = 0;
+// 
+//   virtual void send_scrub_is_finished(epoch_t epoch_queued) = 0;
+// 
+//   virtual void send_maps_compared(epoch_t epoch_queued) = 0;
+
+  virtual void on_applied_when_primary(const eversion_t &applied_version) = 0;
+
   // --------------------------------------------------
 
   [[nodiscard]] virtual bool are_callbacks_pending()


### PR DESCRIPTION
A backport of PR#42714.
Apart from fixing the specific issue below - required to facilitate the next couple of scrub-related backports
that touch the same files.

Only telling the scrubber of 'update' events if these events are awaited.

Only the Primary, and only when there is an active scrubbing going on and the
scrubber's state machine is in WaitUpdates states, should be notified of 'updates'.
The extra messages currently queued and processed are, apart from creating redundant
log lines and wasting CPU time, complicating the task of preventing a race in the handling
of stale scrubs.

Signed-off-by: Ronen Friedman [rfriedma@redhat.com](mailto:rfriedma@redhat.com)
