### PR TITLE
ceph_dedup_tool: adding sample-dedup

### DIFF
--- a/qa/tasks/deduplication.py
+++ b/qa/tasks/deduplication.py
@@ -5,6 +5,9 @@ import contextlib
 import logging
 import gevent
 from teuthology import misc as teuthology
+import json
+import time
+from io import StringIO
 
 
 from teuthology.orchestra import run
@@ -15,9 +18,7 @@ log = logging.getLogger(__name__)
 def task(ctx, config):
     """
     Run ceph-dedup-tool.
-
     The config should be as follows::
-
         ceph-dedup-tool:
           clients: [client list]
           op: <operation name>
@@ -26,13 +27,10 @@ def task(ctx, config):
           chunk_size: <chunk size>
           chunk_algorithm: <chunk algorithm, fixed|fastcdc>
           fingerprint_algorithm: <fingerprint algorithm, sha1|sha256|sha512>
-          object_dedup_threashold: <#% of duplicate chunks within an object to trigger object dedup>
           chunk_dedup_threashold: <the number of duplicate chunks to trigger chunk dedup>
           max_thread: <the number of threads>
           wakeup_period: <duration>
-
     For example::
-
         tasks:
         - exec:
             client.0:
@@ -42,14 +40,13 @@ def task(ctx, config):
             op: 'sample-dedup'
             pool: 'default.rgw.buckets.data'
             chunk_pool: 'low_tier'
-            chunk_size: 8192
+            chunk_size: 131072
             chunk_algorithm: 'fastcdc'
             fingerprint_algorithm: 'sha1'
-            object_dedup_threshold: 15
             chunk_dedup_threshold: 5
             max_thread: 2
             wakeup_period: 20
-
+            sampling_ratio: 100
     """
     log.info('Beginning deduplication...')
     assert isinstance(config, dict), \
@@ -58,59 +55,171 @@ def task(ctx, config):
     #assert hasattr(ctx, 'rgw')
     testdir = teuthology.get_testdir(ctx)
     args = [
-        'adjust-ulimits',
-        'ceph-coverage',
-        '{tdir}/archive/coverage'.format(tdir=testdir),
         'ceph-dedup-tool']
     if config.get('op', None):
         args.extend(['--op', config.get('op', None)])
     if config.get('chunk_pool', None):
         args.extend(['--chunk-pool', config.get('chunk_pool', None)])
     if config.get('chunk_size', False):
-        args.extend(['--chunk-size', str(config.get('chunk_size', 8192))])
+        args.extend(['--chunk-size', str(config.get('chunk_size', 131072))])
     if config.get('chunk_algorithm', False):
         args.extend(['--chunk-algorithm', config.get('chunk_algorithm', None)] )
     if config.get('fingerprint_algorithm', False):
         args.extend(['--fingerprint-algorithm', config.get('fingerprint_algorithm', None)] )
-    if config.get('object_dedup_threshold', False):
-        args.extend(['--object-dedup-threshold', str(config.get('object_dedup_threshold', 50))])
     if config.get('chunk_dedup_threshold', False):
-        args.extend(['--chunk-dedup-threshold', str(config.get('chunk_dedup_threshold', 5))])
+        args.extend(['--chunk-dedup-threshold', str(config.get('chunk_dedup_threshold', 1))])
     if config.get('max_thread', False):
         args.extend(['--max-thread', str(config.get('max_thread', 2))])
+    if config.get('sampling_ratio', False):
+        args.extend(['--sampling-ratio', str(config.get('sampling_ratio', 100))])
     if config.get('wakeup_period', False):
-        args.extend(['"--wakeup-period"', str(config.get('wakeup_period', 30))])
+        args.extend(['--wakeup-period', str(config.get('wakeup_period', 20))])
     if config.get('pool', False):
         args.extend(['--pool', config.get('pool', None)])
 
     args.extend([
         '--debug',
-        '--deamon',
-        '--iterative'])
+        '--daemon',
+        '--loop'])
 
     def thread():
+        run_remote(args, False, 0)
+
+    def run_remote(args, need_wait, client_num):
         clients = ['client.{id}'.format(id=id_) for id_ in teuthology.all_roles_of_type(ctx.cluster, 'client')]
         log.info('clients are %s' % clients)
-        manager = ctx.managers['ceph']
-        tests = {}
-        log.info("args %s", args)
-        for role in config.get('clients', clients):
-            assert isinstance(role, str)
-            PREFIX = 'client.'
-            assert role.startswith(PREFIX)
-            id_ = role[len(PREFIX):]
+        role = 'client.{id}'.format(id=client_num)
+        if role not in clients:
+            raise Exception('wrong client {c}'.format(c=role))
+        assert isinstance(role, str)
+        PREFIX = 'client.'
+        assert role.startswith(PREFIX)
+        testdir = teuthology.get_testdir(ctx)
+        cmd_args = [
+                'adjust-ulimits',
+                'ceph-coverage',
+                '{tdir}/archive/coverage'.format(tdir=testdir)]
+        cmd_args.extend(args)
+        log.info("cmd: %s", cmd_args)
+        tries = 0
+        while True:
             (remote,) = ctx.cluster.only(role).remotes.keys()
             proc = remote.run(
-                args=args,
-                stdin=run.PIPE,
-                wait=False
+                args=cmd_args,
+                wait=need_wait, check_status=False,
+                stdout=StringIO(),
                 )
-            tests[id_] = proc
+            log.info('exitstatus {r}'.format(r=proc.exitstatus))
+            if proc.exitstatus == 0 or need_wait == False:
+                log.info('proc stdout ', proc.stdout.getvalue())
+                return proc.stdout.getvalue().strip()
+            tries += 1
+            if tries > 30:
+                raise Exception('timed out getting correct exitstatus')
+            time.sleep(30)
+
+    def get_chunk_objs(chunk_pool):
+        chunk_obj_list = run_remote(('rados ls -p ' + chunk_pool).split(), True, 1).split()
+        if chunk_obj_list == False:
+            return None
+        else:
+            return chunk_obj_list
+
+    def get_ref_list(chunk_pool, chunk_obj):
+        # get reference list of chunk object
+        dump_str = run_remote(
+            ('ceph-dedup-tool --op dump-chunk-refs --chunk-pool '
+            + chunk_pool + ' --object ' + chunk_obj).split(),
+            True, 1
+        )
+        # fail in case that reference object is not written
+        assert len(dump_str) > 0
+        log.info('{0} obj has {1} refs'
+            .format(chunk_obj, json.loads(dump_str)['count']))
+
+        # check if chunk object's reference object exists in base-tier
+        ref_list = json.loads(dump_str)['refs']
+        return ref_list
+
+    # To validate whether the sample-dedup operation works well, this function checks if
+    #   1. sample-dedup has been started and
+    #   2. reference of chunk objects' exists in correct base pool
+    def validate():
+        log.info('start validating sample-dedup')
+        base_pool = config.get('pool', None)
+        chunk_pool = config.get('chunk_pool', None)
+        max_validation_cnt = 15
+        retry_cnt = 0
+        # chunk objs for re-validation after chunk-repair
+        retry_chunk_objs = list() 
+
+        # check whether sample-dedup has been started
+        chunk_obj_list = get_chunk_objs(chunk_pool)
+        while (chunk_obj_list == None or len(chunk_obj_list) == 0) and retry_cnt < max_validation_cnt:
+            # retry getting # chunk objs after 30 secs of sleep
+            time.sleep(30)
+            chunk_obj_list = get_chunk_objs(chunk_pool)
+            retry_cnt += 1
+            log.info('chunk pool empty. retry ', retry_cnt)
+        assert retry_cnt < max_validation_cnt
+
+        log.info('sample-dedup started successfully')
+
+        retry_cnt = 0
+        max_validation_cnt = 5
+        # validate chunk pool for max_validation_cnt times
+        while retry_cnt < max_validation_cnt:
+            for chunk_obj in chunk_obj_list:
+                ref_list = get_ref_list(chunk_pool, chunk_obj)
+                for ref in ref_list:
+                    ret = run_remote(
+                        ('rados -p ' + base_pool + ' stat ' + ref['oid'])
+                        .split(), True, 1
+                    )
+                    # check if ref exists in base pool
+                    if ret == False or len(ret) == 0:
+                        # if ref not exists in base pool, try repair in order to avoid 
+                        # false-positive inconsistent reference
+                        ret = run_remote(('ceph osd pool stats ' + base_pool).split(), True, 1)
+                        assert len(ret) > 0
+                        base_pool_id = ret.split()[3]
+                        ret = run_remote(
+                            ('ceph-dedup-tool --op chunk-repair --chunk-pool '
+                            + chunk_pool + ' --object ' + chunk_obj + ' --target-ref ' 
+                            + ref['oid'] + ' --target-ref-pool-id ' + base_pool_id)
+                            .split(), True, 1
+                        )
+                        retry_chunk_objs.append(chunk_obj)
+                    log.info('{0} obj exists in {1}'.format(ref['oid'], base_pool))
+
+            # retry validation for repaired objects
+            for chunk_obj in retry_chunk_objs:
+                ref_list = get_ref_list(chunk_pool, chunk_obj)
+                for ref in ref_list:
+                    ret = run_remote(
+                        ('rados -p ' + base_pool + ' stat ' + ref['oid'])
+                        .split(), True, 1
+                    )
+                    assert len(ret) > 0
+                    log.info(
+                        '{0} obj exists in {1} after repair'.format(ref['oid'], 
+                        base_pool)
+                    )
+            retry_chunk_objs = list()
+
+            # get chunk objects for the next loop
+            chunk_obj_list = get_chunk_objs(chunk_pool)
+            retry_cnt += 1
+            time.sleep(30)
+        return True
+
 
     running = gevent.spawn(thread)
+    checker = gevent.spawn(validate)
 
     try:
         yield
     finally:
         log.info('joining ceph-dedup-tool')
         running.get()
+        checker.get()

--- a/qa/tasks/deduplication.py
+++ b/qa/tasks/deduplication.py
@@ -1,0 +1,116 @@
+"""
+Run ceph-dedup-tool
+"""
+import contextlib
+import logging
+import gevent
+from teuthology import misc as teuthology
+
+
+from teuthology.orchestra import run
+
+log = logging.getLogger(__name__)
+
+@contextlib.contextmanager
+def task(ctx, config):
+    """
+    Run ceph-dedup-tool.
+
+    The config should be as follows::
+
+        ceph-dedup-tool:
+          clients: [client list]
+          op: <operation name>
+          pool: <pool name>
+          chunk_pool: <chunk pool name>
+          chunk_size: <chunk size>
+          chunk_algorithm: <chunk algorithm, fixed|fastcdc>
+          fingerprint_algorithm: <fingerprint algorithm, sha1|sha256|sha512>
+          object_dedup_threashold: <#% of duplicate chunks within an object to trigger object dedup>
+          chunk_dedup_threashold: <the number of duplicate chunks to trigger chunk dedup>
+          max_thread: <the number of threads>
+          wakeup_period: <duration>
+
+    For example::
+
+        tasks:
+        - exec:
+            client.0:
+              - sudo ceph osd pool create low_tier 4
+        - deduplication:
+            clients: [client.0]
+            op: 'sample-dedup'
+            pool: 'default.rgw.buckets.data'
+            chunk_pool: 'low_tier'
+            chunk_size: 8192
+            chunk_algorithm: 'fastcdc'
+            fingerprint_algorithm: 'sha1'
+            object_dedup_threshold: 15
+            chunk_dedup_threshold: 5
+            max_thread: 2
+            wakeup_period: 20
+
+    """
+    log.info('Beginning deduplication...')
+    assert isinstance(config, dict), \
+        "please list clients to run on"
+
+    #assert hasattr(ctx, 'rgw')
+    testdir = teuthology.get_testdir(ctx)
+    args = [
+        'adjust-ulimits',
+        'ceph-coverage',
+        '{tdir}/archive/coverage'.format(tdir=testdir),
+        'ceph-dedup-tool']
+    if config.get('op', None):
+        args.extend(['--op', config.get('op', None)])
+    if config.get('chunk_pool', None):
+        args.extend(['--chunk-pool', config.get('chunk_pool', None)])
+    if config.get('chunk_size', False):
+        args.extend(['--chunk-size', str(config.get('chunk_size', 8192))])
+    if config.get('chunk_algorithm', False):
+        args.extend(['--chunk-algorithm', config.get('chunk_algorithm', None)] )
+    if config.get('fingerprint_algorithm', False):
+        args.extend(['--fingerprint-algorithm', config.get('fingerprint_algorithm', None)] )
+    if config.get('object_dedup_threshold', False):
+        args.extend(['--object-dedup-threshold', str(config.get('object_dedup_threshold', 50))])
+    if config.get('chunk_dedup_threshold', False):
+        args.extend(['--chunk-dedup-threshold', str(config.get('chunk_dedup_threshold', 5))])
+    if config.get('max_thread', False):
+        args.extend(['--max-thread', str(config.get('max_thread', 2))])
+    if config.get('wakeup_period', False):
+        args.extend(['"--wakeup-period"', str(config.get('wakeup_period', 30))])
+    if config.get('pool', False):
+        args.extend(['--pool', config.get('pool', None)])
+
+    args.extend([
+        '--debug',
+        '--deamon',
+        '--iterative'])
+
+    def thread():
+        clients = ['client.{id}'.format(id=id_) for id_ in teuthology.all_roles_of_type(ctx.cluster, 'client')]
+        log.info('clients are %s' % clients)
+        manager = ctx.managers['ceph']
+        tests = {}
+        log.info("args %s", args)
+        for role in config.get('clients', clients):
+            assert isinstance(role, str)
+            PREFIX = 'client.'
+            assert role.startswith(PREFIX)
+            id_ = role[len(PREFIX):]
+            (remote,) = ctx.cluster.only(role).remotes.keys()
+            proc = remote.run(
+                args=args,
+                stdin=run.PIPE,
+                wait=False
+                )
+            tests[id_] = proc
+
+    running = gevent.spawn(thread)
+
+    try:
+        yield
+    finally:
+        log.info('joining ceph-dedup-tool')
+        running.get()

--- a/qa/tasks/deduplication.py
+++ b/qa/tasks/deduplication.py
@@ -9,9 +9,6 @@ import json
 import time
 from io import StringIO
 
-
-from teuthology.orchestra import run
-
 log = logging.getLogger(__name__)
 
 @contextlib.contextmanager
@@ -52,8 +49,6 @@ def task(ctx, config):
     assert isinstance(config, dict), \
         "please list clients to run on"
 
-    #assert hasattr(ctx, 'rgw')
-    testdir = teuthology.get_testdir(ctx)
     args = [
         'ceph-dedup-tool']
     if config.get('op', None):

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -642,7 +642,7 @@ private:
   size_t total_object_size = 0;
 
   std::set<std::string> oid_for_evict;
-  size_t chunk_size = 0;
+  const size_t chunk_size = 0;
   pg_pool_t::fingerprint_t fp_type = pg_pool_t::TYPE_FINGERPRINT_NONE;
   std::string chunk_algo;
   SampleDedupGlobal &sample_dedup_global;

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -554,10 +554,7 @@ public:
     bool find(string& fp) {
       std::shared_lock lock(fingerprint_lock);
       auto found_item = fp_map.find(fp);
-      if (found_item != fp_map.end()) {
-        return true;
-      }
-      return false;
+      return found_item != fp_map.end();
     }
 
     // return true if the chunk is duplicate
@@ -570,10 +567,7 @@ public:
       }
       auto &target = found_iter->second;
       target++;
-      if (target >= dedup_threshold && dedup_threshold != -1) {
-        return true;
-      }
-      return false;
+      return target >= dedup_threshold && dedup_threshold != -1;
     }
 
     void init(size_t dedup_threshold_) {

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -628,7 +628,6 @@ private:
   std::vector<size_t> sample_object(size_t count);
   void try_dedup_and_accumulate_result(ObjectItem &object);
   bool ok_to_dedup_all();
-  void do_object_dedup(ObjectItem &object);
   int do_chunk_dedup(chunk_t &chunk);
   void mark_non_dedup(ObjectCursor start, ObjectCursor end);
   bufferlist read_object(ObjectItem &object);
@@ -849,21 +848,6 @@ std::string SampleDedupWorkerThread::generate_fingerprint(bufferlist chunk_data)
       break;
   }
   return ret;
-}
-
-void SampleDedupWorkerThread::do_object_dedup(ObjectItem &object)
-{
-  ObjectReadOperation op;
-  op.tier_flush();
-
-  int ret = io_ctx.operate(
-      object.oid,
-      &op,
-      NULL);
-  if (ret < 0) {
-    cerr << " tier_flush fail : " << cpp_strerror(ret) << std::endl;
-  }
-  return;
 }
 
 int SampleDedupWorkerThread::do_chunk_dedup(chunk_t &chunk)

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -638,7 +638,6 @@ private:
 
   IoCtx io_ctx;
   IoCtx chunk_io_ctx;
-  std::list<chunk_t> duplicable_chunks;
   size_t total_duplicated_size = 0;
   size_t total_object_size = 0;
 

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -739,7 +739,7 @@ void SampleDedupWorkerThread::try_dedup_and_accumulate_result(ObjectItem &object
   bufferlist data = read_object(object);
   if (data.length() == 0) {
     cerr << __func__ << " skip object " << object.oid
-      << " dedup (read failed)\n";
+	 << " read returned size 0" << std::endl;
     return;
   }
   auto chunks = do_cdc(object, data);
@@ -752,7 +752,8 @@ void SampleDedupWorkerThread::try_dedup_and_accumulate_result(ObjectItem &object
   }
   if (chunk_total_amount != data.length()) {
     cerr << __func__ << " sum of chunked length(" << chunk_total_amount
-      << ") is different from object data length(" << data.length() << ")\n";
+	 << ") is different from object data length(" << data.length() << ")"
+	 << std::endl;
     return;
   }
 

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -561,13 +561,13 @@ public:
     bool add(chunk_t& chunk) {
       std::unique_lock lock(fingerprint_lock);
       auto found_iter = fp_map.find(chunk.fingerprint);
+      ssize_t cur_reference = 1;
       if (found_iter == fp_map.end()) {
-        auto ret = fp_map.insert({chunk.fingerprint, 1});
-        found_iter = ret.first;
+        fp_map.insert({chunk.fingerprint, 1});
+      } else {
+	cur_reference = ++found_iter->second;
       }
-      auto &target = found_iter->second;
-      target++;
-      return target >= dedup_threshold && dedup_threshold != -1;
+      return cur_reference >= dedup_threshold && dedup_threshold != -1;
     }
 
     void init(size_t dedup_threshold_) {

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -585,7 +585,7 @@ public:
 
   struct SampleDedupGlobal {
     FpStore fp_store;
-    double sampling_ratio = -1;
+    const double sampling_ratio = -1;
     SampleDedupGlobal(
       int chunk_threshold,
       int sampling_ratio) :

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -629,7 +629,6 @@ private:
   void try_dedup_and_accumulate_result(ObjectItem &object);
   bool ok_to_dedup_all();
   int do_chunk_dedup(chunk_t &chunk);
-  void mark_non_dedup(ObjectCursor start, ObjectCursor end);
   bufferlist read_object(ObjectItem &object);
   std::vector<std::tuple<bufferlist, pair<uint64_t, uint64_t>>> do_cdc(
     ObjectItem &object,

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -48,6 +48,7 @@
 #include "include/stringify.h"
 #include "global/signal_handler.h"
 #include "common/CDC.h"
+#include "common/Preforker.h"
 
 #include <boost/program_options/variables_map.hpp>
 #include <boost/program_options/parsers.hpp>
@@ -1558,21 +1559,6 @@ int make_crawling_daemon(const po::variables_map &opts)
   string chunk_pool_name = get_opts_chunk_pool(opts);
   unsigned max_thread = get_opts_max_thread(opts);
 
-  if (opts.count("daemon")) {
-    pid_t pid = fork();
-    if (pid < 0) {
-      cerr << "daemon process creation failed\n";
-      return -EINVAL;
-    }
-
-    if (pid != 0) {
-      return 0;
-    }
-    signal(SIGHUP, SIG_IGN);
-    close(STDIN_FILENO);
-    close(STDOUT_FILENO);
-  }
-
   bool loop = false;
   if (opts.count("loop")) {
     loop = true;
@@ -1760,21 +1746,45 @@ int main(int argc, const char **argv)
   }
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
-			     CODE_ENVIRONMENT_UTILITY, 0);
+			CODE_ENVIRONMENT_DAEMON,
+			CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS);
+
+  Preforker forker;
+  if (global_init_prefork(g_ceph_context) >= 0) {
+    std::string err;
+    int r = forker.prefork(err);
+    if (r < 0) {
+      cerr << err << std::endl;
+      return r;
+    }
+    if (forker.is_parent()) {
+      g_ceph_context->_log->start();
+      if (forker.parent_wait(err) != 0) {
+        return -ENXIO;
+      }
+      return 0;
+    }
+    global_init_postfork_start(g_ceph_context);
+  }
   common_init_finish(g_ceph_context);
+  if (opts.count("daemon")) {
+    global_init_postfork_finish(g_ceph_context);
+    forker.daemonize();
+  }
   init_async_signal_handler();
   register_async_signal_handler_oneshot(SIGINT, handle_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_signal);
 
   string op_name = get_opts_op_name(opts);
+  int ret = 0;
   if (op_name == "estimate") {
-    return estimate_dedup_ratio(opts);
+    ret = estimate_dedup_ratio(opts);
   } else if (op_name == "chunk-scrub" ||
 	     op_name == "chunk-get-ref" ||
 	     op_name == "chunk-put-ref" ||
 	     op_name == "chunk-repair" ||
 	     op_name == "dump-chunk-refs") {
-    return chunk_scrub_common(opts);
+    ret = chunk_scrub_common(opts);
   } else if (op_name == "chunk-dedup" ||
 	     op_name == "object-dedup") {
     /*
@@ -1787,9 +1797,9 @@ int main(int argc, const char **argv)
      * perform deduplication on the entire object, not a chunk.
      *
      */
-    return make_dedup_object(opts);
+    ret = make_dedup_object(opts);
   } else if (op_name == "sample-dedup") {
-    return make_crawling_daemon(opts);
+    ret = make_crawling_daemon(opts);
   } else {
     cerr << "unrecognized op " << op_name << std::endl;
     exit(1);
@@ -1799,5 +1809,5 @@ int main(int argc, const char **argv)
   unregister_async_signal_handler(SIGTERM, handle_signal);
   shutdown_async_signal_handler();
   
-  return 0;
+  return forker.signal_exit(ret);
 }

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -585,7 +585,6 @@ public:
 
   struct SampleDedupGlobal {
     FpStore fp_store;
-    double object_dedup_threshold = -1;
     double sampling_ratio = -1;
     SampleDedupGlobal(
       int chunk_threshold,

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -155,6 +155,8 @@ po::options_description make_usage() {
      ": perform a chunk dedup---deduplicate only a chunk, which is a part of object.")
     ("op object-dedup --pool <POOL> --object <OID> --chunk-pool <POOL> --fingerprint-algorithm <FP> --dedup-cdc-chunk-size <CHUNK_SIZE> [--snap]",
      ": perform a object dedup---deduplicate the entire object, not a chunk. Related snapshots are also deduplicated if --snap is given")
+    ("op sample-dedup --pool <POOL> --chunk-pool <POOL> --chunk-algorithm <ALGO> --fingerprint-algorithm <FP>",
+     ": perform a sample dedup---make crawling threads which crawl objeccts in base pool and deduplicate them based on their deduplication efficiency")
     ;
   po::options_description op_desc("Opational arguments");
   op_desc.add_options()
@@ -179,6 +181,7 @@ po::options_description make_usage() {
     ("snap", ": deduplciate snapshotted object")
     ("debug", ": enable debug")
     ("pgid", ": set pgid")
+    ("chunk-dedup-threshold", po::value<uint32_t>(), ": set the threshold for chunk dedup (number of duplication) ")
   ;
   desc.add(op_desc);
   return desc;
@@ -224,6 +227,8 @@ public:
     io_ctx(io_ctx), n(n), m(m), begin(begin), end(end), 
     report_period(report_period), total_objects(num_objects), max_read_size(max_read_size)
   {}
+  CrawlerThread() { }
+
   void signal(int signum) {
     std::lock_guard l{m_lock};
     m_stop = true;
@@ -525,6 +530,366 @@ void ChunkScrub::chunk_scrub_common()
   cout << "--done--" << std::endl;
 }
 
+using AioCompRef = unique_ptr<AioCompletion>;
+
+class SampleDedupWorkerThread : public CrawlerThread
+{
+public:
+  struct chunk_t {
+    string oid = "";
+    size_t start = 0;
+    size_t size = 0;
+    string fingerprint = "";
+    bufferlist data;
+  };
+
+  class FpStore {
+  public:
+    using dup_count_t = ssize_t;
+
+    bool find(string& fp) {
+      std::shared_lock lock(fingerprint_lock);
+      auto found_item = fp_map.find(fp);
+      if (found_item != fp_map.end()) {
+        return true;
+      }
+      return false;
+    }
+
+    // return true if the chunk is duplicate
+    bool add(chunk_t& chunk) {
+      std::unique_lock lock(fingerprint_lock);
+      auto found_iter = fp_map.find(chunk.fingerprint);
+      if (found_iter == fp_map.end()) {
+        auto ret = fp_map.insert({chunk.fingerprint, 1});
+        found_iter = ret.first;
+      }
+      auto &target = found_iter->second;
+      target++;
+      if (target >= dedup_threshold && dedup_threshold != -1) {
+        return true;
+      }
+      return false;
+    }
+
+    void init(size_t dedup_threshold_) {
+      std::unique_lock lock(fingerprint_lock);
+      fp_map.clear();
+      dedup_threshold = dedup_threshold_;
+    }
+    FpStore(size_t chunk_threshold) : dedup_threshold(chunk_threshold) { }
+
+  private:
+    ssize_t dedup_threshold = -1;
+    std::unordered_map<std::string, dup_count_t> fp_map;
+    std::shared_mutex fingerprint_lock;
+  };
+
+  struct SampleDedupGlobal {
+    FpStore fp_store;
+    double object_dedup_threshold = -1;
+    SampleDedupGlobal(
+      int chunk_threshold) :
+      fp_store(chunk_threshold) { }
+  };
+
+  SampleDedupWorkerThread(
+    IoCtx &io_ctx,
+    IoCtx &chunk_io_ctx,
+    ObjectCursor begin,
+    ObjectCursor end,
+    size_t chunk_size,
+    std::string &fp_algo,
+    std::string &chunk_algo,
+    SampleDedupGlobal &sample_dedup_global) :
+    io_ctx(io_ctx),
+    chunk_io_ctx(chunk_io_ctx),
+    chunk_size(chunk_size),
+    fp_type(pg_pool_t::get_fingerprint_from_str(fp_algo)),
+    chunk_algo(chunk_algo),
+    sample_dedup_global(sample_dedup_global),
+    begin(begin),
+    end(end) { }
+
+  ~SampleDedupWorkerThread() { };
+
+protected:
+  void* entry() override {
+    crawl();
+    return nullptr;
+  }
+
+private:
+  void crawl();
+  std::tuple<std::vector<ObjectItem>, ObjectCursor> get_objects(
+    ObjectCursor current,
+    ObjectCursor end,
+    size_t max_object_count);
+  std::vector<size_t> sample_object(size_t count);
+  void try_dedup_and_accumulate_result(ObjectItem &object);
+  bool ok_to_dedup_all();
+  void do_object_dedup(ObjectItem &object);
+  int do_chunk_dedup(chunk_t &chunk);
+  void mark_non_dedup(ObjectCursor start, ObjectCursor end);
+  bufferlist read_object(ObjectItem &object);
+  std::vector<std::tuple<bufferlist, pair<uint64_t, uint64_t>>> do_cdc(
+    ObjectItem &object,
+    bufferlist &data);
+  std::string generate_fingerprint(bufferlist chunk_data);
+  AioCompRef do_async_evict(string oid);
+
+  IoCtx io_ctx;
+  IoCtx chunk_io_ctx;
+  std::list<chunk_t> duplicable_chunks;
+  size_t total_duplicated_size = 0;
+  size_t total_object_size = 0;
+
+  std::set<std::string> oid_for_evict;
+  size_t chunk_size = 0;
+  pg_pool_t::fingerprint_t fp_type = pg_pool_t::TYPE_FINGERPRINT_NONE;
+  std::string chunk_algo;
+  SampleDedupGlobal &sample_dedup_global;
+  ObjectCursor begin;
+  ObjectCursor end;
+};
+
+void SampleDedupWorkerThread::crawl()
+{
+  cout << "new iteration" << std::endl;
+
+  for (ObjectCursor current_object = begin;
+      current_object < end;) {
+    std::vector<ObjectItem> objects;
+    // Get the list of object IDs to deduplicate
+    std::tie(objects, current_object) = get_objects(current_object, end, 100);
+
+    // Pick few objects to be processed. Crawling mode decides how many
+    // objects to pick (sampling ratio). Lower sampling ratio makes crawler
+    // have lower crawling overhead but find less duplication.
+    std::set<size_t> sampled_indexes = sample_object(objects.size());
+    for (size_t index : sampled_indexes) {
+      ObjectItem target = objects[index];
+      try_dedup_and_accumulate_result(target);
+    }
+  }
+
+  vector<AioCompRef> evict_completions(oid_for_evict.size());
+  int i = 0;
+  for (auto &oid : oid_for_evict) {
+    auto completion = do_async_evict(oid);
+    evict_completions[i] = move(completion);
+    i++;
+  }
+  for (auto &completion : evict_completions) {
+    completion->wait_for_complete();
+  }
+  cout << "done iteration" << std::endl;
+}
+
+AioCompRef SampleDedupWorkerThread::do_async_evict(string oid)
+{
+  Rados rados;
+  ObjectReadOperation op_tier;
+  AioCompRef completion(rados.aio_create_completion());
+  op_tier.tier_evict();
+  io_ctx.aio_operate(
+      oid,
+      completion.get(),
+      &op_tier,
+      NULL);
+  return completion;
+}
+
+std::tuple<std::vector<ObjectItem>, ObjectCursor> SampleDedupWorkerThread::get_objects(
+  ObjectCursor current, ObjectCursor end, size_t max_object_count)
+{
+  std::vector<ObjectItem> objects;
+  ObjectCursor next;
+  int ret = io_ctx.object_list(
+    current,
+    end,
+    max_object_count,
+    {},
+    &objects,
+    &next);
+  if (ret < 0 ) {
+    cerr << "error object_list" << std::endl;
+    objects.resize(0);
+  }
+
+  return std::make_tuple(objects, next);
+}
+
+std::set<size_t> SampleDedupWorkerThread::sample_object(size_t count)
+{
+  std::set<size_t> indexes;
+  for (size_t index = 0 ; index < count ; index++) {
+    indexes.insert(index);
+  }
+  return indexes;
+}
+
+void SampleDedupWorkerThread::try_dedup_and_accumulate_result(ObjectItem &object)
+{
+  bufferlist data = read_object(object);
+  if (data.length() == 0) {
+    cerr << __func__ << " skip object " << object.oid
+      << " dedup (read failed)\n";
+    return;
+  }
+  auto chunks = do_cdc(object, data);
+  size_t chunk_total_amount = 0;
+
+  // First, check total size of created chunks
+  for (auto &chunk : chunks) {
+    auto &chunk_data = std::get<0>(chunk);
+    chunk_total_amount += chunk_data.length();
+  }
+  if (chunk_total_amount != data.length()) {
+    cerr << __func__ << " sum of chunked length(" << chunk_total_amount
+      << ") is different from object data length(" << data.length() << ")\n";
+    return;
+  }
+
+  size_t duplicated_size = 0;
+  list<chunk_t> redundant_chunks;
+  for (auto &chunk : chunks) {
+    auto &chunk_data = std::get<0>(chunk);
+    std::string fingerprint = generate_fingerprint(chunk_data);
+    std::pair<uint64_t, uint64_t> chunk_boundary = std::get<1>(chunk);
+    chunk_t chunk_info = {
+      .oid = object.oid,
+      .start = chunk_boundary.first,
+      .size = chunk_boundary.second,
+      .fingerprint = fingerprint,
+      .data = chunk_data
+      };
+
+    if (sample_dedup_global.fp_store.find(fingerprint)) {
+      duplicated_size += chunk_data.length();
+    }
+    if (sample_dedup_global.fp_store.add(chunk_info)) {
+      redundant_chunks.push_back(chunk_info);
+    }
+  }
+
+  size_t object_size = data.length();
+
+  // perform chunk-dedup
+  for (auto &p : redundant_chunks) {
+    do_chunk_dedup(p);
+  }
+  total_duplicated_size += duplicated_size;
+  total_object_size += object_size;
+}
+
+bufferlist SampleDedupWorkerThread::read_object(ObjectItem &object)
+{
+  bufferlist whole_data;
+  size_t offset = 0;
+  int ret = -1;
+  while (ret != 0) {
+    bufferlist partial_data;
+    ret = io_ctx.read(object.oid, partial_data, default_op_size, offset);
+    if (ret < 0) {
+      cerr << "read object error " << object.oid << " offset " << offset
+        << " size " << default_op_size << " error(" << cpp_strerror(ret)
+        << std::endl;
+      bufferlist empty_buf;
+      return empty_buf;
+    }
+    offset += ret;
+    whole_data.claim_append(partial_data);
+  }
+  return whole_data;
+}
+
+std::vector<std::tuple<bufferlist, pair<uint64_t, uint64_t>>> SampleDedupWorkerThread::do_cdc(
+  ObjectItem &object,
+  bufferlist &data)
+{
+  std::vector<std::tuple<bufferlist, pair<uint64_t, uint64_t>>> ret;
+
+  unique_ptr<CDC> cdc = CDC::create(chunk_algo, cbits(chunk_size) - 1);
+  vector<pair<uint64_t, uint64_t>> chunks;
+  cdc->calc_chunks(data, &chunks);
+  for (auto &p : chunks) {
+    bufferlist chunk;
+    chunk.substr_of(data, p.first, p.second);
+    ret.push_back(make_tuple(chunk, p));
+  }
+
+  return ret;
+}
+
+std::string SampleDedupWorkerThread::generate_fingerprint(bufferlist chunk_data)
+{
+  string ret;
+
+  switch (fp_type) {
+    case pg_pool_t::TYPE_FINGERPRINT_SHA1:
+      ret = crypto::digest<crypto::SHA1>(chunk_data).to_str();
+      break;
+
+    case pg_pool_t::TYPE_FINGERPRINT_SHA256:
+      ret = crypto::digest<crypto::SHA256>(chunk_data).to_str();
+      break;
+
+    case pg_pool_t::TYPE_FINGERPRINT_SHA512:
+      ret = crypto::digest<crypto::SHA512>(chunk_data).to_str();
+      break;
+    default:
+      ceph_assert(0 == "Invalid fp type");
+      break;
+  }
+  return ret;
+}
+
+void SampleDedupWorkerThread::do_object_dedup(ObjectItem &object)
+{
+  ObjectReadOperation op;
+  op.tier_flush();
+
+  int ret = io_ctx.operate(
+      object.oid,
+      &op,
+      NULL);
+  if (ret < 0) {
+    cerr << " tier_flush fail : " << cpp_strerror(ret) << std::endl;
+  }
+  return;
+}
+
+int SampleDedupWorkerThread::do_chunk_dedup(chunk_t &chunk)
+{
+  uint64_t size;
+  time_t mtime;
+
+  int ret = chunk_io_ctx.stat(chunk.fingerprint, &size, &mtime);
+
+  if (ret == -ENOENT) {
+    bufferlist bl;
+    bl.append(chunk.data);
+    ObjectWriteOperation wop;
+    wop.write_full(bl);
+    chunk_io_ctx.operate(chunk.fingerprint, &wop);
+  } else {
+    ceph_assert(ret == 0);
+  }
+
+  ObjectReadOperation op;
+  op.set_chunk(
+      chunk.start,
+      chunk.size,
+      chunk_io_ctx,
+      chunk.fingerprint,
+      0,
+      CEPH_OSD_OP_FLAG_WITH_REFERENCE);
+  ret = io_ctx.operate(chunk.oid, &op, nullptr);
+  oid_for_evict.insert(chunk.oid);
+  return ret;
+}
+
 void ChunkScrub::print_status(Formatter *f, ostream &out)
 {
   if (f) {
@@ -800,8 +1165,6 @@ int chunk_scrub_common(const po::variables_map &opts)
 
   op_name = get_opts_op_name(opts);
   chunk_pool_name = get_opts_chunk_pool(opts);
-  max_thread = get_opts_max_thread(opts);
-  report_period = get_opts_report_period(opts);
   boost::optional<pg_t> pgid(opts.count("pgid"), pg_t());
 
   ret = rados.init_with_context(g_ceph_context);
@@ -944,6 +1307,8 @@ int chunk_scrub_common(const po::variables_map &opts)
     return 0;
   }
 
+  max_thread = get_opts_max_thread(opts);
+  report_period = get_opts_report_period(opts);
   glock.lock();
   begin = chunk_io_ctx.object_list_begin();
   end = chunk_io_ctx.object_list_end();
@@ -1174,6 +1539,146 @@ out:
   return (ret < 0) ? 1 : 0;
 }
 
+int make_crawling_daemon(const po::variables_map &opts)
+{
+  string base_pool_name = get_opts_pool_name(opts);
+  string chunk_pool_name = get_opts_chunk_pool(opts);
+  unsigned max_thread = get_opts_max_thread(opts);
+
+  size_t chunk_size = 8192;
+  if (opts.count("chunk-size")) {
+    chunk_size = opts["chunk-size"].as<int>();
+  } else {
+    cout << "8192 is set as chunk size by default" << std::endl;
+  }
+
+  uint32_t chunk_dedup_threshold = -1;
+  if (opts.count("chunk-dedup-threshold")) {
+    chunk_size = opts["chunk-dedup-threshold"].as<uint32_t>();
+  }
+
+  std::string chunk_algo = get_opts_chunk_algo(opts);
+
+  Rados rados;
+  int ret = rados.init_with_context(g_ceph_context);
+  if (ret < 0) {
+    cerr << "couldn't initialize rados: " << cpp_strerror(ret) << std::endl;
+    return -EINVAL;
+  }
+  ret = rados.connect();
+  if (ret) {
+    cerr << "couldn't connect to cluster: " << cpp_strerror(ret) << std::endl;
+    return -EINVAL;
+  }
+
+  std::string fp_algo = get_opts_fp_algo(opts);
+
+  list<string> pool_names;
+  IoCtx io_ctx, chunk_io_ctx;
+  pool_names.push_back(base_pool_name);
+  ret = rados.ioctx_create(base_pool_name.c_str(), io_ctx);
+  if (ret < 0) {
+    cerr << "error opening base pool "
+      << base_pool_name << ": "
+      << cpp_strerror(ret) << std::endl;
+    return -EINVAL;
+  }
+
+  ret = rados.ioctx_create(chunk_pool_name.c_str(), chunk_io_ctx);
+  if (ret < 0) {
+    cerr << "error opening chunk pool "
+      << chunk_pool_name << ": "
+      << cpp_strerror(ret) << std::endl;
+    return -EINVAL;
+  }
+  bufferlist inbl;
+  ret = rados.mon_command(
+      make_pool_str(base_pool_name, "fingerprint_algorithm", fp_algo),
+      inbl, NULL, NULL);
+  if (ret < 0) {
+    cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
+    return ret;
+  }
+  ret = rados.mon_command(
+      make_pool_str(base_pool_name, "dedup_chunk_algorithm", "fastcdc"),
+      inbl, NULL, NULL);
+  if (ret < 0) {
+    cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
+    return ret;
+  }
+  ret = rados.mon_command(
+      make_pool_str(base_pool_name, "dedup_cdc_chunk_size", chunk_size),
+      inbl, NULL, NULL);
+  if (ret < 0) {
+    cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
+    return ret;
+  }
+
+  cout << "Object Dedup Threshold : " << object_dedup_threshold << std::endl
+    << "Chunk Dedup Threshold : " << chunk_dedup_threshold << std::endl
+    << "Chunk Size : " << chunk_size << std::endl
+    << std::endl;
+
+  while (true) {
+    lock_guard lock(glock);
+    ObjectCursor begin = io_ctx.object_list_begin();
+    ObjectCursor end = io_ctx.object_list_end();
+    map<string, librados::pool_stat_t> stats;
+    ret = rados.get_pool_stats(pool_names, stats);
+    if (ret < 0) {
+      cerr << "error fetching pool stats: " << cpp_strerror(ret) << std::endl;
+      return -EINVAL;
+    }
+    if (stats.find(base_pool_name) == stats.end()) {
+      cerr << "stats can not find pool name: " << base_pool_name << std::endl;
+      return -EINVAL;
+    }
+
+    bool debug = false;
+    if (opts.count("debug")) {
+      debug = true;
+    }
+
+    estimate_threads.clear();
+    SampleDedupWorkerThread::SampleDedupGlobal sample_dedup_global(
+      chunk_dedup_threshold);
+
+    for (unsigned i = 0; i < max_thread; i++) {
+      cout << " add thread.. " << std::endl;
+      ObjectCursor shard_start;
+      ObjectCursor shard_end;
+      io_ctx.object_list_slice(
+        begin,
+        end,
+        i,
+        max_thread,
+        &shard_start,
+        &shard_end);
+
+      unique_ptr<CrawlerThread> ptr (
+          new SampleDedupWorkerThread(
+            io_ctx,
+            chunk_io_ctx,
+            shard_start,
+            shard_end,
+            chunk_size,
+            fp_algo,
+            chunk_algo,
+            sample_dedup_global));
+      ptr->set_debug(debug);
+      ptr->create("sample_dedup");
+      estimate_threads.push_back(move(ptr));
+    }
+
+    for (auto &p : estimate_threads) {
+      p->join();
+    }
+    break;
+  }
+
+  return 0;
+}
+
 int main(int argc, const char **argv)
 {
   auto args = argv_to_vec(argc, argv);
@@ -1229,6 +1734,8 @@ int main(int argc, const char **argv)
      *
      */
     return make_dedup_object(opts);
+  } else if (op_name == "sample-dedup") {
+    return make_crawling_daemon(opts);
   } else {
     cerr << "unrecognized op " << op_name << std::endl;
     exit(1);

--- a/src/tools/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup_tool.cc
@@ -655,8 +655,8 @@ void SampleDedupWorkerThread::crawl()
 {
   cout << "new iteration" << std::endl;
 
-  for (ObjectCursor current_object = begin;
-      current_object < end;) {
+  ObjectCursor current_object = begin;
+  while (current_object < end) {
     std::vector<ObjectItem> objects;
     // Get the list of object IDs to deduplicate
     std::tie(objects, current_object) = get_objects(current_object, end, 100);
@@ -674,8 +674,7 @@ void SampleDedupWorkerThread::crawl()
   vector<AioCompRef> evict_completions(oid_for_evict.size());
   int i = 0;
   for (auto &oid : oid_for_evict) {
-    auto completion = do_async_evict(oid);
-    evict_completions[i] = move(completion);
+    evict_completions[i] = do_async_evict(oid);
     i++;
   }
   for (auto &completion : evict_completions) {
@@ -712,7 +711,7 @@ std::tuple<std::vector<ObjectItem>, ObjectCursor> SampleDedupWorkerThread::get_o
     &next);
   if (ret < 0 ) {
     cerr << "error object_list" << std::endl;
-    objects.resize(0);
+    objects.clear();
   }
 
   return std::make_tuple(objects, next);


### PR DESCRIPTION


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>

SampleDedup deduplicates the objects in base pool based-on the result of sampled deduplication among sampled objects.

SampleDedup crawls dirty objects in base pool, samples from those dirty objects, derives which objects are good to be deduplicated(dedupable) by doing sampled deduplication among sampled objects. There are two policy to find out dedupable objects. First, the chunks which are duplicated more than chunk_dedup_threshold is regarded as dedupable chunks. Second, The objects which has duplicated chunks more than object_dedup_threshold are also regarded as dedupable objects. There are 
two modes to crawling, shallow and deep modes. Shallow crawling mode, which crawls sampled objects, has relatively lower interference to performance and aims to run-time deduplication alongside with IO requests. Contrarily, deep crawling mode crawls all objects to find more dedupable objects and chunks with higher performance overhead. Deep crawling mode is proper to be triggered as background operation.

The purpose of SampleDedup is the mitigation of the block device space overhead caused by making chunk objects from the origin objects which is expected to be duplicated with other objects. Existing deduplication interfaces and dedup tool does not consider whether data is good to be deduplicated or not. By deduplication via set_chunk(), tier_evict() and tier_flush(), the chunk object and its corresponding metadata such as reference object ID are created and stored to block device. The chunk object which contains unique data incurs unnecessary metadata space consumption because it cannot save any device space.


Signed-off-by: Jinyong Ha <jy200.ha@samsung.com>
Signed-off-by: Myoungwon Oh <myoungwon.oh@samsung.com>
Signed-off-by: Sungmin Lee <sung_min.lee@samsung.com>