### PR TITLE
mds: add an option to disable updating metrics to rank0 periodically

### DIFF
--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1450,3 +1450,12 @@ options:
   - mds
   flags:
   - runtime
+- name: mds_disable_metrics_update_rank0
+  type: bool
+  level: advanced
+  desc: Disable updating metrics to rank0 periodically.
+  default: false
+  services:
+  - mds
+  flags:
+  - runtime

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -548,6 +548,7 @@ MDSRank::MDSRank(
                                          cct->_conf->mds_op_log_threshold);
   op_tracker.set_history_size_and_duration(cct->_conf->mds_op_history_size,
                                            cct->_conf->mds_op_history_duration);
+  disable_metrics_update_rank0 = g_conf().get_val<bool>("mds_disable_metrics_update_rank0");
 
   schedule_update_timer_task();
 }
@@ -3771,6 +3772,9 @@ void MDSRankDispatcher::handle_conf_change(const ConfigProxy& conf, const std::s
 
   if (changed.count("mds_heartbeat_grace")) {
     heartbeat_grace = conf.get_val<double>("mds_heartbeat_grace");
+  }
+  if (changed.count("mds_disable_metrics_update_rank0")) {
+    disable_metrics_update_rank0 = conf.get_val<bool>("mds_disable_metrics_update_rank0");
   }
   if (changed.count("mds_op_complaint_time") || changed.count("mds_op_log_threshold")) {
     op_tracker.set_complaint_and_threshold(conf->mds_op_complaint_time, conf->mds_op_log_threshold);

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -386,6 +386,8 @@ class MDSRank {
 
     std::unique_ptr<MDSMap> &mdsmap; /* MDSDaemon::mdsmap */
 
+    bool disable_metrics_update_rank0;
+
     Objecter *objecter;
 
     // sub systems

--- a/src/mds/MetricsHandler.cc
+++ b/src/mds/MetricsHandler.cc
@@ -386,8 +386,8 @@ void MetricsHandler::notify_mdsmap(const MDSMap &mdsmap) {
 void MetricsHandler::update_rank0() {
   dout(20) << dendl;
 
-  if (!addr_rank0) {
-    dout(20) << ": not yet notified with rank0 address, ignoring" << dendl;
+  if (!addr_rank0 || mds->disable_metrics_update_rank0) {
+    dout(20) << ": not yet notified with rank0 address or the update is disabled, ignoring" << dendl;
     return;
   }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/54411
Signed-off-by: Xiubo Li <xiubli@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
