### PR TITLE
pacific: common: fix FTBFS due to dout & need_dynamic on GCC-12

### DIFF
--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -99,11 +99,12 @@ namespace ceph::dout {
 template<typename T>
 struct dynamic_marker_t {
   T value;
-  operator T() const { return value; }
+  // constexpr ctor isn't needed as it's an aggregate type
+  constexpr operator T() const { return value; }
 };
 
 template<typename T>
-dynamic_marker_t<T> need_dynamic(T&& t) {
+constexpr dynamic_marker_t<T> need_dynamic(T&& t) {
   return dynamic_marker_t<T>{ std::forward<T>(t) };
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54276

---

backport of https://github.com/ceph/ceph/pull/44670
parent tracker: https://tracker.ceph.com/issues/53896

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh