### PR TITLE
rbd-mirror: fix early rollback id setting during snapshot sync

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -12,7 +12,7 @@
 #                          destroy the clusters and remove the temp directory)
 #                          on exit, so it is possible to check the test state
 #                          after failure.
-#  RBD_MIRROR_TEMDIR     - use this path when creating the temporary directory
+#  RBD_MIRROR_TEMPDIR     - use this path when creating the temporary directory
 #                          (should not exist) instead of running mktemp(1).
 #  RBD_MIRROR_ARGS       - use this to pass additional arguments to started
 #                          rbd-mirror daemons.
@@ -22,7 +22,7 @@
 #  RBD_MIRROR_CONFIG_KEY - if not empty, use config-key for remote cluster
 #                          secrets
 # The cleanup can be done as a separate step, running the script with
-# `cleanup ${RBD_MIRROR_TEMDIR}' arguments.
+# `cleanup ${RBD_MIRROR_TEMPDIR}' arguments.
 #
 # Note, as other workunits tests, rbd_mirror_journal.sh expects to find ceph binaries
 # in PATH.
@@ -34,7 +34,7 @@
 #
 #   cd $CEPH_SRC_PATH
 #   PATH=$CEPH_SRC_PATH:$PATH
-#   RBD_MIRROR_NOCLEANUP=1 RBD_MIRROR_TEMDIR=/tmp/tmp.rbd_mirror \
+#   RBD_MIRROR_NOCLEANUP=1 RBD_MIRROR_TEMPDIR=/tmp/tmp.rbd_mirror \
 #     ../qa/workunits/rbd/rbd_mirror_journal.sh
 #
 # After the test failure cd to TEMPDIR and check the current state:
@@ -52,7 +52,7 @@
 # Also you can execute commands (functions) from the script:
 #
 #   cd $CEPH_SRC_PATH
-#   export RBD_MIRROR_TEMDIR=/tmp/tmp.rbd_mirror
+#   export RBD_MIRROR_TEMPDIR=/tmp/tmp.rbd_mirror
 #   ../qa/workunits/rbd/rbd_mirror_journal.sh status
 #   ../qa/workunits/rbd/rbd_mirror_journal.sh stop_mirror cluster1
 #   ../qa/workunits/rbd/rbd_mirror_journal.sh start_mirror cluster2
@@ -62,7 +62,7 @@
 # Eventually, run the cleanup:
 #
 #   cd $CEPH_SRC_PATH
-#   RBD_MIRROR_TEMDIR=/tmp/tmp.rbd_mirror \
+#   RBD_MIRROR_TEMPDIR=/tmp/tmp.rbd_mirror \
 #     ../qa/workunits/rbd/rbd_mirror_journal.sh cleanup
 #
 
@@ -329,10 +329,10 @@ setup_pools()
 
 setup_tempdir()
 {
-    if [ -n "${RBD_MIRROR_TEMDIR}" ]; then
-        test -d "${RBD_MIRROR_TEMDIR}" ||
-        mkdir "${RBD_MIRROR_TEMDIR}"
-        TEMPDIR="${RBD_MIRROR_TEMDIR}"
+    if [ -n "${RBD_MIRROR_TEMPDIR}" ]; then
+        test -d "${RBD_MIRROR_TEMPDIR}" ||
+        mkdir "${RBD_MIRROR_TEMPDIR}"
+        TEMPDIR="${RBD_MIRROR_TEMPDIR}"
         cd ${TEMPDIR}
     else
         TEMPDIR=`mktemp -d`
@@ -388,7 +388,7 @@ cleanup()
             CEPH_ARGS='' ${CEPH_SRC}/mstop.sh ${CLUSTER1}
             CEPH_ARGS='' ${CEPH_SRC}/mstop.sh ${CLUSTER2}
         fi
-        test "${RBD_MIRROR_TEMDIR}" = "${TEMPDIR}" || rm -Rf ${TEMPDIR}
+        test "${RBD_MIRROR_TEMPDIR}" = "${TEMPDIR}" || rm -Rf ${TEMPDIR}
     fi
 
     if [ "${error_code}" -eq 0 ]; then
@@ -1465,13 +1465,13 @@ wait_for_image_in_omap()
 
 if [ "$#" -gt 0 ]
 then
-    if [ -z "${RBD_MIRROR_TEMDIR}" ]
+    if [ -z "${RBD_MIRROR_TEMPDIR}" ]
     then
-       echo "RBD_MIRROR_TEMDIR is not set" >&2
+       echo "RBD_MIRROR_TEMPDIR is not set" >&2
        exit 1
     fi
 
-    TEMPDIR="${RBD_MIRROR_TEMDIR}"
+    TEMPDIR="${RBD_MIRROR_TEMPDIR}"
     cd ${TEMPDIR}
     $@
     exit $?

--- a/qa/workunits/rbd/rbd_mirror_journal.sh
+++ b/qa/workunits/rbd/rbd_mirror_journal.sh
@@ -168,6 +168,19 @@ wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${image} 'up+stopped'
 wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+replaying' 'primary_position'
 compare_images ${POOL} ${image}
 
+# competing promote/demote same cluster
+demote_image ${CLUSTER2} ${POOL} ${image}
+wait_for_image_replay_stopped ${CLUSTER1} ${POOL} ${image}
+wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+unknown'
+wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${image} 'up+unknown'
+promote_image ${CLUSTER2} ${POOL} ${image} &
+promote_image ${CLUSTER2} ${POOL} ${image} &
+wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
+write_image ${CLUSTER2} ${POOL} ${image} 100
+wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${POOL} ${image}
+wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${image} 'up+stopped'
+wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+replaying'
+compare_images ${POOL} ${image}
 # failover (unmodified)
 demote_image ${CLUSTER2} ${POOL} ${image}
 wait_for_image_replay_stopped ${CLUSTER1} ${POOL} ${image}

--- a/qa/workunits/rbd/rbd_mirror_snapshot.sh
+++ b/qa/workunits/rbd/rbd_mirror_snapshot.sh
@@ -174,6 +174,20 @@ wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${image} 'up+stopped'
 wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+replaying'
 compare_images ${POOL} ${image}
 
+# competing promote/demote same cluster
+demote_image ${CLUSTER2} ${POOL} ${image}
+wait_for_image_replay_stopped ${CLUSTER1} ${POOL} ${image}
+wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+unknown'
+wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${image} 'up+unknown'
+promote_image ${CLUSTER2} ${POOL} ${image} &
+promote_image ${CLUSTER2} ${POOL} ${image} &
+wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
+write_image ${CLUSTER2} ${POOL} ${image} 100
+wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${POOL} ${image}
+wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${image} 'up+stopped'
+wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${image} 'up+replaying'
+compare_images ${POOL} ${image}
+
 # failover (unmodified)
 demote_image ${CLUSTER2} ${POOL} ${image}
 wait_for_image_replay_stopped ${CLUSTER1} ${POOL} ${image}

--- a/src/librbd/mirror/snapshot/PromoteRequest.cc
+++ b/src/librbd/mirror/snapshot/PromoteRequest.cc
@@ -56,14 +56,13 @@ template <typename I>
 void PromoteRequest<I>::create_orphan_snapshot() {
   CephContext *cct = m_image_ctx->cct;
   ldout(cct, 15) << dendl;
-  bool requires_orphan = false;
 
   auto ctx = create_context_callback<
     PromoteRequest<I>,
     &PromoteRequest<I>::handle_create_orphan_snapshot>(this);
 
   auto req = CreateNonPrimaryRequest<I>::create(
-    m_image_ctx, false, "", CEPH_NOSNAP, {}, {}, requires_orphan, ctx);
+    m_image_ctx, false, "", CEPH_NOSNAP, {}, {}, nullptr, ctx);
   req->send();
 }
 

--- a/src/librbd/mirror/snapshot/PromoteRequest.h
+++ b/src/librbd/mirror/snapshot/PromoteRequest.h
@@ -82,7 +82,6 @@ private:
   std::string m_global_image_id;
   Context *m_on_finish;
 
-  uint64_t m_rollback_snap_id = CEPH_NOSNAP;
   bool m_lock_acquired = false;
   NoOpProgressContext m_progress_ctx;
 

--- a/src/librbd/mirror/snapshot/Utils.cc
+++ b/src/librbd/mirror/snapshot/Utils.cc
@@ -26,23 +26,23 @@ bool get_rollback_snap_id(
     std::map<librados::snap_t, SnapInfo>::reverse_iterator it,
     std::map<librados::snap_t, SnapInfo>::reverse_iterator end,
     uint64_t *rollback_snap_id) {
-
   for (; it != end; it++) {
-    auto mirror_ns = std::get<cls::rbd::MirrorSnapshotNamespace>(
-      it->second.snap_namespace);
-    if (mirror_ns.state != cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY) {
+    auto mirror_ns = std::get_if<cls::rbd::MirrorSnapshotNamespace>(
+    &it->second.snap_namespace);
+    if (mirror_ns == nullptr) {
+      continue;
+    }
+    if (mirror_ns->state != cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY) {
       break;
     }
-    if (mirror_ns.complete) {
+    if (mirror_ns->complete) {
       break;
     }
   }
-
   if (it != end) {
     *rollback_snap_id = it->first;
     return true;
   }
-
   return false;
 }
 


### PR DESCRIPTION

in scenarios where the snapshot sync happens after rollback snapshot is
set to older version(removed) and new rollback snapshot is available,
set the latest available snapshot rollback id.

fixes: https://tracker.ceph.com/issues/53537
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
