### PR TITLE
qa/suites/rgw: fix and update tempest and barbican tests

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/barbican.yaml
+++ b/qa/suites/rgw/crypt/2-kms/barbican.yaml
@@ -27,8 +27,7 @@ tasks:
 - tox: [ client.0 ]
 - keystone:
     client.0:
-      sha1: 17.0.0.0rc2
-      force-branch: master
+      force-branch: stable/xena
       projects:
         - name: rgwcrypt
           description: Encryption Tenant
@@ -69,8 +68,7 @@ tasks:
           description: Swift Service
 - barbican:
     client.0:
-      sha1: 5.0.1
-      force-branch: master
+      force-branch: stable/xena
       use-keystone-role: client.0
       keystone_authtoken:
         auth_plugin: password

--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -46,6 +46,8 @@ tasks:
         - .*test_object_services.ObjectTest.test_create_object_with_transfer_encoding
         - .*test_container_services.ContainerTest.test_create_container_with_remove_metadata_key
         - .*test_container_services.ContainerTest.test_create_container_with_remove_metadata_value
+        - .*test_object_expiry.ObjectExpiryTest.test_get_object_after_expiry_time
+        - .*test_object_expiry.ObjectExpiryTest.test_get_object_at_expiry_time
 
 overrides:
   ceph:

--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -4,8 +4,7 @@ tasks:
 - tox: [ client.0 ]
 - keystone:
     client.0:
-      sha1: 17.0.0.0rc2
-      force-branch: master
+      force-branch: stable/xena
       services:
         - name: swift
           type: object-store
@@ -16,7 +15,7 @@ tasks:
       use-keystone-role: client.0
 - tempest:
     client.0:
-      sha1: train-last
+      sha1: 30.0.0
       force-branch: master
       use-keystone-role: client.0
       auth:

--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -8,6 +8,7 @@ import http
 import json
 import time
 import math
+import os
 
 from urllib.parse import urlparse
 
@@ -157,11 +158,15 @@ def fix_barbican_api(ctx, cclient):
                          '/prop_dir =/ s#etc/barbican#{}/etc/barbican#'.format(get_barbican_dir(ctx)),
                          'bin/barbican-api'])
 
-def copy_policy_json(ctx, cclient):
-    run_in_barbican_dir(ctx, cclient,
-                        ['cp',
-                         get_barbican_dir(ctx)+'/etc/barbican/policy.json',
-                         get_barbican_dir(ctx)])
+def copy_policy_file(ctx, cclient):
+    policy_json_path = get_barbican_dir(ctx)+'/etc/barbican/policy.json'
+    if os.path.exists(policy_json_path):
+        run_in_barbican_dir(ctx, cclient,
+                            ['cp', policy_json_path, get_barbican_dir(ctx)])
+    policy_yaml_path = get_barbican_dir(ctx)+'/etc/barbican/policy.yaml'
+    if os.path.exists(policy_yaml_path):
+        run_in_barbican_dir(ctx, cclient,
+                            ['cp', policy_yaml_path, get_barbican_dir(ctx)])
 
 def create_barbican_conf(ctx, cclient):
     barbican_host, barbican_port = ctx.barbican.endpoints[cclient]
@@ -189,7 +194,7 @@ def configure_barbican(ctx, config):
     set_authtoken_params(ctx, cclient, cconfig)
     fix_barbican_api(ctx, cclient)
     fix_barbican_api_paste(ctx, cclient)
-    copy_policy_json(ctx, cclient)
+    copy_policy_file(ctx, cclient)
     create_barbican_conf(ctx, cclient)
     try:
         yield

--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -8,7 +8,6 @@ import http
 import json
 import time
 import math
-import os
 
 from urllib.parse import urlparse
 
@@ -158,16 +157,6 @@ def fix_barbican_api(ctx, cclient):
                          '/prop_dir =/ s#etc/barbican#{}/etc/barbican#'.format(get_barbican_dir(ctx)),
                          'bin/barbican-api'])
 
-def copy_policy_file(ctx, cclient):
-    policy_json_path = get_barbican_dir(ctx)+'/etc/barbican/policy.json'
-    if os.path.exists(policy_json_path):
-        run_in_barbican_dir(ctx, cclient,
-                            ['cp', policy_json_path, get_barbican_dir(ctx)])
-    policy_yaml_path = get_barbican_dir(ctx)+'/etc/barbican/policy.yaml'
-    if os.path.exists(policy_yaml_path):
-        run_in_barbican_dir(ctx, cclient,
-                            ['cp', policy_yaml_path, get_barbican_dir(ctx)])
-
 def create_barbican_conf(ctx, cclient):
     barbican_host, barbican_port = ctx.barbican.endpoints[cclient]
     barbican_url = 'http://{host}:{port}'.format(host=barbican_host,
@@ -202,7 +191,6 @@ def configure_barbican(ctx, config):
     set_authtoken_params(ctx, cclient, cconfig)
     fix_barbican_api(ctx, cclient)
     fix_barbican_api_paste(ctx, cclient)
-    copy_policy_file(ctx, cclient)
     create_barbican_conf(ctx, cclient)
     try:
         yield

--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -179,6 +179,14 @@ def create_barbican_conf(ctx, cclient):
                          'echo -n -e "[DEFAULT]\nhost_href=' + barbican_url + '\n" ' + \
                          '>barbican.conf'])
 
+    log.info("run barbican db upgrade")
+    config_path = get_barbican_dir(ctx) + '/barbican.conf'
+    run_in_barbican_venv(ctx, cclient, ['barbican-manage', '--config-file', config_path,
+                                        'db', 'upgrade'])
+    log.info("run barbican db sync_secret_stores")
+    run_in_barbican_venv(ctx, cclient, ['barbican-manage', '--config-file', config_path,
+                                        'db', 'sync_secret_stores'])
+
 @contextlib.contextmanager
 def configure_barbican(ctx, config):
     """


### PR DESCRIPTION
Update the versions used for OpenStack Keystone,
Barbican and Tempest projects.

Signed-off-by: Tobias Urdin <tobias.urdin@binero.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
