### PR TITLE
pacific: src/ceph-crash.in: various enhancements and fixes

### DIFF
--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -41,11 +41,10 @@ def post_crash(path):
                   '-n', n,
                   'crash', 'post', '-i', '-'],
             stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
         f = open(os.path.join(path, 'meta'), 'rb')
-        stdout, stderr = pr.communicate(input=f.read())
+        stderr = pr.communicate(input=f.read())
         rc = pr.wait()
         f.close()
         if rc != 0:

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -51,7 +51,7 @@ def post_crash(path):
         stderr = pr.communicate(input=f.read())
         rc = pr.wait()
         f.close()
-        if rc != 0:
+        if rc != 0 or stderr != "":
             log.warning('post %s as %s failed: %s' % (path, n, stderr))
         if rc == 0:
             break

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -80,6 +80,7 @@ def handler(signum):
     sys.exit(0)
 
 def main():
+    global auth_names
     # exit code 0 on SIGINT, SIGTERM
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -30,6 +30,10 @@ def parse_args():
     parser.add_argument(
         '--name', '-n',
         help='ceph name to authenticate as (default: try client.crash, client.admin)')
+    parser.add_argument(
+        '--log-level', '-l',
+        help='log level output (default: INFO), support INFO or DEBUG')
+
     return parser.parse_args()
 
 
@@ -86,6 +90,9 @@ def main():
     signal.signal(signal.SIGTERM, handler)
 
     args = parse_args()
+    if args.log_level == 'DEBUG':
+        log.setLevel(logging.DEBUG)
+
     postdir = os.path.join(args.path, 'posted')
     if args.name:
         auth_names = [args.name]

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -75,7 +75,7 @@ def scrape_path(path):
                     (metapath, p, os.path.join('posted/', p))
                 )
 
-def handler(signum, frame):
+def handler(signum):
     print('*** Interrupted with signal %d ***' % signum)
     sys.exit(0)
 


### PR DESCRIPTION
Backport of #42055

Cephadm needs the --name parameter fix in pacific for how it handles crash daemons deployed on hosts with FQDNs.
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
