### PR TITLE
quincy: include: Define dlfcn.h on Windows

### DIFF
--- a/src/include/win32/dlfcn.h
+++ b/src/include/win32/dlfcn.h
@@ -1,0 +1,1 @@
+#include "../dlfcn_compat.h"


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/45272 to quincy.  Commit c11455fb4f28 ("build: avoid Windows linking issues") is skipped because the offending commit 22fefb2338cf ("cmake: add ceph-common DENABLE_SHARED=OFF support") is not in quincy.