### PR TITLE
mds: include encoded stray inode when sending dentry unlink message to replicas

### DIFF
--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -877,7 +877,7 @@ class MDCache {
   void decode_replica_inode(CInode *&in, bufferlist::const_iterator& p, CDentry *dn, MDSContext::vec& finished);
 
   void encode_replica_stray(CDentry *straydn, mds_rank_t who, bufferlist& bl);
-  void decode_replica_stray(CDentry *&straydn, const bufferlist &bl, mds_rank_t from);
+  void decode_replica_stray(CDentry *&straydn, CInode **in, const bufferlist &bl, mds_rank_t from);
 
   // -- namespace --
   void encode_remote_dentry_link(CDentry::linkage_t *dnl, bufferlist& bl);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -2702,7 +2702,7 @@ void Server::handle_peer_request(const cref_t<MMDSPeerRequest> &m)
 
   CDentry *straydn = NULL;
   if (m->straybl.length() > 0) {
-    mdcache->decode_replica_stray(straydn, m->straybl, from);
+    mdcache->decode_replica_stray(straydn, nullptr, m->straybl, from);
     ceph_assert(straydn);
     m->straybl.clear();
   }


### PR DESCRIPTION
The series of events that lead to unaccessible dentries is as follows (requires some
hardlinked files, directory pinning and path restricted caps).

Assume 3 hardlinked files:

       d0/f0 <-- primary link
       d1/h1
       d1/h2

with multiple active MDSs -- d0 pinned to rank-0 and d1 to rank-1. Reproducing
this requires deleting a non-primary link first followed by deleting the primary
link and lastly the other non-primary link. If one if unlucky, the last delete
fails with "Permission denied" error. On the MDS side, this is what happens:

Unlinking the first non-primary link would discover the remote inode and link
it in dentry as part of lookup. Unlink would send a remote unlink operation
(_link_remote(op-unlink)) to the auth mds of the remote inode. Now the other
unlinks:

```
               rank0               |                 rank1
                                   |
                x-----<-----unlink: #unlink(d0/f0)
                |                  |
                v                  |
         _unlink_local()           |
                |                  |
                v                  |
                |                  |
   x ---send_dentry_unlink()       |
   |   reply_client_request()      |
   |                               |
   |                       unlink: #lookup(d1/h2)----x
   |                               |                 |
   |                               |                 v
   |                               |       MDCache::path_traverse()
   v                               |       (uses linked remote inode,
   |                               |       which is not a stray inode)-----x
   |                               |                                       |
   x-------------->----------------|---------->------x                     v
         (dentry_unlink msg)       |                 |                     |
                                   |                 v                     |
                                   |       handle_dentry_unlink()          |
                                   |    (relinks inode to stray dentry)    |
                                   |                                       |
                                   |                 x---------------------x
                                   |                 |
                                   |                 v
                                   |       dispatch_client_request()
                                   |        (uses linked inode under
                                   |  stray dentry, no reintegration check)
                                   |                 |
                                   |                 v
                                   |      SessionMap::check_access()
                                   |      (parent is a stray dir,
                                   |    but stray_prior_path is empty)

```
One possible fix could be to fix SessionMap::check_access() to build the
inode path for a inode under stray directory, however, the inode path
would be on the form "#<inode>" and it does not look like there is a
good way to figure out what it was (as seen in inode dump).

Sending the (encoded) inode as part of `dentry_unlink' message seems to
get handled well -- decode_replica_inode() handles the case where the
inode already existed (in MDCache::inode_map) and the auth mds sending
the stray inode to its replicas doesn't seem to cause trouble. (I think
it didn't do this since the replicas have the inode anyway, but in this
case this inode is a _bit_ out of sync with what exists in the auth).

Fixes: http://tracker.ceph.com/issues/54046
Signed-off-by: Venky Shankar <vshankar@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
