### PR TITLE
pacific: rgw: fix segfault in OpsLogRados::log when realm is reloaded

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -600,7 +600,7 @@ namespace rgw {
       ops_log_file->start();
       olog_manifold->add_sink(ops_log_file);
     }
-    olog_manifold->add_sink(new OpsLogRados(store->getRados()));
+    olog_manifold->add_sink(new OpsLogRados(store));
     olog = olog_manifold;
 
     int port = 80;

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -197,9 +197,10 @@ public:
 };
 
 class OpsLogRados : public OpsLogSink {
-  RGWRados* store;
+  // main()'s Store pointer as a reference, possibly modified by RGWRealmReloader
+  rgw::sal::RGWRadosStore* const& store;
 public:
-  OpsLogRados(RGWRados* store);
+  OpsLogRados(rgw::sal::RGWRadosStore* const& store);
   int log(struct req_state* s, struct rgw_log_entry& entry) override;
 };
 

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -516,7 +516,7 @@ int radosgw_Main(int argc, const char **argv)
     ops_log_file->start();
     olog->add_sink(ops_log_file);
   }
-  olog->add_sink(new OpsLogRados(store->getRados()));
+  olog->add_sink(new OpsLogRados(store));
 
   r = signal_fd_init();
   if (r < 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54537

---

backport of https://github.com/ceph/ceph/pull/44893
parent tracker: https://tracker.ceph.com/issues/54130

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh