### PR TITLE
pacific: qa: move certificates for kmip task into /etc/ceph

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/kmip.yaml
+++ b/qa/suites/rgw/crypt/2-kms/kmip.yaml
@@ -3,9 +3,9 @@ overrides:
     conf:
       client:
         rgw crypt s3 kms backend: kmip
-        rgw crypt kmip ca path: /home/ubuntu/cephtest/ca/kmiproot.crt
-        rgw crypt kmip client cert: /home/ubuntu/cephtest/ca/kmip-client.crt
-        rgw crypt kmip client key: /home/ubuntu/cephtest/ca/kmip-client.key
+        rgw crypt kmip ca path: /etc/ceph/kmiproot.crt
+        rgw crypt kmip client cert: /etc/ceph/kmip-client.crt
+        rgw crypt kmip client key: /etc/ceph/kmip-client.key
         rgw crypt kmip kms key template: pykmip-$keyid
   rgw:
     client.0:

--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -153,6 +153,35 @@ def start_rgw(ctx, config, clients):
                 '--rgw_crypt_kmip_addr', "{}:{}".format(*ctx.pykmip.endpoints[pykmip_role]),
             ])
 
+            clientcert = ctx.ssl_certificates.get('kmip-client')
+            servercert = ctx.ssl_certificates.get('kmip-server')
+            clientca = ctx.ssl_certificates.get('kmiproot')
+
+            clientkey = clientcert.key
+            clientcert = clientcert.certificate
+            serverkey = servercert.key
+            servercert = servercert.certificate
+            rootkey = clientca.key
+            rootcert = clientca.certificate
+
+            cert_path = '/etc/ceph/'
+            ctx.cluster.only(client).run(args=['sudo', 'cp', clientcert, cert_path])
+            ctx.cluster.only(client).run(args=['sudo', 'cp', clientkey, cert_path])
+            ctx.cluster.only(client).run(args=['sudo', 'cp', servercert, cert_path])
+            ctx.cluster.only(client).run(args=['sudo', 'cp', serverkey, cert_path])
+            ctx.cluster.only(client).run(args=['sudo', 'cp', rootkey, cert_path])
+            ctx.cluster.only(client).run(args=['sudo', 'cp', rootcert, cert_path])
+
+            clientcert = cert_path + 'kmip-client.crt'
+            clientkey = cert_path + 'kmip-client.key'
+            servercert = cert_path + 'kmip-server.crt'
+            serverkey = cert_path + 'kmip-server.key'
+            rootkey = cert_path + 'kmiproot.key'
+            rootcert = cert_path + 'kmiproot.crt'
+
+            ctx.cluster.only(client).run(args=['sudo', 'chmod', '600', clientcert, clientkey, servercert, serverkey, rootkey, rootcert])
+            ctx.cluster.only(client).run(args=['sudo', 'chown', 'ceph', clientcert, clientkey, servercert, serverkey, rootkey, rootcert])
+
         rgw_cmd.extend([
             '--foreground',
             run.Raw('|'),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54035

---

backport of https://github.com/ceph/ceph/pull/44694
parent tracker: https://tracker.ceph.com/issues/52085

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh