### PR TITLE
crimson/osd: fix osd crash due to buffer reference binding

### DIFF
--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -116,7 +116,7 @@ seastar::future<> Watch::notify_ack(
 {
   logger().info("{}", __func__);
   return seastar::do_for_each(in_progress_notifies,
-    [this_shared=shared_from_this(), &reply_bl] (auto notify) {
+    [this_shared=shared_from_this(), reply_bl] (auto notify) {
       return notify->complete_watcher(this_shared, reply_bl);
     }
   ).then([this] {


### PR DESCRIPTION
Fix osd from crashing (reproducible with rbd's `snap create`) from buffer fault.

```
DEBUG 2022-03-16 13:52:24,764 [shard 0] osd - send_completion sending notify replies: notify_reply_t{watcher_gid=4126, watcher_cookie=140090357664288, bl=buffer::list(len=0,                 
                                                                                                                                                                                              
)}                                                                                                                                                                                            
../src/include/buffer.h:450:12: runtime error: reference binding to misaligned address 0x000000000076 for type 'const struct ptr_node', which requires 8 byte alignment
0x000000000076: note: pointer points here                                                                                                                                                     
<memory cannot be printed>                                                                                                                                                                    
../src/include/buffer.h:398:5: runtime error: member access within misaligned address 0x000000000076 for type 'const struct ptr_node', which requires 8 byte alignment                        
0x000000000076: note: pointer points here                                                                                                                                                     
<memory cannot be printed>                                                                     
Segmentation fault on shard 0.
```

(With this patch creating snap isn't hanging and is returning as expected.)

Signed-off-by: Matan Breizman <mbreizma@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
