### PR TITLE
rgw multisite reshard: generation numbers in data sync are not optional<>

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8954,6 +8954,10 @@ next:
       cerr << "ERROR: bucket not specified" << std::endl;
       return EINVAL;
     }
+    if (!gen.has_value()) {
+      cerr << "ERROR: gen not specified" << std::endl;
+      return EINVAL;
+    }
     int ret = init_bucket_for_sync(user.get(), tenant, bucket_name, bucket_id, &bucket);
     if (ret < 0) {
       return -ret;
@@ -8966,7 +8970,7 @@ next:
       return -ret;
     }
 
-    ret = sync.run(dpp());
+    ret = sync.run(dpp(), *gen);
     if (ret < 0) {
       cerr << "ERROR: sync.run() returned ret=" << ret << std::endl;
       return -ret;

--- a/src/rgw/rgw_bucket_sync_cache.h
+++ b/src/rgw/rgw_bucket_sync_cache.h
@@ -23,7 +23,7 @@ namespace rgw::bucket_sync {
 // per bucket-shard state cached by DataSyncShardCR
 struct State {
   // the source bucket shard to sync
-  rgw_bucket_shard key;
+  std::pair<rgw_bucket_shard, std::optional<uint64_t>> key;
   // current sync obligation being processed by DataSyncSingleEntry
   std::optional<rgw_data_sync_obligation> obligation;
   // incremented with each new obligation
@@ -31,7 +31,10 @@ struct State {
   // highest timestamp applied by all sources
   ceph::real_time progress_timestamp;
 
-  State(const rgw_bucket_shard& key) noexcept : key(key) {}
+  State(const std::pair<rgw_bucket_shard, std::optional<uint64_t>>& key ) noexcept
+    : key(key) {}
+  State(const rgw_bucket_shard& shard, std::optional<uint64_t> gen) noexcept
+    : key(shard, gen) {}
 };
 
 struct Entry;
@@ -39,7 +42,7 @@ struct EntryToKey;
 class Handle;
 
 using lru_config = ceph::common::intrusive_lru_config<
-    rgw_bucket_shard, Entry, EntryToKey>;
+  std::pair<rgw_bucket_shard, std::optional<uint64_t>>, Entry, EntryToKey>;
 
 // a recyclable cache entry
 struct Entry : State, ceph::common::intrusive_lru_base<lru_config> {
@@ -47,7 +50,7 @@ struct Entry : State, ceph::common::intrusive_lru_base<lru_config> {
 };
 
 struct EntryToKey {
-  using type = rgw_bucket_shard;
+  using type = std::pair<rgw_bucket_shard, std::optional<uint64_t>>;
   const type& operator()(const Entry& e) { return e.key; }
 };
 
@@ -71,7 +74,7 @@ class Cache : public thread_unsafe_ref_counter<Cache> {
 
   // find or create a cache entry for the given key, and return a Handle that
   // keeps it lru-pinned until destruction
-  Handle get(const rgw_bucket_shard& key);
+  Handle get(const rgw_bucket_shard& shard, std::optional<uint64_t> gen);
 };
 
 // a State handle that keeps the Cache referenced
@@ -104,9 +107,9 @@ class Handle {
   State* operator->() const noexcept { return entry.get(); }
 };
 
-inline Handle Cache::get(const rgw_bucket_shard& key)
+inline Handle Cache::get(const rgw_bucket_shard& shard, std::optional<uint64_t> gen)
 {
-  auto result = cache.get_or_create(key);
+  auto result = cache.get_or_create({ shard, gen });
   return {this, std::move(result.first)};
 }
 

--- a/src/rgw/rgw_bucket_sync_cache.h
+++ b/src/rgw/rgw_bucket_sync_cache.h
@@ -23,7 +23,7 @@ namespace rgw::bucket_sync {
 // per bucket-shard state cached by DataSyncShardCR
 struct State {
   // the source bucket shard to sync
-  std::pair<rgw_bucket_shard, std::optional<uint64_t>> key;
+  std::pair<rgw_bucket_shard, uint64_t> key;
   // current sync obligation being processed by DataSyncSingleEntry
   std::optional<rgw_data_sync_obligation> obligation;
   // incremented with each new obligation
@@ -31,9 +31,9 @@ struct State {
   // highest timestamp applied by all sources
   ceph::real_time progress_timestamp;
 
-  State(const std::pair<rgw_bucket_shard, std::optional<uint64_t>>& key ) noexcept
+  State(const std::pair<rgw_bucket_shard, uint64_t>& key) noexcept
     : key(key) {}
-  State(const rgw_bucket_shard& shard, std::optional<uint64_t> gen) noexcept
+  State(const rgw_bucket_shard& shard, uint64_t gen) noexcept
     : key(shard, gen) {}
 };
 
@@ -42,7 +42,7 @@ struct EntryToKey;
 class Handle;
 
 using lru_config = ceph::common::intrusive_lru_config<
-  std::pair<rgw_bucket_shard, std::optional<uint64_t>>, Entry, EntryToKey>;
+  std::pair<rgw_bucket_shard, uint64_t>, Entry, EntryToKey>;
 
 // a recyclable cache entry
 struct Entry : State, ceph::common::intrusive_lru_base<lru_config> {
@@ -50,7 +50,7 @@ struct Entry : State, ceph::common::intrusive_lru_base<lru_config> {
 };
 
 struct EntryToKey {
-  using type = std::pair<rgw_bucket_shard, std::optional<uint64_t>>;
+  using type = std::pair<rgw_bucket_shard, uint64_t>;
   const type& operator()(const Entry& e) { return e.key; }
 };
 
@@ -74,7 +74,7 @@ class Cache : public thread_unsafe_ref_counter<Cache> {
 
   // find or create a cache entry for the given key, and return a Handle that
   // keeps it lru-pinned until destruction
-  Handle get(const rgw_bucket_shard& shard, std::optional<uint64_t> gen);
+  Handle get(const rgw_bucket_shard& shard, uint64_t gen);
 };
 
 // a State handle that keeps the Cache referenced
@@ -107,7 +107,7 @@ class Handle {
   State* operator->() const noexcept { return entry.get(); }
 };
 
-inline Handle Cache::get(const rgw_bucket_shard& shard, std::optional<uint64_t> gen)
+inline Handle Cache::get(const rgw_bucket_shard& shard, uint64_t gen)
 {
   auto result = cache.get_or_create({ shard, gen });
   return {this, std::move(result.first)};

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1340,10 +1340,10 @@ public:
           obligation_counter = state->counter;
           progress = ceph::real_time{};
 
-          ldout(cct, 4) << "starting sync on " << bucket_shard_str{state->key}
+          ldout(cct, 4) << "starting sync on " << bucket_shard_str{state->key.first}
               << ' ' << *state->obligation << dendl;
           yield call(new RGWRunBucketSourcesSyncCR(sc, lease_cr,
-                                                   state->key, tn,
+                                                   state->key.first, tn,
                                                    state->obligation->gen,
 						   &progress));
           if (retcode < 0) {
@@ -1355,7 +1355,7 @@ public:
         complete = std::move(*state->obligation);
         state->obligation.reset();
 
-        tn->log(10, SSTR("sync finished on " << bucket_shard_str{state->key}
+        tn->log(10, SSTR("sync finished on " << bucket_shard_str{state->key.first}
                          << " progress=" << progress << ' ' << complete << " r=" << retcode));
       }
       sync_status = retcode;
@@ -1482,7 +1482,7 @@ class RGWDataSyncShardCR : public RGWCoroutine {
   RGWCoroutine* sync_single_entry(const rgw_bucket_shard& src, uint64_t gen,
                                   const std::string& marker,
                                   ceph::real_time timestamp, bool retry) {
-    auto state = bucket_shard_cache->get(src);
+    auto state = bucket_shard_cache->get(src, gen);
     auto obligation = rgw_data_sync_obligation{src, gen, marker, timestamp, retry};
     return new RGWDataSyncSingleEntryCR(sc, std::move(state), std::move(obligation),
                                         &*marker_tracker, error_repo,

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -5410,13 +5410,12 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
   return 0;
 }
 
-RGWCoroutine *RGWRemoteBucketManager::run_sync_cr(int num)
+RGWCoroutine *RGWRemoteBucketManager::run_sync_cr(int num, uint64_t gen)
 {
   if ((size_t)num >= sync_pairs.size()) {
     return nullptr;
   }
 
-  constexpr std::optional<uint64_t> gen; // sync current gen
   return sync_bucket_shard_cr(&sc, nullptr, sync_pairs[num], gen,
                               sync_env->sync_tracer->root_node, nullptr);
 }
@@ -5531,14 +5530,15 @@ int RGWBucketPipeSyncStatusManager::read_sync_status(const DoutPrefixProvider *d
   return 0;
 }
 
-int RGWBucketPipeSyncStatusManager::run(const DoutPrefixProvider *dpp)
+int RGWBucketPipeSyncStatusManager::run(const DoutPrefixProvider *dpp,
+                                        uint64_t gen)
 {
   list<RGWCoroutinesStack *> stacks;
 
   for (auto& mgr : source_mgrs) {
     RGWCoroutinesStack *stack = new RGWCoroutinesStack(store->ctx(), &cr_mgr);
     for (int i = 0; i < mgr->num_pipes(); ++i) {
-      stack->call(mgr->run_sync_cr(i));
+      stack->call(mgr->run_sync_cr(i, gen));
     }
 
     stacks.push_back(stack);

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -71,13 +71,13 @@ void rgw_datalog_shard_data::decode_json(JSONObj *obj) {
 };
 
 // print a bucket shard with [gen]
-std::string to_string(const rgw_bucket_shard& bs, std::optional<uint64_t> gen)
+std::string to_string(const rgw_bucket_shard& bs, uint64_t gen)
 {
   constexpr auto digits10 = std::numeric_limits<uint64_t>::digits10;
   constexpr auto reserve = 2 + digits10; // [value]
   auto str = bs.get_key('/', ':', ':', reserve);
   str.append(1, '[');
-  str.append(std::to_string(gen.value_or(0)));
+  str.append(std::to_string(gen));
   str.append(1, ']');
   return str;
 }
@@ -1267,7 +1267,7 @@ class RGWRunBucketSourcesSyncCR : public RGWCoroutine {
   RGWRESTConn *conn{nullptr};
   rgw_zone_id last_zone;
 
-  std::optional<uint64_t> gen;
+  uint64_t gen;
   rgw_bucket_index_marker_info marker_info;
   BucketIndexShardsManager marker_mgr;
 
@@ -1276,7 +1276,7 @@ public:
                             boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
                             const rgw_bucket_shard& source_bs,
                             const RGWSyncTraceNodeRef& _tn_parent,
-			    std::optional<uint64_t> gen,
+			    uint64_t gen,
                             ceph::real_time* progress);
 
   int operate(const DoutPrefixProvider *dpp) override;
@@ -1479,8 +1479,7 @@ class RGWDataSyncShardCR : public RGWCoroutine {
     return rgw_bucket_parse_bucket_key(sync_env->cct, key,
                                        &bs.bucket, &bs.shard_id);
   }
-  RGWCoroutine* sync_single_entry(const rgw_bucket_shard& src,
-                                  std::optional<uint64_t> gen,
+  RGWCoroutine* sync_single_entry(const rgw_bucket_shard& src, uint64_t gen,
                                   const std::string& marker,
                                   ceph::real_time timestamp, bool retry) {
     auto state = bucket_shard_cache->get(src);
@@ -1610,7 +1609,7 @@ public:
             tn->log(0, SSTR("ERROR: cannot start syncing " << iter->first << ". Duplicate entry?"));
           } else {
             // fetch remote and write locally
-            spawn(sync_single_entry(source_bs, std::nullopt, iter->first,
+            spawn(sync_single_entry(source_bs, 0, iter->first,
                                     entry_timestamp, false), false);
           }
           sync_marker.marker = iter->first;
@@ -1713,7 +1712,7 @@ public:
           for (; iter != error_entries.end(); ++iter) {
             error_marker = iter->first;
             entry_timestamp = rgw::error_repo::decode_value(iter->second);
-            std::optional<uint64_t> gen;
+            uint64_t gen = 0;
             retcode = rgw::error_repo::decode_key(iter->first, source_bs, gen);
             if (retcode == -EINVAL) {
               // backward compatibility for string keys that don't encode a gen
@@ -4710,7 +4709,7 @@ std::ostream& operator<<(std::ostream& out, std::optional<rgw_bucket_shard>& bs)
 static RGWCoroutine* sync_bucket_shard_cr(RGWDataSyncCtx* sc,
                                           boost::intrusive_ptr<const RGWContinuousLeaseCR> lease,
                                           const rgw_bucket_sync_pair_info& sync_pair,
-                                          std::optional<uint64_t> gen,
+                                          uint64_t gen,
                                           const RGWSyncTraceNodeRef& tn,
                                           ceph::real_time* progress);
 
@@ -4718,7 +4717,7 @@ RGWRunBucketSourcesSyncCR::RGWRunBucketSourcesSyncCR(RGWDataSyncCtx *_sc,
                                                      boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
                                                      const rgw_bucket_shard& source_bs,
                                                      const RGWSyncTraceNodeRef& _tn_parent,
-						     std::optional<uint64_t> gen,
+						     uint64_t gen,
                                                      ceph::real_time* progress)
   : RGWCoroutine(_sc->env->cct), sc(_sc), sync_env(_sc->env),
     lease_cr(std::move(lease_cr)),
@@ -5142,7 +5141,7 @@ class RGWSyncBucketCR : public RGWCoroutine {
   boost::intrusive_ptr<RGWContinuousLeaseCR> bucket_lease_cr;
   rgw_bucket_sync_pair_info sync_pair;
   rgw_bucket_sync_pipe sync_pipe;
-  std::optional<uint64_t> gen;
+  uint64_t gen;
   ceph::real_time* progress;
 
   const std::string lock_name = "bucket sync";
@@ -5160,7 +5159,7 @@ public:
   RGWSyncBucketCR(RGWDataSyncCtx *_sc,
                   boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
                   const rgw_bucket_sync_pair_info& _sync_pair,
-                  std::optional<uint64_t> gen,
+                  uint64_t gen,
                   const RGWSyncTraceNodeRef& _tn_parent,
                   ceph::real_time* progress)
     : RGWCoroutine(_sc->cct), sc(_sc), env(_sc->env),
@@ -5181,7 +5180,7 @@ public:
 static RGWCoroutine* sync_bucket_shard_cr(RGWDataSyncCtx* sc,
                                           boost::intrusive_ptr<const RGWContinuousLeaseCR> lease,
                                           const rgw_bucket_sync_pair_info& sync_pair,
-                                          std::optional<uint64_t> gen,
+                                          uint64_t gen,
                                           const RGWSyncTraceNodeRef& tn,
                                           ceph::real_time* progress)
 {
@@ -5364,19 +5363,17 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
       if (bucket_status.state == BucketSyncState::Incremental) {
         // lease not required for incremental sync
         RELEASE_LOCK(bucket_lease_cr);
-
-        // if a specific gen was requested, compare that to the sync status
-        if (gen) {
+        {
           const auto current_gen = bucket_status.incremental_gen;
-          if (*gen > current_gen) {
+          if (gen > current_gen) {
             retcode = -EAGAIN;
             tn->log(10, SSTR("ERROR: requested sync of future generation "
-                             << *gen << " > " << current_gen
+                             << gen << " > " << current_gen
                              << ", returning " << retcode << " for later retry"));
             return set_cr_error(retcode);
-          } else if (*gen < current_gen) {
+          } else if (gen < current_gen) {
             tn->log(10, SSTR("WARNING: requested sync of past generation "
-                             << *gen << " < " << current_gen
+                             << gen << " < " << current_gen
                              << ", returning success"));
             return set_cr_done();
           }

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -22,17 +22,14 @@
 // represents an obligation to sync an entry up a given time
 struct rgw_data_sync_obligation {
   rgw_bucket_shard bs;
-  std::optional<uint64_t> gen;
+  uint64_t gen;
   std::string marker;
   ceph::real_time timestamp;
   bool retry = false;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const rgw_data_sync_obligation& o) {
-  out << "key=" << o.bs;
-  if (o.gen) {
-    out << '[' << *o.gen << ']';
-  }
+  out << "key=" << o.bs << '[' << o.gen << ']';
   if (!o.marker.empty()) {
     out << " marker=" << o.marker;
   }

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -690,7 +690,7 @@ public:
 
   RGWCoroutine *read_sync_status_cr(int num, rgw_bucket_shard_sync_info *sync_status);
   RGWCoroutine *init_sync_status_cr(RGWObjVersionTracker& objv_tracker, rgw_bucket_index_marker_info& info);
-  RGWCoroutine *run_sync_cr(int num);
+  RGWCoroutine *run_sync_cr(int num, uint64_t gen);
 
   int num_pipes() {
     return sync_pairs.size();
@@ -765,7 +765,7 @@ public:
   std::ostream& gen_prefix(std::ostream& out) const override;
 
   int read_sync_status(const DoutPrefixProvider *dpp);
-  int run(const DoutPrefixProvider *dpp);
+  int run(const DoutPrefixProvider *dpp, uint64_t gen);
 };
 
 /// read the full sync status with respect to a source bucket

--- a/src/rgw/rgw_sync_error_repo.cc
+++ b/src/rgw/rgw_sync_error_repo.cc
@@ -28,7 +28,7 @@ constexpr uint8_t binary_key_prefix = 0x80;
 
 struct key_type {
   rgw_bucket_shard bs;
-  std::optional<uint64_t> gen;
+  uint64_t gen;
 };
 
 void encode(const key_type& k, bufferlist& bl, uint64_t f=0)
@@ -47,8 +47,7 @@ void decode(key_type& k, bufferlist::const_iterator& bl)
   DECODE_FINISH(bl);
 }
 
-std::string encode_key(const rgw_bucket_shard& bs,
-                       std::optional<uint64_t> gen)
+std::string encode_key(const rgw_bucket_shard& bs, uint64_t gen)
 {
   using ceph::encode;
   const auto key = key_type{bs, gen};
@@ -58,9 +57,7 @@ std::string encode_key(const rgw_bucket_shard& bs,
   return bl.to_str();
 }
 
-int decode_key(std::string encoded,
-               rgw_bucket_shard& bs,
-               std::optional<uint64_t>& gen)
+int decode_key(std::string encoded, rgw_bucket_shard& bs, uint64_t& gen)
 {
   using ceph::decode;
   key_type key;

--- a/src/rgw/rgw_sync_error_repo.h
+++ b/src/rgw/rgw_sync_error_repo.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <optional>
 #include "include/rados/librados_fwd.hpp"
 #include "include/buffer_fwd.h"
 #include "common/ceph_time.h"
@@ -27,13 +26,10 @@ struct rgw_bucket_shard;
 namespace rgw::error_repo {
 
 // binary-encode a bucket/shard/gen and return it as a string
-std::string encode_key(const rgw_bucket_shard& bs,
-                       std::optional<uint64_t> gen);
+std::string encode_key(const rgw_bucket_shard& bs, uint64_t gen);
 
 // try to decode a key. returns -EINVAL if not in binary format
-int decode_key(std::string encoded,
-               rgw_bucket_shard& bs,
-               std::optional<uint64_t>& gen);
+int decode_key(std::string encoded, rgw_bucket_shard& bs, uint64_t& gen);
 
 // decode a timestamp as a uint64_t for CMPXATTR_MODE_U64
 ceph::real_time decode_value(const ceph::bufferlist& bl);


### PR DESCRIPTION
this removes the idea of 'optional' generation numbers coming from data sync

with explicit generation numbers, there is no longer any ambiguity over the equality of two obligations (one with a generation and one without). so the 'bucket sync cache' can cache each generation separately, and prevent different generations from interacting in `RGWDataSyncSingleEntryCR`. see commit message for details

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
