### PR TITLE
pacific: rgw: add OPT_BUCKET_SYNC_RUN to gc_ops_list, so that

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3911,6 +3911,7 @@ int main(int argc, const char **argv)
 			 OPT::OBJECTS_EXPIRE_STALE_RM,
 			 OPT::LC_PROCESS,
              OPT::BUCKET_SYNC_RUN,
+             OPT::DATA_SYNC_RUN,
     };
 
   bool raw_storage_op = (raw_storage_ops_list.find(opt_cmd) != raw_storage_ops_list.end() ||

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3909,7 +3909,8 @@ int main(int argc, const char **argv)
 			 OPT::USER_RM,    // --purge-data
 			 OPT::OBJECTS_EXPIRE,
 			 OPT::OBJECTS_EXPIRE_STALE_RM,
-			 OPT::LC_PROCESS
+			 OPT::LC_PROCESS,
+             OPT::BUCKET_SYNC_RUN,
     };
 
   bool raw_storage_op = (raw_storage_ops_list.find(opt_cmd) != raw_storage_ops_list.end() ||

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4796,10 +4796,16 @@ int RGWRados::Object::complete_atomic_modification(const DoutPrefixProvider *dpp
   }
 
   string tag = (state->tail_tag.length() > 0 ? state->tail_tag.to_str() : state->obj_tag.to_str());
-  auto ret = store->gc->send_chain(chain, tag); // do it synchronously
-  if (ret < 0) {
-    //Delete objects inline if send chain to gc fails
+  if (store->gc == nullptr) {
+    ldpp_dout(dpp, 0) << "deleting objects inline since gc isn't initialized" << dendl;
+    //Delete objects inline just in case gc hasn't been initialised, prevents crashes
     store->delete_objs_inline(dpp, chain, tag);
+  } else {
+    auto ret = store->gc->send_chain(chain, tag); // do it synchronously
+    if (ret < 0) {
+      //Delete objects inline if send chain to gc fails
+      store->delete_objs_inline(dpp, chain, tag);
+    }
   }
   return 0;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54426, https://tracker.ceph.com/issues/54519

---

backport of https://github.com/ceph/ceph/pull/45166, https://github.com/ceph/ceph/pull/45207
parent tracker: https://tracker.ceph.com/issues/54417, https://tracker.ceph.com/issues/54433

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh