### PR TITLE
Revert "mds: kill session state are open when mds do ms_handle_remote_reset"

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1041,9 +1041,6 @@ void MDSDaemon::ms_handle_remote_reset(Connection *con)
       dout(3) << "ms_handle_remote_reset closing connection for session " << session->info.inst << dendl;
       con->mark_down();
       con->set_priv(nullptr);
-    } else if (session->is_open()) {
-      dout(3) << "ms_handle_remote_reset kill session " << session->info.inst << dendl;
-      mds_rank->server->kill_session(session, nullptr);
     }
   }
 }


### PR DESCRIPTION
Reverts ceph/ceph#44638

Causing issue - https://tracker.ceph.com/issues/54461