### PR TITLE
pacific: rgw/amqp: remove the explicit "disconnect()" interface

### DIFF
--- a/src/rgw/rgw_amqp.h
+++ b/src/rgw/rgw_amqp.h
@@ -72,8 +72,5 @@ size_t get_max_inflight();
 // maximum number of messages in the queue
 size_t get_max_queue();
 
-// disconnect from an amqp broker
-bool disconnect(connection_ptr_t& conn);
-
 }
 

--- a/src/test/rgw/amqp_url.c
+++ b/src/test/rgw/amqp_url.c
@@ -118,6 +118,8 @@ int amqp_parse_url(char *url, struct amqp_connection_info *parsed) {
 
   amqp_default_connection_info(parsed);
 
+  parsed->port = 5672;
+  parsed->ssl = 0;
   /* check the prefix */
   if (!strncmp(url, "amqp://", 7)) {
     /* do nothing */


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51351

---

backport of https://github.com/ceph/ceph/pull/41831
parent tracker: https://tracker.ceph.com/issues/51114

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh