### PR TITLE
octopus: rgw: url_decode before parsing copysource in copyobject

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5003,16 +5003,17 @@ bool RGWCopyObj::parse_copy_location(const boost::string_view& url_src,
     params_str = url_src.substr(pos + 1);
   }
 
-  boost::string_view dec_src{name_str};
-  if (dec_src[0] == '/')
-    dec_src.remove_prefix(1);
+  if (name_str[0] == '/') // trim leading slash
+    name_str.remove_prefix(1);
 
-  pos = url_decode(dec_src).find('/');
+  std::string dec_src = url_decode(name_str);
+
+  pos = dec_src.find('/');
   if (pos == string::npos)
     return false;
 
-  bucket_name = url_decode(dec_src).substr(0, pos);
-  key.name = url_decode(dec_src).substr(pos + 1);
+  bucket_name = dec_src.substr(0, pos);
+  key.name = dec_src.substr(pos + 1);
 
   if (key.name.empty()) {
     return false;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5007,12 +5007,12 @@ bool RGWCopyObj::parse_copy_location(const boost::string_view& url_src,
   if (dec_src[0] == '/')
     dec_src.remove_prefix(1);
 
-  pos = dec_src.find('/');
+  pos = url_decode(dec_src).find('/');
   if (pos == string::npos)
     return false;
 
-  bucket_name = url_decode(dec_src.substr(0, pos));
-  key.name = url_decode(dec_src.substr(pos + 1));
+  bucket_name = url_decode(dec_src).substr(0, pos);
+  key.name = url_decode(dec_src).substr(pos + 1);
 
   if (key.name.empty()) {
     return false;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51700

---

backport of https://github.com/ceph/ceph/pull/42126
parent tracker: https://tracker.ceph.com/issues/43259

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh