### PR TITLE
octopus: rgw: fix md5 not match for RGWBulkUploadOp upload when enable rgw com…

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7366,7 +7366,7 @@ int RGWBulkUploadOp::handle_file(const boost::string_ref path,
     ceph::bufferlist tmp;
     RGWCompressionInfo cs_info;
     cs_info.compression_type = plugin->get_type_name();
-    cs_info.orig_size = s->obj_size;
+    cs_info.orig_size = size;
     cs_info.blocks = std::move(compressor->get_compression_blocks());
     encode(cs_info, tmp);
     attrs.emplace(RGW_ATTR_COMPRESSION, std::move(tmp));


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51702

---

backport of https://github.com/ceph/ceph/pull/36213
parent tracker: https://tracker.ceph.com/issues/46625

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh