### PR TITLE
pacific: rgw: default ms_mon_client_mode = secure

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -444,3 +444,8 @@
   from Octopus) will be automatically migrated when the cluster is
   upgraded.  Note that the NFS ganesha daemons will be redeployed and
   it is possible that their IPs will change.
+
+* RGW now requires a secure connection to the monitor by default
+  (``auth_client_required=cephx`` and ``ms_mon_client_mode=secure``).
+  If you have cephx authentication disabled on your cluster, you may
+  need to adjust these settings for RGW.

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -196,7 +196,9 @@ int radosgw_Main(int argc, const char **argv)
     { "debug_rgw", "1/5" },
     { "keyring", "$rgw_data/keyring" },
     { "objecter_inflight_ops", "24576" },
-    { "ms_mon_client_mode", "secure" }
+    // require a secure mon connection by default
+    { "ms_mon_client_mode", "secure" },
+    { "auth_client_required", "cephx" }
   };
 
   vector<const char*> args;

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -195,7 +195,8 @@ int radosgw_Main(int argc, const char **argv)
   map<string,string> defaults = {
     { "debug_rgw", "1/5" },
     { "keyring", "$rgw_data/keyring" },
-    { "objecter_inflight_ops", "24576" }
+    { "objecter_inflight_ops", "24576" },
+    { "ms_mon_client_mode", "secure" }
   };
 
   vector<const char*> args;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52050

---

backport of https://github.com/ceph/ceph/pull/42587
parent tracker: https://tracker.ceph.com/issues/52000

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh