### PR TITLE
pacific: qa/rgw: barbican and pykmip tasks upgrade pip before installing pytz

### DIFF
--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -99,6 +99,8 @@ def setup_venv(ctx, config):
         run_in_barbican_dir(ctx, client,
                             ['python3', '-m', 'venv', '.barbicanenv'])
         run_in_barbican_venv(ctx, client,
+                             ['pip', 'install', '--upgrade', 'pip'])
+        run_in_barbican_venv(ctx, client,
                              ['pip', 'install', 'pytz',
                               '-e', get_barbican_dir(ctx)])
     yield

--- a/qa/tasks/pykmip.py
+++ b/qa/tasks/pykmip.py
@@ -148,6 +148,7 @@ def setup_venv(ctx, config):
     log.info('Setting up virtualenv for pykmip...')
     for (client, _) in config.items():
         run_in_pykmip_dir(ctx, client, ['python3', '-m', 'venv', '.pykmipenv'])
+        run_in_pykmip_venv(ctx, client, ['pip', 'install', '--upgrade', 'pip'])
         run_in_pykmip_venv(ctx, client, ['pip', 'install', 'pytz', '-e', get_pykmip_dir(ctx)])
     yield
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52113

---

backport of https://github.com/ceph/ceph/pull/42689
parent tracker: https://tracker.ceph.com/issues/52070

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh