### PR TITLE
octopus: qa/rgw: update apache-maven mirror for rgw/hadoop-s3a

### DIFF
--- a/qa/tasks/s3a_hadoop.py
+++ b/qa/tasks/s3a_hadoop.py
@@ -51,7 +51,7 @@ def task(ctx, config):
     # set versions for cloning the repo
     apache_maven = 'apache-maven-{maven_version}-bin.tar.gz'.format(
         maven_version=maven_version)
-    maven_link = 'http://www-us.apache.org/dist/maven/' + \
+    maven_link = 'http://archive.apache.org/dist/maven/' + \
         '{maven_major}/{maven_version}/binaries/'.format(maven_major=maven_major, maven_version=maven_version) + apache_maven
     hadoop_git = 'https://github.com/apache/hadoop'
     hadoop_rel = 'hadoop-{ver} rel/release-{ver}'.format(ver=hadoop_ver)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52114

---

backport of https://github.com/ceph/ceph/pull/42688
parent tracker: https://tracker.ceph.com/issues/52069

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh