### PR TITLE
pacific: rgw: keep underscore in metatdata key

### DIFF
--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -44,8 +44,6 @@ tasks:
         - .*test_container_synchronization.*
         - .*test_object_services.PublicObjectTest.test_access_public_container_object_without_using_creds
         - .*test_object_services.ObjectTest.test_create_object_with_transfer_encoding
-        - .*test_container_services.ContainerTest.test_create_container_with_remove_metadata_key
-        - .*test_container_services.ContainerTest.test_create_container_with_remove_metadata_value
         - .*test_object_expiry.ObjectExpiryTest.test_get_object_after_expiry_time
         - .*test_object_expiry.ObjectExpiryTest.test_get_object_at_expiry_time
 

--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -54,6 +54,8 @@ int ClientIO::init_env(CephContext *cct)
     for (auto src = name.begin(); src != name.end(); ++src, ++dest) {
       if (*src == '-') {
         *dest = '_';
+      } else if (*src == '_') {
+        *dest = '-';
       } else {
         *dest = std::toupper(*src);
       }

--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -638,7 +638,7 @@ get_v4_canonical_headers(const req_info& info,
 
     std::transform(std::begin(token), std::end(token),
                    std::back_inserter(token_env), [](const int c) {
-                     return c == '-' ? '_' : std::toupper(c);
+                     return c == '-' ? '_' : c == '_' ? '-' : std::toupper(c);
                    });
 
     if (token_env == "HTTP_CONTENT_LENGTH") {

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -386,7 +386,7 @@ struct str_len meta_prefixes[] = { STR_LEN_ENTRY("HTTP_X_AMZ_"),
                                    STR_LEN_ENTRY("HTTP_X_ACCOUNT_"),
                                    {NULL, 0} };
 
-void req_info::init_meta_info(const DoutPrefixProvider *dpp, bool *found_bad_meta)
+void req_info::init_meta_info(const DoutPrefixProvider *dpp, bool *found_bad_meta, const int prot_flags)
 {
   x_meta_map.clear();
 
@@ -405,9 +405,8 @@ void req_info::init_meta_info(const DoutPrefixProvider *dpp, bool *found_bad_met
         if (found_bad_meta && strncmp(name, "META_", name_len) == 0)
           *found_bad_meta = true;
 
-        stringstream ss;
-        ss << meta_prefixes[0].str + 5 /* skip HTTP_ */ << name;
-        string name_low = lowercase_dash_underscore_http_attr(ss.str());
+        string name_low = lowercase_dash_http_attr(string(meta_prefixes[0].str + 5) + name,
+                                                   !(prot_flags & RGW_REST_SWIFT));
 
         auto it = x_meta_map.find(name_low);
         if (it != x_meta_map.end()) {
@@ -2093,35 +2092,10 @@ bool match_policy(std::string_view pattern, std::string_view input,
 }
 
 /*
- * make attrs look-like_this
- * converts underscores to dashes, and dashes to underscores
- */
-string lowercase_dash_underscore_http_attr(const string& orig)
-{
-  const char *s = orig.c_str();
-  char buf[orig.size() + 1];
-  buf[orig.size()] = '\0';
-
-  for (size_t i = 0; i < orig.size(); ++i, ++s) {
-    switch (*s) {
-      case '_':
-        buf[i] = '-';
-        break;
-      case '-':
-        buf[i] = '_';
-        break;
-      default:
-        buf[i] = tolower(*s);
-    }
-  }
-  return string(buf);
-}
-
-/*
  * make attrs look-like-this
  * converts underscores to dashes
  */
-string lowercase_dash_http_attr(const string& orig)
+string lowercase_dash_http_attr(const string& orig, bool bidirection)
 {
   const char *s = orig.c_str();
   char buf[orig.size() + 1];
@@ -2132,39 +2106,14 @@ string lowercase_dash_http_attr(const string& orig)
       case '_':
         buf[i] = '-';
         break;
-      default:
-        buf[i] = tolower(*s);
-    }
-  }
-  return string(buf);
-}
-
-/*
- * make attrs Look-Like-This or Look_Like_This
- * converts attrs to camelcase
- */
-string camelcase_http_attr(const string& orig)
-{
-  const char *s = orig.c_str();
-  char buf[orig.size() + 1];
-  buf[orig.size()] = '\0';
-
-  bool last_sep = true;
-
-  for (size_t i = 0; i < orig.size(); ++i, ++s) {
-    switch (*s) {
-      case '_':
       case '-':
-        buf[i] = *s;
-        last_sep = true;
+        if (bidirection)
+          buf[i] = '_';
+        else
+          buf[i] = tolower(*s);
         break;
       default:
-        if (last_sep) {
-          buf[i] = toupper(*s);
-        } else {
-          buf[i] = tolower(*s);
-        }
-        last_sep = false;
+        buf[i] = tolower(*s);
     }
   }
   return string(buf);
@@ -2174,7 +2123,7 @@ string camelcase_http_attr(const string& orig)
  * make attrs Look-Like-This
  * converts underscores to dashes
  */
-string camelcase_dash_http_attr(const string& orig)
+string camelcase_dash_http_attr(const string& orig, bool convert2dash)
 {
   const char *s = orig.c_str();
   char buf[orig.size() + 1];
@@ -2186,7 +2135,7 @@ string camelcase_dash_http_attr(const string& orig)
     switch (*s) {
       case '_':
       case '-':
-        buf[i] = '-';
+        buf[i] = convert2dash ? '-' : *s;
         last_sep = true;
         break;
       default:

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -409,10 +409,12 @@ void req_info::init_meta_info(const DoutPrefixProvider *dpp, bool *found_bad_met
         snprintf(name_low, meta_prefixes[0].len - 5 + name_len + 1, "%s%s", meta_prefixes[0].str + 5 /* skip HTTP_ */, name); // normalize meta prefix
         int j;
         for (j = 0; name_low[j]; j++) {
-          if (name_low[j] != '_')
-            name_low[j] = tolower(name_low[j]);
-          else
+          if (name_low[j] == '_')
             name_low[j] = '-';
+          else if (name_low[j] == '-')
+            name_low[j] = '_';
+          else
+            name_low[j] = tolower(name_low[j]);
         }
         name_low[j] = 0;
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -2263,8 +2263,10 @@ static constexpr uint32_t MATCH_POLICY_STRING = 0x08;
 extern bool match_policy(std::string_view pattern, std::string_view input,
                          uint32_t flag);
 
-extern string camelcase_dash_http_attr(const string& orig);
-extern string lowercase_dash_http_attr(const string& orig);
+extern std::string camelcase_dash_http_attr(const std::string& orig);
+extern std::string camelcase_http_attr(const std::string& orig);
+extern std::string lowercase_dash_http_attr(const std::string& orig);
+extern std::string lowercase_dash_underscore_http_attr(const std::string& orig);
 
 void rgw_setup_saved_curl_handles();
 void rgw_release_all_curl_handles();

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1176,7 +1176,7 @@ struct req_info {
 
   req_info(CephContext *cct, const RGWEnv *env);
   void rebuild_from(req_info& src);
-  void init_meta_info(const DoutPrefixProvider *dpp, bool *found_bad_meta);
+  void init_meta_info(const DoutPrefixProvider *dpp, bool *found_bad_meta, const int prot_flags);
 };
 
 typedef cls_rgw_obj_key rgw_obj_index_key;
@@ -2263,10 +2263,8 @@ static constexpr uint32_t MATCH_POLICY_STRING = 0x08;
 extern bool match_policy(std::string_view pattern, std::string_view input,
                          uint32_t flag);
 
-extern std::string camelcase_dash_http_attr(const std::string& orig);
-extern std::string camelcase_http_attr(const std::string& orig);
-extern std::string lowercase_dash_http_attr(const std::string& orig);
-extern std::string lowercase_dash_underscore_http_attr(const std::string& orig);
+extern std::string camelcase_dash_http_attr(const std::string& orig, bool convert2dash = true);
+extern std::string lowercase_dash_http_attr(const std::string& orig, bool bidirection = false);
 
 void rgw_setup_saved_curl_handles();
 void rgw_release_all_curl_handles();

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3357,7 +3357,7 @@ void RGWCreateBucket::execute(optional_yield y)
    * recover from a partial create by retrying it. */
   ldpp_dout(this, 20) << "rgw_create_bucket returned ret=" << op_ret << " bucket=" << s->bucket.get() << dendl;
 
-  if (op_ret < 0 && op_ret != EEXIST && op_ret != ERR_BUCKET_EXISTS)
+  if (op_ret < 0 && op_ret != -EEXIST && op_ret != -ERR_BUCKET_EXISTS)
     return;
 
   const bool existed = s->bucket_exists;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3357,7 +3357,7 @@ void RGWCreateBucket::execute(optional_yield y)
    * recover from a partial create by retrying it. */
   ldpp_dout(this, 20) << "rgw_create_bucket returned ret=" << op_ret << " bucket=" << s->bucket.get() << dendl;
 
-  if (op_ret)
+  if (op_ret < 0 && op_ret != EEXIST && op_ret != ERR_BUCKET_EXISTS)
     return;
 
   const bool existed = s->bucket_exists;

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -2265,8 +2265,6 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
   }
   s->op = op_from_method(info.method);
 
-  info.init_meta_info(s, &s->has_bad_meta);
-
   return 0;
 }
 
@@ -2305,6 +2303,8 @@ RGWHandler_REST* RGWREST::get_handler(
     m->put_handler(handler);
     return nullptr;
   }
+
+  s->info.init_meta_info(s, &s->has_bad_meta, s->prot_flags);
 
   return handler;
 } /* get stream handler */

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -149,7 +149,7 @@ static void dump_account_metadata(struct req_state * const s,
       dump_header(s, geniter->second, iter->second);
     } else if (strncmp(name, RGW_ATTR_META_PREFIX, PREFIX_LEN) == 0) {
       dump_header_prefixed(s, "X-Account-Meta-",
-                           camelcase_http_attr(name + PREFIX_LEN),
+                           camelcase_dash_http_attr(name + PREFIX_LEN, false),
                            iter->second);
     }
   }
@@ -491,7 +491,7 @@ static void dump_container_metadata(struct req_state *s,
         dump_header(s, geniter->second, iter->second);
       } else if (strncmp(name, RGW_ATTR_META_PREFIX, PREFIX_LEN) == 0) {
         dump_header_prefixed(s, "X-Container-Meta-",
-                             camelcase_http_attr(name + PREFIX_LEN),
+                             camelcase_dash_http_attr(name + PREFIX_LEN, false),
                              iter->second);
       }
     }
@@ -664,7 +664,12 @@ static void get_rmattrs_from_headers(const req_state * const s,
 
     if (prefix_len > 0) {
       string name(RGW_ATTR_META_PREFIX);
-      name.append(lowercase_dash_underscore_http_attr(p + prefix_len));
+      /* For backward compatibility */
+      name.append(lowercase_dash_http_attr(p + prefix_len, true));
+      rmattr_names.insert(name);
+
+      name = RGW_ATTR_META_PREFIX;
+      name.append(lowercase_dash_http_attr(p + prefix_len, false));
       rmattr_names.insert(name);
     }
   }
@@ -1339,7 +1344,7 @@ static void dump_object_metadata(const DoutPrefixProvider* dpp, struct req_state
 		       sizeof(RGW_ATTR_META_PREFIX)-1) == 0) {
       name += sizeof(RGW_ATTR_META_PREFIX) - 1;
       dump_header_prefixed(s, "X-Object-Meta-",
-                           camelcase_http_attr(name), kv.second);
+                           camelcase_dash_http_attr(name, false), kv.second);
     }
   }
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -149,7 +149,7 @@ static void dump_account_metadata(struct req_state * const s,
       dump_header(s, geniter->second, iter->second);
     } else if (strncmp(name, RGW_ATTR_META_PREFIX, PREFIX_LEN) == 0) {
       dump_header_prefixed(s, "X-Account-Meta-",
-                           camelcase_dash_http_attr(name + PREFIX_LEN),
+                           camelcase_http_attr(name + PREFIX_LEN),
                            iter->second);
     }
   }
@@ -491,7 +491,7 @@ static void dump_container_metadata(struct req_state *s,
         dump_header(s, geniter->second, iter->second);
       } else if (strncmp(name, RGW_ATTR_META_PREFIX, PREFIX_LEN) == 0) {
         dump_header_prefixed(s, "X-Container-Meta-",
-                             camelcase_dash_http_attr(name + PREFIX_LEN),
+                             camelcase_http_attr(name + PREFIX_LEN),
                              iter->second);
       }
     }
@@ -664,7 +664,7 @@ static void get_rmattrs_from_headers(const req_state * const s,
 
     if (prefix_len > 0) {
       string name(RGW_ATTR_META_PREFIX);
-      name.append(lowercase_dash_http_attr(p + prefix_len));
+      name.append(lowercase_dash_underscore_http_attr(p + prefix_len));
       rmattr_names.insert(name);
     }
   }
@@ -1339,7 +1339,7 @@ static void dump_object_metadata(const DoutPrefixProvider* dpp, struct req_state
 		       sizeof(RGW_ATTR_META_PREFIX)-1) == 0) {
       name += sizeof(RGW_ATTR_META_PREFIX) - 1;
       dump_header_prefixed(s, "X-Object-Meta-",
-                           camelcase_dash_http_attr(name), kv.second);
+                           camelcase_http_attr(name), kv.second);
     }
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52286

---

backport of https://github.com/ceph/ceph/pull/38737
parent tracker: https://tracker.ceph.com/issues/48716

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh