### PR TITLE
pacific: rgw: cls_bucket_list_unordered() might return one redundent entry every time is_truncated is true

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8760,6 +8760,7 @@ int RGWRados::cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
 	  ent_list.emplace_back(std::move(dirent));
 	  ++count;
 	} else {
+	  last_added_entry = dirent.key;
 	  *is_truncated = true;
 	  goto check_updates;
 	}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53036

---

backport of https://github.com/ceph/ceph/pull/42151
parent tracker: https://tracker.ceph.com/issues/51466

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh