### PR TITLE
pacific: src/rgw: Fix for malformed url

### DIFF
--- a/src/rgw/rgw_url.cc
+++ b/src/rgw/rgw_url.cc
@@ -14,7 +14,7 @@ namespace {
   const std::string schema_re = "([[:alpha:]]+:\\/\\/)";
   const std::string user_pass_re = "(([^:\\s]+):([^@\\s]+)@)?";
   const std::string host_port_re = "([[:alnum:].:-]+)";
-  const std::string path_re = "(/[[:print:]]+)?";
+  const std::string path_re = "(/[[:print:]]*)?";
 }
 
 bool parse_url_authority(const std::string& url, std::string& host, std::string& user, std::string& password) {

--- a/src/test/rgw/test_rgw_url.cc
+++ b/src/test/rgw/test_rgw_url.cc
@@ -19,6 +19,18 @@ TEST(TestURL, SimpleAuthority)
     EXPECT_STREQ(host.c_str(), "example.com"); 
 }
 
+TEST(TestURL, SimpleAuthority_1)
+{
+    std::string host;
+    std::string user;
+    std::string password;
+    const std::string url = "http://example.com/";
+    ASSERT_TRUE(parse_url_authority(url, host, user, password));
+    ASSERT_TRUE(user.empty());
+    ASSERT_TRUE(password.empty());
+    EXPECT_STREQ(host.c_str(), "example.com");
+}
+
 TEST(TestURL, IPAuthority)
 {
     std::string host;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53079

---

backport of https://github.com/ceph/ceph/pull/43528
parent tracker: https://tracker.ceph.com/issues/52738

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh