### PR TITLE
pacific: rgw:When KMS encryption is used and the key does not exist, we should…

### DIFF
--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -1035,7 +1035,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
 	  ldpp_dout(s, 5) << "ERROR: not provide a valid key id" << dendl;
 	  s->err.message = "Server Side Encryption with KMS managed key requires "
 	    "HTTP header x-amz-server-side-encryption-aws-kms-key-id";
-	  return -ERR_INVALID_ACCESS_KEY;
+	  return -EINVAL;
 	}
 	/* try to retrieve actual key */
 	std::string key_selector = create_random_key_selector(s->cct);
@@ -1054,7 +1054,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
 	  ldpp_dout(s, 5) << "ERROR: key obtained from key_id:" <<
             key_id << " is not 256 bit size" << dendl;
 	  s->err.message = "KMS provided an invalid key for the given kms-keyid.";
-	  return -ERR_INVALID_ACCESS_KEY;
+	  return -EINVAL;
 	}
 
 	if (block_crypt) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53158

---

backport of https://github.com/ceph/ceph/pull/37184
parent tracker: https://tracker.ceph.com/issues/48860

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh