### PR TITLE
octopus: rgw:When KMS encryption is used and the key does not exist, we should…

### DIFF
--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -783,7 +783,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
 	  ldout(s->cct, 5) << "ERROR: not provide a valid key id" << dendl;
 	  s->err.message = "Server Side Encryption with KMS managed key requires "
 	    "HTTP header x-amz-server-side-encryption-aws-kms-key-id";
-	  return -ERR_INVALID_ACCESS_KEY;
+	  return -EINVAL;
 	}
 	/* try to retrieve actual key */
 	std::string key_selector = create_random_key_selector(s->cct);
@@ -798,7 +798,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
 	  ldout(s->cct, 5) << "ERROR: key obtained from key_id:" <<
             key_id << " is not 256 bit size" << dendl;
 	  s->err.message = "KMS provided an invalid key for the given kms-keyid.";
-	  return -ERR_INVALID_ACCESS_KEY;
+	  return -EINVAL;
 	}
 	set_attr(attrs, RGW_ATTR_CRYPT_MODE, "SSE-KMS");
 	set_attr(attrs, RGW_ATTR_CRYPT_KEYID, key_id);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53157

---

backport of https://github.com/ceph/ceph/pull/37184
parent tracker: https://tracker.ceph.com/issues/48860

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh