### PR TITLE
A module and decorator for generically handling format= in python mgr modules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -54,6 +54,7 @@ mgr:
   - src/pybind/mgr/ceph_module.pyi
   - src/pybind/mgr/mgr_module.py
   - src/pybind/mgr/mgr_util.py
+  - src/pybind/mgr/object_format.py
   - src/pybind/mgr/requirements.txt
   - src/pybind/mgr/tox.ini
   - src/test/mgr/**

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1738,6 +1738,7 @@ fi
 %dir %{_datadir}/ceph/mgr
 %{_datadir}/ceph/mgr/mgr_module.*
 %{_datadir}/ceph/mgr/mgr_util.*
+%{_datadir}/ceph/mgr/object_format.*
 %{_unitdir}/ceph-mgr@.service
 %{_unitdir}/ceph-mgr.target
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/mgr

--- a/src/pybind/mgr/CMakeLists.txt
+++ b/src/pybind/mgr/CMakeLists.txt
@@ -58,5 +58,5 @@ set(mgr_modules
 install(DIRECTORY ${mgr_modules}
   DESTINATION ${CEPH_INSTALL_DATADIR}/mgr
   ${mgr_module_install_excludes})
-install(FILES mgr_module.py mgr_util.py
+install(FILES mgr_module.py mgr_util.py object_format.py
   DESTINATION ${CEPH_INSTALL_DATADIR}/mgr)

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -329,6 +329,26 @@ class CRUSHMap(ceph_module.BasePyCRUSH):
 
 HandlerFuncType = Callable[..., Tuple[int, str, str]]
 
+def _extract_target_func(
+    f: HandlerFuncType
+) -> Tuple[HandlerFuncType, Dict[str, Any]]:
+    """In order to interoperate with other decorated functions,
+    we need to find the original function which will provide
+    the main set of arguments. While we descend through the
+    stack of wrapped functions, gather additional arguments
+    the decorators may want to provide.
+    """
+    # use getattr to keep mypy happy
+    wrapped = getattr(f, "__wrapped__", None)
+    if not wrapped:
+        return f, {}
+    extra_args = {}
+    while wrapped is not None:
+        extra_args.update(getattr(f, "extra_args", {}))
+        f = wrapped
+        wrapped = getattr(f, "__wrapped__", None)
+    return f, extra_args
+
 
 class CLICommand(object):
     COMMANDS = {}  # type: Dict[str, CLICommand]
@@ -348,6 +368,7 @@ class CLICommand(object):
 
     @classmethod
     def _load_func_metadata(cls: Any, f: HandlerFuncType) -> Tuple[str, Dict[str, Any], int, str]:
+        f, extra_args = _extract_target_func(f)
         desc = (inspect.getdoc(f) or '').replace('\n', ' ')
         full_argspec = inspect.getfullargspec(f)
         arg_spec = full_argspec.annotations
@@ -377,6 +398,14 @@ class CLICommand(object):
                                                dict(name=arg),
                                                has_default,
                                                positional))
+        for argname, argtype in extra_args.items():
+            # avoid shadowing args from the function
+            if argname in arg_spec:
+                continue
+            arg_spec[argname] = argtype
+            args.append(CephArgtype.to_argdesc(
+                argtype, dict(name=arg), has_default=True, positional=False
+            ))
         return desc, arg_spec, first_default, ' '.join(args)
 
     def store_func_metadata(self, f: HandlerFuncType) -> None:

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -346,8 +346,8 @@ class CLICommand(object):
 
     KNOWN_ARGS = '_', 'self', 'mgr', 'inbuf', 'return'
 
-    @staticmethod
-    def load_func_metadata(f: HandlerFuncType) -> Tuple[str, Dict[str, Any], int, str]:
+    @classmethod
+    def _load_func_metadata(cls: Any, f: HandlerFuncType) -> Tuple[str, Dict[str, Any], int, str]:
         desc = (inspect.getdoc(f) or '').replace('\n', ' ')
         full_argspec = inspect.getfullargspec(f)
         arg_spec = full_argspec.annotations
@@ -357,7 +357,7 @@ class CLICommand(object):
         args = []
         positional = True
         for index, arg in enumerate(full_argspec.args):
-            if arg in CLICommand.KNOWN_ARGS:
+            if arg in cls.KNOWN_ARGS:
                 continue
             if arg == '_end_positional_':
                 positional = False
@@ -381,7 +381,7 @@ class CLICommand(object):
 
     def store_func_metadata(self, f: HandlerFuncType) -> None:
         self.desc, self.arg_spec, self.first_default, self.args = \
-            self.load_func_metadata(f)
+            self._load_func_metadata(f)
 
     def __call__(self, func: HandlerFuncType) -> HandlerFuncType:
         self.store_func_metadata(func)

--- a/src/pybind/mgr/object_format.py
+++ b/src/pybind/mgr/object_format.py
@@ -1,0 +1,13 @@
+# object_format.py provides types and functions for working with
+# requested output formats such as JSON, YAML, etc.
+
+import enum
+
+class Format(enum.Enum):
+    plain = 'plain'
+    json = 'json'
+    json_pretty = 'json-pretty'
+    yaml = 'yaml'
+    xml_pretty = 'xml-pretty'
+    xml = 'xml'
+

--- a/src/pybind/mgr/object_format.py
+++ b/src/pybind/mgr/object_format.py
@@ -2,6 +2,32 @@
 # requested output formats such as JSON, YAML, etc.
 
 import enum
+import json
+import sys
+
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    TYPE_CHECKING,
+)
+
+import yaml
+
+# this uses a version check as opposed to a try/except because this
+# form makes mypy happy and try/except doesn't.
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+elif TYPE_CHECKING:
+    # typing_extensions will not be available for the real mgr server
+    from typing_extensions import Protocol
+else:
+    # fallback type that is acceptable to older python on prod. builds
+    class Protocol:  # type: ignore
+        pass
+
+
+DEFAULT_JSON_INDENT: int = 2
 
 
 class Format(enum.Enum):
@@ -11,3 +37,133 @@ class Format(enum.Enum):
     yaml = "yaml"
     xml_pretty = "xml-pretty"
     xml = "xml"
+
+
+# SimpleData is a type alias for Any unless we can determine the
+# exact set of subtypes we want to support. But it is explicit!
+SimpleData = Any
+
+
+class SimpleDataProvider(Protocol):
+    def to_simplified(self) -> SimpleData:
+        """Return a simplified representation of the current object.
+        The simplified representation should be trivially serializable.
+        """
+        ...  # pragma: no cover
+
+
+class JSONDataProvider(Protocol):
+    def to_json(self) -> Any:
+        """Return a python object that can be serialized into JSON.
+        This function does _not_ return a JSON string.
+        """
+        ...  # pragma: no cover
+
+
+class YAMLDataProvider(Protocol):
+    def to_yaml(self) -> Any:
+        """Return a python object that can be serialized into YAML.
+        This function does _not_ return a string of YAML.
+        """
+        ...  # pragma: no cover
+
+
+class JSONFormatter(Protocol):
+    def format_json(self) -> str:
+        """Return a JSON formatted representation of an object."""
+        ...  # pragma: no cover
+
+
+class YAMLFormatter(Protocol):
+    def format_yaml(self) -> str:
+        """Return a JSON formatted representation of an object."""
+        ...  # pragma: no cover
+
+
+# The _is_name_of_protocol_type functions below are here because the production
+# builds of the ceph manager are lower than python 3.8 and do not have
+# typing_extensions available in the resulting images. This means that
+# runtime_checkable is not available and isinstance can not be used with a
+# protocol type.  These could be replaced by isinstance in a later version of
+# python.  Note that these functions *can not* be methods of the protocol types
+# for neatness - including methods on the protocl types makes mypy consider
+# those methods as part of the protcol & a required method. Using decorators
+# did not change that - I checked.
+
+
+def _is_simple_data_provider(obj: SimpleDataProvider) -> bool:
+    """Return true if obj is usable as a SimpleDataProvider."""
+    return callable(getattr(obj, 'to_simplified', None))
+
+
+def _is_json_data_provider(obj: JSONDataProvider) -> bool:
+    """Return true if obj is usable as a JSONDataProvider."""
+    return callable(getattr(obj, 'to_json', None))
+
+
+def _is_yaml_data_provider(obj: YAMLDataProvider) -> bool:
+    """Return true if obj is usable as a YAMLDataProvider."""
+    return callable(getattr(obj, 'to_yaml', None))
+
+
+class ObjectFormatAdapter:
+    """A format adapater for a single object.
+    Given an input object, this type will adapt the object, or a simplified
+    representation of the object, to either JSON or YAML when the format_json or
+    format_yaml methods are used.
+
+    If the compatible flag is true and the object provided to the adapter has
+    methods such as `to_json` and/or `to_yaml` these methods will be called in
+    order to get a JSON/YAML compatible simplified representation of the
+    object.
+
+    If the above case is not satisfied and the object provided to the adapter
+    has a method `to_simplified`, this method will be called to acquire a
+    simplified representation of the object.
+
+    If none of the above cases is true, the object itself will be used for
+    serialization. If the object can not be safely serialized an exception will
+    be raised.
+
+    NOTE: Some code may use methods named like `to_json` to return a JSON
+    string. If that is the case, you should not use that method with the
+    ObjectFormatAdapter. Do not set compatible=True for objects of this type.
+    """
+
+    def __init__(
+        self,
+        obj: Any,
+        json_indent: Optional[int] = DEFAULT_JSON_INDENT,
+        compatible: bool = False,
+    ) -> None:
+        self.obj = obj
+        self._compatible = compatible
+        self.json_indent = json_indent
+
+    def _fetch_json_data(self) -> Any:
+        # if the data object provides a specific simplified representation for
+        # JSON (and compatible mode is enabled) get the data via that method
+        if self._compatible and _is_json_data_provider(self.obj):
+            return self.obj.to_json()
+        # otherwise we use our specific method `to_simplified` if it exists
+        if _is_simple_data_provider(self.obj):
+            return self.obj.to_simplified()
+        # and fall back to the "raw" object
+        return self.obj
+
+    def format_json(self) -> str:
+        """Return a JSON formatted string representing the input object."""
+        return json.dumps(
+            self._fetch_json_data(), indent=self.json_indent, sort_keys=True
+        )
+
+    def _fetch_yaml_data(self) -> Any:
+        if self._compatible and _is_yaml_data_provider(self.obj):
+            return self.obj.to_yaml()
+        # nothing specific to YAML was found. use the simplified representation
+        # for JSON, as all valid JSON is valid YAML.
+        return self._fetch_json_data()
+
+    def format_yaml(self) -> str:
+        """Return a YAML formatted string representing the input object."""
+        return yaml.safe_dump(self._fetch_yaml_data())

--- a/src/pybind/mgr/object_format.py
+++ b/src/pybind/mgr/object_format.py
@@ -3,11 +3,11 @@
 
 import enum
 
-class Format(enum.Enum):
-    plain = 'plain'
-    json = 'json'
-    json_pretty = 'json-pretty'
-    yaml = 'yaml'
-    xml_pretty = 'xml-pretty'
-    xml = 'xml'
 
+class Format(enum.Enum):
+    plain = "plain"
+    json = "json"
+    json_pretty = "json-pretty"
+    yaml = "yaml"
+    xml_pretty = "xml-pretty"
+    xml = "xml"

--- a/src/pybind/mgr/object_format.py
+++ b/src/pybind/mgr/object_format.py
@@ -278,7 +278,11 @@ class Responder:
 
     A function that returns a Python object will have the object converted into
     a return value and formatted response body, based on the `format` argument
-    passed to the mgr.
+    passed to the mgr. When used from the ceph cli tool the `--format=[name]`
+    argument is mapped to a `format` keyword argument. The decorated function
+    may provide a `format` argument (type str). If the decorated function does
+    not provide a `format` argument itself, the Responder decorator will
+    implicitly add one to the MGR's "CLI arguments" handling stack.
 
     The Responder object is callable and is expected to be used as a decorator.
     """
@@ -344,4 +348,8 @@ class Responder:
                 return e.format_response()
             return retval, body, ""
 
+        # set the extra args on our wrapper function. this will be consumed by
+        # the CLICommand decorator and added to the set of optional arguments
+        # on the ceph cli/api
+        setattr(_format_response, "extra_args", {"format": str})
         return _format_response

--- a/src/pybind/mgr/object_format.py
+++ b/src/pybind/mgr/object_format.py
@@ -8,6 +8,7 @@ import sys
 from typing import (
     Any,
     Dict,
+    Iterable,
     Optional,
     TYPE_CHECKING,
 )
@@ -30,7 +31,7 @@ else:
 DEFAULT_JSON_INDENT: int = 2
 
 
-class Format(enum.Enum):
+class Format(str, enum.Enum):
     plain = "plain"
     json = "json"
     json_pretty = "json-pretty"
@@ -86,6 +87,16 @@ class ReturnValueProvider(Protocol):
         for the MGR's response tuple. Zero means success. Return an negative
         errno otherwise.
         """
+        ...  # pragma: no cover
+
+
+class CommonFormatter(Protocol):
+    """A protocol that indicates the type is a formatter for multiple
+    possible formats.
+    """
+
+    def valid_formats(self) -> Iterable[str]:
+        """Return the names of known valid formats."""
         ...  # pragma: no cover
 
 
@@ -181,6 +192,12 @@ class ObjectFormatAdapter:
     def format_yaml(self) -> str:
         """Return a YAML formatted string representing the input object."""
         return yaml.safe_dump(self._fetch_yaml_data())
+
+    format_json_pretty = format_json
+
+    def valid_formats(self) -> Iterable[str]:
+        """Return valid format names."""
+        return set(str(v) for v in Format.__members__)
 
 
 class ReturnValueAdapter:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -22,6 +22,7 @@ from ceph.utils import datetime_now
 
 from mgr_util import to_pretty_timedelta, format_dimless, format_bytes
 from mgr_module import MgrModule, HandleCommandResult, Option
+from object_format import Format
 
 from ._interface import OrchestratorClientMixin, DeviceLightLoc, _cli_read_command, \
     raise_if_exception, _cli_write_command, OrchestratorError, \
@@ -42,15 +43,6 @@ def nice_bytes(v: Optional[int]) -> str:
     if not v:
         return '-'
     return format_bytes(v, 5)
-
-
-class Format(enum.Enum):
-    plain = 'plain'
-    json = 'json'
-    json_pretty = 'json-pretty'
-    yaml = 'yaml'
-    xml_pretty = 'xml-pretty'
-    xml = 'xml'
 
 
 class ServiceType(enum.Enum):

--- a/src/pybind/mgr/tests/test_object_format.py
+++ b/src/pybind/mgr/tests/test_object_format.py
@@ -1,0 +1,105 @@
+from typing import Any, Dict, Type, TypeVar
+
+import pytest
+
+import object_format
+
+
+T = TypeVar("T", bound="Parent")
+
+
+class Simpler:
+    def __init__(self, name, val=None):
+        self.name = name
+        self.val = val or {}
+        self.version = 1
+
+    def to_simplified(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "name": self.name,
+            "value": self.val,
+        }
+
+
+class JSONer(Simpler):
+    def to_json(self) -> Dict[str, Any]:
+        d = self.to_simplified()
+        d["_json"] = True
+        return d
+
+    @classmethod
+    def from_json(cls: Type[T], data) -> T:
+        o = cls(data.get("name", ""), data.get("value"))
+        o.version = data.get("version", 1) + 1
+        return o
+
+
+class YAMLer(Simpler):
+    def to_yaml(self) -> Dict[str, Any]:
+        d = self.to_simplified()
+        d["_yaml"] = True
+        return d
+
+
+@pytest.mark.parametrize(
+    "obj, compatible, json_val",
+    [
+        ({}, False, "{}"),
+        ({"name": "foobar"}, False, '{"name": "foobar"}'),
+        ([1, 2, 3], False, "[1, 2, 3]"),
+        (JSONer("bob"), False, '{"name": "bob", "value": {}, "version": 1}'),
+        (
+            JSONer("betty", 77),
+            False,
+            '{"name": "betty", "value": 77, "version": 1}',
+        ),
+        ({}, True, "{}"),
+        ({"name": "foobar"}, True, '{"name": "foobar"}'),
+        (
+            JSONer("bob"),
+            True,
+            '{"_json": true, "name": "bob", "value": {}, "version": 1}',
+        ),
+    ],
+)
+def test_format_json(obj: Any, compatible: bool, json_val: str):
+    assert (
+        object_format.ObjectFormatAdapter(
+            obj, compatible=compatible, json_indent=None
+        ).format_json()
+        == json_val
+    )
+
+
+@pytest.mark.parametrize(
+    "obj, compatible, yaml_val",
+    [
+        ({}, False, "{}\n"),
+        ({"name": "foobar"}, False, "name: foobar\n"),
+        (
+            {"stuff": [1, 88, 909, 32]},
+            False,
+            "stuff:\n- 1\n- 88\n- 909\n- 32\n",
+        ),
+        (
+            JSONer("zebulon", "999"),
+            False,
+            "name: zebulon\nvalue: '999'\nversion: 1\n",
+        ),
+        ({}, True, "{}\n"),
+        ({"name": "foobar"}, True, "name: foobar\n"),
+        (
+            YAMLer("thingy", "404"),
+            True,
+            "_yaml: true\nname: thingy\nvalue: '404'\nversion: 1\n",
+        ),
+    ],
+)
+def test_format_yaml(obj: Any, compatible: bool, yaml_val: str):
+    assert (
+        object_format.ObjectFormatAdapter(
+            obj, compatible=compatible
+        ).format_yaml()
+        == yaml_val
+    )

--- a/src/pybind/mgr/tests/test_object_format.py
+++ b/src/pybind/mgr/tests/test_object_format.py
@@ -128,3 +128,12 @@ def test_return_value(obj: Any, ret: int):
     # a ReturnValueAdapter instance meets the ReturnValueProvider protocol.
     assert object_format._is_return_value_provider(rva)
     assert rva.mgr_return_value() == ret
+
+
+def test_valid_formats():
+    ofa = object_format.ObjectFormatAdapter({"fred": "wilma"})
+    vf = ofa.valid_formats()
+    assert "json" in vf
+    assert "yaml" in vf
+    assert "xml" in vf
+    assert "plain" in vf

--- a/src/pybind/mgr/tests/test_object_format.py
+++ b/src/pybind/mgr/tests/test_object_format.py
@@ -103,3 +103,28 @@ def test_format_yaml(obj: Any, compatible: bool, yaml_val: str):
         ).format_yaml()
         == yaml_val
     )
+
+
+class Retty:
+    def __init__(self, v) -> None:
+        self.value = v
+
+    def mgr_return_value(self) -> int:
+        return self.value
+
+
+@pytest.mark.parametrize(
+    "obj, ret",
+    [
+        ({}, 0),
+        ({"fish": "sticks"}, 0),
+        (-55, 0),
+        (Retty(0), 0),
+        (Retty(-55), -55),
+    ],
+)
+def test_return_value(obj: Any, ret: int):
+    rva = object_format.ReturnValueAdapter(obj)
+    # a ReturnValueAdapter instance meets the ReturnValueProvider protocol.
+    assert object_format._is_return_value_provider(rva)
+    assert rva.mgr_return_value() == ret


### PR DESCRIPTION
This is a prototype of a module to provide a decorator and supporting functions that make it easy to write mgr "CLI Commands"/APIs that automatically respond to common serialization formats such as JSON and YAML and are more easily extended to plain/xml, etc.

The idea is to make it simpler and easier for the authors of mgr modules to handle `--format` options from the `ceph` cli command - largely by automating the process away. Instead of writing functions that return the tuple that the mgr will send back to clients, the function is decorated with `@object_format.Responder()` after `@CLIComand(...)`. 

This decorator can then convert any json serializable python objects returned by the mgr module method to either JSON or YAML automatically. There are also hooks that allow serialization to plain text and xml with custom formatters as needed.  The decorator is also responsible for constructing the rest of the response tulple. On return without error the error code will be zero and the "status" string will be empty. On error/exception, the error code will be non-zero (typically -EINVAL and the error string will map to the exception. While most code will not need to change this behavior there are hooks to customize it if needed.


This also needed some tweaks to how the CLICommand decorator and it's dependencies works.

Unit tests are included.

I'm starting this in DRAFT state to solicit opinions/suggestions on the naming, location, and various functions/APIs that these patches add.
The final patch in this series is _NOT_ something I'd want to merge in it's current state. It's not tested enough and doesn't cover enough  of the module. However, I do feel it largely demonstrates the changes that need to be done in order for an existing module to make use of the new decorator.

PS. I'm marking this as "Code Cleanup" even though its more like code infrastructure that can lead to code cleanup ;-)


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
