### PR TITLE
quincy: osd/scrub: add scrub duration to pg stats

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2863,6 +2863,7 @@ void pg_stat_t::dump(Formatter *f) const
   f->dump_unsigned("snaptrimq_len", snaptrimq_len);
   f->dump_int("last_scrub_duration", last_scrub_duration);
   f->dump_string("scrub_schedule", dump_scrub_schedule());
+  f->dump_float("scrub_duration", scrub_duration);
   stats.dump(f);
   f->open_array_section("up");
   for (auto p = up.cbegin(); p != up.cend(); ++p)
@@ -3014,6 +3015,7 @@ void pg_stat_t::encode(ceph::buffer::list &bl) const
   encode((scrub_sched_status.m_is_deep==scrub_level_t::deep), bl);
   encode(scrub_sched_status.m_is_periodic, bl);
   encode(objects_scrubbed, bl);
+  encode(scrub_duration, bl);
 
   ENCODE_FINISH(bl);
 }
@@ -3103,6 +3105,7 @@ void pg_stat_t::decode(ceph::buffer::list::const_iterator &bl)
       decode(tmp, bl);
       scrub_sched_status.m_is_periodic = tmp;
       decode(objects_scrubbed, bl);
+      decode(scrub_duration, bl);
     }
   }
   DECODE_FINISH(bl);
@@ -3137,6 +3140,7 @@ void pg_stat_t::generate_test_instances(list<pg_stat_t*>& o)
   a.last_deep_scrub_stamp = utime_t(15, 16);
   a.last_clean_scrub_stamp = utime_t(17, 18);
   a.last_scrub_duration = 3617;
+  a.scrub_duration = 0.003;
   a.snaptrimq_len = 1048576;
   a.objects_scrubbed = 0;
   list<object_stat_collection_t*> l;
@@ -3214,7 +3218,8 @@ bool operator==(const pg_stat_t& l, const pg_stat_t& r)
     l.snaptrimq_len == r.snaptrimq_len &&
     l.last_scrub_duration == r.last_scrub_duration &&
     l.scrub_sched_status == r.scrub_sched_status &&
-    l.objects_scrubbed == r.objects_scrubbed;
+    l.objects_scrubbed == r.objects_scrubbed &&
+    l.scrub_duration == r.scrub_duration;
 }
 
 // -- store_statfs_t --

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2247,6 +2247,7 @@ struct pg_stat_t {
   int64_t log_size;
   int64_t ondisk_log_size;    // >= active_log_size
   int64_t objects_scrubbed;
+  double scrub_duration;
 
   std::vector<int32_t> up, acting;
   std::vector<pg_shard_t> avail_no_missing;
@@ -2288,6 +2289,7 @@ struct pg_stat_t {
       parent_split_bits(0),
       log_size(0), ondisk_log_size(0),
       objects_scrubbed(0),
+      scrub_duration(0),
       mapping_epoch(0),
       up_primary(-1),
       acting_primary(-1),

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2137,6 +2137,7 @@ void PgScrubber::set_scrub_duration()
   utime_t duration = stamp - scrub_begin_stamp;
   m_pg->recovery_state.update_stats([=](auto& history, auto& stats) {
     stats.last_scrub_duration = ceill(duration.to_msec()/1000.0);
+    stats.scrub_duration = double(duration);
     return true;
   });
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54601

---

backport of https://github.com/ceph/ceph/pull/45337
parent tracker: https://tracker.ceph.com/issues/54600

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh