### PR TITLE
pacific: rgw: add object null point judging when listing pubsub  topics

### DIFF
--- a/src/rgw/rgw_sync_module_pubsub_rest.cc
+++ b/src/rgw/rgw_sync_module_pubsub_rest.cc
@@ -136,7 +136,7 @@ protected:
     if (s->init_state.url_bucket.empty()) {
       return nullptr;
     }
-    if (s->object->empty()) {
+    if (s->object == nullptr || s->object->empty()) {
       return new RGWPSListTopics_ObjStore();
     }
     return new RGWPSGetTopic_ObjStore();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53518

---

backport of https://github.com/ceph/ceph/pull/44186
parent tracker: https://tracker.ceph.com/issues/53464

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh