### PR TITLE
pacific: test/rgw: disable cls_rgw_gc test cases with defer_gc()

### DIFF
--- a/src/test/cls_rgw_gc/test_cls_rgw_gc.cc
+++ b/src/test/cls_rgw_gc/test_cls_rgw_gc.cc
@@ -206,6 +206,7 @@ TEST(cls_rgw_gc, gc_queue_ops2)
   ASSERT_EQ("chain-1", it.tag);
 }
 
+#if 0 // TODO: fix or remove defer_gc()
 TEST(cls_rgw_gc, gc_queue_ops3)
 {
   //Testing remove queue entries
@@ -358,6 +359,7 @@ TEST(cls_rgw_gc, gc_queue_ops4)
   ASSERT_EQ(0, list_info2.size());
 
 }
+#endif // defer_gc() disabled
 
 TEST(cls_rgw_gc, gc_queue_ops5)
 {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53637

---

backport of https://github.com/ceph/ceph/pull/44262
parent tracker: https://tracker.ceph.com/issues/53325

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh