### PR TITLE
pacific: rgw/amqp: add default case to silence compiler warning

### DIFF
--- a/src/rgw/rgw_amqp.cc
+++ b/src/rgw/rgw_amqp.cc
@@ -321,8 +321,9 @@ std::string to_string(amqp_status_enum s) {
       return "AMQP_STATUS_SSL_CONNECTION_FAILED";
     case _AMQP_STATUS_SSL_NEXT_VALUE:
       return "AMQP_STATUS_INTERNAL"; 
+    default:
+      return "AMQP_STATUS_UNKNOWN";
   }
-  return "AMQP_STATUS_UNKNOWN";
 }
 
 // TODO: add status_to_string on the connection object to prinf full status


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53639

---

backport of https://github.com/ceph/ceph/pull/44323
parent tracker: https://tracker.ceph.com/issues/53252

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh