### PR TITLE
pacific: rgw: RadosBucket::get_bucket_info() updates RGWBucketEnt

### DIFF
--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -192,6 +192,7 @@ int RGWRadosBucket::get_bucket_info(const DoutPrefixProvider *dpp, optional_yiel
   if (ret == 0) {
     bucket_version = ep_ot.read_version;
     ent.placement_rule = info.placement_rule;
+    ent.bucket = info.bucket; // we looked up bucket_id
   }
   return ret;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53818

---

backport of https://github.com/ceph/ceph/pull/42200
parent tracker: https://tracker.ceph.com/issues/47861

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh