### PR TITLE
pacific: rgw: document S3 bucket replication support

### DIFF
--- a/doc/radosgw/s3.rst
+++ b/doc/radosgw/s3.rst
@@ -40,6 +40,8 @@ The following table describes the support status for current Amazon S3 functiona
 +---------------------------------+-----------------+----------------------------------------+
 | **Bucket Lifecycle**            | Supported       |                                        |
 +---------------------------------+-----------------+----------------------------------------+
+| **Bucket Replication**          | Partial         | Only permitted across zones            |
++---------------------------------+-----------------+----------------------------------------+
 | **Policy (Buckets, Objects)**   | Supported       | ACLs & bucket policies are supported   |
 +---------------------------------+-----------------+----------------------------------------+
 | **Bucket Website**              | Supported       |                                        |


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53835

---

backport of https://github.com/ceph/ceph/pull/38774
parent tracker: https://tracker.ceph.com/issues/48755

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh