### PR TITLE
pacific: rgw: remove bucket API returns NoSuchKey than NoSuchBucket

### DIFF
--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -224,6 +224,9 @@ void RGWOp_Bucket_Remove::execute(optional_yield y)
   op_ret = store->get_bucket(s, s->user.get(), string(), bucket_name, &bucket, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "get_bucket returned ret=" << op_ret << dendl;
+    if (op_ret == -ENOENT) {
+      op_ret = -ERR_NO_SUCH_BUCKET;
+    }
     return;
   }
 
@@ -405,4 +408,3 @@ RGWOp *RGWHandler_Bucket::op_delete()
 
   return new RGWOp_Bucket_Remove;
 }
-

--- a/src/rgw/services/svc_bucket_sobj.cc
+++ b/src/rgw/services/svc_bucket_sobj.cc
@@ -640,4 +640,3 @@ int RGWSI_Bucket_SObj::read_buckets_stats(RGWSI_Bucket_X_Ctx& ctx,
 
   return m.size();
 }
-


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54041

---

backport of https://github.com/ceph/ceph/pull/44413
parent tracker: https://tracker.ceph.com/issues/53731

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh