### PR TITLE
octopus: rgw: bucket chown bad memory usage

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -3635,7 +3635,6 @@ int RGWBucketCtl::chown(rgw::sal::RGWRadosStore *store, RGWBucketInfo& bucket_in
                         const rgw_user& user_id, const std::string& display_name,
                         const std::string& marker, optional_yield y)
 {
-  RGWObjectCtx obj_ctx(store);
   std::vector<rgw_bucket_dir_entry> objs;
   map<string, bool> common_prefixes;
 
@@ -3653,6 +3652,7 @@ int RGWBucketCtl::chown(rgw::sal::RGWRadosStore *store, RGWBucketInfo& bucket_in
   //Loop through objects and update object acls to point to bucket owner
 
   do {
+    RGWObjectCtx obj_ctx(store);
     objs.clear();
     int ret = list_op.list_objects(max_entries, &objs, &common_prefixes, &is_truncated, y);
     if (ret < 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54075

---

backport of https://github.com/ceph/ceph/pull/44357
parent tracker: https://tracker.ceph.com/issues/53599

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh