### PR TITLE
octopus: librgw: make rgw file handle versioned

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -736,6 +736,7 @@ namespace rgw {
         rgw_fh->set_acls(*(req.get_attr(RGW_ATTR_ACL))); 
 
 	get<0>(mkr) = rgw_fh;
+	rgw_fh->file_ondisk_version = 0; // inital version
 	rgw_fh->mtx.unlock();
       } else
 	rc = -EIO;
@@ -953,7 +954,7 @@ namespace rgw {
     rgw::sal::RGWRadosUser ruser(rgwlib.get_store(), user);
     RGWSetAttrsRequest req(cct, &ruser, rgw_fh->bucket_name(), obj_name);
 
-    rgw_fh->encode_attrs(ux_key, ux_attrs);
+    rgw_fh->encode_attrs(ux_key, ux_attrs, false);
 
     req.emplace_attr(RGW_ATTR_UNIX_KEY1, std::move(ux_key));
     req.emplace_attr(RGW_ATTR_UNIX1, std::move(ux_attrs));
@@ -1187,12 +1188,23 @@ namespace rgw {
   }
 
   void RGWFileHandle::encode_attrs(ceph::buffer::list& ux_key1,
-				   ceph::buffer::list& ux_attrs1)
+				   ceph::buffer::list& ux_attrs1,
+				   bool inc_ov)
   {
     using ceph::encode;
     fh_key fhk(this->fh.fh_hk);
     encode(fhk, ux_key1);
+    bool need_ondisk_version =
+      (fh.fh_type == RGW_FS_TYPE_FILE ||
+       fh.fh_type == RGW_FS_TYPE_SYMBOLIC_LINK);
+    if (need_ondisk_version &&
+	file_ondisk_version < 0) {
+      file_ondisk_version = 0;
+    }
     encode(*this, ux_attrs1);
+    if (need_ondisk_version && inc_ov) {
+      file_ondisk_version++;
+    }
   } /* RGWFileHandle::encode_attrs */
 
   DecodeAttrsResult RGWFileHandle::decode_attrs(const ceph::buffer::list* ux_key1,
@@ -1205,8 +1217,35 @@ namespace rgw {
     decode(fhk, bl_iter_key1);
     get<0>(dar) = true;
 
+    // decode to a temporary file handle which may not be
+    // copied to the current file handle if its file_ondisk_version
+    // is not newer
+    RGWFileHandle tmp_fh(fs);
+    tmp_fh.fh.fh_type = fh.fh_type;
     auto bl_iter_unix1 = ux_attrs1->cbegin();
-    decode(*this, bl_iter_unix1);
+    decode(tmp_fh, bl_iter_unix1);
+
+    fh.fh_type = tmp_fh.fh.fh_type;
+    // for file handles that represent files and whose file_ondisk_version
+    // is newer, no updates are need, otherwise, go updating the current
+    // file handle
+    if (!((fh.fh_type == RGW_FS_TYPE_FILE ||
+	    fh.fh_type == RGW_FS_TYPE_SYMBOLIC_LINK) &&
+	  file_ondisk_version >= tmp_fh.file_ondisk_version)) {
+      // make sure the following "encode" always encode a greater version
+      file_ondisk_version = tmp_fh.file_ondisk_version + 1;
+      state.dev = tmp_fh.state.dev;
+      state.size = tmp_fh.state.size;
+      state.nlink = tmp_fh.state.nlink;
+      state.owner_uid = tmp_fh.state.owner_uid;
+      state.owner_gid = tmp_fh.state.owner_gid;
+      state.unix_mode = tmp_fh.state.unix_mode;
+      state.ctime = tmp_fh.state.ctime;
+      state.mtime = tmp_fh.state.mtime;
+      state.atime = tmp_fh.state.atime;
+      state.version = tmp_fh.state.version;
+    }
+
     if (this->state.version < 2) {
       get<1>(dar) = true;
     }

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -318,6 +318,57 @@ namespace rgw {
       }
     }
 
+    void encode(buffer::list& bl) const {
+      ENCODE_START(3, 1, bl);
+      encode(uint32_t(fh.fh_type), bl);
+      encode(state.dev, bl);
+      encode(state.size, bl);
+      encode(state.nlink, bl);
+      encode(state.owner_uid, bl);
+      encode(state.owner_gid, bl);
+      encode(state.unix_mode, bl);
+      for (const auto& t : { state.ctime, state.mtime, state.atime }) {
+	encode(real_clock::from_timespec(t), bl);
+      }
+      encode((uint32_t)2, bl);
+      encode(file_ondisk_version.load(), bl);
+      ENCODE_FINISH(bl);
+    }
+
+    //XXX: RGWFileHandle::decode method can only be called from
+    //	   RGWFileHandle::decode_attrs, otherwise the file_ondisk_version
+    //	   fied would be contaminated
+    void decode(bufferlist::const_iterator& bl) {
+      DECODE_START(3, bl);
+      uint32_t fh_type;
+      decode(fh_type, bl);
+      if ((fh.fh_type != fh_type) &&
+	 (fh_type == RGW_FS_TYPE_SYMBOLIC_LINK))
+        fh.fh_type = RGW_FS_TYPE_SYMBOLIC_LINK;
+      decode(state.dev, bl);
+      decode(state.size, bl);
+      decode(state.nlink, bl);
+      decode(state.owner_uid, bl);
+      decode(state.owner_gid, bl);
+      decode(state.unix_mode, bl);
+      ceph::real_time enc_time;
+      for (auto t : { &(state.ctime), &(state.mtime), &(state.atime) }) {
+	decode(enc_time, bl);
+	*t = real_clock::to_timespec(enc_time);
+      }
+      if (struct_v >= 2) {
+        decode(state.version, bl);
+      }
+      if (struct_v >= 3) {
+	int64_t fov;
+	decode(fov, bl);
+	file_ondisk_version = fov;
+      }
+      DECODE_FINISH(bl);
+    }
+
+    friend void encode(const RGWFileHandle& c, ::ceph::buffer::list &bl, uint64_t features);
+    friend void decode(RGWFileHandle &c, ::ceph::bufferlist::const_iterator &p);
   public:
     RGWFileHandle(RGWLibFS* _fs, RGWFileHandle* _parent,
 		  const fh_key& _fhk, std::string& _name, uint32_t _flags)
@@ -671,56 +722,6 @@ namespace rgw {
 
     void set_acls(const ceph::buffer::list& _acls ) {
       acls = _acls;
-    }
-
-    void encode(buffer::list& bl) const {
-      ENCODE_START(3, 1, bl);
-      encode(uint32_t(fh.fh_type), bl);
-      encode(state.dev, bl);
-      encode(state.size, bl);
-      encode(state.nlink, bl);
-      encode(state.owner_uid, bl);
-      encode(state.owner_gid, bl);
-      encode(state.unix_mode, bl);
-      for (const auto& t : { state.ctime, state.mtime, state.atime }) {
-	encode(real_clock::from_timespec(t), bl);
-      }
-      encode((uint32_t)2, bl);
-      encode(file_ondisk_version.load(), bl);
-      ENCODE_FINISH(bl);
-    }
-
-    //XXX: RGWFileHandle::decode method can only be called from
-    //	   RGWFileHandle::decode_attrs, otherwise the file_ondisk_version
-    //	   fied would be contaminated
-    void decode(bufferlist::const_iterator& bl) {
-      DECODE_START(3, bl);
-      uint32_t fh_type;
-      decode(fh_type, bl);
-      if ((fh.fh_type != fh_type) &&
-	 (fh_type == RGW_FS_TYPE_SYMBOLIC_LINK))
-        fh.fh_type = RGW_FS_TYPE_SYMBOLIC_LINK;  
-      ceph_assert(fh.fh_type == fh_type);
-      decode(state.dev, bl);
-      decode(state.size, bl);
-      decode(state.nlink, bl);
-      decode(state.owner_uid, bl);
-      decode(state.owner_gid, bl);
-      decode(state.unix_mode, bl);
-      ceph::real_time enc_time;
-      for (auto t : { &(state.ctime), &(state.mtime), &(state.atime) }) {
-	decode(enc_time, bl);
-	*t = real_clock::to_timespec(enc_time);
-      }
-      if (struct_v >= 2) {
-        decode(state.version, bl);
-      }
-      if (struct_v >= 3) {
-	int64_t fov;
-	decode(fov, bl);
-	file_ondisk_version = fov;
-      }
-      DECODE_FINISH(bl);
     }
 
     void encode_attrs(ceph::buffer::list& ux_key1,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54085

---

backport of https://github.com/ceph/ceph/pull/38750
parent tracker: https://tracker.ceph.com/issues/50194

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh