### PR TITLE
quincy: rgw/admin: fix radosgw-admin datalog list max-entries issue

### DIFF
--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -767,8 +767,8 @@ int RGWDataChangesLog::list_entries(const DoutPrefixProvider *dpp, int max_entri
     if (ret < 0) {
       return ret;
     }
-    if (truncated) {
-      *ptruncated = true;
+    if (!truncated) {
+      *ptruncated = false;
       return 0;
     }
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54146

---

backport of https://github.com/ceph/ceph/pull/44866
parent tracker: https://tracker.ceph.com/issues/54116

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh