### PR TITLE
quincy: rgw: RGWPostObj::execute() may lost data.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4404,6 +4404,9 @@ void RGWPostObj::execute(optional_yield y)
 
       hash.Update((const unsigned char *)data.c_str(), data.length());
       op_ret = filter->process(std::move(data), ofs);
+      if (op_ret < 0) {
+        return;
+      }
 
       ofs += len;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54150

---

backport of https://github.com/ceph/ceph/pull/42330
parent tracker: https://tracker.ceph.com/issues/54114

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh