### PR TITLE
quincy: rgw: in bucket reshard list, clarify new num shards is tentative

### DIFF
--- a/qa/workunits/rgw/test_rgw_reshard.py
+++ b/qa/workunits/rgw/test_rgw_reshard.py
@@ -149,7 +149,7 @@ def main():
     json_op = json.loads(cmd)
     log.debug('bucket name %s', json_op[0]['bucket_name'])
     assert json_op[0]['bucket_name'] == BUCKET_NAME1
-    assert json_op[0]['new_num_shards'] == num_shards_expected
+    assert json_op[0]['tentative_new_num_shards'] == num_shards_expected
 
     # TESTCASE 'reshard-process','reshard','','process bucket resharding','succeeds'
     log.debug(' test: reshard process')
@@ -174,7 +174,7 @@ def main():
     json_op = json.loads(cmd)
     log.debug('bucket name %s', json_op[0]['bucket_name'])
     assert json_op[0]['bucket_name'] == BUCKET_NAME1
-    assert json_op[0]['new_num_shards'] == num_shards_expected
+    assert json_op[0]['tentative_new_num_shards'] == num_shards_expected
 
     # TESTCASE 'reshard process ,'reshard','process','reshard non empty bucket','succeeds'
     log.debug(' test: reshard process non empty bucket')

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -721,8 +721,7 @@ void cls_rgw_reshard_entry::dump(Formatter *f) const
   encode_json("bucket_id", bucket_id, f);
   encode_json("new_instance_id", new_instance_id, f);
   encode_json("old_num_shards", old_num_shards, f);
-  encode_json("new_num_shards", new_num_shards, f);
-
+  encode_json("tentative_new_num_shards", new_num_shards, f);
 }
 
 void cls_rgw_reshard_entry::generate_test_instances(list<cls_rgw_reshard_entry*>& ls)

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7563,7 +7563,6 @@ next:
   }
 
   if (opt_cmd == OPT::RESHARD_LIST) {
-    list<cls_rgw_reshard_entry> entries;
     int ret;
     int count = 0;
     if (max_entries < 0) {
@@ -7578,19 +7577,20 @@ next:
     formatter->open_array_section("reshard");
     for (int i = 0; i < num_logshards; i++) {
       bool is_truncated = true;
-      string marker;
+      std::string marker;
       do {
-        entries.clear();
+	std::list<cls_rgw_reshard_entry> entries;
         ret = reshard.list(dpp(), i, marker, max_entries - count, entries, &is_truncated);
         if (ret < 0) {
           cerr << "Error listing resharding buckets: " << cpp_strerror(-ret) << std::endl;
           return ret;
         }
-        for (auto iter=entries.begin(); iter != entries.end(); ++iter) {
-          cls_rgw_reshard_entry& entry = *iter;
+        for (const auto& entry : entries) {
           encode_json("entry", entry, formatter.get());
-          entry.get_key(&marker);
         }
+	if (is_truncated) {
+	  entries.crbegin()->get_key(&marker); // last entry's key becomes marker
+	}
         count += entries.size();
         formatter->flush(cout);
       } while (is_truncated && count < max_entries);
@@ -7602,6 +7602,7 @@ next:
 
     formatter->close_section();
     formatter->flush(cout);
+
     return 0;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54154

---

backport of https://github.com/ceph/ceph/pull/44386
parent tracker: https://tracker.ceph.com/issues/53705

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh