### PR TITLE
mgr/dashboard: highlight the search text in cluster logs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
@@ -27,7 +27,8 @@
             <p *ngFor="let line of clog">
               <span class="timestamp">{{ line.stamp | cdDate }}</span>
               <span class="priority {{ line.priority | logPriority }}">{{ line.priority }}</span>
-              <span class="message">{{ line.message }}</span>
+              <span class="message"
+                    [innerHTML]="line.message | searchHighlight: search"></span>
             </p>
 
             <ng-container *ngIf="clog.length != 0 else noEntriesTpl"></ng-container>
@@ -57,7 +58,8 @@
             <p *ngFor="let line of audit_log">
               <span class="timestamp">{{ line.stamp | cdDate }}</span>
               <span class="priority {{ line.priority | logPriority }}">{{ line.priority }}</span>
-              <span class="message">{{ line.message }}</span>
+              <span class="message"
+                    [innerHTML]="line.message | searchHighlight: search"></span>
             </p>
 
             <ng-container *ngIf="audit_log.length != 0 else noEntriesTpl"></ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
@@ -27,8 +27,9 @@
             <p *ngFor="let line of clog">
               <span class="timestamp">{{ line.stamp | cdDate }}</span>
               <span class="priority {{ line.priority | logPriority }}">{{ line.priority }}</span>
-              <span class="message"
-                    [innerHTML]="line.message | searchHighlight: search"></span>
+              <span class="message" 
+                    [cdHighlight]="line.message"
+                    [cdSearchTerm]="search"></span>
             </p>
 
             <ng-container *ngIf="clog.length != 0 else noEntriesTpl"></ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.ts
@@ -70,8 +70,7 @@ export class LogsComponent implements OnInit, OnDestroy {
 
   abstractFilters(): any {
     const priority = this.priority;
-    const key = this.search.toLowerCase().replace(/,/g, '');
-
+    const key = this.search.toLowerCase();
     let yearMonthDay: string;
     if (this.selectedDate) {
       const m = this.selectedDate.month;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/directives.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/directives.module.ts
@@ -13,6 +13,7 @@ import { CdFormControlDirective } from './ng-bootstrap-form-validation/cd-form-c
 import { CdFormGroupDirective } from './ng-bootstrap-form-validation/cd-form-group.directive';
 import { CdFormValidationDirective } from './ng-bootstrap-form-validation/cd-form-validation.directive';
 import { PasswordButtonDirective } from './password-button.directive';
+import { SearchHighlightDirective } from './search-highlight.directive';
 import { StatefulTabDirective } from './stateful-tab.directive';
 import { TrimDirective } from './trim.directive';
 
@@ -33,7 +34,8 @@ import { TrimDirective } from './trim.directive';
     CdFormControlDirective,
     CdFormGroupDirective,
     CdFormValidationDirective,
-    AuthStorageDirective
+    AuthStorageDirective,
+    SearchHighlightDirective
   ],
   exports: [
     AutofocusDirective,
@@ -50,7 +52,8 @@ import { TrimDirective } from './trim.directive';
     CdFormControlDirective,
     CdFormGroupDirective,
     CdFormValidationDirective,
-    AuthStorageDirective
+    AuthStorageDirective,
+    SearchHighlightDirective
   ]
 })
 export class DirectivesModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/search-highlight.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/search-highlight.directive.ts
@@ -1,0 +1,44 @@
+import { Directive, ElementRef, Input, OnChanges, SimpleChanges } from '@angular/core';
+
+@Directive({
+  selector: '[cdHighlight]'
+})
+export class SearchHighlightDirective implements OnChanges {
+
+  @Input('cdHighlight')
+  highlight: string;
+
+  @Input()
+  cdSearchTerm: string;
+
+  @Input()
+  cdCaseSensitive = false;
+
+  constructor(private el: ElementRef) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.highlight?.isFirstChange()) {
+      (this.el.nativeElement as HTMLElement).innerHTML = changes.highlight.currentValue;
+      return;
+    }
+    if (this.el?.nativeElement) {
+      if ('cdSearchTerm' in changes || 'cdCaseSensitive' in changes) {
+        let text = (this.el.nativeElement as HTMLElement).textContent;
+        if (this.cdSearchTerm !== '') {
+          const regex = new RegExp(
+            this.escapeRegExp(this.cdSearchTerm),
+            this.cdCaseSensitive ? 'g' : 'gi'
+          );
+          text = text.replace(regex, (match: string) => {
+            return `<span style="background-color:yellow;">${match}</span>`;
+          });
+        }
+        (this.el.nativeElement as HTMLElement).innerHTML = text;
+      }
+    }
+  }
+  private escapeRegExp(str: string) {
+    // $& means the whole matched string
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/pipes.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/pipes.module.ts
@@ -27,6 +27,7 @@ import { RbdConfigurationSourcePipe } from './rbd-configuration-source.pipe';
 import { RelativeDatePipe } from './relative-date.pipe';
 import { RoundPipe } from './round.pipe';
 import { SanitizeHtmlPipe } from './sanitize-html.pipe';
+import { SearchHighlightPipe } from './search-highlight.pipe';
 import { TruncatePipe } from './truncate.pipe';
 import { UpperFirstPipe } from './upper-first.pipe';
 
@@ -60,7 +61,8 @@ import { UpperFirstPipe } from './upper-first.pipe';
     DurationPipe,
     MapPipe,
     TruncatePipe,
-    SanitizeHtmlPipe
+    SanitizeHtmlPipe,
+    SearchHighlightPipe
   ],
   exports: [
     ArrayPipe,
@@ -90,7 +92,8 @@ import { UpperFirstPipe } from './upper-first.pipe';
     DurationPipe,
     MapPipe,
     TruncatePipe,
-    SanitizeHtmlPipe
+    SanitizeHtmlPipe,
+    SearchHighlightPipe
   ],
   providers: [
     ArrayPipe,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/search-highlight.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/search-highlight.pipe.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { SearchHighlightPipe } from './search-highlight.pipe';
+
+describe('SearchHighlightPipe', () => {
+  let pipe: SearchHighlightPipe;
+
+  configureTestBed({
+    providers: [SearchHighlightPipe]
+  });
+
+  beforeEach(() => {
+    pipe = TestBed.inject(SearchHighlightPipe);
+  });
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('transforms with a matching keyword ', () => {
+    const value = 'overall HEALTH_WARN Dashboard debug mode is enabled';
+    const args = 'Dashboard';
+    const expected = 'overall HEALTH_WARN <mark>Dashboard</mark> debug mode is enabled';
+
+    expect(pipe.transform(value, args)).toEqual(expected);
+  });
+
+  it('transforms with a matching keyword having regex character', () => {
+    const value = 'loreum ipsum .? dolor sit amet';
+    const args = '.?';
+    const expected = 'loreum ipsum <mark>.?</mark> dolor sit amet';
+
+    expect(pipe.transform(value, args)).toEqual(expected);
+  });
+
+  it('transforms with empty search keyword', () => {
+    const value = 'overall HEALTH_WARN Dashboard debug mode is enabled';
+    expect(pipe.transform(value, '')).toBe(value);
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/search-highlight.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/search-highlight.pipe.ts
@@ -1,0 +1,26 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'searchHighlight'
+})
+export class SearchHighlightPipe implements PipeTransform {
+  transform(value: string, args: string): string {
+    if (!args) {
+      return value;
+    }
+    args = this.escapeRegExp(args);
+    const regex = new RegExp(args, 'gi');
+    const match = value.match(regex);
+
+    if (!match) {
+      return value;
+    }
+
+    return value.replace(regex, '<mark>$&</mark>');
+  }
+
+  private escapeRegExp(str: string) {
+    // $& means the whole matched string
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/search-highlight.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/search-highlight.pipe.ts
@@ -1,10 +1,13 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 
 @Pipe({
   name: 'searchHighlight'
 })
 export class SearchHighlightPipe implements PipeTransform {
-  transform(value: string, args: string): string {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(value: string, args: string): any {
     if (!args) {
       return value;
     }
@@ -15,8 +18,8 @@ export class SearchHighlightPipe implements PipeTransform {
     if (!match) {
       return value;
     }
-
-    return value.replace(regex, '<mark>$&</mark>');
+    value = value.replace(regex, '<span style="background-color:yellow;">$&</span>');
+    return this.sanitizer.bypassSecurityTrustHtml(value);
   }
 
   private escapeRegExp(str: string) {


### PR DESCRIPTION
This is a draft PR that improves upon #45218.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
