### PR TITLE
pacific: mgr/nfs: support managing exports without orchestration enabled 

### DIFF
--- a/doc/mgr/nfs.rst
+++ b/doc/mgr/nfs.rst
@@ -533,20 +533,26 @@ The NFS log level can be adjusted using `nfs cluster config set` command (see :r
 Manual Ganesha deployment
 =========================
 
-It may be possible to deploy and manage the NFS ganesha daemons manually
-instead of allowing cephadm or rook to do so.
+It may be possible to deploy and manage the NFS ganesha daemons without
+orchestration frameworks such as cephadm or rook.
 
 .. note:: Manual configuration is not tested or fully documented; your
           mileage may vary. If you make this work, please help us by
           updating this documentation.
 
-Known issues
+Limitations
 ------------
 
-* The ``mgr/nfs`` module enumerates NFS clusters via the orchestrator API; if NFS is
-  not managed by the orchestrator (e.g., cephadm or rook) then this will not work.  It
-  may be possible to create the cluster, mark the cephadm service as 'unmanaged', but this
-  is awkward and not ideal.
+If no orchestrator module is enabled for the Ceph Manager the NFS cluster
+management commands, such as those starting with ``ceph nfs cluster``, will not
+function. However, commands that manage NFS exports, like those prefixed with
+``ceph nfs export`` are expected to work as long as the necessary RADOS objects
+have already been created. The exact RADOS objects required are not documented
+at this time as support for this feature is incomplete. A curious reader can
+find some details about the object by reading the source code for the
+``mgr/nfs`` module (found in the ceph source tree under
+``src/pybind/mgr/nfs``).
+
 
 Requirements
 ------------

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -20,8 +20,7 @@ from orchestrator import NoOrchestrator
 from mgr_module import NFS_POOL_NAME as POOL_NAME, NFS_GANESHA_SUPPORTED_FSALS
 
 from .export_utils import GaneshaConfParser, Export, RawBlock, CephFSFSAL, RGWFSAL
-from .exception import NFSException, NFSInvalidOperation, FSNotFound, \
-    ClusterNotFound
+from .exception import NFSException, NFSInvalidOperation, FSNotFound
 from .utils import (
     CONF_PREFIX,
     EXPORT_PREFIX,
@@ -716,8 +715,6 @@ class ExportMgr:
         for k in ['path', 'pseudo']:
             if k not in new_export_dict:
                 raise NFSInvalidOperation(f'Export missing required field {k}')
-        if cluster_id not in available_clusters(self.mgr):
-            raise ClusterNotFound()
         if cluster_id not in self.exports:
             self.exports[cluster_id] = []
 

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -196,7 +196,7 @@ class ExportMgr:
             for cluster_id in known_cluster_ids(self.mgr):
                 self.export_conf_objs = []  # type: List[Export]
                 self._read_raw_config(cluster_id)
-                self.exports[cluster_id] = self.export_conf_objs
+                self._exports[cluster_id] = self.export_conf_objs
                 log.info("Exports parsed successfully %s", self.exports.items())
         return self._exports
 

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -38,7 +38,7 @@ def export_cluster_checker(func: FuncT) -> FuncT:
         This method checks if cluster exists
         """
         if kwargs['cluster_id'] not in available_clusters(export.mgr):
-            return -errno.ENOENT, "", "Cluster does not exists"
+            return -errno.ENOENT, "", "Cluster does not exist"
         return func(export, *args, **kwargs)
     return cast(FuncT, cluster_check)
 

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -12,7 +12,7 @@ from rados import ObjectNotFound
 
 from ceph.deployment.service_spec import NFSServiceSpec
 from nfs import Module
-from nfs.export import ExportMgr
+from nfs.export import ExportMgr, normalize_path
 from nfs.export_utils import GaneshaConfParser, Export, RawBlock
 from nfs.cluster import NFSCluster
 from orchestrator import ServiceDescription, DaemonDescription, OrchResult
@@ -1018,3 +1018,19 @@ NFS_CORE_PARAM {
 
     def test_cluster_config(self):
         self._do_mock_test(self._do_test_cluster_config)
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/foo/bar/baz", "/foo/bar/baz"),
+        ("/foo/bar/baz/", "/foo/bar/baz"),
+        ("/foo/bar/baz ", "/foo/bar/baz"),
+        ("/foo/./bar/baz", "/foo/bar/baz"),
+        ("/foo/bar/baz/..", "/foo/bar"),
+        ("//foo/bar/baz", "/foo/bar/baz"),
+        ("", ""),
+    ]
+)
+def test_normalize_path(path, expected):
+    assert normalize_path(path) == expected

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -5,6 +5,25 @@ import orchestrator
 if TYPE_CHECKING:
     from nfs.module import Module
 
+EXPORT_PREFIX: str = "export-"
+CONF_PREFIX: str = "conf-nfs."
+USER_CONF_PREFIX: str = "userconf-nfs."
+
+
+def export_obj_name(export_id: int) -> str:
+    """Return a rados object name for the export."""
+    return f"{EXPORT_PREFIX}{export_id}"
+
+
+def conf_obj_name(cluster_id: str) -> str:
+    """Return a rados object name for the config."""
+    return f"{CONF_PREFIX}{cluster_id}"
+
+
+def user_conf_obj_name(cluster_id: str) -> str:
+    """Returna a rados object name for the user config."""
+    return f"{USER_CONF_PREFIX}{cluster_id}"
+
 
 def available_clusters(mgr: 'Module') -> List[str]:
     '''


### PR DESCRIPTION

Includes backports of PRs: #44845, #44870, #45211

Issue: https://tracker.ceph.com/issues/54043



<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
