### PR TITLE
crimson: split ObjectDataBlock when overwriting

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -75,3 +75,8 @@ options:
   level: advanced
   desc: Size in bytes of extents to keep in cache.
   default: 64_M
+- name: seastore_obj_data_write_amplification
+  type: float
+  level: advanced
+  desc: split extent if ratio of total extent size to write size exceeds this value
+  default: 1.25

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -643,10 +643,10 @@ public:
      * See TransactionManager::get_extent_if_live and
      * LBAManager::get_physical_extent_if_live.
      */
-    using get_extent_if_live_iertr = extent_mapping_iertr;
-    using get_extent_if_live_ret = get_extent_if_live_iertr::future<
-      CachedExtentRef>;
-    virtual get_extent_if_live_ret get_extent_if_live(
+    using get_extents_if_live_iertr = extent_mapping_iertr;
+    using get_extents_if_live_ret = get_extents_if_live_iertr::future<
+      std::list<CachedExtentRef>>;
+    virtual get_extents_if_live_ret get_extents_if_live(
       Transaction &t,
       extent_types_t type,
       paddr_t addr,

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -54,6 +54,10 @@ std::ostream &operator<<(std::ostream &out, CachedExtent::extent_state_t state)
     return out << "CLEAN";
   case CachedExtent::extent_state_t::DIRTY:
     return out << "DIRTY";
+  case CachedExtent::extent_state_t::EXIST_CLEAN:
+    return out << "EXIST_CLEAN";
+  case CachedExtent::extent_state_t::EXIST_MUTATION_PENDING:
+    return out << "EXIST_MUTATION_PENDING";
   case CachedExtent::extent_state_t::INVALID:
     return out << "INVALID";
   default:

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -552,6 +552,10 @@ public:
     return !is_zero() && !is_null();
   }
 
+  bool is_absolute() const {
+    return get_device_id() <= DEVICE_ID_MAX_VALID;
+  }
+
   DENC(paddr_t, v, p) {
     DENC_START(1, 1, p);
     denc(v.dev_addr, p);

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -82,15 +82,20 @@ public:
   };
   get_extent_ret get_extent(paddr_t addr, CachedExtentRef *out) {
     LOG_PREFIX(Transaction::get_extent);
-    if (retired_set.count(addr)) {
-      return get_extent_ret::RETIRED;
-    } else if (auto iter = write_set.find_offset(addr);
+    // it's possible that both write_set and retired_set contain
+    // this addr at the same time when addr is absolute and the
+    // corresponding extent is used to map existing extent on disk.
+    // So search write_set first.
+    if (auto iter = write_set.find_offset(addr);
 	iter != write_set.end()) {
       if (out)
 	*out = CachedExtentRef(&*iter);
       SUBTRACET(seastore_cache, "{} is present in write_set -- {}",
                 *this, addr, *iter);
+      assert((*out)->is_valid());
       return get_extent_ret::PRESENT;
+    } else if (retired_set.count(addr)) {
+      return get_extent_ret::RETIRED;
     } else if (
       auto iter = read_set.find(addr);
       iter != read_set.end()) {
@@ -109,7 +114,12 @@ public:
 
   void add_to_retired_set(CachedExtentRef ref) {
     ceph_assert(!is_weak());
-    if (ref->is_initial_pending()) {
+    if (ref->is_exist_clean() ||
+	ref->is_exist_mutation_pending()) {
+      existing_block_stats.dec(ref);
+      ref->state = CachedExtent::extent_state_t::INVALID;
+      write_set.erase(*ref);
+    } else if (ref->is_initial_pending()) {
       ref->state = CachedExtent::extent_state_t::INVALID;
       write_set.erase(*ref);
     } else if (ref->is_mutation_pending()) {
@@ -137,19 +147,23 @@ public:
   void add_fresh_extent(
     CachedExtentRef ref) {
     ceph_assert(!is_weak());
-    if (ref->get_paddr().is_delayed()) {
+    if (ref->is_exist_clean()) {
+      existing_block_stats.inc(ref);
+      existing_block_list.push_back(ref);
+    } else if (ref->get_paddr().is_delayed()) {
       assert(ref->get_paddr() == make_delayed_temp_paddr(0));
       assert(ref->is_logical());
       ref->set_paddr(make_delayed_temp_paddr(delayed_temp_offset));
       delayed_temp_offset += ref->get_length();
       delayed_alloc_list.emplace_back(ref->cast<LogicalCachedExtent>());
+      fresh_block_stats.increment(ref->get_length());
     } else {
       assert(ref->get_paddr() == make_record_relative_paddr(0));
       ref->set_paddr(make_record_relative_paddr(offset));
       offset += ref->get_length();
       inline_block_list.push_back(ref);
+      fresh_block_stats.increment(ref->get_length());
     }
-    fresh_block_stats.increment(ref->get_length());
     write_set.insert(*ref);
     if (is_backref_node(ref->get_type()))
       fresh_backref_extents++;
@@ -178,9 +192,15 @@ public:
 
   void add_mutated_extent(CachedExtentRef ref) {
     ceph_assert(!is_weak());
-    assert(read_set.count(ref->prior_instance->get_paddr()));
+    assert(ref->is_exist_mutation_pending() ||
+	   read_set.count(ref->prior_instance->get_paddr()));
     mutated_block_list.push_back(ref);
-    write_set.insert(*ref);
+    if (!ref->is_exist_mutation_pending()) {
+      write_set.insert(*ref);
+    } else {
+      assert(write_set.find_offset(ref->get_paddr()) !=
+	     write_set.end());
+    }
   }
 
   void replace_placeholder(CachedExtent& placeholder, CachedExtent& extent) {
@@ -233,8 +253,29 @@ public:
     return mutated_block_list;
   }
 
+  const auto &get_existing_block_list() {
+    return existing_block_list;
+  }
+
   const auto &get_retired_set() {
     return retired_set;
+  }
+
+  bool is_retired(laddr_t laddr, extent_len_t len, paddr_t paddr) {
+    if (retired_set.empty()) {
+      return false;
+    }
+    auto iter = retired_set.lower_bound(paddr);
+    if (iter == retired_set.end() ||
+	(*iter)->get_paddr() > paddr) {
+      assert(iter != retired_set.begin());
+      --iter;
+    }
+
+    auto lextent = (*iter)->cast<LogicalCachedExtent>();
+    auto ext_laddr = lextent->get_laddr();
+    return ext_laddr <= laddr &&
+      ext_laddr + lextent->get_length() >= laddr + len;
   }
 
   bool should_record_release(paddr_t addr) {
@@ -337,6 +378,8 @@ public:
     ool_block_list.clear();
     retired_set.clear();
     no_release_delta_retired_set.clear();
+    existing_block_list.clear();
+    existing_block_stats = {};
     onode_tree_stats = {};
     omap_tree_stats = {};
     lba_tree_stats = {};
@@ -404,6 +447,31 @@ public:
     return rewrite_version_stats;
   }
 
+  struct existing_block_stats_t {
+    uint64_t valid_num = 0;
+    uint64_t clean_num = 0;
+    uint64_t mutated_num = 0;
+    void inc(const CachedExtentRef &ref) {
+      valid_num++;
+      if (ref->is_exist_clean()) {
+	clean_num++;
+      } else {
+	mutated_num++;
+      }
+    }
+    void dec(const CachedExtentRef &ref) {
+      valid_num--;
+      if (ref->is_exist_clean()) {
+	clean_num--;
+      } else {
+	mutated_num--;
+      }
+    }
+  };
+  existing_block_stats_t& get_existing_block_stats() {
+    return existing_block_stats;
+  }
+
 private:
   friend class Cache;
   friend Ref make_test_transaction();
@@ -454,6 +522,10 @@ private:
 
   /// list of mutated blocks, holds refcounts, subset of write_set
   std::list<CachedExtentRef> mutated_block_list;
+
+  /// partial blocks of extents on disk, with data and refcounts
+  std::list<CachedExtentRef> existing_block_list;
+  existing_block_stats_t existing_block_stats;
 
   /**
    * retire_set

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -389,7 +389,8 @@ TransactionManager::submit_transaction_direct(
       // ...but add_pin from parent->leaf
       std::vector<CachedExtentRef> lba_to_link;
       std::vector<CachedExtentRef> backref_to_link;
-      lba_to_link.reserve(tref.get_fresh_block_stats().num);
+      lba_to_link.reserve(tref.get_fresh_block_stats().num +
+			  tref.get_existing_block_stats().valid_num);
       backref_to_link.reserve(tref.get_fresh_block_stats().num);
       tref.for_each_fresh_block([&](auto &e) {
 	if (e->is_valid()) {
@@ -399,6 +400,12 @@ TransactionManager::submit_transaction_direct(
 	    backref_to_link.push_back(e);
 	}
       });
+
+      for (auto &e: tref.get_existing_block_list()) {
+	if (e->is_valid()) {
+	  lba_to_link.push_back(e);
+	}
+      }
 
       lba_manager->complete_transaction(tref, lba_to_clear, lba_to_link);
       backref_manager->complete_transaction(tref, backref_to_clear, backref_to_link);

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -508,8 +508,8 @@ public:
     reclaim_gen_t target_generation,
     sea_time_point modify_time) final;
 
-  using AsyncCleaner::ExtentCallbackInterface::get_extent_if_live_ret;
-  get_extent_if_live_ret get_extent_if_live(
+  using AsyncCleaner::ExtentCallbackInterface::get_extents_if_live_ret;
+  get_extents_if_live_ret get_extents_if_live(
     Transaction &t,
     extent_types_t type,
     paddr_t addr,

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -135,6 +135,13 @@ struct object_data_handler_test_t:
       }
     }
   }
+  std::list<LBAPinRef> get_mappings(objaddr_t offset, extent_len_t length) {
+    auto t = create_mutate_transaction();
+    auto ret = with_trans_intr(*t, [&](auto &t) {
+      return tm->get_pins(t, offset, length);
+    }).unsafe_get0();
+    return ret;
+  }
 
   seastar::future<> set_up_fut() final {
     onode = new TestOnode(
@@ -304,5 +311,107 @@ TEST_F(object_data_handler_test_t, truncate)
 
     truncate(base - (12<<10));
     read(base, 64<<10);
+  });
+}
+
+TEST_F(object_data_handler_test_t, no_split) {
+  run_async([this] {
+    write(0, 8<<10, 'x');
+    write(0, 8<<10, 'a');
+
+    auto pins = get_mappings(0, 8<<10);
+    EXPECT_EQ(pins.size(), 1);
+
+    read(0, 8<<10);
+  });
+}
+
+TEST_F(object_data_handler_test_t, split_left) {
+  run_async([this] {
+    write(0, 128<<10, 'x');
+
+    write(64<<10, 60<<10, 'a');
+
+    auto pins = get_mappings(0, 128<<10);
+    EXPECT_EQ(pins.size(), 2);
+
+    size_t res[2] = {0, 64<<10};
+    auto base = pins.front()->get_key();
+    int i = 0;
+    for (auto &pin : pins) {
+      EXPECT_EQ(pin->get_key() - base, res[i]);
+      i++;
+    }
+    read(0, 128<<10);
+  });
+}
+
+TEST_F(object_data_handler_test_t, split_right) {
+  run_async([this] {
+    write(0, 128<<10, 'x');
+    write(4<<10, 60<<10, 'a');
+
+    auto pins = get_mappings(0, 128<<10);
+    EXPECT_EQ(pins.size(), 2);
+
+    size_t res[2] = {0, 64<<10};
+    auto base = pins.front()->get_key();
+    int i = 0;
+    for (auto &pin : pins) {
+      EXPECT_EQ(pin->get_key() - base, res[i]);
+      i++;
+    }
+    read(0, 128<<10);
+  });
+}
+TEST_F(object_data_handler_test_t, split_left_right) {
+  run_async([this] {
+    write(0, 128<<10, 'x');
+    write(48<<10, 32<<10, 'a');
+
+    auto pins = get_mappings(0, 128<<10);
+    EXPECT_EQ(pins.size(), 3);
+
+    size_t res[3] = {0, 48<<10, 80<<10};
+    auto base = pins.front()->get_key();
+    int i = 0;
+    for (auto &pin : pins) {
+      EXPECT_EQ(pin->get_key() - base, res[i]);
+      i++;
+    }
+  });
+}
+TEST_F(object_data_handler_test_t, multiple_split) {
+  run_async([this] {
+    write(0, 128<<10, 'x');
+
+    auto t = create_mutate_transaction();
+    // normal split
+    write(*t, 120<<10, 4<<10, 'a');
+    // not aligned right
+    write(*t, 4<<10, 5<<10, 'b');
+    // split right extent of last split result
+    write(*t, 32<<10, 4<<10, 'c');
+    // non aligned overwrite
+    write(*t, 13<<10, 4<<10, 'd');
+
+    write(*t, 64<<10, 32<<10, 'e');
+    // not split right
+    write(*t, 60<<10, 8<<10, 'f');
+
+    submit_transaction(std::move(t));
+
+    auto pins = get_mappings(0, 128<<10);
+    EXPECT_EQ(pins.size(), 10);
+
+    size_t res[10] = {0, 4<<10, 12<<10, 20<<10, 32<<10,
+		      36<<10, 60<<10, 96<<10, 120<<10, 124<<10};
+    auto base = pins.front()->get_key();
+    int i = 0;
+    for (auto &pin : pins) {
+      EXPECT_EQ(pin->get_key() - base, res[i]);
+      i++;
+    }
+    read(0, 128<<10);
   });
 }


### PR DESCRIPTION
This PR introduces a straightforward strategy to reduce write amplification.
The design and changes can be found in the commit message and comments.

# Benchmark
The benchmark of splitting extents contains two major aspects:
1. write to new object. In such cases, no extra read and write occurs, it can get the overhead of maintaining the data structure and the procedure of splitting.
2. overwrite, the length of original extent is 4KiB and greater. When the length is greater than 4KiB, splitting can reduce the read and write amplification so that performance could be better.

for 1. create a new rbd image and test with fio;
for 2. create a rbd image and sequential write, then random write to the full image.

start command:

```
MGR=1 MON=1 OSD=1 MDS=0 RGW=0 ../src/vstart.sh -n -x --without-dashboard --seastore --crimson --redirect-output --seastore-devs /dev/nvme1n1
```

## 1. random write to empty image

<details>
<summary>fio config</summary>

```
[global]
ioengine=rbd
clientname=admin
pool=test_pool
rbdname=test_img
direct=1
sync=1
time_based=1
runtime=600
randseed=1259
[randwrite-4k]
rw=randwrite
bs=4K
numjobs=1
iodepth=768
random_distribution=zoned:90/10:10/90
```

</details>

Result:
|        | IOPS | BW        |
| --- | --- | --- |
| master | 2637 | 10.3MiB/s |
| split  | 3037 | 11.9MiB/s |

## 2. random write to full image

### 2.1. the length of extent in image is 4KiB

<details>
<summary> sequential write with fio </summary>

```
[global]
ioengine=rbd
clientname=admin
pool=test_pool
rbdname=test_img
direct=1
sync=1
randseed=1259
[write-4k]
rw=write
bs=4K
numjobs=1
iodepth=768
random_distribution=zoned:90/10:10/90
```

</details>

|        | IOPS  | BW        |
| --- | --- | --- |
| master | 20.8k | 81.3MiB/s |
| split  | 20.3k | 79.2MiB/s |

After the image is full, start random writes

<details>
<summary> random write with fio </summary>

```
[global]
ioengine=rbd
clientname=admin
pool=test_pool
rbdname=test_img
direct=1
sync=1
time_based=1
runtime=600
randseed=1259
[randwrite-4k]
rw=randwrite
bs=4K
numjobs=1
iodepth=768
random_distribution=zoned:90/10:10/90
```

</details>

|        | IOPS | BW        |
| --- | --- | --- |
| master |  141 | 567KiB/s  |
| split  | 2307 | 9231KiB/s |

### 2.2. the length of extent in image is 64KiB

<details>
<summary> sequential write with fio </summary>

```
[global]
ioengine=rbd
clientname=admin
pool=test_pool
rbdname=test_img
direct=1
sync=1
randseed=1259
[write-4k]
rw=write
bs=64K
numjobs=1
iodepth=768
random_distribution=zoned:90/10:10/90
```

</details>

|        | IOPS | BW       |
| --- | --- | --- |
| master | 8530 | 533MiB/s |
| split  | 7484 | 468MiB/s |

After the image is full, start random writes

<details>
<summary> random write with fio </summary>

```
[global]
ioengine=rbd
clientname=admin
pool=test_pool
rbdname=test_img
direct=1
sync=1
time_based=1
runtime=600
randseed=1259
[randwrite-4k]
rw=randwrite
bs=4K
numjobs=1
iodepth=768
random_distribution=zoned:90/10:10/90
```

</details>

|        | IOPS | BW        |
| --- | --- | --- |
| master |   77 | 311KiB/s  |
| split  | 2671 | 10.4MiB/s |



## 3. summary
The results are annoying. The performance of random writes to a full image is much
worse than expected that the difference of 2.1 test could be insignificant. There may be other factors present.

But the results of splitting are as expected:
writing to empty image has best performance;
writing to 64KiB extent is second;
writing to 4KiB extent is last. 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
