### PR TITLE
mon: mgr/osd beacon timeout under high mon_command load

### DIFF
--- a/src/messages/MLog.h
+++ b/src/messages/MLog.h
@@ -25,10 +25,16 @@ public:
   uuid_d fsid;
   std::deque<LogEntry> entries;
 
-  MLog() : PaxosServiceMessage{MSG_LOG, 0} {}
+  MLog() : PaxosServiceMessage{MSG_LOG, 0} {
+    set_priority(CEPH_MSG_PRIO_DEFAULT);
+  }
   MLog(const uuid_d& f, std::deque<LogEntry>&& e)
-    : PaxosServiceMessage{MSG_LOG, 0}, fsid(f), entries{std::move(e)} { }
-  MLog(const uuid_d& f) : PaxosServiceMessage(MSG_LOG, 0), fsid(f) { }
+    : PaxosServiceMessage{MSG_LOG, 0}, fsid(f), entries{std::move(e)} {
+    set_priority(CEPH_MSG_PRIO_DEFAULT);
+  }
+  MLog(const uuid_d& f) : PaxosServiceMessage(MSG_LOG, 0), fsid(f) {
+    set_priority(CEPH_MSG_PRIO_DEFAULT);
+  }
 private:
   ~MLog() final {}
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4029,7 +4029,18 @@ void Monitor::forward_request_leader(MonOpRequestRef op)
                                      req,
 				     rr->con_features,
 				     rr->session->caps);
-    forward->set_priority(req->get_priority());
+
+    switch (req->get_type()) {
+    case MSG_OSD_BEACON:
+    case MSG_MGR_BEACON:
+      if (req->get_priority() < CEPH_MSG_PRIO_HIGH) {
+        forward->set_priority(CEPH_MSG_PRIO_HIGH);
+        break;
+      }
+    default:
+      forward->set_priority(req->get_priority());
+    }
+
     if (session->auth_handler) {
       forward->entity_name = session->entity_name;
     } else if (req->get_source().is_mon()) {


### PR DESCRIPTION
When mons handle a large amount of mon_commands, osdbeacon|mgrbeacon sent to peon mon
will wait for a long time with many forward(log) messages in leader mon's dispatch queue.
We should give forward(osdbeacon)|forward(mgrbeacon) high priority since they have
queued up in peon mon's dispatch queue with normal priority.

Fixes: https://tracker.ceph.com/issues/54617
Signed-off-by: wencong wan wanwc@chinatelecom.cn





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
