### PR TITLE
crimson/os/seastore: coordinate segment seq of journal and ool segments

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -544,7 +544,8 @@ public:
    * Construct the record for Journal from transaction.
    */
   record_t prepare_record(
-    Transaction &t ///< [in, out] current transaction
+    Transaction &t, ///< [in, out] current transaction
+    SegmentProvider *cleaner
   );
 
   /**

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -75,7 +75,10 @@ class SegmentProvider;
 class SegmentedAllocator : public ExtentAllocator {
   class Writer : public ExtentOolWriter {
   public:
-    Writer(std::string name, SegmentProvider& sp, SegmentManager& sm);
+    Writer(std::string name,
+           SegmentProvider& sp,
+           SegmentManager& sm,
+           SegmentSeqAllocator &ssa);
     Writer(Writer &&) = default;
 
     open_ertr::future<> open() final {
@@ -111,7 +114,8 @@ class SegmentedAllocator : public ExtentAllocator {
 public:
   SegmentedAllocator(
     SegmentProvider& sp,
-    SegmentManager& sm);
+    SegmentManager& sm,
+    SegmentSeqAllocator &ssa);
 
   Writer &get_writer(placement_hint_t hint) {
     assert(hint >= placement_hint_t::COLD);

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -7,6 +7,7 @@
 
 #include "crimson/os/seastore/ordering_handle.h"
 #include "crimson/os/seastore/seastore_types.h"
+#include "crimson/os/seastore/segment_seq_allocator.h"
 
 namespace crimson::os::seastore {
 
@@ -83,6 +84,8 @@ public:
 	       seastar::lowres_system_clock::time_point last_modified)>;
   virtual replay_ret replay(
     delta_handler_t &&delta_handler) = 0;
+
+  virtual SegmentSeqAllocator& get_segment_seq_allocator() = 0;
 
   virtual ~Journal() {}
 };

--- a/src/crimson/os/seastore/journal/segment_allocator.cc
+++ b/src/crimson/os/seastore/journal/segment_allocator.cc
@@ -16,11 +16,13 @@ SegmentAllocator::SegmentAllocator(
   std::string name,
   segment_type_t type,
   SegmentProvider &sp,
-  SegmentManager &sm)
+  SegmentManager &sm,
+  SegmentSeqAllocator &ssa)
   : name{name},
     type{type},
     segment_provider{sp},
-    segment_manager{sm}
+    segment_manager{sm},
+    segment_seq_allocator(ssa)
 {
   ceph_assert(type != segment_type_t::NULL_SEG);
   std::ostringstream oss;
@@ -29,23 +31,20 @@ SegmentAllocator::SegmentAllocator(
   reset();
 }
 
-void SegmentAllocator::set_next_segment_seq(segment_seq_t seq)
-{
-  LOG_PREFIX(SegmentAllocator::set_next_segment_seq);
-  INFO("{} next_segment_seq={}",
-       print_name, segment_seq_printer_t{seq});
-  assert(type == segment_seq_to_type(seq));
-  next_segment_seq = seq;
-}
-
 SegmentAllocator::open_ret
 SegmentAllocator::do_open()
 {
   LOG_PREFIX(SegmentAllocator::do_open);
   ceph_assert(!current_segment);
-  segment_seq_t new_segment_seq = get_new_segment_seq_and_increment();
+  segment_seq_t new_segment_seq =
+    segment_seq_allocator.get_and_inc_next_segment_seq();
+  auto meta = segment_manager.get_meta();
+  current_segment_nonce = ceph_crc32c(
+    new_segment_seq,
+    reinterpret_cast<const unsigned char *>(meta.seastore_id.bytes()),
+    sizeof(meta.seastore_id.uuid));
   auto new_segment_id = segment_provider.get_segment(
-      get_device_id(), new_segment_seq);
+      get_device_id(), new_segment_seq, type);
   return segment_manager.open(new_segment_id
   ).handle_error(
     open_ertr::pass_further{},
@@ -65,7 +64,8 @@ SegmentAllocator::do_open()
       new_segment_seq,
       segment_id,
       new_journal_tail,
-      current_segment_nonce};
+      current_segment_nonce,
+      type};
     INFO("{} writing header to new segment ... -- {}",
          print_name, header);
 
@@ -108,7 +108,8 @@ SegmentAllocator::do_open()
       }
       DEBUG("{} rolled new segment id={}",
             print_name, current_segment->get_segment_id());
-      ceph_assert(new_journal_seq.segment_seq == get_current_segment_seq());
+      ceph_assert(new_journal_seq.segment_seq ==
+        segment_provider.get_seq(current_segment->get_segment_id()));
       return new_journal_seq;
     });
   });
@@ -142,7 +143,7 @@ SegmentAllocator::write(ceph::bufferlist to_write)
   auto write_length = to_write.length();
   auto write_start_offset = written_to;
   auto write_start_seq = journal_seq_t{
-    get_current_segment_seq(),
+    segment_provider.get_seq(current_segment->get_segment_id()),
     paddr_t::make_seg_paddr(
       current_segment->get_segment_id(), write_start_offset)
   };
@@ -200,15 +201,11 @@ SegmentAllocator::close_segment(bool is_rolling)
   // Note: make sure no one can access the current segment once closing
   auto seg_to_close = std::move(current_segment);
   auto close_segment_id = seg_to_close->get_segment_id();
-  INFO("{} close segment id={}, seq={}, written_to={}, nonce={}",
-       print_name,
-       close_segment_id,
-       segment_seq_printer_t{get_current_segment_seq()},
-       written_to,
-       current_segment_nonce);
   if (is_rolling) {
     segment_provider.close_segment(close_segment_id);
   }
+  segment_seq_t cur_segment_seq =
+    segment_provider.get_seq(seg_to_close->get_segment_id());
   journal_seq_t cur_journal_tail;
   if (type == segment_type_t::JOURNAL) {
     cur_journal_tail = segment_provider.get_journal_tail_target();
@@ -216,16 +213,24 @@ SegmentAllocator::close_segment(bool is_rolling)
     cur_journal_tail = NO_DELTAS;
   }
   auto tail = segment_tail_t{
-    get_current_segment_seq(),
+    segment_provider.get_seq(close_segment_id),
     close_segment_id,
     cur_journal_tail,
     current_segment_nonce,
+    type,
     segment_provider.get_last_modified(
       close_segment_id).time_since_epoch().count(),
     segment_provider.get_last_rewritten(
       close_segment_id).time_since_epoch().count()};
   ceph::bufferlist bl;
   encode(tail, bl);
+  INFO("{} close segment id={}, seq={}, written_to={}, nonce={}, journal_tail={}",
+       print_name,
+       close_segment_id,
+       cur_segment_seq,
+       written_to,
+       current_segment_nonce,
+       tail.journal_tail);
 
   bufferptr bp(
     ceph::buffer::create_page_aligned(

--- a/src/crimson/os/seastore/journal/segmented_journal.h
+++ b/src/crimson/os/seastore/journal/segmented_journal.h
@@ -16,9 +16,9 @@
 #include "crimson/os/seastore/seastore_types.h"
 #include "crimson/osd/exceptions.h"
 #include "segment_allocator.h"
+#include "crimson/os/seastore/segment_seq_allocator.h"
 
 namespace crimson::os::seastore::journal {
-
 /**
  * Manages stream of atomically written records to a SegmentManager.
  */
@@ -46,6 +46,9 @@ public:
     write_pipeline = _write_pipeline;
   }
 
+  SegmentSeqAllocator& get_segment_seq_allocator() final {
+    return *segment_seq_allocator;
+  }
 private:
   submit_record_ret do_submit_record(
     record_t &&record,
@@ -53,6 +56,7 @@ private:
   );
 
   SegmentProvider& segment_provider;
+  SegmentSeqAllocatorRef segment_seq_allocator;
   SegmentAllocator journal_segment_allocator;
   RecordSubmitter record_submitter;
   ExtentReader& scanner;

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -80,26 +80,13 @@ std::ostream& operator<<(std::ostream& out, segment_type_t t)
   }
 }
 
-segment_type_t segment_seq_to_type(segment_seq_t seq)
-{
-  if (seq <= MAX_VALID_SEG_SEQ) {
-    return segment_type_t::JOURNAL;
-  } else if (seq == OOL_SEG_SEQ) {
-    return segment_type_t::OOL;
-  } else {
-    assert(seq == NULL_SEG_SEQ);
-    return segment_type_t::NULL_SEG;
-  }
-}
-
 std::ostream& operator<<(std::ostream& out, segment_seq_printer_t seq)
 {
-  auto type = segment_seq_to_type(seq.seq);
-  switch(type) {
-  case segment_type_t::JOURNAL:
+  if (seq.seq == NULL_SEG_SEQ) {
+    return out << "NULL_SEG_SEQ";
+  } else {
+    assert(seq.seq <= MAX_VALID_SEG_SEQ);
     return out << seq.seq;
-  default:
-    return out << type;
   }
 }
 
@@ -211,6 +198,7 @@ std::ostream &operator<<(std::ostream &out, const delta_info_t &delta)
 	     << ", final_crc: " << delta.final_crc
 	     << ", length: " << delta.length
 	     << ", pversion: " << delta.pversion
+	     << ", ext_seq: " << delta.ext_seq
 	     << ")";
 }
 
@@ -230,6 +218,7 @@ std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
 	     << ", segment_id=" << header.physical_segment_id
 	     << ", journal_tail=" << header.journal_tail
 	     << ", segment_nonce=" << header.segment_nonce
+	     << ", type=" << header.type
 	     << ")";
 }
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -208,7 +208,6 @@ using segment_seq_t = uint32_t;
 static constexpr segment_seq_t MAX_SEG_SEQ =
   std::numeric_limits<segment_seq_t>::max();
 static constexpr segment_seq_t NULL_SEG_SEQ = MAX_SEG_SEQ;
-static constexpr segment_seq_t OOL_SEG_SEQ = MAX_SEG_SEQ - 1;
 static constexpr segment_seq_t MAX_VALID_SEG_SEQ = MAX_SEG_SEQ - 2;
 
 enum class segment_type_t {
@@ -218,8 +217,6 @@ enum class segment_type_t {
 };
 
 std::ostream& operator<<(std::ostream& out, segment_type_t t);
-
-segment_type_t segment_seq_to_type(segment_seq_t seq);
 
 struct segment_seq_printer_t {
   segment_seq_t seq;
@@ -760,10 +757,6 @@ struct journal_seq_t {
     return {segment_seq, offset.add_offset(o)};
   }
 
-  segment_type_t get_type() const {
-    return segment_seq_to_type(segment_seq);
-  }
-
   DENC(journal_seq_t, v, p) {
     DENC_START(1, 1, p);
     denc(v.segment_seq, p);
@@ -918,6 +911,7 @@ struct delta_info_t {
   uint32_t final_crc = 0;
   seastore_off_t length = NULL_SEG_OFF;         ///< extent length
   extent_version_t pversion;                   ///< prior version
+  segment_seq_t ext_seq;		       ///< seq of the extent's segment
   ceph::bufferlist bl;                         ///< payload
 
   DENC(delta_info_t, v, p) {
@@ -929,6 +923,7 @@ struct delta_info_t {
     denc(v.final_crc, p);
     denc(v.length, p);
     denc(v.pversion, p);
+    denc(v.ext_seq, p);
     denc(v.bl, p);
     DENC_FINISH(p);
   }
@@ -942,6 +937,7 @@ struct delta_info_t {
       final_crc == rhs.final_crc &&
       length == rhs.length &&
       pversion == rhs.pversion &&
+      ext_seq == rhs.ext_seq &&
       bl == rhs.bl
     );
   }
@@ -1300,8 +1296,10 @@ struct segment_header_t {
   journal_seq_t journal_tail;
   segment_nonce_t segment_nonce;
 
+  segment_type_t type;
+
   segment_type_t get_type() const {
-    return segment_seq_to_type(journal_segment_seq);
+    return type;
   }
 
   DENC(segment_header_t, v, p) {
@@ -1310,6 +1308,7 @@ struct segment_header_t {
     denc(v.physical_segment_id, p);
     denc(v.journal_tail, p);
     denc(v.segment_nonce, p);
+    denc(v.type, p);
     DENC_FINISH(p);
   }
 };
@@ -1321,8 +1320,15 @@ struct segment_tail_t {
 
   journal_seq_t journal_tail;
   segment_nonce_t segment_nonce;
+
+  segment_type_t type;
+
   mod_time_point_t last_modified;
   mod_time_point_t last_rewritten;
+
+  segment_type_t get_type() const {
+    return type;
+  }
 
   DENC(segment_tail_t, v, p) {
     DENC_START(1, 1, p);
@@ -1330,6 +1336,7 @@ struct segment_tail_t {
     denc(v.physical_segment_id, p);
     denc(v.journal_tail, p);
     denc(v.segment_nonce, p);
+    denc(v.type, p);
     denc(v.last_modified, p);
     denc(v.last_rewritten, p);
     DENC_FINISH(p);
@@ -1749,6 +1756,43 @@ struct denc_traits<crimson::os::seastore::device_type_t> {
     crimson::os::seastore::device_type_t& o,
     ceph::buffer::list::const_iterator &p) {
     p.copy(sizeof(crimson::os::seastore::device_type_t),
+           reinterpret_cast<char*>(&o));
+  }
+};
+
+template<>
+struct denc_traits<crimson::os::seastore::segment_type_t> {
+  static constexpr bool supported = true;
+  static constexpr bool featured = false;
+  static constexpr bool bounded = true;
+  static constexpr bool need_contiguous = false;
+
+  static void bound_encode(
+    const crimson::os::seastore::segment_type_t &o,
+    size_t& p,
+    uint64_t f=0) {
+    p += sizeof(crimson::os::seastore::segment_type_t);
+  }
+  template<class It>
+  static std::enable_if_t<!is_const_iterator_v<It>>
+  encode(
+    const crimson::os::seastore::segment_type_t &o,
+    It& p,
+    uint64_t f=0) {
+    get_pos_add<crimson::os::seastore::segment_type_t>(p) = o;
+  }
+  template<class It>
+  static std::enable_if_t<is_const_iterator_v<It>>
+  decode(
+    crimson::os::seastore::segment_type_t& o,
+    It& p,
+    uint64_t f=0) {
+    o = get_pos_add<crimson::os::seastore::segment_type_t>(p);
+  }
+  static void decode(
+    crimson::os::seastore::segment_type_t& o,
+    ceph::buffer::list::const_iterator &p) {
+    p.copy(sizeof(crimson::os::seastore::segment_type_t),
            reinterpret_cast<char*>(&o));
   }
 };

--- a/src/crimson/os/seastore/segment_seq_allocator.h
+++ b/src/crimson/os/seastore/segment_seq_allocator.h
@@ -1,0 +1,33 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "crimson/os/seastore/logging.h"
+#include "crimson/os/seastore/seastore_types.h"
+
+namespace crimson::os::seastore::journal {
+class SegmentedJournal;
+}
+
+namespace crimson::os::seastore {
+
+class SegmentSeqAllocator {
+public:
+  segment_seq_t get_and_inc_next_segment_seq() {
+    return next_segment_seq++;
+  }
+private:
+  void set_next_segment_seq(segment_seq_t seq) {
+    LOG_PREFIX(SegmentSeqAllocator::set_next_segment_seq);
+    SUBINFO(seastore_journal, "next_segment_seq={}", segment_seq_printer_t{seq});
+    next_segment_seq = seq;
+  }
+  segment_seq_t next_segment_seq = 0;
+  friend class journal::SegmentedJournal;
+};
+
+using SegmentSeqAllocatorRef =
+  std::unique_ptr<SegmentSeqAllocator>;
+
+};

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -323,7 +323,7 @@ TransactionManager::submit_transaction_direct(
     return tref.get_handle().enter(write_pipeline.prepare);
   }).si_then([this, FNAME, &tref]() mutable
 	      -> submit_transaction_iertr::future<> {
-    auto record = cache->prepare_record(tref);
+    auto record = cache->prepare_record(tref, segment_cleaner.get());
 
     tref.get_handle().maybe_release_collection_lock();
 

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -549,7 +549,8 @@ public:
       device_type_t::SEGMENTED,
       std::make_unique<SegmentedAllocator>(
 	*segment_cleaner,
-	*sm));
+	*sm,
+	journal->get_segment_seq_allocator()));
   }
 
   ~TransactionManager();

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -31,7 +31,7 @@ struct cache_test_t : public seastar_test_suite_t {
 
   seastar::future<paddr_t> submit_transaction(
     TransactionRef t) {
-    auto record = cache->prepare_record(*t);
+    auto record = cache->prepare_record(*t, nullptr);
 
     bufferlist bl;
     for (auto &&block : record.extents) {

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -80,6 +80,8 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
 
   segment_id_t next;
 
+  std::map<segment_id_t, segment_seq_t> segment_seqs;
+
   journal_test_t() = default;
 
   seastar::lowres_system_clock::time_point get_last_modified(
@@ -94,12 +96,21 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
 
   void update_segment_avail_bytes(paddr_t offset) final {}
 
-  segment_id_t get_segment(device_id_t id, segment_seq_t seq) final {
+  segment_id_t get_segment(
+    device_id_t id,
+    segment_seq_t seq,
+    segment_type_t) final
+  {
     auto ret = next;
     next = segment_id_t{
       next.device_id(),
       next.device_segment_id() + 1};
+    segment_seqs[ret] = seq;
     return ret;
+  }
+
+  segment_seq_t get_seq(segment_id_t id) {
+    return segment_seqs[id];
   }
 
   journal_seq_t get_journal_tail_target() const final { return journal_seq_t{}; }
@@ -224,6 +235,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
       0, 0,
       block_size,
       1,
+      MAX_SEG_SEQ,
       bl
     };
   }


### PR DESCRIPTION
the segment seq in ool segments' headers also need to be set to the
current journal segment seq, because we rely on this to judge whether a
delta needs to be replayed

Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
