### PR TITLE
osd/PGLog.cc: Trim duplicates by number of entries

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -131,10 +131,8 @@ void PGLog::IndexedLog::trim(
     }
   }
 
-  while (!dups.empty()) {
+  while (dups.size() > cct->_conf->osd_pg_log_dups_tracked) {
     const auto& e = *dups.begin();
-    if (e.version.version >= earliest_dup_version)
-      break;
     lgeneric_subdout(cct, osd, 20) << "trim dup " << e << dendl;
     if (trimmed_dups)
       trimmed_dups->insert(e.get_key_name());

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -56,7 +56,7 @@ void PGLog::IndexedLog::split_out_child(
 void PGLog::IndexedLog::trim(
   CephContext* cct,
   eversion_t s,
-  set<eversion_t> *trimmed,
+  set<string> *trimmed,
   set<string>* trimmed_dups,
   eversion_t *write_from_dups)
 {
@@ -76,7 +76,7 @@ void PGLog::IndexedLog::trim(
       break;
     lgeneric_subdout(cct, osd, 20) << "trim " << e << dendl;
     if (trimmed)
-      trimmed->emplace(e.version);
+      trimmed->insert(e.get_key_name());
 
     unindex(e);         // remove from index,
 
@@ -681,7 +681,7 @@ void PGLog::write_log_and_missing(
     eversion_t::max(),
     eversion_t(),
     eversion_t(),
-    set<eversion_t>(),
+    set<string>(),
     set<string>(),
     missing,
     true, require_rollback, false,
@@ -815,7 +815,7 @@ void PGLog::_write_log_and_missing(
   eversion_t dirty_to,
   eversion_t dirty_from,
   eversion_t writeout_from,
-  set<eversion_t> &&trimmed,
+  set<string> &&trimmed,
   set<string> &&trimmed_dups,
   const pg_missing_tracker_t &missing,
   bool touch_log,
@@ -829,8 +829,7 @@ void PGLog::_write_log_and_missing(
   ) {
   set<string> to_remove;
   to_remove.swap(trimmed_dups);
-  for (auto& t : trimmed) {
-    string key = t.get_key_name();
+  for (auto& key : trimmed) {
     if (log_keys_debug) {
       auto it = log_keys_debug->find(key);
       ceph_assert(it != log_keys_debug->end());

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1395,7 +1395,7 @@ public:
     bool debug_verify_stored_missing = false
     ) {
     return read_log_and_missing(
-      store, ch, pgmeta_oid, info,
+      cct, store, ch, pgmeta_oid, info,
       log, missing, oss,
       tolerate_divergent_missing_log,
       &clear_divergent_priors,
@@ -1406,6 +1406,7 @@ public:
 
   template <typename missing_type>
   static void read_log_and_missing(
+    CephContext *cct,
     ObjectStore *store,
     ObjectStore::CollectionHandle &ch,
     ghobject_t pgmeta_oid,
@@ -1475,6 +1476,9 @@ public:
 	    ceph_assert(dups.back().version < dup.version);
 	  }
 	  dups.push_back(dup);
+	  if (dups.size() >= cct->_conf->osd_pg_log_dups_tracked) {
+	    dups.pop_front();
+	  }
 	} else {
 	  pg_log_entry_t e;
 	  e.decode_with_checksum(bp);

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -633,7 +633,7 @@ public:
     void trim(
       CephContext* cct,
       eversion_t s,
-      std::set<eversion_t> *trimmed,
+      std::set<std::string> *trimmed,
       std::set<std::string>* trimmed_dups,
       eversion_t *write_from_dups);
 
@@ -650,7 +650,7 @@ protected:
   eversion_t dirty_to;         ///< must clear/writeout all keys <= dirty_to
   eversion_t dirty_from;       ///< must clear/writeout all keys >= dirty_from
   eversion_t writeout_from;    ///< must writout keys >= writeout_from
-  std::set<eversion_t> trimmed;     ///< must clear keys in trimmed
+  std::set<std::string> trimmed;     ///< must clear keys in trimmed
   eversion_t dirty_to_dups;    ///< must clear/writeout all dups <= dirty_to_dups
   eversion_t dirty_from_dups;  ///< must clear/writeout all dups >= dirty_from_dups
   eversion_t write_from_dups;  ///< must write keys >= write_from_dups
@@ -1372,7 +1372,7 @@ public:
     eversion_t dirty_to,
     eversion_t dirty_from,
     eversion_t writeout_from,
-    std::set<eversion_t> &&trimmed,
+    std::set<std::string> &&trimmed,
     std::set<std::string> &&trimmed_dups,
     const pg_missing_tracker_t &missing,
     bool touch_log,

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -2740,8 +2740,8 @@ TEST_F(PGLogTrimTest, TestPartialTrim)
   EXPECT_EQ(eversion_t(19, 160), write_from_dups2);
   EXPECT_EQ(2u, log.log.size());
   EXPECT_EQ(1u, trimmed2.size());
-  EXPECT_EQ(2u, log.dups.size());
-  EXPECT_EQ(1u, trimmed_dups2.size());
+  EXPECT_EQ(3u, log.dups.size());
+  EXPECT_EQ(0u, trimmed_dups2.size());
 }
 
 
@@ -3024,7 +3024,7 @@ TEST_F(PGLogTrimTest, TestTrimDups) {
 
   EXPECT_EQ(eversion_t(20, 103), write_from_dups) << log;
   EXPECT_EQ(2u, log.log.size()) << log;
-  EXPECT_EQ(3u, log.dups.size()) << log;
+  EXPECT_EQ(4u, log.dups.size()) << log;
 }
 
 // This tests trim() to make copies of
@@ -3068,7 +3068,50 @@ TEST_F(PGLogTrimTest, TestTrimDups2) {
 
   EXPECT_EQ(eversion_t(10, 100), write_from_dups) << log;
   EXPECT_EQ(4u, log.log.size()) << log;
-  EXPECT_EQ(5u, log.dups.size()) << log;
+  EXPECT_EQ(6u, log.dups.size()) << log;
+}
+
+// This tests trim() to make copies of
+// 5 log entries (107, 106, 105, 104, 103) and trim all dups
+TEST_F(PGLogTrimTest, TestTrimAllDups) {
+  SetUp(0);
+  PGLog::IndexedLog log;
+  log.head = mk_evt(21, 107);
+  log.skip_can_rollback_to_to_head();
+  log.tail = mk_evt(9, 99);
+  log.head = mk_evt(9, 99);
+
+  entity_name_t client = entity_name_t::CLIENT(777);
+
+  log.dups.push_back(pg_log_dup_t(mk_ple_mod(mk_obj(1),
+	  mk_evt(9, 98), mk_evt(8, 97), osd_reqid_t(client, 8, 1))));
+  log.dups.push_back(pg_log_dup_t(mk_ple_mod(mk_obj(1),
+	  mk_evt(9, 99), mk_evt(8, 98), osd_reqid_t(client, 8, 1))));
+
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(10, 100), mk_evt(9, 99),
+		     osd_reqid_t(client, 8, 1)));
+  log.add(mk_ple_dt(mk_obj(2), mk_evt(15, 101), mk_evt(10, 100),
+		    osd_reqid_t(client, 8, 2)));
+  log.add(mk_ple_mod_rb(mk_obj(3), mk_evt(15, 102), mk_evt(15, 101),
+			osd_reqid_t(client, 8, 3)));
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(20, 103), mk_evt(15, 102),
+		     osd_reqid_t(client, 8, 4)));
+  log.add(mk_ple_mod(mk_obj(4), mk_evt(21, 104), mk_evt(20, 103),
+		     osd_reqid_t(client, 8, 5)));
+  log.add(mk_ple_dt_rb(mk_obj(5), mk_evt(21, 105), mk_evt(21, 104),
+		       osd_reqid_t(client, 8, 6)));
+  log.add(mk_ple_dt_rb(mk_obj(5), mk_evt(21, 106), mk_evt(21, 105),
+		       osd_reqid_t(client, 8, 6)));
+  log.add(mk_ple_dt_rb(mk_obj(5), mk_evt(21, 107), mk_evt(21, 106),
+		       osd_reqid_t(client, 8, 6)));
+
+  eversion_t write_from_dups = eversion_t::max();
+
+  log.trim(cct, mk_evt(20, 102), nullptr, nullptr, &write_from_dups);
+
+  EXPECT_EQ(eversion_t::max(), write_from_dups) << log;
+  EXPECT_EQ(5u, log.log.size()) << log;
+  EXPECT_EQ(0u, log.dups.size()) << log;
 }
 
 // This tests copy_up_to() to make copies of

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -2717,7 +2717,7 @@ TEST_F(PGLogTrimTest, TestPartialTrim)
   log.add(mk_ple_mod(mk_obj(4), mk_evt(21, 165), mk_evt(26, 160)));
   log.add(mk_ple_dt_rb(mk_obj(5), mk_evt(21, 167), mk_evt(31, 166)));
 
-  std::set<eversion_t> trimmed;
+  std::set<std::string> trimmed;
   std::set<std::string> trimmed_dups;
   eversion_t write_from_dups = eversion_t::max();
 
@@ -2731,7 +2731,7 @@ TEST_F(PGLogTrimTest, TestPartialTrim)
 
   SetUp(15);
 
-  std::set<eversion_t> trimmed2;
+  std::set<std::string> trimmed2;
   std::set<std::string> trimmed_dups2;
   eversion_t write_from_dups2 = eversion_t::max();
 
@@ -2784,7 +2784,7 @@ TEST_F(PGLogTrimTest, TestTrimNoDups)
   log.add(mk_ple_mod(mk_obj(4), mk_evt(21, 165), mk_evt(26, 160)));
   log.add(mk_ple_dt_rb(mk_obj(5), mk_evt(21, 167), mk_evt(31, 166)));
 
-  std::set<eversion_t> trimmed;
+  std::set<std::string> trimmed;
   std::set<std::string> trimmed_dups;
   eversion_t write_from_dups = eversion_t::max();
 
@@ -2812,7 +2812,7 @@ TEST_F(PGLogTrimTest, TestNoTrim)
   log.add(mk_ple_mod(mk_obj(4), mk_evt(21, 165), mk_evt(26, 160)));
   log.add(mk_ple_dt_rb(mk_obj(5), mk_evt(21, 167), mk_evt(31, 166)));
 
-  std::set<eversion_t> trimmed;
+  std::set<std::string> trimmed;
   std::set<std::string> trimmed_dups;
   eversion_t write_from_dups = eversion_t::max();
 
@@ -2841,7 +2841,7 @@ TEST_F(PGLogTrimTest, TestTrimAll)
   log.add(mk_ple_mod(mk_obj(4), mk_evt(21, 165), mk_evt(26, 160)));
   log.add(mk_ple_dt_rb(mk_obj(5), mk_evt(21, 167), mk_evt(31, 166)));
 
-  std::set<eversion_t> trimmed;
+  std::set<std::string> trimmed;
   std::set<std::string> trimmed_dups;
   eversion_t write_from_dups = eversion_t::max();
 

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -447,7 +447,7 @@ int get_log(ObjectStore *fs, __u8 struct_ver,
     ostringstream oss;
     ceph_assert(struct_ver > 0);
     PGLog::read_log_and_missing(
-      fs, ch,
+      g_ceph_context, fs, ch,
       pgid.make_pgmeta_oid(),
       info, log, missing,
       oss,

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -632,6 +632,20 @@ int write_pg(ObjectStore::Transaction &t, epoch_t epoch, pg_info_t &info,
   return 0;
 }
 
+bool need_trim_dups(ObjectStore *store, ObjectStore::CollectionHandle ch,
+                      const ghobject_t &oid) {
+  size_t count_dups = 0;
+  ObjectMap::ObjectMapIterator p = store->get_omap_iterator(ch, oid);
+  if (!p)
+    return false;
+  for (p->seek_to_first(); p->valid(); p->next()) {
+    if (p->key().substr(0, 4) == string("dup_"))
+       if (++count_dups > g_ceph_context->_conf->osd_pg_log_dups_tracked)
+        return true;
+   }
+   return false;
+}
+
 int do_trim_pg_log(ObjectStore *store, const coll_t &coll,
 		   pg_info_t &info, const spg_t &pgid,
 		   epoch_t map_epoch,
@@ -646,23 +660,34 @@ int do_trim_pg_log(ObjectStore *store, const coll_t &coll,
 
   cerr << "Log bounds are: " << "(" << info.log_tail << ","
        << info.last_update << "]" << std::endl;
-
-  uint64_t max_entries = g_ceph_context->_conf->osd_max_pg_log_entries;
-  if (info.last_update.version - info.log_tail.version <= max_entries) {
-    cerr << "Log not larger than osd_max_pg_log_entries " << max_entries << std::endl;
+  uint64_t max_entries = std::min<uint64_t>(g_ceph_context->_conf->osd_max_pg_log_entries,
+					    (info.last_update.version) ? (info.last_update.version - 1)
+					        : g_ceph_context->_conf->osd_max_pg_log_entries
+					    );
+  if (info.last_update.version - info.log_tail.version <= max_entries &&
+      !need_trim_dups(store, ch, oid)) {
+    cerr << "Log not larger than osd_max_pg_log_entries " << max_entries << " and no duplicate entries to trim" << std::endl;
     return 0;
   }
 
+  PGLog::IndexedLog pg_log;
+  pg_log.head = info.last_update;
+  pg_log.skip_can_rollback_to_to_head();
+
   ceph_assert(info.last_update.version > max_entries);
-  version_t trim_to = info.last_update.version - max_entries;
+  eversion_t trim_to(info.last_update.epoch, info.last_update.version - max_entries);
+
   size_t trim_at_once = g_ceph_context->_conf->osd_pg_log_trim_max;
+  size_t tracked_dups = g_ceph_context->_conf->osd_pg_log_dups_tracked;
+  std::deque<pg_log_dup_t> latest_dups;
+  g_ceph_context->_conf->osd_pg_log_dups_tracked = 0; // Fake dup trimming all
+
   eversion_t new_tail;
   bool done = false;
 
   while (!done) {
     // gather keys so we can delete them in a batch without
     // affecting the iterator
-    set<string> keys_to_trim;
     {
     ObjectMap::ObjectMapIterator p = store->get_omap_iterator(ch, oid);
     if (!p)
@@ -680,47 +705,80 @@ int do_trim_pg_log(ObjectStore *store, const coll_t &coll,
 	continue;
       if (p->key().substr(0, 7) == string("missing"))
 	continue;
-      if (p->key().substr(0, 4) == string("dup_"))
-	continue;
-
       bufferlist bl = p->value();
       auto bp = bl.cbegin();
-      pg_log_entry_t e;
-      try {
-	e.decode_with_checksum(bp);
-      } catch (const buffer::error &e) {
-	cerr << "Error reading pg log entry: " << e.what() << std::endl;
-      }
-      if (debug) {
-	cerr << "read entry " << e << std::endl;
-      }
-      if (e.version.version > trim_to) {
-	done = true;
-	break;
-      }
-      keys_to_trim.insert(p->key());
-      new_tail = e.version;
-      if (keys_to_trim.size() >= trim_at_once)
-	break;
-    }
 
+      if (p->key().substr(0, 4) == string("dup_")) {
+        pg_log_dup_t dup;
+	try {
+	  dup.decode(bp);
+	  latest_dups.push_back(dup);
+	  if (latest_dups.size() > tracked_dups) {
+	    pg_log.dups.push_back(latest_dups.front());
+	    latest_dups.pop_front();
+	  }
+	  if (debug) {
+            cerr << "read entry " << dup << std::endl;
+          }
+	} catch (buffer::error& e) {
+	  cerr << "error reading log dup: " << p->key() << std::endl;
+	  return -EFAULT;
+	}
+      } else {
+        pg_log_entry_t e;
+        try {
+	  e.decode_with_checksum(bp);
+	  pg_log.log.push_back(e);
+	  if (debug) {
+            cerr << "read entry " << e << std::endl;
+          }
+	} catch (const buffer::error &e) {
+          cerr << "Error reading pg log entry: " << e.what() << std::endl;
+        }
+      }
+      // We have enough pg logs entries to trim
+      if ((pg_log.log.size() + pg_log.dups.size()) >= trim_at_once) {
+        break;
+      }
+    }
     if (!p->valid())
       done = true;
+
+    pg_log.index();
+
     } // deconstruct ObjectMapIterator
 
-    // delete the keys
-    if (!dry_run && !keys_to_trim.empty()) {
-      cout << "Removing keys " << *keys_to_trim.begin() << " - " << *keys_to_trim.rbegin() << std::endl;
-      ObjectStore::Transaction t;
-      t.omap_rmkeys(coll, oid, keys_to_trim);
-      store->queue_transaction(ch, std::move(t));
-      ch->flush();
+    if (!dry_run && ((pg_log.log.size() > 0) || (pg_log.dups.size() > 0))) {
+      std::set<std::string> trimmed;
+      std::set<std::string> trimmed_dups;
+      eversion_t write_from_dups = eversion_t::max();
+
+      pg_log.trim(g_ceph_context, trim_to, &trimmed, &trimmed_dups, &write_from_dups);
+      // Is there any trimming to do?
+      if (!trimmed.empty() || !trimmed_dups.empty()) {
+        new_tail = pg_log.tail;
+
+        ObjectStore::Transaction t;
+        if (!trimmed.empty()) {
+	  cerr << "Removing keys " << *trimmed.begin() << " - " << *trimmed.rbegin() << std::endl;
+          t.omap_rmkeys(coll, oid, trimmed);
+	}
+	if (!trimmed_dups.empty()) {
+          cerr << "Removing Dups " << *trimmed_dups.begin() << " - " << *trimmed_dups.rbegin() << std::endl;
+          t.omap_rmkeys(coll, oid, trimmed_dups);
+	}
+        store->queue_transaction(ch, std::move(t));
+        ch->flush();
+	pg_log.log.clear();
+	pg_log.dups.clear();
+      }
     }
   }
 
   // update pg info with new tail
   if (!dry_run && new_tail !=  eversion_t()) {
     info.log_tail = new_tail;
+
     ObjectStore::Transaction t;
     int ret = write_info(t, map_epoch, info, past_intervals);
     if (ret)
@@ -729,6 +787,7 @@ int do_trim_pg_log(ObjectStore *store, const coll_t &coll,
     ch->flush();
   }
 
+  g_ceph_context->_conf->osd_pg_log_dups_tracked = tracked_dups; //Restore original
   // compact the db since we just removed a bunch of data
   cerr << "Finished trimming, now compacting..." << std::endl;
   if (!dry_run)


### PR DESCRIPTION
PGLog needs to trim duplicates by the number of entries rather than the versions. That way, we prevent unbounded duplicate growth.

Fixed: https://tracker.ceph.com/issues/53729
Signed-off-by: Nitzan Mordechai <nmordec@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
