### PR TITLE
octopus: mgr/rbd_support: cast pool_id from int to str when collecting LevelSpec

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -1179,8 +1179,8 @@ test_trash_purge_schedule() {
     rbd trash purge schedule status
     rbd trash purge schedule status --format xml |
         $XMLSTARLET sel -t -v '//scheduled/item/pool' | grep 'rbd2'
-    test "$(echo $(rbd trash purge schedule status --format xml |
-        $XMLSTARLET sel -t -v '//scheduled/item/pool'))" = 'rbd rbd2 rbd2'
+    echo $(rbd trash purge schedule status --format xml |
+        $XMLSTARLET sel -t -v '//scheduled/item/pool') | grep 'rbd rbd2 rbd2'
     test "$(rbd trash purge schedule status -p rbd --format xml |
         $XMLSTARLET sel -t -v '//scheduled/item/pool')" = 'rbd'
     test "$(echo $(rbd trash purge schedule status -p rbd2 --format xml |

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -1155,6 +1155,8 @@ test_trash_purge_schedule() {
     rbd trash purge schedule status
     test "$(rbd trash purge schedule status --format xml |
         $XMLSTARLET sel -t -v '//scheduled/item/pool')" = 'rbd'
+    test "$(rbd trash purge schedule status -p rbd --format xml |
+        $XMLSTARLET sel -t -v '//scheduled/item/pool')" = 'rbd'
 
     rbd trash purge schedule add 2d 00:17
     rbd trash purge schedule ls | grep 'every 2d starting at 00:17'
@@ -1177,6 +1179,12 @@ test_trash_purge_schedule() {
     rbd trash purge schedule status
     rbd trash purge schedule status --format xml |
         $XMLSTARLET sel -t -v '//scheduled/item/pool' | grep 'rbd2'
+    test "$(echo $(rbd trash purge schedule status --format xml |
+        $XMLSTARLET sel -t -v '//scheduled/item/pool'))" = 'rbd rbd2 rbd2'
+    test "$(rbd trash purge schedule status -p rbd --format xml |
+        $XMLSTARLET sel -t -v '//scheduled/item/pool')" = 'rbd'
+    test "$(echo $(rbd trash purge schedule status -p rbd2 --format xml |
+        $XMLSTARLET sel -t -v '//scheduled/item/pool'))" = 'rbd2 rbd2'
 
     test "$(echo $(rbd trash purge schedule ls -R --format xml |
         $XMLSTARLET sel -t -v '//schedules/schedule/items'))" = "2d00:17:00 1d01:30:00"
@@ -1199,6 +1207,7 @@ test_trash_purge_schedule() {
         rbd trash ls rbd2/ns1 | wc -l | grep '^1$'
 
         rbd trash purge schedule add -p $p 1m
+        rbd trash purge schedule list -p rbd2 -R | grep 'every 1m'
         rbd trash purge schedule list -p rbd2/ns1 -R | grep 'every 1m'
 
         for i in `seq 12`; do
@@ -1207,7 +1216,14 @@ test_trash_purge_schedule() {
         done
         rbd trash ls rbd2/ns1 | wc -l | grep '^0$'
 
+        # repeat with kicked in schedule, see https://tracker.ceph.com/issues/53915
+        rbd trash purge schedule list -p rbd2 -R | grep 'every 1m'
+        rbd trash purge schedule list -p rbd2/ns1 -R | grep 'every 1m'
+
         rbd trash purge schedule status | grep 'rbd2  *ns1'
+        rbd trash purge schedule status -p rbd2 | grep 'rbd2  *ns1'
+        rbd trash purge schedule status -p rbd2/ns1 | grep 'rbd2  *ns1'
+
         rbd trash purge schedule rm -p $p 1m
     done
 
@@ -1251,8 +1267,14 @@ test_mirror_snapshot_schedule() {
     test "$(rbd mirror image status rbd2/ns1/test1 |
         grep -c mirror.primary)" = '1'
 
-    rbd mirror snapshot schedule add --image rbd2/ns1/test1 1m
-    test "$(rbd mirror snapshot schedule ls --image rbd2/ns1/test1)" = 'every 1m'
+    rbd mirror snapshot schedule add -p rbd2/ns1 --image test1 1m
+    expect_fail rbd mirror snapshot schedule ls
+    rbd mirror snapshot schedule ls -R | grep 'rbd2 *ns1 *test1 *every 1m'
+    expect_fail rbd mirror snapshot schedule ls -p rbd2
+    rbd mirror snapshot schedule ls -p rbd2 -R | grep 'rbd2 *ns1 *test1 *every 1m'
+    expect_fail rbd mirror snapshot schedule ls -p rbd2/ns1
+    rbd mirror snapshot schedule ls -p rbd2/ns1 -R | grep 'rbd2 *ns1 *test1 *every 1m'
+    test "$(rbd mirror snapshot schedule ls -p rbd2/ns1 --image test1)" = 'every 1m'
 
     for i in `seq 12`; do
         test "$(rbd mirror image status rbd2/ns1/test1 |
@@ -1263,15 +1285,36 @@ test_mirror_snapshot_schedule() {
     test "$(rbd mirror image status rbd2/ns1/test1 |
         grep -c mirror.primary)" -gt '1'
 
+    # repeat with kicked in schedule, see https://tracker.ceph.com/issues/53915
+    expect_fail rbd mirror snapshot schedule ls
     rbd mirror snapshot schedule ls -R | grep 'rbd2 *ns1 *test1 *every 1m'
+    expect_fail rbd mirror snapshot schedule ls -p rbd2
+    rbd mirror snapshot schedule ls -p rbd2 -R | grep 'rbd2 *ns1 *test1 *every 1m'
+    expect_fail rbd mirror snapshot schedule ls -p rbd2/ns1
+    rbd mirror snapshot schedule ls -p rbd2/ns1 -R | grep 'rbd2 *ns1 *test1 *every 1m'
     test "$(rbd mirror snapshot schedule ls -p rbd2/ns1 --image test1)" = 'every 1m'
 
     rbd mirror snapshot schedule status
     test "$(rbd mirror snapshot schedule status --format xml |
         $XMLSTARLET sel -t -v '//scheduled_images/image/image')" = 'rbd2/ns1/test1'
+    test "$(rbd mirror snapshot schedule status -p rbd2 --format xml |
+        $XMLSTARLET sel -t -v '//scheduled_images/image/image')" = 'rbd2/ns1/test1'
+    test "$(rbd mirror snapshot schedule status -p rbd2/ns1 --format xml |
+        $XMLSTARLET sel -t -v '//scheduled_images/image/image')" = 'rbd2/ns1/test1'
+    test "$(rbd mirror snapshot schedule status -p rbd2/ns1 --image test1 --format xml |
+        $XMLSTARLET sel -t -v '//scheduled_images/image/image')" = 'rbd2/ns1/test1'
 
     rbd mirror snapshot schedule add 1h 00:15
     test "$(rbd mirror snapshot schedule ls)" = 'every 1h starting at 00:15:00'
+    rbd mirror snapshot schedule ls -R | grep 'every 1h starting at 00:15:00'
+    rbd mirror snapshot schedule ls -R | grep 'rbd2 *ns1 *test1 *every 1m'
+    expect_fail rbd mirror snapshot schedule ls -p rbd2
+    rbd mirror snapshot schedule ls -p rbd2 -R | grep 'every 1h starting at 00:15:00'
+    rbd mirror snapshot schedule ls -p rbd2 -R | grep 'rbd2 *ns1 *test1 *every 1m'
+    expect_fail rbd mirror snapshot schedule ls -p rbd2/ns1
+    rbd mirror snapshot schedule ls -p rbd2/ns1 -R | grep 'every 1h starting at 00:15:00'
+    rbd mirror snapshot schedule ls -p rbd2/ns1 -R | grep 'rbd2 *ns1 *test1 *every 1m'
+    test "$(rbd mirror snapshot schedule ls -p rbd2/ns1 --image test1)" = 'every 1m'
 
     # Negative tests
     expect_fail rbd mirror snapshot schedule add dummy

--- a/src/tools/rbd/action/TrashPurgeSchedule.cc
+++ b/src/tools/rbd/action/TrashPurgeSchedule.cc
@@ -98,7 +98,7 @@ public:
     for (auto &item : scheduled) {
       f->open_object_section("item");
       f->dump_string("pool", item.pool_name);
-      f->dump_string("namespce", item.namespace_name);
+      f->dump_string("namespace", item.namespace_name);
       f->dump_string("schedule_time", item.schedule_time);
       f->close_section(); // item
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54483

---

backport of https://github.com/ceph/ceph/pull/45149 and https://github.com/ceph/ceph/pull/45525
parent tracker: https://tracker.ceph.com/issues/53915