### PR TITLE
multisite/test: running the multisite test script with custom devices

### DIFF
--- a/src/test/rgw/test-rgw-common.sh
+++ b/src/test/rgw/test-rgw-common.sh
@@ -160,3 +160,36 @@ function call_rgw_admin {
   shift 1
   x $(rgw_admin $cid) "$@"
 }
+
+function get_mstart_parameters {
+  [ $# -ne 1 ] && echo "get_mstart_parameters() needs 1 param" && exit 1
+  # bash arrays start from zero
+  index="$1"
+	index=$((index-1))
+  if [ -n "$DEV_LIST" ]; then
+    IFS=', ' read -r -a dev_list <<< "$DEV_LIST"
+    if [ ${#dev_list[@]} -gt "$index" ]; then
+      local dev_name=${dev_list["$index"]}
+      parameters="--bluestore-devs $dev_name"
+    fi
+  fi
+
+  if [ -n "$DB_DEV_LIST" ]; then
+    IFS=', ' read -r -a db_dev_list <<< "$DB_DEV_LIST"
+    if [ ${#db_dev_list[@]} -gt "$index" ]; then
+      local dev_name=${db_dev_list["$index"]}
+      parameters="$parameters"" -o bluestore_block_db_path=$dev_name"
+    fi
+  fi
+  
+  if [ -n "$WAL_DEV_LIST" ]; then
+    IFS=', ' read -r -a wal_dev_list <<< "$WAL_DEV_LIST"
+    if [ ${#wal_dev_list[@]} -gt "$index" ]; then
+      local dev_name=${wal_dev_list["$index"]}
+      parameters="$parameters"" -o bluestore_block_wal_path=$dev_name"
+    fi
+  fi
+
+  echo "$parameters"
+}
+

--- a/src/test/rgw/test-rgw-multisite.sh
+++ b/src/test/rgw/test-rgw-multisite.sh
@@ -19,7 +19,7 @@ system_access_key="1234567890"
 system_secret="pencil"
 
 # bring up first cluster
-x $(start_ceph_cluster c1) -n
+x $(start_ceph_cluster c1) -n $(get_mstart_parameters 1)
 
 # create realm, zonegroup, zone, start rgw
 init_first_zone c1 $realm_name $zg ${zg}-1 8001 $system_access_key $system_secret
@@ -33,7 +33,7 @@ echo realm_status=$output
 
 i=2
 while [ $i -le $num_clusters ]; do
-  x $(start_ceph_cluster c$i) -n
+  x $(start_ceph_cluster c$i) -n $(get_mstart_parameters $i)
 
   # create new zone, start rgw
   init_zone_in_existing_zg c$i $realm_name $zg ${zg}-${i} 8001 $((8000+$i)) $zone_port $system_access_key $system_secret


### PR DESCRIPTION
following environment variables should be set to allow that:

DEV_LIST: comma separated list of devices that should be used by each
clusteri as bluestore block devices.
for example in: DEV_LIST=/dev/nvme7n1,/dev/nvme6n1
the device /dev/nvme7n1 to be used by cluster "c1, while /dev/nvme6n1
will be used by cluster "c2".

DB_DEV_LIST: similar mechanism for DB
WAL_DEV_LIST: similar mechanism for WAL

note that if any of these variables is missing, or has less values than
clusters, the default device would be used.

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
