### PR TITLE
rgw: fix potentially misbehaving conditional in rgw_kms.cc

### DIFF
--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -80,7 +80,7 @@ public:
 	return r;
     }
     void* Realloc(void* p, size_t old, size_t nw) {
-	void *r;
+	void *r = nullptr;
 	if (nw) r = malloc(nw);
 	if (nw > old) nw = old;
 	if (r && old) memcpy(r, p, nw);


### PR DESCRIPTION
GCC has spotted the following undefined behaviour:

```
[1898/2008] Building CXX object src/rgw/CMakeFiles/rgw_common.dir/rgw_kms.cc.o
../src/rgw/rgw_kms.cc: In function ‘void add_name_val_to_obj(const char*, std::string&, rapidjson::GenericValue<Encoding, Allocator>&, A&) [with E = rapidjson::UTF8<>; A = ZeroPoolAllocator]’:
../src/rgw/rgw_kms.cc:86:22: warning: ‘r’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   86 |  if (r && old) memcpy(r, p, nw);
      |                ~~~~~~^~~~~~~~~~
../src/rgw/rgw_kms.cc:83:8: note: ‘r’ was declared here
   83 |  void *r;

```

I believe the compiler is right here and we can accidentally damage the memory by copying into a region selected basing on junks.

Signed-off-by: Radosław Zarzyński <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
