### PR TITLE
ceph-fuse: restrict already_fuse_mounted function only for linux

### DIFF
--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -4,6 +4,7 @@ from tasks.cephfs.fuse_mount import FuseMount
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from teuthology.exceptions import CommandFailedError
 import errno
+import platform
 import time
 import json
 import logging
@@ -30,6 +31,9 @@ class TestMisc(CephFSTestCase):
         p.wait()
 
     def test_fuse_mount_on_already_mounted_path(self):
+        if platform.system() != "Linux":
+            self.skipTest("Require Linux platform")
+
         if not isinstance(self.mount_a, FuseMount):
             self.skipTest("Require FUSE client")
 

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -23,10 +23,13 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
+
+#if defined(__linux__)
 #include <libgen.h>
 #include <sys/vfs.h>
 #include <sys/xattr.h>
 #include <linux/magic.h>
+#endif
 
 // ceph
 #include "common/errno.h"
@@ -57,11 +60,13 @@
 #define MINOR(dev)	((unsigned int) ((dev) & MINORMASK))
 #define MKDEV(ma,mi)	(((ma) << MINORBITS) | (mi))
 
+#if defined(__linux__)
 #ifndef FUSE_SUPER_MAGIC
 #define FUSE_SUPER_MAGIC 0x65735546
 #endif
 
 #define _CEPH_CLIENT_ID	"ceph.client_id"
+#endif
 
 using namespace std;
 
@@ -173,6 +178,7 @@ public:
   struct fuse_args args;
 };
 
+#if defined(__linux__)
 static int already_fuse_mounted(const char *path, bool &already_mounted)
 {
   struct statx path_statx;
@@ -242,6 +248,13 @@ static int already_fuse_mounted(const char *path, bool &already_mounted)
 
   return err;
 }
+#else // non-linux platforms
+static int already_fuse_mounted(const char *path, bool &already_mounted)
+{
+  already_mounted = false;
+  return 0;
+}
+#endif
 
 static int getgroups(fuse_req_t req, gid_t **sgids)
 {

--- a/src/mount.fuse.ceph
+++ b/src/mount.fuse.ceph
@@ -28,6 +28,7 @@ id=myuser,conf=/etc/ceph/foo.conf  /mnt/ceph   fuse.ceph   defaults   0 0
 import sys
 import argparse
 import errno
+import platform
 from subprocess import Popen
 
 def ceph_options(mntops):
@@ -74,7 +75,10 @@ def main(arguments):
     mount_cmd.communicate()
 
     if (mount_cmd.returncode != 0):
-        if (mount_cmd.returncode != errno.EBUSY):
+        if (platform.system() == "Linux"):
+            if (mount_cmd.returncode != errno.EBUSY):
+                print("Mount failed with status code: {}".format(mount_cmd.returncode))
+        else:
             print("Mount failed with status code: {}".format(mount_cmd.returncode))
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: Nikhilkumar Shelke <nshelke@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
