### PR TITLE
pacific: qa: ignore expected metadata cluster log error

### DIFF
--- a/qa/suites/fs/functional/tasks/journal-repair.yaml
+++ b/qa/suites/fs/functional/tasks/journal-repair.yaml
@@ -6,6 +6,7 @@ overrides:
       - Metadata damage detected
       - slow requests are blocked
       - Behind on trimming
+      - error reading sessionmap
 tasks:
   - cephfs_test_runner:
       modules:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/52427

---

backport of https://github.com/ceph/ceph/pull/42530
parent tracker: https://tracker.ceph.com/issues/51905

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh