### PR TITLE
mgr/dashboard: add latency chart 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/health.py
+++ b/src/pybind/mgr/dashboard/controllers/health.py
@@ -172,8 +172,8 @@ class HealthData(object):
         for osd in osd_stats['osd_stats']:
             osd_perf += [{ 
                 'osd': osd['osd'],
-                'apply_latency_ms': osd['perf_stat']['apply_latency_ns']  / 1000000.0, # ns -> ms
-                'commit_latency_ms': osd['perf_stat']['commit_latency_ns']  / 1000000.0 # ns -> ms
+                'apply_latency_ms': osd['perf_stat']['apply_latency_ns']  / 1000000.0,
+                'commit_latency_ms': osd['perf_stat']['commit_latency_ns']  / 1000000.0, 
             }]
         return { 'osd_perf': osd_perf }
         

--- a/src/pybind/mgr/dashboard/controllers/health.py
+++ b/src/pybind/mgr/dashboard/controllers/health.py
@@ -170,13 +170,12 @@ class HealthData(object):
         osd_stats = mgr.get('osd_stats')
 
         for osd in osd_stats['osd_stats']:
-            osd_perf += [{ 
+            osd_perf += [{
                 'osd': osd['osd'],
-                'apply_latency_ms': osd['perf_stat']['apply_latency_ns']  / 1000000.0,
-                'commit_latency_ms': osd['perf_stat']['commit_latency_ns']  / 1000000.0, 
+                'apply_latency_ms': osd['perf_stat']['apply_latency_ns'] / 1000000.0,
+                'commit_latency_ms': osd['perf_stat']['commit_latency_ns'] / 1000000.0,
             }]
-        return { 'osd_perf': osd_perf }
-        
+        return {'osd_perf': osd_perf}
 
     def basic_health(self):
         health_data = mgr.get("health")

--- a/src/pybind/mgr/dashboard/controllers/health.py
+++ b/src/pybind/mgr/dashboard/controllers/health.py
@@ -170,11 +170,11 @@ class HealthData(object):
         osd_stats = mgr.get('osd_stats')
 
         for osd in osd_stats['osd_stats']:
-            osd_perf += [{
+            osd_perf.append({
                 'osd': osd['osd'],
                 'apply_latency_ms': osd['perf_stat']['apply_latency_ns'] / 1000000.0,
                 'commit_latency_ms': osd['perf_stat']['commit_latency_ns'] / 1000000.0,
-            }]
+            })
         return {'osd_perf': osd_perf}
 
     def basic_health(self):

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.ts
@@ -106,7 +106,7 @@ export class HealthPieComponent implements OnChanges, OnInit {
       id: 'center_text',
       beforeDraw(chart: Chart) {
         if (chart.config.type !== 'doughnut') {
-          return; 
+          return;
         }
 
         const cssHelper = new CssHelper();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.ts
@@ -105,6 +105,10 @@ export class HealthPieComponent implements OnChanges, OnInit {
     {
       id: 'center_text',
       beforeDraw(chart: Chart) {
+        if (chart.config.type !== 'doughnut') {
+          return; 
+        }
+
         const cssHelper = new CssHelper();
         const defaultFontFamily = 'Helvetica Neue, Helvetica, Arial, sans-serif';
         Chart.defaults.global.defaultFontFamily = defaultFontFamily;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
@@ -227,7 +227,7 @@
       {{ healthData.scrub_status }}
     </cd-info-card>
 
-    <cd-info-card cardTitle="Latency"
+    <cd-info-card cardTitle="OSDs Latency"
                     i18n-cardTitle
                     class="cd-performance-card cd-chart-card"
                     contentClass="content-chart"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
@@ -228,10 +228,10 @@
     </cd-info-card>
 
     <cd-info-card cardTitle="OSDs Latency"
-                    i18n-cardTitle
-                    class="cd-performance-card cd-chart-card"
-                    contentClass="content-chart"
-                    *ngIf="healthData.perf_stat">
+                  i18n-cardTitle
+                  class="cd-performance-card cd-chart-card"
+                  contentClass="content-chart"
+                  *ngIf="healthData.perf_stat">
       <cd-health-pie [data]="healthData"
                      [config]="latencyChartConfig"
                      (prepareFn)="prepareLatency($event[0], $event[1])">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
@@ -145,16 +145,6 @@
       </cd-health-pie>
     </cd-info-card>
 
-    <cd-info-card cardTitle="Perf Statistics"
-                  i18n-cardTitle
-                  class="cd-capacity-card cd-chart-card"
-                  contentClass="content-chart"
-                  *ngIf="healthData.pg_info?.object_stats?.num_objects != null">
-      <cd-health-pie [data]="healthData"
-                     (prepareFn)="prepareLatency($event[0], $event[1])">
-      </cd-health-pie>
-    </cd-info-card>
-
     <cd-info-card cardTitle="PG Status"
                   i18n-cardTitle
                   class="cd-capacity-card cd-chart-card"
@@ -198,7 +188,7 @@
 
   <cd-info-group groupTitle="Performance"
                  i18n-groupTitle
-                 *ngIf="healthData.client_perf || healthData.scrub_status">
+                 *ngIf="healthData.client_perf || healthData.scrub_status || healthData.perf_stat">
     <cd-info-card cardTitle="Client Read/Write"
                   i18n-cardTitle
                   class="cd-performance-card cd-chart-card"
@@ -236,6 +226,18 @@
                   *ngIf="healthData.scrub_status">
       {{ healthData.scrub_status }}
     </cd-info-card>
+
+    <cd-info-card cardTitle="Latency"
+                    i18n-cardTitle
+                    class="cd-performance-card cd-chart-card"
+                    contentClass="content-chart"
+                    *ngIf="healthData.perf_stat">
+      <cd-health-pie [data]="healthData"
+                     [config]="latencyChartConfig"
+                     (prepareFn)="prepareLatency($event[0], $event[1])">
+      </cd-health-pie>
+    </cd-info-card>
+
   </cd-info-group>
 
   <ng-template #logsLink>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
@@ -145,6 +145,16 @@
       </cd-health-pie>
     </cd-info-card>
 
+    <cd-info-card cardTitle="Perf Statistics"
+                  i18n-cardTitle
+                  class="cd-capacity-card cd-chart-card"
+                  contentClass="content-chart"
+                  *ngIf="healthData.pg_info?.object_stats?.num_objects != null">
+      <cd-health-pie [data]="healthData"
+                     (prepareFn)="prepareLatency($event[0], $event[1])">
+      </cd-health-pie>
+    </cd-info-card>
+
     <cd-info-card cardTitle="PG Status"
                   i18n-cardTitle
                   class="cd-capacity-card cd-chart-card"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
@@ -98,6 +98,7 @@ export class HealthComponent implements OnInit, OnDestroy {
     this.healthService.getMinimalHealth().subscribe((data: any) => {
       this.healthData = data;
     });
+    console.log(this.healthData)
   }
 
   prepareReadWriteRatio(chart: Record<string, any>) {
@@ -259,6 +260,34 @@ export class HealthComponent implements OnInit, OnDestroy {
     chart.dataset[0].label = `${this.dimless.transform(
       data.pg_info.object_stats.num_objects
     )}\n${$localize`objects`}`;
+  }
+
+  prepareLatency(chart: Record<string, any>, data: Record<string, any>) {
+    const perf_stats = data.perf_stat.osd_perf;
+    let total_perf_score = 0;
+    let perf_data: Array<number> = [];
+    perf_stats.map((osd_stat: any) => {
+      total_perf_score += ((osd_stat.apply_latency_ms + osd_stat.commit_latency_ms) / 2)
+    })
+
+    perf_stats.map((osd_stat: any) => {
+      const perf_stat = this.calcPercentage((osd_stat.apply_latency_ms + osd_stat.commit_latency_ms) / 2, total_perf_score);
+      if (perf_stat) { perf_data.push(perf_stat); }
+    })
+
+    // chart.chartType = 'bar';
+  
+    chart.labels = [
+      `${$localize`Number of OSDs`}: ${(perf_data).length}`,
+    ];
+    chart.dataset[0].borderWidth = 1;
+
+    // chart.dataset[0].data = [20, 40, 3, 2, 192];
+    chart.dataset[0].data = perf_data || [0];
+
+    chart.dataset[0].label = `${this.dimless.transform(
+      (perf_data).length
+    )}\n${$localize`perf_stat`}`;
   }
 
   isClientReadWriteChartShowable() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
@@ -63,14 +63,21 @@ export class HealthComponent implements OnInit, OnDestroy {
   };
 
   latencyChartConfig = {
-    chartType: 'line',
+    chartType: 'bar',
+    colors: [
+      {
+        backgroundColor: 'rgba(0, 255, 0, 0.4)',
+      }
+    ],
     options: {
       events: [''],
       scales: {
+        xAxes: [{ stacked: true }],
         yAxes: [{
-            ticks: {
-                beginAtZero: true
-            }
+          stacked: false,
+          ticks: {
+            beginAtZero: true,
+          },
         }]
       },
     }
@@ -290,22 +297,16 @@ export class HealthComponent implements OnInit, OnDestroy {
     chart.labels = osds;
     
     chart.dataset[0] = {  
-      label: "apply latency (ms)",        
-      data: apply_latencies,       
-      order: 1,
-      tension: 0.1,  
-      fill: true, 
-      borderColor: 'rgb(50,205,50)', 
-      backgroundColor: 'rgba(50,205,50, 0.2)'
+      label: "apply latency (ms)",
+      data: apply_latencies,
+      order: 2,
+      backgroundColor: 'rgba(0, 255, 0, 0.4)'
     };
     chart.dataset[1] = {  
-      label: `commit latency (ms)`,       
-      data: commit_latencies,       
-      order: 2,
-      tension: 0.1,  
-      fill: true, 
-      borderColor: 'rgb(75, 192, 192)', 
-      backgroundColor: 'rgba(75, 192, 192, 0.2)'
+      label: `commit latency (ms)`,
+      data: commit_latencies,
+      order: 1,
+      backgroundColor: 'rgba(0,0,255, 0.4)',
      };
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
@@ -64,26 +64,28 @@ export class HealthComponent implements OnInit, OnDestroy {
 
   latencyChartConfig = {
     chartType: 'bar',
-    colors: [
-      { backgroundColor: 'rgb(116, 164, 174)', }
-    ],
+    colors: [{ backgroundColor: 'rgb(116, 164, 174)' }],
     options: {
       events: [''],
       scales: {
-        xAxes: [{ 
-          stacked: true,
-          scaleLabel: {
-            display: true,
-            labelString: 'n-th percentile',
-          },
-        }],
-        yAxes: [{
-          stacked: true,
-          ticks: {
-            beginAtZero: true,
-          },
-        }]
-      },
+        xAxes: [
+          {
+            stacked: true,
+            scaleLabel: {
+              display: true,
+              labelString: 'n-th percentile'
+            }
+          }
+        ],
+        yAxes: [
+          {
+            stacked: true,
+            ticks: {
+              beginAtZero: true
+            }
+          }
+        ]
+      }
     }
   };
 
@@ -291,50 +293,49 @@ export class HealthComponent implements OnInit, OnDestroy {
     let apply_latencies: Array<number> = [];
 
     perf_stats.map((osd_stat: any) => {
-      apply_latencies.push(osd_stat.apply_latency_ms)
-    })
+      apply_latencies.push(osd_stat.apply_latency_ms);
+    });
 
     apply_latencies = _.sortBy(apply_latencies);
 
-    let latency_count = apply_latencies.length;
+    const latency_count = apply_latencies.length;
 
     if (latency_count < 5) {
-      let fifth_percentile: number = Math.floor(0.05 * latency_count);
-      let median_percentile: number = Math.floor(0.5 * latency_count);
-      let ninty_fifth_percentile: number = Math.floor(0.95 * latency_count);
+      const fifth_percentile: number = Math.floor(0.05 * latency_count);
+      const median_percentile: number = Math.floor(0.5 * latency_count);
+      const ninty_fifth_percentile: number = Math.floor(0.95 * latency_count);
 
-      let data = [
+      const latency_data = [
         apply_latencies[fifth_percentile],
         apply_latencies[median_percentile],
-        apply_latencies[ninty_fifth_percentile],
-      ]
+        apply_latencies[ninty_fifth_percentile]
+      ];
 
-      chart.labels = ["5%", "50%", "95%"];
-      chart.dataset[0] = {  
-        label: "apply latency (ms)",
-        data: data,
-        backgroundColor: 'rgb(116, 164, 174)',
+      chart.labels = ['5%', '50%', '95%'];
+      chart.dataset[0] = {
+        label: 'apply latency (ms)',
+        data: latency_data,
+        backgroundColor: 'rgb(116, 164, 174)'
       };
-
     } else {
-      let zero_percentile: number = 0;
-      let hundred_percentile: number = latency_count - 1;
-      let median_percentile: number = Math.floor(0.5 * latency_count);
-      let fifth_percentile: number = Math.ceil(0.05 * latency_count);
-      let ninty_fifth_percentile: number = Math.floor(0.95 * latency_count) - 1;
+      const zero_percentile = 0;
+      const hundred_percentile: number = latency_count - 1;
+      const median_percentile: number = Math.floor(0.5 * latency_count);
+      const fifth_percentile: number = Math.ceil(0.05 * latency_count);
+      const ninty_fifth_percentile: number = Math.floor(0.95 * latency_count) - 1;
 
-      let data = [
+      const latency_data = [
         apply_latencies[zero_percentile],
         apply_latencies[fifth_percentile],
         apply_latencies[median_percentile],
         apply_latencies[ninty_fifth_percentile],
-        apply_latencies[hundred_percentile],
-      ]
+        apply_latencies[hundred_percentile]
+      ];
 
-      chart.labels = ["0%", "5%", "50%", "95%", "100%"];
-      chart.dataset[0] = {  
-        label: "apply latency (ms)",
-        data: data,
+      chart.labels = ['0%', '5%', '50%', '95%', '100%'];
+      chart.dataset[0] = {
+        label: 'apply latency (ms)',
+        data: latency_data,
         backgroundColor: 'rgb(116, 164, 174)'
       };
     }

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -3332,6 +3332,31 @@ paths:
                     required:
                     - osds
                     type: object
+                  perf_stat:
+                    description: ''
+                    properties:
+                      osd_perf:
+                        description: ''
+                        items:
+                          properties:
+                            apply_latency_ms:
+                              description: ''
+                              type: integer
+                            commit_latency_ms:
+                              description: ''
+                              type: integer
+                            osd:
+                              description: ''
+                              type: integer
+                          required:
+                          - osd
+                          - commit_latency_ms
+                          - apply_latency_ms
+                          type: object
+                        type: array
+                    required:
+                    - osd_perf
+                    type: object
                   pg_info:
                     description: ''
                     properties:
@@ -3390,6 +3415,7 @@ paths:
                 - mgr_map
                 - mon_status
                 - osd_map
+                - perf_stat
                 - pg_info
                 - pools
                 - rgw


### PR DESCRIPTION
Visualize "ceph osd perf" command with a latency chart on the dashboard's Performance section.  

Why did I choose this chart? To compare values of grouped items, line chart and bar chart (or similar charts like histogram) are two great options. To decide between the two, line chart showed the difference between the commit_latency and apply_latency more clearly than overlapping bar charts did. So, I decided to go for the line chart! 


Line chart:
![image](https://user-images.githubusercontent.com/50358181/159566387-c11a94e4-ec28-4799-b67f-e8e0b600de8c.png)

Alternatively, Bar Chart (showing the exact same data as above):
![image](https://user-images.githubusercontent.com/50358181/159566019-8f54aab7-5fcf-4f8e-8b52-b42deff21598.png)


Tests: 
One of dashboard's e2e frontend visual tests `visualTests/dashboard.vrt-spec.ts` is failing (because I made UI changes), please let me know how to update the tests for this!   


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
