### PR TITLE
tools/cephfs-shell: fix typos in comments

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -142,7 +142,7 @@ def get_chunks(file_size):
 
 
 def to_bytes(param):
-    # don't convert as follows as it can lead unusable results like coverting
+    # don't convert as follows as it can lead unusable results like converting
     # [1, 2, 3, 4] to '[1, 2, 3, 4]' -
     # str(param).encode('utf-8')
     if isinstance(param, bytes):
@@ -1126,7 +1126,7 @@ class CephFSShell(Cmd):
         # Arguments to the with_argpaser decorator function are sticky.
         # The items in args.path do not get overwritten in subsequent calls.
         # The arguments remain in args.paths after the function exits and we
-        # neeed to clean it up to ensure the next call works as expected.
+        # need to clean it up to ensure the next call works as expected.
         args.paths.clear()
 
     def do_lpwd(self, arglist):
@@ -1660,7 +1660,7 @@ def execute_cmds_and_quit(args):
         if ',' in cmdarg:
             args_to_onecmd += ' ' + cmdarg[0:-1]
             onecmd_retval = shell.onecmd(args_to_onecmd)
-            # if the curent command failed, let's abort the execution of
+            # if the current command failed, let's abort the execution of
             # series of commands passed.
             if onecmd_retval is not stop_exec_val:
                 return onecmd_retval


### PR DESCRIPTION
fix typos in comments

Signed-off-by: wangxinyu <wangxinyu@inspur.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
