### PR TITLE
mgr/dashboard: remove transition-through-oci image workaround in grafana  build

### DIFF
--- a/monitoring/grafana/build/Makefile
+++ b/monitoring/grafana/build/Makefile
@@ -72,15 +72,8 @@ providers: \\n\
 	sudo buildah commit --format docker --squash $(CONTAINER) $(LOCALTAG)
 
 push:
-	# this transition-through-oci image is a workaround for
-	# https://github.com/containers/buildah/issues/3253 and
-	# can be removed when that is fixed and released.  The
-	# --format v2s2 on push is to convert oci back to docker format.
-	sudo podman push $(LOCALTAG) --format=oci dir://tmp/oci-image
-	sudo podman pull dir://tmp/oci-image
-	sudo rm -rf /tmp/oci-image
-	sudo podman tag localhost/tmp/oci-image docker.io/${TAG}
-	sudo podman tag localhost/tmp/oci-image quay.io/${TAG}
+	sudo podman tag ${LOCALTAG} docker.io/${TAG}
+	sudo podman tag ${LOCALTAG} quay.io/${TAG}
 	# sudo podman has issues with auth.json; just override it
 	sudo podman login --authfile=auth.json -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD} docker.io
 	sudo podman login --authfile=auth.json -u $(CONTAINER_REPO_USERNAME) -p $(CONTAINER_REPO_PASSWORD) quay.io
@@ -91,6 +84,5 @@ clean:
 	sudo podman rmi ${LOCALTAG} || true
 	sudo podman rmi docker.io/${TAG} || true
 	sudo podman rmi quay.io/${TAG} || true
-	sudo podman rmi localhost/tmp/oci-image || true
 	rm -f grafana-*.rpm* auth.json
 	rm -f ${DASHBOARD_PROVISIONING}


### PR DESCRIPTION
remove transition-through-oci image workaround in grafana  build

The ceph-grafana-build is failing with this error -
```
+ make push
# this transition-through-oci image is a workaround for
# https://github.com/containers/buildah/issues/3253 and
# can be removed when that is fixed and released.  The
# --format v2s2 on push is to convert oci back to docker format.
sudo podman push ceph-grafana:8.2.6-x86_64 --format=oci dir://tmp/oci-image
Getting image source signatures
Copying blob sha256:bce624159a7606daa904a85f0e600a78bf7d2903de877653defe064f731c2793
Copying config sha256:9756a21e11f8999c31a6e5928d3adcdb9a1b1ed3a28ad638feaacb3a20b8e45d
Writing manifest to image destination
Storing signatures
sudo podman pull dir://tmp/oci-image
Getting image source signatures
Copying blob sha256:bce624159a7606daa904a85f0e600a78bf7d2903de877653defe064f731c2793
Copying config sha256:9756a21e11f8999c31a6e5928d3adcdb9a1b1ed3a28ad638feaacb3a20b8e45d
Writing manifest to image destination
Storing signatures
9756a21e11f8999c31a6e5928d3adcdb9a1b1ed3a28ad638feaacb3a20b8e45d
sudo rm -rf /tmp/oci-image
sudo podman tag localhost/tmp/oci-image docker.io/ceph/ceph-grafana:8.2.6-x86_64
Error: localhost/tmp/oci-image: image not known
make: *** [Makefile:82: push] Error 125
Build step 'Execute shell' marked build as failure
New run name is '#45 master, x86_64'
[Checks API] No suitable checks publisher found.
Finished: FAILURE
```
Removing the above workaround should fix this.

Fixes: https://tracker.ceph.com/issues/54311
Signed-off-by: Aashish Sharma <aasharma@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
