### PR TITLE
mgr/dashboard: RGW users and buckets tables are empty if the selected gateway is down

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.spec.ts
@@ -12,7 +12,7 @@ describe('RgwDaemonService', () => {
   let httpTesting: HttpTestingController;
   let selectDaemonSpy: jasmine.Spy;
 
-  const daemonList = RgwHelper.getDaemonList();
+  const daemonList: Array<RgwDaemon> = RgwHelper.getDaemonList();
   const retrieveDaemonList = (reqDaemonList: RgwDaemon[], daemon: RgwDaemon) => {
     service
       .request((params) => of(params))
@@ -75,5 +75,16 @@ describe('RgwDaemonService', () => {
     retrieveDaemonList(noDefaultDaemonList, noDefaultDaemonList[0]);
     expect(selectDaemonSpy).toHaveBeenCalledTimes(1);
     expect(selectDaemonSpy).toHaveBeenCalledWith(noDefaultDaemonList[0]);
+  }));
+
+  it('should update default daemon if not exist in daemon list', fakeAsync(() => {
+    const tmpDaemonList = [...daemonList];
+    service.selectDaemon(tmpDaemonList[1]); // Select 'default' daemon.
+    tmpDaemonList.splice(1, 1); // Remove 'default' daemon.
+    tmpDaemonList[0].default = true; // Set new 'default' daemon.
+    service.list().subscribe();
+    const testReq = httpTesting.expectOne('api/rgw/daemon');
+    testReq.flush(tmpDaemonList);
+    expect(service['selectedDaemon'].getValue()).toEqual(tmpDaemonList[0]);
   }));
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.ts
@@ -25,7 +25,10 @@ export class RgwDaemonService {
     return this.http.get<RgwDaemon[]>(this.url).pipe(
       tap((daemons: RgwDaemon[]) => {
         this.daemons.next(daemons);
-        if (_.isEmpty(this.selectedDaemon.getValue())) {
+        const selectedDaemon = this.selectedDaemon.getValue();
+        // Set or re-select the default daemon if the current one is not
+        // in the list anymore.
+        if (_.isEmpty(selectedDaemon) || undefined === _.find(daemons, { id: selectedDaemon.id })) {
           this.selectDefaultDaemon(daemons);
         }
       })


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/54983

Signed-off-by: Volker Theile <vtheile@suse.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
