### PR TITLE
octopus: librados: check latest osdmap on ENOENT in pool_reverse_lookup()

### DIFF
--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -390,7 +390,7 @@ extern "C" int _rados_pool_reverse_lookup(rados_t cluster, int64_t id,
   tracepoint(librados, rados_pool_reverse_lookup_enter, cluster, id, maxlen);
   librados::RadosClient *radosp = (librados::RadosClient *)cluster;
   std::string name;
-  int r = radosp->pool_get_name(id, &name);
+  int r = radosp->pool_get_name(id, &name, true);
   if (r < 0) {
     tracepoint(librados, rados_pool_reverse_lookup_exit, r, "");
     return r;

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -2559,7 +2559,7 @@ int64_t librados::Rados::pool_lookup(const char *name)
 
 int librados::Rados::pool_reverse_lookup(int64_t id, std::string *name)
 {
-  return client->pool_get_name(id, name);
+  return client->pool_get_name(id, name, true);
 }
 
 int librados::Rados::mon_command(string cmd, const bufferlist& inbl,

--- a/src/test/librados/pool.cc
+++ b/src/test/librados/pool.cc
@@ -63,6 +63,40 @@ TEST(LibRadosPools, PoolLookup2) {
   ASSERT_EQ(0, destroy_one_pool(pool_name, &cluster));
 }
 
+TEST(LibRadosPools, PoolLookupOtherInstance) {
+  rados_t cluster1;
+  ASSERT_EQ("", connect_cluster(&cluster1));
+
+  rados_t cluster2;
+  std::string pool_name = get_temp_pool_name();
+  ASSERT_EQ("", create_one_pool(pool_name, &cluster2));
+  int64_t pool_id = rados_pool_lookup(cluster2, pool_name.c_str());
+  ASSERT_GT(pool_id, 0);
+
+  ASSERT_EQ(pool_id, rados_pool_lookup(cluster1, pool_name.c_str()));
+
+  ASSERT_EQ(0, destroy_one_pool(pool_name, &cluster2));
+  rados_shutdown(cluster1);
+}
+
+TEST(LibRadosPools, PoolReverseLookupOtherInstance) {
+  rados_t cluster1;
+  ASSERT_EQ("", connect_cluster(&cluster1));
+
+  rados_t cluster2;
+  std::string pool_name = get_temp_pool_name();
+  ASSERT_EQ("", create_one_pool(pool_name, &cluster2));
+  int64_t pool_id = rados_pool_lookup(cluster2, pool_name.c_str());
+  ASSERT_GT(pool_id, 0);
+
+  char buf[100];
+  ASSERT_LT(0, rados_pool_reverse_lookup(cluster1, pool_id, buf, 100));
+  ASSERT_EQ(0, strcmp(buf, pool_name.c_str()));
+
+  ASSERT_EQ(0, destroy_one_pool(pool_name, &cluster2));
+  rados_shutdown(cluster1);
+}
+
 TEST(LibRadosPools, PoolDelete) {
   rados_t cluster;
   std::string pool_name = get_temp_pool_name();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55012

---

backport of https://github.com/ceph/ceph/pull/45468
parent tracker: https://tracker.ceph.com/issues/54593