### PR TITLE
pacific: common: fix missing name in PriorityCache perf counters

### DIFF
--- a/src/common/PriorityCache.cc
+++ b/src/common/PriorityCache.cc
@@ -73,8 +73,7 @@ namespace PriorityCache
       reserve_extra(reserve_extra),
       name(name.empty() ? "prioritycache" : name)
   {
-    PerfCountersBuilder b(cct, name,
-                          MallocStats::M_FIRST, MallocStats::M_LAST);
+    PerfCountersBuilder b(cct, this->name, MallocStats::M_FIRST, MallocStats::M_LAST);
 
     b.add_u64(MallocStats::M_TARGET_BYTES, "target_bytes",
               "target process memory usage in bytes", "t",


### PR DESCRIPTION
There was a problem with PriorityCache perf counters, where part of the name was missing (i.e. "mon.a.cache_bytes" instead of "mon.a.prioritycache.cache_bytes"). The problem was happening because a 'this' pointer was missing in the original implementation.

Signed-off-by: Laura Flores <lflores@redhat.com>
(cherry picked from commit 9e07175b3c9a5c69b8694bc05e0baa26a351582d)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2064627

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
