### PR TITLE
quincy: scrub/osd: add a missing 'publish stats to osd'

### DIFF
--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2163,6 +2163,7 @@ void PgScrubber::cleanup_on_finish()
   requeue_waiting();
 
   reset_internal_state();
+  m_pg->publish_stats_to_osd();
   m_flags = scrub_flags_t{};
 
   // type-specific state clear
@@ -2201,6 +2202,7 @@ void PgScrubber::clear_pgscrub_state()
 
   // type-specific state clear
   _scrub_clear_state();
+  m_pg->publish_stats_to_osd();
 }
 
 void PgScrubber::replica_handling_done()


### PR DESCRIPTION
to publish the last scrub status report.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
(cherry picked from commit ab032e9ac577b32c47528ae32c91b652079288c3)
