### PR TITLE
quincy: osd/PrimaryLogPG.cc: CEPH_OSD_OP_OMAPRMKEYRANGE should mark omap dirty

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7965,6 +7965,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  goto fail;
 	}
 	t->omap_rmkeyrange(soid, key_begin, key_end);
+        ctx->clean_regions.mark_omap_dirty();
 	ctx->delta_stats.num_wr++;
       }
       obs.oi.clear_omap_digest();


### PR DESCRIPTION
We should mark_omap_dirty() for all omap write ops, just like we did
in cb927925af1f3df4b9c31df85cf31f982aae1988.

Currently, for CEPH_OSD_OP_OMAPRMKEYRANGE ops, clean_omap gets set to true,
which results in incomplete recovery of objects and results in
inconsistent PGs after a scrub.

Fixes: https://tracker.ceph.com/issues/54592
Signed-off-by: Neha Ojha <nojha@redhat.com>
(cherry picked from commit f7fd5895fd3d7d7c4691be91434868d90f7a4e0f)

Backport Tracker: https://tracker.ceph.com/issues/55018

