### PR TITLE
quincy: osd/scrub: ignoring unsolicited DigestUpdate events

### DIFF
--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2297,6 +2297,11 @@ std::ostream& PgScrubber::gen_prefix(std::ostream& out) const
   }
 }
 
+void PgScrubber::log_cluster_warning(const std::string& warning) const
+{
+  m_osds->clog->do_log(CLOG_WARN, warning);
+}
+
 ostream& PgScrubber::show(ostream& out) const
 {
   return out << " [ " << m_pg_id << ": " << m_flags << " ] ";

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -444,6 +444,8 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
   utime_t scrub_begin_stamp;
   std::ostream& gen_prefix(std::ostream& out) const final;
 
+  void log_cluster_warning(const std::string& warning) const final;
+
  protected:
   bool state_test(uint64_t m) const { return m_pg->state_test(m); }
   void state_set(uint64_t m) { m_pg->state_set(m); }

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -435,6 +435,15 @@ sc::result WaitReplicas::react(const GotReplicas&)
   }
 }
 
+sc::result WaitReplicas::react(const DigestUpdate&)
+{
+  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  std::string warn_msg = "WaitReplicas::react(const DigestUpdate&): Unexpected DigestUpdate event";
+  dout(10) << warn_msg << dendl;
+  scrbr->log_cluster_warning(warn_msg);
+  return discard_event();
+}
+
 // ----------------------- WaitDigestUpdate -----------------------------------
 
 WaitDigestUpdate::WaitDigestUpdate(my_context ctx) : my_base(ctx)

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -299,11 +299,11 @@ struct WaitReplicas : sc::state<WaitReplicas, ActiveScrubbing> {
   using reactions =
     mpl::list<sc::custom_reaction<GotReplicas>,	 // all replicas are accounted for
 	      sc::transition<MapsCompared, WaitDigestUpdate>,
-	      sc::deferral<DigestUpdate>  // might arrive before we've reached WDU
+	      sc::custom_reaction<DigestUpdate>
 	      >;
 
   sc::result react(const GotReplicas&);
-
+  sc::result react(const DigestUpdate&);
   bool all_maps_already_called{false};	// see comment in react code
 };
 

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -186,4 +186,7 @@ struct ScrubMachineListener {
 
   /// exposed to be used by the scrub_machine logger
   virtual std::ostream& gen_prefix(std::ostream& out) const = 0;
+
+  /// sending cluster-log warnings
+  virtual void log_cluster_warning(const std::string& msg) const = 0;
 };


### PR DESCRIPTION
   
Cherry-picking of PR #44050. Manual editing was required
to fix the WaitDigestUpdate state reactions, as
the relevant change was missing in the picked commit
(was pushed by mistake in a separate PR)
    
(cherry picked from commit 84fe3622b887b645ffdb0b110963b89755c3c0f9)

