### PR TITLE
rgw/dbstore: Object versioning feature support

### DIFF
--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1148,6 +1148,7 @@ namespace rgw::sal {
 
     obj_op.meta.owner = owner.get_id();
     obj_op.meta.flags = PUT_OBJ_CREATE;
+    obj_op.meta.category = RGWObjCategory::Main;
     obj_op.meta.modify_tail = true;
     obj_op.meta.completeMultipart = true;
 
@@ -1525,6 +1526,7 @@ namespace rgw::sal {
     parent_op.meta.if_nomatch = if_nomatch;
     parent_op.meta.user_data = user_data;
     parent_op.meta.zones_trace = zones_trace;
+    parent_op.meta.category = RGWObjCategory::Main;
     
     /* XXX: handle accounted size */
     accounted_size = total_data_size;

--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -51,7 +51,7 @@ struct DBOpBucketInfo {
 
 struct DBOpObjectInfo {
   RGWAccessControlPolicy acls;
-  RGWObjState state;
+  RGWObjState state = {};
 
   /* Below are taken from rgw_bucket_dir_entry */
   RGWObjCategory category;
@@ -91,6 +91,10 @@ struct DBOpObjectInfo {
   std::string prefix;
   std::list<rgw_bucket_dir_entry> list_entries;
   /* XXX: Maybe use std::vector instead of std::list */
+
+  /* for versioned objects */
+  bool is_versioned;
+  uint64_t version_num = 1; // default value for plain entries (non-versioned)
 };
 
 struct DBOpObjectDataInfo {
@@ -259,8 +263,8 @@ struct DBOpObjectPrepareInfo {
   static constexpr const char* fake_tag = ":fake_tag";
   static constexpr const char* shadow_obj = ":shadow_obj";
   static constexpr const char* has_data = ":has_data";
-  static constexpr const char* is_olh = ":is_ols";
-  static constexpr const char* olh_tag = ":olh_tag";
+  static constexpr const char* is_versioned = ":is_versioned";
+  static constexpr const char* version_num = ":version_num";
   static constexpr const char* pg_ver = ":pg_ver";
   static constexpr const char* zone_short_id = ":zone_short_id";
   static constexpr const char* obj_version = ":obj_version";
@@ -288,6 +292,7 @@ struct DBOpObjectPrepareInfo {
   static constexpr const char* new_obj_name = ":new_obj_name";
   static constexpr const char* new_obj_instance = ":new_obj_instance";
   static constexpr const char* new_obj_ns  = ":new_obj_ns";
+  static constexpr const char* versions = ":versions";
 };
 
 struct DBOpObjectDataPrepareInfo {
@@ -369,6 +374,7 @@ class ObjectOp {
     std::shared_ptr<class GetObjectOp> GetObject;
     std::shared_ptr<class UpdateObjectOp> UpdateObject;
     std::shared_ptr<class ListBucketObjectsOp> ListBucketObjects;
+    std::shared_ptr<class ListVersionedObjectsOp> ListVersionedObjects;
     std::shared_ptr<class PutObjectDataOp> PutObjectData;
     std::shared_ptr<class UpdateObjectDataOp> UpdateObjectData;
     std::shared_ptr<class GetObjectDataOp> GetObjectData;
@@ -542,8 +548,8 @@ class DBOp {
       FakeTag BOOL,   \
       ShadowObj   TEXT,   \
       HasData  BOOL,  \
-      IsOLH BOOL,  \
-      OLHTag    BLOB, \
+      IsVersioned BOOL,  \
+      VersionNum  INTEGER, \
       PGVer   INTEGER, \
       ZoneShortID  INTEGER,  \
       ObjVersion   INTEGER,    \
@@ -563,6 +569,7 @@ class DBOp {
       IsMultipart     BOOL,   \
       MPPartsList    BLOB,   \
       HeadData  BLOB,   \
+      VERSIONS BLOB,    \
       PRIMARY KEY (ObjName, ObjInstance, BucketName), \
       FOREIGN KEY (BucketName) \
       REFERENCES '{}' (BucketName) ON DELETE CASCADE ON UPDATE CASCADE \n);";
@@ -784,7 +791,7 @@ class GetUserOp: virtual public DBOp {
                                   System, PlacementName, PlacementStorageClass, PlacementTags, \
                                   BucketQuota, TempURLKeys, UserQuota, Type, MfaIDs, AssumedRoleARN, \
                                   UserAttrs, UserVersion, UserVersionTag \
-                                  from '{}' where Tenant = {} and UserID = {} and NS = {}";
+                                  from '{}' where UserID = {}";
 
   public:
     virtual ~GetUserOp() {}
@@ -800,9 +807,7 @@ class GetUserOp: virtual public DBOp {
       } else if (params.op.query_str == "user_id") {
         return fmt::format(QueryByUserID,
             params.user_table,
-            params.op.user.tenant,
-            params.op.user.user_id,
-            params.op.user.ns);
+            params.op.user.user_id);
       } else {
         return fmt::format(Query, params.user_table,
             params.op.user.user_id);
@@ -985,13 +990,14 @@ class PutObjectOp: virtual public DBOp {
        Flags, VersionedEpoch, ObjCategory, Etag, Owner, OwnerDisplayName, \
        StorageClass, Appendable, ContentType, IndexHashSource, ObjSize, \
        AccountedSize, Mtime, Epoch, ObjTag, TailTag, WriteTag, FakeTag, \
-       ShadowObj, HasData, IsOLH, OLHTag, PGVer, ZoneShortID, \
+       ShadowObj, HasData, IsVersioned, VersionNum, PGVer, ZoneShortID, \
        ObjVersion, ObjVersionTag, ObjAttrs, HeadSize, MaxHeadSize, \
        ObjID, TailInstance, HeadPlacementRuleName, HeadPlacementRuleStorageClass, \
        TailPlacementRuleName, TailPlacementStorageClass, \
-       ManifestPartObjs, ManifestPartRules, Omap, IsMultipart, MPPartsList, HeadData )     \
+       ManifestPartObjs, ManifestPartRules, Omap, IsMultipart, MPPartsList, \
+       HeadData, Versions)     \
       VALUES ({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, \
-          {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, \
+          {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, \
           {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {})";
 
   public:
@@ -1010,7 +1016,7 @@ class PutObjectOp: virtual public DBOp {
           params.op.obj.accounted_size, params.op.obj.mtime,
           params.op.obj.epoch, params.op.obj.obj_tag, params.op.obj.tail_tag,
           params.op.obj.write_tag, params.op.obj.fake_tag, params.op.obj.shadow_obj,
-          params.op.obj.has_data, params.op.obj.is_olh, params.op.obj.olh_tag,
+          params.op.obj.has_data, params.op.obj.is_versioned, params.op.obj.version_num,
           params.op.obj.pg_ver, params.op.obj.zone_short_id,
           params.op.obj.obj_version, params.op.obj.obj_version_tag,
           params.op.obj.obj_attrs, params.op.obj.head_size,
@@ -1022,7 +1028,8 @@ class PutObjectOp: virtual public DBOp {
           params.op.obj.tail_placement_storage_class,
           params.op.obj.manifest_part_objs,
           params.op.obj.manifest_part_rules, params.op.obj.omap,
-          params.op.obj.is_multipart, params.op.obj.mp_parts, params.op.obj.head_data);
+          params.op.obj.is_multipart, params.op.obj.mp_parts,
+          params.op.obj.head_data, params.op.obj.versions);
     }
 };
 
@@ -1050,11 +1057,12 @@ class GetObjectOp: virtual public DBOp {
       Flags, VersionedEpoch, ObjCategory, Etag, Owner, OwnerDisplayName, \
       StorageClass, Appendable, ContentType, IndexHashSource, ObjSize, \
       AccountedSize, Mtime, Epoch, ObjTag, TailTag, WriteTag, FakeTag, \
-      ShadowObj, HasData, IsOLH, OLHTag, PGVer, ZoneShortID, \
+      ShadowObj, HasData, IsVersioned, VersionNum, PGVer, ZoneShortID, \
       ObjVersion, ObjVersionTag, ObjAttrs, HeadSize, MaxHeadSize, \
       ObjID, TailInstance, HeadPlacementRuleName, HeadPlacementRuleStorageClass, \
       TailPlacementRuleName, TailPlacementStorageClass, \
-      ManifestPartObjs, ManifestPartRules, Omap, IsMultipart, MPPartsList, HeadData from '{}' \
+      ManifestPartObjs, ManifestPartRules, Omap, IsMultipart, MPPartsList, \
+      HeadData, Versions from '{}' \
       where BucketName = {} and ObjName = {} and ObjInstance = {}";
 
   public:
@@ -1079,7 +1087,7 @@ class ListBucketObjectsOp: virtual public DBOp {
       Flags, VersionedEpoch, ObjCategory, Etag, Owner, OwnerDisplayName, \
       StorageClass, Appendable, ContentType, IndexHashSource, ObjSize, \
       AccountedSize, Mtime, Epoch, ObjTag, TailTag, WriteTag, FakeTag, \
-      ShadowObj, HasData, IsOLH, OLHTag, PGVer, ZoneShortID, \
+      ShadowObj, HasData, IsVersioned, VersionNum, PGVer, ZoneShortID, \
       ObjVersion, ObjVersionTag, ObjAttrs, HeadSize, MaxHeadSize, \
       ObjID, TailInstance, HeadPlacementRuleName, HeadPlacementRuleStorageClass, \
       TailPlacementRuleName, TailPlacementStorageClass, \
@@ -1095,6 +1103,37 @@ class ListBucketObjectsOp: virtual public DBOp {
           params.op.bucket.bucket_name,
           params.op.obj.min_marker,
           params.op.obj.prefix,
+          params.op.list_max_count);
+    }
+};
+
+#define MAX_VERSIONED_OBJECTS 20
+class ListVersionedObjectsOp: virtual public DBOp {
+  private:
+    // once we have stats also stored, may have to update this query to join
+    // these two tables.
+    static constexpr std::string_view Query =
+      "SELECT  \
+      ObjName, ObjInstance, ObjNS, BucketName, ACLs, IndexVer, Tag, \
+      Flags, VersionedEpoch, ObjCategory, Etag, Owner, OwnerDisplayName, \
+      StorageClass, Appendable, ContentType, IndexHashSource, ObjSize, \
+      AccountedSize, Mtime, Epoch, ObjTag, TailTag, WriteTag, FakeTag, \
+      ShadowObj, HasData, IsVersioned, VersionNum, PGVer, ZoneShortID, \
+      ObjVersion, ObjVersionTag, ObjAttrs, HeadSize, MaxHeadSize, \
+      ObjID, TailInstance, HeadPlacementRuleName, HeadPlacementRuleStorageClass, \
+      TailPlacementRuleName, TailPlacementStorageClass, \
+      ManifestPartObjs, ManifestPartRules, Omap, IsMultipart, MPPartsList, \
+      HeadData, Versions from '{}' \
+      where BucketName = {} and ObjName = {} ORDER BY VersionNum DESC LIMIT {}";
+  public:
+    virtual ~ListVersionedObjectsOp() {}
+
+    static std::string Schema(DBOpPrepareParams &params) {
+      /* XXX: Include obj_id, delim */
+      return fmt::format(Query,
+          params.object_table,
+          params.op.bucket.bucket_name,
+          params.op.obj.obj_name,
           params.op.list_max_count);
     }
 };
@@ -1118,13 +1157,13 @@ class UpdateObjectOp: virtual public DBOp {
        StorageClass = {}, Appendable = {}, ContentType = {}, \
        IndexHashSource = {}, ObjSize = {}, AccountedSize = {}, Mtime = {}, \
        Epoch = {}, ObjTag = {}, TailTag = {}, WriteTag = {}, FakeTag = {}, \
-       ShadowObj = {}, HasData = {}, IsOLH = {}, OLHTag = {}, PGVer = {}, \
+       ShadowObj = {}, HasData = {}, IsVersioned = {}, VersionNum = {}, PGVer = {}, \
        ZoneShortID = {}, ObjVersion = {}, ObjVersionTag = {}, ObjAttrs = {}, \
        HeadSize = {}, MaxHeadSize = {}, ObjID = {}, TailInstance = {}, \
        HeadPlacementRuleName = {}, HeadPlacementRuleStorageClass = {}, \
        TailPlacementRuleName = {}, TailPlacementStorageClass = {}, \
        ManifestPartObjs = {}, ManifestPartRules = {}, Omap = {}, \
-       IsMultipart = {}, MPPartsList = {}, HeadData = {} \
+       IsMultipart = {}, MPPartsList = {}, HeadData = {}, Versions = {} \
        WHERE ObjName = {} and ObjInstance = {} and BucketName = {}";
 
   public:
@@ -1167,7 +1206,7 @@ class UpdateObjectOp: virtual public DBOp {
           params.op.obj.accounted_size, params.op.obj.mtime,
           params.op.obj.epoch, params.op.obj.obj_tag, params.op.obj.tail_tag,
           params.op.obj.write_tag, params.op.obj.fake_tag, params.op.obj.shadow_obj,
-          params.op.obj.has_data, params.op.obj.is_olh, params.op.obj.olh_tag,
+          params.op.obj.has_data, params.op.obj.is_versioned, params.op.obj.version_num,
           params.op.obj.pg_ver, params.op.obj.zone_short_id,
           params.op.obj.obj_version, params.op.obj.obj_version_tag,
           params.op.obj.obj_attrs, params.op.obj.head_size,
@@ -1179,7 +1218,8 @@ class UpdateObjectOp: virtual public DBOp {
           params.op.obj.tail_placement_storage_class,
           params.op.obj.manifest_part_objs,
           params.op.obj.manifest_part_rules, params.op.obj.omap,
-          params.op.obj.is_multipart, params.op.obj.mp_parts, params.op.obj.head_data,
+          params.op.obj.is_multipart, params.op.obj.mp_parts,
+          params.op.obj.head_data, params.op.obj.versions,
           params.op.obj.obj_name, params.op.obj.obj_instance,
           params.op.bucket.bucket_name);
       }
@@ -1233,6 +1273,7 @@ class UpdateObjectDataOp: virtual public DBOp {
           params.op.obj.obj_id);
     }
 };
+
 class GetObjectDataOp: virtual public DBOp {
   private:
     static constexpr std::string_view Query =
@@ -1853,6 +1894,7 @@ class DB {
             bool assume_noent, bool modify_tail);
         int write_meta(const DoutPrefixProvider *dpp, uint64_t size,
 	    uint64_t accounted_size, std::map<std::string, bufferlist>& attrs);
+        int write_versioned_obj(const DoutPrefixProvider *dpp, DBOpParams& params);
       };
 
       struct Delete {
@@ -1887,19 +1929,19 @@ class DB {
         explicit Delete(DB::Object *_target) : target(_target) {}
 
         int delete_obj(const DoutPrefixProvider *dpp);
+        int delete_obj_impl(const DoutPrefixProvider *dpp, DBOpParams& del_params);
+        int delete_versioned_obj(const DoutPrefixProvider *dpp, DBOpParams& del_params);
       };
 
       /* XXX: the parameters may be subject to change. All we need is bucket name
        * & obj name,instance - keys */
+      int get_object_impl(const DoutPrefixProvider *dpp, DBOpParams& params);
       int get_obj_state(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
                         const rgw_obj& obj,
                         bool follow_olh, RGWObjState **state);
-      int get_olh_target_state(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
-          RGWObjState* olh_state, RGWObjState** target);
-      int follow_olh(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, RGWObjState *state,
-          const rgw_obj& olh_obj, rgw_obj *target);
-
       int get_state(const DoutPrefixProvider *dpp, RGWObjState **pstate, bool follow_olh);
+      int list_versioned_objects(const DoutPrefixProvider *dpp,
+                                 std::list<rgw_bucket_dir_entry>& list_entries);
 
       DB *get_store() { return store; }
       rgw_obj& get_obj() { return obj; }
@@ -1927,6 +1969,9 @@ class DB {
           const RGWBucketInfo& bucket_info, const rgw_obj& obj,
           off_t ofs, off_t end, uint64_t max_chunk_size,
           iterate_obj_cb cb, void *arg);
+      int update_obj_next_version(const DoutPrefixProvider *dpp,
+                                  rgw_bucket_dir_entry &obj_entry,
+                                  bool promote, uint64_t& version_num);
     };
     int get_obj_iterate_cb(const DoutPrefixProvider *dpp,
         const raw_obj& read_obj, off_t obj_ofs,

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.cc
@@ -42,7 +42,7 @@ using namespace std;
 
 #define SQL_BIND_TEXT(dpp, stmt, index, str, sdb)			\
   do {								\
-      rc = sqlite3_bind_text(stmt, index, str, -1, SQLITE_TRANSIENT); 	\
+    rc = sqlite3_bind_text(stmt, index, str, -1, SQLITE_TRANSIENT); 	\
     if (rc != SQLITE_OK) {					      	\
       ldpp_dout(dpp, 0)<<"sqlite bind text failed for index("     	\
       <<index<<"), str("<<str<<") in stmt("   	\
@@ -194,6 +194,9 @@ int SQLiteDB::InitPrepareParams(const DoutPrefixProvider *dpp,
     }
     if (params->object_view.empty()) {
       params->object_view = getObjectView(bucket);
+    }
+    if (params->object_trigger.empty()) {
+      params->object_trigger = getObjectTrigger(bucket);
     }
     p_params.object_table = params->object_table;
     p_params.objectdata_table = params->objectdata_table;
@@ -787,6 +790,22 @@ int SQLiteDB::createObjectTable(const DoutPrefixProvider *dpp, DBOpParams *param
     ldpp_dout(dpp, 0)<<"CreateObjectTable failed " << dendl;
 
   ldpp_dout(dpp, 20)<<"CreateObjectTable suceeded " << dendl;
+
+  return ret;
+}
+
+int SQLiteDB::createObjectTableTrigger(const DoutPrefixProvider *dpp, DBOpParams *params)
+{
+  int ret = -1;
+  string schema;
+
+  schema = CreateTableSchema("ObjectTrigger", params);
+
+  ret = exec(dpp, schema.c_str(), NULL);
+  if (ret)
+    ldpp_dout(dpp, 0)<<"CreateObjectTableTrigger failed " << dendl;
+
+  ldpp_dout(dpp, 20)<<"CreateObjectTableTrigger suceeded " << dendl;
 
   return ret;
 }
@@ -1428,6 +1447,7 @@ int SQLInsertBucket::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *p
 
   (void)createObjectTable(dpp, params);
   (void)createObjectDataTable(dpp, params);
+  (void)createObjectTableTrigger(dpp, params);
 out:
   return ret;
 }
@@ -1761,7 +1781,12 @@ int SQLPutObject::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
 {
   int index = -1;
   int rc = 0;
+  int VersionNum = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (params->op.obj.state.obj.key.instance.empty()) {
+    params->op.obj.state.obj.key.instance = "null";
+  }
 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.name.c_str(), sdb);
@@ -1848,7 +1873,7 @@ int SQLPutObject::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.is_versioned, sdb);
 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.version_num, sdb);
-  SQL_BIND_INT(dpp, stmt, index, params->op.obj.version_num, sdb);
+  SQL_BIND_INT(dpp, stmt, index, VersionNum, sdb);
 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.pg_ver, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.state.pg_ver, sdb);
@@ -1943,6 +1968,10 @@ int SQLDeleteObject::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *para
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
+  if (params->op.obj.state.obj.key.instance.empty()) {
+    params->op.obj.state.obj.key.instance = "null";
+  }
+
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
@@ -1986,6 +2015,10 @@ int SQLGetObject::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
   int index = -1;
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (params->op.obj.state.obj.key.instance.empty()) {
+    params->op.obj.state.obj.key.instance = "null";
+  }
 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
@@ -2061,6 +2094,10 @@ int SQLUpdateObject::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *para
     ldpp_dout(dpp, 0)<<"In SQLUpdateObject invalid query_str:" <<
       params->op.query_str << dendl;
     goto out;
+  }
+
+  if (params->op.obj.state.obj.key.instance.empty()) {
+    params->op.obj.state.obj.key.instance = "null";
   }
 
   SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.bucket.bucket_name, sdb);
@@ -2273,6 +2310,10 @@ int SQLListBucketObjects::Bind(const DoutPrefixProvider *dpp, struct DBOpParams 
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
+  if (params->op.obj.state.obj.key.instance.empty()) {
+    params->op.obj.state.obj.key.instance = "null";
+  }
+
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
@@ -2322,6 +2363,10 @@ int SQLListVersionedObjects::Bind(const DoutPrefixProvider *dpp, struct DBOpPara
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
+  if (params->op.obj.state.obj.key.instance.empty()) {
+    params->op.obj.state.obj.key.instance = "null";
+  }
+
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
@@ -2367,6 +2412,10 @@ int SQLPutObjectData::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *par
   int index = -1;
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (params->op.obj.state.obj.key.instance.empty()) {
+    params->op.obj.state.obj.key.instance = "null";
+  }
 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name, sdb);
 
@@ -2445,6 +2494,10 @@ int SQLUpdateObjectData::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
+  if (params->op.obj.state.obj.key.instance.empty()) {
+    params->op.obj.state.obj.key.instance = "null";
+  }
+
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.name.c_str(), sdb);
 
@@ -2496,6 +2549,10 @@ int SQLGetObjectData::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *par
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
 
+  if (params->op.obj.state.obj.key.instance.empty()) {
+    params->op.obj.state.obj.key.instance = "null";
+  }
+
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
 
@@ -2543,6 +2600,10 @@ int SQLDeleteObjectData::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *
   int index = -1;
   int rc = 0;
   struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (params->op.obj.state.obj.key.instance.empty()) {
+    params->op.obj.state.obj.key.instance = "null";
+  }
 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.cc
@@ -42,12 +42,7 @@ using namespace std;
 
 #define SQL_BIND_TEXT(dpp, stmt, index, str, sdb)			\
   do {								\
-    if (strcmp(str, "null") == 0) {          \
-      rc = sqlite3_bind_text(stmt, index, "", -1, SQLITE_TRANSIENT); 	\
-    } else {                                                       \
       rc = sqlite3_bind_text(stmt, index, str, -1, SQLITE_TRANSIENT); 	\
-    }                                   \
-    \
     if (rc != SQLITE_OK) {					      	\
       ldpp_dout(dpp, 0)<<"sqlite bind text failed for index("     	\
       <<index<<"), str("<<str<<") in stmt("   	\
@@ -309,8 +304,8 @@ enum GetObject {
   FakeTag,
   ShadowObj,
   HasData,
-  IsOLH,
-  OLHTag,
+  IsVersioned,
+  VersionNum,
   PGVer,
   ZoneShortID,
   ObjVersion,
@@ -329,7 +324,8 @@ enum GetObject {
   Omap,
   IsMultipart,
   MPPartsList,
-  HeadData
+  HeadData,
+  Versions
 };
 
 enum GetObjectData {
@@ -497,8 +493,8 @@ static int list_object(const DoutPrefixProvider *dpp, DBOpInfo &op, sqlite3_stmt
   op.obj.state.fake_tag = sqlite3_column_int(stmt, FakeTag);
   op.obj.state.shadow_obj = (const char*)sqlite3_column_text(stmt, ShadowObj);
   op.obj.state.has_data = sqlite3_column_int(stmt, HasData); 
-  op.obj.state.is_olh = sqlite3_column_int(stmt, IsOLH); 
-  SQL_DECODE_BLOB_PARAM(dpp, stmt, OLHTag, op.obj.state.olh_tag, sdb);
+  op.obj.is_versioned = sqlite3_column_int(stmt, IsVersioned); 
+  op.obj.version_num = sqlite3_column_int(stmt, VersionNum); 
   op.obj.state.pg_ver = sqlite3_column_int(stmt, PGVer); 
   op.obj.state.zone_short_id = sqlite3_column_int(stmt, ZoneShortID); 
   op.obj.state.objv_tracker.read_version.ver = sqlite3_column_int(stmt, ObjVersion); 
@@ -1046,6 +1042,7 @@ int SQLObjectOp::InitializeObjectOps(string db_name, const DoutPrefixProvider *d
   GetObject = make_shared<SQLGetObject>(sdb, db_name, cct);
   UpdateObject = make_shared<SQLUpdateObject>(sdb, db_name, cct);
   ListBucketObjects = make_shared<SQLListBucketObjects>(sdb, db_name, cct);
+  ListVersionedObjects = make_shared<SQLListVersionedObjects>(sdb, db_name, cct);
   PutObjectData = make_shared<SQLPutObjectData>(sdb, db_name, cct);
   UpdateObjectData = make_shared<SQLUpdateObjectData>(sdb, db_name, cct);
   GetObjectData = make_shared<SQLGetObjectData>(sdb, db_name, cct);
@@ -1270,14 +1267,8 @@ int SQLGetUser::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
       SQL_BIND_TEXT(dpp, ak_stmt, index, access_key.c_str(), sdb);
     }
   } else if (params->op.query_str == "user_id") { 
-    SQL_BIND_INDEX(dpp, userid_stmt, index, p_params.op.user.tenant, sdb);
-    SQL_BIND_TEXT(dpp, userid_stmt, index, params->op.user.uinfo.user_id.tenant.c_str(), sdb);
-
     SQL_BIND_INDEX(dpp, userid_stmt, index, p_params.op.user.user_id, sdb);
     SQL_BIND_TEXT(dpp, userid_stmt, index, params->op.user.uinfo.user_id.id.c_str(), sdb);
-
-    SQL_BIND_INDEX(dpp, userid_stmt, index, p_params.op.user.ns, sdb);
-    SQL_BIND_TEXT(dpp, userid_stmt, index, params->op.user.uinfo.user_id.ns.c_str(), sdb);
   } else { // by default by userid
     SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.user_id, sdb);
     SQL_BIND_TEXT(dpp, stmt, index, params->op.user.uinfo.user_id.id.c_str(), sdb);
@@ -1853,11 +1844,11 @@ int SQLPutObject::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.has_data, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.state.has_data, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.is_olh, sdb);
-  SQL_BIND_INT(dpp, stmt, index, params->op.obj.state.is_olh, sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.is_versioned, sdb);
+  SQL_BIND_INT(dpp, stmt, index, params->op.obj.is_versioned, sdb);
 
-  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.olh_tag, sdb);
-  SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.state.olh_tag, sdb);
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.version_num, sdb);
+  SQL_BIND_INT(dpp, stmt, index, params->op.obj.version_num, sdb);
 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.pg_ver, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.obj.state.pg_ver, sdb);
@@ -1915,7 +1906,6 @@ int SQLPutObject::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.head_data, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.obj.head_data, sdb);
-
 
 out:
   return rc;
@@ -2167,11 +2157,11 @@ int SQLUpdateObject::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *para
     SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.has_data, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.state.has_data, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.is_olh, sdb);
-    SQL_BIND_INT(dpp, *stmt, index, params->op.obj.state.is_olh, sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.is_versioned, sdb);
+    SQL_BIND_INT(dpp, *stmt, index, params->op.obj.is_versioned, sdb);
 
-    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.olh_tag, sdb);
-    SQL_ENCODE_BLOB_PARAM(dpp, *stmt, index, params->op.obj.state.olh_tag, sdb);
+    SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.version_num, sdb);
+    SQL_BIND_INT(dpp, *stmt, index, params->op.obj.version_num, sdb);
 
     SQL_BIND_INDEX(dpp, *stmt, index, p_params.op.obj.pg_ver, sdb);
     SQL_BIND_INT(dpp, *stmt, index, params->op.obj.state.pg_ver, sdb);
@@ -2300,6 +2290,52 @@ out:
 }
 
 int SQLListBucketObjects::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+
+  SQL_EXECUTE(dpp, params, stmt, list_object);
+out:
+  return ret;
+}
+
+int SQLListVersionedObjects::Prepare(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int ret = -1;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  if (!*sdb) {
+    ldpp_dout(dpp, 0)<<"In SQLListVersionedObjects - no db" << dendl;
+    goto out;
+  }
+
+  InitPrepareParams(dpp, p_params, params);
+
+  SQL_PREPARE(dpp, p_params, sdb, stmt, ret, "PrepareListVersionedObjects");
+
+out:
+  return ret;
+}
+
+int SQLListVersionedObjects::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params)
+{
+  int index = -1;
+  int rc = 0;
+  struct DBOpPrepareParams p_params = PrepareParams;
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.bucket.bucket_name, sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.bucket.info.bucket.name.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.obj_name, sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.state.obj.key.name.c_str(), sdb);
+
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.list_max_count, sdb);
+  SQL_BIND_INT(dpp, stmt, index, params->op.list_max_count, sdb);
+
+out:
+  return rc;
+}
+
+int SQLListVersionedObjects::Execute(const DoutPrefixProvider *dpp, struct DBOpParams *params)
 {
   int ret = -1;
 

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.h
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.h
@@ -51,6 +51,7 @@ class SQLiteDB : public DB, virtual public DBOp {
     int createObjectTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int createObjectDataTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     int createObjectView(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int createObjectTableTrigger(const DoutPrefixProvider *dpp, DBOpParams *params);
     int createQuotaTable(const DoutPrefixProvider *dpp, DBOpParams *params);
     void populate_object_params(const DoutPrefixProvider *dpp,
                                 struct DBOpPrepareParams& p_params,

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.h
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.h
@@ -327,6 +327,24 @@ class SQLListBucketObjects : public SQLiteDB, public ListBucketObjectsOp {
     int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
 };
 
+class SQLListVersionedObjects : public SQLiteDB, public ListVersionedObjectsOp {
+  private:
+    sqlite3 **sdb = NULL;
+    sqlite3_stmt *stmt = NULL; // Prepared statement
+
+  public:
+    SQLListVersionedObjects(void **db, std::string db_name, CephContext *cct) : SQLiteDB((sqlite3 *)(*db), db_name, cct), sdb((sqlite3 **)db) {}
+    SQLListVersionedObjects(sqlite3 **sdbi, std::string db_name, CephContext *cct) : SQLiteDB(*sdbi, db_name, cct), sdb(sdbi) {}
+
+    ~SQLListVersionedObjects() {
+      if (stmt)
+        sqlite3_finalize(stmt);
+    }
+    int Prepare(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Execute(const DoutPrefixProvider *dpp, DBOpParams *params);
+    int Bind(const DoutPrefixProvider *dpp, DBOpParams *params);
+};
+
 class SQLPutObjectData : public SQLiteDB, public PutObjectDataOp {
   private:
     sqlite3 **sdb = NULL;

--- a/src/rgw/store/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/store/dbstore/tests/dbstore_tests.cc
@@ -895,6 +895,209 @@ TEST_F(DBStoreTest, DeleteObj) {
   ASSERT_EQ(ret, -2);
 }
 
+TEST_F(DBStoreTest, WriteVersionedObject) {
+  struct DBOpParams params = GlobalParams;
+  int ret = -1;
+  std::string instances[] = {"inst1", "inst2", "inst3"};
+  bufferlist b1;
+
+  params.op.obj.flags |= rgw_bucket_dir_entry::FLAG_CURRENT;
+  params.op.obj.state.obj.key.name = "object1";
+
+  /* Write versioned objects */
+  DB::Object op_target(db, params.op.bucket.info, params.op.obj.state.obj);
+  DB::Object::Write write_op(&op_target);
+
+  /* Version1 */
+  params.op.obj.state.obj.key.instance = instances[0];
+  encode("HELLO WORLD", b1);
+  params.op.obj.head_data = b1;
+  params.op.obj.state.size = 12;
+  ret = write_op.write_versioned_obj(dpp, params);
+  ASSERT_EQ(ret, 0);
+
+  /* Version2 */
+  params.op.obj.state.obj.key.instance = instances[1];
+  b1.clear();
+  encode("HELLO WORLD ABC", b1);
+  params.op.obj.head_data = b1;
+  params.op.obj.state.size = 16;
+  ret = write_op.write_versioned_obj(dpp, params);
+  ASSERT_EQ(ret, 0);
+
+  /* Version3 */
+  params.op.obj.state.obj.key.instance = instances[2];
+  b1.clear();
+  encode("HELLO WORLD A", b1);
+  params.op.obj.head_data = b1;
+  params.op.obj.state.size = 14;
+  ret = write_op.write_versioned_obj(dpp, params);
+  ASSERT_EQ(ret, 0);
+}
+
+TEST_F(DBStoreTest, ListVersionedObject) {
+  struct DBOpParams params = GlobalParams;
+  int ret = -1;
+  std::string instances[] = {"inst1", "inst2", "inst3"};
+  int i = 0;
+
+  /* list versioned objects */
+  params.op.obj.state.obj.key.instance.clear();
+  params.op.list_max_count = MAX_VERSIONED_OBJECTS;
+  ret = db->ProcessOp(dpp, "ListVersionedObjects", &params);
+  ASSERT_EQ(ret, 0);
+
+  i = 2;
+  for (auto ent: params.op.obj.list_entries) {
+    string is_current = (ent.flags & rgw_bucket_dir_entry::FLAG_CURRENT)? "true" : "false";
+    cout << "ent.name: " << ent.key.name << ". ent.instance: " << ent.key.instance << " is:current = " << is_current << "\n";
+
+    if (i == 2) {
+      ASSERT_EQ(is_current, "true");
+    } else {
+      ASSERT_EQ(is_current, "false");
+    }
+
+    ASSERT_EQ(ent.key.instance, instances[i]);
+    i--;
+  }
+}
+
+TEST_F(DBStoreTest, ReadVersionedObject) {
+  struct DBOpParams params = GlobalParams;
+  int ret = -1;
+  std::string instances[] = {"inst1", "inst2", "inst3"};
+  std::string data;
+
+  /* read object.. should fetch latest version */
+  RGWObjState* s;
+  params = GlobalParams;
+  params.op.obj.state.obj.key.instance.clear();
+  DB::Object op_target2(db, params.op.bucket.info, params.op.obj.state.obj);
+  ret = op_target2.get_obj_state(dpp, params.op.bucket.info, params.op.obj.state.obj,
+                                 true, &s);
+  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(s->obj.key.instance, instances[2]);
+  decode(data, s->data);
+  ASSERT_EQ(data, "HELLO WORLD A");
+  ASSERT_EQ(s->size, 14);
+
+  /* read a particular non-current version */
+  params.op.obj.state.obj.key.instance = instances[1];
+  DB::Object op_target3(db, params.op.bucket.info, params.op.obj.state.obj);
+  ret = op_target3.get_obj_state(dpp, params.op.bucket.info, params.op.obj.state.obj,
+                                 true, &s);
+  ASSERT_EQ(ret, 0);
+  decode(data, s->data);
+  ASSERT_EQ(data, "HELLO WORLD ABC");
+  ASSERT_EQ(s->size, 16);
+}
+
+TEST_F(DBStoreTest, DeleteVersionedObject) {
+  struct DBOpParams params = GlobalParams;
+  int ret = -1;
+  std::string instances[] = {"inst1", "inst2", "inst3"};
+  std::string data;
+  std::string dm_instance;
+  int i = 0;
+
+  /* Delete object..should create delete marker */
+  params.op.obj.state.obj.key.instance.clear();
+  DB::Object op_target(db, params.op.bucket.info, params.op.obj.state.obj);
+  DB::Object::Delete delete_op(&op_target);
+  delete_op.params.versioning_status |= BUCKET_VERSIONED;
+
+  ret = delete_op.delete_obj(dpp);
+  ASSERT_EQ(ret, 0);
+
+  /* list versioned objects */
+  params = GlobalParams;
+  params.op.obj.state.obj.key.instance.clear();
+  params.op.list_max_count = MAX_VERSIONED_OBJECTS;
+  ret = db->ProcessOp(dpp, "ListVersionedObjects", &params);
+
+  i = 3;
+  for (auto ent: params.op.obj.list_entries) {
+    string is_current = (ent.flags & rgw_bucket_dir_entry::FLAG_CURRENT)? "true" : "false";
+    string is_delete_marker = (ent.flags & rgw_bucket_dir_entry::FLAG_DELETE_MARKER)? "true" : "false";
+    cout << "ent.name: " << ent.key.name << ". ent.instance: " << ent.key.instance << " is_delete_marker = " << is_delete_marker << "\n";
+
+    if (i == 3) {
+      ASSERT_EQ(is_delete_marker, "true");
+      ASSERT_EQ(is_current, "true");
+      dm_instance = ent.key.instance;
+    } else {
+      ASSERT_EQ(is_current, "false");
+      ASSERT_EQ(is_delete_marker, "false");
+      ASSERT_EQ(ent.key.instance, instances[i]);
+    }
+
+    i--;
+  }
+
+  /* read object.. should return -ENOENT */
+  RGWObjState* s;
+  params = GlobalParams;
+  params.op.obj.state.obj.key.instance.clear();
+  DB::Object op_target2(db, params.op.bucket.info, params.op.obj.state.obj);
+  ret = op_target2.get_obj_state(dpp, params.op.bucket.info, params.op.obj.state.obj,
+                                 true, &s);
+  ASSERT_EQ(ret, -ENOENT);
+
+  /* Delete delete marker..should be able to read object now */ 
+  params.op.obj.state.obj.key.instance = dm_instance;
+  DB::Object op_target3(db, params.op.bucket.info, params.op.obj.state.obj);
+  DB::Object::Delete delete_op2(&op_target3);
+  delete_op2.params.versioning_status |= BUCKET_VERSIONED;
+
+  ret = delete_op2.delete_obj(dpp);
+  ASSERT_EQ(ret, 0);
+
+  /* read object.. should fetch latest version */
+  params = GlobalParams;
+  params.op.obj.state.obj.key.instance.clear();
+  DB::Object op_target4(db, params.op.bucket.info, params.op.obj.state.obj);
+  ret = op_target4.get_obj_state(dpp, params.op.bucket.info, params.op.obj.state.obj,
+                                 true, &s);
+  ASSERT_EQ(s->obj.key.instance, instances[2]);
+  decode(data, s->data);
+  ASSERT_EQ(data, "HELLO WORLD A");
+  ASSERT_EQ(s->size, 14);
+
+  /* delete latest version using version-id. Next version should get promoted */
+  params.op.obj.state.obj.key.instance = instances[2];
+  DB::Object op_target5(db, params.op.bucket.info, params.op.obj.state.obj);
+  DB::Object::Delete delete_op3(&op_target5);
+  delete_op3.params.versioning_status |= BUCKET_VERSIONED;
+
+  ret = delete_op3.delete_obj(dpp);
+  ASSERT_EQ(ret, 0);
+
+  /* list versioned objects..only two versions should be present
+   * with second version marked as CURRENT */
+  params = GlobalParams;
+  params.op.obj.state.obj.key.instance.clear();
+  params.op.list_max_count = MAX_VERSIONED_OBJECTS;
+  ret = db->ProcessOp(dpp, "ListVersionedObjects", &params);
+
+  i = 1;
+  for (auto ent: params.op.obj.list_entries) {
+    string is_current = (ent.flags & rgw_bucket_dir_entry::FLAG_CURRENT)? "true" : "false";
+    cout << "ent.name: " << ent.key.name << ". ent.instance: " << ent.key.instance << " is_current = " << is_current << "\n";
+
+    if (i == 1) {
+      ASSERT_EQ(is_current, "true");
+      dm_instance = ent.key.instance;
+    } else {
+      ASSERT_EQ(is_current, "false");
+      ASSERT_EQ(ent.key.instance, instances[i]);
+    }
+
+    i--;
+  }
+
+}
+
 TEST_F(DBStoreTest, ObjectOmapSetVal) {
   struct DBOpParams params = GlobalParams;
   int ret = -1;


### PR DESCRIPTION
This commit adds support for Object versioning feature in DBStore

In DBStore, each object is uniquely identified by <objectName, objectNS, instance-id>
In addition, for each object upload, a unique objectID is created to handle racing writes.
Note: For non-versioned objects, both head and tail entries have instance-id empty which is mapped to "null" before storing in sqlite table. 

Versioned objects:
 - same as non-versioned objects but with instance-id & objectID set to version-id i.e,
   each version upload will have a unique versionID created which will act as that object's intanceID and objectID as well.
 - In addition a version-number is stored (starting with '1' & incremented atomically) for each version/delete-marker being created for that object.
   This version-number is used to identify the CURRENT version.
 

**PutObject:**
 - Same as regular object write but with below addition.
 - If non-null versionID provided, mark the object with flag 'rgw_bucket_dir_entry::FLAG_VER' .

 
**DeleteObject:**
 a) if no versionID specified,
 
    - if there is entry with versionID "null": 
        - case:  bucket_versioned:
               - create_delete_marker;
        - case: bucket_suspended:
               - delete entry (as we found an entry with "null" versionID)
               - create delete marker with version-id null;
        - default:
               - delete entry
               
     - else fetch list of versioned objects & read top entry
         - case LIST_EMPTY:
              - return ENOENT
         - case TOP entry is DELETE_MARKER:
              - nothing to do; return
         - case:  bucket_versioned:
              - create_delete_marker;
          - case: bucket_suspended:
              - delete entry (as we found an entry with "null" versionID)
              - create delete marker with version-id null;
 

Current status:
- Basic functionality seem to be working when the bucket is versioned.
- If an object is removed, only one delete-marker is created for now. Subsequent deletes will be no-op (unless the object is re-created & deleted with the same name)
- Test cases added to verify Versioned objects.
- List of s3-tests which pass have been updated - https://github.com/ceph/s3-tests/pull/458/files


Signed-off-by: Soumya Koduri <skoduri@redhat.com>


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
