### PR TITLE
quincy: tests: ceph_test_rados_api_watch_notify: watch2Delete reconnect

### DIFF
--- a/src/test/librados/watch_notify.cc
+++ b/src/test/librados/watch_notify.cc
@@ -162,7 +162,10 @@ TEST_F(LibRadosWatchNotify, Watch2Delete) {
   }
   ASSERT_TRUE(left > 0);
   ASSERT_EQ(-ENOTCONN, notify_err);
-  ASSERT_EQ(-ENOTCONN, rados_watch_check(ioctx, handle));
+  int rados_watch_check_err = rados_watch_check(ioctx, handle);
+  // We may hit ENOENT due to socket failure and a forced reconnect
+  EXPECT_TRUE(rados_watch_check_err == -ENOTCONN || rados_watch_check_err == -ENOENT)
+    << "Where rados_watch_check_err = " << rados_watch_check_err;
   rados_unwatch2(ioctx, handle);
   rados_watch_flush(cluster);
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55021

---

backport of https://github.com/ceph/ceph/pull/45366
parent tracker: https://tracker.ceph.com/issues/51307

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh