### PR TITLE
pacific: mgr/dashboard: Language dropdown box is partly hidden on login page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/language-selector/language-selector.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/language-selector/language-selector.component.html
@@ -1,4 +1,5 @@
 <div ngbDropdown
+     display="dynamic"
      placement="bottom-right">
   <a ngbDropdownToggle
      i18n-title


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55006

---

backport of https://github.com/ceph/ceph/pull/45429
parent tracker: https://tracker.ceph.com/issues/54591

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh