### PR TITLE
mgr/rbd_support: add messages to mirror schedule remove on error

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -1329,6 +1329,10 @@ test_mirror_snapshot_schedule() {
     expect_fail rbd mirror snapshot schedule remove -p rbd2/ns1 --image test1 dummy
     test "$(rbd mirror snapshot schedule ls)" = 'every 1h starting at 00:15:00'
     test "$(rbd mirror snapshot schedule ls -p rbd2/ns1 --image test1)" = 'every 1m'
+    test "$(rbd mirror snapshot schedule remove -p rbd2/ns1 --image test1 7h)" = 'Interval does not exist(7h)'
+    rbd mirror snapshot schedule remove -p rbd2/ns1 --image test1 1m
+    test "$(rbd mirror snapshot schedule remove -p rbd2/ns1 --image test1 7h)" = 'Schedule does not exist'
+    test "$(rbd mirror snapshot schedule remove -p rbd2/ns1 --image test1)" = 'Schedule does not exist'
 
     rbd rm rbd2/ns1/test1
 

--- a/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
+++ b/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
@@ -700,12 +700,13 @@ class MirrorSnapshotScheduleHandler:
             "remove_schedule: level_spec={}, interval={}, start_time={}".format(
                 level_spec.name, interval, start_time))
 
+        response = ""
         with self.lock:
-            self.schedules.remove(level_spec, interval, start_time)
+            response = self.schedules.remove(level_spec, interval, start_time)
 
         # TODO: optimize to rebuild only affected part of the queue
         self.rebuild_queue()
-        return 0, "", ""
+        return 0, response, ""
 
     def list(self, level_spec: LevelSpec) -> Tuple[int, str, str]:
         self.log.debug("list: level_spec={}".format(level_spec.name))

--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -318,7 +318,11 @@ class Schedule:
     def remove(self,
                interval: Interval,
                start_time: Optional[StartTime] = None) -> None:
-        self.items.discard((interval, start_time))
+        if (interval, start_time) in self.items:
+            self.items.remove((interval, start_time))
+        else:
+            return "Interval does not exist({})".format(interval.to_string())
+        return ""
 
     def next_run(self, now: datetime.datetime) -> str:
         schedule_time = None
@@ -509,19 +513,23 @@ class Schedules:
                interval: Optional[str],
                start_time: Optional[str]) -> None:
         schedule = self.schedules.pop(level_spec.id, None)
+        response = ""
         if schedule:
             if interval is None:
                 schedule = None
             else:
                 try:
-                    schedule.remove(Interval.from_string(interval),
+                    response = schedule.remove(Interval.from_string(interval),
                                     StartTime.from_string(start_time))
                 finally:
                     if schedule:
                         self.schedules[level_spec.id] = schedule
             if not schedule:
                 del self.level_specs[level_spec.id]
+        else:
+            return "Schedule does not exist"
         self.save(level_spec, schedule)
+        return response
 
     def find(self,
              pool_id: str,


### PR DESCRIPTION
Add failure messages to mirror schedule remove and add test coverage.

Fixes: https://tracker.ceph.com/issues/54999
Signed-off-by: Christopher Hoffman <choffman@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
