### PR TITLE
osd: add perf counter to record osd slow ops

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4374,10 +4374,13 @@ void PrimaryLogPG::log_op_stats(const OpRequest& op,
   auto m = op.get_req<MOSDOp>();
   const utime_t now = ceph_clock_now();
 
-  const utime_t latency = now - m->get_recv_stamp();
+  const utime_t latency = now - op.get_initiated();
   const utime_t process_latency = now - op.get_dequeued_time();
 
   osd->logger->inc(l_osd_op);
+  if (latency >= g_conf()->osd_op_complaint_time) {
+    osd->logger->inc(l_osd_op_slow);
+  }
 
   osd->logger->inc(l_osd_op_outb, outb);
   osd->logger->inc(l_osd_op_inb, inb);

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -38,6 +38,10 @@ PerfCounters *build_osd_logger(CephContext *cct) {
     "Client operations",
     "ops", PerfCountersBuilder::PRIO_CRITICAL);
   osd_plb.add_u64_counter(
+    l_osd_op_slow,  "slow_op",
+    "Client operations which are considered slow",
+    "sl", PerfCountersBuilder::PRIO_INTERESTING);
+  osd_plb.add_u64_counter(
     l_osd_op_inb,   "op_in_bytes",
     "Client operations total write size",
     "wr", PerfCountersBuilder::PRIO_INTERESTING, unit_t(UNIT_BYTES));

--- a/src/osd/osd_perf_counters.h
+++ b/src/osd/osd_perf_counters.h
@@ -10,6 +10,7 @@ enum {
   l_osd_first = 10000,
   l_osd_op_wip,
   l_osd_op,
+  l_osd_op_slow,
   l_osd_op_inb,
   l_osd_op_outb,
   l_osd_op_lat,


### PR DESCRIPTION
Use a seperate slow op counter to record total slow ops.

Signed-off-by: haoyixing <haoyixing@kuaishou.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
