### PR TITLE
quincy: Doc: Improve mclock config reference documentation & update PendingReleaseNotes.

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -60,7 +60,10 @@
 * OSD: Ceph now uses mclock_scheduler for bluestore OSDs as its default osd_op_queue
   to provide QoS. The 'mclock_scheduler' is not supported for filestore OSDs.
   Therefore, the default 'osd_op_queue' is set to 'wpq' for filestore OSDs
-  and is enforced even if the user attempts to change it.
+  and is enforced even if the user attempts to change it. For more details on
+  configuring mclock see,
+
+  https://docs.ceph.com/en/latest/rados/configuration/mclock-config-ref/
 
 * CephFS: Failure to replay the journal by a standby-replay daemon will now
   cause the rank to be marked damaged.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55069

---

backport of https://github.com/ceph/ceph/pull/45522
parent tracker: https://tracker.ceph.com/issues/54619

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh