### PR TITLE
client: windows warnings fix

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7971,10 +7971,10 @@ int Client::_setattr(InodeRef &in, struct stat *attr, int mask,
   stat_to_statx(attr, &stx);
   mask &= ~CEPH_SETATTR_BTIME;
 
-  if ((mask & CEPH_SETATTR_UID) && attr->st_uid == (short)static_cast<uid_t>(-1)) {
+  if ((mask & CEPH_SETATTR_UID) && attr.st_uid == static_cast<uid_t>(-1)) {
     mask &= ~CEPH_SETATTR_UID;
   }
-  if ((mask & CEPH_SETATTR_GID) && attr->st_gid == (short)static_cast<uid_t>(-1)) {
+  if ((mask & CEPH_SETATTR_GID) && attr.st_gid == static_cast<gid_t>(-1)) {
     mask &= ~CEPH_SETATTR_GID;
   }
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7971,10 +7971,10 @@ int Client::_setattr(InodeRef &in, struct stat *attr, int mask,
   stat_to_statx(attr, &stx);
   mask &= ~CEPH_SETATTR_BTIME;
 
-  if ((mask & CEPH_SETATTR_UID) && attr->st_uid == static_cast<uid_t>(-1)) {
+  if ((mask & CEPH_SETATTR_UID) && attr->st_uid == (short)static_cast<uid_t>(-1)) {
     mask &= ~CEPH_SETATTR_UID;
   }
-  if ((mask & CEPH_SETATTR_GID) && attr->st_gid == static_cast<uid_t>(-1)) {
+  if ((mask & CEPH_SETATTR_GID) && attr->st_gid == (short)static_cast<uid_t>(-1)) {
     mask &= ~CEPH_SETATTR_GID;
   }
 


### PR DESCRIPTION
fix type conversion when comparing short int with unsigned int for windows

Fixes: https://tracker.ceph.com/issues/52754
Signed-off-by: Yuanming Chai <ychai@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
