### PR TITLE
ceph-volume: fix closing dmcrypts on deactivate

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/deactivate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/deactivate.py
@@ -28,8 +28,8 @@ def deactivate_osd(osd_id=None, osd_uuid=None):
 
     for lv in lvs:
         if lv.tags.get('ceph.encrypted', '0') == '1':
-            encryption.dmcrypt_close(lv.lv_uuid)
-
+            dmcrypt_path = "/dev/mapper/{}".format(lv.lv_uuid)
+            encryption.dmcrypt_close(dmcrypt_path)
 
 class Deactivate(object):
 


### PR DESCRIPTION
When deactivating an encrypted osd with `ceph-volume lvm deactivate ${OSD_ID} ${OSD_FSID}` the dmcrypts are not getting closed.

The `dmcrypt_close` function expected a full device path and at the moment we pass a lv uuid into it which just returns without closing the crypts when the os path is checked.
This patch adds the full path and passes it to `dmcrypt_close`.