### PR TITLE
ceph-fuse: add option to map local user/group IDs to remote IDs

### DIFF
--- a/doc/cephfs/mount-using-fuse.rst
+++ b/doc/cephfs/mount-using-fuse.rst
@@ -55,6 +55,16 @@ If you have more than one FS on your Ceph cluster, use the option
 
 You may also add a ``client_fs`` setting to your ``ceph.conf``
 
+You may specify a mapping between the local user's UID (or GID) and the remote
+server's UID (or GID) by using::
+
+    ceph-fuse --id foo --uid-mapping uid_map_file_name --gid-mapping gid_map_file_name
+
+Both files referred to by ``uid_map_file_name`` and ``gid_map_file_name`` have the following structure::
+
+    local_id_1:remote_id_1
+    local_id_2:remote_id_2
+
 Unmounting CephFS
 =================
 

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -327,7 +327,7 @@ static void fuse_ll_lookup(fuse_req_t req, fuse_ino_t parent, const char *name)
   struct fuse_entry_param fe;
   Inode *i2, *i1 = cfuse->iget(parent); // see below
   int r;
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   get_fuse_groups(perms, req);
 
   if (!i1)
@@ -376,7 +376,7 @@ static void fuse_ll_getattr(fuse_req_t req, fuse_ino_t ino,
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
   struct stat stbuf;
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *in = cfuse->iget(ino);
   if (!in) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -403,7 +403,7 @@ static void fuse_ll_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
 {
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *in = cfuse->iget(ino);
   if (!in) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -424,6 +424,7 @@ static void fuse_ll_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
   if (to_set & FUSE_SET_ATTR_ATIME_NOW) mask |= CEPH_SETATTR_ATIME_NOW;
 #endif
 
+  cfuse->client->convert_attr_to_remote(attr);
   int r = cfuse->client->ll_setattr(in, attr, mask, perms);
   if (r == 0)
     fuse_reply_attr(req, attr, 0);
@@ -445,7 +446,7 @@ static void fuse_ll_setxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
 {
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *in = cfuse->iget(ino);
   if (!in) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -465,7 +466,7 @@ static void fuse_ll_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size)
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
   char buf[size];
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *in = cfuse->iget(ino);
   if (!in) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -495,7 +496,7 @@ static void fuse_ll_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
   char buf[size];
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *in = cfuse->iget(ino);
   if (!in) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -520,7 +521,7 @@ static void fuse_ll_removexattr(fuse_req_t req, fuse_ino_t ino,
 {
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *in = cfuse->iget(ino);
   if (!in) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -540,7 +541,7 @@ static void fuse_ll_opendir(fuse_req_t req, fuse_ino_t ino,
 {
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   void *dirp;
   Inode *in = cfuse->iget(ino);
   if (!in) {
@@ -567,7 +568,7 @@ static void fuse_ll_readlink(fuse_req_t req, fuse_ino_t ino)
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
   char buf[PATH_MAX + 1];  // leave room for a null terminator
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *in = cfuse->iget(ino);
   if (!in) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -592,7 +593,7 @@ static void fuse_ll_mknod(fuse_req_t req, fuse_ino_t parent, const char *name,
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
   struct fuse_entry_param fe;
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *i2, *i1 = cfuse->iget(parent);
   if (!i1) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -627,7 +628,7 @@ static void fuse_ll_mkdir(fuse_req_t req, fuse_ino_t parent, const char *name,
   struct fuse_entry_param fe;
 
   memset(&fe, 0, sizeof(fe));
-  UserPerm perm(ctx->uid, ctx->gid);
+  UserPerm perm = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   get_fuse_groups(perm, req);
 #ifdef HAVE_SYS_SYNCFS
   auto fuse_multithreaded = cfuse->client->cct->_conf.get_val<bool>(
@@ -681,7 +682,7 @@ static void fuse_ll_unlink(fuse_req_t req, fuse_ino_t parent, const char *name)
 {
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
-  UserPerm perm(ctx->uid, ctx->gid);
+  UserPerm perm = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *in = cfuse->iget(parent);
   if (!in) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -700,7 +701,7 @@ static void fuse_ll_rmdir(fuse_req_t req, fuse_ino_t parent, const char *name)
 {
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *in = cfuse->iget(parent);
   if (!in) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -721,7 +722,7 @@ static void fuse_ll_symlink(fuse_req_t req, const char *existing,
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
   struct fuse_entry_param fe;
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *i2, *i1 = cfuse->iget(parent);
   if (!i1) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -755,7 +756,7 @@ static void fuse_ll_rename(fuse_req_t req, fuse_ino_t parent, const char *name,
 {
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
-  UserPerm perm(ctx->uid, ctx->gid);
+  UserPerm perm = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *in = cfuse->iget(parent);
   Inode *nin = cfuse->iget(newparent);
   if (!in || !nin) {
@@ -786,7 +787,7 @@ static void fuse_ll_link(fuse_req_t req, fuse_ino_t ino, fuse_ino_t newparent,
   }
 
   memset(&fe, 0, sizeof(fe));
-  UserPerm perm(ctx->uid, ctx->gid);
+  UserPerm perm = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   get_fuse_groups(perm, req);
 
   /*
@@ -824,7 +825,7 @@ static void fuse_ll_open(fuse_req_t req, fuse_ino_t ino,
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
   Fh *fh = NULL;
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *in = cfuse->iget(ino);
   if (!in) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -1061,7 +1062,7 @@ static void fuse_ll_access(fuse_req_t req, fuse_ino_t ino, int mask)
 {
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *in = cfuse->iget(ino);
   if (!in) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -1082,7 +1083,7 @@ static void fuse_ll_create(fuse_req_t req, fuse_ino_t parent, const char *name,
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
   struct fuse_entry_param fe;
   Fh *fh = NULL;
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *i1 = cfuse->iget(parent), *i2;
   if (!i1) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
@@ -1122,7 +1123,7 @@ static void fuse_ll_statfs(fuse_req_t req, fuse_ino_t ino)
   struct statvfs stbuf;
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
-  UserPerm perms(ctx->uid, ctx->gid);
+  UserPerm perms = cfuse->client->convert_perms_to_remote(UserPerm(ctx->uid, ctx->gid));
   Inode *in = cfuse->iget(ino);
   if (!in) {
     fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));


### PR DESCRIPTION
I've added a feature to the ceph-fuse binary that allows users to specify a mapping between local IDs and IDs on the remote server. This is useful when a user wants to mount a CEPH filesystem on their local machine, where their UID is e.g. `1000`, but has UID e.g. `1234` on the remote server.

This change translates IDs both ways, so the remote `1234` is translated to `1000` on local machine and local `1000` is translated to `1234` on the remote machine.

I tried to have as much of this functionality as possible inside `Client.cc`, however I'm not familiar enough with the code base to achieve this completely. Therefore translation of `perms` is handled in `fuse_ll.cc`. Someone more familiar with the code base might be able to move this functionality to `Client.cc` and make it completely independent of fuse, so if someone were wiling to do this I would very much welcome it :)

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
