### PR TITLE
quincy: mgr/snap_schedule: restart old schedules

### DIFF
--- a/qa/tasks/cephfs/test_snap_schedules.py
+++ b/qa/tasks/cephfs/test_snap_schedules.py
@@ -355,20 +355,30 @@ class TestSnapSchedules(CephFSTestCase):
 
         self.mount_a.run_shell(['rmdir', TestSnapSchedules.TEST_DIRECTORY])
 
-    def verify_snap_stats(self, dir_path):
+    def get_snap_stats(self, dir_path):
         snap_path = f"{dir_path}/.snap"[1:]
         snapshots = self.mount_a.ls(path=snap_path)
         fs_count = len(snapshots)
-        log.debug('snapshots: {snapshots}');
+        log.debug(f'snapshots: {snapshots}');
 
-        result = self.fs_snap_schedule_cmd('status', path=dir_path, snap_schedule='1M', format='json')
+        result = self.fs_snap_schedule_cmd('status', path=dir_path,
+                                           snap_schedule='1M', format='json')
         json_res = json.loads(result)[0]
         db_count = int(json_res['created_count'])
         log.debug(f'json_res: {json_res}')
 
-        self.assertTrue(fs_count == db_count)
+        snap_stats = dict()
+        snap_stats['fs_count'] = fs_count
+        snap_stats['db_count'] = db_count
+
+        return snap_stats
+
+    def verify_snap_stats(self, dir_path):
+        snap_stats = self.get_snap_stats(dir_path)
+        self.assertTrue(snap_stats['fs_count'] == snap_stats['db_count'])
 
     def test_concurrent_snap_creates(self):
+        """Test concurrent snap creates in same file-system without db issues"""
         """
         Test snap creates at same cadence on same fs to verify correct stats.
         A single SQLite DB Connection handle cannot be used to run concurrent
@@ -407,3 +417,40 @@ class TestSnapSchedules(CephFSTestCase):
             self.fs_snap_schedule_cmd('remove', path=d, snap_schedule='1M')
             self.remove_snapshots(d[1:])
             self.mount_a.run_shell(['rmdir', d[1:]])
+
+    def test_snap_schedule_with_mgr_restart(self):
+        """Test that snap schedule is resumed after mgr restart"""
+        self.mount_a.run_shell(['mkdir', '-p', TestSnapSchedules.TEST_DIRECTORY])
+        testdir = os.path.join("/", TestSnapSchedules.TEST_DIRECTORY, "test_restart")
+        self.mount_a.run_shell(['mkdir', '-p', testdir[1:]])
+        self.fs_snap_schedule_cmd('add', path=testdir, snap_schedule='1M')
+
+        exec_time = time.time()
+        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+
+        self.fs_snap_schedule_cmd('activate', path=testdir, snap_schedule='1M')
+
+        # we wait for 10 snaps to be taken
+        wait_time = timo_1 + 10 * 60 + 15
+        time.sleep(wait_time)
+
+        old_stats = self.get_snap_stats(testdir)
+        self.assertTrue(old_stats['fs_count'] == old_stats['db_count'])
+        self.assertTrue(old_stats['fs_count'] > 9)
+
+        # restart mgr
+        active_mgr = self.mgr_cluster.mon_manager.get_mgr_dump()['active_name']
+        log.debug(f'restarting active mgr: {active_mgr}')
+        self.mgr_cluster.mon_manager.revive_mgr(active_mgr)
+        time.sleep(300)  # sleep for 5 minutes
+        self.fs_snap_schedule_cmd('deactivate', path=testdir, snap_schedule='1M')
+
+        new_stats = self.get_snap_stats(testdir)
+        self.assertTrue(new_stats['fs_count'] == new_stats['db_count'])
+        self.assertTrue(new_stats['fs_count'] > old_stats['fs_count'])
+        self.assertTrue(new_stats['db_count'] > old_stats['db_count'])
+
+        # cleanup
+        self.fs_snap_schedule_cmd('remove', path=testdir, snap_schedule='1M')
+        self.remove_snapshots(testdir[1:])
+        self.mount_a.run_shell(['rmdir', testdir[1:]])

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -321,6 +321,15 @@ class CephfsClient(Generic[Module_T]):
             return fs['mdsmap']['metadata_pool']
         return None
 
+    def get_all_filesystems(self) -> List[str]:
+        fs_list: List[str] = []
+        fs_map = self.mgr.get('fs_map')
+        if fs_map['filesystems']:
+            for fs in fs_map['filesystems']:
+                fs_list.append(fs['mdsmap']['fs_name'])
+        return fs_list
+
+
 
 @contextlib.contextmanager
 def open_filesystem(fsc: CephfsClient, fs_name: str) -> Generator["cephfs.LibCephFS", None, None]:

--- a/src/pybind/mgr/snap_schedule/fs/schedule.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule.py
@@ -241,6 +241,14 @@ class Schedule(object):
                                (f'{path}',))
             return [cls._from_db_row(row, fs) for row in c.fetchall()]
 
+    @classmethod
+    def list_all_schedules(cls,
+                           db: sqlite3.Connection,
+                           fs: str) -> List['Schedule']:
+        with db:
+            c = db.execute(cls.PROTO_GET_SCHEDULES + " path LIKE '%'")
+            return [cls._from_db_row(row, fs) for row in c.fetchall()]
+
     INSERT_SCHEDULE = '''INSERT INTO
         schedules(path, subvol, retention, rel_path)
         Values(?, ?, ?, ?);'''

--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -144,8 +144,6 @@ class SnapSchedClient(CephfsClient):
 
     def __init__(self, mgr: Any) -> None:
         super(SnapSchedClient, self).__init__(mgr)
-        # TODO maybe iterate over all fs instance in fsmap and load snap dbs?
-        #
         # Each db connection is now guarded by a Lock; this is required to
         # avoid concurrent DB transactions when more than one paths in a
         # file-system are scheduled at the same interval eg. 1h; without the
@@ -154,6 +152,14 @@ class SnapSchedClient(CephfsClient):
         self.sqlite_connections: Dict[str, DBInfo] = {}
         self.active_timers: Dict[Tuple[str, str], List[Timer]] = {}
         self.conn_lock: Lock = Lock()  # lock to protect add/lookup db connections
+
+        # restart old schedules
+        for fs_name in self.get_all_filesystems():
+            with self.get_schedule_db(fs_name) as conn_mgr:
+                db = conn_mgr.dbinfo.db
+                sched_list = Schedule.list_all_schedules(db, fs_name)
+                for sched in sched_list:
+                    self.refresh_snap_timers(fs_name, sched.path, db)
 
     @property
     def allow_minute_snaps(self) -> None:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55055

---

backport of https://github.com/ceph/ceph/pull/45115
parent tracker: https://tracker.ceph.com/issues/54052

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh