### PR TITLE
quincy: mgr/dashboard: highlight the search text in cluster logs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
@@ -27,7 +27,8 @@
             <p *ngFor="let line of clog">
               <span class="timestamp">{{ line.stamp | cdDate }}</span>
               <span class="priority {{ line.priority | logPriority }}">{{ line.priority }}</span>
-              <span class="message">{{ line.message }}</span>
+              <span class="message"
+                    [innerHTML]="line.message | searchHighlight: search"></span>
             </p>
 
             <ng-container *ngIf="clog.length != 0 else noEntriesTpl"></ng-container>
@@ -57,7 +58,8 @@
             <p *ngFor="let line of audit_log">
               <span class="timestamp">{{ line.stamp | cdDate }}</span>
               <span class="priority {{ line.priority | logPriority }}">{{ line.priority }}</span>
-              <span class="message">{{ line.message }}</span>
+              <span class="message"
+                    [innerHTML]="line.message | searchHighlight: search"></span>
             </p>
 
             <ng-container *ngIf="audit_log.length != 0 else noEntriesTpl"></ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.ts
@@ -70,8 +70,7 @@ export class LogsComponent implements OnInit, OnDestroy {
 
   abstractFilters(): any {
     const priority = this.priority;
-    const key = this.search.toLowerCase().replace(/,/g, '');
-
+    const key = this.search.toLowerCase();
     let yearMonthDay: string;
     if (this.selectedDate) {
       const m = this.selectedDate.month;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/pipes.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/pipes.module.ts
@@ -27,6 +27,7 @@ import { RbdConfigurationSourcePipe } from './rbd-configuration-source.pipe';
 import { RelativeDatePipe } from './relative-date.pipe';
 import { RoundPipe } from './round.pipe';
 import { SanitizeHtmlPipe } from './sanitize-html.pipe';
+import { SearchHighlightPipe } from './search-highlight.pipe';
 import { TruncatePipe } from './truncate.pipe';
 import { UpperFirstPipe } from './upper-first.pipe';
 
@@ -60,7 +61,8 @@ import { UpperFirstPipe } from './upper-first.pipe';
     DurationPipe,
     MapPipe,
     TruncatePipe,
-    SanitizeHtmlPipe
+    SanitizeHtmlPipe,
+    SearchHighlightPipe
   ],
   exports: [
     ArrayPipe,
@@ -90,7 +92,8 @@ import { UpperFirstPipe } from './upper-first.pipe';
     DurationPipe,
     MapPipe,
     TruncatePipe,
-    SanitizeHtmlPipe
+    SanitizeHtmlPipe,
+    SearchHighlightPipe
   ],
   providers: [
     ArrayPipe,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/search-highlight.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/search-highlight.pipe.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { SearchHighlightPipe } from './search-highlight.pipe';
+
+describe('SearchHighlightPipe', () => {
+  let pipe: SearchHighlightPipe;
+
+  configureTestBed({
+    providers: [SearchHighlightPipe]
+  });
+
+  beforeEach(() => {
+    pipe = TestBed.inject(SearchHighlightPipe);
+  });
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('transforms with a matching keyword ', () => {
+    const value = 'overall HEALTH_WARN Dashboard debug mode is enabled';
+    const args = 'Dashboard';
+    const expected = 'overall HEALTH_WARN <mark>Dashboard</mark> debug mode is enabled';
+
+    expect(pipe.transform(value, args)).toEqual(expected);
+  });
+
+  it('transforms with a matching keyword having regex character', () => {
+    const value = 'loreum ipsum .? dolor sit amet';
+    const args = '.?';
+    const expected = 'loreum ipsum <mark>.?</mark> dolor sit amet';
+
+    expect(pipe.transform(value, args)).toEqual(expected);
+  });
+
+  it('transforms with empty search keyword', () => {
+    const value = 'overall HEALTH_WARN Dashboard debug mode is enabled';
+    expect(pipe.transform(value, '')).toBe(value);
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/search-highlight.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/search-highlight.pipe.ts
@@ -1,0 +1,26 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'searchHighlight'
+})
+export class SearchHighlightPipe implements PipeTransform {
+  transform(value: string, args: string): string {
+    if (!args) {
+      return value;
+    }
+    args = this.escapeRegExp(args);
+    const regex = new RegExp(args, 'gi');
+    const match = value.match(regex);
+
+    if (!match) {
+      return value;
+    }
+
+    return value.replace(regex, '<mark>$&</mark>');
+  }
+
+  private escapeRegExp(str: string) {
+    // $& means the whole matched string
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_basics.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_basics.scss
@@ -17,6 +17,11 @@ option {
   font-weight: normal;
 }
 
+mark {
+  background-color: vv.$yellow;
+  padding: 0;
+}
+
 .full-height {
   height: 100vh;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54587

---

backport of https://github.com/ceph/ceph/pull/45218
parent tracker: https://tracker.ceph.com/issues/54445

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh