### PR TITLE
quincy: mgr/dashboard: Remove padding in search highlighted text

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_basics.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_basics.scss
@@ -17,6 +17,11 @@ option {
   font-weight: normal;
 }
 
+mark {
+  background-color: vv.$yellow;
+  padding: 0;
+}
+
 .full-height {
   height: 100vh;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55084

---

backport of https://github.com/ceph/ceph/pull/45539
parent tracker: https://tracker.ceph.com/issues/54984

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh