### PR TITLE
multisite/test: running the multisite test script with multiple RGWs per zone

### DIFF
--- a/src/test/rgw/test-rgw-common.sh
+++ b/src/test/rgw/test-rgw-common.sh
@@ -93,7 +93,7 @@ function init_first_zone {
   realm=$2
   zg=$3
   zone=$4
-  endpoints=$url:$5
+  endpoints=$5
 
   access_key=$6
   secret=$7
@@ -117,7 +117,7 @@ function init_zone_in_existing_zg {
   zg=$3
   zone=$4
   master_zg_zone1_port=$5
-  endpoints=$url:$6
+  endpoints=$6
 
   access_key=$7
   secret=$8
@@ -136,7 +136,7 @@ function init_first_zone_in_slave_zg {
   zg=$3
   zone=$4
   master_zg_zone1_port=$5
-  endpoints=$url:$6
+  endpoints=$6
 
   access_key=$7
   secret=$8

--- a/src/test/rgw/test-rgw-multisite.sh
+++ b/src/test/rgw/test-rgw-multisite.sh
@@ -21,9 +21,29 @@ system_secret="pencil"
 # bring up first cluster
 x $(start_ceph_cluster c1) -n $(get_mstart_parameters 1)
 
-# create realm, zonegroup, zone, start rgw
-init_first_zone c1 $realm_name $zg ${zg}-1 8001 $system_access_key $system_secret
-x $(rgw c1 8001 "$@")
+if [ -n "$RGW_PER_ZONE" ]; then
+  rgws="$RGW_PER_ZONE"
+else
+  rgws=1
+fi
+
+url=http://localhost
+
+i=1
+while [ $i -le $rgws ]; do
+  port=$((8100+i))
+  endpoints="$endpoints""$url:$port,"
+  i=$((i+1))
+done
+
+# create realm, zonegroup, zone, start rgws
+init_first_zone c1 $realm_name $zg ${zg}-1 $endpoints $system_access_key $system_secret
+i=1
+while [ $i -le $rgws ]; do
+  port=$((8100+i))
+  x $(rgw c1 "$port" "$@")
+  i="$((i+1))"
+done
 
 output=`$(rgw_admin c1) realm get`
 
@@ -31,14 +51,25 @@ echo realm_status=$output
 
 # bring up next clusters
 
+endpoints=""
 i=2
 while [ $i -le $num_clusters ]; do
   x $(start_ceph_cluster c$i) -n $(get_mstart_parameters $i)
+  j=1
+  while [ $j -le $rgws ]; do
+    port=$((8000+i*100+j))
+    endpoints="$endpoints""$url:$port,"
+    j=$((j+1))
+  done
 
   # create new zone, start rgw
-  init_zone_in_existing_zg c$i $realm_name $zg ${zg}-${i} 8001 $((8000+$i)) $zone_port $system_access_key $system_secret
-  x $(rgw c$i $((8000+$i)) "$@")
-
+  init_zone_in_existing_zg c$i $realm_name $zg ${zg}-${i} 8101 $endpoints $zone_port $system_access_key $system_secret
+  j=1
+  while [ $j -le $rgws ]; do
+    port=$((8000+i*100+j))
+    x $(rgw c$i "$port" "$@")
+    j="$((j+1))"
+  done
   i=$((i+1))
 done
 


### PR DESCRIPTION
the RGW_PER_ZONE environment variables should be set to allow that
if not set, we assume 1 RGW per zone

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
