### PR TITLE
mount.ceph: remove `ms_mode' mount option when switching to old-syntax

### DIFF
--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -21,7 +21,7 @@
 bool verboseflag = false;
 bool fakeflag = false;
 bool skip_mtab_flag = false;
-bool v2_addrs = false;
+bool v2_addrs = true;
 bool no_fallback = false;
 bool ms_mode_specified = false;
 bool mon_addr_specified = false;
@@ -203,6 +203,10 @@ static int parse_old_dev(const char *dev_str, struct ceph_mount_info *cmi,
 		cmi->cmi_mons = strndup(dev_str, len);
 		if (!cmi->cmi_mons)
 			return -ENOMEM;
+		mon_addr_specified = true;
+	} else {
+		/* reset mon_addr=<> mount option */
+		mon_addr_specified = false;
 	}
 
 	mount_path++;
@@ -298,11 +302,9 @@ static int parse_new_dev(const char *dev_str, struct ceph_mount_info *cmi,
 	}
 
 	/* new-style dev - force using v2 addrs first */
-	if (!ms_mode_specified && !mon_addr_specified) {
-		v2_addrs = true;
-		append_opt("ms_mode", CEPH_DEFAULT_V2_MS_MODE, cmi,
-			   opt_pos);
-	}
+	if (!ms_mode_specified && !mon_addr_specified)
+	  append_opt("ms_mode", CEPH_DEFAULT_V2_MS_MODE, cmi,
+		     opt_pos);
 
 	cmi->format = MOUNT_DEV_FORMAT_NEW;
 	return 0;
@@ -323,8 +325,12 @@ static int parse_dev(const char *dev_str, struct ceph_mount_info *cmi,
 	return ret;
 }
 
-/* resolve monitor host and record in option string */
-static int finalize_src(struct ceph_mount_info *cmi, int *opt_pos)
+/* resolve monitor host and optionally record in option string.
+ * use opt_pos to determine if the caller wants to record the
+ * resolved address in mount option (c.f., mount_old_device_format).
+ */
+static int finalize_src(struct ceph_mount_info *cmi, int *opt_pos,
+			char **resolved_addr)
 {
 	char *src;
         size_t len = strlen(cmi->cmi_mons);
@@ -337,8 +343,13 @@ static int finalize_src(struct ceph_mount_info *cmi, int *opt_pos)
 	if (!src)
 		return -1;
 
-	resolved_mon_addr_as_mount_opt(src);
-	append_opt("mon_addr", src, cmi, opt_pos);
+	mount_ceph_debug("mount.ceph: resolved to: \"%s\"\n", src);
+	if (opt_pos) {
+		resolved_mon_addr_as_mount_opt(src);
+		append_opt("mon_addr", src, cmi, opt_pos);
+	} else if (resolved_addr) {
+                *resolved_addr = strdup(src);
+        }
 	free(src);
 	return 0;
 }
@@ -765,13 +776,37 @@ static int mount_old_device_format(const char *node, struct ceph_mount_info *cmi
 	int r;
 	int len = 0;
 	int pos = 0;
-	char *mon_addr;
+	char *mon_addr = NULL;
 	char *rsrc = NULL;
 
 	r = remove_opt(cmi, "mon_addr", &mon_addr);
 	if (r) {
 		fprintf(stderr, "failed to switch using old device format\n");
 		return -EINVAL;
+	}
+
+	/* if we reach here and still have a v2 addr, we'd need to
+	 * refresh with v1 addrs, since we'll be not passing ms_mode
+	 * with the old syntax.
+	 */
+	if (v2_addrs && !ms_mode_specified && !mon_addr_specified) {
+		mount_ceph_debug("mount.ceph: switching to using v1 address with old syntax\n");
+		v2_addrs = false;
+		free(mon_addr);
+		free(cmi->cmi_mons);
+		mon_addr = NULL;
+		cmi->cmi_mons = NULL;
+		fetch_config_info(cmi);
+		if (!cmi->cmi_mons) {
+			fprintf(stderr, "unable to determine (v1) mon addresses\n");
+			return -EINVAL;
+		}
+		r = finalize_src(cmi, NULL, &mon_addr);
+		if (r) {
+			fprintf(stderr, "failed to resolve (v1) mon addresses\n");
+			return -EINVAL;
+		}
+		remove_opt(cmi, "ms_mode", NULL);
 	}
 
 	pos = strlen(cmi->cmi_opts);
@@ -836,10 +871,10 @@ static int do_mount(const char *dev, const char *node,
 	bool fallback = true;
 
         /* no v2 addresses available via config - try v1 addresses */
-	if (!cmi->cmi_mons &&
+	if (v2_addrs &&
+	    !cmi->cmi_mons &&
 	    !ms_mode_specified &&
-	    !mon_addr_specified &&
-	    cmi->format == MOUNT_DEV_FORMAT_NEW) {
+	    !mon_addr_specified) {
 		mount_ceph_debug("mount.ceph: switching to using v1 address\n");
 		v2_addrs = false;
 		fetch_config_info(cmi);
@@ -852,7 +887,7 @@ static int do_mount(const char *dev, const char *node,
 	}
 
 	pos = strlen(cmi->cmi_opts);
-	retval = finalize_src(cmi, &pos);
+	retval = finalize_src(cmi, &pos, NULL);
 	if (retval) {
 		fprintf(stderr, "failed to resolve source\n");
 		return -EINVAL;


### PR DESCRIPTION
... if the user hasn't specified using one explicity. kernel versions
< 5.11 do not understand `ms_mode' mount option which would result in
mount failures.

Fixes: http://tracker.ceph.com/issues/55110
Signed-off-by: Venky Shankar <vshankar@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
