### PR TITLE
common/options: warn about rgw_enable_ops_log option

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1421,6 +1421,10 @@ options:
   level: advanced
   desc: Enable ops log
   fmt_desc: Enable logging for each successful Ceph Object Gateway operation.
+  long_desc: Log every Ceph Object Gateway operation. This option is very
+    verbose and may fill up the rgw.log pool quickly. Please use --debug-rgw
+    and --debug-ms command-line options for the Ceph Object Gateway nodes
+    instead.
   default: false
   services:
   - rgw


### PR DESCRIPTION
Users can easily fill up rgw.pool with this configuration option. Warn users about the problems associated with it.