### PR TITLE
qa/rgw: reenable wait-for-scrub

### DIFF
--- a/qa/suites/rgw/crypt/1-ceph-install/install.yaml
+++ b/qa/suites/rgw/crypt/1-ceph-install/install.yaml
@@ -1,7 +1,3 @@
-overrides:
-  ceph:
-    wait-for-scrub: false
-
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rgw/lifecycle/overrides.yaml
+++ b/qa/suites/rgw/lifecycle/overrides.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    wait-for-scrub: false
     conf:
       client:
         setuser: ceph

--- a/qa/suites/rgw/multifs/overrides.yaml
+++ b/qa/suites/rgw/multifs/overrides.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    wait-for-scrub: false
     conf:
       client:
         setuser: ceph

--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    wait-for-scrub: false
     conf:
       client:
         setuser: ceph

--- a/qa/suites/rgw/notifications/overrides.yaml
+++ b/qa/suites/rgw/notifications/overrides.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    wait-for-scrub: false
     conf:
       client:
         setuser: ceph

--- a/qa/suites/rgw/singleton/overrides.yaml
+++ b/qa/suites/rgw/singleton/overrides.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    wait-for-scrub: false
     conf:
       client:
         setuser: ceph

--- a/qa/suites/rgw/sts/overrides.yaml
+++ b/qa/suites/rgw/sts/overrides.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    wait-for-scrub: false
     conf:
       client:
         setuser: ceph

--- a/qa/suites/rgw/upgrade/overrides.yaml
+++ b/qa/suites/rgw/upgrade/overrides.yaml
@@ -9,7 +9,6 @@ overrides:
       - \(PG_DEGRADED\)
       - slow request
       - failed to encode map
-    wait-for-scrub: false
     conf:
       mon:
         mon warn on osd down out interval zero: false

--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -239,6 +239,7 @@ def start_rgw(ctx, config, clients):
                     ],
                 )
             ctx.cluster.only(client).run(args=['sudo', 'rm', '-f', token_path])
+            ctx.cluster.only(client).run(args=['radosgw-admin', 'gc', 'process', '--include-all'])
 
 def assign_endpoints(ctx, config, default_cert):
     role_endpoints = {}


### PR DESCRIPTION
let the osds finish a deep scrub at the end of rgw tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
