### PR TITLE
cmake: WITH_SYSTEM_UTF8PROC defaults to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,7 +402,7 @@ option(WITH_RADOSGW_MOTR "CORTX-Motr backend for Rados Gateway" OFF)
 option(WITH_RADOSGW_SELECT_PARQUET "Support for s3 select on parquet objects" ON)
 
 option(WITH_SYSTEM_ARROW "Use system-provided arrow" OFF)
-option(WITH_SYSTEM_UTF8PROC "Use system-provided utf8proc" ON)
+option(WITH_SYSTEM_UTF8PROC "Use system-provided utf8proc" OFF)
 
 if(WITH_RADOSGW)
   find_package(EXPAT REQUIRED)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1356,8 +1356,8 @@ cmake .. \
 %if 0%{with system_arrow}
     -DWITH_SYSTEM_ARROW:BOOL=ON \
 %endif
-%if 0%{without system_utf8proc}
-    -DWITH_SYSTEM_UTF8PROC:BOOL=OFF \
+%if 0%{with system_utf8proc}
+    -DWITH_SYSTEM_UTF8PROC:BOOL=ON \
 %endif
     -DWITH_GRAFANA:BOOL=ON
 

--- a/debian/rules
+++ b/debian/rules
@@ -25,6 +25,7 @@ ifneq ($(filter pkg.ceph.arrow,$(DEB_BUILD_PROFILES)),)
   extraopts += -DWITH_SYSTEM_ARROW=ON
 endif
 
+extraopts += -DWITH_SYSTEM_UTF8PROC=ON
 extraopts += -DWITH_OCF=ON -DWITH_LTTNG=ON
 extraopts += -DWITH_MGR_DASHBOARD_FRONTEND=OFF
 extraopts += -DWITH_PYTHON3=3


### PR DESCRIPTION
change the default value of WITH_SYSTEM_UTF8PROC from ON to OFF, so that centos/rhel users can build with the default cmake configuration. no other WITH_SYSTEM_* variable in ceph defaults to ON, so this is consistent with other bundled libraries like boost and rocksdb

unfortunately, this also means that users that do have system packages must opt-in to using them with -DWITH_SYSTEM_UTF8PROC=ON

both deb and rpm builds dependended on the previous default value, so their logic was negated to match the new default

Fixes: https://tracker.ceph.com/issues/55114

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
