### PR TITLE
octopus: ceph.spec.in: remove build directory at end of %install

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1356,12 +1356,11 @@ install -m 644 -D monitoring/prometheus/alerts/ceph_default_alerts.yml %{buildro
 %py_byte_compile %{__python3} %{buildroot}%{python3_sitelib}
 %endif
 
+%clean
+rm -rf %{buildroot}
 # built binaries are no longer necessary at this point,
 # but are consuming ~17GB of disk in the build environment
 rm -rf build
-
-%clean
-rm -rf %{buildroot}
 
 #################################################################################
 # files and systemd scriptlets

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1356,6 +1356,10 @@ install -m 644 -D monitoring/prometheus/alerts/ceph_default_alerts.yml %{buildro
 %py_byte_compile %{__python3} %{buildroot}%{python3_sitelib}
 %endif
 
+# built binaries are no longer necessary at this point,
+# but are consuming ~17GB of disk in the build environment
+rm -rf build
+
 %clean
 rm -rf %{buildroot}
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55099

---

backport of https://github.com/ceph/ceph/pull/45664
parent tracker: https://tracker.ceph.com/issues/55079

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh