### PR TITLE
quincy: ceph.spec.in: Use libthrift-devel on SUSE distros

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -262,7 +262,11 @@ BuildRequires:	socat
 %if 0%{with zbd}
 BuildRequires:  libzbd-devel
 %endif
+%if 0%{?suse_version}
+BuildRequires:  libthrift-devel >= 0.13.0
+%else
 BuildRequires:  thrift-devel >= 0.13.0
+%endif
 BuildRequires:  re2-devel
 %if 0%{with jaeger}
 BuildRequires:  bison


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55100

---

backport of https://github.com/ceph/ceph/pull/45666
parent tracker: https://tracker.ceph.com/issues/55087

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh