### PR TITLE
* [cephadm]: [RFE] adding Environment variables to set custom DEFAULT_XXX_IMAGE …

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -48,15 +48,15 @@ FuncT = TypeVar('FuncT', bound=Callable)
 DEFAULT_IMAGE = 'quay.ceph.io/ceph-ci/ceph:master'
 DEFAULT_IMAGE_IS_MASTER = True
 DEFAULT_IMAGE_RELEASE = 'quincy'
-DEFAULT_PROMETHEUS_IMAGE = 'quay.io/prometheus/prometheus:v2.18.1'
-DEFAULT_LOKI_IMAGE = 'docker.io/grafana/loki:2.4.0'
-DEFAULT_PROMTAIL_IMAGE = 'docker.io/grafana/promtail:2.4.0'
-DEFAULT_NODE_EXPORTER_IMAGE = 'quay.io/prometheus/node-exporter:v0.18.1'
-DEFAULT_ALERT_MANAGER_IMAGE = 'quay.io/prometheus/alertmanager:v0.20.0'
-DEFAULT_GRAFANA_IMAGE = 'quay.io/ceph/ceph-grafana:6.7.4'
-DEFAULT_HAPROXY_IMAGE = 'docker.io/library/haproxy:2.3'
-DEFAULT_KEEPALIVED_IMAGE = 'docker.io/arcts/keepalived'
-DEFAULT_SNMP_GATEWAY_IMAGE = 'docker.io/maxwo/snmp-notifier:v1.2.1'
+DEFAULT_PROMETHEUS_IMAGE = os.environ.get('DEFAULT_PROMETHEUS_IMAGE', 'quay.io/prometheus/prometheus:v2.18.1')
+DEFAULT_LOKI_IMAGE = os.environ.get('DEFAULT_LOKI_IMAGE', 'docker.io/grafana/loki:2.4.0')
+DEFAULT_PROMTAIL_IMAGE = os.environ.get('DEFAULT_PROMTAIL_IMAGE', 'docker.io/grafana/promtail:2.4.0')
+DEFAULT_NODE_EXPORTER_IMAGE = os.environ.get('DEFAULT_NODE_EXPORTER_IMAGE', 'quay.io/prometheus/node-exporter:v0.18.1')
+DEFAULT_ALERT_MANAGER_IMAGE = os.environ.get('DEFAULT_ALERT_MANAGER_IMAGE', 'quay.io/prometheus/alertmanager:v0.20.0')
+DEFAULT_GRAFANA_IMAGE = os.environ.get('DEFAULT_GRAFANA_IMAGE', 'quay.io/ceph/ceph-grafana:6.7.4')
+DEFAULT_HAPROXY_IMAGE = os.environ.get('DEFAULT_HAPROXY_IMAGE', 'docker.io/library/haproxy:2.3')
+DEFAULT_KEEPALIVED_IMAGE = os.environ.get('DEFAULT_KEEPALIVED_IMAGE', 'docker.io/arcts/keepalived')
+DEFAULT_SNMP_GATEWAY_IMAGE = os.environ.get('DEFAULT_SNMP_GATEWAY_IMAGE', 'docker.io/maxwo/snmp-notifier:v1.2.1')
 DEFAULT_REGISTRY = 'docker.io'   # normalize unqualified digests to this
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
  - For disconnected/offline installations when using Satellite the
    official way to set custom images is documented to run ceph set mgr
    after bootstraping the Cluster. Until done, the Cluster is in state
    "HEALTH_WARN".
    Automated deployment and testing require the additional shell commands
    to be executed which makes it difficult and cumbersum.
    The Request for Enhanchement provides the functionality to bootstrap
    with custom images when approriate Environment variables are set.

    * example usage

    ```
    $ export DEFAULT_NODE_EXPORTER_IMAGE=quay.io/prometheus/node-exporter:latest
    $ export DEFAULT_GRAFANA_IMAGE=private-registry.local/grafana/customer-build:special-plugins

    $ cephadm bootstrap ....





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
