### PR TITLE
ceph.spec.in: remove build directory in %clean, not %install

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1469,12 +1469,11 @@ install -m 644 -D monitoring/ceph-mixin/prometheus_alerts.yml %{buildroot}/etc/p
 %py_byte_compile %{__python3} %{buildroot}%{python3_sitelib}
 %endif
 
+%clean
+rm -rf %{buildroot}
 # built binaries are no longer necessary at this point,
 # but are consuming ~17GB of disk in the build environment
 rm -rf %{_vpath_builddir}
-
-%clean
-rm -rf %{buildroot}
 
 #################################################################################
 # files and systemd scriptlets


### PR DESCRIPTION
Removing the build directory at the end of %install is too soon, and means we get rid of a bunch of stuff needed to correctly
create debuginfo/debugsource packages, which happens automatically right after %install.  So, let's put it where it really belongs, in the %clean section.

Fixes: aa18cb12003e3526c8e8f23dc2335a483fbfa68e
Fixes: https://tracker.ceph.com/issues/55079
Signed-off-by: Tim Serong <tserong@suse.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

I'm sorry I didn't pick this up in my testing yesterday - the failure manifested as a whole lot of error lines like "cpio: build/boost/include/boost/accumulators/accumulators_fwd.hpp: Cannot stat: No such file or directory" in the find-debuginfo step, but, these errors didn't actually cause the build to _fail_ :-/ Anyway, this change works just fine in the %clean section, and I've already done a test build on shaman, plus builds on our internal SUSE build server to confirm it does the right thing.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
