### PR TITLE
mgr/dashboard: Imrove error message of '/api/grafana/validation' API endpoint

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/grafana.py
+++ b/src/pybind/mgr/dashboard/controllers/grafana.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from .. import mgr
-from ..exceptions import DashboardException
 from ..grafana import GrafanaRestClient, push_local_dashboards
 from ..security import Scope
+from ..services.exception import handle_error
 from ..settings import Settings
 from . import APIDoc, APIRouter, BaseController, Endpoint, EndpointDoc, \
     ReadPermission, UpdatePermission
@@ -31,6 +31,7 @@ class Grafana(BaseController):
 
     @Endpoint()
     @ReadPermission
+    @handle_error('grafana')
     def validation(self, params):
         grafana = GrafanaRestClient()
         method = 'GET'
@@ -41,14 +42,8 @@ class Grafana(BaseController):
 
     @Endpoint(method='POST')
     @UpdatePermission
+    @handle_error('grafana', 500)
     def dashboards(self):
         response = dict()
-        try:
-            response['success'] = push_local_dashboards()
-        except Exception as e:  # pylint: disable=broad-except
-            raise DashboardException(
-                msg=str(e),
-                component='grafana',
-                http_status_code=500,
-            )
+        response['success'] = push_local_dashboards()
         return response

--- a/src/pybind/mgr/dashboard/services/exception.py
+++ b/src/pybind/mgr/dashboard/services/exception.py
@@ -115,3 +115,11 @@ def handle_request_error(component):
                 raise DashboardException(
                     msg=content_message, component=component)
         raise DashboardException(e=e, component=component)
+
+
+@contextmanager
+def handle_error(component, http_status_code=None):
+    try:
+        yield
+    except Exception as e:  # pylint: disable=broad-except
+        raise DashboardException(e, component=component, http_status_code=http_status_code)

--- a/src/pybind/mgr/dashboard/tests/test_grafana.py
+++ b/src/pybind/mgr/dashboard/tests/test_grafana.py
@@ -53,6 +53,14 @@ class GrafanaTest(ControllerTestCase, KVStoreMockMixin):
         self.assertStatus(200)
         self.assertBody(b'"404"')
 
+    @patch('dashboard.controllers.grafana.GrafanaRestClient.url_validation')
+    def test_validation_endpoint_fails(self, url_validation):
+        url_validation.side_effect = RequestException
+        self.server_settings()
+        self._get('/api/grafana/validation/bar')
+        self.assertStatus(400)
+        self.assertJsonBody({'detail': '', 'code': 'Error', 'component': 'grafana'})
+
     def test_dashboards_unavailable_no_url(self):
         self.server_settings(url="")
         self._post('/api/grafana/dashboards')


### PR DESCRIPTION
In case the validation of the Grafana URL fails, e.g. because of an invalid SSL certificate, a useless and not helping default error message is displayed in the UI.
This PR will re-raise the exception as a DashboardException which includes the detailed description of what happened. This will help to identify SSL cert issues much easier for example.

Before:
![before](https://user-images.githubusercontent.com/1897962/160844286-71725bbf-9700-4047-bdc2-d66ffe267c66.png)

After:
![after](https://user-images.githubusercontent.com/1897962/160844305-33a8c9ba-92ae-474a-9513-cae359ae3fe6.png)

Fixes: https://tracker.ceph.com/issues/55133

Signed-off-by: Volker Theile <vtheile@suse.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
