### PR TITLE
BlueFS.cc: adaptively extend bluefs_log_compact_min_size to avoid endless log compact

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2715,6 +2715,15 @@ void BlueFS::_compact_log_async_LD_LNF_D() //also locks FW for new_writer
   log.writer->pos = log.writer->file->fnode.size =
     log.writer->pos - old_log_jump_to + new_log_jump_to;
 
+  // extend the size threshold for triggering log compact if the compacted
+  // log size is larger than the current threshold. So that we avoid endless
+  // log compact triggering on every write request.
+  if (log.writer->file->fnode.size >=
+          cct->_conf->bluefs_log_compact_min_size) {
+    cct->_conf->bluefs_log_compact_min_size +=
+          cct->_conf->bluefs_log_compact_min_size;
+  }
+
   vselector->add_usage(log_file->vselector_hint, log_file->fnode);
 
   log.lock.unlock();


### PR DESCRIPTION
extend the size threshold for triggering log compact if the compacted log size is larger than the current threshold. So that we avoid endless log compact triggering on every write request.

Signed-off-by: Sheng Qiu <herbert1984106@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
