### PR TITLE
mds: add Pacific and Quincy cephfs feature bits

### DIFF
--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -1137,7 +1137,11 @@ void MDSMap::set_min_compat_client(ceph_release_t version)
 {
   vector<size_t> bits = CEPHFS_FEATURES_MDS_REQUIRED;
 
-  if (version >= ceph_release_t::octopus)
+  if (version >= ceph_release_t::quincy)
+    bits.push_back(CEPHFS_FEATURE_QUINCY);
+  else if (version >= ceph_release_t::pacific)
+    bits.push_back(CEPHFS_FEATURE_PACIFIC);
+  else if (version >= ceph_release_t::octopus)
     bits.push_back(CEPHFS_FEATURE_OCTOPUS);
   else if (version >= ceph_release_t::nautilus)
     bits.push_back(CEPHFS_FEATURE_NAUTILUS);

--- a/src/mds/cephfs_features.h
+++ b/src/mds/cephfs_features.h
@@ -41,7 +41,9 @@ namespace ceph {
 #define CEPHFS_FEATURE_NAUTILUS         12
 #define CEPHFS_FEATURE_DELEG_INO        13
 #define CEPHFS_FEATURE_OCTOPUS          13
+#define CEPHFS_FEATURE_PACIFIC          14
 #define CEPHFS_FEATURE_METRIC_COLLECT   14
+#define CEPHFS_FEATURE_QUINCY           15
 #define CEPHFS_FEATURE_ALTERNATE_NAME   15
 #define CEPHFS_FEATURE_MAX              15
 
@@ -58,7 +60,9 @@ namespace ceph {
   CEPHFS_FEATURE_NAUTILUS,              \
   CEPHFS_FEATURE_DELEG_INO,             \
   CEPHFS_FEATURE_OCTOPUS,               \
+  CEPHFS_FEATURE_PACIFIC,               \
   CEPHFS_FEATURE_METRIC_COLLECT,        \
+  CEPHFS_FEATURE_QUINCY,                \
   CEPHFS_FEATURE_ALTERNATE_NAME,        \
 }
 


### PR DESCRIPTION
Signed-off-by: Xiubo Li <xiubli@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
