### PR TITLE
crimson/os/seastore: use different segment seq allocator from journal and ool segments

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -985,6 +985,7 @@ record_t Cache::prepare_record(
 	  0,
 	  t.root->get_version() - 1,
 	  MAX_SEG_SEQ,
+	  segment_type_t::NULL_SEG,
 	  std::move(delta_bl)
 	});
     } else {
@@ -1002,6 +1003,9 @@ record_t Cache::prepare_record(
 	  cleaner
 	  ? cleaner->get_seq(i->get_paddr().as_seg_paddr().get_segment_id())
 	  : MAX_SEG_SEQ,
+	  cleaner
+	  ? cleaner->get_type(i->get_paddr().as_seg_paddr().get_segment_id())
+	  : segment_type_t::NULL_SEG,
 	  std::move(delta_bl)
 	});
       i->last_committed_crc = final_crc;

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1389,13 +1389,12 @@ Cache::get_next_dirty_extents_ret Cache::get_next_dirty_extents(
        i != dirty.end() && bytes_so_far < max_bytes;
        ++i) {
     auto dirty_from = i->get_dirty_from();
-    if (!(dirty_from != JOURNAL_SEQ_NULL &&
+    if (unlikely(!(dirty_from != JOURNAL_SEQ_NULL &&
                 dirty_from != JOURNAL_SEQ_MAX &&
-                dirty_from != NO_DELTAS))
-      ERRORT("{}", *i);
-    ceph_assert(dirty_from != JOURNAL_SEQ_NULL &&
-                dirty_from != JOURNAL_SEQ_MAX &&
-                dirty_from != NO_DELTAS);
+                dirty_from != NO_DELTAS))) {
+      ERRORT("{}", t, *i);
+      ceph_abort();
+    }
     if (dirty_from < seq) {
       TRACET("next extent -- {}", t, *i);
       if (!cand.empty() && cand.back()->get_dirty_from() > dirty_from) {

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -85,8 +85,6 @@ public:
   virtual replay_ret replay(
     delta_handler_t &&delta_handler) = 0;
 
-  virtual SegmentSeqAllocator& get_segment_seq_allocator() = 0;
-
   virtual ~Journal() {}
 };
 using JournalRef = std::unique_ptr<Journal>;

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -76,12 +76,12 @@ SegmentedJournal::prep_replay_segments(
     segments.begin(),
     segments.end(),
     [](const auto &lt, const auto &rt) {
-      return lt.second.journal_segment_seq <
-	rt.second.journal_segment_seq;
+      return lt.second.segment_seq <
+	rt.second.segment_seq;
     });
 
   segment_seq_allocator->set_next_segment_seq(
-    segments.rbegin()->second.journal_segment_seq + 1);
+    segments.rbegin()->second.segment_seq + 1);
   std::for_each(
     segments.begin(),
     segments.end(),
@@ -107,7 +107,7 @@ SegmentedJournal::prep_replay_segments(
 	auto& seg_addr = replay_from.as_seg_paddr();
 	return seg.first == seg_addr.get_segment_id();
       });
-    if (from->second.journal_segment_seq != journal_tail.segment_seq) {
+    if (from->second.segment_seq != journal_tail.segment_seq) {
       ERROR("journal_tail {} does not match {}",
             journal_tail, from->second);
       ceph_abort();
@@ -126,7 +126,7 @@ SegmentedJournal::prep_replay_segments(
     from, segments.end(), ret.begin(),
     [this](const auto &p) {
       auto ret = journal_seq_t{
-	p.second.journal_segment_seq,
+	p.second.segment_seq,
 	paddr_t::make_seg_paddr(
 	  p.first,
 	  journal_segment_allocator.get_block_size())

--- a/src/crimson/os/seastore/journal/segmented_journal.h
+++ b/src/crimson/os/seastore/journal/segmented_journal.h
@@ -46,9 +46,6 @@ public:
     write_pipeline = _write_pipeline;
   }
 
-  SegmentSeqAllocator& get_segment_seq_allocator() final {
-    return *segment_seq_allocator;
-  }
 private:
   submit_record_ret do_submit_record(
     record_t &&record,

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -214,7 +214,7 @@ std::ostream &operator<<(std::ostream &out, const extent_info_t &info)
 std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
 {
   return out << "segment_header_t("
-	     << "segment_seq=" << segment_seq_printer_t{header.journal_segment_seq}
+	     << "segment_seq=" << segment_seq_printer_t{header.segment_seq}
 	     << ", segment_id=" << header.physical_segment_id
 	     << ", journal_tail=" << header.journal_tail
 	     << ", segment_nonce=" << header.segment_nonce
@@ -225,7 +225,7 @@ std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
 std::ostream &operator<<(std::ostream &out, const segment_tail_t &tail)
 {
   return out << "segment_tail_t("
-	     << "segment_seq=" << tail.journal_segment_seq
+	     << "segment_seq=" << tail.segment_seq
 	     << ", segment_id=" << tail.physical_segment_id
 	     << ", journal_tail=" << tail.journal_tail
 	     << ", segment_nonce=" << tail.segment_nonce

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -199,6 +199,7 @@ std::ostream &operator<<(std::ostream &out, const delta_info_t &delta)
 	     << ", length: " << delta.length
 	     << ", pversion: " << delta.pversion
 	     << ", ext_seq: " << delta.ext_seq
+	     << ", seg_type: " << delta.seg_type
 	     << ")";
 }
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1290,7 +1290,7 @@ using segment_nonce_t = uint32_t;
  * 2) Replay starting at record located at that segment's journal_tail
  */
 struct segment_header_t {
-  segment_seq_t journal_segment_seq;
+  segment_seq_t segment_seq;
   segment_id_t physical_segment_id; // debugging
 
   journal_seq_t journal_tail;
@@ -1304,7 +1304,7 @@ struct segment_header_t {
 
   DENC(segment_header_t, v, p) {
     DENC_START(1, 1, p);
-    denc(v.journal_segment_seq, p);
+    denc(v.segment_seq, p);
     denc(v.physical_segment_id, p);
     denc(v.journal_tail, p);
     denc(v.segment_nonce, p);
@@ -1315,7 +1315,7 @@ struct segment_header_t {
 std::ostream &operator<<(std::ostream &out, const segment_header_t &header);
 
 struct segment_tail_t {
-  segment_seq_t journal_segment_seq;
+  segment_seq_t segment_seq;
   segment_id_t physical_segment_id; // debugging
 
   journal_seq_t journal_tail;
@@ -1332,7 +1332,7 @@ struct segment_tail_t {
 
   DENC(segment_tail_t, v, p) {
     DENC_START(1, 1, p);
-    denc(v.journal_segment_seq, p);
+    denc(v.segment_seq, p);
     denc(v.physical_segment_id, p);
     denc(v.journal_tail, p);
     denc(v.segment_nonce, p);

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -210,7 +210,7 @@ static constexpr segment_seq_t MAX_SEG_SEQ =
 static constexpr segment_seq_t NULL_SEG_SEQ = MAX_SEG_SEQ;
 static constexpr segment_seq_t MAX_VALID_SEG_SEQ = MAX_SEG_SEQ - 2;
 
-enum class segment_type_t {
+enum class segment_type_t : uint8_t {
   JOURNAL = 0,
   OOL,
   NULL_SEG,
@@ -912,6 +912,7 @@ struct delta_info_t {
   seastore_off_t length = NULL_SEG_OFF;         ///< extent length
   extent_version_t pversion;                   ///< prior version
   segment_seq_t ext_seq;		       ///< seq of the extent's segment
+  segment_type_t seg_type;
   ceph::bufferlist bl;                         ///< payload
 
   DENC(delta_info_t, v, p) {
@@ -924,6 +925,7 @@ struct delta_info_t {
     denc(v.length, p);
     denc(v.pversion, p);
     denc(v.ext_seq, p);
+    denc(v.seg_type, p);
     denc(v.bl, p);
     DENC_FINISH(p);
   }

--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -183,6 +183,8 @@ SegmentCleaner::SegmentCleaner(
   : detailed(detailed),
     config(config),
     scanner(std::move(scr)),
+    ool_segment_seq_allocator(
+      new SegmentSeqAllocator(segment_type_t::OOL)),
     gc_process(*this)
 {}
 

--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -575,7 +575,7 @@ SegmentCleaner::mount_ret SegmentCleaner::mount(
 	    }
 	    init_mark_segment_closed(
 	      segment_id,
-	      header.journal_segment_seq,
+	      header.segment_seq,
 	      header.type);
 	    return seastar::now();
 	  }).handle_error(
@@ -662,7 +662,7 @@ SegmentCleaner::scan_extents_ret SegmentCleaner::scan_nonfull_segment(
     }).safe_then([this, segment_id, header](auto) {
       init_mark_segment_closed(
 	segment_id,
-	header.journal_segment_seq,
+	header.segment_seq,
 	header.type);
       return seastar::now();
     });
@@ -676,7 +676,7 @@ SegmentCleaner::scan_extents_ret SegmentCleaner::scan_nonfull_segment(
   }
   init_mark_segment_closed(
     segment_id,
-    header.journal_segment_seq,
+    header.segment_seq,
     header.type);
   return seastar::now();
 }

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -16,6 +16,7 @@
 #include "crimson/os/seastore/seastore_types.h"
 #include "crimson/os/seastore/segment_manager.h"
 #include "crimson/os/seastore/transaction.h"
+#include "crimson/os/seastore/segment_seq_allocator.h"
 
 namespace crimson::os::seastore {
 
@@ -298,6 +299,8 @@ public:
   virtual void update_journal_tail_committed(journal_seq_t tail_committed) = 0;
 
   virtual segment_seq_t get_seq(segment_id_t id) { return 0; }
+
+  virtual segment_type_t get_type(segment_id_t id) = 0;
 
   virtual seastar::lowres_system_clock::time_point get_last_modified(
     segment_id_t id) const = 0;
@@ -718,11 +721,17 @@ private:
   /// populated if there is an IO blocked on hard limits
   std::optional<seastar::promise<>> blocked_io_wake;
 
+  SegmentSeqAllocatorRef ool_segment_seq_allocator;
+
 public:
   SegmentCleaner(
     config_t config,
     ExtentReaderRef&& scanner,
     bool detailed = false);
+
+  SegmentSeqAllocator& get_ool_segment_seq_allocator() {
+    return *ool_segment_seq_allocator;
+  }
 
   using mount_ertr = crimson::errorator<
     crimson::ct_error::input_output_error>;
@@ -761,6 +770,10 @@ public:
 
   segment_seq_t get_seq(segment_id_t id) final {
     return segments[id].journal_segment_seq;
+  }
+
+  segment_type_t get_type(segment_id_t id) final {
+    return segments[id].get_type();
   }
 
   void mark_segment_released(segment_id_t segment) {
@@ -1321,9 +1334,10 @@ private:
     segment_seq_t seq,
     segment_type_t s_type) {
     crimson::get_logger(ceph_subsys_seastore_cleaner).debug(
-      "SegmentCleaner::init_mark_segment_closed: segment {}, seq {}",
+      "SegmentCleaner::init_mark_segment_closed: segment {}, seq {}, s_type {}",
       segment,
-      segment_seq_printer_t{seq});
+      segment_seq_printer_t{seq},
+      s_type);
     mark_closed(segment);
     segments[segment].journal_segment_seq = seq;
     assert(s_type != segment_type_t::NULL_SEG);
@@ -1331,6 +1345,9 @@ private:
     if (s_type == segment_type_t::JOURNAL) {
       assert(journal_device_id == segment.device_id());
       segments.new_journal_segment();
+    } else {
+      assert(s_type == segment_type_t::OOL);
+      ool_segment_seq_allocator->set_next_segment_seq(seq);
     }
   }
 
@@ -1411,11 +1428,12 @@ private:
     assert(stats.empty_segments > 0);
     stats.empty_segments--;
     crimson::get_logger(ceph_subsys_seastore_cleaner
-      ).info("mark open: {} {}, empty_segments {}"
+      ).info("mark open: {} {} {}, empty_segments {}"
 	", opened_segments {}, should_block_on_gc {}"
 	", projected_avail_ratio {}, projected_reclaim_ratio {}",
 	segment,
 	segment_seq_printer_t{seq},
+	segment_info.type,
 	stats.empty_segments,
 	segments.get_opened_segments(),
 	should_block_on_gc(),

--- a/src/crimson/os/seastore/segment_seq_allocator.h
+++ b/src/crimson/os/seastore/segment_seq_allocator.h
@@ -6,6 +6,10 @@
 #include "crimson/os/seastore/logging.h"
 #include "crimson/os/seastore/seastore_types.h"
 
+namespace crimson::os::seastore {
+class SegmentCleaner;
+}
+
 namespace crimson::os::seastore::journal {
 class SegmentedJournal;
 }
@@ -14,17 +18,30 @@ namespace crimson::os::seastore {
 
 class SegmentSeqAllocator {
 public:
+  SegmentSeqAllocator(segment_type_t type)
+    : type(type) {}
   segment_seq_t get_and_inc_next_segment_seq() {
     return next_segment_seq++;
   }
 private:
   void set_next_segment_seq(segment_seq_t seq) {
     LOG_PREFIX(SegmentSeqAllocator::set_next_segment_seq);
-    SUBINFO(seastore_journal, "next_segment_seq={}", segment_seq_printer_t{seq});
-    next_segment_seq = seq;
+    SUBINFO(
+      seastore_journal,
+      "type {}, next_segment_seq={}, cur_segment_seq={}",
+      type,
+      segment_seq_printer_t{seq},
+      segment_seq_printer_t{next_segment_seq});
+    assert(type == segment_type_t::JOURNAL
+      ? seq >= next_segment_seq
+      : true);
+    if (seq > next_segment_seq)
+      next_segment_seq = seq;
   }
   segment_seq_t next_segment_seq = 0;
+  segment_type_t type = segment_type_t::NULL_SEG;
   friend class journal::SegmentedJournal;
+  friend class SegmentCleaner;
 };
 
 using SegmentSeqAllocatorRef =

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -550,7 +550,7 @@ public:
       std::make_unique<SegmentedAllocator>(
 	*segment_cleaner,
 	*sm,
-	journal->get_segment_seq_allocator()));
+	segment_cleaner->get_ool_segment_seq_allocator()));
   }
 
   ~TransactionManager();

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -42,7 +42,7 @@ struct btree_test_base :
   btree_test_base() = default;
 
   std::map<segment_id_t, segment_seq_t> segment_seqs;
-
+  std::map<segment_id_t, segment_type_t> segment_types;
 
 
   seastar::lowres_system_clock::time_point get_last_modified(
@@ -59,18 +59,23 @@ struct btree_test_base :
   segment_id_t get_segment(
     device_id_t id,
     segment_seq_t seq,
-    segment_type_t) final
+    segment_type_t type) final
   {
     auto ret = next;
     next = segment_id_t{
       next.device_id(),
       next.device_segment_id() + 1};
     segment_seqs[ret] = seq;
+    segment_types[ret] = type;
     return ret;
   }
 
   segment_seq_t get_seq(segment_id_t id) {
     return segment_seqs[id];
+  }
+
+  segment_type_t get_type(segment_id_t id) {
+    return segment_types[id];
   }
 
   journal_seq_t get_journal_tail_target() const final { return journal_seq_t{}; }

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -81,6 +81,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
   segment_id_t next;
 
   std::map<segment_id_t, segment_seq_t> segment_seqs;
+  std::map<segment_id_t, segment_type_t> segment_types;
 
   journal_test_t() = default;
 
@@ -99,18 +100,23 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
   segment_id_t get_segment(
     device_id_t id,
     segment_seq_t seq,
-    segment_type_t) final
+    segment_type_t type) final
   {
     auto ret = next;
     next = segment_id_t{
       next.device_id(),
       next.device_segment_id() + 1};
     segment_seqs[ret] = seq;
+    segment_types[ret] = type;
     return ret;
   }
 
   segment_seq_t get_seq(segment_id_t id) {
     return segment_seqs[id];
+  }
+
+  segment_type_t get_type(segment_id_t id) final {
+    return segment_types[id];
   }
 
   journal_seq_t get_journal_tail_target() const final { return journal_seq_t{}; }
@@ -236,6 +242,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
       block_size,
       1,
       MAX_SEG_SEQ,
+      segment_type_t::NULL_SEG,
       bl
     };
   }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/55143
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
