### PR TITLE
pacific: mgr/dashboard: NFS pages shows 'Page not found' 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nfs.py
+++ b/src/pybind/mgr/dashboard/controllers/nfs.py
@@ -97,7 +97,7 @@ class NFSGanesha(RESTController):
         status = {'available': True, 'message': None}
         try:
             mgr.remote('nfs', 'cluster_ls')
-        except ImportError as error:
+        except (ImportError, RuntimeError) as error:
             logger.exception(error)
             status['available'] = False
             status['message'] = str(error)  # type: ignore

--- a/src/pybind/mgr/dashboard/tests/test_nfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_nfs.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 
 from .. import mgr
 from ..controllers._version import APIVersion
-from ..controllers.nfs import NFSGaneshaExports, NFSGaneshaUi
+from ..controllers.nfs import NFSGanesha, NFSGaneshaExports, NFSGaneshaUi
 from ..tests import ControllerTestCase
 from ..tools import NotificationQueue, TaskManager
 
@@ -227,3 +227,20 @@ class NFSGaneshaUiControllerTest(ControllerTestCase):
         cephfs_class.return_value.ls_dir.assert_called_once_with('/foo', 3)
         self.assertStatus(200)
         self.assertJsonBody({'paths': []})
+
+
+class NFSGaneshaControllerTest(ControllerTestCase):
+    @classmethod
+    def setup_server(cls):
+        cls.setup_controllers([NFSGanesha])
+
+    def test_status_available(self):
+        self._get('/api/nfs-ganesha/status')
+        self.assertStatus(200)
+        self.assertJsonBody({'available': True, 'message': None})
+
+    def test_status_not_available(self):
+        mgr.remote = Mock(side_effect=RuntimeError('Test'))
+        self._get('/api/nfs-ganesha/status')
+        self.assertStatus(200)
+        self.assertJsonBody({'available': False, 'message': 'Test'})


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53884

---

backport of https://github.com/ceph/ceph/pull/44507
parent tracker: https://tracker.ceph.com/issues/53813

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh