### PR TITLE
mon/ConfigMonitor: fix config get key with whitespaces

### DIFF
--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -189,9 +189,9 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
   bufferlist odata;
   if (prefix == "config help") {
     stringstream ss;
-    string name;
-    cmd_getval(cmdmap, "key", name);
-    name = ConfFile::normalize_key_name(name);
+    string name, name_b_norm;
+    cmd_getval(cmdmap, "key", name_b_norm);
+    name = ConfFile::normalize_key_name(name_b_norm);
     const Option *opt = g_conf().find_option(name);
     if (!opt) {
       opt = mon.mgrmon()->find_module_option(name);
@@ -289,7 +289,7 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
       f->flush(odata);
     }
   } else if (prefix == "config get") {
-    string who, name;
+    string who, name, name_b_norm;
     cmd_getval(cmdmap, "who", who);
 
     EntityName entity;
@@ -321,8 +321,8 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
       device_class,
       &src);
 
-    if (cmd_getval(cmdmap, "key", name)) {
-      name = ConfFile::normalize_key_name(name);
+    if (cmd_getval(cmdmap, "key", name_b_norm)) {
+      name = ConfFile::normalize_key_name(name_b_norm);
       const Option *opt = g_conf().find_option(name);
       if (!opt) {
 	opt = mon.mgrmon()->find_module_option(name);
@@ -532,13 +532,13 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
   if (prefix == "config set" ||
       prefix == "config rm") {
     string who;
-    string name, value;
+    string name, name_b_norm, value;
     bool force = false;
     cmd_getval(cmdmap, "who", who);
-    cmd_getval(cmdmap, "name", name);
+    cmd_getval(cmdmap, "name", name_b_norm);
     cmd_getval(cmdmap, "value", value);
     cmd_getval(cmdmap, "force", force);
-    name = ConfFile::normalize_key_name(name);
+    name = ConfFile::normalize_key_name(name_b_norm);
     
     if (prefix == "config set" && !force) {
       const Option *opt = g_conf().find_option(name);


### PR DESCRIPTION
fix config get key with whitespaces Use a different variable names for normalize output to prevent errors during normalize

Fixes: https://tracker.ceph.com/issues/54516
Signed-off-by: Nitzan Mordechai <nmordech@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
