### PR TITLE
pacific: osd/scrub: destruct the scrubber shortly before the PG is destructed

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1683,6 +1683,11 @@ PrimaryLogPG::PrimaryLogPG(OSDService *o, OSDMapRef curmap,
   m_scrubber = make_unique<PrimaryLogScrub>(this);
 }
 
+PrimaryLogPG::~PrimaryLogPG()
+{
+  m_scrubber.reset();
+}
+
 void PrimaryLogPG::get_src_oloc(const object_t& oid, const object_locator_t& oloc, object_locator_t& src_oloc)
 {
   src_oloc = oloc;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1489,7 +1489,7 @@ public:
 	       const PGPool &_pool,
 	       const std::map<std::string,std::string>& ec_profile,
 	       spg_t p);
-  ~PrimaryLogPG() override {}
+  ~PrimaryLogPG() override;
 
   void do_command(
     const std::string_view& prefix,


### PR DESCRIPTION
By destructing the scrubber when the PG is still intact, we guarantee that
Scrubber's code can refer to the PG object - especially in dout()s.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
(cherry picked from commit bcd13e134c1f335506e425800170d55cd8a2af1b)



