### PR TITLE
os/BlueStore: NCB fix for SimpleBitmap boundary check

### DIFF
--- a/src/os/bluestore/simple_bitmap.cc
+++ b/src/os/bluestore/simple_bitmap.cc
@@ -49,9 +49,9 @@ bool SimpleBitmap::set(uint64_t offset, uint64_t length)
 {
   dout(20) <<" [" << std::hex << offset << ", " << length << "]" << dendl;
 
-  if (offset + length >= m_num_bits) {
+  if (offset + length > m_num_bits) {
     derr << __func__ << "::offset + length = " << offset + length << " exceeds map size = " << m_num_bits << dendl;
-    ceph_assert(offset + length < m_num_bits);
+    ceph_assert(offset + length <= m_num_bits);
     return false;
   }
 
@@ -103,9 +103,9 @@ bool SimpleBitmap::set(uint64_t offset, uint64_t length)
 //----------------------------------------------------------------------------
 bool SimpleBitmap::clr(uint64_t offset, uint64_t length)
 {
-  if (offset + length >= m_num_bits) {
+  if (offset + length > m_num_bits) {
     derr << __func__ << "::offset + length = " << offset + length << " exceeds map size = " << m_num_bits << dendl;
-    ceph_assert(offset + length < m_num_bits);
+    ceph_assert(offset + length <= m_num_bits);
     return false;
   }
 
@@ -186,6 +186,9 @@ extent_t SimpleBitmap::get_next_set_extent(uint64_t offset)
   int           ffs = __builtin_ffsll(word) - 1;
   extent_t      ext;
   ext.offset = words_to_bits(word_idx) + ffs;
+  if (ext.offset >= m_num_bits ) {
+    return null_extent;
+  }
 
   // set all bits from current to LSB
   uint64_t      clr_mask = FULL_MASK << ffs;
@@ -245,6 +248,9 @@ extent_t SimpleBitmap::get_next_clr_extent(uint64_t offset)
   int      ffz = __builtin_ffsll(~word) - 1;
   extent_t ext;
   ext.offset = words_to_bits(word_idx) + ffz;
+  if (ext.offset >= m_num_bits ) {
+    return null_extent;
+  }
 
   // clear all bits from current position to LSB
   word &= (FULL_MASK << ffz);

--- a/src/os/bluestore/simple_bitmap.h
+++ b/src/os/bluestore/simple_bitmap.h
@@ -24,6 +24,9 @@
 struct extent_t {
   uint64_t offset;
   uint64_t length;
+  bool operator==(const extent_t& other) const {
+    return (this->offset == other.offset && this->length == other.length);
+  }
 };
 
 class SimpleBitmap {

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -2149,6 +2149,39 @@ TEST(SimpleBitmap, boundaries)
   }
 }
 
+//---------------------------------------------------------------------------------
+TEST(SimpleBitmap, boundaries2)
+{
+  const uint64_t bit_count_base = 64 << 10; // 64Kb = 8MB
+  const extent_t null_extent    = {0, 0};
+
+  for (unsigned i = 0; i < 64; i++) {
+    uint64_t     bit_count   = bit_count_base + i;
+    extent_t     full_extent = {0, bit_count};
+    SimpleBitmap sbmap(g_ceph_context, bit_count);
+
+    sbmap.set(0, bit_count);
+    ASSERT_TRUE(sbmap.get_next_set_extent(0) == full_extent);
+    ASSERT_TRUE(sbmap.get_next_clr_extent(0) == null_extent);
+
+    for (uint64_t bit = 0; bit < bit_count; bit++) {
+      sbmap.clr(bit, 1);
+    }
+    ASSERT_TRUE(sbmap.get_next_set_extent(0) == null_extent);
+    ASSERT_TRUE(sbmap.get_next_clr_extent(0) == full_extent);
+
+    for (uint64_t bit = 0; bit < bit_count; bit++) {
+      sbmap.set(bit, 1);
+    }
+    ASSERT_TRUE(sbmap.get_next_set_extent(0) == full_extent);
+    ASSERT_TRUE(sbmap.get_next_clr_extent(0) == null_extent);
+
+    sbmap.clr(0, bit_count);
+    ASSERT_TRUE(sbmap.get_next_set_extent(0) == null_extent);
+    ASSERT_TRUE(sbmap.get_next_clr_extent(0) == full_extent);
+  }
+}
+
 TEST(shared_blob_2hash_tracker_t, basic_test)
 {
   shared_blob_2hash_tracker_t t1(1024 * 1024, 4096);


### PR DESCRIPTION
The boundary check in SimpleBitmap is off by one causing an assert to trigger
Fixes: https://tracker.ceph.com/issues/55145
Signed-off-by: Gabriel BenHanokh <gbenhano@redhat.com>





<!--
  - Please give your pull request a title like

      os/BlueStore

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: https://tracker.ceph.com/issues/55145
      Signed-off-by: Gabriel BenHanokh <gbenhano@redhat.com>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
