### PR TITLE
rgw: add missing virtual decls for dtors

### DIFF
--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -294,8 +294,7 @@ public:
   io_ctx(ioc), objs_container(_objs_container), max_aio(_max_aio)
   {}
 
-  virtual ~CLSRGWConcurrentIO()
-  {}
+  virtual ~CLSRGWConcurrentIO() {}
 
   int operator()();
 }; // class CLSRGWConcurrentIO
@@ -311,6 +310,7 @@ public:
 			     std::map<int, std::string>& _bucket_objs,
 			     uint32_t _max_aio) :
     CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio) {}
+  virtual ~CLSRGWIssueBucketIndexInit() override {}
 };
 
 
@@ -327,6 +327,7 @@ public:
 			      uint32_t _max_aio) :
   CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio)
   {}
+  virtual ~CLSRGWIssueBucketIndexClean() override {}
 };
 
 
@@ -338,6 +339,7 @@ public:
   CLSRGWIssueSetTagTimeout(librados::IoCtx& ioc, std::map<int, std::string>& _bucket_objs,
                      uint32_t _max_aio, uint64_t _tag_timeout) :
     CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio), tag_timeout(_tag_timeout) {}
+  virtual ~CLSRGWIssueSetTagTimeout() override {}
 };
 
 void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
@@ -470,6 +472,7 @@ public:
                        std::map<int, cls_rgw_bi_log_list_ret>& bi_log_lists, uint32_t max_aio) :
     CLSRGWConcurrentIO(io_ctx, oids, max_aio), result(bi_log_lists),
     marker_mgr(_marker_mgr), max(_max) {}
+  virtual ~CLSRGWIssueBILogList() override {}
 };
 
 void cls_rgw_bilog_trim(librados::ObjectWriteOperation& op,
@@ -495,6 +498,7 @@ public:
       BucketIndexShardsManager& _end_marker_mgr, std::map<int, std::string>& _bucket_objs, uint32_t max_aio) :
     CLSRGWConcurrentIO(io_ctx, _bucket_objs, max_aio),
     start_marker_mgr(_start_marker_mgr), end_marker_mgr(_end_marker_mgr) {}
+  virtual ~CLSRGWIssueBILogTrim() override {}
 };
 
 /**
@@ -515,6 +519,7 @@ public:
 			 std::map<int, rgw_cls_check_index_ret>& bucket_objs_ret,
 			 uint32_t _max_aio) :
     CLSRGWConcurrentIO(ioc, oids, _max_aio), result(bucket_objs_ret) {}
+  virtual ~CLSRGWIssueBucketCheck() override {}
 };
 
 class CLSRGWIssueBucketRebuild : public CLSRGWConcurrentIO {
@@ -523,6 +528,7 @@ protected:
 public:
   CLSRGWIssueBucketRebuild(librados::IoCtx& io_ctx, std::map<int, std::string>& bucket_objs,
                            uint32_t max_aio) : CLSRGWConcurrentIO(io_ctx, bucket_objs, max_aio) {}
+  virtual ~CLSRGWIssueBucketRebuild() override {}
 };
 
 class CLSRGWIssueGetDirHeader : public CLSRGWConcurrentIO {
@@ -533,6 +539,7 @@ public:
   CLSRGWIssueGetDirHeader(librados::IoCtx& io_ctx, std::map<int, std::string>& oids, std::map<int, rgw_cls_list_ret>& dir_headers,
                           uint32_t max_aio) :
     CLSRGWConcurrentIO(io_ctx, oids, max_aio), result(dir_headers) {}
+  virtual ~CLSRGWIssueGetDirHeader() override {}
 };
 
 class CLSRGWIssueSetBucketResharding : public CLSRGWConcurrentIO {
@@ -543,6 +550,7 @@ public:
   CLSRGWIssueSetBucketResharding(librados::IoCtx& ioc, std::map<int, std::string>& _bucket_objs,
                                  const cls_rgw_bucket_instance_entry& _entry,
                                  uint32_t _max_aio) : CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio), entry(_entry) {}
+  virtual ~CLSRGWIssueSetBucketResharding() override {}
 };
 
 class CLSRGWIssueResyncBucketBILog : public CLSRGWConcurrentIO {
@@ -551,6 +559,7 @@ protected:
 public:
   CLSRGWIssueResyncBucketBILog(librados::IoCtx& io_ctx, std::map<int, std::string>& _bucket_objs, uint32_t max_aio) :
     CLSRGWConcurrentIO(io_ctx, _bucket_objs, max_aio) {}
+  virtual ~CLSRGWIssueResyncBucketBILog() override {}
 };
 
 class CLSRGWIssueBucketBILogStop : public CLSRGWConcurrentIO {
@@ -559,6 +568,7 @@ protected:
 public:
   CLSRGWIssueBucketBILogStop(librados::IoCtx& io_ctx, std::map<int, std::string>& _bucket_objs, uint32_t max_aio) :
     CLSRGWConcurrentIO(io_ctx, _bucket_objs, max_aio) {}
+  virtual ~CLSRGWIssueBucketBILogStop() override {}
 };
 
 int cls_rgw_get_dir_header_async(librados::IoCtx& io_ctx, std::string& oid, RGWGetDirHeader_CB *ctx);

--- a/src/rgw/rgw_acl_s3.h
+++ b/src/rgw/rgw_acl_s3.h
@@ -20,7 +20,7 @@ class ACLPermission_S3 : public ACLPermission, public XMLObj
 {
 public:
   ACLPermission_S3() {}
-  ~ACLPermission_S3() override {}
+  virtual ~ACLPermission_S3() override {}
 
   bool xml_end(const char *el) override;
   void to_xml(std::ostream& out);
@@ -30,7 +30,7 @@ class ACLGrantee_S3 : public ACLGrantee, public XMLObj
 {
 public:
   ACLGrantee_S3() {}
-  ~ACLGrantee_S3() override {}
+  virtual ~ACLGrantee_S3() override {}
 
   bool xml_start(const char *el, const char **attr);
 };
@@ -40,7 +40,7 @@ class ACLGrant_S3 : public ACLGrant, public XMLObj
 {
 public:
   ACLGrant_S3() {}
-  ~ACLGrant_S3() override {}
+  virtual ~ACLGrant_S3() override {}
 
   void to_xml(CephContext *cct, std::ostream& out);
   bool xml_end(const char *el) override;
@@ -54,7 +54,7 @@ class RGWAccessControlList_S3 : public RGWAccessControlList, public XMLObj
 {
 public:
   explicit RGWAccessControlList_S3(CephContext *_cct) : RGWAccessControlList(_cct) {}
-  ~RGWAccessControlList_S3() override {}
+  virtual ~RGWAccessControlList_S3() override {}
 
   bool xml_end(const char *el) override;
   void to_xml(std::ostream& out);
@@ -67,7 +67,7 @@ class ACLOwner_S3 : public ACLOwner, public XMLObj
 {
 public:
   ACLOwner_S3() {}
-  ~ACLOwner_S3() override {}
+  virtual ~ACLOwner_S3() override {}
 
   bool xml_end(const char *el) override;
   void to_xml(std::ostream& out);
@@ -79,7 +79,7 @@ class RGWAccessControlPolicy_S3 : public RGWAccessControlPolicy, public XMLObj
 {
 public:
   explicit RGWAccessControlPolicy_S3(CephContext *_cct) : RGWAccessControlPolicy(_cct) {}
-  ~RGWAccessControlPolicy_S3() override {}
+  virtual ~RGWAccessControlPolicy_S3() override {}
 
   bool xml_end(const char *el) override;
 

--- a/src/rgw/rgw_aio_throttle.h
+++ b/src/rgw/rgw_aio_throttle.h
@@ -45,7 +45,7 @@ class Throttle {
  public:
   Throttle(uint64_t window) : window(window) {}
 
-  ~Throttle() {
+  virtual ~Throttle() {
     // must drain before destructing
     ceph_assert(pending.empty());
     ceph_assert(completed.empty());
@@ -65,6 +65,8 @@ class BlockingAioThrottle final : public Aio, private Throttle {
   };
  public:
   BlockingAioThrottle(uint64_t window) : Throttle(window) {}
+
+  virtual ~BlockingAioThrottle() override {};
 
   AioResultList get(const RGWSI_RADOS::Obj& obj, OpFunc&& f,
                     uint64_t cost, uint64_t id) override final;
@@ -99,6 +101,8 @@ class YieldingAioThrottle final : public Aio, private Throttle {
                       yield_context yield)
     : Throttle(window), context(context), yield(yield)
   {}
+
+  virtual ~YieldingAioThrottle() override {};
 
   AioResultList get(const RGWSI_RADOS::Obj& obj, OpFunc&& f,
                     uint64_t cost, uint64_t id) override final;

--- a/src/rgw/rgw_compression.h
+++ b/src/rgw/rgw_compression.h
@@ -33,7 +33,7 @@ public:
                        RGWCompressionInfo* cs_info_, 
                        bool partial_content_,
                        RGWGetObj_Filter* next);
-  ~RGWGetObj_Decompress() override {}
+  virtual ~RGWGetObj_Decompress() override {}
 
   int handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len) override;
   int fixup_range(off_t& ofs, off_t& end) override;
@@ -51,6 +51,7 @@ public:
   RGWPutObj_Compress(CephContext* cct_, CompressorRef compressor,
                      rgw::sal::DataProcessor *next)
     : Pipe(next), cct(cct_), compressor(compressor) {}
+  virtual ~RGWPutObj_Compress() override {};
 
   int process(bufferlist&& data, uint64_t logical_offset) override;
 

--- a/src/rgw/rgw_coroutine.h
+++ b/src/rgw/rgw_coroutine.h
@@ -65,7 +65,7 @@ protected:
   void _complete(RGWAioCompletionNotifier *cn, const rgw_io_id& io_id, void *user_info);
 public:
   explicit RGWCompletionManager(CephContext *_cct);
-  ~RGWCompletionManager() override;
+  virtual ~RGWCompletionManager() override;
 
   void complete(RGWAioCompletionNotifier *cn, const rgw_io_id& io_id, void *user_info);
   int get_next(io_completion *io);
@@ -94,7 +94,7 @@ class RGWAioCompletionNotifier : public RefCountedObject {
 
 public:
   RGWAioCompletionNotifier(RGWCompletionManager *_mgr, const rgw_io_id& _io_id, void *_user_data);
-  ~RGWAioCompletionNotifier() override {
+  virtual ~RGWAioCompletionNotifier() override {
     c->release();
     lock.lock();
     bool need_unregister = registered;
@@ -466,7 +466,7 @@ protected:
   bool collect_next(RGWCoroutine *op, int *ret, RGWCoroutinesStack **collected_stack); /* returns true if found a stack to collect */
 public:
   RGWCoroutinesStack(CephContext *_cct, RGWCoroutinesManager *_ops_mgr, RGWCoroutine *start = NULL);
-  ~RGWCoroutinesStack() override;
+  virtual ~RGWCoroutinesStack() override;
 
   int64_t get_id() const {
     return id;
@@ -718,7 +718,7 @@ class RGWSimpleCoroutine : public RGWCoroutine {
 
 public:
   RGWSimpleCoroutine(CephContext *_cct) : RGWCoroutine(_cct), called_cleanup(false) {}
-  ~RGWSimpleCoroutine() override;
+  virtual ~RGWSimpleCoroutine() override;
 
   virtual int init() { return 0; }
   virtual int send_request(const DoutPrefixProvider *dpp) = 0;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -229,7 +229,7 @@ protected:
 public:
 
   LCRule(){};
-  ~LCRule(){};
+  virtual ~LCRule() {}
 
   const std::string& get_id() const {
       return id;
@@ -498,7 +498,7 @@ public:
     bool should_work(utime_t& now);
     int schedule_next_start_time(utime_t& start, utime_t& now);
     std::set<std::string>& get_cloud_targets() { return cloud_targets; }
-    ~LCWorker();
+    virtual ~LCWorker() override;
 
     friend class RGWRados;
     friend class RGWLC;
@@ -510,7 +510,7 @@ public:
   std::vector<std::unique_ptr<RGWLC::LCWorker>> workers;
 
   RGWLC() : cct(nullptr), store(nullptr) {}
-  ~RGWLC();
+  virtual ~RGWLC() override;
 
   void initialize(CephContext *_cct, rgw::sal::Store* _store);
   void finalize();

--- a/src/rgw/rgw_putobj.h
+++ b/src/rgw/rgw_putobj.h
@@ -26,6 +26,8 @@ class Pipe : public rgw::sal::DataProcessor {
  public:
   explicit Pipe(rgw::sal::DataProcessor *next) : next(next) {}
 
+  virtual ~Pipe() override {}
+
   // passes the data on to the next processor
   int process(bufferlist&& data, uint64_t offset) override {
     return next->process(std::move(data), offset);
@@ -40,6 +42,7 @@ class ChunkProcessor : public Pipe {
   ChunkProcessor(rgw::sal::DataProcessor *next, uint64_t chunk_size)
     : Pipe(next), chunk_size(chunk_size)
   {}
+  virtual ~ChunkProcessor() override {}
 
   int process(bufferlist&& data, uint64_t offset) override;
 };
@@ -62,6 +65,7 @@ class StripeProcessor : public Pipe {
                   uint64_t first_stripe_size)
     : Pipe(next), gen(gen), bounds(0, first_stripe_size)
   {}
+  virtual ~StripeProcessor() override {}
 
   int process(bufferlist&& data, uint64_t data_offset) override;
 };

--- a/src/rgw/rgw_xml.h
+++ b/src/rgw/rgw_xml.h
@@ -20,7 +20,7 @@ public:
   typedef std::map<std::string, XMLObj *>::iterator const_map_iter_t;
 
   XMLObjIter();
-  ~XMLObjIter();
+  virtual ~XMLObjIter();
   void set(const XMLObjIter::const_map_iter_t &_cur, const XMLObjIter::const_map_iter_t &_end);
   XMLObj *get_next();
   bool get_name(std::string& name) const;
@@ -133,7 +133,7 @@ protected:
 
 public:
   RGWXMLParser();
-  ~RGWXMLParser() override;
+  virtual ~RGWXMLParser() override;
 
   // initialize the parser, must be called before parsing
   bool init();


### PR DESCRIPTION
As a side effect or benefit of zipper loadable module work have
found several classes that are missing virtual decl on dtors, or
are missing a dtor decl entirely.

In the zipper loadable module work these missing decls result in
undefined references the vtable for the various classes during the
link.

Signed-off-by: Kaleb S. KEITHLEY <kkeithle@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
