### PR TITLE
rgw: change default ops log backend from rados to file

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,9 @@
+>=18.0.0
+
+* RGW's default backend for `rgw_enable_ops_log` changed from RADOS to file.
+  The default value of `rgw_ops_log_rados` is now false, and `rgw_ops_log_file_path`
+  defaults to "/var/log/ceph/ops-log-$cluster-$name.log".
+
 >=17.0.0
 
 * Filestore has been deprecated in Quincy, considering that BlueStore has been

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1447,7 +1447,10 @@ options:
   type: bool
   level: advanced
   desc: Use RADOS for ops log
-  long_desc: If set, RGW will store ops log information in RADOS.
+  long_desc: If set, RGW will store ops log information in RADOS. WARNING,
+    there is no automation to clean up these log entries, so by default they
+    will pile up without bound. This MUST NOT be enabled unless the admin has
+    a strategy to manage and trim these log entries with `radosgw-admin log rm`.
   fmt_desc: Whether the operations log should be written to the
     Ceph Storage Cluster backend.
   default: false
@@ -1455,6 +1458,8 @@ options:
   - rgw
   see_also:
   - rgw_enable_ops_log
+  - rgw_log_object_name_utc
+  - rgw_log_object_name
   with_legacy: true
 # path to unix domain socket where ops log can go
 - name: rgw_ops_log_socket_path

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1450,7 +1450,7 @@ options:
   long_desc: If set, RGW will store ops log information in RADOS.
   fmt_desc: Whether the operations log should be written to the
     Ceph Storage Cluster backend.
-  default: true
+  default: false
   services:
   - rgw
   see_also:

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1480,8 +1480,10 @@ options:
   type: str
   level: advanced
   desc: File-system path for ops log.
-  long_desc: Path to file that RGW will log ops logs to.
+  long_desc: Path to file that RGW will log ops logs to. A cephadm deployment will automatically
+    rotate these logs under /var/log/ceph/. Other deployments should arrange for similar log rotation.
   fmt_desc: The file-system path for writing operations logs.
+  daemon_default: /var/log/ceph/ops-log-$cluster-$name.log
   services:
   - rgw
   see_also:

--- a/src/test/cli/ceph-conf/show-config.t
+++ b/src/test/cli/ceph-conf/show-config.t
@@ -2,5 +2,6 @@
   admin_socket = /var/run/ceph/ceph-osd.0.asok
   log_file = /var/log/ceph/ceph-osd.0.log
   mon_debug_dump_location = /var/log/ceph/ceph-osd.0.tdump
+  rgw_ops_log_file_path = /var/log/ceph/ops-log-ceph-osd.0.log
   $ CEPH_ARGS="--fsid 96a3abe6-7552-4635-a79b-f3c096ff8b95" ceph-conf -n osd.0 --show-config -c /dev/null | grep fsid
   fsid = 96a3abe6-7552-4635-a79b-f3c096ff8b95


### PR DESCRIPTION
a proposed change to the default backend when `rgw_enable_ops_log` is enabled, based on discussion in https://github.com/ceph/ceph/pull/45691

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
