### PR TITLE
grafana/Makefile: don't push to docker

### DIFF
--- a/monitoring/grafana/build/Makefile
+++ b/monitoring/grafana/build/Makefile
@@ -1,5 +1,5 @@
 
-GRAFANA_VERSION ?= 8.2.6-1
+GRAFANA_VERSION ?= 8.3.5
 PIECHART_VERSION ?= "1.6.1"
 STATUS_PANEL_VERSION ?= "1.0.9"
 DASHBOARD_DIR := "../../ceph-mixin/dashboards_out"
@@ -72,17 +72,13 @@ providers: \\n\
 	sudo buildah commit --format docker --squash $(CONTAINER) $(LOCALTAG)
 
 push:
-	sudo podman tag ${LOCALTAG} docker.io/${TAG}
 	sudo podman tag ${LOCALTAG} quay.io/${TAG}
 	# sudo podman has issues with auth.json; just override it
-	sudo podman login --authfile=auth.json -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD} docker.io
 	sudo podman login --authfile=auth.json -u $(CONTAINER_REPO_USERNAME) -p $(CONTAINER_REPO_PASSWORD) quay.io
-	sudo podman push --authfile=auth.json --format v2s2 docker.io/${TAG}
 	sudo podman push --authfile=auth.json --format v2s2 quay.io/${TAG}
 
 clean:
 	sudo podman rmi ${LOCALTAG} || true
-	sudo podman rmi docker.io/${TAG} || true
 	sudo podman rmi quay.io/${TAG} || true
 	rm -f grafana-*.rpm* auth.json
 	rm -f ${DASHBOARD_PROVISIONING}


### PR DESCRIPTION
And upgrade [Grafana to 8.3.5](https://github.com/grafana/grafana/releases/tag/v8.3.5) (fixes 3 Medium CVEs)

Fixes: https://tracker.ceph.com/issues/55155
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
