### PR TITLE
README: document cmake options for system packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ for a couple of external dependencies:
 	-DCMAKE_INSTALL_PREFIX=/opt/ceph -DCMAKE_C_FLAGS="-Og -g3 -gdwarf-4" \
 	..
 
+Ceph has several bundled dependencies such as Boost, RocksDB and Arrow. By
+default, cmake will build these bundled dependencies from source instead of
+using libraries that are already installed on the system. You can opt-in to
+using these system libraries, provided they meet the minimum version required
+by Ceph, with cmake options like `WITH_SYSTEM_BOOST`:
+
+	cmake -DWITH_SYSTEM_BOOST=ON [...]
+
 To view an exhaustive list of -D options, you can invoke `cmake` with:
 
 	cmake -LH


### PR DESCRIPTION
add a paragraph under `### CMake Options` of `README.md` describing the cmake configuration for bundled library dependencies. based on mailing list discussion 'rgw: arrow packaging status for quincy'

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
