### PR TITLE
Revert "cmake/modules: avoid using distutils"

### DIFF
--- a/cmake/modules/Distutils.cmake
+++ b/cmake/modules/Distutils.cmake
@@ -64,7 +64,7 @@ function(distutils_add_cython_module target name src)
   set(PY_LDSHARED ${link_launcher} ${CMAKE_C_COMPILER} ${c_compiler_arg1} "-shared")
 
   execute_process(COMMAND "${Python3_EXECUTABLE}" -c
-    "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"
+    "from distutils import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"
     RESULT_VARIABLE result
     OUTPUT_VARIABLE ext_suffix
     ERROR_VARIABLE error

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -32,14 +32,7 @@ endif(CMAKE_INSTALL_PREFIX)
 
 execute_process(
   COMMAND
-  ${Python3_EXECUTABLE} -c
-    "import sysconfig;\
-     print(\
-     sysconfig.get_path(\
-     name='purelib',\
-     vars=\
-     {'base': '${PYTHON_INSTALL_TEMPLATE}',\
-      'py_version_short': sysconfig.get_config_var('py_version_short')}))"
+  ${Python3_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix='${PYTHON_INSTALL_TEMPLATE}'))"
   OUTPUT_VARIABLE "PYTHON3_INSTDIR"
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 


### PR DESCRIPTION
This reverts commit 637dd7b40404e644519b1fc3b5ef03f2d18def00.

Causes https://github.com/ceph/ceph/pull/45648#issuecomment-1084941006