### PR TITLE
rgw: allow S3 delete-marker behavior to be restored via config

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1751,8 +1751,15 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
   BIOLHEntry olh(hctx, op.key);
   bool olh_read_attempt = false;
   bool olh_found = false;
-  if (!existed && op.delete_marker) {
-    /* read olh */
+  if (!existed && op.delete_marker && !op.s3_seq_dms) {
+    /* see if this would create a sequential delete-marker, and if so
+     * error out; note that configuration option can restore standard
+     * S3 behavior, as passed in through the op; note: op.s3_seq_dms
+     * should reflect config option
+     * rgw_enable_s3_consecutive_delete_markers
+     */
+
+    // read olh
     ret = olh.init(&olh_found);
     if (ret < 0) {
       return ret;

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -494,24 +494,41 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const std::string& oid,
   return 0;
 }
 
-int cls_rgw_bucket_link_olh(librados::IoCtx& io_ctx, const string& oid,
-                            const cls_rgw_obj_key& key, const bufferlist& olh_tag,
-                            bool delete_marker, const string& op_tag, const rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace)
+int cls_rgw_bucket_link_olh(librados::IoCtx& io_ctx,
+			    const std::string& oid,
+			    const cls_rgw_obj_key& key,
+			    const bufferlist& olh_tag,
+			    bool delete_marker,
+			    const std::string& op_tag,
+			    const rgw_bucket_dir_entry_meta *meta,
+			    uint64_t olh_epoch,
+			    ceph::real_time unmod_since,
+			    bool high_precision_time,
+			    bool log_op,
+			    const rgw_zone_set& zones_trace,
+			    bool s3_seq_dms)
 {
   librados::ObjectWriteOperation op;
   cls_rgw_bucket_link_olh(op, key, olh_tag, delete_marker, op_tag, meta,
                           olh_epoch, unmod_since, high_precision_time, log_op,
-                          zones_trace);
+                          zones_trace, s3_seq_dms);
 
   return io_ctx.operate(oid, &op);
 }
 
 
-void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& key,
-                            const bufferlist& olh_tag, bool delete_marker,
-                            const string& op_tag, const rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace)
+void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op,
+			     const cls_rgw_obj_key& key,
+			     const bufferlist& olh_tag,
+			     bool delete_marker,
+			     const std::string& op_tag,
+			     const rgw_bucket_dir_entry_meta *meta,
+			     uint64_t olh_epoch,
+			     ceph::real_time unmod_since,
+			     bool high_precision_time,
+			     bool log_op,
+			     const rgw_zone_set& zones_trace,
+			     bool s3_seq_dms)
 {
   bufferlist in, out;
   rgw_cls_link_olh_op call;
@@ -527,6 +544,7 @@ void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op, const cls_rgw_o
   call.unmod_since = unmod_since;
   call.high_precision_time = high_precision_time;
   call.zones_trace = zones_trace;
+  call.s3_seq_dms = s3_seq_dms;
   encode(call, in);
   op.exec(RGW_CLASS, RGW_BUCKET_LINK_OLH, in);
 }

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -371,9 +371,14 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const std::string& oid,
 
 
 void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op,
-                            const cls_rgw_obj_key& key, const ceph::buffer::list& olh_tag,
-                            bool delete_marker, const std::string& op_tag, const rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace);
+			     const cls_rgw_obj_key& key,
+			     const ceph::buffer::list& olh_tag,
+			     bool delete_marker, const std::string& op_tag,
+			     const rgw_bucket_dir_entry_meta *meta,
+			     uint64_t olh_epoch, ceph::real_time unmod_since,
+			     bool high_precision_time, bool log_op,
+			     const rgw_zone_set& zones_trace,
+			     bool s3_seq_dms);
 void cls_rgw_bucket_unlink_instance(librados::ObjectWriteOperation& op,
                                    const cls_rgw_obj_key& key, const std::string& op_tag,
                                    const std::string& olh_tag, uint64_t olh_epoch, bool log_op, const rgw_zone_set& zones_trace);
@@ -385,9 +390,14 @@ void cls_rgw_clear_olh(librados::ObjectWriteOperation& op, const cls_rgw_obj_key
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
 #ifndef CLS_CLIENT_HIDE_IOCTX
 int cls_rgw_bucket_link_olh(librados::IoCtx& io_ctx, const std::string& oid,
-                            const cls_rgw_obj_key& key, const ceph::buffer::list& olh_tag,
-                            bool delete_marker, const std::string& op_tag, const rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, const rgw_zone_set& zones_trace);
+                            const cls_rgw_obj_key& key,
+			    const ceph::buffer::list& olh_tag,
+                            bool delete_marker, const std::string& op_tag,
+			    const rgw_bucket_dir_entry_meta *meta,
+                            uint64_t olh_epoch, ceph::real_time unmod_since,
+			    bool high_precision_time, bool log_op,
+			    const rgw_zone_set& zones_trace,
+			    bool s3_seq_dms);
 int cls_rgw_bucket_unlink_instance(librados::IoCtx& io_ctx, const std::string& oid,
                                    const cls_rgw_obj_key& key, const std::string& op_tag,
                                    const std::string& olh_tag, uint64_t olh_epoch, bool log_op, const rgw_zone_set& zones_trace);

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -201,6 +201,7 @@ void rgw_cls_link_olh_op::dump(Formatter *f) const
   encode_json("unmod_since", ut, f);
   encode_json("high_precision_time", high_precision_time, f);
   encode_json("zones_trace", zones_trace, f);
+  encode_json("s3_seq_dms", s3_seq_dms, f);
 }
 
 void rgw_cls_unlink_instance_op::generate_test_instances(list<rgw_cls_unlink_instance_op*>& o)

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -176,11 +176,15 @@ struct rgw_cls_link_olh_op {
   ceph::real_time unmod_since; /* only create delete marker if newer then this */
   bool high_precision_time;
   rgw_zone_set zones_trace;
+  bool s3_seq_dms; // enable S3 protocol of allowing sequential (consecutive) delete-markers
 
-  rgw_cls_link_olh_op() : delete_marker(false), olh_epoch(0), log_op(false), bilog_flags(0), high_precision_time(false) {}
+  rgw_cls_link_olh_op() :
+    delete_marker(false), olh_epoch(0), log_op(false), bilog_flags(0),
+    high_precision_time(false), s3_seq_dms(false)
+  {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(5, 1, bl);
+    ENCODE_START(6, 1, bl);
     encode(key, bl);
     encode(olh_tag, bl);
     encode(delete_marker, bl);
@@ -194,11 +198,12 @@ struct rgw_cls_link_olh_op {
     encode(unmod_since, bl);
     encode(high_precision_time, bl);
     encode(zones_trace, bl);
+    encode(s3_seq_dms, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(5, bl);
+    DECODE_START(6, bl);
     decode(key, bl);
     decode(olh_tag, bl);
     decode(delete_marker, bl);
@@ -222,6 +227,9 @@ struct rgw_cls_link_olh_op {
     }
     if (struct_v >= 5) {
       decode(zones_trace, bl);
+    }
+    if (struct_v >= 6) {
+      decode(s3_seq_dms, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1795,6 +1795,22 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_enable_s3_consecutive_delete_markers
+  type: bool
+  level: advanced
+  desc: RGW enable S3 consecutive delete-markers
+  long_desc: According to S3 documentation, issuing a delete to an
+    already-deleted object in a versioned bucket results in another
+    delete-marker being added to the bucket index. In some cases, this
+    can lead to extra work and large buck indicies. So by default RGW
+    will not add that consecutive delete-marker, but standard S3 behavior
+    can be restored by setting this to true.
+  fmt_desc: Enables S3 behavior of allowing multiple consecutive
+    delete-markers.
+  default: false
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_defer_to_bucket_acls
   type: str
   level: advanced

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6960,19 +6960,25 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
   return -ERR_BUSY_RESHARDING;
 }
 
-int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, RGWObjState& olh_state, const rgw_obj& obj_instance,
+int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp,
+				    const RGWBucketInfo& bucket_info,
+				    RGWObjState& olh_state,
+				    const rgw_obj& obj_instance,
                                     bool delete_marker,
-                                    const string& op_tag,
+                                    const std::string& op_tag,
                                     struct rgw_bucket_dir_entry_meta *meta,
                                     uint64_t olh_epoch,
                                     real_time unmod_since, bool high_precision_time,
-                                    rgw_zone_set *_zones_trace, bool log_data_change)
+                                    rgw_zone_set *_zones_trace,
+				    bool log_data_change)
 {
   rgw_rados_ref ref;
   int r = get_obj_head_ref(dpp, bucket_info, obj_instance, &ref);
   if (r < 0) {
     return r;
   }
+
+  const bool s3_seq_dms = cct->_conf->rgw_enable_s3_consecutive_delete_markers;
 
   rgw_zone_set zones_trace;
   if (_zones_trace) {
@@ -6991,7 +6997,7 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, const RGWBuck
 		      cls_rgw_bucket_link_olh(op, key, olh_state.olh_tag,
                                               delete_marker, op_tag, meta, olh_epoch,
 					      unmod_since, high_precision_time,
-					      svc.zone->get_zone().log_data, zones_trace);
+					      svc.zone->get_zone().log_data, zones_trace, s3_seq_dms);
                       return rgw_rados_operate(dpp, ref.pool.ioctx(), ref.obj.oid, &op, null_yield);
                     });
   if (r < 0) {


### PR DESCRIPTION
According to S3 documentation a removal of an already-removed object from a versioned bucket creates an additional delete-marker. This has the potential to create a huge number of delete-markers for an object. An earlier commit inhibited this behavior and did not add additional delete-markers. This commit adds a configuratrion option -- rgw_enable_s3_consecutive_delete_markers -- that allows the standard S3 behavior to be restored should a client rely upon it.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>

Fixes: https://tracker.ceph.com/issues/54476

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
