### PR TITLE
common/options: Disable AVL allocator first-fit optimizations

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5326,13 +5326,13 @@ options:
   level: dev
   desc: Search for this many ranges in first-fit mode before switching over to
     to best-fit mode. 0 to iterate through all ranges for required chunk.
-  default: 100
+  default: 0
 - name: bluestore_avl_alloc_ff_max_search_bytes
   type: size
   level: dev
   desc: Maximum distance to search in first-fit mode before switching over to
     to best-fit mode. 0 to iterate through all ranges for required chunk.
-  default: 16_M
+  default: 0
 - name: bluestore_avl_alloc_bf_threshold
   type: uint
   level: dev


### PR DESCRIPTION
This PR disables the optimizations for the AVL allocator that were implemented in #41615.  The gist of it is that we are seeing very different IO patterns during large writes (seqential or random) with the current defaults vs disabled.  blktrace shows consistent 64K writes to the device in both cases, but when the current first-fit optimizations are used it results in scattered writes across the whole disk. Disabling those optimizations results in far more sequential writes to the underlying device.  The scattered writes with ff optimizations enabled does not appear to negatively affect our test nodes with Intel P4510 NVMe drives, but it is having a huge negative impact on our nodes with Samsung PM983 drives.  For example, the following numbers show behavior of 4MB random writes after a series of smaller random and sequential writes:

4MB Random Writes (MB/s):

8TB Intel P4510  | | |  
-- | -- | -- | --
  | Iter 0 | Iter 1 | Iter 2
quincy-406c2368 | 2968 | 3009 | 3001
quincy-406c2368 ff=0,0 | 2969 | 2979 | 2987

4TB Samsung PM983  | | |  
-- | -- | -- | --
  | Iter 0 | Iter 1 | Iter 2
quincy-406c2368 | 1223 | 1260 | 1221
quincy-406c2368 ff=0,0 | 1811 | 1804 | 1815

More test result data is available here:
https://docs.google.com/spreadsheets/d/18jFchgrl1tSpQsv0rwPnKsilbBaBl0DZFmgkIG5nwrE/edit?usp=sharing

Surprisingly, replaying the trace with fio using the "replay_no_stall" option is yielding around 1.8GB/s for both the good and bad traces on the samsung PM983.  It may mean that some of the leadup workload (4KB and 128KB random writes) is necessary to get the drive into the slow state.  Nevertheless, we should disable the first-fit optimizations for now given the negative impact they are having on a fairly common NVMe setup.

### 4MB Random Write Hybrid (AVL+Bitmap) Allocator IO Patterns (Current Defaults)
![mako-quincy-406c2368-4MBrandwrite](https://user-images.githubusercontent.com/1286295/161337268-86482fe1-31bc-4ee0-b919-baa84f3a439d.svg)

### 4MB Random Write Hybrid (AVL+Bitmap) Allocator IO Patterns (This PR)
![mako-quincy-406c2368-alloc_ff0-4MBrandwrite](https://user-images.githubusercontent.com/1286295/161337274-0e070636-e98d-4ca2-804a-700c626857d0.svg)

Signed-off-by: Mark Nelson <mnelson@redhat.com>


