### PR TITLE
fsmap: switch to using iterator based loop

### DIFF
--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -259,17 +259,21 @@ public:
       return;
     }
 
-    for (auto &f : filesystems) {
-      string_view fs_name = f.second->mds_map.get_fs_name();
+    for(auto it = filesystems.begin(); it != filesystems.end();) {
+      std::string_view fs_name = (*it).second->mds_map.get_fs_name();
       if (std::find(allowed.begin(), allowed.end(), fs_name) == allowed.end()) {
-	filesystems.erase(f.first);
+        it = filesystems.erase( it );
+      } else {
+        ++ it;
       }
     }
 
-    for (auto r : mds_roles) {
-      string_view fs_name = fs_name_from_gid(r.first);
+    for(auto it = mds_roles.begin(); it != mds_roles.end();) {
+      std::string_view fs_name = fs_name_from_gid((*it).first);
       if (std::find(allowed.begin(), allowed.end(), fs_name) == allowed.end()) {
-	mds_roles.erase(r.first);
+        it = mds_roles.erase( it );
+      } else {
+        ++ it;
       }
     }
   }


### PR DESCRIPTION
Segfault was triggered by the fs/mirror test.
The problem is in potential undefined behaviour
after erasing element and iterator invalidation in
FSMap::filter().
Fixed by explicit iterator increment.

Fixes: https://tracker.ceph.com/issues/55134

Signed-off-by: Aliaksei Makarau <aliaksei.makarau@ibm.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
