### PR TITLE
test/multisite: dont use path when mrun outside of src tree

### DIFF
--- a/src/mrun
+++ b/src/mrun
@@ -5,26 +5,25 @@
 root=`dirname $0`
 run_name=$1
 command=$2
-CEPH_BIN=$root
-
-[[ "$run_name" == "noname" ]] && CEPH_CONF_PATH=$root || CEPH_CONF_PATH=$root/run/$run_name
+CEPH_BIN=""
+CEPH_CONF_PATH="/etc/ceph/"
 
 [ -z "$BUILD_DIR" ] && BUILD_DIR=build
 
 if [ -e CMakeCache.txt ]; then
-    CEPH_BIN=$PWD/bin
-    [[ "$run_name" == "noname" ]] && CEPH_CONF_PATH=$PWD || CEPH_CONF_PATH=$PWD/run/$run_name
+    CEPH_BIN=$PWD/bin/
+    [[ "$run_name" == "noname" ]] && CEPH_CONF_PATH=$PWD/ || CEPH_CONF_PATH=$PWD/run/$run_name/
 elif [ -e $root/../${BUILD_DIR}/CMakeCache.txt ]; then
     cd $root/../${BUILD_DIR}
-    CEPH_BIN=$PWD/bin
-    [[ "$run_name" == "noname" ]] && CEPH_CONF_PATH=$PWD || CEPH_CONF_PATH=$PWD/run/$run_name
+    CEPH_BIN=$PWD/bin/
+    [[ "$run_name" == "noname" ]] && CEPH_CONF_PATH=$PWD/ || CEPH_CONF_PATH=$PWD/run/$run_name/
 fi
 
 shift 2
 
 if [ "$RGW_VALGRIND" = "yes" ] && [ "$command" = "radosgw" ]; then
-    valgrind --trace-children=yes --tool=memcheck --max-threads=1024 $CEPH_BIN/$command -c $CEPH_CONF_PATH/ceph.conf "$@"
+    valgrind --trace-children=yes --tool=memcheck --max-threads=1024 "$CEPH_BIN""$command" -c "$CEPH_CONF_PATH"ceph.conf "$@"
     sleep 10
 else
-    $CEPH_BIN/$command -c $CEPH_CONF_PATH/ceph.conf "$@"
+    "$CEPH_BIN""$command" -c "$CEPH_CONF_PATH"ceph.conf "$@"
 fi


### PR DESCRIPTION
when running in teuthology we should take the binaries
from the machine without specifying a path

Fixes: https://tracker.ceph.com/issues/54416

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
