### PR TITLE
os/bluestore: Switch to time-based adaptive near-fit alogrithm

### DIFF
--- a/src/common/options.h
+++ b/src/common/options.h
@@ -399,6 +399,18 @@ struct Option {
   }
 };
 
+constexpr double operator"" _ns (unsigned long long ns) {
+  return double(ns * 0.000000001L);
+}
+
+constexpr double operator"" _us (unsigned long long us) {
+  return double(us * 0.000001L);
+}
+
+constexpr double operator"" _ms (unsigned long long ms) {
+  return double(ms * 0.001L);
+}
+
 constexpr unsigned long long operator"" _min (unsigned long long min) {
   return min * 60;
 }

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5321,18 +5321,38 @@ options:
   - hdd
   - ssd
   with_legacy: true
-- name: bluestore_avl_alloc_ff_max_search_count
+- name: bluestore_avl_alloc_nf_search_time
+  type: float 
+  level: dev
+  desc: Maximum time in seconds to spend in near-fit mode.  Set to 0 to disable.
+  long_desc: 'Maximum time in seconds to spend in near-fit mode before giving up and 
+    switching to best-fit mode.  Increasing this parameter may allow for less 
+    fragmented large writes, but also increases the time spent in _block_picker()
+    which can itself become a performance bottleneck.  Setting this value to 0 disables
+    the limit.'
+  default: 1_ms 
+- name: bluestore_avl_alloc_nf_min_distance
   type: uint
   level: dev
-  desc: Search for this many ranges in first-fit mode before switching over to
-    to best-fit mode. 0 to iterate through all ranges for required chunk.
-  default: 100
-- name: bluestore_avl_alloc_ff_max_search_bytes
-  type: size
+  desc: Starting distance to search in near-fit mode between ceph_clock_now() checks.
+  long_desc: 'Starting distance to search forward between ceph_clock_now() time checks
+    when in near-fit mode. Every time we check ceph_clock_now() we will double the current
+    value to reduce the total number of time checks while keeping the maximum time overage
+    to 2x or the average search * bluestore_avl_alloc_nf_max_distance, whichever is lower.'
+  default: 8
+  see_also:
+  - bluestore_avl_alloc_nf_search_time
+  - bluestore_avl_alloc_nf_max_distance
+- name: bluestore_avl_alloc_nf_max_distance
+  type: uint
   level: dev
-  desc: Maximum distance to search in first-fit mode before switching over to
-    to best-fit mode. 0 to iterate through all ranges for required chunk.
-  default: 16_M
+  desc: Maximum distance to search in near-fit mode between ceph_clock_now() checks.
+  long_desc: 'Maximum distance to search in near-fit mode between ceph_clock_now() checks.
+    This provides an upper bound on how many searches we will do between clock checks.'
+  default: 1024
+  see_also:
+  - bluestore_avl_alloc_nf_search_time
+  - bluestore_avl_alloc_nf_min_distance
 - name: bluestore_avl_alloc_bf_threshold
   type: uint
   level: dev

--- a/src/common/options/y2c.py
+++ b/src/common/options/y2c.py
@@ -36,7 +36,10 @@ def eval_value(v, typ):
         else:
             return f'"{v}"'
     except ValueError:
-        times = dict(_min=60,
+        times = dict(_ns=0.000000001,
+                     _us=0.000001,
+                     _ms=0.001,
+                     _min=60,
                      _hr=60*60,
                      _day=24*60*60,
                      _K=1 << 10,

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -99,6 +99,7 @@ private:
     uint64_t align);
   // pick a range with exactly the same size or larger
   uint64_t _pick_block_fits(
+    uint64_t *cursor,
     uint64_t size,
     uint64_t align);
   int _allocate(


### PR DESCRIPTION
Previously the AVL allocator had no limits on how long near-fit mode could run.  This resulting in the AVL allocator doing a very good job searching for contiguous space but when the disk was heavily fragmented could result in extremely long allocation requests as documented in https://tracker.ceph.com/issues/52804 and https://github.com/ceph/ceph/pull/45755.  To remedy this, byte and count limits were added in #41615 which prevented long allocation requests.  Unfortunately these limits quickly resulted in fragmentation that hurt large write performance on the Samsung PM983 drives in our test cluster.  The following tests are only short 30s iterations, but demonstrate the problem:

### Quincy Off (search_count=0, search_bytes=0MB)

Iteration | 4KB (IOPS) | 128KB (MiB/s) | 4MB (MiB/s)
-- | -- | -- | --
0 | 79092 | 1766 | 1812
1 | 73365 | 1784 | 1814
2 | 74780 | 1808 | 1816

![mako-quincy-406c2368-alloc_ff0-4MBrandwrite_sm](https://user-images.githubusercontent.com/1286295/161640444-a099635e-51ab-4472-91c7-7a1548436f2c.svg)


### Quincy Default (search_count=100, search_bytes=16MB)

Iteration | 4KB (IOPS) | 128KB (MiB/s) | 4MB (MiB/s)
-- | -- | -- | --
0 | 80492 | **1680** | 1818
1 | 77406 | **1711** | **1671**
2 | 75956 | **906.7** | **1350**

![mako-quincy-406c2368-4MBrandwrite_sm](https://user-images.githubusercontent.com/1286295/161640462-8ca6aaab-e13c-4f7d-a0be-75f40062213c.svg)

Choosing larger values for the count and byte limits helps to some extent, but it's difficult to guess at what those defaults should be, and even an 8x increase over the defaults does not get us back to previous performance levels and may actually hurt performance when set too high:

### Quincy 4X (search_count=400, search_bytes=64MB)

Iteration | 4KB (IOPS) | 128KB (MiB/s) | 4MB (MiB/s)
-- | -- | -- | --
0 | 79769 | 1802 | 1773
1 | **72407** | 1786 | 1802
2 | **72319** | 1792 | **1601**

![mako-quincy-406c2368-alloc_ff4x-4MBrandwrite_sm](https://user-images.githubusercontent.com/1286295/161641094-509360a2-9823-4651-99ca-0d02fd003647.svg)


### Quincy 8X (search_count=800, search_bytes=128MB)

Iteration | 4KB (IOPS) | 128KB (MiB/s) | 4MB (MiB/s)
-- | -- | -- | --
0 | 79488 | 1797 | **1474**
1 | **70332** | 1785 | **1563**
2 | **71895** | 1785 | **1608**

![mako-quincy-406c2368-alloc_ff8x-4MBrandwrite_sm](https://user-images.githubusercontent.com/1286295/161644308-0132205c-a798-4615-a38d-e95bfb3082a6.svg)

To combat this issue, this PR replaces the count and byte limits from #41615 with a single search_time parameter that indicates the maximum amount of time that the AVL allocator should stay in near-first mode before switching to best-first.  It also has an optimization to reduce the number of times we call ceph_time_now() when quickly searching for allocations.  This single value is easier to tune than the dual count/byte limits and easier to think about in terms of the near-first contribution to total allocator lookup time.

When nf_search_time is lower than the time it takes for the allocator to stay in near-first, allocations will be fragmented (though not as badly) like in the current code:

### Adaptive NF (nf_search_time=500us)

Iteration | 4KB (IOPS) | 128KB (MiB/s) | 4MB (MiB/s)
-- | -- | -- | --
0 | 71975 | 1793 | 1776
0 | **68608** | 1808 | 1799
0 | 76577 | 1787 | **1713**

![mako-quincy-406c2368-alloc_aff2_0500us-4MBrandwrite_sm](https://user-images.githubusercontent.com/1286295/161641796-526a1520-2035-4b78-bf86-9e95fdd807e7.svg)

However setting it higher (1ms) results in a similar allocation pattern to when we disable search_count and search_bytes in the current code:

### Adaptive NF (nf_search_time=1ms)

Iteration | 4KB (IOPS) | 128KB (MiB/s) | 4MB (MiB/s)
-- | -- | -- | --
0 | 79504 | 1801 | 1830
1 | **68696** | 1795 | 1832
2 | 72557 | 1794 | 1829

![mako-quincy-406c2368-alloc_aff2_1000us-4MBrandwrite_sm](https://user-images.githubusercontent.com/1286295/161642086-83ed7539-ebca-45da-9b4e-5b6d5d1b9bd9.svg)

Setting it even higher (2ms) may provide more headroom to allow for allocator stalls without fragmenting, but oddly may have an initial (but not permanent?) impact on 4k random write performance.  This would likely be the case with the current code if search_count and/or search_bytes were set much higher.

### Adaptive NF (nf_search_time=2ms)

Iteration | 4KB (IOPS) | 128KB (MiB/s) | 4MB (MiB/s)
-- | -- | -- | --
0 | **52731** | 1766 | 1831
1 | **68494** | 1815 | 1816
2 | 77683 | 1798 | 1830

![mako-quincy-406c2368-alloc_aff2_2000us-4MBrandwrite_sm](https://user-images.githubusercontent.com/1286295/161642348-af506bd0-193f-4f15-95fe-8b31d9cb43b8.svg)

@ifed01 I don't have the the bin file you used in your ceph_test_alloc_replay test.  If you think this PR makes sense, would you want to try it?  Given that I'm limiting near-first search to 1ms, I think it makes sense that it wouldn't prevent what I think is the 746us allocation from your output in #45755?

Signed-off-by: Mark Nelson <mnelson@redhat.com>