### PR TITLE
pacific: mgr/telemetry: fix waiting for mgr to warm up

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -204,13 +204,17 @@ class Module(MgrModule):
         self.last_report = dict()
         self.report_id = None
         self.salt = None
+        self.config_update_module_option()
 
-    def config_notify(self):
+    def config_update_module_option(self):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
                     self.get_module_option(opt['name']))
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
+
+    def config_notify(self):
+        self.config_update_module_option()
         # wake up serve() thread
         self.event.set()
 
@@ -823,11 +827,10 @@ class Module(MgrModule):
 
     def serve(self):
         self.load()
-        self.config_notify()
         self.run = True
 
         self.log.debug('Waiting for mgr to warm up')
-        self.event.wait(10)
+        time.sleep(10)
 
         while self.run:
             self.event.clear()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53605

---

backport of https://github.com/ceph/ceph/pull/43864
parent tracker: https://tracker.ceph.com/issues/53204

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh