### PR TITLE
cephfs-shell: chmod should be allowed for changing all mode bits.

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -168,11 +168,11 @@ class TestMkdir(TestCephFSShell):
         o = self.mount_a.stat('d1')
         log.info("mount_a output:\n{}".format(o))
 
-    def test_mkdir_with_07000_octal_mode(self):
+    def test_mkdir_with_070000_octal_mode(self):
         """
-        Test that mkdir fails with octal mode greater than 0777
+        Test that mkdir fails with octal mode greater than 07777
         """
-        self.negtest_cephfs_shell_cmd(cmd="mkdir -m 07000 d2")
+        self.negtest_cephfs_shell_cmd(cmd="mkdir -m 070000 d2")
         try:
             self.mount_a.stat('d2')
         except CommandFailedError:
@@ -968,6 +968,14 @@ class TestMisc(TestCephFSShell):
         o = self.get_cephfs_shell_cmd_output("help all")
         log.info("output:\n{}".format(o))
 
+    def test_chmod(self):
+        """Test chmod is allowed above o0777 """
+        
+        test_file1 = "test_file2.txt"
+        file1_content = 'A' * 102
+        self.run_cephfs_shell_cmd(f"write {test_file1}", stdin=file1_content)
+        self.run_cephfs_shell_cmd(f"chmod 01777 {test_file1}")
+        
 class TestShellOpts(TestCephFSShell):
     """
     Contains tests for shell options from conf file and shell prompt.

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -507,10 +507,9 @@ class CephFSShell(Cmd):
             except ValueError:
                 res = re.match('((u?g?o?)|(a?))(=)(r?w?x?)', values)
                 if res is None:
-                    parser.error("invalid mode: %s\n"
+                    parser.error(f"invalid mode: {values}\n"
                                  "mode must be a numeric octal literal\n"
-                                 "or   ((u?g?o?)|(a?))(=)(r?w?x?)" %
-                                 values)
+                                 "or   ((u?g?o?)|(a?))(=)(r?w?x?)")
                 else:
                     # we are supporting only assignment of mode and not + or -
                     # as is generally available with the chmod command
@@ -524,9 +523,8 @@ class CephFSShell(Cmd):
                         parser.error("need assignment operator between user "
                                      "and mode specifiers")
                     if val[4] == '':
-                        parser.error("invalid mode: %s\n"
-                                     "mode must be combination of: r | w | x" %
-                                     values)
+                        parser.error(f"invalid mode: {values}\n"
+                                     "mode must be combination of: r | w | x")
                     users = ''
                     if val[2] is None:
                         users = val[1]
@@ -552,11 +550,11 @@ class CephFSShell(Cmd):
                         o_mode |= t_mode
 
             if o_mode < 0:
-                parser.error("invalid mode: %s\n"
-                             "mode cannot be negative" % values)
-            if o_mode > 0o777:
-                parser.error("invalid mode: %s\n"
-                             "mode cannot be greater than octal 0777" % values)
+                parser.error(f"invalid mode: {values}\n"
+                             "mode cannot be negative")
+            if o_mode > 0o7777:
+                parser.error(f"invalid mode: {values}\n"
+                             "mode cannot be greater than octal 07777")
 
             setattr(namespace, self.dest, str(oct(o_mode)))
 
@@ -1002,15 +1000,15 @@ class CephFSShell(Cmd):
         """
         return self.complete_filenames(text, line, begidx, endidx)
 
-    chmod_parser = argparse.ArgumentParser(description='Create Directory.')
+    chmod_parser = argparse.ArgumentParser(description='Change permission of a file/directory.')
     chmod_parser.add_argument('mode', type=str, action=ModeAction, help='Mode')
     chmod_parser.add_argument('paths', type=str, action=path_to_bytes,
-                              help='Name of the file', nargs='+')
+                              help='Path of the file/directory', nargs='+')
 
     @with_argparser(chmod_parser)
     def do_chmod(self, args):
         """
-        Change permission of a file
+        Change permission of a file/directory
         """
         for path in args.paths:
             mode = int(args.mode, base=8)


### PR DESCRIPTION
The allowable mask is changed to 07777 for chmod.

Fix: https://tracker.ceph.com/issues/48863
Signed-off-by: Neeraj Pratap Singh <neesingh@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
