### PR TITLE
mount.ceph: remove `ms_mode' mount option when switching to old-syntax

### DIFF
--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -19,7 +19,7 @@
 
 bool verboseflag = false;
 bool skip_mtab_flag = false;
-bool v2_addrs = false;
+bool v2_addrs = true;
 bool no_fallback = false;
 bool ms_mode_specified = false;
 bool mon_addr_specified = false;
@@ -201,6 +201,7 @@ static int parse_old_dev(const char *dev_str, struct ceph_mount_info *cmi,
 		cmi->cmi_mons = strndup(dev_str, len);
 		if (!cmi->cmi_mons)
 			return -ENOMEM;
+		mon_addr_specified = true;
 	}
 
 	mount_path++;
@@ -296,11 +297,9 @@ static int parse_new_dev(const char *dev_str, struct ceph_mount_info *cmi,
 	}
 
 	/* new-style dev - force using v2 addrs first */
-	if (!ms_mode_specified && !mon_addr_specified) {
-		v2_addrs = true;
-		append_opt("ms_mode", CEPH_DEFAULT_V2_MS_MODE, cmi,
-			   opt_pos);
-	}
+	if (!ms_mode_specified && !mon_addr_specified)
+	  append_opt("ms_mode", CEPH_DEFAULT_V2_MS_MODE, cmi,
+		     opt_pos);
 
 	cmi->format = MOUNT_DEV_FORMAT_NEW;
 	return 0;
@@ -321,7 +320,10 @@ static int parse_dev(const char *dev_str, struct ceph_mount_info *cmi,
 	return ret;
 }
 
-/* resolve monitor host and record in option string */
+/* resolve monitor host and optionallyrecord in option string.
+ * use opt_pos to determine if the caller wants to record the
+ * resolved address in mount option (c.f., mount_old_device_format).
+ */
 static int finalize_src(struct ceph_mount_info *cmi, int *opt_pos)
 {
 	char *src;
@@ -335,8 +337,10 @@ static int finalize_src(struct ceph_mount_info *cmi, int *opt_pos)
 	if (!src)
 		return -1;
 
-	resolved_mon_addr_as_mount_opt(src);
-	append_opt("mon_addr", src, cmi, opt_pos);
+	if (opt_pos) {
+		resolved_mon_addr_as_mount_opt(src);
+		append_opt("mon_addr", src, cmi, opt_pos);
+	}
 	free(src);
 	return 0;
 }
@@ -745,11 +749,36 @@ static int mount_old_device_format(const char *node, struct ceph_mount_info *cmi
 	int pos = 0;
 	char *mon_addr;
 	char *rsrc = NULL;
+	bool free_addr = true;
 
 	r = remove_opt(cmi, "mon_addr", &mon_addr);
 	if (r) {
 		fprintf(stderr, "failed to switch using old device format\n");
 		return -EINVAL;
+	}
+
+	/* if we reach here and still have a v2 addr, we'd need to
+	 * refresh with v1 addrs, since we'll be not passing ms_mode
+	 * with the old syntax.
+	 */
+	if (v2_addrs && !ms_mode_specified) {
+		mount_ceph_debug("mount.ceph: switching to using v1 address with old syntax\n");
+		v2_addrs = false;
+		free(cmi->cmi_mons);
+		cmi->cmi_mons = NULL;
+		fetch_config_info(cmi);
+		if (!cmi->cmi_mons) {
+			fprintf(stderr, "unable to determine (v1) mon addresses\n");
+			return -EINVAL;
+		}
+		r = finalize_src(cmi, NULL);
+		if (r) {
+			fprintf(stderr, "failed to resolve (v1) mon addresses\n");
+			return -EINVAL;
+		}
+		mon_addr = cmi->cmi_mons;
+		remove_opt(cmi, "ms_mode", NULL);
+		free_addr = false;
 	}
 
 	pos = strlen(cmi->cmi_opts);
@@ -772,7 +801,8 @@ static int mount_old_device_format(const char *node, struct ceph_mount_info *cmi
 				 cmi->cmi_opts);
 
 	r = mount(rsrc, node, "ceph", cmi->cmi_flags, cmi->cmi_opts);
-	free(mon_addr);
+	if (free_addr)
+		free(mon_addr);
 	free(rsrc);
 
 	return r;
@@ -814,10 +844,9 @@ static int do_mount(const char *dev, const char *node,
 	bool fallback = true;
 
         /* no v2 addresses available via config - try v1 addresses */
-	if (!cmi->cmi_mons &&
-	    !ms_mode_specified &&
-	    !mon_addr_specified &&
-	    cmi->format == MOUNT_DEV_FORMAT_NEW) {
+	if (v2_addrs &&
+	    !cmi->cmi_mons &&
+	    !ms_mode_specified) {
 		mount_ceph_debug("mount.ceph: switching to using v1 address\n");
 		v2_addrs = false;
 		fetch_config_info(cmi);


### PR DESCRIPTION
... and switch to using v1 addresses (if users haven't specified those
explicitly). kernel versions <5.11 do not understand `ms_mode' mount
option which would result in mount failure.

Fixes: http://tracker.ceph.com/issues/55110
Signed-off-by: Venky Shankar <vshankar@redhat.com>
(cherry picked from commit 5540038e1f06bccb0f06a2de305ef9c29207cb38)

 Conflicts:
	src/mount/mount.ceph.c

call_mount_system_call() helper is not in quincy.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
