### PR TITLE
pacific: osd/scrub: restart snap trimming only after scrubbing is done

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4770,8 +4770,8 @@ void PrimaryLogPG::kick_snap_trim()
 
 void PrimaryLogPG::snap_trimmer_scrub_complete()
 {
-  if (is_primary() && is_active() && is_clean()) {
-    ceph_assert(!snap_trimq.empty());
+  if (is_primary() && is_active() && is_clean() && !snap_trimq.empty()) {
+    dout(10) << "scrub finished - requeuing snap_trimmer" << dendl;
     snap_trimmer_machine.process_event(ScrubComplete());
   }
 }

--- a/src/osd/pg_scrubber.cc
+++ b/src/osd/pg_scrubber.cc
@@ -179,6 +179,9 @@ void PgScrubber::initiate_regular_scrub(epoch_t epoch_queued)
     m_fsm->my_states();
     m_fsm->process_event(StartScrub{});
     dout(10) << "scrubber event --<< StartScrub" << dendl;
+  } else {
+    // and just in case snap trimming was blocked by the aborted scrub
+    m_pg->snap_trimmer_scrub_complete();
   }
 }
 
@@ -192,9 +195,10 @@ void PgScrubber::initiate_scrub_after_repair(epoch_t epoch_queued)
     m_fsm->my_states();
     m_fsm->process_event(AfterRepairScrub{});
     dout(10) << "scrubber event --<< AfterRepairScrub" << dendl;
+  } else {
+    m_pg->snap_trimmer_scrub_complete();
   }
 }
-
 void PgScrubber::send_scrub_unblock(epoch_t epoch_queued)
 {
   dout(10) << "scrubber event -->> " << __func__ << " epoch: " << epoch_queued << dendl;
@@ -1783,11 +1787,6 @@ void PgScrubber::scrub_finish()
       &t);
     int tr = m_osds->store->queue_transaction(m_pg->ch, std::move(t), nullptr);
     ceph_assert(tr == 0);
-
-    if (!m_pg->snap_trimq.empty()) {
-      dout(10) << "scrub finished, requeuing snap_trimmer" << dendl;
-      m_pg->snap_trimmer_scrub_complete();
-    }
   }
 
   if (has_error) {
@@ -1807,6 +1806,9 @@ void PgScrubber::scrub_finish()
   if (m_pg->is_active() && m_pg->is_primary()) {
     m_pg->recovery_state.share_pg_info();
   }
+
+  // we may have blocked the snap trimmer
+  m_pg->snap_trimmer_scrub_complete();
 }
 
 void PgScrubber::on_digest_updates()


### PR DESCRIPTION
Snap trimming that was postponed as the target PG was scrubbing
must be restarted at scrub completion.
PR #38111 moved trimming restart to just before the scrub fully
terminated. The current PR fixes that.

Trimming is also restarted in those cases where scrub was
queued but aborted immediately.

Fixes: https://tracker.ceph.com/issues/52026

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
(cherry picked from commit 948d3266c67bf896d1c20472977b849178d233d3)

Conflicts:
	src/osd/pg_scrubber.cc

Conflict resolved by removing a clear_queued_or_active() call that
was dragged in.

