### PR TITLE
crimson: bring the core of op tracking

### DIFF
--- a/src/crimson/admin/osd_admin.h
+++ b/src/crimson/admin/osd_admin.h
@@ -17,6 +17,7 @@ class InjectDataErrorHook;
 class InjectMDataErrorHook;
 class OsdStatusHook;
 class SendBeaconHook;
+class DumpInFlightOpsHook;
 
 template<class Hook, class... Args>
 std::unique_ptr<AdminSocketHook> make_asok_hook(Args&&... args);

--- a/src/crimson/common/operation.cc
+++ b/src/crimson/common/operation.cc
@@ -67,4 +67,31 @@ void AggregateBlocker::dump_detail(ceph::Formatter *f) const
   f->close_section();
 }
 
+namespace detail {
+void dump_time_event(const char* name,
+		     const utime_t& timestamp,
+		     ceph::Formatter* f)
+{
+  assert(f);
+  f->open_object_section("time_event");
+  f->dump_string("name", name);
+  f->dump_stream("initiated_at") << timestamp;
+  f->close_section();
 }
+
+void dump_blocking_event(const char* name,
+			 const utime_t& timestamp,
+			 const Blocker* const blocker,
+			 ceph::Formatter* f)
+{
+  assert(f);
+  f->open_object_section("blocking_event");
+  f->dump_string("name", name);
+  f->dump_stream("initiated_at") << timestamp;
+  if (blocker) {
+    blocker->dump(f);
+  }
+  f->close_section();
+}
+} // namespace detail
+} // namespace crimson

--- a/src/crimson/common/operation.cc
+++ b/src/crimson/common/operation.cc
@@ -16,10 +16,15 @@ void Operation::dump(ceph::Formatter* f) const
     dump_detail(f);
     f->close_section();
   }
+#if 0
+  // TODO: implement when necessary at the leaf class layer
+  // as that's the place that will be aware about the exact
+  // type of an event container.
   f->open_array_section("blockers");
   for (auto &blocker : blockers) {
     blocker->dump(f);
   }
+#endif
   f->close_section();
   f->close_section();
 }

--- a/src/crimson/common/operation.cc
+++ b/src/crimson/common/operation.cc
@@ -67,12 +67,4 @@ void AggregateBlocker::dump_detail(ceph::Formatter *f) const
   f->close_section();
 }
 
-void OrderedExclusivePhase::dump_detail(ceph::Formatter* f) const
-{
-}
-
-void OrderedConcurrentPhase::dump_detail(ceph::Formatter* f) const
-{
-}
-
 }

--- a/src/crimson/common/operation.cc
+++ b/src/crimson/common/operation.cc
@@ -24,8 +24,8 @@ void Operation::dump(ceph::Formatter* f) const
   for (auto &blocker : blockers) {
     blocker->dump(f);
   }
-#endif
   f->close_section();
+#endif
   f->close_section();
 }
 

--- a/src/crimson/common/operation.cc
+++ b/src/crimson/common/operation.cc
@@ -16,16 +16,6 @@ void Operation::dump(ceph::Formatter* f) const
     dump_detail(f);
     f->close_section();
   }
-#if 0
-  // TODO: implement when necessary at the leaf class layer
-  // as that's the place that will be aware about the exact
-  // type of an event container.
-  f->open_array_section("blockers");
-  for (auto &blocker : blockers) {
-    blocker->dump(f);
-  }
-  f->close_section();
-#endif
   f->close_section();
 }
 
@@ -51,17 +41,6 @@ void Blocker::dump(ceph::Formatter* f) const
   {
     f->open_object_section("detail");
     dump_detail(f);
-    f->close_section();
-  }
-  f->close_section();
-}
-
-void AggregateBlocker::dump_detail(ceph::Formatter *f) const
-{
-  f->open_array_section("parent_blockers");
-  for (auto b : parent_blockers) {
-    f->open_object_section("parent_blocker");
-    b->dump(f);
     f->close_section();
   }
   f->close_section();

--- a/src/crimson/common/operation.h
+++ b/src/crimson/common/operation.h
@@ -161,7 +161,7 @@ public:
   virtual ~BlockerT() = default;
 private:
   const char *get_type_name() const final {
-    return T::type_name;
+    return static_cast<const T*>(this)->type_name;
   }
 };
 

--- a/src/crimson/common/operation.h
+++ b/src/crimson/common/operation.h
@@ -486,8 +486,9 @@ class OperationRegistryT : public OperationRegistryI {
 
 protected:
   void do_register(Operation *op) final {
-    registries[op->get_type()].push_back(*op);
-    op->set_id(++op_id_counters[op->get_type()]);
+    const auto op_type = op->get_type();
+    registries[op_type].push_back(*op);
+    op->set_id(++op_id_counters[op_type]);
   }
 
   bool registries_empty() const final {

--- a/src/crimson/common/operation.h
+++ b/src/crimson/common/operation.h
@@ -517,12 +517,6 @@ private:
   seastar::shared_mutex mutex;
 };
 
-// TODO: drop this after migrating to the new event tracking infrastructure.
-struct OrderedExclusivePhase : OrderedExclusivePhaseT<OrderedExclusivePhase> {
-  OrderedExclusivePhase(const char *type_name) : type_name(type_name) {}
-  const char * type_name;
-};
-
 /**
  * Permits multiple ops to inhabit the stage concurrently, but ensures that
  * they will proceed to the next stage in the order in which they called
@@ -608,11 +602,6 @@ private:
   seastar::shared_mutex mutex;
 };
 
-struct OrderedConcurrentPhase : OrderedConcurrentPhaseT<OrderedConcurrentPhase> {
-  OrderedConcurrentPhase(const char *type_name) : type_name(type_name) {}
-  const char * type_name;
-};
-
 /**
  * Imposes no ordering or exclusivity at all.  Ops enter without constraint and
  * may exit in any order.  Useful mainly for informational purposes between
@@ -643,11 +632,6 @@ public:
     return seastar::make_ready_future<PipelineExitBarrierI::Ref>(
       new ExitBarrier);
   }
-};
-
-struct UnorderedStage : UnorderedStageT<UnorderedStage> {
-  UnorderedStage(const char *type_name) : type_name(type_name) {}
-  const char * type_name;
 };
 
 }

--- a/src/crimson/os/seastore/ordering_handle.h
+++ b/src/crimson/os/seastore/ordering_handle.h
@@ -6,8 +6,35 @@
 #include <seastar/core/shared_mutex.hh>
 
 #include "crimson/common/operation.h"
+#include "crimson/osd/osd_operation.h"
 
 namespace crimson::os::seastore {
+
+struct WritePipeline {
+  struct ReserveProjectedUsage : OrderedExclusivePhaseT<ReserveProjectedUsage> {
+    constexpr static auto type_name = "WritePipeline::reserve_projected_usage";
+  } reserve_projected_usage;
+  struct OolWrites : UnorderedStageT<OolWrites> {
+    constexpr static auto type_name = "UnorderedStage::ool_writes_stage";
+  } ool_writes;
+  struct Prepare : OrderedExclusivePhaseT<Prepare> {
+    constexpr static auto type_name = "WritePipeline::prepare_phase";
+  } prepare;
+  struct DeviceSubmission : OrderedConcurrentPhaseT<DeviceSubmission> {
+    constexpr static auto type_name = "WritePipeline::device_submission_phase";
+  } device_submission;
+  struct Finalize : OrderedExclusivePhaseT<Finalize> {
+    constexpr static auto type_name = "WritePipeline::finalize_phase";
+  } finalize;
+
+  using  BlockingEvents = std::tuple<
+    ReserveProjectedUsage::BlockingEvent,
+    OolWrites::BlockingEvent,
+    Prepare::BlockingEvent,
+    DeviceSubmission::BlockingEvent,
+    Finalize::BlockingEvent
+  >;
+};
 
 /**
  * PlaceholderOperation
@@ -17,31 +44,85 @@ namespace crimson::os::seastore {
  * Until then (and for tests likely permanently) we'll use this unregistered
  * placeholder for the pipeline phases necessary for journal correctness.
  */
-class PlaceholderOperation : public Operation {
+class PlaceholderOperation : public crimson::osd::PhasedOperationT<PlaceholderOperation> {
 public:
-  using IRef = boost::intrusive_ptr<PlaceholderOperation>;
+  constexpr static auto type = 0U;
+  constexpr static auto type_name =
+    "crimson::os::seastore::PlaceholderOperation";
 
-  unsigned get_type() const final {
-    return 0;
+  static PlaceholderOperation::IRef create() {
+    return IRef{new PlaceholderOperation()};
   }
 
-  const char *get_type_name() const final {
-    return "crimson::os::seastore::PlaceholderOperation";
-  }
+  WritePipeline::BlockingEvents tracking_events;
 
 private:
   void dump_detail(ceph::Formatter *f) const final {}
   void print(std::ostream &) const final {}
 };
 
-struct OrderingHandle {
+struct OperationProxy {
   OperationRef op;
-  PipelineHandle phase_handle;
+  OperationProxy(OperationRef op) : op(std::move(op)) {}
+
+  virtual seastar::future<> enter(WritePipeline::ReserveProjectedUsage&) = 0;
+  virtual seastar::future<> enter(WritePipeline::OolWrites&) = 0;
+  virtual seastar::future<> enter(WritePipeline::Prepare&) = 0;
+  virtual seastar::future<> enter(WritePipeline::DeviceSubmission&) = 0;
+  virtual seastar::future<> enter(WritePipeline::Finalize&) = 0;
+
+  virtual void exit() = 0;
+  virtual seastar::future<> complete() = 0;
+
+  virtual ~OperationProxy() = default;
+};
+
+template <typename OpT>
+struct OperationProxyT : OperationProxy {
+  OperationProxyT(typename OpT::IRef op) : OperationProxy(op) {}
+
+  OpT* that() {
+    return static_cast<OpT*>(op.get());
+  }
+  const OpT* that() const {
+    return static_cast<const OpT*>(op.get());
+  }
+
+  seastar::future<> enter(WritePipeline::ReserveProjectedUsage& s) final {
+    return that()->enter_stage(s);
+  }
+  seastar::future<> enter(WritePipeline::OolWrites& s) final {
+    return that()->enter_stage(s);
+  }
+  seastar::future<> enter(WritePipeline::Prepare& s) final {
+    return that()->enter_stage(s);
+  }
+  seastar::future<> enter(WritePipeline::DeviceSubmission& s) final {
+    return that()->enter_stage(s);
+  }
+  seastar::future<> enter(WritePipeline::Finalize& s) final {
+    return that()->enter_stage(s);
+  }
+
+  void exit() final {
+    return that()->handle.exit();
+  }
+  seastar::future<> complete() final {
+    return that()->handle.complete();
+  }
+};
+
+struct OrderingHandle {
+  // we can easily optimize this dynalloc out as all concretes are
+  // supposed to have exactly the same size.
+  std::unique_ptr<OperationProxy> op;
   seastar::shared_mutex *collection_ordering_lock = nullptr;
 
-  OrderingHandle(OperationRef &&op) : op(std::move(op)) {}
+  // in the future we might add further constructors / template to type
+  // erasure while extracting the location of tracking events.
+  OrderingHandle(std::unique_ptr<OperationProxy> op) : op(std::move(op)) {}
   OrderingHandle(OrderingHandle &&other)
-    : op(std::move(other.op)), phase_handle(std::move(other.phase_handle)),
+    : op(std::move(other.op)),
       collection_ordering_lock(other.collection_ordering_lock) {
     other.collection_ordering_lock = nullptr;
   }
@@ -61,16 +142,15 @@ struct OrderingHandle {
 
   template <typename T>
   seastar::future<> enter(T &t) {
-    //return op->with_blocking_future(phase_handle.enter(t));
-    return seastar::now();
+    return op->enter(t);
   }
 
   void exit() {
-    return phase_handle.exit();
+    op->exit();
   }
 
   seastar::future<> complete() {
-    return phase_handle.complete();
+    return op->complete();
   }
 
   ~OrderingHandle() {
@@ -79,25 +159,19 @@ struct OrderingHandle {
 };
 
 inline OrderingHandle get_dummy_ordering_handle() {
-  return OrderingHandle{new PlaceholderOperation};
+  using PlaceholderOpProxy = OperationProxyT<PlaceholderOperation>;
+  return OrderingHandle{
+    std::make_unique<PlaceholderOpProxy>(PlaceholderOperation::create())};
 }
 
-struct WritePipeline {
-  OrderedExclusivePhase reserve_projected_usage{
-    "WritePipeline::reserve_projected_usage"
-  };
-  UnorderedStage ool_writes{
-    "UnorderedStage::ool_writes_stage"
-  };
-  OrderedExclusivePhase prepare{
-    "WritePipeline::prepare_phase"
-  };
-  OrderedConcurrentPhase device_submission{
-    "WritePipeline::device_submission_phase"
-  };
-  OrderedExclusivePhase finalize{
-    "WritePipeline::finalize_phase"
-  };
-};
+} // namespace crimson::os::seastore
 
-}
+namespace crimson {
+  template <>
+  struct EventBackendRegistry<os::seastore::PlaceholderOperation> {
+    static std::tuple<> get_backends() {
+      return {};
+    }
+  };
+} // namespace crimson
+

--- a/src/crimson/os/seastore/ordering_handle.h
+++ b/src/crimson/os/seastore/ordering_handle.h
@@ -61,7 +61,8 @@ struct OrderingHandle {
 
   template <typename T>
   seastar::future<> enter(T &t) {
-    return op->with_blocking_future(phase_handle.enter(t));
+    //return op->with_blocking_future(phase_handle.enter(t));
+    return seastar::now();
   }
 
   void exit() {

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(crimson-osd
   scheduler/scheduler.cc
   scheduler/mclock_scheduler.cc
   osdmap_gate.cc
+  pg_activation_blocker.cc
   pg_map.cc
   pg_interval_interrupt_condition.cc
   objclass.cc

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1436,6 +1436,12 @@ blocking_future<Ref<PG>> OSD::wait_for_pg(
   return pg_map.wait_for_pg(pgid).first;
 }
 
+seastar::future<Ref<PG>> OSD::wait_for_pg(
+  PGMap::PGCreationBlockingEvent::TriggerI&& trigger, spg_t pgid)
+{
+  return pg_map.wait_for_pg(std::move(trigger), pgid).first;
+}
+
 Ref<PG> OSD::get_pg(spg_t pgid)
 {
   return pg_map.get_pg(pgid);

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -545,6 +545,9 @@ seastar::future<> OSD::start_asok_admin()
     // PG commands
     asok->register_command(make_asok_hook<pg::QueryCommand>(*this));
     asok->register_command(make_asok_hook<pg::MarkUnfoundLostCommand>(*this));
+    // ops commands
+    asok->register_command(make_asok_hook<DumpInFlightOpsHook>(
+      std::as_const(get_shard_services().registry)));
   });
 }
 

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1412,24 +1412,6 @@ seastar::future<> OSD::consume_map(epoch_t epoch)
 }
 
 
-blocking_future<Ref<PG>>
-OSD::get_or_create_pg(
-  spg_t pgid,
-  epoch_t epoch,
-  std::unique_ptr<PGCreateInfo> info)
-{
-  if (info) {
-    auto [fut, creating] = pg_map.wait_for_pg(pgid);
-    if (!creating) {
-      pg_map.set_creating(pgid);
-      (void)handle_pg_create_info(std::move(info));
-    }
-    return std::move(fut);
-  } else {
-    return make_ready_blocking_future<Ref<PG>>(pg_map.get_pg(pgid));
-  }
-}
-
 seastar::future<Ref<PG>>
 OSD::get_or_create_pg(
   PGMap::PGCreationBlockingEvent::TriggerI&& trigger,
@@ -1447,12 +1429,6 @@ OSD::get_or_create_pg(
   } else {
     return seastar::make_ready_future<Ref<PG>>(pg_map.get_pg(pgid));
   }
-}
-
-blocking_future<Ref<PG>> OSD::wait_for_pg(
-  spg_t pgid)
-{
-  return pg_map.wait_for_pg(pgid).first;
 }
 
 seastar::future<Ref<PG>> OSD::wait_for_pg(

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -240,6 +240,11 @@ public:
     spg_t pgid,
     epoch_t epoch,
     std::unique_ptr<PGCreateInfo> info);
+  seastar::future<Ref<PG>> get_or_create_pg(
+    PGMap::PGCreationBlockingEvent::TriggerI&&,
+    spg_t pgid,
+    epoch_t epoch,
+    std::unique_ptr<PGCreateInfo> info);
   blocking_future<Ref<PG>> wait_for_pg(
     spg_t pgid);
   seastar::future<Ref<PG>> wait_for_pg(

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -242,6 +242,8 @@ public:
     std::unique_ptr<PGCreateInfo> info);
   blocking_future<Ref<PG>> wait_for_pg(
     spg_t pgid);
+  seastar::future<Ref<PG>> wait_for_pg(
+    PGMap::PGCreationBlockingEvent::TriggerI&&, spg_t pgid);
   Ref<PG> get_pg(spg_t pgid);
   seastar::future<> send_beacon();
 

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -37,7 +37,6 @@ class MOSDMap;
 class MOSDRepOpReply;
 class MOSDRepOp;
 class MOSDScrub2;
-class OSDMap;
 class OSDMeta;
 class Heartbeat;
 

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -210,7 +210,7 @@ private:
   seastar::future<> start_asok_admin();
 
 public:
-  OSDMapGate osdmap_gate;
+  OSD_OSDMapGate osdmap_gate;
 
   ShardServices &get_shard_services() {
     return shard_services;

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -236,17 +236,11 @@ private:
   friend class RemotePeeringEvent;
 
 public:
-  blocking_future<Ref<PG>> get_or_create_pg(
-    spg_t pgid,
-    epoch_t epoch,
-    std::unique_ptr<PGCreateInfo> info);
   seastar::future<Ref<PG>> get_or_create_pg(
     PGMap::PGCreationBlockingEvent::TriggerI&&,
     spg_t pgid,
     epoch_t epoch,
     std::unique_ptr<PGCreateInfo> info);
-  blocking_future<Ref<PG>> wait_for_pg(
-    spg_t pgid);
   seastar::future<Ref<PG>> wait_for_pg(
     PGMap::PGCreationBlockingEvent::TriggerI&&, spg_t pgid);
   Ref<PG> get_pg(spg_t pgid);

--- a/src/crimson/osd/osd_operation.cc
+++ b/src/crimson/osd/osd_operation.cc
@@ -3,8 +3,27 @@
 
 #include "osd_operation.h"
 #include "common/Formatter.h"
+#include "crimson/common/log.h"
+#include "crimson/osd/osd_operations/client_request.h"
+
+namespace {
+  seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_osd);
+  }
+}
 
 namespace crimson::osd {
+
+size_t OSDOperationRegistry::dump_client_requests(ceph::Formatter* f) const
+{
+  const auto& client_registry =
+    get_registry<static_cast<size_t>(ClientRequest::type)>();
+  logger().warn("{} num_ops={}", __func__, std::size(client_registry));
+  for (const auto& op : client_registry) {
+    op.dump(f);
+  }
+  return std::size(client_registry);
+}
 
 OperationThrottler::OperationThrottler(ConfigProxy &conf)
   : scheduler(crimson::osd::scheduler::make_scheduler(conf))

--- a/src/crimson/osd/osd_operation.cc
+++ b/src/crimson/osd/osd_operation.cc
@@ -50,13 +50,13 @@ void OperationThrottler::release_throttle()
   wake();
 }
 
-blocking_future<> OperationThrottler::acquire_throttle(
+seastar::future<> OperationThrottler::acquire_throttle(
   crimson::osd::scheduler::params_t params)
 {
   crimson::osd::scheduler::item_t item{params, seastar::promise<>()};
   auto fut = item.wake.get_future();
   scheduler->enqueue(std::move(item));
-  return make_blocking_future(std::move(fut));
+  return fut;
 }
 
 void OperationThrottler::dump_detail(Formatter *f) const

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -115,14 +115,6 @@ using OSDOperationRegistry = OperationRegistryT<
  */
 class OperationThrottler : public Blocker,
 			private md_config_obs_t {
-public:
-  OperationThrottler(ConfigProxy &conf);
-
-  const char** get_tracked_conf_keys() const final;
-  void handle_conf_change(const ConfigProxy& conf,
-			  const std::set<std::string> &changed) final;
-  void update_from_config(const ConfigProxy &conf);
-
   template <typename F>
   auto with_throttle(
     OperationRef op,
@@ -137,6 +129,14 @@ public:
 	return x;
       });
   }
+
+public:
+  OperationThrottler(ConfigProxy &conf);
+
+  const char** get_tracked_conf_keys() const final;
+  void handle_conf_change(const ConfigProxy& conf,
+			  const std::set<std::string> &changed) final;
+  void update_from_config(const ConfigProxy &conf);
 
   template <typename F>
   seastar::future<> with_throttle_while(

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -148,6 +148,9 @@ class TrackableOperationT : public OperationT<T> {
 protected:
   using OperationT<T>::OperationT;
 
+  struct StartEvent : TimeEvent<StartEvent> {};
+  struct CompletionEvent : TimeEvent<CompletionEvent> {};
+
   template <class EventT, class... Args>
   void track_event(Args&&... args) {
     // the idea is to have a visitor-like interface that allows to double

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -113,8 +113,11 @@ using OSDOperationRegistry = OperationRegistryT<
  * expensive and simply limits the number that can be
  * concurrently active.
  */
-class OperationThrottler : public Blocker,
+class OperationThrottler : public BlockerT<OperationThrottler>,
 			private md_config_obs_t {
+  friend BlockerT<OperationThrottler>;
+  static constexpr const char* type_name = "OperationThrottler";
+
   template <typename OperationT, typename F>
   auto with_throttle(
     OperationT* op,
@@ -153,11 +156,7 @@ public:
 
 private:
   void dump_detail(Formatter *f) const final;
-  const char *get_type_name() const final {
-    return "OperationThrottler";
-  }
 
-private:
   crimson::osd::scheduler::SchedulerRef scheduler;
 
   uint64_t max_in_progress = 0;

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -156,6 +156,14 @@ protected:
   }
 };
 
+template <class T>
+class PhasedOperationT : public TrackableOperationT<T> {
+  using base_t = TrackableOperationT<T>;
+protected:
+  using TrackableOperationT<T>::TrackableOperationT;
+
+  PipelineHandle handle;
+};
 
 /**
  * Maintains a set of lists of all active ops.

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -205,10 +205,7 @@ public:
     crimson::osd::scheduler::params_t params,
     F &&f) {
     return with_throttle(op, params, f).then([this, params, op, f](bool cont) {
-      if (cont)
-	return with_throttle_while(op, params, f);
-      else
-	return seastar::make_ready_future<>();
+      return cont ? with_throttle_while(op, params, f) : seastar::now();
     });
   }
 

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -186,10 +186,11 @@ protected:
 /**
  * Maintains a set of lists of all active ops.
  */
-using OSDOperationRegistry = OperationRegistryT<
+struct OSDOperationRegistry : OperationRegistryT<
   static_cast<size_t>(OperationTypeCode::last_op)
-  >;
-
+> {
+  size_t dump_client_requests(ceph::Formatter* f) const;
+};
 /**
  * Throttles set of currently running operations
  *

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -115,9 +115,9 @@ using OSDOperationRegistry = OperationRegistryT<
  */
 class OperationThrottler : public Blocker,
 			private md_config_obs_t {
-  template <typename F>
+  template <typename OperationT, typename F>
   auto with_throttle(
-    OperationRef op,
+    OperationT* op,
     crimson::osd::scheduler::params_t params,
     F &&f) {
     if (!max_in_progress) return f();
@@ -138,9 +138,9 @@ public:
 			  const std::set<std::string> &changed) final;
   void update_from_config(const ConfigProxy &conf);
 
-  template <typename F>
+  template <typename OperationT, typename F>
   seastar::future<> with_throttle_while(
-    OperationRef op,
+    OperationT* op,
     crimson::osd::scheduler::params_t params,
     F &&f) {
     return with_throttle(op, params, f).then([this, params, op, f](bool cont) {

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -183,6 +183,10 @@ class OperationThrottler : public BlockerT<OperationThrottler>,
     F &&f) {
     if (!max_in_progress) return f();
     auto fut = acquire_throttle(params);
+    // At any given moment a particular op can  be blocked by a given
+    // OperationThrottler instance no more than once. This means the
+    // same throtter won't be on the op's blockers list more than one
+    // time.
     return op->with_blocking_future(std::move(fut))
       .then(std::forward<F>(f))
       .then([this](auto x) {

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -56,66 +56,7 @@ struct InterruptibleOperation : Operation {
 };
 
 template <typename T>
-class OperationT : public InterruptibleOperation {
-  std::vector<Blocker*> blockers;
-
-  void add_blocker(Blocker *b) {
-    blockers.push_back(b);
-  }
-
-  void clear_blocker(Blocker *b) {
-    auto iter = std::find(blockers.begin(), blockers.end(), b);
-    if (iter != blockers.end()) {
-      blockers.erase(iter);
-    }
-  }
-
-public:
-  template <typename U>
-  seastar::future<U> with_blocking_future(blocking_future<U> &&f) {
-    if (f.fut.available()) {
-      return std::move(f.fut);
-    }
-    assert(f.blocker);
-    add_blocker(f.blocker);
-    return std::move(f.fut).then_wrapped([this, blocker=f.blocker](auto &&arg) {
-      clear_blocker(blocker);
-      return std::move(arg);
-    });
-  }
-
-  template <typename InterruptCond, typename U>
-  ::crimson::interruptible::interruptible_future<InterruptCond, U>
-  with_blocking_future_interruptible(blocking_future<U> &&f) {
-    if (f.fut.available()) {
-      return std::move(f.fut);
-    }
-    assert(f.blocker);
-    add_blocker(f.blocker);
-    auto fut = std::move(f.fut).then_wrapped([this, blocker=f.blocker](auto &&arg) {
-      clear_blocker(blocker);
-      return std::move(arg);
-    });
-    return ::crimson::interruptible::interruptible_future<
-      InterruptCond, U>(std::move(fut));
-  }
-
-  template <typename InterruptCond, typename U>
-  ::crimson::interruptible::interruptible_future<InterruptCond, U>
-  with_blocking_future_interruptible(
-    blocking_interruptible_future<InterruptCond, U> &&f) {
-    if (f.fut.available()) {
-      return std::move(f.fut);
-    }
-    assert(f.blocker);
-    add_blocker(f.blocker);
-    return std::move(f.fut).template then_wrapped_interruptible(
-      [this, blocker=f.blocker](auto &&arg) {
-      clear_blocker(blocker);
-      return std::move(arg);
-    });
-  }
-
+struct OperationT : InterruptibleOperation {
   static constexpr const char *type_name = OP_NAMES[static_cast<int>(T::type)];
   using IRef = boost::intrusive_ptr<T>;
 

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -8,6 +8,11 @@
 #include "crimson/osd/scheduler/scheduler.h"
 #include "osd/osd_types.h"
 
+namespace crimson::os::seastore {
+  template<class OpT>
+  class OperationProxyT;
+}
+
 namespace crimson::osd {
 
 enum class OperationTypeCode {
@@ -188,6 +193,9 @@ protected:
   }
 
   PipelineHandle handle;
+
+  template <class OpT>
+  friend class crimson::os::seastore::OperationProxyT;
 };
 
 /**

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -9,6 +9,8 @@
 #include "crimson/osd/osd_operations/peering_event.h"
 #include "crimson/osd/osd_operations/recovery_subrequest.h"
 #include "crimson/osd/osd_operations/replicated_request.h"
+#include "crimson/osd/pg_activation_blocker.h"
+#include "crimson/osd/pg_map.h"
 
 namespace crimson::osd {
 
@@ -17,6 +19,17 @@ struct LttngBackend
   : ClientRequest::StartEvent::Backend,
     ClientRequest::ConnectionPipeline::AwaitMap::BlockingEvent::Backend,
     OSD_OSDMapGate::OSDMapBlocker::BlockingEvent::Backend,
+    ClientRequest::ConnectionPipeline::GetPG::BlockingEvent::Backend,
+    PGMap::PGCreationBlockingEvent::Backend,
+    ClientRequest::PGPipeline::AwaitMap::BlockingEvent::Backend,
+    PG_OSDMapGate::OSDMapBlocker::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::WaitForActive::BlockingEvent::Backend,
+    PGActivationBlocker::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::GetOBC::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::Process::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::WaitRepop::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::SendReply::BlockingEvent::Backend,
     ClientRequest::CompletionEvent::Backend
 {
   void handle(ClientRequest::StartEvent&,
@@ -30,6 +43,61 @@ struct LttngBackend
   void handle(OSD_OSDMapGate::OSDMapBlocker::BlockingEvent&,
               const Operation&,
               const OSD_OSDMapGate::OSDMapBlocker&) override {
+  }
+
+  void handle(ClientRequest::ConnectionPipeline::GetPG::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::ConnectionPipeline::GetPG& blocker) override {
+  }
+
+  void handle(PGMap::PGCreationBlockingEvent&,
+              const Operation&,
+              const PGMap::PGCreationBlocker&) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::AwaitMap::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::AwaitMap& blocker) override {
+  }
+
+  void handle(PG_OSDMapGate::OSDMapBlocker::BlockingEvent&,
+              const Operation&,
+              const PG_OSDMapGate::OSDMapBlocker&) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::WaitForActive::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::WaitForActive& blocker) override {
+  }
+
+  void handle(PGActivationBlocker::BlockingEvent& ev,
+              const Operation& op,
+              const PGActivationBlocker& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::RecoverMissing& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::GetOBC::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::GetOBC& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::Process::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::Process& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::WaitRepop::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::WaitRepop& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::SendReply::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::SendReply& blocker) override {
   }
 
   void handle(ClientRequest::CompletionEvent&,

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -6,6 +6,7 @@
 #include "crimson/osd/osdmap_gate.h"
 #include "crimson/osd/osd_operations/background_recovery.h"
 #include "crimson/osd/osd_operations/client_request.h"
+#include "crimson/osd/osd_operations/compound_peering_request.h"
 #include "crimson/osd/osd_operations/peering_event.h"
 #include "crimson/osd/osd_operations/recovery_subrequest.h"
 #include "crimson/osd/osd_operations/replicated_request.h"
@@ -104,6 +105,24 @@ struct LttngBackend
               const Operation&) override {}
 };
 
+struct LttngBackendCompoundPeering
+  : CompoundPeeringRequest::StartEvent::Backend,
+    CompoundPeeringRequest::SubOpBlocker::BlockingEvent::Backend,
+    CompoundPeeringRequest::CompletionEvent::Backend
+{
+  void handle(CompoundPeeringRequest::StartEvent&,
+              const Operation&) override {}
+
+  void handle(CompoundPeeringRequest::SubOpBlocker::BlockingEvent& ev,
+              const Operation& op,
+              const CompoundPeeringRequest::SubOpBlocker& blocker) override {
+  }
+
+  void handle(CompoundPeeringRequest::CompletionEvent&,
+              const Operation&) override {}
+};
+
+
 } // namespace crimson::osd
 
 namespace crimson {
@@ -133,6 +152,13 @@ template <>
 struct EventBackendRegistry<osd::RecoverySubRequest> {
   static std::tuple<> get_backends() {
     return {/* no extenral backends */};
+  }
+};
+
+template <>
+struct EventBackendRegistry<osd::CompoundPeeringRequest> {
+  static std::tuple<osd::LttngBackendCompoundPeering> get_backends() {
+    return { {} };
   }
 };
 

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -162,4 +162,11 @@ struct EventBackendRegistry<osd::CompoundPeeringRequest> {
   }
 };
 
+template <>
+struct EventBackendRegistry<osd::BackfillRecovery> {
+  static std::tuple<> get_backends() {
+    return {};
+  }
+};
+
 } // namespace crimson

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -8,6 +8,7 @@
 #include "crimson/osd/osd_operations/client_request.h"
 #include "crimson/osd/osd_operations/compound_peering_request.h"
 #include "crimson/osd/osd_operations/peering_event.h"
+#include "crimson/osd/osd_operations/pg_advance_map.h"
 #include "crimson/osd/osd_operations/recovery_subrequest.h"
 #include "crimson/osd/osd_operations/replicated_request.h"
 #include "crimson/osd/pg_activation_blocker.h"
@@ -164,6 +165,13 @@ struct EventBackendRegistry<osd::CompoundPeeringRequest> {
 
 template <>
 struct EventBackendRegistry<osd::BackfillRecovery> {
+  static std::tuple<> get_backends() {
+    return {};
+  }
+};
+
+template <>
+struct EventBackendRegistry<osd::PGAdvanceMap> {
   static std::tuple<> get_backends() {
     return {};
   }

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -14,9 +14,14 @@ namespace crimson::osd {
 
 // Just the boilerplate currently. Implementing
 struct LttngBackend
-  : ClientRequest::ConnectionPipeline::AwaitMap::BlockingEvent::Backend,
-    OSD_OSDMapGate::OSDMapBlocker::BlockingEvent::Backend
+  : ClientRequest::StartEvent::Backend,
+    ClientRequest::ConnectionPipeline::AwaitMap::BlockingEvent::Backend,
+    OSD_OSDMapGate::OSDMapBlocker::BlockingEvent::Backend,
+    ClientRequest::CompletionEvent::Backend
 {
+  void handle(ClientRequest::StartEvent&,
+              const Operation&) override {}
+
   void handle(ClientRequest::ConnectionPipeline::AwaitMap::BlockingEvent& ev,
               const Operation& op,
               const ClientRequest::ConnectionPipeline::AwaitMap& blocker) override {
@@ -26,6 +31,9 @@ struct LttngBackend
               const Operation&,
               const OSD_OSDMapGate::OSDMapBlocker&) override {
   }
+
+  void handle(ClientRequest::CompletionEvent&,
+              const Operation&) override {}
 };
 
 } // namespace crimson::osd

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -136,7 +136,14 @@ struct EventBackendRegistry<osd::ClientRequest> {
 };
 
 template <>
-struct EventBackendRegistry<osd::PeeringEvent> {
+struct EventBackendRegistry<osd::RemotePeeringEvent> {
+  static std::tuple<> get_backends() {
+    return {/* no extenral backends */};
+  }
+};
+
+template <>
+struct EventBackendRegistry<osd::LocalPeeringEvent> {
   static std::tuple<> get_backends() {
     return {/* no extenral backends */};
   }

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -1,0 +1,63 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "crimson/osd/osdmap_gate.h"
+#include "crimson/osd/osd_operations/background_recovery.h"
+#include "crimson/osd/osd_operations/client_request.h"
+#include "crimson/osd/osd_operations/peering_event.h"
+#include "crimson/osd/osd_operations/recovery_subrequest.h"
+#include "crimson/osd/osd_operations/replicated_request.h"
+
+namespace crimson::osd {
+
+// Just the boilerplate currently. Implementing
+struct LttngBackend
+  : ClientRequest::ConnectionPipeline::AwaitMap::BlockingEvent::Backend,
+    OSD_OSDMapGate::OSDMapBlocker::BlockingEvent::Backend
+{
+  void handle(ClientRequest::ConnectionPipeline::AwaitMap::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::ConnectionPipeline::AwaitMap& blocker) override {
+  }
+
+  void handle(OSD_OSDMapGate::OSDMapBlocker::BlockingEvent&,
+              const Operation&,
+              const OSD_OSDMapGate::OSDMapBlocker&) override {
+  }
+};
+
+} // namespace crimson::osd
+
+namespace crimson {
+
+template <>
+struct EventBackendRegistry<osd::ClientRequest> {
+  static std::tuple<osd::LttngBackend/*, HistoricBackend*/> get_backends() {
+    return { {} };
+  }
+};
+
+template <>
+struct EventBackendRegistry<osd::PeeringEvent> {
+  static std::tuple<> get_backends() {
+    return {/* no extenral backends */};
+  }
+};
+
+template <>
+struct EventBackendRegistry<osd::RepRequest> {
+  static std::tuple<> get_backends() {
+    return {/* no extenral backends */};
+  }
+};
+
+template <>
+struct EventBackendRegistry<osd::RecoverySubRequest> {
+  static std::tuple<> get_backends() {
+    return {/* no extenral backends */};
+  }
+};
+
+} // namespace crimson

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -31,6 +31,7 @@ struct LttngBackend
     ClientRequest::PGPipeline::GetOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::Process::BlockingEvent::Backend,
     ClientRequest::PGPipeline::WaitRepop::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent::Backend,
     ClientRequest::PGPipeline::SendReply::BlockingEvent::Backend,
     ClientRequest::CompletionEvent::Backend
 {
@@ -95,6 +96,10 @@ struct LttngBackend
   void handle(ClientRequest::PGPipeline::WaitRepop::BlockingEvent& ev,
               const Operation& op,
               const ClientRequest::PGPipeline::WaitRepop& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent& ev,
+              const Operation& op) override {
   }
 
   void handle(ClientRequest::PGPipeline::SendReply::BlockingEvent& ev,

--- a/src/crimson/osd/osd_operations/background_recovery.cc
+++ b/src/crimson/osd/osd_operations/background_recovery.cc
@@ -75,6 +75,18 @@ seastar::future<> BackgroundRecovery::start()
   });
 }
 
+UrgentRecovery::UrgentRecovery(
+    const hobject_t& soid,
+    const eversion_t& need,
+    Ref<PG> pg,
+    ShardServices& ss,
+    epoch_t epoch_started)
+  : BackgroundRecovery{pg, ss, epoch_started,
+                       crimson::osd::scheduler::scheduler_class_t::immediate},
+    soid{soid}, need(need)
+{
+}
+
 UrgentRecovery::interruptible_future<bool>
 UrgentRecovery::do_recovery()
 {

--- a/src/crimson/osd/osd_operations/background_recovery.cc
+++ b/src/crimson/osd/osd_operations/background_recovery.cc
@@ -9,6 +9,7 @@
 #include "crimson/osd/pg.h"
 #include "crimson/osd/shard_services.h"
 #include "common/Formatter.h"
+#include "crimson/osd/osd_operation_external_tracking.h"
 #include "crimson/osd/osd_operations/background_recovery.h"
 
 namespace {
@@ -19,7 +20,8 @@ namespace {
 
 namespace crimson::osd {
 
-BackgroundRecovery::BackgroundRecovery(
+template <class T>
+BackgroundRecoveryT<T>::BackgroundRecoveryT(
   Ref<PG> pg,
   ShardServices &ss,
   epoch_t epoch_started,
@@ -32,12 +34,14 @@ BackgroundRecovery::BackgroundRecovery(
     scheduler_class(scheduler_class)
 {}
 
-void BackgroundRecovery::print(std::ostream &lhs) const
+template <class T>
+void BackgroundRecoveryT<T>::print(std::ostream &lhs) const
 {
   lhs << "BackgroundRecovery(" << pg->get_pgid() << ")";
 }
 
-void BackgroundRecovery::dump_detail(Formatter *f) const
+template <class T>
+void BackgroundRecoveryT<T>::dump_detail(Formatter *f) const
 {
   f->dump_stream("pgid") << pg->get_pgid();
   f->open_object_section("recovery_detail");
@@ -47,11 +51,12 @@ void BackgroundRecovery::dump_detail(Formatter *f) const
   f->close_section();
 }
 
-seastar::future<> BackgroundRecovery::start()
+template <class T>
+seastar::future<> BackgroundRecoveryT<T>::start()
 {
   logger().debug("{}: start", *this);
 
-  IRef ref = this;
+  typename T::IRef ref = static_cast<T*>(this);
   auto maybe_delay = seastar::now();
   if (delay) {
     maybe_delay = seastar::sleep(
@@ -60,7 +65,7 @@ seastar::future<> BackgroundRecovery::start()
   return maybe_delay.then([ref, this] {
     return ss.throttler.with_throttle_while(
       this, get_scheduler_params(), [this] {
-        return interruptor::with_interruption([this] {
+        return T::interruptor::with_interruption([this] {
           return do_recovery();
         }, [](std::exception_ptr) {
 	  return seastar::make_ready_future<bool>(false);
@@ -81,8 +86,8 @@ UrgentRecovery::UrgentRecovery(
     Ref<PG> pg,
     ShardServices& ss,
     epoch_t epoch_started)
-  : BackgroundRecovery{pg, ss, epoch_started,
-                       crimson::osd::scheduler::scheduler_class_t::immediate},
+  : BackgroundRecoveryT{pg, ss, epoch_started,
+                        crimson::osd::scheduler::scheduler_class_t::immediate},
     soid{soid}, need(need)
 {
 }
@@ -124,7 +129,7 @@ PglogBasedRecovery::PglogBasedRecovery(
   ShardServices &ss,
   const epoch_t epoch_started,
   float delay)
-  : BackgroundRecovery(
+  : BackgroundRecoveryT(
       std::move(pg),
       ss,
       epoch_started,
@@ -159,16 +164,20 @@ BackfillRecovery::do_recovery()
     return seastar::make_ready_future<bool>(false);
   }
   // TODO: limits
-  return with_blocking_future_interruptible<interruptor::condition>(
+  return enter_stage<interruptor>(
     // process_event() of our boost::statechart machine is non-reentrant.
     // with the backfill_pipeline we protect it from a second entry from
     // the implementation of BackfillListener.
     // additionally, this stage serves to synchronize with PeeringEvent.
-    handle.enter(bp(*pg).process)
+    bp(*pg).process
   ).then_interruptible([this] {
     pg->get_recovery_handler()->dispatch_backfill_event(std::move(evt));
     return seastar::make_ready_future<bool>(false);
   });
 }
+
+template class BackgroundRecoveryT<UrgentRecovery>;
+template class BackgroundRecoveryT<PglogBasedRecovery>;
+template class BackgroundRecoveryT<BackfillRecovery>;
 
 } // namespace crimson::osd

--- a/src/crimson/osd/osd_operations/background_recovery.cc
+++ b/src/crimson/osd/osd_operations/background_recovery.cc
@@ -18,6 +18,22 @@ namespace {
   }
 }
 
+namespace crimson {
+  template <>
+  struct EventBackendRegistry<osd::UrgentRecovery> {
+    static std::tuple<> get_backends() {
+      return {};
+    }
+  };
+
+  template <>
+  struct EventBackendRegistry<osd::PglogBasedRecovery> {
+    static std::tuple<> get_backends() {
+      return {};
+    }
+  };
+}
+
 namespace crimson::osd {
 
 template <class T>
@@ -97,9 +113,10 @@ UrgentRecovery::do_recovery()
 {
   logger().debug("{}: {}", __func__, *this);
   if (!pg->has_reset_since(epoch_started)) {
-    return with_blocking_future_interruptible<interruptor::condition>(
-      pg->get_recovery_handler()->recover_missing(soid, need)
-    ).then_interruptible([] {
+    return with_blocking_event<RecoveryBackend::RecoveryBlockingEvent,
+			       interruptor>([this] (auto&& trigger) {
+      return pg->get_recovery_handler()->recover_missing(trigger, soid, need);
+    }).then_interruptible([] {
       return seastar::make_ready_future<bool>(false);
     });
   }
@@ -143,9 +160,12 @@ PglogBasedRecovery::do_recovery()
   if (pg->has_reset_since(epoch_started)) {
     return seastar::make_ready_future<bool>(false);
   }
-  return with_blocking_future_interruptible<interruptor::condition>(
-    pg->get_recovery_handler()->start_recovery_ops(
-      crimson::common::local_conf()->osd_recovery_max_single_start));
+  return with_blocking_event<RecoveryBackend::RecoveryBlockingEvent,
+			     interruptor>([this] (auto&& trigger) {
+    return pg->get_recovery_handler()->start_recovery_ops(
+      trigger,
+      crimson::common::local_conf()->osd_recovery_max_single_start);
+  });
 }
 
 BackfillRecovery::BackfillRecoveryPipeline &BackfillRecovery::bp(PG &pg)

--- a/src/crimson/osd/osd_operations/background_recovery.h
+++ b/src/crimson/osd/osd_operations/background_recovery.h
@@ -15,7 +15,7 @@ namespace crimson::osd {
 class PG;
 class ShardServices;
 
-class BackgroundRecovery : public OperationT<BackgroundRecovery> {
+class BackgroundRecovery : public TrackableOperationT<BackgroundRecovery> {
 public:
   static constexpr OperationTypeCode type = OperationTypeCode::background_recovery;
 

--- a/src/crimson/osd/osd_operations/background_recovery.h
+++ b/src/crimson/osd/osd_operations/background_recovery.h
@@ -89,7 +89,10 @@ public:
       static constexpr auto type_name = "BackfillRecovery::PGPipeline::process";
     } process;
     friend class BackfillRecovery;
+    template <class T>
     friend class PeeringEvent;
+    friend class LocalPeeringEvent;
+    friend class RemotePeeringEvent;
   };
 
   template <class EventT>

--- a/src/crimson/osd/osd_operations/background_recovery.h
+++ b/src/crimson/osd/osd_operations/background_recovery.h
@@ -60,10 +60,7 @@ public:
     const eversion_t& need,
     Ref<PG> pg,
     ShardServices& ss,
-    epoch_t epoch_started)
-  : BackgroundRecovery{pg, ss, epoch_started,
-                       crimson::osd::scheduler::scheduler_class_t::immediate},
-    soid{soid}, need(need) {}
+    epoch_t epoch_started);
   void print(std::ostream&) const final;
 
 private:

--- a/src/crimson/osd/osd_operations/background_recovery.h
+++ b/src/crimson/osd/osd_operations/background_recovery.h
@@ -7,6 +7,7 @@
 
 #include "crimson/net/Connection.h"
 #include "crimson/osd/osd_operation.h"
+#include "crimson/osd/recovery_backend.h"
 #include "crimson/common/type_helpers.h"
 
 namespace crimson::osd {
@@ -63,6 +64,10 @@ public:
     epoch_t epoch_started);
   void print(std::ostream&) const final;
 
+  std::tuple<
+    RecoveryBackend::RecoveryBlockingEvent
+  > tracking_events;
+
 private:
   void dump_detail(Formatter* f) const final;
   interruptible_future<bool> do_recovery() override;
@@ -77,6 +82,10 @@ public:
     ShardServices &ss,
     epoch_t epoch_started,
     float delay = 0);
+
+  std::tuple<
+    RecoveryBackend::RecoveryBlockingEvent
+  > tracking_events;
 
 private:
   interruptible_future<bool> do_recovery() override;

--- a/src/crimson/osd/osd_operations/background_recovery.h
+++ b/src/crimson/osd/osd_operations/background_recovery.h
@@ -9,8 +9,6 @@
 #include "crimson/osd/osd_operation.h"
 #include "crimson/common/type_helpers.h"
 
-#include "messages/MOSDOp.h"
-
 namespace crimson::osd {
 class PG;
 class ShardServices;
@@ -85,9 +83,9 @@ private:
 class BackfillRecovery final : public BackgroundRecovery {
 public:
   class BackfillRecoveryPipeline {
-    OrderedExclusivePhase process = {
-      "BackfillRecovery::PGPipeline::process"
-    };
+    struct Process : OrderedExclusivePhaseT<Process> {
+      static constexpr auto type_name = "BackfillRecovery::PGPipeline::process";
+    } process;
     friend class BackfillRecovery;
     friend class PeeringEvent;
   };

--- a/src/crimson/osd/osd_operations/background_recovery.h
+++ b/src/crimson/osd/osd_operations/background_recovery.h
@@ -65,6 +65,7 @@ public:
   void print(std::ostream&) const final;
 
   std::tuple<
+    OperationThrottler::BlockingEvent,
     RecoveryBackend::RecoveryBlockingEvent
   > tracking_events;
 
@@ -84,6 +85,7 @@ public:
     float delay = 0);
 
   std::tuple<
+    OperationThrottler::BlockingEvent,
     RecoveryBackend::RecoveryBlockingEvent
   > tracking_events;
 
@@ -114,6 +116,7 @@ public:
   static BackfillRecoveryPipeline &bp(PG &pg);
 
   std::tuple<
+    OperationThrottler::BlockingEvent,
     BackfillRecoveryPipeline::Process::BlockingEvent
   > tracking_events;
 

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -78,6 +78,7 @@ seastar::future<> ClientRequest::start()
 {
   logger().debug("{}: start", *this);
 
+  track_event<StartEvent>();
   return seastar::repeat([this, opref=IRef{this}]() mutable {
       logger().debug("{}: in repeat", *this);
       return enter_stage(cp().await_map).then([this]() {
@@ -146,6 +147,8 @@ seastar::future<> ClientRequest::start()
           }
 	}, pgref);
       });
+    }).then([this] {
+      track_event<CompletionEvent>();
     });
 }
 

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -79,8 +79,7 @@ seastar::future<> ClientRequest::start()
 
   return seastar::repeat([this, opref=IRef{this}]() mutable {
       logger().debug("{}: in repeat", *this);
-      return with_blocking_future(handle.enter(cp().await_map))
-      .then([this]() {
+      return enter_stage(cp().await_map).then([this]() {
 	return with_blocking_future(
 	    osd.osdmap_gate.wait_for_map(
 	      m->get_min_epoch()));

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -11,6 +11,7 @@
 #include "crimson/osd/osd.h"
 #include "common/Formatter.h"
 #include "crimson/osd/osd_operation_sequencer.h"
+#include "crimson/osd/osd_operation_external_tracking.h"
 #include "crimson/osd/osd_operations/client_request.h"
 #include "crimson/osd/osd_connection_priv.h"
 

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -85,7 +85,7 @@ seastar::future<> ClientRequest::start()
   track_event<StartEvent>();
   return seastar::repeat([this, opref=IRef{this}]() mutable {
       logger().debug("{}: in repeat", *this);
-      return enter_stage(cp().await_map).then([this]() {
+      return enter_stage<>(cp().await_map).then([this]() {
 	return with_blocking_event<OSD_OSDMapGate::OSDMapBlocker::BlockingEvent>(
 	  [this](auto&& trigger) {
 	  return osd.osdmap_gate.wait_for_map(std::move(trigger),

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -43,6 +43,10 @@ void ClientRequest::print(std::ostream &lhs) const
 
 void ClientRequest::dump_detail(Formatter *f) const
 {
+  logger().debug("{}: dumping", *this);
+  std::apply([f] (auto... event) {
+    (..., event.dump(f));
+  }, tracking_events);
 }
 
 ClientRequest::ConnectionPipeline &ClientRequest::cp()

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -92,9 +92,12 @@ seastar::future<> ClientRequest::start()
 			                      m->get_min_epoch());
 	});
       }).then([this](epoch_t epoch) {
-	return with_blocking_future(handle.enter(cp().get_pg));
+	return enter_stage<>(cp().get_pg);
       }).then([this] {
-	return with_blocking_future(osd.wait_for_pg(m->get_spg()));
+	return with_blocking_event<PGMap::PGCreationBlockingEvent>(
+	  [this] (auto&& trigger) {
+	  return osd.wait_for_pg(std::move(trigger), m->get_spg());
+	});
       }).then([this](Ref<PG> pgref) mutable {
 	return interruptor::with_interruption([this, pgref]() mutable {
           epoch_t same_interval_since = pgref->get_interval_start_epoch();
@@ -111,17 +114,21 @@ seastar::future<> ClientRequest::start()
                   return interruptor::now();
               });
             }
-            return with_blocking_future_interruptible<interruptor::condition>(
-              handle.enter(pp(pg).await_map)
-            ).then_interruptible([this, &pg] {
-              return with_blocking_future_interruptible<interruptor::condition>(
-                pg.osdmap_gate.wait_for_map(m->get_min_epoch()));
-            }).then_interruptible([this, &pg](auto map) {
-              return with_blocking_future_interruptible<interruptor::condition>(
-                handle.enter(pp(pg).wait_for_active));
+	    return enter_stage<interruptor>(
+	      pp(pg).await_map
+	    ).then_interruptible([this, &pg] {
+	      return with_blocking_event<PG_OSDMapGate::OSDMapBlocker::BlockingEvent>(
+		[this, &pg] (auto&& trigger) {
+                  return pg.osdmap_gate.wait_for_map(std::move(trigger),
+						     m->get_min_epoch());
+		});
+            }).then_interruptible([this, &pg](auto&&) {
+              return enter_stage<>(pp(pg).wait_for_active);
             }).then_interruptible([this, &pg]() {
-              return with_blocking_future_interruptible<interruptor::condition>(
-                pg.wait_for_active_blocker.wait());
+	      return with_blocking_event<PGActivationBlocker::BlockingEvent>(
+		[&pg] (auto&& trigger) {
+                return pg.wait_for_active_blocker.wait(std::move(trigger));
+	      });
             }).then_interruptible([this, pgref=std::move(pgref)]() mutable {
               if (is_pg_op()) {
                 return process_pg_op(pgref).then_interruptible([this] {
@@ -169,9 +176,9 @@ ClientRequest::process_pg_op(
 ClientRequest::interruptible_future<ClientRequest::seq_mode_t>
 ClientRequest::process_op(Ref<PG> &pg)
 {
-  return with_blocking_future_interruptible<interruptor::condition>(
-      handle.enter(pp(*pg).recover_missing))
-  .then_interruptible(
+  return enter_stage<interruptor>(
+    pp(*pg).recover_missing
+  ).then_interruptible(
     [this, pg]() mutable {
     return do_recover_missing(pg, m->get_hobj());
   }).then_interruptible([this, pg]() mutable {
@@ -186,8 +193,7 @@ ClientRequest::process_op(Ref<PG> &pg)
           return seastar::make_ready_future<seq_mode_t>(seq_mode_t::OUT_OF_ORDER);
         });
       } else {
-        return with_blocking_future_interruptible<interruptor::condition>(
-            handle.enter(pp(*pg).get_obc)).then_interruptible(
+        return enter_stage<interruptor>(pp(*pg).get_obc).then_interruptible(
           [this, pg]() mutable -> PG::load_obc_iertr::future<seq_mode_t> {
           logger().debug("{}: got obc lock", *this);
           op_info.set_from_op(&*m, *pg->get_osdmap());
@@ -196,9 +202,8 @@ ClientRequest::process_op(Ref<PG> &pg)
           return seastar::do_with(seq_mode_t{}, [this, &pg] (seq_mode_t& mode) {
             return pg->with_locked_obc(m->get_hobj(), op_info,
                                        [this, pg, &mode](auto obc) mutable {
-              return with_blocking_future_interruptible<interruptor::condition>(
-                handle.enter(pp(*pg).process)
-              ).then_interruptible([this, pg, obc, &mode]() mutable {
+              return enter_stage<interruptor>(pp(*pg).process).then_interruptible(
+              [this, pg, obc, &mode]() mutable {
                 return do_process(pg, obc).then_interruptible([&mode] (seq_mode_t _mode) {
                   mode = _mode;
                   return seastar::now();
@@ -264,21 +269,18 @@ ClientRequest::do_process(Ref<PG>& pg, crimson::osd::ObjectContextRef obc)
 
   return pg->do_osd_ops(m, obc, op_info).safe_then_unpack_interruptible(
     [this, pg](auto submitted, auto all_completed) mutable {
-    return submitted.then_interruptible(
-      [this, pg] {
-        return with_blocking_future_interruptible<interruptor::condition>(
-            handle.enter(pp(*pg).wait_repop));
+    return submitted.then_interruptible([this, pg] {
+      return enter_stage<interruptor>(pp(*pg).wait_repop);
     }).then_interruptible(
       [this, pg, all_completed=std::move(all_completed)]() mutable {
       return all_completed.safe_then_interruptible(
         [this, pg](MURef<MOSDOpReply> reply) {
-        return with_blocking_future_interruptible<interruptor::condition>(
-            handle.enter(pp(*pg).send_reply)).then_interruptible(
-              [this, reply=std::move(reply)]() mutable{
-              return conn->send(std::move(reply)).then([] {
-                return seastar::make_ready_future<seq_mode_t>(seq_mode_t::IN_ORDER);
-              });
-            });
+        return enter_stage<interruptor>(pp(*pg).send_reply).then_interruptible(
+          [this, reply=std::move(reply)]() mutable {
+          return conn->send(std::move(reply)).then([] {
+            return seastar::make_ready_future<seq_mode_t>(seq_mode_t::IN_ORDER);
+          });
+        });
       }, crimson::ct_error::eagain::handle([this, pg]() mutable {
         return process_op(pg);
       }));

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -16,7 +16,7 @@ namespace crimson::osd {
 class PG;
 class OSD;
 
-class ClientRequest final : public OperationT<ClientRequest>,
+class ClientRequest final : public TrackableOperationT<ClientRequest>,
                             private CommonClientRequest {
   OSD &osd;
   crimson::net::ConnectionRef conn;

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -37,6 +37,7 @@ public:
     } get_pg;
 
     friend class ClientRequest;
+    friend class LttngBackend;
   };
 
   class PGPipeline : public CommonPGPipeline {
@@ -50,6 +51,7 @@ public:
       static constexpr auto type_name = "ClientRequest::PGPipeline::send_reply";
     } send_reply;
     friend class ClientRequest;
+    friend class LttngBackend;
   };
 
   static constexpr OperationTypeCode type = OperationTypeCode::client_request;

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -26,24 +26,29 @@ class ClientRequest final : public OperationT<ClientRequest>,
 
 public:
   class ConnectionPipeline {
-    OrderedExclusivePhase await_map = {
-      "ClientRequest::ConnectionPipeline::await_map"
-    };
-    OrderedExclusivePhase get_pg = {
-      "ClientRequest::ConnectionPipeline::get_pg"
-    };
+    struct AwaitMap : OrderedExclusivePhaseT<AwaitMap> {
+      static constexpr auto type_name =
+        "ClientRequest::ConnectionPipeline::await_map";
+    } await_map;
+
+    struct GetPG : OrderedExclusivePhaseT<GetPG> {
+      static constexpr auto type_name =
+        "ClientRequest::ConnectionPipeline::get_pg";
+    } get_pg;
+
     friend class ClientRequest;
   };
+
   class PGPipeline : public CommonPGPipeline {
-    OrderedExclusivePhase await_map = {
-      "ClientRequest::PGPipeline::await_map"
-    };
-    OrderedConcurrentPhase wait_repop = {
-      "ClientRequest::PGPipeline::wait_repop"
-    };
-    OrderedExclusivePhase send_reply = {
-      "ClientRequest::PGPipeline::send_reply"
-    };
+    struct AwaitMap : OrderedExclusivePhaseT<AwaitMap> {
+      static constexpr auto type_name = "ClientRequest::PGPipeline::await_map";
+    } await_map;
+    struct WaitRepop : OrderedConcurrentPhaseT<WaitRepop> {
+      static constexpr auto type_name = "ClientRequest::PGPipeline::wait_repop";
+    } wait_repop;
+    struct SendReply : OrderedExclusivePhaseT<SendReply> {
+      static constexpr auto type_name = "ClientRequest::PGPipeline::send_reply";
+    } send_reply;
     friend class ClientRequest;
   };
 

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -16,13 +16,12 @@ namespace crimson::osd {
 class PG;
 class OSD;
 
-class ClientRequest final : public TrackableOperationT<ClientRequest>,
+class ClientRequest final : public PhasedOperationT<ClientRequest>,
                             private CommonClientRequest {
   OSD &osd;
   crimson::net::ConnectionRef conn;
   Ref<MOSDOp> m;
   OpInfo op_info;
-  PipelineHandle handle;
 
 public:
   class ConnectionPipeline {

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -100,6 +100,11 @@ private:
       Errorator>;
 
   bool is_misdirected(const PG& pg) const;
+
+public:
+  std::tuple<
+    ConnectionPipeline::AwaitMap::BlockingEvent
+  > tracking_events;
 };
 
 }

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -6,6 +6,7 @@
 #include "osd/osd_op_util.h"
 #include "crimson/net/Connection.h"
 #include "crimson/osd/object_context.h"
+#include "crimson/osd/osdmap_gate.h"
 #include "crimson/osd/osd_operation.h"
 #include "crimson/osd/osd_operations/client_request_common.h"
 #include "crimson/osd/osd_operations/common/pg_pipeline.h"
@@ -103,7 +104,8 @@ private:
 
 public:
   std::tuple<
-    ConnectionPipeline::AwaitMap::BlockingEvent
+    ConnectionPipeline::AwaitMap::BlockingEvent,
+    OSD_OSDMapGate::OSDMapBlocker::BlockingEvent
   > tracking_events;
 };
 

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -10,6 +10,8 @@
 #include "crimson/osd/osd_operation.h"
 #include "crimson/osd/osd_operations/client_request_common.h"
 #include "crimson/osd/osd_operations/common/pg_pipeline.h"
+#include "crimson/osd/pg_activation_blocker.h"
+#include "crimson/osd/pg_map.h"
 #include "crimson/common/type_helpers.h"
 #include "messages/MOSDOp.h"
 
@@ -109,6 +111,17 @@ public:
     StartEvent,
     ConnectionPipeline::AwaitMap::BlockingEvent,
     OSD_OSDMapGate::OSDMapBlocker::BlockingEvent,
+    ConnectionPipeline::GetPG::BlockingEvent,
+    PGMap::PGCreationBlockingEvent,
+    PGPipeline::AwaitMap::BlockingEvent,
+    PG_OSDMapGate::OSDMapBlocker::BlockingEvent,
+    PGPipeline::WaitForActive::BlockingEvent,
+    PGActivationBlocker::BlockingEvent,
+    PGPipeline::RecoverMissing::BlockingEvent,
+    PGPipeline::GetOBC::BlockingEvent,
+    PGPipeline::Process::BlockingEvent,
+    PGPipeline::WaitRepop::BlockingEvent,
+    PGPipeline::SendReply::BlockingEvent,
     CompletionEvent
   > tracking_events;
 

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -99,7 +99,7 @@ private:
     ::crimson::interruptible::interruptible_errorator<
       ::crimson::osd::IOInterruptCondition,
       Errorator>;
-private:
+
   bool is_misdirected(const PG& pg) const;
 };
 

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -106,9 +106,14 @@ private:
 
 public:
   std::tuple<
+    StartEvent,
     ConnectionPipeline::AwaitMap::BlockingEvent,
-    OSD_OSDMapGate::OSDMapBlocker::BlockingEvent
+    OSD_OSDMapGate::OSDMapBlocker::BlockingEvent,
+    CompletionEvent
   > tracking_events;
+
+  friend class LttngBackend;
+  friend class HistoricBackend;
 };
 
 }

--- a/src/crimson/osd/osd_operations/common/pg_pipeline.h
+++ b/src/crimson/osd/osd_operations/common/pg_pipeline.h
@@ -12,18 +12,18 @@ class CommonPGPipeline {
 protected:
   friend class InternalClientRequest;
 
-  OrderedExclusivePhase wait_for_active = {
-    "CommonPGPipeline:::wait_for_active"
-  };
-  OrderedExclusivePhase recover_missing = {
-    "CommonPGPipeline::recover_missing"
-  };
-  OrderedExclusivePhase get_obc = {
-    "CommonPGPipeline::get_obc"
-  };
-  OrderedExclusivePhase process = {
-    "CommonPGPipeline::process"
-  };
+  struct WaitForActive : OrderedExclusivePhaseT<WaitForActive> {
+    static constexpr auto type_name = "CommonPGPipeline:::wait_for_active";
+  } wait_for_active;
+  struct RecoverMissing : OrderedExclusivePhaseT<RecoverMissing> {
+    static constexpr auto type_name = "CommonPGPipeline::recover_missing";
+  } recover_missing;
+  struct GetOBC : OrderedExclusivePhaseT<GetOBC> {
+    static constexpr auto type_name = "CommonPGPipeline::get_obc";
+  } get_obc;
+  struct Process : OrderedExclusivePhaseT<Process> {
+    static constexpr auto type_name = "CommonPGPipeline::process";
+  } process;
 };
 
 } // namespace crimson::osd

--- a/src/crimson/osd/osd_operations/compound_peering_request.cc
+++ b/src/crimson/osd/osd_operations/compound_peering_request.cc
@@ -125,6 +125,7 @@ void CompoundPeeringRequest::dump_detail(Formatter *f) const
 seastar::future<> CompoundPeeringRequest::start()
 {
   logger().info("{}: starting", *this);
+  track_event<StartEvent>();
   auto state = seastar::make_lw_shared<compound_state>();
   auto blocker = std::make_unique<SubOpBlocker>(
     [&] {
@@ -146,6 +147,7 @@ seastar::future<> CompoundPeeringRequest::start()
       logger().info("{}: sub events complete", *this);
       return osd.get_shard_services().dispatch_context_messages(std::move(ctx));
     }).then([this, ref=std::move(ref)] {
+      track_event<CompletionEvent>();
       logger().info("{}: complete", *this);
     });
   });

--- a/src/crimson/osd/osd_operations/compound_peering_request.cc
+++ b/src/crimson/osd/osd_operations/compound_peering_request.cc
@@ -100,24 +100,6 @@ std::vector<crimson::OperationRef> handle_pg_create(
   return ret;
 }
 
-struct SubOpBlocker : crimson::BlockerT<SubOpBlocker> {
-  static constexpr const char * type_name = "CompoundOpBlocker";
-
-  std::vector<crimson::OperationRef> subops;
-  SubOpBlocker(std::vector<crimson::OperationRef> &&subops)
-    : subops(subops) {}
-
-  virtual void dump_detail(Formatter *f) const {
-    f->open_array_section("dependent_operations");
-    {
-      for (auto &i : subops) {
-	i->dump_brief(f);
-      }
-    }
-    f->close_section();
-  }
-};
-
 } // namespace
 
 namespace crimson::osd {

--- a/src/crimson/osd/osd_operations/compound_peering_request.h
+++ b/src/crimson/osd/osd_operations/compound_peering_request.h
@@ -23,6 +23,24 @@ public:
   static constexpr OperationTypeCode type =
     OperationTypeCode::compound_peering_request;
 
+  struct SubOpBlocker : crimson::BlockerT<SubOpBlocker> {
+    static constexpr const char * type_name = "CompoundOpBlocker";
+
+    std::vector<crimson::OperationRef> subops;
+    SubOpBlocker(std::vector<crimson::OperationRef> &&subops)
+      : subops(subops) {}
+
+    virtual void dump_detail(Formatter *f) const {
+      f->open_array_section("dependent_operations");
+      {
+        for (auto &i : subops) {
+          i->dump_brief(f);
+        }
+      }
+      f->close_section();
+    }
+  };
+
 private:
   OSD &osd;
   crimson::net::ConnectionRef conn;

--- a/src/crimson/osd/osd_operations/compound_peering_request.h
+++ b/src/crimson/osd/osd_operations/compound_peering_request.h
@@ -18,7 +18,7 @@ class PG;
 
 using osd_id_t = int;
 
-class CompoundPeeringRequest : public OperationT<CompoundPeeringRequest> {
+class CompoundPeeringRequest : public TrackableOperationT<CompoundPeeringRequest> {
 public:
   static constexpr OperationTypeCode type =
     OperationTypeCode::compound_peering_request;

--- a/src/crimson/osd/osd_operations/compound_peering_request.h
+++ b/src/crimson/osd/osd_operations/compound_peering_request.h
@@ -19,6 +19,7 @@ class PG;
 using osd_id_t = int;
 
 class CompoundPeeringRequest : public TrackableOperationT<CompoundPeeringRequest> {
+  friend class LttngBackendCompoundPeering;
 public:
   static constexpr OperationTypeCode type =
     OperationTypeCode::compound_peering_request;
@@ -53,6 +54,12 @@ public:
   void print(std::ostream &) const final;
   void dump_detail(Formatter *f) const final;
   seastar::future<> start();
+
+  std::tuple<
+    StartEvent,
+    SubOpBlocker::BlockingEvent,
+    CompletionEvent
+  > tracking_events;
 };
 
 }

--- a/src/crimson/osd/osd_operations/internal_client_request.h
+++ b/src/crimson/osd/osd_operations/internal_client_request.h
@@ -6,7 +6,9 @@
 #include "crimson/common/type_helpers.h"
 #include "crimson/osd/osd_operation.h"
 #include "crimson/osd/osd_operations/client_request_common.h"
+#include "crimson/osd/osd_operations/common/pg_pipeline.h"
 #include "crimson/osd/pg.h"
+#include "crimson/osd/pg_activation_blocker.h"
 
 namespace crimson::osd {
 
@@ -43,6 +45,17 @@ private:
 
   Ref<PG> pg;
   OpInfo op_info;
+
+public:
+  std::tuple<
+    StartEvent,
+    CommonPGPipeline::WaitForActive::BlockingEvent,
+    PGActivationBlocker::BlockingEvent,
+    CommonPGPipeline::RecoverMissing::BlockingEvent,
+    CommonPGPipeline::GetOBC::BlockingEvent,
+    CommonPGPipeline::Process::BlockingEvent,
+    CompletionEvent
+  > tracking_events;
 };
 
 } // namespace crimson::osd

--- a/src/crimson/osd/osd_operations/internal_client_request.h
+++ b/src/crimson/osd/osd_operations/internal_client_request.h
@@ -10,7 +10,7 @@
 
 namespace crimson::osd {
 
-class InternalClientRequest : public TrackableOperationT<InternalClientRequest>,
+class InternalClientRequest : public PhasedOperationT<InternalClientRequest>,
                               private CommonClientRequest {
 public:
   explicit InternalClientRequest(Ref<PG> pg);
@@ -42,7 +42,6 @@ private:
   seastar::future<> do_process();
 
   Ref<PG> pg;
-  PipelineHandle handle;
   OpInfo op_info;
 };
 

--- a/src/crimson/osd/osd_operations/internal_client_request.h
+++ b/src/crimson/osd/osd_operations/internal_client_request.h
@@ -10,7 +10,7 @@
 
 namespace crimson::osd {
 
-class InternalClientRequest : public OperationT<InternalClientRequest>,
+class InternalClientRequest : public TrackableOperationT<InternalClientRequest>,
                               private CommonClientRequest {
 public:
   explicit InternalClientRequest(Ref<PG> pg);

--- a/src/crimson/osd/osd_operations/peering_event.h
+++ b/src/crimson/osd/osd_operations/peering_event.h
@@ -21,7 +21,7 @@ class OSD;
 class ShardServices;
 class PG;
 
-class PeeringEvent : public OperationT<PeeringEvent> {
+class PeeringEvent : public TrackableOperationT<PeeringEvent> {
 public:
   static constexpr OperationTypeCode type = OperationTypeCode::peering_event;
 

--- a/src/crimson/osd/osd_operations/pg_advance_map.cc
+++ b/src/crimson/osd/osd_operations/pg_advance_map.cc
@@ -1,8 +1,6 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "crimson/osd/osd_operations/pg_advance_map.h"
-
 #include <boost/smart_ptr/local_shared_ptr.hpp>
 #include <seastar/core/future.hh>
 
@@ -10,6 +8,9 @@
 #include "common/Formatter.h"
 #include "crimson/osd/pg.h"
 #include "crimson/osd/osd.h"
+#include "crimson/osd/osd_operations/pg_advance_map.h"
+#include "crimson/osd/osd_operation_external_tracking.h"
+#include "osd/PeeringState.h"
 
 namespace {
   seastar::logger& logger() {
@@ -56,9 +57,9 @@ seastar::future<> PGAdvanceMap::start()
   logger().debug("{}: start", *this);
 
   IRef ref = this;
-  return with_blocking_future(
-    handle.enter(pg->peering_request_pg_pipeline.process))
-  .then([this] {
+  return enter_stage<>(
+    pg->peering_request_pg_pipeline.process
+  ).then([this] {
     if (do_init) {
       pg->handle_initialize(rctx);
       pg->handle_activate_map(rctx);

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -20,7 +20,7 @@ namespace crimson::osd {
 class OSD;
 class PG;
 
-class PGAdvanceMap : public OperationT<PGAdvanceMap> {
+class PGAdvanceMap : public TrackableOperationT<PGAdvanceMap> {
 public:
   static constexpr OperationTypeCode type = OperationTypeCode::pg_advance_map;
 

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -45,7 +45,7 @@ public:
   seastar::future<> start();
 
   std::tuple<
-    PeeringEvent::PGPipeline::Process::BlockingEvent
+    PGPeeringPipeline::Process::BlockingEvent
   > tracking_events;
 };
 

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -7,9 +7,9 @@
 #include <seastar/core/future.hh>
 
 #include "crimson/osd/osd_operation.h"
+#include "crimson/osd/osd_operations/peering_event.h"
 #include "osd/osd_types.h"
 #include "crimson/common/type_helpers.h"
-#include "osd/PeeringState.h"
 
 namespace ceph {
   class Formatter;
@@ -43,6 +43,10 @@ public:
   void print(std::ostream &) const final;
   void dump_detail(ceph::Formatter *f) const final;
   seastar::future<> start();
+
+  std::tuple<
+    PeeringEvent::PGPipeline::Process::BlockingEvent
+  > tracking_events;
 };
 
 }

--- a/src/crimson/osd/osd_operations/pg_advance_map.h
+++ b/src/crimson/osd/osd_operations/pg_advance_map.h
@@ -20,13 +20,11 @@ namespace crimson::osd {
 class OSD;
 class PG;
 
-class PGAdvanceMap : public TrackableOperationT<PGAdvanceMap> {
+class PGAdvanceMap : public PhasedOperationT<PGAdvanceMap> {
 public:
   static constexpr OperationTypeCode type = OperationTypeCode::pg_advance_map;
 
 protected:
-  PipelineHandle handle;
-
   OSD &osd;
   Ref<PG> pg;
 

--- a/src/crimson/osd/osd_operations/recovery_subrequest.cc
+++ b/src/crimson/osd/osd_operations/recovery_subrequest.cc
@@ -2,6 +2,7 @@
 #include <fmt/ostream.h>
 
 #include "crimson/osd/osd_operations/recovery_subrequest.h"
+#include "crimson/osd/pg.h"
 
 namespace {
   seastar::logger& logger() {

--- a/src/crimson/osd/osd_operations/recovery_subrequest.h
+++ b/src/crimson/osd/osd_operations/recovery_subrequest.h
@@ -15,7 +15,7 @@ namespace crimson::osd {
 class OSD;
 class PG;
 
-class RecoverySubRequest final : public OperationT<RecoverySubRequest> {
+class RecoverySubRequest final : public TrackableOperationT<RecoverySubRequest> {
 public:
   static constexpr OperationTypeCode type = OperationTypeCode::background_recovery_sub;
 

--- a/src/crimson/osd/osd_operations/recovery_subrequest.h
+++ b/src/crimson/osd/osd_operations/recovery_subrequest.h
@@ -36,6 +36,14 @@ private:
   OSD& osd;
   crimson::net::ConnectionRef conn;
   Ref<MOSDFastDispatchOp> m;
+
+public:
+  std::tuple<
+    StartEvent,
+    OSD_OSDMapGate::OSDMapBlocker::BlockingEvent,
+    PGMap::PGCreationBlockingEvent,
+    CompletionEvent
+  > tracking_events;
 };
 
 }

--- a/src/crimson/osd/osd_operations/replicated_request.h
+++ b/src/crimson/osd/osd_operations/replicated_request.h
@@ -18,7 +18,7 @@ namespace crimson::osd {
 class OSD;
 class PG;
 
-class RepRequest final : public TrackableOperationT<RepRequest> {
+class RepRequest final : public PhasedOperationT<RepRequest> {
 public:
   class ConnectionPipeline {
     OrderedExclusivePhase await_map = {
@@ -52,7 +52,6 @@ private:
   OSD &osd;
   crimson::net::ConnectionRef conn;
   Ref<MOSDRepOp> req;
-  PipelineHandle handle;
 };
 
 }

--- a/src/crimson/osd/osd_operations/replicated_request.h
+++ b/src/crimson/osd/osd_operations/replicated_request.h
@@ -18,7 +18,7 @@ namespace crimson::osd {
 class OSD;
 class PG;
 
-class RepRequest final : public OperationT<RepRequest> {
+class RepRequest final : public TrackableOperationT<RepRequest> {
 public:
   class ConnectionPipeline {
     OrderedExclusivePhase await_map = {

--- a/src/crimson/osd/osdmap_gate.cc
+++ b/src/crimson/osd/osdmap_gate.cc
@@ -14,14 +14,16 @@ namespace {
 
 namespace crimson::osd {
 
-void OSDMapGate::OSDMapBlocker::dump_detail(Formatter *f) const
+template <OSDMapGateType OSDMapGateTypeV>
+void OSDMapGate<OSDMapGateTypeV>::OSDMapBlocker::dump_detail(Formatter *f) const
 {
   f->open_object_section("OSDMapGate");
   f->dump_int("epoch", epoch);
   f->close_section();
 }
 
-blocking_future<epoch_t> OSDMapGate::wait_for_map(epoch_t epoch)
+template <OSDMapGateType OSDMapGateTypeV>
+blocking_future<epoch_t> OSDMapGate<OSDMapGateTypeV>::wait_for_map(epoch_t epoch)
 {
   if (__builtin_expect(stopping, false)) {
     return make_exception_blocking_future<epoch_t>(
@@ -46,7 +48,37 @@ blocking_future<epoch_t> OSDMapGate::wait_for_map(epoch_t epoch)
   }
 }
 
-void OSDMapGate::got_map(epoch_t epoch) {
+template <OSDMapGateType OSDMapGateTypeV>
+seastar::future<epoch_t> OSDMapGate<OSDMapGateTypeV>::wait_for_map(
+  typename OSDMapBlocker::BlockingEvent::TriggerI&& trigger,
+  epoch_t epoch)
+{
+  if (__builtin_expect(stopping, false)) {
+    return seastar::make_exception_future<epoch_t>(
+	crimson::common::system_shutdown_exception());
+  }
+  if (current >= epoch) {
+    return seastar::make_ready_future<epoch_t>(current);
+  } else {
+    logger().info("evt epoch is {}, i have {}, will wait", epoch, current);
+    auto &blocker = waiting_peering.emplace(
+      epoch, std::make_pair(blocker_type, epoch)).first->second;
+    auto fut = blocker.promise.get_shared_future();
+    if (shard_services) {
+      return trigger.maybe_record_blocking(
+	(*shard_services).get().osdmap_subscribe(current, true).then(
+	  [fut=std::move(fut)]() mutable {
+	    return std::move(fut);
+	  }),
+	blocker);
+    } else {
+      return trigger.maybe_record_blocking(std::move(fut), blocker);
+    }
+  }
+}
+
+template <OSDMapGateType OSDMapGateTypeV>
+void OSDMapGate<OSDMapGateTypeV>::got_map(epoch_t epoch) {
   current = epoch;
   auto first = waiting_peering.begin();
   auto last = waiting_peering.upper_bound(epoch);
@@ -56,7 +88,8 @@ void OSDMapGate::got_map(epoch_t epoch) {
   waiting_peering.erase(first, last);
 }
 
-seastar::future<> OSDMapGate::stop() {
+template <OSDMapGateType OSDMapGateTypeV>
+seastar::future<> OSDMapGate<OSDMapGateTypeV>::stop() {
   logger().info("osdmap::stop");
   stopping = true;
   auto first = waiting_peering.begin();
@@ -68,4 +101,7 @@ seastar::future<> OSDMapGate::stop() {
   return seastar::now();
 }
 
-}
+template class OSDMapGate<OSDMapGateType::PG>;
+template class OSDMapGate<OSDMapGateType::OSD>;
+
+} // namespace crimson::osd

--- a/src/crimson/osd/osdmap_gate.cc
+++ b/src/crimson/osd/osdmap_gate.cc
@@ -23,32 +23,6 @@ void OSDMapGate<OSDMapGateTypeV>::OSDMapBlocker::dump_detail(Formatter *f) const
 }
 
 template <OSDMapGateType OSDMapGateTypeV>
-blocking_future<epoch_t> OSDMapGate<OSDMapGateTypeV>::wait_for_map(epoch_t epoch)
-{
-  if (__builtin_expect(stopping, false)) {
-    return make_exception_blocking_future<epoch_t>(
-	crimson::common::system_shutdown_exception());
-  }
-  if (current >= epoch) {
-    return make_ready_blocking_future<epoch_t>(current);
-  } else {
-    logger().info("evt epoch is {}, i have {}, will wait", epoch, current);
-    auto &blocker = waiting_peering.emplace(
-      epoch, std::make_pair(blocker_type, epoch)).first->second;
-    auto fut = blocker.promise.get_shared_future();
-    if (shard_services) {
-      return blocker.make_blocking_future(
-	(*shard_services).get().osdmap_subscribe(current, true).then(
-	  [fut=std::move(fut)]() mutable {
-	    return std::move(fut);
-	  }));
-    } else {
-      return blocker.make_blocking_future(std::move(fut));
-    }
-  }
-}
-
-template <OSDMapGateType OSDMapGateTypeV>
 seastar::future<epoch_t> OSDMapGate<OSDMapGateTypeV>::wait_for_map(
   typename OSDMapBlocker::BlockingEvent::TriggerI&& trigger,
   epoch_t epoch)

--- a/src/crimson/osd/osdmap_gate.h
+++ b/src/crimson/osd/osdmap_gate.h
@@ -64,8 +64,6 @@ public:
     : blocker_type(blocker_type), shard_services(shard_services) {}
 
   // wait for an osdmap whose epoch is greater or equal to given epoch
-  blocking_future<epoch_t>
-  wait_for_map(epoch_t epoch);
   // TODO: define me!
   seastar::future<epoch_t>
   wait_for_map(typename OSDMapBlocker::BlockingEvent::TriggerI&& trigger,

--- a/src/crimson/osd/osdmap_gate.h
+++ b/src/crimson/osd/osdmap_gate.h
@@ -66,6 +66,7 @@ public:
   // wait for an osdmap whose epoch is greater or equal to given epoch
   blocking_future<epoch_t>
   wait_for_map(epoch_t epoch);
+  // TODO: define me!
   seastar::future<epoch_t>
   wait_for_map(typename OSDMapBlocker::BlockingEvent::TriggerI&& trigger,
 	       epoch_t epoch);

--- a/src/crimson/osd/osdmap_gate.h
+++ b/src/crimson/osd/osdmap_gate.h
@@ -22,7 +22,7 @@ namespace crimson::osd {
 class ShardServices;
 
 class OSDMapGate {
-  struct OSDMapBlocker : public Blocker {
+  struct OSDMapBlocker : public BlockerT<OSDMapBlocker> {
     const char * type_name;
     epoch_t epoch;
 
@@ -37,10 +37,6 @@ class OSDMapGate {
     seastar::shared_promise<epoch_t> promise;
 
     void dump_detail(Formatter *f) const final;
-  private:
-    const char *get_type_name() const final {
-      return type_name;
-    }
   };
 
   // order the promises in ascending order of the waited osdmap epoch,

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -542,32 +542,6 @@ std::ostream& operator<<(std::ostream& os, const PG& pg)
   return os;
 }
 
-void PG::WaitForActiveBlocker::dump_detail(Formatter *f) const
-{
-  f->dump_stream("pgid") << pg->pgid;
-}
-
-void PG::WaitForActiveBlocker::on_active()
-{
-  p.set_value();
-  p = {};
-}
-
-blocking_future<> PG::WaitForActiveBlocker::wait()
-{
-  if (pg->peering_state.is_active()) {
-    return make_blocking_future(seastar::now());
-  } else {
-    return make_blocking_future(p.get_shared_future());
-  }
-}
-
-seastar::future<> PG::WaitForActiveBlocker::stop()
-{
-  p.set_exception(crimson::common::system_shutdown_exception());
-  return seastar::now();
-}
-
 std::tuple<PG::interruptible_future<>,
            PG::interruptible_future<>>
 PG::submit_transaction(

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -31,6 +31,7 @@
 #include "crimson/osd/osd_operations/background_recovery.h"
 #include "crimson/osd/shard_services.h"
 #include "crimson/osd/osdmap_gate.h"
+#include "crimson/osd/pg_activation_blocker.h"
 #include "crimson/osd/pg_recovery.h"
 #include "crimson/osd/pg_recovery_listener.h"
 #include "crimson/osd/recovery_backend.h"
@@ -721,23 +722,7 @@ private:
   // continuations here.
   bool stopping = false;
 
-  class WaitForActiveBlocker : public BlockerT<WaitForActiveBlocker> {
-    PG *pg;
-
-    const spg_t pgid;
-    seastar::shared_promise<> p;
-
-  protected:
-    void dump_detail(Formatter *f) const;
-
-  public:
-    static constexpr const char *type_name = "WaitForActiveBlocker";
-
-    WaitForActiveBlocker(PG *pg) : pg(pg) {}
-    void on_active();
-    blocking_future<> wait();
-    seastar::future<> stop();
-  } wait_for_active_blocker;
+  PGActivationBlocker wait_for_active_blocker;
 
   friend std::ostream& operator<<(std::ostream&, const PG& pg);
   friend class ClientRequest;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -69,7 +69,7 @@ class PG : public boost::intrusive_ref_counter<
   using cached_map_t = boost::local_shared_ptr<const OSDMap>;
 
   ClientRequest::PGPipeline client_request_pg_pipeline;
-  PeeringEvent::PGPipeline peering_request_pg_pipeline;
+  PGPeeringPipeline peering_request_pg_pipeline;
   RepRequest::PGPipeline replicated_request_pg_pipeline;
 
   spg_t pgid;
@@ -728,6 +728,7 @@ private:
   friend class ClientRequest;
   friend struct CommonClientRequest;
   friend class PGAdvanceMap;
+  template <class T>
   friend class PeeringEvent;
   friend class RepRequest;
   friend class BackfillRecovery;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -613,7 +613,7 @@ private:
     eversion_t& v);
 
 private:
-  OSDMapGate osdmap_gate;
+  PG_OSDMapGate osdmap_gate;
   ShardServices &shard_services;
 
   cached_map_t osdmap;

--- a/src/crimson/osd/pg_activation_blocker.cc
+++ b/src/crimson/osd/pg_activation_blocker.cc
@@ -1,0 +1,35 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab expandtab
+
+#include "crimson/osd/pg.h"
+#include "crimson/osd/pg_activation_blocker.h"
+
+namespace crimson::osd {
+
+void PGActivationBlocker::dump_detail(Formatter *f) const
+{
+  f->dump_stream("pgid") << pg->get_pgid();
+}
+
+void PGActivationBlocker::on_active()
+{
+  p.set_value();
+  p = {};
+}
+
+blocking_future<> PGActivationBlocker::wait()
+{
+  if (pg->get_peering_state().is_active()) {
+    return make_blocking_future(seastar::now());
+  } else {
+    return make_blocking_future(p.get_shared_future());
+  }
+}
+
+seastar::future<> PGActivationBlocker::stop()
+{
+  p.set_exception(crimson::common::system_shutdown_exception());
+  return seastar::now();
+}
+
+} // namespace crimson::osd

--- a/src/crimson/osd/pg_activation_blocker.cc
+++ b/src/crimson/osd/pg_activation_blocker.cc
@@ -17,6 +17,16 @@ void PGActivationBlocker::on_active()
   p = {};
 }
 
+seastar::future<>
+PGActivationBlocker::wait(PGActivationBlocker::BlockingEvent::TriggerI&& trigger)
+{
+  if (pg->get_peering_state().is_active()) {
+    return seastar::now();
+  } else {
+    return trigger.maybe_record_blocking(p.get_shared_future(), *this);
+  }
+}
+
 blocking_future<> PGActivationBlocker::wait()
 {
   if (pg->get_peering_state().is_active()) {

--- a/src/crimson/osd/pg_activation_blocker.cc
+++ b/src/crimson/osd/pg_activation_blocker.cc
@@ -27,15 +27,6 @@ PGActivationBlocker::wait(PGActivationBlocker::BlockingEvent::TriggerI&& trigger
   }
 }
 
-blocking_future<> PGActivationBlocker::wait()
-{
-  if (pg->get_peering_state().is_active()) {
-    return make_blocking_future(seastar::now());
-  } else {
-    return make_blocking_future(p.get_shared_future());
-  }
-}
-
 seastar::future<> PGActivationBlocker::stop()
 {
   p.set_exception(crimson::common::system_shutdown_exception());

--- a/src/crimson/osd/pg_activation_blocker.h
+++ b/src/crimson/osd/pg_activation_blocker.h
@@ -28,6 +28,7 @@ public:
   PGActivationBlocker(PG *pg) : pg(pg) {}
   void on_active();
   blocking_future<> wait();
+  seastar::future<> wait(PGActivationBlocker::BlockingEvent::TriggerI&&);
   seastar::future<> stop();
 };
 

--- a/src/crimson/osd/pg_activation_blocker.h
+++ b/src/crimson/osd/pg_activation_blocker.h
@@ -1,0 +1,34 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab expandtab
+
+#pragma once
+
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_future.hh>
+
+#include "crimson/common/operation.h"
+#include "crimson/osd/osd_operation.h"
+
+namespace crimson::osd {
+
+class PG;
+
+class PGActivationBlocker : public crimson::BlockerT<PGActivationBlocker> {
+  PG *pg;
+
+  const spg_t pgid;
+  seastar::shared_promise<> p;
+
+protected:
+  void dump_detail(Formatter *f) const;
+
+public:
+  static constexpr const char *type_name = "PGActivationBlocker";
+
+  PGActivationBlocker(PG *pg) : pg(pg) {}
+  void on_active();
+  blocking_future<> wait();
+  seastar::future<> stop();
+};
+
+} // namespace crimson::osd

--- a/src/crimson/osd/pg_activation_blocker.h
+++ b/src/crimson/osd/pg_activation_blocker.h
@@ -27,7 +27,6 @@ public:
 
   PGActivationBlocker(PG *pg) : pg(pg) {}
   void on_active();
-  blocking_future<> wait();
   seastar::future<> wait(PGActivationBlocker::BlockingEvent::TriggerI&&);
   seastar::future<> stop();
 };

--- a/src/crimson/osd/pg_map.cc
+++ b/src/crimson/osd/pg_map.cc
@@ -37,6 +37,20 @@ std::pair<blocking_future<Ref<PG>>, bool> PGMap::wait_for_pg(spg_t pgid)
   }
 }
 
+std::pair<seastar::future<Ref<PG>>, bool>
+PGMap::wait_for_pg(PGCreationBlockingEvent::TriggerI&& trigger, spg_t pgid)
+{
+  if (auto pg = get_pg(pgid)) {
+    return make_pair(seastar::make_ready_future<Ref<PG>>(pg), true);
+  } else {
+    auto &state = pgs_creating.emplace(pgid, pgid).first->second;
+    return make_pair(
+      // TODO: add to blocker Trigger-taking make_blocking_future
+      trigger.maybe_record_blocking(state.promise.get_shared_future(), state),
+      state.creating);
+  }
+}
+
 Ref<PG> PGMap::get_pg(spg_t pgid)
 {
   if (auto pg = pgs.find(pgid); pg != pgs.end()) {

--- a/src/crimson/osd/pg_map.cc
+++ b/src/crimson/osd/pg_map.cc
@@ -25,18 +25,6 @@ void PGMap::PGCreationState::dump_detail(Formatter *f) const
   f->dump_bool("creating", creating);
 }
 
-std::pair<blocking_future<Ref<PG>>, bool> PGMap::wait_for_pg(spg_t pgid)
-{
-  if (auto pg = get_pg(pgid)) {
-    return make_pair(make_ready_blocking_future<Ref<PG>>(pg), true);
-  } else {
-    auto &state = pgs_creating.emplace(pgid, pgid).first->second;
-    return make_pair(
-      state.make_blocking_future(state.promise.get_shared_future()),
-      state.creating);
-  }
-}
-
 std::pair<seastar::future<Ref<PG>>, bool>
 PGMap::wait_for_pg(PGCreationBlockingEvent::TriggerI&& trigger, spg_t pgid)
 {

--- a/src/crimson/osd/pg_map.h
+++ b/src/crimson/osd/pg_map.h
@@ -11,7 +11,6 @@
 #include "include/types.h"
 #include "crimson/common/type_helpers.h"
 #include "crimson/osd/osd_operation.h"
-#include "crimson/osd/pg.h"
 #include "osd/osd_types.h"
 
 namespace crimson::osd {

--- a/src/crimson/osd/pg_map.h
+++ b/src/crimson/osd/pg_map.h
@@ -40,11 +40,15 @@ class PGMap {
   pgs_t pgs;
 
 public:
+  using PGCreationBlocker = PGCreationState;
+  using PGCreationBlockingEvent = PGCreationBlocker::BlockingEvent;
   /**
    * Get future for pg with a bool indicating whether it's already being
    * created.
    */
   std::pair<blocking_future<Ref<PG>>, bool> wait_for_pg(spg_t pgid);
+  std::pair<seastar::future<Ref<PG>>, bool>
+  wait_for_pg(PGCreationBlockingEvent::TriggerI&&, spg_t pgid);
 
   /**
    * get PG in non-blocking manner

--- a/src/crimson/osd/pg_map.h
+++ b/src/crimson/osd/pg_map.h
@@ -46,7 +46,6 @@ public:
    * Get future for pg with a bool indicating whether it's already being
    * created.
    */
-  std::pair<blocking_future<Ref<PG>>, bool> wait_for_pg(spg_t pgid);
   std::pair<seastar::future<Ref<PG>>, bool>
   wait_for_pg(PGCreationBlockingEvent::TriggerI&&, spg_t pgid);
 

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -34,8 +34,10 @@ void PGRecovery::start_pglogbased_recovery()
     float(0.001));
 }
 
-PGRecovery::blocking_interruptible_future<bool>
-PGRecovery::start_recovery_ops(size_t max_to_start)
+PGRecovery::interruptible_future<bool>
+PGRecovery::start_recovery_ops(
+  RecoveryBackend::RecoveryBlockingEvent::TriggerI& trigger,
+  size_t max_to_start)
 {
   assert(pg->is_primary());
   assert(pg->is_peered());
@@ -49,16 +51,20 @@ PGRecovery::start_recovery_ops(size_t max_to_start)
   assert(!pg->is_backfilling());
   assert(!pg->get_peering_state().is_deleting());
 
-  std::vector<blocking_interruptible_future<>> started;
+  std::vector<RecoveryBackend::interruptible_future<>> new_started;
+  std::vector<interruptible_future<>> started;
+  new_started.reserve(max_to_start);
   started.reserve(max_to_start);
-  max_to_start -= start_primary_recovery_ops(max_to_start, &started);
+  max_to_start -= start_primary_recovery_ops(trigger, max_to_start, &started);
   if (max_to_start > 0) {
-    max_to_start -= start_replica_recovery_ops(max_to_start, &started);
+    max_to_start -= start_replica_recovery_ops(trigger, max_to_start, &started);
   }
-  return crimson::join_blocking_interruptible_futures<
-    ::crimson::osd::IOInterruptCondition>(std::move(started)).then_interruptible<
-    ::crimson::osd::IOInterruptCondition>(
-    [this] {
+  using interruptor =
+    crimson::interruptible::interruptor<crimson::osd::IOInterruptCondition>;
+  return interruptor::parallel_for_each(std::move(new_started),
+					[] (auto&& ifut) {
+    return std::move(ifut);
+  }).then_interruptible([this] {
     bool done = !pg->get_peering_state().needs_recovery();
     if (done) {
       logger().debug("start_recovery_ops: AllReplicasRecovered for pg: {}",
@@ -93,8 +99,9 @@ PGRecovery::start_recovery_ops(size_t max_to_start)
 }
 
 size_t PGRecovery::start_primary_recovery_ops(
+  RecoveryBackend::RecoveryBlockingEvent::TriggerI& trigger,
   size_t max_to_start,
-  std::vector<PGRecovery::blocking_interruptible_future<>> *out)
+  std::vector<PGRecovery::interruptible_future<>> *out)
 {
   if (!pg->is_recovering()) {
     return 0;
@@ -149,13 +156,13 @@ size_t PGRecovery::start_primary_recovery_ops(
     // TODO: handle lost/unfound
     if (pg->get_recovery_backend()->is_recovering(soid)) {
       auto& recovery_waiter = pg->get_recovery_backend()->get_recovering(soid);
-      out->push_back(recovery_waiter.wait_for_recovered_blocking<
-	    ::crimson::osd::IOInterruptCondition>());
+      out->emplace_back(recovery_waiter.wait_for_recovered(
+	*trigger.create_part_trigger()));
       ++started;
     } else if (pg->get_recovery_backend()->is_recovering(head)) {
       ++skipped;
     } else {
-      out->push_back(recover_missing(soid, item.need));
+      out->emplace_back(recover_missing(trigger, soid, item.need));
       ++started;
     }
 
@@ -169,8 +176,9 @@ size_t PGRecovery::start_primary_recovery_ops(
 }
 
 size_t PGRecovery::start_replica_recovery_ops(
+  RecoveryBackend::RecoveryBlockingEvent::TriggerI& trigger,
   size_t max_to_start,
-  std::vector<PGRecovery::blocking_interruptible_future<>> *out)
+  std::vector<PGRecovery::interruptible_future<>> *out)
 {
   if (!pg->is_recovering()) {
     return 0;
@@ -217,8 +225,8 @@ size_t PGRecovery::start_replica_recovery_ops(
       if (pg->get_recovery_backend()->is_recovering(soid)) {
 	logger().debug("{}: already recovering object {}", __func__, soid);
 	auto& recovery_waiter = pg->get_recovery_backend()->get_recovering(soid);
-	out->push_back(recovery_waiter.wait_for_recovered_blocking<
-	    ::crimson::osd::IOInterruptCondition>());
+	out->emplace_back(recovery_waiter.wait_for_recovered(
+	  *trigger.create_part_trigger()));
 	started++;
 	continue;
       }
@@ -227,8 +235,9 @@ size_t PGRecovery::start_replica_recovery_ops(
 	logger().debug("{}: soid {} is a delete, removing", __func__, soid);
 	map<hobject_t,pg_missing_item>::const_iterator r =
 	  pm.get_items().find(soid);
-	started += prep_object_replica_deletes(
-	  soid, r->second.need, out);
+	started++;
+	out->emplace_back(
+	  prep_object_replica_deletes(trigger, soid, r->second.need));
 	continue;
       }
 
@@ -248,23 +257,27 @@ size_t PGRecovery::start_replica_recovery_ops(
       logger().debug("{}: recover_object_replicas({})", __func__,soid);
       map<hobject_t,pg_missing_item>::const_iterator r = pm.get_items().find(
 	soid);
-      started += prep_object_replica_pushes(
-	soid, r->second.need, out);
+      started++;
+      out->emplace_back(
+	prep_object_replica_pushes(trigger, soid, r->second.need));
     }
   }
 
   return started;
 }
 
-PGRecovery::blocking_interruptible_future<>
+PGRecovery::interruptible_future<>
 PGRecovery::recover_missing(
+  RecoveryBackend::RecoveryBlockingEvent::TriggerI& trigger,
   const hobject_t &soid, eversion_t need)
 {
   if (pg->get_peering_state().get_missing_loc().is_deleted(soid)) {
-    return pg->get_recovery_backend()->add_recovering(soid).make_blocking_future(
-	pg->get_recovery_backend()->recover_delete(soid, need));
+    return pg->get_recovery_backend()->add_recovering(soid).track_blocking(
+      trigger,
+      pg->get_recovery_backend()->recover_delete(soid, need));
   } else {
-    return pg->get_recovery_backend()->add_recovering(soid).make_blocking_future(
+    return pg->get_recovery_backend()->add_recovering(soid).track_blocking(
+      trigger,
       pg->get_recovery_backend()->recover_object(soid, need)
       .handle_exception_interruptible(
 	[=, soid = std::move(soid)] (auto e) {
@@ -275,41 +288,37 @@ PGRecovery::recover_missing(
   }
 }
 
-size_t PGRecovery::prep_object_replica_deletes(
+RecoveryBackend::interruptible_future<> PGRecovery::prep_object_replica_deletes(
+  RecoveryBackend::RecoveryBlockingEvent::TriggerI& trigger,
   const hobject_t& soid,
-  eversion_t need,
-  std::vector<PGRecovery::blocking_interruptible_future<>> *in_progress)
+  eversion_t need)
 {
-  in_progress->push_back(
-    pg->get_recovery_backend()->add_recovering(soid).make_blocking_future(
-      pg->get_recovery_backend()->push_delete(soid, need).then_interruptible(
-	[=] {
-	object_stat_sum_t stat_diff;
-	stat_diff.num_objects_recovered = 1;
-	on_global_recover(soid, stat_diff, true);
-	return seastar::make_ready_future<>();
-      })
-    )
+  return pg->get_recovery_backend()->add_recovering(soid).track_blocking(
+    trigger,
+    pg->get_recovery_backend()->push_delete(soid, need).then_interruptible(
+      [=] {
+      object_stat_sum_t stat_diff;
+      stat_diff.num_objects_recovered = 1;
+      on_global_recover(soid, stat_diff, true);
+      return seastar::make_ready_future<>();
+    })
   );
-  return 1;
 }
 
-size_t PGRecovery::prep_object_replica_pushes(
+RecoveryBackend::interruptible_future<> PGRecovery::prep_object_replica_pushes(
+  RecoveryBackend::RecoveryBlockingEvent::TriggerI& trigger,
   const hobject_t& soid,
-  eversion_t need,
-  std::vector<PGRecovery::blocking_interruptible_future<>> *in_progress)
+  eversion_t need)
 {
-  in_progress->push_back(
-    pg->get_recovery_backend()->add_recovering(soid).make_blocking_future(
-      pg->get_recovery_backend()->recover_object(soid, need)
-      .handle_exception_interruptible(
-	[=, soid = std::move(soid)] (auto e) {
-	on_failed_recover({ pg->get_pg_whoami() }, soid, need);
-	return seastar::make_ready_future<>();
-      })
-    )
+  return pg->get_recovery_backend()->add_recovering(soid).track_blocking(
+    trigger,
+    pg->get_recovery_backend()->recover_object(soid, need)
+    .handle_exception_interruptible(
+      [=, soid = std::move(soid)] (auto e) {
+      on_failed_recover({ pg->get_pg_whoami() }, soid, need);
+      return seastar::make_ready_future<>();
+    })
   );
-  return 1;
 }
 
 void PGRecovery::on_local_recover(

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -20,14 +20,14 @@ class PGBackend;
 class PGRecovery : public crimson::osd::BackfillState::BackfillListener {
 public:
   template <typename T = void>
-  using blocking_interruptible_future =
-    ::crimson::blocking_interruptible_future<
-      ::crimson::osd::IOInterruptCondition, T>;
+  using interruptible_future = RecoveryBackend::interruptible_future<T>;
   PGRecovery(PGRecoveryListener* pg) : pg(pg) {}
   virtual ~PGRecovery() {}
   void start_pglogbased_recovery();
 
-  blocking_interruptible_future<bool> start_recovery_ops(size_t max_to_start);
+  interruptible_future<bool> start_recovery_ops(
+    RecoveryBackend::RecoveryBlockingEvent::TriggerI&,
+    size_t max_to_start);
   void on_backfill_reserved();
   void dispatch_backfill_event(
     boost::intrusive_ptr<const boost::statechart::event_base> evt);
@@ -36,25 +36,28 @@ public:
 private:
   PGRecoveryListener* pg;
   size_t start_primary_recovery_ops(
+    RecoveryBackend::RecoveryBlockingEvent::TriggerI&,
     size_t max_to_start,
-    std::vector<blocking_interruptible_future<>> *out);
+    std::vector<interruptible_future<>> *out);
   size_t start_replica_recovery_ops(
+    RecoveryBackend::RecoveryBlockingEvent::TriggerI&,
     size_t max_to_start,
-    std::vector<blocking_interruptible_future<>> *out);
+    std::vector<interruptible_future<>> *out);
 
   std::vector<pg_shard_t> get_replica_recovery_order() const {
     return pg->get_replica_recovery_order();
   }
-  blocking_interruptible_future<> recover_missing(
+  RecoveryBackend::interruptible_future<> recover_missing(
+    RecoveryBackend::RecoveryBlockingEvent::TriggerI&,
     const hobject_t &soid, eversion_t need);
-  size_t prep_object_replica_deletes(
+  RecoveryBackend::interruptible_future<> prep_object_replica_deletes(
+    RecoveryBackend::RecoveryBlockingEvent::TriggerI& trigger,
     const hobject_t& soid,
-    eversion_t need,
-    std::vector<blocking_interruptible_future<>> *in_progress);
-  size_t prep_object_replica_pushes(
+    eversion_t need);
+  RecoveryBackend::interruptible_future<> prep_object_replica_pushes(
+    RecoveryBackend::RecoveryBlockingEvent::TriggerI& trigger,
     const hobject_t& soid,
-    eversion_t need,
-    std::vector<blocking_interruptible_future<>> *in_progress);
+    eversion_t need);
 
   void on_local_recover(
     const hobject_t& soid,


### PR DESCRIPTION
This is a reincarnation of #39094.

TODO:
  * [ ] external logging backends like LTTng (the interfaces are already laid down),
  * [ ] dumping in-flight ops (aka serialization of the `InternalBackend`,
  * [ ] historic / slow ops backend.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
