### PR TITLE
mgr/dashboard: upgrade grafana pie-chart and vonage-status-panel versions

### DIFF
--- a/monitoring/grafana/build/Makefile
+++ b/monitoring/grafana/build/Makefile
@@ -1,7 +1,7 @@
 
 GRAFANA_VERSION ?= 8.3.5-1
-PIECHART_VERSION ?= "1.6.1"
-STATUS_PANEL_VERSION ?= "1.0.9"
+PIECHART_VERSION ?= "1.6.2"
+STATUS_PANEL_VERSION ?= "1.0.11"
 DASHBOARD_DIR := "../../ceph-mixin/dashboards_out"
 DASHBOARD_PROVISIONING := "ceph-dashboard.yml"
 IMAGE := "docker.io/redhat/ubi8:8.5"


### PR DESCRIPTION
upgrade grafana pie-chart and vonage-status-panel versions

Fixes:https://tracker.ceph.com/issues/55195
Signed-off-by: Aashish Sharma <aasharma@redhat.com>


To test the changes I installed the upgraded versions of piechart-panel and vonage status panel manually inside the grafana container using ceph-dev env and it worked
Before:-
![Screenshot from 2022-04-06 17-19-18](https://user-images.githubusercontent.com/66050535/161969838-d2bfe275-3bf8-4f54-96ca-e3101a2e2381.png)

After:-
![Screenshot from 2022-04-06 17-19-36](https://user-images.githubusercontent.com/66050535/161969904-545ddaa2-e26c-465b-a9a6-e17445148e50.png)
![Screenshot from 2022-04-06 17-26-25](https://user-images.githubusercontent.com/66050535/161969909-fea2f70e-559e-4622-9cb4-d6021adb3e21.png)




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
