### PR TITLE
mgr/cephadm: ceph cephadm set-user does not reflect the user change in ssh-config

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -979,6 +979,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             return 0, "value unchanged", ""
 
         self._validate_and_set_ssh_val('ssh_user', user, current_user)
+        current_ssh_config = self._get_ssh_config()
+        new_ssh_config = re.sub(r"(\s{2}User\s)(.*)", r"\1" + user, current_ssh_config.stdout)
+        self._set_ssh_config(new_ssh_config)
 
         msg = 'ssh user set to %s' % user
         if user != 'root':


### PR DESCRIPTION
Changing the user account used by cephadm for its ssh connections is not applied to the ssh-config.

Fixes: https://tracker.ceph.com/issues/54618

Signed-off-by: Teoman ONAY <tonay@redhat.com>
