### PR TITLE
quincy: PendingReleaseNotes: Update mclock release note regarding an existing issue.

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -64,13 +64,20 @@
 * RGW: `radosgw-admin realm delete` is now renamed to `radosgw-admin realm rm`. This
   is consistent with the help message.
 
-* OSD: Ceph now uses mclock_scheduler for bluestore OSDs as its default osd_op_queue
+* OSD: Ceph now uses mclock_scheduler for BlueStore OSDs as its default osd_op_queue
   to provide QoS. The 'mclock_scheduler' is not supported for filestore OSDs.
-  Therefore, the default 'osd_op_queue' is set to 'wpq' for filestore OSDs
+  Therefore, the default 'osd_op_queue' is set to 'wpq' for Filestore OSDs
   and is enforced even if the user attempts to change it. For more details on
   configuring mclock see,
 
   https://docs.ceph.com/en/latest/rados/configuration/mclock-config-ref/
+
+  An outstanding issue exists during runtime where the mclock config options
+  related to reservation, weight and limit cannot be modified after switching
+  to the 'custom' mclock profile using the "ceph config set ..." command.
+  This is tracked by: https://tracker.ceph.com/issues/55153. Until the issue is
+  fixed, users are advised to avoid using the 'custom' profile or use the
+  workaround mentioned in the tracker.
 
 * CephFS: Failure to replay the journal by a standby-replay daemon will now
   cause the rank to be marked damaged.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55219

---

backport of https://github.com/ceph/ceph/pull/45781
parent tracker: https://tracker.ceph.com/issues/55186

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh