### PR TITLE
cmake: bump project version to 18.0.0 for reef

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(ceph
-  VERSION 17.0.0
+  VERSION 18.0.0
   LANGUAGES CXX C ASM)
 
 cmake_policy(SET CMP0028 NEW)

--- a/src/ceph_release
+++ b/src/ceph_release
@@ -1,3 +1,3 @@
-17
-quincy
+18
+reef
 dev


### PR DESCRIPTION
just to get the ball rolling for reef. i see that Sage did this last year for quincy in https://github.com/ceph/ceph/pull/39039, along with lots of additional changes

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
