### PR TITLE
cmake: use rapidjson headers from s3select's submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,9 +38,6 @@
 [submodule "src/blkin"]
 	path = src/blkin
 	url = https://github.com/ceph/blkin
-[submodule "src/rapidjson"]
-	path = src/rapidjson
-	url = https://github.com/ceph/rapidjson
 [submodule "src/dmclock"]
 	path = src/dmclock
 	url = https://github.com/ceph/dmclock.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -312,7 +312,13 @@ list(APPEND mds_files
 add_subdirectory(json_spirit)
 
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/xxHash")
-include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/rapidjson/include")
+
+# use the rapidjson headers from s3select's submodule
+if(NOT TARGET RapidJSON::RapidJSON)
+  add_library(RapidJSON::RapidJSON INTERFACE IMPORTED)
+  set_target_properties(RapidJSON::RapidJSON PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/s3select/rapidjson/include")
+endif()
 
 option(WITH_FMT_HEADER_ONLY "use header-only version of fmt library" OFF)
 find_package(fmt 7.0.0 QUIET)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -253,6 +253,7 @@ target_link_libraries(rgw_common
     ${ALLOC_LIBS}
   PUBLIC
     ${LUA_LIBRARIES}
+    RapidJSON::RapidJSON
     spawn)
 target_include_directories(rgw_common
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/services"
@@ -359,7 +360,6 @@ add_library(rgw_a STATIC
 target_compile_definitions(rgw_a PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 
 target_include_directories(rgw_a
-  SYSTEM PUBLIC "../rapidjson/include"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/store/rados"
@@ -494,6 +494,7 @@ target_link_libraries(rgw
   ${CURL_LIBRARIES}
   ${EXPAT_LIBRARIES}
   PUBLIC
+  RapidJSON::RapidJSON
   dmclock::dmclock)
 
 if(WITH_RADOSGW_AMQP_ENDPOINT)

--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -10,6 +10,7 @@
 #include "include/types.h"
 #include "global/global_context.h"
 #include "common/Cond.h"
+#include "common/ceph_crypto.h"
 #include "test/librados/test_cxx.h"
 #include "test/librados/testcase_cxx.h"
 #include "json_spirit/json_spirit.h"
@@ -29,6 +30,7 @@
 
 using namespace std;
 using namespace librados;
+using ceph::crypto::SHA1;
 
 typedef RadosTestPP LibRadosTierPP;
 typedef RadosTestECPP LibRadosTierECPP;
@@ -108,9 +110,14 @@ void manifest_set_chunk(Rados& cluster, librados::IoCtx& src_ioctx,
   completion->release();
 }
 
-#include "common/ceph_crypto.h"
-using ceph::crypto::SHA1;
-#include "rgw/rgw_common.h"
+static inline void buf_to_hex(const unsigned char *buf, int len, char *str)
+{
+  int i;
+  str[0] = '\0';
+  for (i = 0; i < len; i++) {
+    sprintf(&str[i*2], "%02x", (int)buf[i]);
+  }
+}
 
 void check_fp_oid_refcount(librados::IoCtx& ioctx, std::string foid, uint64_t count,
 			   std::string fp_algo = NULL)
@@ -3549,9 +3556,6 @@ TEST_F(LibRadosTwoPoolsPP, ManifestUnset) {
   cluster.wait_for_latest_osdmap();
 }
 
-#include "common/ceph_crypto.h"
-using ceph::crypto::SHA1;
-#include "rgw/rgw_common.h"
 TEST_F(LibRadosTwoPoolsPP, ManifestDedupRefRead) {
   SKIP_IF_CRIMSON();
   // skip test if not yet nautilus


### PR DESCRIPTION
s3select now also dependends on rapidjson, so added it as a nested submodule

rgw will now use the rapidjson headers from s3select's submodule, instead of carrying an extra copy of the rapidjson submodule

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
