### PR TITLE
cephfs-shell: get cmd must get both path and should validate them

### DIFF
--- a/doc/man/8/cephfs-shell.rst
+++ b/doc/man/8/cephfs-shell.rst
@@ -104,7 +104,7 @@ Copy a file from Ceph File System to Local File System.
 
 Usage : 
 
-    get [options] <source_path> [target_path]
+    get [options] <source_path> <target_path>
 
 * source_path - remote file/directory path which is to be copied to local file system.
     * if `.` copies all the file/directories in the remote working directory.

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -308,6 +308,7 @@ class TestRmdir(TestCephFSShell):
         self.run_cephfs_shell_cmd("rmdir -p " + self.dir_name)
         self.mount_a.stat(self.dir_name)
 
+
 class TestGetAndPut(TestCephFSShell):
     def test_without_target_dir(self):
         """
@@ -367,31 +368,23 @@ class TestGetAndPut(TestCephFSShell):
 
     def test_get_without_target_name(self):
         """
-        Test that get passes with target name
+        Test that get should fail when there is no target name
         """
-        s = 'D' * 1024
-        o = self.get_cephfs_shell_cmd_output("put - dump5", stdin=s)
-        log.info("cephfs-shell output:\n{}".format(o))
-
+        s = 'Somedata'
         # put - dump5 should pass
-        o = self.mount_a.stat('dump5')
-        log.info("mount_a output:\n{}".format(o))
+        self.get_cephfs_shell_cmd_output("put - dump5", stdin=s)
 
-        # get dump5 should fail
-        o = self.get_cephfs_shell_cmd_output("get dump5")
-        o = self.get_cephfs_shell_cmd_output("!stat dump5 || echo $?")
-        log.info("cephfs-shell output:\n{}".format(o))
-        l = o.split('\n')
-        try:
-            ret = int(l[1])
-            # verify that stat dump5 passes
-            # if ret == 1, then that implies the stat failed
-            # which implies that there was a problem with "get dump5"
-            assert(ret != 1)
-        except ValueError:
-            # we have a valid stat output; so this is good
-            # if the int() fails then that means there's a valid stat output
-            pass
+        self.mount_a.stat('dump5')
+
+        # get dump5 should fail as there is no local_path mentioned
+        with self.assertRaises(CommandFailedError):
+            self.get_cephfs_shell_cmd_output("get dump5")
+
+        # stat dump would return non-zero exit code as get dump failed
+        # cwd=None because we want to run it at CWD, not at cephfs mntpt.
+        r = self.mount_a.run_shell('stat dump5', cwd=None,
+                                   check_status=False).returncode
+        self.assertEqual(r, 1)
 
     def test_get_to_console(self):
         """

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -704,12 +704,11 @@ class CephFSShell(Cmd):
         return self.complete_filenames(text, line, begidx, endidx)
 
     get_parser = argparse.ArgumentParser(
-        description='Copy a file from Ceph File System from Local Directory.')
+        description='Copy a file from Ceph File System to Local Directory.')
     get_parser.add_argument('remote_path', type=str, action=path_to_bytes,
                             help='Path of the file in the remote system')
     get_parser.add_argument('local_path', type=str, action=path_to_bytes,
-                            help='Path of the file in the local system',
-                            nargs='?', default='.')
+                            help='Path of the file in the local system')
     get_parser.add_argument('-f', '--force', action='store_true',
                             help='Overwrites the destination if it already exists.')
 
@@ -718,6 +717,19 @@ class CephFSShell(Cmd):
         """
         Copy a file/directory from CephFS to given path.
         """
+        if not is_file_exists(args.remote_path) and not \
+                is_dir_exists(args.remote_path):
+            set_exit_code_msg(errno.ENOENT, "error: no file/directory"
+                                            " found at specified remote "
+                                            "path")
+            return
+        if (os.path.isfile(args.local_path) or
+            os.path.isdir(args.local_path)) and not args.force:
+            set_exit_code_msg(msg=f"error: file/directory "
+                                  f"{args.local_path.decode('utf-8')}"
+                                  f" already exists, use --force to "
+                                  f"overwrite")
+            return
         root_src_dir = args.remote_path
         root_dst_dir = args.local_path
         fname = root_src_dir.rsplit(b'/', 1)
@@ -737,17 +749,6 @@ class CephFSShell(Cmd):
             copy_to_local(root_src_dir, root_dst_dir)
         else:
             files = list(reversed(sorted(dirwalk(root_src_dir))))
-            if len(files) == 0:
-                try:
-                    os.makedirs(root_dst_dir + b'/' + root_src_dir)
-                except OSError as e:
-                    if args.force:
-                        pass
-                    else:
-                        set_exit_code_msg(e.errno, f"{root_src_dir.decode('utf-8')}: "
-                                          "already exists! use --force to overwrite")
-                        return
-
             for file_ in files:
                 dst_dirpath, dst_file = file_.rsplit(b'/', 1)
                 if dst_dirpath in files:
@@ -760,16 +761,7 @@ class CephFSShell(Cmd):
                     except OSError:
                         pass
                 else:
-                    if not args.force:
-                        try:
-                            os.stat(dst_path)
-                            set_exit_code_msg(errno.EEXIST, f"{file_.decode('utf-8')}: "
-                                              "file already exists! use --force to override")
-                            return
-                        except OSError:
-                            copy_to_local(file_, dst_path)
-                    else:
-                        copy_to_local(file_, dst_path)
+                    copy_to_local(file_, dst_path)
 
         return 0
 


### PR DESCRIPTION
Description:

- While using `get` command, `local_path` parameter is optional. Changing it
  to mandatory.
  - Rationale: Till now, there used to be a default path of `local_path` as
           `default='.'` but wasn't mentioned anywhere. It led to confusion.
           On top of it, considering get command to be a ssh inspired utlity,
           or any other CLI tool that copies file between filesystems, source
           and destination path are always mandatory. Therefore in order to
           simulate this behavior in cephfs-shell`s command(s), my opinion is
           to make get command accept both the paths.
- Added checks to make sure:
	1) File does exist at `remote_path`
	2) File with the same name doesn't exist in `local_path`
	3) Removed code that would run through the directory and if it finds
	   nothing in `root_src_dir`, then it will try to do:
	   `os.makedirs(root_dst_dir + b'/' + root_src_dir)`, but it will
	   never be empty as 1) takes care of it.

Fixes: https://tracker.ceph.com/issues/55216

Signed-off-by: dparmar18 <dparmar@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
