### PR TITLE
cephfs-shell: fix put and get cmd

### DIFF
--- a/doc/man/8/cephfs-shell.rst
+++ b/doc/man/8/cephfs-shell.rst
@@ -101,7 +101,7 @@ Copy a file/directory to Ceph File System from Local File System.
 
 Usage : 
     
-        put [options] <source_path> [target_path]
+        put [options] <source_path> <target_path>
 
 * source_path - local file/directory path to be copied to cephfs.
     * if `.` copies all the file/directories in the local working directory.

--- a/doc/man/8/cephfs-shell.rst
+++ b/doc/man/8/cephfs-shell.rst
@@ -121,7 +121,7 @@ Copy a file from Ceph File System to Local File System.
 
 Usage : 
 
-    get [options] <source_path> [target_path]
+    get [options] <source_path> <target_path>
 
 * source_path - remote file/directory path which is to be copied to local file system.
     * if `.` copies all the file/directories in the remote working directory.

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -378,6 +378,19 @@ class TestGetAndPut(TestCephFSShell):
         # NOTE: following command must run successfully.
         self.mount_a.run_shell('stat dump5', cwd=None)
 
+    def test_get_doesnt_create_dir(self):
+        # if get cmd is creating subdirs on its own then dump7 will be
+        # stored as ./dump7/tmp/dump7 and not ./dump7, therefore
+        # if doing `cat ./dump7` returns non-zero exit code(i.e. 1) then
+        # it implies that no such file exists at that location
+        dir_abspath = path.join(self.mount_a.mountpoint, 'tmp')
+        self.mount_a.run_shell_payload(f"mkdir {dir_abspath}")
+        self.mount_a.client_remote.write_file(path.join(dir_abspath, 'dump7'),
+                                              'somedata')
+        self.get_cephfs_shell_cmd_output("get /tmp/dump7 ./dump7")
+        # test that dump7 exists
+        self.mount_a.run_shell("cat ./dump7", cwd=None)
+
     def test_get_to_console(self):
         """
         Test that get passes with target name

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -335,43 +335,6 @@ class TestRmdir(TestCephFSShell):
 
 
 class TestGetAndPut(TestCephFSShell):
-    def test_without_target_dir(self):
-        """
-        Test put and get commands without target path.
-        """
-        tempdir = self.mount_a.client_remote.mkdtemp()
-        tempdirname = path.basename(tempdir)
-        files = ('dump1', 'dump2', 'dump3', tempdirname)
-
-        for i, file_ in enumerate(files[: -1]):
-            size = i + 1
-            ofarg = 'of=' + path.join(tempdir, file_)
-            bsarg = 'bs=' + str(size) + 'M'
-            self.mount_a.run_shell_payload("dd if=/dev/urandom "
-                                           f"{ofarg} {bsarg} count=1")
-
-        self.run_cephfs_shell_cmd('put ' + tempdir)
-        for file_ in files:
-            if file_ == tempdirname:
-                self.mount_a.stat(path.join(self.mount_a.mountpoint, file_))
-            else:
-                self.mount_a.stat(path.join(self.mount_a.mountpoint,
-                                            tempdirname, file_))
-
-        self.mount_a.run_shell_payload(f"rm -rf {tempdir}")
-
-        self.run_cephfs_shell_cmd('get ' + tempdirname)
-        # NOTE: cwd=None because we want to run it at CWD, not at cephfs mntpt.
-        pwd = self.mount_a.run_shell('pwd', cwd=None).stdout.getvalue(). \
-            strip()
-        for file_ in files:
-            if file_ == tempdirname:
-                self.mount_a.run_shell_payload(f"stat {path.join(pwd, file_)}")
-            else:
-                self.mount_a.run_shell_payload(
-                    f"stat "
-                    f"{path.join(pwd, tempdirname, file_)}")
-
     def test_get_with_target_name(self):
         """
         Test that get passes with target name

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -363,20 +363,23 @@ class TestGetAndPut(TestCephFSShell):
 
     def test_get_without_target_name(self):
         """
-        Test that get passes with target name
+        Test that get should fail when there is no target name
         """
-        s = 'D' * 1024
-        o = self.get_cephfs_shell_cmd_output("put - dump5", stdin=s)
-        log.info("cephfs-shell output:\n{}".format(o))
-
+        s = 'Somedata'
         # put - dump5 should pass
-        o = self.mount_a.stat('dump5')
-        log.info("mount_a output:\n{}".format(o))
+        self.get_cephfs_shell_cmd_output("put - dump5", stdin=s)
 
-        o = self.get_cephfs_shell_cmd_output("get dump5")
-        # NOTE: cwd=None because we want to run it at CWD, not at cephfs mntpt.
-        # NOTE: following command must run successfully.
-        self.mount_a.run_shell('stat dump5', cwd=None)
+        self.mount_a.stat('dump5')
+
+        # get dump5 should fail as there is no local_path mentioned
+        with self.assertRaises(CommandFailedError):
+            self.get_cephfs_shell_cmd_output("get dump5")
+
+        # stat dump would return non-zero exit code as get dump failed
+        # cwd=None because we want to run it at CWD, not at cephfs mntpt.
+        r = self.mount_a.run_shell('stat dump5', cwd=None,
+                                   check_status=False).returncode
+        self.assertEqual(r, 1)
 
     def test_get_doesnt_create_dir(self):
         # if get cmd is creating subdirs on its own then dump7 will be

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -439,6 +439,23 @@ class TestGetAndPut(TestCephFSShell):
         assert (s_hash == o_hash)
 
 
+    def test_put_without_target_name(self):
+        """
+        put - should fail as the cmd expects both arguments are mandatory.
+        """
+        with self.assertRaises(CommandFailedError):
+            self.get_cephfs_shell_cmd_output("put -")
+
+    def test_put_validate_local_path(self):
+        """
+        This test is intended to make sure local_path is validated before
+        trying to put the file from local fs to cephfs and the command
+        put ./dumpXYZ dump8 would fail as dumpXYX doesn't exist.
+        """
+        with self.assertRaises(CommandFailedError):
+            o = self.get_cephfs_shell_cmd_output("put ./dumpXYZ dump8")
+            log.info("cephfs-shell output:\n{}".format(o))
+
 class TestSnapshots(TestCephFSShell):
     def test_snap(self):
         """

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -348,7 +348,7 @@ class TestGetAndPut(TestCephFSShell):
         o = self.mount_a.stat('dump4')
         log.info("mount_a output:\n{}".format(o))
 
-        o = self.get_cephfs_shell_cmd_output("get dump4 .")
+        o = self.get_cephfs_shell_cmd_output("get dump4 ./dump4")
         log.info("cephfs-shell output:\n{}".format(o))
 
         # NOTE: cwd=None because we want to run it at CWD, not at cephfs mntpt.

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -611,8 +611,7 @@ class CephFSShell(Cmd):
     put_parser.add_argument('local_path', type=str, action=path_to_bytes,
                             help='Path of the file in the local system')
     put_parser.add_argument('remote_path', type=str, action=path_to_bytes,
-                            help='Path of the file in the remote system.',
-                            nargs='?', default='.')
+                            help='Path of the file in the remote system')
     put_parser.add_argument('-f', '--force', action='store_true',
                             help='Overwrites the destination if it already exists.')
 
@@ -621,6 +620,21 @@ class CephFSShell(Cmd):
         """
         Copy a local file/directory to CephFS.
         """
+        if args.local_path != b'-' and not os.path.isfile(args.local_path) \
+                and not os.path.isdir(args.local_path):
+            set_exit_code_msg(errno.ENOENT,
+                              msg=f"error: "
+                                  f"{args.local_path.decode('utf-8')}: "
+                                  f"No such file or directory")
+            return
+
+        if (is_file_exists(args.remote_path) or is_dir_exists(
+                args.remote_path)) and not args.force:
+            set_exit_code_msg(msg=f"error: file/directory "
+                                  f"{args.remote_path.decode('utf-8')} "
+                                  f"exists, use --force to overwrite")
+            return
+
         root_src_dir = args.local_path
         root_dst_dir = args.remote_path
         if args.local_path == b'.' or args.local_path == b'./':
@@ -654,14 +668,6 @@ class CephFSShell(Cmd):
             root_dst_dir += b'/'
 
         if args.local_path == b'-' or os.path.isfile(root_src_dir):
-            if not args.force:
-                if os.path.isfile(root_src_dir):
-                    dst_file = root_dst_dir
-                    if is_file_exists(dst_file):
-                        set_exit_code_msg(errno.EEXIST,
-                                          f"{dst_file.decode('utf-8')}: file "
-                                          "exists! use --force to overwrite")
-                        return
             if args.local_path == b'-':
                 root_src_dir = b'-'
             copy_from_local(root_src_dir, root_dst_dir)

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -743,8 +743,7 @@ class CephFSShell(Cmd):
                 return
             copy_to_local(root_src_dir, b'-')
         elif is_file_exists(args.remote_path):
-            copy_to_local(root_src_dir,
-                          root_dst_dir + b'/' + root_src_dir)
+            copy_to_local(root_src_dir, root_dst_dir)
         elif b'/' in root_src_dir and is_file_exists(fname[1], fname[0]):
             copy_to_local(root_src_dir, root_dst_dir)
         else:

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -716,12 +716,11 @@ class CephFSShell(Cmd):
         return self.complete_filenames(text, line, begidx, endidx)
 
     get_parser = argparse.ArgumentParser(
-        description='Copy a file from Ceph File System from Local Directory.')
+        description='Copy a file from Ceph File System to Local Directory.')
     get_parser.add_argument('remote_path', type=str, action=path_to_bytes,
                             help='Path of the file in the remote system')
     get_parser.add_argument('local_path', type=str, action=path_to_bytes,
-                            help='Path of the file in the local system',
-                            nargs='?', default='.')
+                            help='Path of the file in the local system')
     get_parser.add_argument('-f', '--force', action='store_true',
                             help='Overwrites the destination if it already exists.')
 
@@ -730,6 +729,19 @@ class CephFSShell(Cmd):
         """
         Copy a file/directory from CephFS to given path.
         """
+        if not is_file_exists(args.remote_path) and not \
+                is_dir_exists(args.remote_path):
+            set_exit_code_msg(errno.ENOENT, "error: no file/directory"
+                                            " found at specified remote "
+                                            "path")
+            return
+        if (os.path.isfile(args.local_path) or os.path.isdir(
+                args.local_path)) and not args.force:
+            set_exit_code_msg(msg=f"error: file/directory "
+                                  f"{args.local_path.decode('utf-8')}"
+                                  f" already exists, use --force to "
+                                  f"overwrite")
+            return
         root_src_dir = args.remote_path
         root_dst_dir = args.local_path
         fname = root_src_dir.rsplit(b'/', 1)
@@ -748,17 +760,6 @@ class CephFSShell(Cmd):
             copy_to_local(root_src_dir, root_dst_dir)
         else:
             files = list(reversed(sorted(dirwalk(root_src_dir))))
-            if len(files) == 0:
-                try:
-                    os.makedirs(root_dst_dir + b'/' + root_src_dir)
-                except OSError as e:
-                    if args.force:
-                        pass
-                    else:
-                        set_exit_code_msg(e.errno, f"{root_src_dir.decode('utf-8')}: "
-                                          "already exists! use --force to overwrite")
-                        return
-
             for file_ in files:
                 dst_dirpath, dst_file = file_.rsplit(b'/', 1)
                 if dst_dirpath in files:
@@ -771,16 +772,7 @@ class CephFSShell(Cmd):
                     except OSError:
                         pass
                 else:
-                    if not args.force:
-                        try:
-                            os.stat(dst_path)
-                            set_exit_code_msg(errno.EEXIST, f"{file_.decode('utf-8')}: "
-                                              "file already exists! use --force to override")
-                            return
-                        except OSError:
-                            copy_to_local(file_, dst_path)
-                    else:
-                        copy_to_local(file_, dst_path)
+                    copy_to_local(file_, dst_path)
 
         return 0
 


### PR DESCRIPTION
Description:

This PR intends to fix put and get command of cephfs-shell.

1) put cmd:
    - `put` command didn't display any error when the file at local_path was not
    found. added a check for it.
    - Rationale: Till now, there used to be a default path of `remote_path` as
           `default='.'` but wasn't mentioned anywhere. It could lead to confusion.
           On top of it, considering put command to be a ssh inspired utlity,
           or any other CLI tool that copies file between filesystems, source
           and destination path are always mandatory. Therefore in order to
           simulate this behavior in cephfs-shell`s command(s), my opinion is
           to make put command accept both the paths.

2) get cmd:
    - When using the get command on a single file, it would append the remote path to
      source path and create directories that shouldn't be created. For instance,
      file 'foo.txt' resides at /dir1/dir2/ and get command is used to copy it to
      /tmp/foo.txt then it would do /tmp/dir1/dir2/foo.txt which is not the expected
      behavior. Therefore this PR intends to correct this behavior.
    - While using get command, local_path parameter is optional. Changing it
to mandatory.
Rationale: Till now, there used to be a default path of local_path as
default='.' but wasn't mentioned anywhere. It led to confusion.
On top of it, considering get command to be a ssh inspired utlity,
or any other CLI tool that copies file between filesystems, source
and destination path are always mandatory. Therefore in order to
simulate this behavior in cephfs-shell`s command(s), my opinion is
to make get command accept both the paths.

    - Added checks to make sure:
      1. File does exist at `remote_path`
      2. File with the same name doesn't exist in `local_path`
      3. Removed code that would run through the directory and if it finds
nothing in `root_src_dir,` then it will try to do:
`os.makedirs(root_dst_dir + b'/' + root_src_dir)`, but it will
never be empty as 1) takes care of it.

Fixes: https://tracker.ceph.com/issues/55242, https://tracker.ceph.com/issues/55216, https://tracker.ceph.com/issues/55112

Signed-off-by: Dhairya Parmar <dparmar@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
