### PR TITLE
mgr/dashboard: save mgr logs inside a folder 

### DIFF
--- a/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
@@ -5,31 +5,36 @@ set -eEx
 cleanup() {
     set +x
     if [[ -n "$JENKINS_HOME" ]]; then
-        printf "\n\nStarting cleanup...\n\n"
+        echo "Starting cleanup..."
         kcli delete plan -y ceph || true
         kcli delete network ceph-dashboard -y
         docker container prune -f
-        printf "\n\nCleanup completed.\n\n"
+        echo "Cleanup completed."
     fi
 }
 
 on_error() {
     set +x
     if [ "$1" != "0" ]; then
-        printf "\n\nERROR $1 thrown on line $2\n\n"
-        printf "\n\nCollecting info...\n\n"
-        printf "\n\nDisplaying MGR logs:\n\n"
-        kcli ssh -u root -- ceph-node-00 'cephadm logs -n \$(cephadm ls | grep -Eo "mgr\.ceph[0-9a-z.-]+" | head -n 1) -- --no-tail --no-pager'
-        for vm_id in 0 1 2
+        echo "ERROR $1 thrown on line $2"
+        echo
+        echo "Collecting info..."
+        echo
+        echo "Saving MGR logs:"
+        echo
+        mkdir -p ${CEPH_DEV_FOLDER}/logs
+        kcli ssh -u root -- ceph-node-00 'cephadm logs -n \$(cephadm ls | grep -Eo "mgr\.ceph[0-9a-z.-]+" | head -n 1) -- --no-tail --no-pager' > ${CEPH_DEV_FOLDER}/logs/mgr.cephadm.log
+        for vm_id in {0..3}
         do
             local vm="ceph-node-0${vm_id}"
-            printf "\n\nDisplaying journalctl from VM ${vm}:\n\n"
-            kcli ssh -u root -- ${vm} 'journalctl --no-tail --no-pager -t cloud-init' || true
-            printf "\n\nEnd of journalctl from VM ${vm}\n\n"
-            printf "\n\nDisplaying container logs:\n\n"
-            kcli ssh -u root -- ${vm} 'podman logs --names --since 30s \$(podman ps -aq)' || true
+            echo "Saving journalctl from VM ${vm}:"
+            echo
+            kcli ssh -u root -- ${vm} 'journalctl --no-tail --no-pager -t cloud-init' > ${CEPH_DEV_FOLDER}/logs/journal.ceph-node-0${vm_id}.log || true
+            echo "Saving container logs:"
+            echo
+            kcli ssh -u root -- ${vm} 'podman logs --names --since 30s \$(podman ps -aq)' > ${CEPH_DEV_FOLDER}/logs/container.ceph-node-0${vm_id}.log || true
         done
-        printf "\n\nTEST FAILED.\n\n"
+        echo "TEST FAILED."
     fi
 }
 


### PR DESCRIPTION
Save the mgr container logs of cephadm inside a folder and later on
archive it and get it as an artifact on the cephadm dashboard e2e jobs

this saves the mgr logs in `ceph/logs/mgr.cephadm.log`
and also the container logs and journal logs in the same folder.

Fixes: https://tracker.ceph.com/issues/55247
Signed-off-by: Nizamudeen A <nia@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
