### PR TITLE
common/ceph_json: dump bool using f->dump_bool()

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -5,3 +5,41 @@
   defaults to "/var/log/ceph/ops-log-$cluster-$name.log".
 * The SPDK backend for BlueStore is now able to connect to an NVMeoF target.
   Please note that this is not an officially supported feature.
+* RGW's pubsub interface now returns boolean fields using bool. Before this change,
+  `/topics/<topic-name>` returns "stored_secret" and "persistent" using a string
+  of "true" or "false" with quotes around them. After this change, these fields
+  are returned without quotes so they can be decoded as boolean values in JSON.
+  The same applies to the `is_truncated` field returned by `/subscriptions/<sub-name>`.
+* RGW's response of `Action=GetTopicAttributes&TopicArn=<topic-arn>` REST API now
+  returns `HasStoredSecret` and `Persistent` as boolean in the JSON string
+  encoded in `Attributes/EndPoint`.
+* All boolean fields previously rendered as string by `rgw-admin` command when
+  the JSON format is used are now rendered as boolean. If your scripts/tools
+  relies on this behavior, please update them accordingly. The impacted field names
+  are:
+  * absolute
+  * add
+  * admin
+  * appendable
+  * bucket_key_enabled
+  * delete_marker
+  * exists
+  * has_bucket_info
+  * high_precision_time
+  * index
+  * is_master
+  * is_prefix
+  * is_truncated
+  * linked
+  * log_meta
+  * log_op
+  * pending_removal
+  * read_only
+  * retain_head_object
+  * rule_exist
+  * start_with_full_sync
+  * sync_from_all
+  * syncstopped
+  * system
+  * truncated
+  * user_stats_sync

--- a/doc/radosgw/pubsub-module.rst
+++ b/doc/radosgw/pubsub-module.rst
@@ -280,8 +280,8 @@ Response will have the following format (JSON):
                "push_endpoint":"",
                "push_endpoint_args":"",
                "push_endpoint_topic":"",
-               "stored_secret":"",
-               "persistent":""
+               "stored_secret":false,
+               "persistent":true,
            },
            "arn":""
            "opaqueData":""
@@ -519,7 +519,7 @@ The response will hold information on the current marker and whether there are m
 
 ::
 
-   {"next_marker":"","is_truncated":"",...}
+   {"next_marker":"","is_truncated":false,...}
 
 
 The actual content of the response is depended with how the subscription was created.

--- a/src/common/ceph_json.cc
+++ b/src/common/ceph_json.cc
@@ -531,13 +531,7 @@ void encode_json(const char *name, const char *val, Formatter *f)
 
 void encode_json(const char *name, bool val, Formatter *f)
 {
-  string s;
-  if (val)
-    s = "true";
-  else
-    s = "false";
-
-  f->dump_string(name, s);
+  f->dump_bool(name, val);
 }
 
 void encode_json(const char *name, int val, Formatter *f)

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -5,7 +5,6 @@ import json
 import logging
 import re
 import xml.etree.ElementTree as ET  # noqa: N814
-from distutils.util import strtobool
 from subprocess import SubprocessError
 
 from mgr_util import build_url
@@ -467,7 +466,7 @@ class RgwClient(RestClient):
     def _is_system_user(self, admin_path, userid, request=None) -> bool:
         # pylint: disable=unused-argument
         response = request()
-        return strtobool(response['data']['system'])
+        return response['data']['system']
 
     def is_system_user(self) -> bool:
         return self._is_system_user(self.admin_path, self.userid)


### PR DESCRIPTION


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>

Fixes: https://tracker.ceph.com/issues/55189