### PR TITLE
octopus:rgw: fix lock scope in ObjectCache::get()

### DIFF
--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -13,6 +13,7 @@ int ObjectCache::get(const string& name, ObjectCacheInfo& info, uint32_t mask, r
 {
 
   std::shared_lock rl{lock};
+  std::unique_lock wl{lock, std::defer_lock};
   if (!enabled) {
     return -ENOENT;
   }
@@ -29,7 +30,7 @@ int ObjectCache::get(const string& name, ObjectCacheInfo& info, uint32_t mask, r
        (ceph::coarse_mono_clock::now() - iter->second.info.time_added) > expiry) {
     ldout(cct, 10) << "cache get: name=" << name << " : expiry miss" << dendl;
     rl.unlock();
-    std::unique_lock wl{lock};  // write lock for insertion
+    wl.lock(); // write lock for expiration
     // check that wasn't already removed by other thread
     iter = cache_map.find(name);
     if (iter != cache_map.end()) {
@@ -50,7 +51,7 @@ int ObjectCache::get(const string& name, ObjectCacheInfo& info, uint32_t mask, r
     ldout(cct, 20) << "cache get: touching lru, lru_counter=" << lru_counter
                    << " promotion_ts=" << entry->lru_promotion_ts << dendl;
     rl.unlock();
-    std::unique_lock wl{lock};  // write lock for insertion
+    wl.lock(); // write lock for touch_lru()
     /* need to redo this because entry might have dropped off the cache */
     iter = cache_map.find(name);
     if (iter == cache_map.end()) {


### PR DESCRIPTION

Based on @cupnes's changes on #44747

> in the touch_lru() case, we promote the shared_lock to a unique_lock.
but because the unique_lock is in a nested scope, the lock drops with
its scope and we continue accessing the map without any protection

> this moves the unique_lock up to function scope, where it's
constructed as unlocked with std::defer_lock. after promotion, this
lock will be held until the function returns

Fixes: https://tracker.ceph.com/issues/51927
Signed-off-by: Ramin Najarbashi <ramin.najarbashi@gmail.com>

## Checklist
- Tracker 
  - [x] References tracker ticket [#51927](https://tracker.ceph.com/issues/51927)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation 
  - [x] No doc update is appropriate
- Tests
  - [x] No tests

