### PR TITLE
octopus:ImportError: cannot import name 'environmentfilter' from 'jinja2'

### DIFF
--- a/admin/doc-read-the-docs.txt
+++ b/admin/doc-read-the-docs.txt
@@ -1,2 +1,2 @@
 plantweb
-git+https://github.com/readthedocs/readthedocs-sphinx-search@master
+git+https://github.com/readthedocs/readthedocs-sphinx-search@main

--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -3,6 +3,7 @@ git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
 breathe >= 4.20.0
 pyyaml >= 5.1.2
 Cython
+Jinja2 < 3.1
 prettytable
 sphinx-autodoc-typehints
 sphinx-prompt

--- a/src/pybind/mgr/dashboard/constraints.txt
+++ b/src/pybind/mgr/dashboard/constraints.txt
@@ -4,6 +4,6 @@ more-itertools==4.1.0
 PyJWT==2.0.1
 bcrypt==3.1.4
 python3-saml==1.4.1
-requests==2.25.1
+requests==2.26
 Routes==2.4.1
 six==1.14.0


### PR DESCRIPTION
Date:      Sun Apr 10 15:16925 2022 +0430

On branch fix_jinja2_version
Changes to be committed:
	modified:   admin/doc-requirements.txt

Signed-off-by: Ramin Najarbashi <ramin.najarbashi@gmail.com>

## Checklist
- Component impact
  - [X] No impact that needs to be tracked
- Documentation
  - [X] No doc update is appropriate
- Tests
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
