### PR TITLE
ceph-volume/migrate: fix make_new_volume()

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/migrate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/migrate.py
@@ -583,7 +583,7 @@ class NewVolume(object):
         try:
             tag_tracker.update_tags_when_lv_create(self.create_type)
 
-            stdout, stderr, exit_code = process.call([
+            command = [
                 'ceph-bluestore-tool',
                 '--path',
                 osd_path,
@@ -591,7 +591,13 @@ class NewVolume(object):
                 target_lv.lv_path,
                 '--command',
                 'bluefs-bdev-new-{}'.format(self.create_type)
-            ])
+            ]
+
+            if self.create_type == 'db':
+                command.extend(['--bluestore-block-db-size',
+                                target_lv.lv_size])
+
+            stdout, stderr, exit_code = process.call(command)
             if exit_code != 0:
                 mlogger.error(
                     'failed to attach new volume, error code:{}'.format(

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_migrate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_migrate.py
@@ -599,6 +599,7 @@ class TestNew(object):
         self.mock_volume = api.Volume(lv_name='target_volume1', lv_uuid='y',
                                       vg_name='vg',
                                       lv_path='/dev/VolGroup/target_volume',
+                                      lv_size=123,
                                       lv_tags='')
         monkeypatch.setattr(api, 'get_lv_by_fullname',
             self.mock_get_lv_by_fullname)
@@ -658,7 +659,8 @@ class TestNew(object):
             'ceph-bluestore-tool',
             '--path', '/var/lib/ceph/osd/ceph_cluster-1',
             '--dev-target', '/dev/VolGroup/target_volume',
-            '--command', 'bluefs-bdev-new-db']
+            '--command', 'bluefs-bdev-new-db',
+            '--bluestore-block-db-size', 123]
 
     def test_newdb_active_systemd(self, is_root, monkeypatch, capsys):
         source_tags = \
@@ -755,6 +757,7 @@ class TestNew(object):
         self.mock_volume = api.Volume(lv_name='target_volume1', lv_uuid='y',
                                       vg_name='vg',
                                       lv_path='/dev/VolGroup/target_volume',
+                                      lv_size=123,
                                       lv_tags='')
         monkeypatch.setattr(api, 'get_lv_by_fullname',
             self.mock_get_lv_by_fullname)
@@ -812,7 +815,8 @@ class TestNew(object):
             'ceph-bluestore-tool',
             '--path', '/var/lib/ceph/osd/ceph_cluster-1',
             '--dev-target', '/dev/VolGroup/target_volume',
-            '--command', 'bluefs-bdev-new-db']
+            '--command', 'bluefs-bdev-new-db',
+            '--bluestore-block-db-size', 123]
 
     @patch('os.getuid')
     def test_newwal(self, m_getuid, monkeypatch, capsys):


### PR DESCRIPTION
Typical error encountered:
```
stderr: Might need DB size specification, please set Ceph bluestore-block-db-size config parameter
```

This wasn't required until pacific. Something must have changed as of Quincy.

Fixes: https://tracker.ceph.com/issues/55260

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>