### PR TITLE
mgr/dashboard: Add cypress env for login credentials

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress.json
+++ b/src/pybind/mgr/dashboard/frontend/cypress.json
@@ -18,5 +18,9 @@
       "mochaFile": "cypress/reports/results-[hash].xml"
     }
   },
-  "retries": 1
+  "retries": 1,
+  "env": {
+    "LOGIN_USER": "admin",
+    "LOGIN_PASSWORD": "admin"
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/cypress/support/commands.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/support/commands.ts
@@ -26,8 +26,8 @@ const fillAuth = () => {
 };
 
 Cypress.Commands.add('login', () => {
-  const username = Cypress.env('LOGIN_USER') || 'admin';
-  const password = Cypress.env('LOGIN_PWD') || 'admin';
+  const username = Cypress.env('LOGIN_USER');
+  const password = Cypress.env('LOGIN_PWD');
 
   if (auth === undefined) {
     cy.request({


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/55270
Signed-off-by: Sarthak0702 <sarthak.dev.0702@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
