### PR TITLE
pacific: mgr/dashboard: datatable in Cluster Host page hides wrong column on selection 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -470,7 +470,6 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
     } else {
       // mark host facts columns unavailable
       for (let column = 4; column < this.columns.length; column++) {
-        this.columns[column]['prop'] = '';
         this.columns[column]['cellTemplate'] = this.orchTmpl;
       }
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -513,6 +513,15 @@ describe('TableComponent', () => {
       equalStorageConfig();
     });
 
+    it('should toggle on off columns', () => {
+      for (const column of component.columns) {
+        component.toggleColumn(column);
+        expect(column.isHidden).toBeTruthy();
+        component.toggleColumn(column);
+        expect(column.isHidden).toBeFalsy();
+      }
+    });
+
     afterEach(() => {
       clearLocalStorage();
     });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55273

---

backport of https://github.com/ceph/ceph/pull/45790
parent tracker: https://tracker.ceph.com/issues/55176

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh