### PR TITLE
quincy: mgr/dashboard: RGW users and buckets tables are empty if the selected gateway is down

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.spec.ts
@@ -12,7 +12,7 @@ describe('RgwDaemonService', () => {
   let httpTesting: HttpTestingController;
   let selectDaemonSpy: jasmine.Spy;
 
-  const daemonList = RgwHelper.getDaemonList();
+  const daemonList: Array<RgwDaemon> = RgwHelper.getDaemonList();
   const retrieveDaemonList = (reqDaemonList: RgwDaemon[], daemon: RgwDaemon) => {
     service
       .request((params) => of(params))
@@ -75,5 +75,16 @@ describe('RgwDaemonService', () => {
     retrieveDaemonList(noDefaultDaemonList, noDefaultDaemonList[0]);
     expect(selectDaemonSpy).toHaveBeenCalledTimes(1);
     expect(selectDaemonSpy).toHaveBeenCalledWith(noDefaultDaemonList[0]);
+  }));
+
+  it('should update default daemon if not exist in daemon list', fakeAsync(() => {
+    const tmpDaemonList = [...daemonList];
+    service.selectDaemon(tmpDaemonList[1]); // Select 'default' daemon.
+    tmpDaemonList.splice(1, 1); // Remove 'default' daemon.
+    tmpDaemonList[0].default = true; // Set new 'default' daemon.
+    service.list().subscribe();
+    const testReq = httpTesting.expectOne('api/rgw/daemon');
+    testReq.flush(tmpDaemonList);
+    expect(service['selectedDaemon'].getValue()).toEqual(tmpDaemonList[0]);
   }));
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.ts
@@ -25,7 +25,10 @@ export class RgwDaemonService {
     return this.http.get<RgwDaemon[]>(this.url).pipe(
       tap((daemons: RgwDaemon[]) => {
         this.daemons.next(daemons);
-        if (_.isEmpty(this.selectedDaemon.getValue())) {
+        const selectedDaemon = this.selectedDaemon.getValue();
+        // Set or re-select the default daemon if the current one is not
+        // in the list anymore.
+        if (_.isEmpty(selectedDaemon) || undefined === _.find(daemons, { id: selectedDaemon.id })) {
           this.selectDefaultDaemon(daemons);
         }
       })


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55275

---

backport of https://github.com/ceph/ceph/pull/45584
parent tracker: https://tracker.ceph.com/issues/54983

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh