### PR TITLE
mgr/snap_schedule: replace .snap with the client configured snap dir name

### DIFF
--- a/qa/suites/fs/functional/tasks/snap_schedule_snapdir.yaml
+++ b/qa/suites/fs/functional/tasks/snap_schedule_snapdir.yaml
@@ -1,0 +1,30 @@
+overrides:
+  ceph:
+    conf:
+      mgr:
+        debug mgr: 20
+        debug ms: 1
+        debug finisher: 20
+        debug client: 20
+    log-whitelist:
+      - OSD full dropping all updates
+      - OSD near full
+      - pausewr flag
+      - failsafe engaged, dropping updates
+      - failsafe disengaged, no longer dropping
+      - is full \(reached quota
+      - POOL_FULL
+      - POOL_BACKFILLFULL
+
+overrides:
+  kclient:
+    snapdirname: .customsnapkernel
+  ceph:
+    conf:
+      client:
+        client snapdir: .customsnapfuse
+
+tasks:
+  - cephfs_test_runner:
+      modules:
+        - tasks.cephfs.test_snap_schedules.TestSnapSchedulesSnapdir

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -32,6 +32,7 @@ class KernelMount(CephFSMount):
         self.client_config = client_config
         self.dynamic_debug = client_config.get('dynamic_debug', False)
         self.rbytes = client_config.get('rbytes', False)
+        self.snapdirname = client_config.get('snapdirname', '.snap')
         self.syntax_style = client_config.get('syntax', 'v2')
         self.inst = None
         self.addr = None
@@ -109,6 +110,8 @@ class KernelMount(CephFSMount):
             opts += ",rbytes"
         else:
             opts += ",norbytes"
+        if self.snapdirname != '.snap':
+            opts += f',snapdirname={self.snapdirname}'
 
         mount_cmd = ['sudo'] + self._nsenter_args
         stx_opt = self._make_mount_cmd_old_or_new_style()

--- a/qa/tasks/cephfs/test_snap_schedules.py
+++ b/qa/tasks/cephfs/test_snap_schedules.py
@@ -19,7 +19,7 @@ def seconds_upto_next_schedule(time_from, timo):
     ts = int(time_from)
     return ((int(ts / 60) * 60) + timo) - ts
 
-class TestSnapSchedules(CephFSTestCase):
+class TestSnapSchedulesHelper(CephFSTestCase):
     CLIENTS_REQUIRED = 1
 
     TEST_VOLUME_NAME = 'snap_vol'
@@ -54,7 +54,7 @@ class TestSnapSchedules(CephFSTestCase):
         result = json.loads(self._fs_cmd("volume", "ls"))
         if len(result) == 0:
             self.vol_created = True
-            self.volname = TestSnapSchedules.TEST_VOLUME_NAME
+            self.volname = TestSnapSchedulesHelper.TEST_VOLUME_NAME
             self._fs_cmd("volume", "create", self.volname)
         else:
             self.volname = result[0]['name']
@@ -72,7 +72,7 @@ class TestSnapSchedules(CephFSTestCase):
         self.config_set('mgr', 'mgr/snap_schedule/dump_on_update', True)
 
     def setUp(self):
-        super(TestSnapSchedules, self).setUp()
+        super(TestSnapSchedulesHelper, self).setUp()
         self.volname = None
         self.vol_created = False
         self._create_or_reuse_test_volume()
@@ -88,7 +88,7 @@ class TestSnapSchedules(CephFSTestCase):
         if self.vol_created:
             self._delete_test_volume()
         self._disable_snap_schedule()
-        super(TestSnapSchedules, self).tearDown()
+        super(TestSnapSchedulesHelper, self).tearDown()
 
     def _schedule_to_timeout(self, schedule):
         mult = schedule[-1]
@@ -120,14 +120,14 @@ class TestSnapSchedules(CephFSTestCase):
 
     def verify(self, dir_path, max_trials):
         trials = 0
-        snap_path = "{0}/.snap".format(dir_path)
+        snap_path = f'{dir_path}/.snap'
         while (len(self.create_cbks) or len(self.remove_cbks)) and trials < max_trials:
             snapshots = set(self.mount_a.ls(path=snap_path))
-            log.info(f"snapshots: {snapshots}")
+            log.info(f'snapshots: {snapshots}')
             added = snapshots - self.snapshots
-            log.info(f"added: {added}")
+            log.info(f'added: {added}')
             removed = self.snapshots - snapshots
-            log.info(f"removed: {removed}")
+            log.info(f'removed: {removed}')
             if added:
                 for cbk in list(self.create_cbks):
                     res = cbk(list(added))
@@ -151,7 +151,7 @@ class TestSnapSchedules(CephFSTestCase):
 
         # expected "scheduled" snapshot name
         ts_name = (datetime.utcfromtimestamp(snap_sched_exec_epoch)
-                   + timedelta(seconds=wait_timo)).strftime(TestSnapSchedules.SNAPSHOT_TS_FORMAT)
+                   + timedelta(seconds=wait_timo)).strftime(TestSnapSchedulesHelper.SNAPSHOT_TS_FORMAT)
         return (wait_timo, ts_name)
 
     def verify_schedule(self, dir_path, schedules, retentions=[]):
@@ -165,7 +165,8 @@ class TestSnapSchedules(CephFSTestCase):
             self.assertTrue(schedule in json_res['schedule'])
         for retention in retentions:
             self.assertTrue(retention in json_res['retention'])
-
+    
+class TestSnapSchedules(TestSnapSchedulesHelper):
     def remove_snapshots(self, dir_path):
         snap_path = f'{dir_path}/.snap'
 
@@ -359,7 +360,7 @@ class TestSnapSchedules(CephFSTestCase):
         snap_path = f"{dir_path}/.snap"[1:]
         snapshots = self.mount_a.ls(path=snap_path)
         fs_count = len(snapshots)
-        log.debug(f'snapshots: {snapshots}');
+        log.debug(f'snapshots: {snapshots}')
 
         result = self.fs_snap_schedule_cmd('status', path=dir_path,
                                            format='json')
@@ -453,4 +454,50 @@ class TestSnapSchedules(CephFSTestCase):
         # cleanup
         self.fs_snap_schedule_cmd('remove', path=testdir, snap_schedule='1M')
         self.remove_snapshots(testdir[1:])
-        self.mount_a.run_shell(['rmdir', testdir[1:]])
+        self.mount_a.run_shell(['rmdir', testdir[1:]])    
+
+class TestSnapSchedulesSnapdir(TestSnapSchedulesHelper):
+    def remove_snapshots(self, dir_path, sdn):
+        snap_path = f'{dir_path}/{sdn}'
+
+        snapshots = self.mount_a.ls(path=snap_path)
+        for snapshot in snapshots:
+            snapshot_path = os.path.join(snap_path, snapshot)
+            log.debug(f'removing snapshot: {snapshot_path}')
+            self.mount_a.run_shell(['rmdir', snapshot_path])
+
+    def get_snap_dir_name(self):
+        from tasks.cephfs.fuse_mount import FuseMount
+        from tasks.cephfs.kernel_mount import KernelMount
+
+        if isinstance(self.mount_a, KernelMount):
+            sdn = self.mount_a.client_config.get('snapdirname', '.snap')
+        elif isinstance(self.mount_a, FuseMount):
+            sdn = self.mount_a.client_config.get('client_snapdir', '.snap')
+            self.fs.set_ceph_conf('client', 'client snapdir', sdn)
+            self.mount_a.remount()
+        return sdn
+
+    def test_snap_dir_name(self):
+        """Test the correctness of snap directory name"""
+        self.mount_a.run_shell(['mkdir', '-p', TestSnapSchedulesSnapdir.TEST_DIRECTORY])
+
+        # set a schedule on the dir
+        self.fs_snap_schedule_cmd('add', path=TestSnapSchedulesSnapdir.TEST_DIRECTORY, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('retention', 'add', path=TestSnapSchedulesSnapdir.TEST_DIRECTORY, retention_spec_or_period='1M')
+        exec_time = time.time()
+
+        timo, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        sdn = self.get_snap_dir_name()
+        log.info(f'expecting snap {TestSnapSchedulesSnapdir.TEST_DIRECTORY}/{sdn}/scheduled-{snap_sfx} in ~{timo}s...')
+        
+        # verify snapshot schedule
+        self.verify_schedule(TestSnapSchedulesSnapdir.TEST_DIRECTORY, ['1M'], retentions=[{'M':1}])
+        
+        # remove snapshot schedule
+        self.fs_snap_schedule_cmd('remove', path=TestSnapSchedulesSnapdir.TEST_DIRECTORY)
+
+        # remove all scheduled snapshots
+        self.remove_snapshots(TestSnapSchedulesSnapdir.TEST_DIRECTORY, sdn)
+
+        self.mount_a.run_shell(['rmdir', TestSnapSchedulesSnapdir.TEST_DIRECTORY])

--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -287,7 +287,8 @@ class SnapSchedClient(CephfsClient):
                     time = datetime.now(timezone.utc)
                     with open_filesystem(self, fs_name) as fs_handle:
                         snap_ts = time.strftime(SNAPSHOT_TS_FORMAT_TZ)
-                        snap_name = f'{path}/.snap/{SNAPSHOT_PREFIX}-{snap_ts}'
+                        snap_dir = self.mgr.rados.conf_get('client_snapdir')
+                        snap_name = f'{path}/{snap_dir}/{SNAPSHOT_PREFIX}-{snap_ts}'
                         fs_handle.mkdir(snap_name, 0o755)
                     log.info(f'created scheduled snapshot of {path}')
                     log.debug(f'created scheduled snapshot {snap_name}')
@@ -313,7 +314,8 @@ class SnapSchedClient(CephfsClient):
             prune_candidates = set()
             time = datetime.now(timezone.utc)
             with open_filesystem(self, sched.fs) as fs_handle:
-                with fs_handle.opendir(f'{path}/.snap') as d_handle:
+                snap_dir = self.mgr.rados.conf_get('client_snapdir')
+                with fs_handle.opendir(f'{path}/{snap_dir}') as d_handle:
                     dir_ = fs_handle.readdir(d_handle)
                     while dir_:
                         if dir_.d_name.decode('utf-8').startswith(f'{SNAPSHOT_PREFIX}-'):
@@ -328,7 +330,7 @@ class SnapSchedClient(CephfsClient):
                 for k in to_prune:
                     dirname = k[0].d_name.decode('utf-8')
                     log.debug(f'rmdir on {dirname}')
-                    fs_handle.rmdir(f'{path}/.snap/{dirname}')
+                    fs_handle.rmdir(f'{path}/{snap_dir}/{dirname}')
                 if to_prune:
                     with self.get_schedule_db(sched.fs) as conn_mgr:
                         db = conn_mgr.dbinfo.db


### PR DESCRIPTION
snap_schedule assumes that the client snap dir is always ".snap" .
It is now replaced with the client configured snap dir name.

Fix: https://tracker.ceph.com/issues/55234
Signed-off-by: Neeraj Pratap Singh <neesingh@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
