### PR TITLE
rgw: Avoid segfault when OPA authz is enabled

### DIFF
--- a/src/rgw/rgw_opa.cc
+++ b/src/rgw/rgw_opa.cc
@@ -47,10 +47,18 @@ int rgw_opa_authorize(RGWOp *& op,
   jf.dump_string("decoded_uri", s->decoded_uri.c_str());
   jf.dump_string("params", s->info.request_params.c_str());
   jf.dump_string("request_uri_aws4", s->info.request_uri_aws4.c_str());
-  jf.dump_string("object_name", s->object->get_name().c_str());
-  jf.dump_string("subuser", s->auth.identity->get_subuser().c_str());
-  jf.dump_object("user_info", s->user->get_info());
-  jf.dump_object("bucket_info", s->bucket->get_info());
+  if (s->object) {
+    jf.dump_string("object_name", s->object->get_name().c_str());
+  }
+  if (s->auth.identity) {
+    jf.dump_string("subuser", s->auth.identity->get_subuser().c_str());
+  }
+  if (s->user) {
+    jf.dump_object("user_info", s->user->get_info());
+  }
+  if (s->bucket) {
+    jf.dump_object("bucket_info", s->bucket->get_info());
+  }
   jf.close_section();
   jf.close_section();
 


### PR DESCRIPTION
When `rgw_use_opa_authz=true`, radosgw would segfault on any request that
didn't target a specific object or bucket, because `s->object` or `s->bucket`
would be `nullptr` in that case, but that code path would try to dereference
them anyway.

This commit only adds the `object_name`, `subuser`, `user_info` and
`bucket_info` JSON objects if the corresponding `s->X` object is defined,
thereby avoiding segfaults in radosgw when Open Policy Agent authorization is
enabled.

Fixes: https://tracker.ceph.com/issues/55286
Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
