### PR TITLE
pacific: mgr/dashboard: fix api test issue with pip

### DIFF
--- a/src/pybind/mgr/dashboard/constraints.txt
+++ b/src/pybind/mgr/dashboard/constraints.txt
@@ -4,5 +4,5 @@ more-itertools==4.1.0
 PyJWT==2.0.1
 bcrypt==3.1.4
 python3-saml==1.4.1
-requests==2.20.0
+requests==2.26
 Routes==2.4.1

--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -44,7 +44,7 @@ setup_teuthology() {
     ${TEUTHOLOGY_PYTHON_BIN:-/usr/bin/python3} -m venv venv
     source venv/bin/activate
     pip install -U pip 'setuptools>=12,<60'
-    pip install git+https://github.com/ceph/teuthology#egg=teuthology[test]
+    pip install "git+https://github.com/ceph/teuthology@7039075#egg=teuthology[test]"
     pushd $CURR_DIR
     pip install -r requirements.txt -c constraints.txt
     popd


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55119

---

backport of https://github.com/ceph/ceph/pull/45647
parent tracker: https://tracker.ceph.com/issues/55060

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh