### PR TITLE
os/bluestore: Always update the cursor position in AVL near-fit search.

### DIFF
--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -39,8 +39,8 @@ uint64_t AvlAllocator::_pick_block_after(uint64_t *cursor,
   auto rs_start = range_tree.lower_bound(range_t{*cursor, size}, compare);
   for (auto rs = rs_start; rs != range_tree.end(); ++rs) {
     uint64_t offset = p2roundup(rs->start, align);
+    *cursor = offset + size;
     if (offset + size <= rs->end) {
-      *cursor = offset + size;
       return offset;
     }
     if (max_search_count > 0 && ++search_count > max_search_count) {
@@ -51,6 +51,7 @@ uint64_t AvlAllocator::_pick_block_after(uint64_t *cursor,
       return -1ULL;
     }
   }
+
   if (*cursor == 0) {
     // If we already started from beginning, don't bother with searching from beginning
     return -1ULL;
@@ -58,8 +59,8 @@ uint64_t AvlAllocator::_pick_block_after(uint64_t *cursor,
   // If we reached end, start from beginning till cursor.
   for (auto rs = range_tree.begin(); rs != rs_start; ++rs) {
     uint64_t offset = p2roundup(rs->start, align);
+    *cursor = offset + size;
     if (offset + size <= rs->end) {
-      *cursor = offset + size;
       return offset;
     }
     if (max_search_count > 0 && ++search_count > max_search_count) {


### PR DESCRIPTION
This PR is the minimalist change from #45771 to only update the cursor position for near-fit searches in the AVL allocator.  Changing to a time-based algorithm for switching to best-fit mode improved results on it's own, but it turns out that the even bigger fix is making sure that we always update the cursor position when doing near-fit searches so we don't end up repeating the exact same search over and over again.  The additional changes in #45771 may reduce fragmentation by providing more leeway in near-fit mode, but overall this fix appears to both improve the speed of allocation requests and (separately) revert our IO patterns to look closer to what they were before #41615 merged on it's own.  There may be additional benefit for very low near-fit search thresholds to updating the position of the cursor to the offset we found in best-fit mode, but it's not clear how much that actually matters in practice (with very small thresholds updating to the best-fit offset resulted in fewer overall near-fit misses).

Beyond reducing the overall time spent in near-fit mode, this PR dramatically improves performance on a specific model of NVMe drive in our test lab (but not models from a different brand).  The results are now comparable to what we saw with pacific, while still maintaining a limit on time spent in near-fit mode for any given allocation.

### 4MB Random Write (MiB/s)
  | Trial 0 | Trial 1 | Trial 2
-- | -- | -- | --
master | 1688 | 1433 | 1149
fix | 1811 | 1829 | 1821

### 128KB Random Write (MiB/s)
  | Trial 0 | Trial 1 | Trial 2
-- | -- | -- | --
master | 1261 | 1311 | 1093
fix | 1772 | 1788 | 1788

### 4KB Random Write (IOPS)
  | Trial 0 | Trial 1 | Trial 2
-- | -- | -- | --
master | 79051 | 74160 | 74673
fix | 78645 | 69708 | 72903

Full test results available here: 
https://docs.google.com/spreadsheets/d/18jFchgrl1tSpQsv0rwPnKsilbBaBl0DZFmgkIG5nwrE/edit?usp=sharing

Signed-off-by: Mark Nelson <mnelson@redhat.com>
