### PR TITLE
quincy: rbd persistent cache UX improvements (status report, metrics, flush command)

### DIFF
--- a/doc/rbd/rbd-persistent-write-log-cache.rst
+++ b/doc/rbd/rbd-persistent-write-log-cache.rst
@@ -60,10 +60,6 @@ Here are some cache configuration settings:
 - ``rbd_persistent_cache_size`` The cache size per image. The minimum cache
   size is 1 GB.
 
-- ``rbd_persistent_cache_log_periodic_stats`` This is a debug option. It is
-  used to emit periodic perf stats to the debug log if ``debug rbd pwl`` is
-  set to ``1`` or higher.
-
 The above configurations can be set per-host, per-pool, per-image etc. Eg, to
 set per-host, add the overrides to the appropriate `section`_ in the host's
 ``ceph.conf`` file. To set per-pool, per-image, etc, please refer to the

--- a/doc/rbd/rbd-persistent-write-log-cache.rst
+++ b/doc/rbd/rbd-persistent-write-log-cache.rst
@@ -99,20 +99,20 @@ For example::
                 hit_bytes: 192 MiB / 66%
                 miss_bytes: 97 MiB
 
-Discard Cache
--------------
+Invalidate Cache
+----------------
 
-To discard a cache file with ``rbd``, specify the ``image-cache invalidate``
-option, the pool name and the image name.  ::
+To invalidate (discard) a cache file with ``rbd``, specify the
+``persistent-cache invalidate`` command, the pool name and the image name.  ::
 
-        rbd image-cache invalidate {pool-name}/{image-name}
+        rbd persistent-cache invalidate {pool-name}/{image-name}
 
-The command removes the cache metadata of the corresponding image, disable
+The command removes the cache metadata of the corresponding image, disables
 the cache feature and deletes the local cache file if it exists.
 
 For example::
 
-        $ rbd image-cache invalidate rbd/foo
+        $ rbd persistent-cache invalidate rbd/foo
 
 .. _section: ../../rados/configuration/ceph-conf/#configuration-sections
 .. _commands: ../../man/8/rbd#commands

--- a/doc/rbd/rbd-persistent-write-log-cache.rst
+++ b/doc/rbd/rbd-persistent-write-log-cache.rst
@@ -75,15 +75,29 @@ users may use the command ``rbd status``.  ::
         rbd status {pool-name}/{image-name}
 
 The status of the cache is shown, including present, clean, cache size and the
-location. Currently the status is updated only at the time the cache is opened
-and closed and therefore may appear to be out of date (e.g. show that the cache
-is clean when it is actually dirty).
+location as well as some basic metrics.
 
 For example::
 
         $ rbd status rbd/foo
-        Watchers: none
-        Image cache state: {"present":"true","empty":"false","clean":"true","cache_type":"ssd","pwl_host":"sceph9","pwl_path":"/tmp/rbd-pwl.rbd.abcdef123456.pool","pwl_size":1073741824}
+        Watchers:
+                watcher=10.10.0.102:0/1061883624 client.25496 cookie=140338056493088
+        Persistent cache state:
+                host: sceph9
+                path: /mnt/nvme0/rbd-pwl.rbd.101e5824ad9a.pool
+                size: 1 GiB
+                mode: ssd
+                stats_timestamp: Sun Apr 10 13:26:32 2022
+                present: true   empty: false    clean: false
+                allocated: 509 MiB
+                cached: 501 MiB
+                dirty: 338 MiB
+                free: 515 MiB
+                hits_full: 1450 / 61%
+                hits_partial: 0 / 0%
+                misses: 924
+                hit_bytes: 192 MiB / 66%
+                miss_bytes: 97 MiB
 
 Discard Cache
 -------------

--- a/doc/rbd/rbd-persistent-write-log-cache.rst
+++ b/doc/rbd/rbd-persistent-write-log-cache.rst
@@ -99,6 +99,21 @@ For example::
                 hit_bytes: 192 MiB / 66%
                 miss_bytes: 97 MiB
 
+Flush Cache
+-----------
+
+To flush a cache file with ``rbd``, specify the ``persistent-cache flush``
+command, the pool name and the image name.  ::
+
+        rbd persistent-cache flush {pool-name}/{image-name}
+
+If the application dies unexpectedly, this command can also be used to flush
+the cache back to OSDs.
+
+For example::
+
+        $ rbd persistent-cache flush rbd/foo
+
 Invalidate Cache
 ----------------
 

--- a/src/common/options/rbd.yaml.in
+++ b/src/common/options/rbd.yaml.in
@@ -830,13 +830,6 @@ options:
   - disabled
   - rwl
   - ssd
-- name: rbd_persistent_cache_log_periodic_stats
-  type: bool
-  level: advanced
-  desc: emit periodic perf stats to debug log
-  default: false
-  services:
-  - rbd
 - name: rbd_persistent_cache_size
   type: uint
   level: advanced

--- a/src/librbd/cache/Types.h
+++ b/src/librbd/cache/Types.h
@@ -20,7 +20,7 @@ enum ImageCacheType {
 
 typedef std::list<Context *> Contexts;
 
-const std::string IMAGE_CACHE_STATE = ".librbd/image_cache_state";
+const std::string PERSISTENT_CACHE_STATE = ".rbd_persistent_cache_state";
 
 } // namespace cache
 } // namespace librbd

--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -575,8 +575,29 @@ void AbstractWriteLog<I>::pwl_init(Context *on_finish, DeferredContexts &later) 
 }
 
 template <typename I>
+void AbstractWriteLog<I>::update_image_cache_state() {
+  using klass = AbstractWriteLog<I>;
+  Context *ctx = util::create_context_callback<
+                 klass, &klass::handle_update_image_cache_state>(this);
+  update_image_cache_state(ctx);
+}
+
+template <typename I>
 void AbstractWriteLog<I>::update_image_cache_state(Context *on_finish) {
+  ldout(m_image_ctx.cct, 10) << dendl;
   m_cache_state->write_image_cache_state(on_finish);
+}
+
+template <typename I>
+void AbstractWriteLog<I>::handle_update_image_cache_state(int r) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to update image cache state: " << cpp_strerror(r)
+               << dendl;
+    return;
+  }
 }
 
 template <typename I>
@@ -630,8 +651,9 @@ void AbstractWriteLog<I>::shut_down(Context *on_finish) {
         std::lock_guard locker(m_lock);
         check_image_cache_state_clean();
         m_wake_up_enabled = false;
-        m_cache_state->clean = true;
         m_log_entries.clear();
+        m_cache_state->clean = true;
+        m_cache_state->empty = true;
 
         remove_pool_file();
 
@@ -1304,6 +1326,10 @@ void AbstractWriteLog<I>::complete_op_log_entries(GenericLogOperations &&ops,
       std::lock_guard locker(m_lock);
       m_unpublished_reserves -= published_reserves;
       m_dirty_log_entries.splice(m_dirty_log_entries.end(), dirty_entries);
+      if (m_cache_state->clean && !this->m_dirty_log_entries.empty()) {
+        m_cache_state->clean = false;
+        update_image_cache_state();
+      }
     }
     op->complete(result);
     m_perfcounter->tinc(l_librbd_pwl_log_op_dis_to_app_t,
@@ -1733,6 +1759,10 @@ void AbstractWriteLog<I>::process_writeback_dirty_entries() {
         ldout(cct, 20) << "Nothing new to flush" << dendl;
         /* Do flush complete only when all flush ops are finished */
         all_clean = !m_flush_ops_in_flight;
+        if (!m_cache_state->clean && all_clean) {
+          m_cache_state->clean = true;
+          update_image_cache_state();
+        }
         break;
       }
 
@@ -1982,6 +2012,10 @@ void AbstractWriteLog<I>::flush_dirty_entries(Context *on_finish) {
     std::lock_guard locker(m_lock);
     flushing = (0 != m_flush_ops_in_flight);
     all_clean = m_dirty_log_entries.empty();
+    if (!m_cache_state->clean && all_clean && !flushing) {
+      m_cache_state->clean = true;
+      update_image_cache_state();
+    }
     stop_flushing = (m_shutting_down);
   }
 

--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -315,17 +315,6 @@ void AbstractWriteLog<I>::log_perf() {
 template <typename I>
 void AbstractWriteLog<I>::periodic_stats() {
   std::lock_guard locker(m_lock);
-  m_cache_state->allocated_bytes = m_bytes_allocated;
-  m_cache_state->cached_bytes = m_bytes_cached;
-  m_cache_state->dirty_bytes = m_bytes_dirty;
-  m_cache_state->free_bytes = m_bytes_allocated_cap - m_bytes_allocated;
-  m_cache_state->hits_full = m_perfcounter->get(l_librbd_pwl_rd_hit_req);
-  m_cache_state->hits_partial = m_perfcounter->get(l_librbd_pwl_rd_part_hit_req);
-  m_cache_state->misses = m_perfcounter->get(l_librbd_pwl_rd_req) -
-      m_cache_state->hits_full - m_cache_state->hits_partial;
-  m_cache_state->hit_bytes = m_perfcounter->get(l_librbd_pwl_rd_hit_bytes);
-  m_cache_state->miss_bytes = m_perfcounter->get(l_librbd_pwl_rd_bytes) -
-      m_cache_state->hit_bytes;
   update_image_cache_state();
   ldout(m_image_ctx.cct, 5) << "STATS: m_log_entries=" << m_log_entries.size()
                             << ", m_dirty_log_entries=" << m_dirty_log_entries.size()
@@ -591,6 +580,19 @@ void AbstractWriteLog<I>::update_image_cache_state() {
 template <typename I>
 void AbstractWriteLog<I>::update_image_cache_state(Context *on_finish) {
   ldout(m_image_ctx.cct, 10) << dendl;
+
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+  m_cache_state->allocated_bytes = m_bytes_allocated;
+  m_cache_state->cached_bytes = m_bytes_cached;
+  m_cache_state->dirty_bytes = m_bytes_dirty;
+  m_cache_state->free_bytes = m_bytes_allocated_cap - m_bytes_allocated;
+  m_cache_state->hits_full = m_perfcounter->get(l_librbd_pwl_rd_hit_req);
+  m_cache_state->hits_partial = m_perfcounter->get(l_librbd_pwl_rd_part_hit_req);
+  m_cache_state->misses = m_perfcounter->get(l_librbd_pwl_rd_req) -
+      m_cache_state->hits_full - m_cache_state->hits_partial;
+  m_cache_state->hit_bytes = m_perfcounter->get(l_librbd_pwl_rd_hit_bytes);
+  m_cache_state->miss_bytes = m_perfcounter->get(l_librbd_pwl_rd_bytes) -
+      m_cache_state->hit_bytes;
   m_cache_state->write_image_cache_state(on_finish);
 }
 
@@ -620,6 +622,7 @@ void AbstractWriteLog<I>::init(Context *on_finish) {
   Context *ctx = new LambdaContext(
     [this, on_finish](int r) {
       if (r >= 0) {
+        std::lock_guard locker(m_lock);
         update_image_cache_state(on_finish);
       } else {
         on_finish->complete(r);
@@ -639,6 +642,9 @@ void AbstractWriteLog<I>::shut_down(Context *on_finish) {
 
   Context *ctx = new LambdaContext(
     [this, on_finish](int r) {
+      if (m_perfcounter) {
+        perf_stop();
+      }
       ldout(m_image_ctx.cct, 6) << "shutdown complete" << dendl;
       m_image_ctx.op_work_queue->queue(on_finish, r);
     });
@@ -647,20 +653,14 @@ void AbstractWriteLog<I>::shut_down(Context *on_finish) {
       ldout(m_image_ctx.cct, 6) << "image cache cleaned" << dendl;
       Context *next_ctx = override_ctx(r, ctx);
       periodic_stats();
-      {
-        std::lock_guard locker(m_lock);
-        check_image_cache_state_clean();
-        m_wake_up_enabled = false;
-        m_log_entries.clear();
-        m_cache_state->clean = true;
-        m_cache_state->empty = true;
 
-        remove_pool_file();
-
-        if (m_perfcounter) {
-          perf_stop();
-        }
-      }
+      std::lock_guard locker(m_lock);
+      check_image_cache_state_clean();
+      m_wake_up_enabled = false;
+      m_log_entries.clear();
+      m_cache_state->clean = true;
+      m_cache_state->empty = true;
+      remove_pool_file();
       update_image_cache_state(next_ctx);
     });
   ctx = new LambdaContext(

--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -315,7 +315,19 @@ void AbstractWriteLog<I>::log_perf() {
 template <typename I>
 void AbstractWriteLog<I>::periodic_stats() {
   std::lock_guard locker(m_lock);
-  ldout(m_image_ctx.cct, 1) << "STATS: m_log_entries=" << m_log_entries.size()
+  m_cache_state->allocated_bytes = m_bytes_allocated;
+  m_cache_state->cached_bytes = m_bytes_cached;
+  m_cache_state->dirty_bytes = m_bytes_dirty;
+  m_cache_state->free_bytes = m_bytes_allocated_cap - m_bytes_allocated;
+  m_cache_state->hits_full = m_perfcounter->get(l_librbd_pwl_rd_hit_req);
+  m_cache_state->hits_partial = m_perfcounter->get(l_librbd_pwl_rd_part_hit_req);
+  m_cache_state->misses = m_perfcounter->get(l_librbd_pwl_rd_req) -
+      m_cache_state->hits_full - m_cache_state->hits_partial;
+  m_cache_state->hit_bytes = m_perfcounter->get(l_librbd_pwl_rd_hit_bytes);
+  m_cache_state->miss_bytes = m_perfcounter->get(l_librbd_pwl_rd_bytes) -
+      m_cache_state->hit_bytes;
+  update_image_cache_state();
+  ldout(m_image_ctx.cct, 5) << "STATS: m_log_entries=" << m_log_entries.size()
                             << ", m_dirty_log_entries=" << m_dirty_log_entries.size()
                             << ", m_free_log_entries=" << m_free_log_entries
                             << ", m_bytes_allocated=" << m_bytes_allocated
@@ -332,15 +344,12 @@ void AbstractWriteLog<I>::periodic_stats() {
 template <typename I>
 void AbstractWriteLog<I>::arm_periodic_stats() {
   ceph_assert(ceph_mutex_is_locked(*m_timer_lock));
-  if (m_periodic_stats_enabled) {
-    m_timer_ctx = new LambdaContext(
-      [this](int r) {
-        /* m_timer_lock is held */
-        periodic_stats();
-        arm_periodic_stats();
-      });
-    m_timer->add_event_after(LOG_STATS_INTERVAL_SECONDS, m_timer_ctx);
-  }
+  m_timer_ctx = new LambdaContext([this](int r) {
+      /* m_timer_lock is held */
+      periodic_stats();
+      arm_periodic_stats();
+    });
+  m_timer->add_event_after(LOG_STATS_INTERVAL_SECONDS, m_timer_ctx);
 }
 
 template <typename I>
@@ -560,17 +569,14 @@ void AbstractWriteLog<I>::pwl_init(Context *on_finish, DeferredContexts &later) 
   // Start the thread
   m_thread_pool.start();
 
-  m_periodic_stats_enabled = m_cache_state->log_periodic_stats;
   /* Do these after we drop lock */
   later.add(new LambdaContext([this](int r) {
-    if (m_periodic_stats_enabled) {
       /* Log stats for the first time */
       periodic_stats();
       /* Arm periodic stats logging for the first time */
       std::lock_guard timer_locker(*m_timer_lock);
       arm_periodic_stats();
-    }
-  }));
+    }));
   m_image_ctx.op_work_queue->queue(on_finish, 0);
 }
 
@@ -640,13 +646,7 @@ void AbstractWriteLog<I>::shut_down(Context *on_finish) {
     [this, ctx](int r) {
       ldout(m_image_ctx.cct, 6) << "image cache cleaned" << dendl;
       Context *next_ctx = override_ctx(r, ctx);
-      bool periodic_stats_enabled = m_periodic_stats_enabled;
-      m_periodic_stats_enabled = false;
-
-      if (periodic_stats_enabled) {
-        /* Log stats one last time if they were enabled */
-        periodic_stats();
-      }
+      periodic_stats();
       {
         std::lock_guard locker(m_lock);
         check_image_cache_state_clean();
@@ -681,9 +681,7 @@ void AbstractWriteLog<I>::shut_down(Context *on_finish) {
         /* Flush all writes to OSDs (unless disabled) and wait for all
            in-progress flush writes to complete */
         ldout(m_image_ctx.cct, 6) << "flushing" << dendl;
-        if (m_periodic_stats_enabled) {
-          periodic_stats();
-        }
+        periodic_stats();
       }
       flush_dirty_entries(next_ctx);
     });

--- a/src/librbd/cache/pwl/AbstractWriteLog.h
+++ b/src/librbd/cache/pwl/AbstractWriteLog.h
@@ -236,6 +236,7 @@ private:
 
   void pwl_init(Context *on_finish, pwl::DeferredContexts &later);
   void update_image_cache_state(Context *on_finish);
+  void handle_update_image_cache_state(int r);
   void check_image_cache_state_clean();
 
   void flush_dirty_entries(Context *on_finish);
@@ -399,7 +400,7 @@ protected:
   virtual uint64_t get_max_extent() {
     return 0;
   }
-
+  void update_image_cache_state(void);
 };
 
 } // namespace pwl

--- a/src/librbd/cache/pwl/AbstractWriteLog.h
+++ b/src/librbd/cache/pwl/AbstractWriteLog.h
@@ -212,8 +212,6 @@ private:
   /* Throttle writes concurrently allocating & replicating */
   unsigned int m_free_lanes = pwl::MAX_CONCURRENT_WRITES;
 
-  /* Initialized from config, then set false during shutdown */
-  std::atomic<bool> m_periodic_stats_enabled = {false};
   SafeTimer *m_timer = nullptr; /* Used with m_timer_lock */
   mutable ceph::mutex *m_timer_lock = nullptr; /* Used with and by m_timer */
   Context *m_timer_ctx = nullptr;

--- a/src/librbd/cache/pwl/DiscardRequest.cc
+++ b/src/librbd/cache/pwl/DiscardRequest.cc
@@ -68,7 +68,13 @@ void DiscardRequest<I>::delete_image_cache_file() {
   if (m_cache_state->present &&
       !m_cache_state->host.compare(ceph_get_short_hostname()) &&
       fs::exists(m_cache_state->path)) {
-    fs::remove(m_cache_state->path);
+    std::error_code ec;
+    fs::remove(m_cache_state->path, ec);
+    if (ec) {
+      lderr(cct) << "failed to remove persistent cache file: " << ec.message()
+                 << dendl;
+      // not fatal
+    }
   }
 
   remove_image_cache_state();

--- a/src/librbd/cache/pwl/DiscardRequest.cc
+++ b/src/librbd/cache/pwl/DiscardRequest.cc
@@ -113,10 +113,6 @@ void DiscardRequest<I>::remove_feature_bit() {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 10) << dendl;
 
-  if (!(m_image_ctx.features &&RBD_FEATURE_DIRTY_CACHE)) {
-    finish();
-    return;
-  }
   uint64_t new_features = m_image_ctx.features & ~RBD_FEATURE_DIRTY_CACHE;
   uint64_t features_mask = RBD_FEATURE_DIRTY_CACHE;
   ldout(cct, 10) << "old_features=" << m_image_ctx.features

--- a/src/librbd/cache/pwl/ImageCacheState.cc
+++ b/src/librbd/cache/pwl/ImageCacheState.cc
@@ -23,37 +23,26 @@ namespace pwl {
 
 using namespace std;
 
-namespace {
-bool get_json_format(const std::string& s, json_spirit::mObject *o) {
-  json_spirit::mValue json_root;
-  if (!json_spirit::read(s.c_str(), json_root)) {
-    return false;
-  } else {
-    auto cache_state_root = json_root.get_obj()["persistent_cache"];
-    *o = cache_state_root.get_obj();
-  }
-  return true;
-}
-} // namespace
-
 template <typename I>
-ImageCacheState<I>::ImageCacheState(I *image_ctx, plugin::Api<I>& plugin_api) :
-    m_image_ctx(image_ctx), m_plugin_api(plugin_api) {
-  ldout(image_ctx->cct, 20) << "Initialize RWL cache state with config data. "
-                            << dendl;
+void ImageCacheState<I>::init_from_config() {
+  ldout(m_image_ctx->cct, 20) << dendl;
 
-  ConfigProxy &config = image_ctx->config;
+  present = false;
+  empty = true;
+  clean = true;
+  host = "";
+  path = "";
+  ConfigProxy &config = m_image_ctx->config;
   mode = config.get_val<std::string>("rbd_persistent_cache_mode");
+  size = 0;
 }
 
 template <typename I>
-ImageCacheState<I>::ImageCacheState(
-    I *image_ctx, json_spirit::mObject &o, plugin::Api<I>& plugin_api) :
-    m_image_ctx(image_ctx), m_plugin_api(plugin_api) {
-  ldout(image_ctx->cct, 20) << "Initialize RWL cache state with data from "
-                            << "server side"<< dendl;
+bool ImageCacheState<I>::init_from_metadata(json_spirit::mValue& json_root) {
+  ldout(m_image_ctx->cct, 20) << dendl;
 
   try {
+    auto& o = json_root.get_obj();
     present = o["present"].get_bool();
     empty = o["empty"].get_bool();
     clean = o["clean"].get_bool();
@@ -62,9 +51,12 @@ ImageCacheState<I>::ImageCacheState(
     mode = o["mode"].get_str();
     size = o["size"].get_uint64();
   } catch (std::runtime_error& e) {
-    lderr(image_ctx->cct) << "failed to parse cache state: " << e.what()
-                          << dendl;
+    lderr(m_image_ctx->cct) << "failed to parse cache state: " << e.what()
+                            << dendl;
+    return false;
   }
+
+  return true;
 }
 
 template <typename I>
@@ -89,11 +81,7 @@ void ImageCacheState<I>::write_image_cache_state(Context *on_finish) {
   o["misses"] = misses;
   o["hit_bytes"] = hit_bytes;
   o["miss_bytes"] = miss_bytes;
-  json_spirit::mObject cache_state_obj;
-  cache_state_obj["persistent_cache"] = o;
-  stringstream json_string;
-  json_spirit::write(cache_state_obj, json_string);
-  std::string image_state_json = json_string.str();
+  std::string image_state_json = json_spirit::write(o);
 
   ldout(m_image_ctx->cct, 20) << __func__ << " Store state: "
                               << image_state_json << dendl;
@@ -139,22 +127,23 @@ ImageCacheState<I>* ImageCacheState<I>::create_image_cache_state(
     r = -EINVAL;
   }else if ((!dirty_cache || cache_state_str.empty()) && cache_desired) {
     cache_state = new ImageCacheState<I>(image_ctx, plugin_api);
+    cache_state->init_from_config();
   } else {
     ceph_assert(!cache_state_str.empty());
-    json_spirit::mObject o;
-    bool success = get_json_format(cache_state_str, &o);
-    if (!success) {
-      lderr(image_ctx->cct) << "failed to parse cache state: "
-                            << cache_state_str << dendl;
+    json_spirit::mValue json_root;
+    if (!json_spirit::read(cache_state_str.c_str(), json_root)) {
+      lderr(image_ctx->cct) << "failed to parse cache state" << dendl;
       r = -EINVAL;
       return nullptr;
     }
-
-    bool cache_exists = o["present"].get_bool();
-    if (!cache_exists) {
-      cache_state = new ImageCacheState<I>(image_ctx, plugin_api);
-    } else {
-      cache_state = new ImageCacheState<I>(image_ctx, o, plugin_api);
+    cache_state = new ImageCacheState<I>(image_ctx, plugin_api);
+    if (!cache_state->init_from_metadata(json_root)) {
+      delete cache_state;
+      r = -EINVAL;
+      return nullptr;
+    }
+    if (!cache_state->present) {
+      cache_state->init_from_config();
     }
   }
   return cache_state;
@@ -168,13 +157,13 @@ ImageCacheState<I>* ImageCacheState<I>::get_image_cache_state(
   cls_client::metadata_get(&image_ctx->md_ctx, image_ctx->header_oid,
 			   IMAGE_CACHE_STATE, &cache_state_str);
   if (!cache_state_str.empty()) {
-    json_spirit::mObject o;
-    bool success = get_json_format(cache_state_str, &o);
-    if (!success) {
+    // ignore errors, best effort
+    cache_state = new ImageCacheState<I>(image_ctx, plugin_api);
+    json_spirit::mValue json_root;
+    if (!json_spirit::read(cache_state_str.c_str(), json_root)) {
       lderr(image_ctx->cct) << "failed to parse cache state" << dendl;
-      cache_state = new ImageCacheState<I>(image_ctx, plugin_api);
     } else {
-      cache_state = new ImageCacheState<I>(image_ctx, o, plugin_api);
+      cache_state->init_from_metadata(json_root);
     }
   }
   return cache_state;

--- a/src/librbd/cache/pwl/ImageCacheState.cc
+++ b/src/librbd/cache/pwl/ImageCacheState.cc
@@ -7,7 +7,6 @@
 #include "librbd/ImageCtx.h"
 #include "librbd/Operations.h"
 #include "common/config_proxy.h"
-#include "common/ceph_json.h"
 #include "common/environment.h"
 #include "common/hostname.h"
 #include "librbd/plugin/Api.h"
@@ -25,13 +24,15 @@ namespace pwl {
 using namespace std;
 
 namespace {
-bool get_json_format(const std::string& s, JSONFormattable *f) {
-  JSONParser p;
-  bool success = p.parse(s.c_str(), s.size());
-  if (success) {
-    decode_json_obj(*f, &p);
+bool get_json_format(const std::string& s, json_spirit::mObject *o) {
+  json_spirit::mValue json_root;
+  if (!json_spirit::read(s.c_str(), json_root)) {
+    return false;
+  } else {
+    auto cache_state_root = json_root.get_obj()["persistent_cache"];
+    *o = cache_state_root.get_obj();
   }
-  return success;
+  return true;
 }
 } // namespace
 
@@ -42,41 +43,57 @@ ImageCacheState<I>::ImageCacheState(I *image_ctx, plugin::Api<I>& plugin_api) :
                             << dendl;
 
   ConfigProxy &config = image_ctx->config;
-  log_periodic_stats = config.get_val<bool>("rbd_persistent_cache_log_periodic_stats");
-  cache_type = config.get_val<std::string>("rbd_persistent_cache_mode");
+  mode = config.get_val<std::string>("rbd_persistent_cache_mode");
 }
 
 template <typename I>
 ImageCacheState<I>::ImageCacheState(
-    I *image_ctx, JSONFormattable &f, plugin::Api<I>& plugin_api) :
+    I *image_ctx, json_spirit::mObject &o, plugin::Api<I>& plugin_api) :
     m_image_ctx(image_ctx), m_plugin_api(plugin_api) {
   ldout(image_ctx->cct, 20) << "Initialize RWL cache state with data from "
                             << "server side"<< dendl;
 
-  present = (bool)f["present"];
-  empty = (bool)f["empty"];
-  clean = (bool)f["clean"];
-  cache_type = f["cache_type"];
-  host = f["pwl_host"];
-  path = f["pwl_path"];
-  uint64_t pwl_size;
-  std::istringstream iss(f["pwl_size"]);
-  iss >> pwl_size;
-  size = pwl_size;
-
-  // Others from config
-  ConfigProxy &config = image_ctx->config;
-  log_periodic_stats = config.get_val<bool>("rbd_persistent_cache_log_periodic_stats");
+  try {
+    present = o["present"].get_bool();
+    empty = o["empty"].get_bool();
+    clean = o["clean"].get_bool();
+    host = o["host"].get_str();
+    path = o["path"].get_str();
+    mode = o["mode"].get_str();
+    size = o["size"].get_uint64();
+  } catch (std::runtime_error& e) {
+    lderr(image_ctx->cct) << "failed to parse cache state: " << e.what()
+                          << dendl;
+  }
 }
 
 template <typename I>
 void ImageCacheState<I>::write_image_cache_state(Context *on_finish) {
+  stats_timestamp = ceph_clock_now();
   std::shared_lock owner_lock{m_image_ctx->owner_lock};
-  JSONFormattable f;
-  ::encode_json(IMAGE_CACHE_STATE.c_str(), *this, &f);
-  std::ostringstream oss;
-  f.flush(oss);
-  std::string image_state_json = oss.str();
+  json_spirit::mObject o;
+  o["present"] = present;
+  o["empty"] = empty;
+  o["clean"] = clean;
+  o["host"] = host;
+  o["path"] = path;
+  o["mode"] = mode;
+  o["size"] = size;
+  o["stats_timestamp"] = stats_timestamp.sec();
+  o["allocated_bytes"] = allocated_bytes;
+  o["cached_bytes"] = cached_bytes;
+  o["dirty_bytes"] = dirty_bytes;
+  o["free_bytes"] = free_bytes;
+  o["hits_full"] = hits_full;
+  o["hits_partial"] = hits_partial;
+  o["misses"] = misses;
+  o["hit_bytes"] = hit_bytes;
+  o["miss_bytes"] = miss_bytes;
+  json_spirit::mObject cache_state_obj;
+  cache_state_obj["persistent_cache"] = o;
+  stringstream json_string;
+  json_spirit::write(cache_state_obj, json_string);
+  std::string image_state_json = json_string.str();
 
   ldout(m_image_ctx->cct, 20) << __func__ << " Store state: "
                               << image_state_json << dendl;
@@ -90,17 +107,6 @@ void ImageCacheState<I>::clear_image_cache_state(Context *on_finish) {
   ldout(m_image_ctx->cct, 20) << __func__ << " Remove state: " << dendl;
   m_plugin_api.execute_image_metadata_remove(
     m_image_ctx, IMAGE_CACHE_STATE, on_finish);
-}
-
-template <typename I>
-void ImageCacheState<I>::dump(ceph::Formatter *f) const {
-  ::encode_json("present", present, f);
-  ::encode_json("empty", empty, f);
-  ::encode_json("clean", clean, f);
-  ::encode_json("cache_type", cache_type, f);
-  ::encode_json("pwl_host", host, f);
-  ::encode_json("pwl_path", path, f);
-  ::encode_json("pwl_size", size, f);
 }
 
 template <typename I>
@@ -135,20 +141,20 @@ ImageCacheState<I>* ImageCacheState<I>::create_image_cache_state(
     cache_state = new ImageCacheState<I>(image_ctx, plugin_api);
   } else {
     ceph_assert(!cache_state_str.empty());
-    JSONFormattable f;
-    bool success = get_json_format(cache_state_str, &f);
+    json_spirit::mObject o;
+    bool success = get_json_format(cache_state_str, &o);
     if (!success) {
-      lderr(image_ctx->cct) << "Failed to parse cache state: "
+      lderr(image_ctx->cct) << "failed to parse cache state: "
                             << cache_state_str << dendl;
       r = -EINVAL;
       return nullptr;
     }
 
-    bool cache_exists = (bool)f["present"];
+    bool cache_exists = o["present"].get_bool();
     if (!cache_exists) {
       cache_state = new ImageCacheState<I>(image_ctx, plugin_api);
     } else {
-      cache_state = new ImageCacheState<I>(image_ctx, f, plugin_api);
+      cache_state = new ImageCacheState<I>(image_ctx, o, plugin_api);
     }
   }
   return cache_state;
@@ -162,12 +168,13 @@ ImageCacheState<I>* ImageCacheState<I>::get_image_cache_state(
   cls_client::metadata_get(&image_ctx->md_ctx, image_ctx->header_oid,
 			   IMAGE_CACHE_STATE, &cache_state_str);
   if (!cache_state_str.empty()) {
-    JSONFormattable f;
-    bool success = get_json_format(cache_state_str, &f);
+    json_spirit::mObject o;
+    bool success = get_json_format(cache_state_str, &o);
     if (!success) {
+      lderr(image_ctx->cct) << "failed to parse cache state" << dendl;
       cache_state = new ImageCacheState<I>(image_ctx, plugin_api);
     } else {
-      cache_state = new ImageCacheState<I>(image_ctx, f, plugin_api);
+      cache_state = new ImageCacheState<I>(image_ctx, o, plugin_api);
     }
   }
   return cache_state;

--- a/src/librbd/cache/pwl/ImageCacheState.cc
+++ b/src/librbd/cache/pwl/ImageCacheState.cc
@@ -85,7 +85,7 @@ void ImageCacheState<I>::write_image_cache_state(Context *on_finish) {
 
   ldout(m_image_ctx->cct, 20) << __func__ << " Store state: "
                               << image_state_json << dendl;
-  m_plugin_api.execute_image_metadata_set(m_image_ctx, IMAGE_CACHE_STATE,
+  m_plugin_api.execute_image_metadata_set(m_image_ctx, PERSISTENT_CACHE_STATE,
                                           image_state_json, on_finish);
 }
 
@@ -94,7 +94,7 @@ void ImageCacheState<I>::clear_image_cache_state(Context *on_finish) {
   std::shared_lock owner_lock{m_image_ctx->owner_lock};
   ldout(m_image_ctx->cct, 20) << __func__ << " Remove state: " << dendl;
   m_plugin_api.execute_image_metadata_remove(
-    m_image_ctx, IMAGE_CACHE_STATE, on_finish);
+    m_image_ctx, PERSISTENT_CACHE_STATE, on_finish);
 }
 
 template <typename I>
@@ -107,7 +107,7 @@ ImageCacheState<I>* ImageCacheState<I>::create_image_cache_state(
   bool dirty_cache = plugin_api.test_image_features(image_ctx, RBD_FEATURE_DIRTY_CACHE);
   if (dirty_cache) {
     cls_client::metadata_get(&image_ctx->md_ctx, image_ctx->header_oid,
-                             IMAGE_CACHE_STATE, &cache_state_str);
+                             PERSISTENT_CACHE_STATE, &cache_state_str);
   }
 
   ldout(image_ctx->cct, 20) << "image_cache_state: " << cache_state_str << dendl;
@@ -155,7 +155,7 @@ ImageCacheState<I>* ImageCacheState<I>::get_image_cache_state(
   ImageCacheState<I>* cache_state = nullptr;
   string cache_state_str;
   cls_client::metadata_get(&image_ctx->md_ctx, image_ctx->header_oid,
-			   IMAGE_CACHE_STATE, &cache_state_str);
+			   PERSISTENT_CACHE_STATE, &cache_state_str);
   if (!cache_state_str.empty()) {
     // ignore errors, best effort
     cache_state = new ImageCacheState<I>(image_ctx, plugin_api);

--- a/src/librbd/cache/pwl/ImageCacheState.h
+++ b/src/librbd/cache/pwl/ImageCacheState.h
@@ -46,10 +46,8 @@ public:
   uint64_t hit_bytes = 0;
   uint64_t miss_bytes = 0;
 
-  ImageCacheState(ImageCtxT* image_ctx, plugin::Api<ImageCtxT>& plugin_api);
-
-  ImageCacheState(ImageCtxT* image_ctx, json_spirit::mObject& f,
-                  plugin::Api<ImageCtxT>& plugin_api);
+  ImageCacheState(ImageCtxT* image_ctx, plugin::Api<ImageCtxT>& plugin_api)
+      : m_image_ctx(image_ctx), m_plugin_api(plugin_api) {}
 
   ~ImageCacheState() {}
 
@@ -61,6 +59,9 @@ public:
     }
     return IMAGE_CACHE_TYPE_UNKNOWN;
   }
+
+  void init_from_config();
+  bool init_from_metadata(json_spirit::mValue& json_root);
 
   void write_image_cache_state(Context *on_finish);
 

--- a/src/librbd/cache/pwl/InitRequest.cc
+++ b/src/librbd/cache/pwl/InitRequest.cc
@@ -85,8 +85,8 @@ void InitRequest<I>::get_image_cache_state() {
     return;
   }
 
-  auto cache_type = cache_state->get_image_cache_type();
-  switch(cache_type) {
+  auto mode = cache_state->get_image_cache_mode();
+  switch (mode) {
     #ifdef WITH_RBD_RWL
     case cache::IMAGE_CACHE_TYPE_RWL:
       m_image_cache =

--- a/src/librbd/cache/pwl/ShutdownRequest.cc
+++ b/src/librbd/cache/pwl/ShutdownRequest.cc
@@ -132,7 +132,7 @@ void ShutdownRequest<I>::send_remove_image_cache_state() {
   Context *ctx = create_context_callback<klass, &klass::handle_remove_image_cache_state>(
     this);
   std::shared_lock owner_lock{m_image_ctx.owner_lock};
-  m_plugin_api.execute_image_metadata_remove(&m_image_ctx, IMAGE_CACHE_STATE, ctx);
+  m_plugin_api.execute_image_metadata_remove(&m_image_ctx, PERSISTENT_CACHE_STATE, ctx);
 }
 
 template <typename I>

--- a/src/librbd/cache/pwl/rwl/WriteLog.cc
+++ b/src/librbd/cache/pwl/rwl/WriteLog.cc
@@ -117,6 +117,10 @@ void WriteLog<I>::alloc_op_log_entries(GenericLogOperations &ops)
     m_log_entries.push_back(log_entry);
     ldout(m_image_ctx.cct, 20) << "operation=[" << *operation << "]" << dendl;
   }
+  if (m_cache_state->empty && !m_log_entries.empty()) {
+    m_cache_state->empty = false;
+    this->update_image_cache_state();
+  }
 }
 
 /*
@@ -321,7 +325,7 @@ bool WriteLog<I>::initialize_pool(Context *on_finish, pwl::DeferredContexts &lat
     } TX_FINALLY {
     } TX_END;
   } else {
-    m_cache_state->present = true;
+    ceph_assert(m_cache_state->present);
     /* Open existing pool */
     if ((m_log_pool =
          pmemobj_open(this->m_log_pool_name.c_str(),
@@ -552,6 +556,10 @@ bool WriteLog<I>::retire_entries(const unsigned long int frees_per_tx) {
       ceph_assert(this->m_first_valid_entry == initial_first_valid_entry);
       this->m_first_valid_entry = first_valid_entry;
       this->m_free_log_entries += retiring_entries.size();
+      if (!m_cache_state->empty && m_log_entries.empty()) {
+        m_cache_state->empty = true;
+        this->update_image_cache_state();
+      }
       for (auto &entry: retiring_entries) {
         if (entry->write_bytes()) {
           ceph_assert(this->m_bytes_cached >= entry->write_bytes());

--- a/src/librbd/cache/pwl/rwl/WriteLog.cc
+++ b/src/librbd/cache/pwl/rwl/WriteLog.cc
@@ -250,8 +250,6 @@ void WriteLog<I>::remove_pool_file() {
         lderr(m_image_ctx.cct) << "failed to remove empty pool \"" << this->m_log_pool_name << "\": "
           << pmemobj_errormsg() << dendl;
       } else {
-        m_cache_state->clean = true;
-        m_cache_state->empty = true;
         m_cache_state->present = false;
       }
   } else {

--- a/src/librbd/cache/pwl/ssd/WriteLog.cc
+++ b/src/librbd/cache/pwl/ssd/WriteLog.cc
@@ -197,7 +197,7 @@ bool WriteLog<I>::initialize_pool(Context *on_finish,
       return false;
     }
   } else {
-    m_cache_state->present = true;
+    ceph_assert(m_cache_state->present);
     r = create_and_open_bdev();
     if (r < 0) {
       on_finish->complete(r);
@@ -541,6 +541,10 @@ void WriteLog<I>::alloc_op_log_entries(GenericLogOperations &ops) {
     m_log_entries.push_back(log_entry);
     ldout(m_image_ctx.cct, 20) << "operation=[" << *operation << "]" << dendl;
   }
+  if (m_cache_state->empty && !m_log_entries.empty()) {
+    m_cache_state->empty = false;
+    this->update_image_cache_state();
+  }
 }
 
 template <typename I>
@@ -813,6 +817,10 @@ bool WriteLog<I>::retire_entries(const unsigned long int frees_per_tx) {
           this->m_bytes_allocated -= allocated_bytes;
           ceph_assert(this->m_bytes_cached >= cached_bytes);
           this->m_bytes_cached -= cached_bytes;
+          if (!m_cache_state->empty && m_log_entries.empty()) {
+            m_cache_state->empty = true;
+            this->update_image_cache_state();
+          }
 
           ldout(m_image_ctx.cct, 20)
             << "Finished root update: initial_first_valid_entry="

--- a/src/librbd/cache/pwl/ssd/WriteLog.cc
+++ b/src/librbd/cache/pwl/ssd/WriteLog.cc
@@ -271,8 +271,6 @@ void WriteLog<I>::remove_pool_file() {
       lderr(m_image_ctx.cct) << "failed to remove empty pool \""
                              << this->m_log_pool_name << "\": " << dendl;
     } else {
-      m_cache_state->clean = true;
-      m_cache_state->empty = true;
       m_cache_state->present = false;
     }
   } else {

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -56,7 +56,6 @@
       group snap remove (... rm)        Remove a snapshot from a group.
       group snap rename                 Rename group's snapshot.
       group snap rollback               Rollback group to snapshot.
-      image-cache invalidate            Discard existing / dirty image cache
       image-meta get                    Image metadata get the value associated
                                         with the key.
       image-meta list (image-meta ls)   Image metadata list keys with values.
@@ -125,6 +124,8 @@
       object-map rebuild                Rebuild an invalid object map.
       perf image iostat                 Display image IO statistics.
       perf image iotop                  Display a top-like IO monitor.
+      persistent-cache invalidate       Invalidate (discard) existing / dirty
+                                        persistent cache.
       pool init                         Initialize pool for use by RBD.
       pool stats                        Display pool statistics.
       remove (rm)                       Delete an image.
@@ -1106,23 +1107,6 @@
     --namespace arg      namespace name
     --group arg          group name
     --snap arg           snapshot name
-  
-  rbd help image-cache invalidate
-  usage: rbd image-cache invalidate [--pool <pool>] [--namespace <namespace>] 
-                                    [--image <image>] [--image-id <image-id>] 
-                                    <image-spec> 
-  
-  Discard existing / dirty image cache
-  
-  Positional arguments
-    <image-spec>         image specification
-                         (example: [<pool-name>/[<namespace>/]]<image-name>)
-  
-  Optional arguments
-    -p [ --pool ] arg    pool name
-    --namespace arg      namespace name
-    --image arg          image name
-    --image-id arg       image id
   
   rbd help image-meta get
   usage: rbd image-meta get [--pool <pool>] [--namespace <namespace>] 
@@ -2123,6 +2107,25 @@
   Optional arguments
     -p [ --pool ] arg    pool name
     --namespace arg      namespace name
+  
+  rbd help persistent-cache invalidate
+  usage: rbd persistent-cache invalidate
+                                        [--pool <pool>] 
+                                        [--namespace <namespace>] 
+                                        [--image <image>] [--image-id <image-id>] 
+                                        <image-spec> 
+  
+  Invalidate (discard) existing / dirty persistent cache.
+  
+  Positional arguments
+    <image-spec>         image specification
+                         (example: [<pool-name>/[<namespace>/]]<image-name>)
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    --namespace arg      namespace name
+    --image arg          image name
+    --image-id arg       image id
   
   rbd help pool init
   usage: rbd pool init [--pool <pool>] [--force] 

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -124,6 +124,7 @@
       object-map rebuild                Rebuild an invalid object map.
       perf image iostat                 Display image IO statistics.
       perf image iotop                  Display a top-like IO monitor.
+      persistent-cache flush            Flush persistent cache.
       persistent-cache invalidate       Invalidate (discard) existing / dirty
                                         persistent cache.
       pool init                         Initialize pool for use by RBD.
@@ -2107,6 +2108,23 @@
   Optional arguments
     -p [ --pool ] arg    pool name
     --namespace arg      namespace name
+  
+  rbd help persistent-cache flush
+  usage: rbd persistent-cache flush [--pool <pool>] [--namespace <namespace>] 
+                                    [--image <image>] [--image-id <image-id>] 
+                                    <image-spec> 
+  
+  Flush persistent cache.
+  
+  Positional arguments
+    <image-spec>         image specification
+                         (example: [<pool-name>/[<namespace>/]]<image-name>)
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    --namespace arg      namespace name
+    --image arg          image name
+    --image-id arg       image id
   
   rbd help persistent-cache invalidate
   usage: rbd persistent-cache invalidate

--- a/src/test/librbd/cache/pwl/test_mock_ReplicatedWriteLog.cc
+++ b/src/test/librbd/cache/pwl/test_mock_ReplicatedWriteLog.cc
@@ -132,34 +132,22 @@ TEST_F(TestMockCacheReplicatedWriteLog, init_state_write) {
   ASSERT_EQ(0, finish_ctx.wait());
 }
 
-static void get_jf(const string& s, json_spirit::mObject *f)
-{
-  json_spirit::mValue json_root;
-  bool result = json_spirit::read(s.c_str(), json_root);
-  if (!result) {
-    cout << "failed to parse: '" << s << "'" << std::endl;
-  } else {
-    auto cache_state_root = json_root.get_obj()["persistent_cache"];
-    *f = cache_state_root.get_obj();
-  }
-  ASSERT_EQ(true, result);
-}
-
 TEST_F(TestMockCacheReplicatedWriteLog, init_state_json_write) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockImageCtx mock_image_ctx(*ictx);
-
-  json_spirit::mObject f;
-  string strf = "{ \"present\": \"1\", \"empty\": \"0\", \"clean\": \"0\", \
-                   \"pwl_host\": \"testhost\", \
-                   \"pwl_path\": \"/tmp\", \
-                   \"pwl_size\": \"1024\" }";
-  get_jf(strf, &f);
   MockApi mock_api;
-  MockImageCacheStateRWL image_cache_state(&mock_image_ctx, f, mock_api);
+  MockImageCacheStateRWL image_cache_state(&mock_image_ctx, mock_api);
 
+  string strf = "{ \"present\": true, \"empty\": false, \"clean\": false, \
+                   \"host\": \"testhost\", \
+                   \"path\": \"/tmp\", \
+                   \"mode\": \"rwl\", \
+                   \"size\": 1024 }";
+  json_spirit::mValue json_root;
+  ASSERT_TRUE(json_spirit::read(strf.c_str(), json_root));
+  ASSERT_TRUE(image_cache_state.init_from_metadata(json_root));
   validate_cache_state(ictx, image_cache_state, true, false, false,
                        "testhost", "/tmp", 1024);
 

--- a/src/test/librbd/cache/pwl/test_mock_ReplicatedWriteLog.cc
+++ b/src/test/librbd/cache/pwl/test_mock_ReplicatedWriteLog.cc
@@ -84,13 +84,6 @@ struct TestMockCacheReplicatedWriteLog : public TestMockFixture {
     ASSERT_EQ(size, state.size);
   }
 
-  void expect_op_work_queue(MockImageCtx& mock_image_ctx) {
-    EXPECT_CALL(*mock_image_ctx.op_work_queue, queue(_, _))
-      .WillRepeatedly(Invoke([](Context* ctx, int r) {
-                        ctx->complete(r);
-                      }));
-  }
-
   void expect_context_complete(MockContextRWL& mock_context, int r) {
     EXPECT_CALL(mock_context, complete(r))
       .WillRepeatedly(Invoke([&mock_context](int r) {

--- a/src/test/librbd/cache/pwl/test_mock_SSDWriteLog.cc
+++ b/src/test/librbd/cache/pwl/test_mock_SSDWriteLog.cc
@@ -77,7 +77,6 @@ struct TestMockCacheSSDWriteLog : public TestMockFixture {
                             bool present, bool empty, bool clean,
                             string host, string path,
                             uint64_t size) {
-    ConfigProxy &config = image_ctx->config;
     ASSERT_EQ(present, state.present);
     ASSERT_EQ(empty, state.empty);
     ASSERT_EQ(clean, state.clean);
@@ -85,8 +84,6 @@ struct TestMockCacheSSDWriteLog : public TestMockFixture {
     ASSERT_EQ(host, state.host);
     ASSERT_EQ(path, state.path);
     ASSERT_EQ(size, state.size);
-    ASSERT_EQ(config.get_val<bool>("rbd_persistent_cache_log_periodic_stats"),
-	      state.log_periodic_stats);
   }
 
   void expect_op_work_queue(MockImageCtx& mock_image_ctx) {
@@ -137,19 +134,17 @@ TEST_F(TestMockCacheSSDWriteLog, init_state_write) {
   ASSERT_EQ(0, finish_ctx.wait());
 }
 
-static void get_jf(const string& s, JSONFormattable *f)
+static void get_jf(const string& s, json_spirit::mObject *f)
 {
-  JSONParser p;
-  bool result = p.parse(s.c_str(), s.size());
+  json_spirit::mValue json_root;
+  bool result = json_spirit::read(s.c_str(), json_root);
   if (!result) {
-    cout << "Failed to parse: '" << s << "'" << std::endl;
+    cout << "failed to parse: '" << s << "'" << std::endl;
+  } else {
+    auto cache_state_root = json_root.get_obj()["persistent_cache"];
+    *f = cache_state_root.get_obj();
   }
   ASSERT_EQ(true, result);
-  try {
-    decode_json_obj(*f, &p);
-  } catch (JSONDecoder::err& e) {
-    ASSERT_TRUE(0 == "Failed to decode JSON object");
-  }
 }
 
 TEST_F(TestMockCacheSSDWriteLog, init_state_json_write) {
@@ -158,7 +153,7 @@ TEST_F(TestMockCacheSSDWriteLog, init_state_json_write) {
 
   MockImageCtx mock_image_ctx(*ictx);
 
-  JSONFormattable f;
+  json_spirit::mObject f;
   string strf = "{ \"present\": \"1\", \"empty\": \"0\", \"clean\": \"0\", \
                    \"pwl_host\": \"testhost\", \
                    \"pwl_path\": \"/tmp\", \

--- a/src/test/librbd/cache/pwl/test_mock_SSDWriteLog.cc
+++ b/src/test/librbd/cache/pwl/test_mock_SSDWriteLog.cc
@@ -86,13 +86,6 @@ struct TestMockCacheSSDWriteLog : public TestMockFixture {
     ASSERT_EQ(size, state.size);
   }
 
-  void expect_op_work_queue(MockImageCtx& mock_image_ctx) {
-    EXPECT_CALL(*mock_image_ctx.op_work_queue, queue(_, _))
-      .WillRepeatedly(Invoke([](Context* ctx, int r) {
-                        ctx->complete(r);
-                      }));
-  }
-
   void expect_context_complete(MockContextSSD& mock_context, int r) {
     EXPECT_CALL(mock_context, complete(r))
       .WillRepeatedly(Invoke([&mock_context](int r) {

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -26,7 +26,6 @@ set(rbd_srcs
   action/Flatten.cc
   action/Ggate.cc
   action/Group.cc
-  action/ImageCache.cc
   action/ImageMeta.cc
   action/Import.cc
   action/Info.cc
@@ -43,6 +42,7 @@ set(rbd_srcs
   action/Nbd.cc
   action/ObjectMap.cc
   action/Perf.cc
+  action/PersistentCache.cc
   action/Pool.cc
   action/Remove.cc
   action/Rename.cc

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -44,7 +44,7 @@ static std::string mgr_command_args_to_str(
 
 int ProgressContext::update_progress(uint64_t offset, uint64_t total) {
   if (progress) {
-    int pc = total ? (offset * 100ull / total) : 0;
+    int pc = get_percentage(offset, total);
     if (pc > last_pc) {
       std::cerr << "\r" << operation << ": "
 		<< pc << "% complete..." << std::flush;
@@ -65,6 +65,10 @@ void ProgressContext::fail() {
     std::cerr << "\r" << operation << ": " << last_pc << "% complete...failed."
 	      << std::endl;
   }
+}
+
+int get_percentage(uint64_t part, uint64_t whole) {
+  return whole ? (100 * part / whole) : 0;
 }
 
 void aio_context_callback(librbd::completion_t completion, void *arg)

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -82,6 +82,8 @@ struct ProgressContext : public librbd::ProgressContext {
   void fail();
 };
 
+int get_percentage(uint64_t part, uint64_t whole);
+
 template <typename T, void(T::*MF)(int)>
 librbd::RBD::AioCompletion *create_aio_completion(T *t) {
   return new librbd::RBD::AioCompletion(

--- a/src/tools/rbd/action/PersistentCache.cc
+++ b/src/tools/rbd/action/PersistentCache.cc
@@ -59,10 +59,63 @@ int execute_invalidate(const po::variables_map &vm,
   return 0;
 }
 
+void get_arguments_flush(po::options_description *positional,
+                         po::options_description *options) {
+  at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_image_id_option(options);
+}
+
+int execute_flush(const po::variables_map &vm,
+                  const std::vector<std::string> &ceph_global_init_args) {
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string namespace_name;
+  std::string image_name;
+  std::string snap_name;
+  int r = utils::get_pool_image_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &namespace_name,
+    &image_name, &snap_name, true, utils::SNAPSHOT_PRESENCE_NONE,
+    utils::SPEC_VALIDATION_NONE);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  librbd::Image image;
+  r = utils::init_and_open_image(pool_name, namespace_name, image_name, "", "",
+                                 false, &rados, &io_ctx, &image);
+  if (r < 0) {
+    return r;
+  }
+
+  uint64_t features;
+  r = image.features(&features);
+  if (r < 0) {
+    return r;
+  }
+
+  if (features & RBD_FEATURE_DIRTY_CACHE) {
+    r = image.flush();
+    if (r < 0) {
+      std::cerr << "rbd: flushing persistent cache failed: "
+                << cpp_strerror(r) << std::endl;
+      return r;
+    }
+  } else {
+    std::cout << "rbd: persistent cache is clean or disabled" << std::endl;
+  }
+
+  return 0;
+}
+
 Shell::Action action_invalidate(
   {"persistent-cache", "invalidate"}, {},
   "Invalidate (discard) existing / dirty persistent cache.", "",
   &get_arguments_invalidate, &execute_invalidate);
+Shell::Action action_flush(
+  {"persistent-cache", "flush"}, {}, "Flush persistent cache.", "",
+  &get_arguments_flush, &execute_flush);
 
 } // namespace persistent_cache
 } // namespace action

--- a/src/tools/rbd/action/Status.cc
+++ b/src/tools/rbd/action/Status.cc
@@ -9,6 +9,7 @@
 #include "tools/rbd/Utils.h"
 #include "include/rbd_types.h"
 #include "include/stringify.h"
+#include "librbd/cache/Types.h"
 #include <iostream>
 #include <boost/program_options.hpp>
 
@@ -18,12 +19,6 @@ namespace status {
 
 namespace at = argument_types;
 namespace po = boost::program_options;
-
-namespace {
-
-const std::string IMAGE_CACHE_STATE = ".librbd/image_cache_state";
-
-} // anonymous namespace
 
 static int do_show_status(librados::IoCtx& io_ctx, const std::string &image_name,
                           librbd::Image &image, Formatter *f)
@@ -133,7 +128,7 @@ static int do_show_status(librados::IoCtx& io_ctx, const std::string &image_name
   } cache_state;
   std::string cache_str;
   if (features & RBD_FEATURE_DIRTY_CACHE) {
-    r = image.metadata_get(IMAGE_CACHE_STATE, &cache_str);
+    r = image.metadata_get(librbd::cache::PERSISTENT_CACHE_STATE, &cache_str);
     if (r < 0) {
       std::cerr << "rbd: getting persistent cache state failed: " << cpp_strerror(r)
                 << std::endl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55293

---

backport of https://github.com/ceph/ceph/pull/45660, https://github.com/ceph/ceph/pull/45684 and https://github.com/ceph/ceph/pull/44236
parent tracker: https://tracker.ceph.com/issues/50614