### PR TITLE
test/rbd_mirror: grab timer lock before calling add_event_after()

### DIFF
--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -880,6 +880,7 @@ TEST_F(TestMockImageReplayer, StopJoinInterruptedReplayer) {
   const double DELAY = 10;
   EXPECT_CALL(mock_replayer, shut_down(_))
     .WillOnce(Invoke([this, DELAY](Context* ctx) {
+		std::lock_guard l(m_threads->timer_lock);
 		m_threads->timer->add_event_after(DELAY, ctx);
               }));
   EXPECT_CALL(mock_replayer, destroy());
@@ -927,6 +928,7 @@ TEST_F(TestMockImageReplayer, StopJoinRequestedStop) {
   const double DELAY = 10;
   EXPECT_CALL(mock_replayer, shut_down(_))
     .WillOnce(Invoke([this, DELAY](Context* ctx) {
+		std::lock_guard l(m_threads->timer_lock);
 		m_threads->timer->add_event_after(DELAY, ctx);
               }));
   EXPECT_CALL(mock_replayer, destroy());


### PR DESCRIPTION
add_event_after() expects an externally provided mutex to be held
for the call.  This was missed in commit 8965a0f2a6f7 ("rbd-mirror:
synchronize with in-flight stop in ImageReplayer::stop()").

Fixes: https://tracker.ceph.com/issues/55317
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
