### PR TITLE
pacific: cls/rgw: rgw_dir_suggest_changes detects race with completion

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2198,6 +2198,8 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         return -EINVAL;
       }
 
+      // remove any pending entries whose tag timeout has expired. until expiry,
+      // these pending entries will prevent us from applying suggested changes
       real_time cur_time = real_clock::now();
       auto iter = cur_disk.pending_map.begin();
       while(iter != cur_disk.pending_map.end()) {
@@ -2208,9 +2210,18 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
       }
     }
 
-    CLS_LOG(20, "cur_disk.pending_map.empty()=%d op=%d cur_disk.exists=%d cur_change.pending_map.size()=%d cur_change.exists=%d",
+    CLS_LOG(20, "cur_disk.pending_map.empty()=%d op=%d cur_disk.exists=%d "
+            "cur_disk.index_ver=%d cur_change.exists=%d cur_change.index_ver=%d",
 	    cur_disk.pending_map.empty(), (int)op, cur_disk.exists,
-	    (int)cur_change.pending_map.size(), cur_change.exists);
+            (int)cur_disk.index_ver, cur_change.exists,
+            (int)cur_change.index_ver);
+
+    if (cur_change.index_ver < cur_disk.index_ver) {
+      // a pending on-disk entry was completed since this suggestion was made,
+      // don't apply it yet. if the index really is inconsistent, the next
+      // listing will get the latest version and resend the suggestion
+      continue;
+    }
 
     if (cur_disk.pending_map.empty()) {
       if (cur_disk.exists) {

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -262,7 +262,7 @@ TEST_F(cls_rgw, index_remove_object)
 
 TEST_F(cls_rgw, index_suggest)
 {
-  string bucket_oid = str_int("bucket", 3);
+  string bucket_oid = str_int("suggest", 1);
   {
     ObjectWriteOperation op;
     cls_rgw_bucket_init_index(op);
@@ -366,6 +366,71 @@ TEST_F(cls_rgw, index_suggest)
   test_stats(ioctx, bucket_oid, RGWObjCategory::None, num_objs / 2, total_size);
 }
 
+static void list_entries(librados::IoCtx& ioctx,
+                         const std::string& oid,
+                         uint32_t num_entries,
+                         std::map<int, rgw_cls_list_ret>& results)
+{
+  std::map<int, std::string> oids = { {0, oid} };
+  cls_rgw_obj_key start_key;
+  string empty_prefix;
+  string empty_delimiter;
+  ASSERT_EQ(0, CLSRGWIssueBucketList(ioctx, start_key, empty_prefix,
+                                     empty_delimiter, num_entries,
+                                     true, oids, results, 1)());
+}
+
+TEST_F(cls_rgw, index_suggest_complete)
+{
+  string bucket_oid = str_int("suggest", 2);
+  {
+    ObjectWriteOperation op;
+    cls_rgw_bucket_init_index(op);
+    ASSERT_EQ(0, ioctx.operate(bucket_oid, &op));
+  }
+
+  cls_rgw_obj_key obj = str_int("obj", 0);
+  string tag = str_int("tag-prepare", 0);
+  string loc = str_int("loc", 0);
+
+  // prepare entry
+  index_prepare(ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, obj, loc);
+
+  // list entry before completion
+  rgw_bucket_dir_entry dirent;
+  {
+    std::map<int, rgw_cls_list_ret> listing;
+    list_entries(ioctx, bucket_oid, 1, listing);
+    ASSERT_EQ(1, listing.size());
+    const auto& entries = listing.begin()->second.dir.m;
+    ASSERT_EQ(1, entries.size());
+    dirent = entries.begin()->second;
+    ASSERT_EQ(obj, dirent.key);
+  }
+  // complete entry
+  {
+    rgw_bucket_dir_entry_meta meta;
+    index_complete(ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, 1, obj, meta);
+  }
+  // suggest removal of listed entry
+  {
+    bufferlist updates;
+    cls_rgw_encode_suggestion(CEPH_RGW_REMOVE, dirent, updates);
+
+    ObjectWriteOperation op;
+    cls_rgw_suggest_changes(op, updates);
+    ASSERT_EQ(0, ioctx.operate(bucket_oid, &op));
+  }
+  // list entry again, verify that suggested removal was not applied
+  {
+    std::map<int, rgw_cls_list_ret> listing;
+    list_entries(ioctx, bucket_oid, 1, listing);
+    ASSERT_EQ(1, listing.size());
+    const auto& entries = listing.begin()->second.dir.m;
+    ASSERT_EQ(1, entries.size());
+    EXPECT_TRUE(entries.begin()->second.exists);
+  }
+}
 
 /*
  * This case is used to test whether get_obj_vals will


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55044

---

backport of https://github.com/ceph/ceph/pull/45345
parent tracker: https://tracker.ceph.com/issues/54528

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh