### PR TITLE
debian: Fix File not found ... cephfs_top-*.egg-info

### DIFF
--- a/debian/cephfs-top.install
+++ b/debian/cephfs-top.install
@@ -1,2 +1,3 @@
+#! /usr/bin/dh-exec
 usr/bin/cephfs-top
-usr/lib/python3*/dist-packages/cephfs_top-*.egg-info
+usr/lib/python3*/site-packages/cephfs_top-*.egg-info /usr/lib/python3/dist-packages/


### PR DESCRIPTION
Copying what was done in e6eee052220e78b09fab04dab27ef7901ffbe8f3 but for cephfs-top

Jenkins build: https://jenkins.ceph.com/job/ceph-dev-new-build/ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=centos8,DIST=centos8,MACHINE_SIZE=gigantic/62024/console

This should fix master builds.

Signed-off-by: David Galloway <dgallowa@redhat.com>