### PR TITLE
quincy: test/rbd_mirror: grab timer lock before calling add_event_after()

### DIFF
--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -880,6 +880,7 @@ TEST_F(TestMockImageReplayer, StopJoinInterruptedReplayer) {
   const double DELAY = 10;
   EXPECT_CALL(mock_replayer, shut_down(_))
     .WillOnce(Invoke([this, DELAY](Context* ctx) {
+		std::lock_guard l(m_threads->timer_lock);
 		m_threads->timer->add_event_after(DELAY, ctx);
               }));
   EXPECT_CALL(mock_replayer, destroy());
@@ -927,6 +928,7 @@ TEST_F(TestMockImageReplayer, StopJoinRequestedStop) {
   const double DELAY = 10;
   EXPECT_CALL(mock_replayer, shut_down(_))
     .WillOnce(Invoke([this, DELAY](Context* ctx) {
+		std::lock_guard l(m_threads->timer_lock);
 		m_threads->timer->add_event_after(DELAY, ctx);
               }));
   EXPECT_CALL(mock_replayer, destroy());


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55330

---

backport of https://github.com/ceph/ceph/pull/45897
parent tracker: https://tracker.ceph.com/issues/55317