### PR TITLE
mgr/cephadm: allow disable dashboard tls verify for alertmanager

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/alertmanager/alertmanager.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/alertmanager/alertmanager.yml.j2
@@ -32,6 +32,9 @@ receivers:
   webhook_configs:
 {% for url in dashboard_urls %}
   - url: '{{ url }}/api/prometheus_receiver'
+    http_config:
+      tls_config:
+        insecure_skip_verify: true
 {% endfor %}
 {% if snmp_gateway_urls %}
 - name: 'snmp-gateway'


### PR DESCRIPTION
When using self-signed/untrusted CA certificates, alertmanager displays
an error in logs. This change avoid having the log full of these
messages produced by prometheus.
The same patch has been applied to ceph-ansible [1]

[1] https://github.com/ceph/ceph-ansible/commit/9f77b929d145512e0d8886b96caf6047c5072a68

Fixes: https://tracker.ceph.com/issues/55333
Signed-off-by: Francesco Pantano <fpantano@redhat.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket

- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket

- Tests (select at least one)
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
