### PR TITLE
rgw/dbstore: Handle prefix/delim while listing objects

### DIFF
--- a/src/rgw/store/dbstore/common/dbstore.cc
+++ b/src/rgw/store/dbstore/common/dbstore.cc
@@ -1226,6 +1226,7 @@ int DB::Object::get_obj_state(const DoutPrefixProvider *dpp,
   /* XXX: For now use state->shadow_obj to store ObjectID string */
   s->shadow_obj = params.op.obj.obj_id;
 
+  *state = &obj_state;
   **state = *s;
 
   if (follow_olh && params.op.obj.state.obj.key.instance.empty()) {
@@ -1249,8 +1250,7 @@ int DB::Object::get_state(const DoutPrefixProvider *dpp, RGWObjState **pstate, b
 
 int DB::Object::Read::get_attr(const DoutPrefixProvider *dpp, const char *name, bufferlist& dest)
 {
-  RGWObjState base_state;
-  RGWObjState *state = &base_state;
+  RGWObjState *state;
   int r = source->get_state(dpp, &state, true);
   if (r < 0)
     return r;
@@ -1271,8 +1271,7 @@ int DB::Object::Read::prepare(const DoutPrefixProvider *dpp)
 
   map<string, bufferlist>::iterator iter;
 
-  RGWObjState base_state;
-  RGWObjState *astate = &base_state;
+  RGWObjState *astate;
 
   /* XXX Read obj_id too */
   int r = source->get_state(dpp, &astate, true);
@@ -1360,8 +1359,7 @@ int DB::Object::Read::read(int64_t ofs, int64_t end, bufferlist& bl, const DoutP
   bufferlist read_bl;
   uint64_t max_chunk_size = store->get_max_chunk_size();
 
-  RGWObjState base_state;
-  RGWObjState *astate = &base_state;
+  RGWObjState *astate;
   int r = source->get_state(dpp, &astate, true);
   if (r < 0)
     return r;
@@ -1497,8 +1495,7 @@ int DB::Object::iterate_obj(const DoutPrefixProvider *dpp,
 {
   DB *store = get_store();
   uint64_t len;
-  RGWObjState base_state;
-  RGWObjState *astate = &base_state;
+  RGWObjState *astate;
 
   int r = get_state(dpp, &astate, true);
   if (r < 0) {
@@ -1752,8 +1749,7 @@ int DB::Object::Write::write_meta(const DoutPrefixProvider *dpp, uint64_t size, 
 int DB::Object::Delete::delete_obj(const DoutPrefixProvider *dpp) {
   int ret = 0;
   DB *store = target->get_store();
-  RGWObjState base_state;
-  RGWObjState *astate = &base_state;
+  RGWObjState *astate;
 
   int r = target->get_state(dpp, &astate, true);
   if (r < 0)

--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -1743,7 +1743,7 @@ class DB {
       RGWBucketInfo bucket_info;
       rgw_obj obj;
 
-      RGWObjState *state;
+      RGWObjState obj_state;
       std::string obj_id;
 
       bool versioning_disabled;
@@ -1753,7 +1753,7 @@ class DB {
       public:
       Object(DB *_store, const RGWBucketInfo& _bucket_info, const rgw_obj& _obj) : store(_store), bucket_info(_bucket_info),
       obj(_obj),
-      state(NULL), versioning_disabled(false),
+      versioning_disabled(false),
       bs_initialized(false) {}
 
       Object(DB *_store, const RGWBucketInfo& _bucket_info, const rgw_obj& _obj, const std::string& _obj_id) : store(_store), bucket_info(_bucket_info), obj(_obj), obj_id(_obj_id) {}

--- a/src/rgw/store/dbstore/common/dbstore.h
+++ b/src/rgw/store/dbstore/common/dbstore.h
@@ -86,6 +86,7 @@ struct DBOpObjectInfo {
   bufferlist head_data;
   std::string min_marker;
   std::string max_marker;
+  std::string prefix;
   std::list<rgw_bucket_dir_entry> list_entries;
   /* XXX: Maybe use std::vector instead of std::list */
 };
@@ -279,6 +280,7 @@ struct DBOpObjectPrepareInfo {
   static constexpr const char* head_data = ":head_data";
   static constexpr const char* min_marker = ":min_marker";
   static constexpr const char* max_marker = ":max_marker";
+  static constexpr const char* prefix = ":prefix";
   /* Below used to update mp_parts obj name
    * from meta object to src object on completion */
   static constexpr const char* new_obj_name = ":new_obj_name";
@@ -1083,7 +1085,7 @@ class ListBucketObjectsOp: virtual public DBOp {
       ObjID, TailInstance, HeadPlacementRuleName, HeadPlacementRuleStorageClass, \
       TailPlacementRuleName, TailPlacementStorageClass, \
       ManifestPartObjs, ManifestPartRules, Omap, IsMultipart, MPPartsList, HeadData from '{}' \
-      where BucketName = {} and ObjName > {} ORDER BY ObjName ASC LIMIT {}";
+      where BucketName = {} and ObjName >= {} and ObjName LIKE {} ORDER BY ObjName ASC LIMIT {}";
   public:
     virtual ~ListBucketObjectsOp() {}
 
@@ -1093,6 +1095,7 @@ class ListBucketObjectsOp: virtual public DBOp {
           params.object_table,
           params.op.bucket.bucket_name,
           params.op.obj.min_marker,
+          params.op.obj.prefix,
           params.op.list_max_count);
     }
 };

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.cc
@@ -2325,6 +2325,9 @@ int SQLListBucketObjects::Bind(const DoutPrefixProvider *dpp, struct DBOpParams 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.min_marker, sdb);
   SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.min_marker.c_str(), sdb);
 
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.obj.prefix, sdb);
+  SQL_BIND_TEXT(dpp, stmt, index, params->op.obj.prefix.c_str(), sdb);
+
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.list_max_count, sdb);
   SQL_BIND_INT(dpp, stmt, index, params->op.list_max_count, sdb);
 

--- a/src/rgw/store/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/store/dbstore/tests/dbstore_tests.cc
@@ -687,8 +687,7 @@ TEST_F(DBStoreTest, GetObject) {
 TEST_F(DBStoreTest, GetObjectState) {
   struct DBOpParams params = GlobalParams;
   int ret = -1;
-  RGWObjState state;
-  RGWObjState *s = &state;
+  RGWObjState* s;
 
   params.op.obj.state.obj.key.name = "object2";
   params.op.obj.state.obj.key.instance = "inst2";
@@ -698,14 +697,14 @@ TEST_F(DBStoreTest, GetObjectState) {
   ret = op_target.get_obj_state(dpp, params.op.bucket.info, params.op.obj.state.obj,
       false, &s);
   ASSERT_EQ(ret, 0);
-  ASSERT_EQ(state.size, 12);
-  ASSERT_EQ(state.is_olh, false);
+  ASSERT_EQ(s->size, 12);
+  ASSERT_EQ(s->is_olh, false);
 
   /* Recheck with get_state API */
   ret = op_target.get_state(dpp, &s, false);
   ASSERT_EQ(ret, 0);
-  ASSERT_EQ(state.size, 12);
-  ASSERT_EQ(state.is_olh, false);
+  ASSERT_EQ(s->size, 12);
+  ASSERT_EQ(s->is_olh, false);
 }
 
 TEST_F(DBStoreTest, ObjAttrs) {
@@ -880,8 +879,7 @@ TEST_F(DBStoreTest, ListBucketObjects) {
 TEST_F(DBStoreTest, DeleteObj) {
   struct DBOpParams params = GlobalParams;
   int ret = -1;
-  RGWObjState state;
-  RGWObjState *s = &state;
+  RGWObjState *s;
 
   /* delete object2 */
   params.op.obj.state.obj.key.name = "object2";


### PR DESCRIPTION
This change is to handle prefix/delim in DBBucket::list operation .

Given a prefix, fetch only those objects matching the prefix. Also skip the entries with "delim" and  instead add them to common_prefixes list.
Fixes: https://tracker.ceph.com/issues/55288

Also cleaned up the code reading object state ( get_obj_state()).
Fixes:  https://tracker.ceph.com/issues/55225


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
