### PR TITLE
[DNM] pacific: ceph-fuse: ignore fuse mount failure if path is already mounted

### DIFF
--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -29,6 +29,21 @@ class TestMisc(CephFSTestCase):
         self.mount_a.umount_wait(force=True)
         p.wait()
 
+    def test_fuse_mount_on_already_mounted_path(self):
+        if not isinstance(self.mount_a, FuseMount):
+            self.skipTest("Require FUSE client")
+
+        # Try to mount already mounted path
+        # expecting EBUSY error
+        try:
+            mount_cmd = ['sudo'] + self.mount_a._mount_bin + [self.mount_a.hostfs_mntpt]
+            self.mount_a.client_remote.run(args=mount_cmd, stderr=StringIO(),
+                    stdout=StringIO(), timeout=60, omit_sudo=False)
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.EBUSY)
+        else:
+            self.fail("Expected EBUSY")
+
     def test_getattr_caps(self):
         """
         Check if MDS recognizes the 'mask' parameter of open request.

--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -4,6 +4,7 @@ from tasks.cephfs.fuse_mount import FuseMount
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from teuthology.orchestra.run import CommandFailedError
 import errno
+import platform
 import time
 import json
 import logging
@@ -30,6 +31,9 @@ class TestMisc(CephFSTestCase):
         p.wait()
 
     def test_fuse_mount_on_already_mounted_path(self):
+        if platform.system() != "Linux":
+            self.skipTest("Require Linux platform")
+
         if not isinstance(self.mount_a, FuseMount):
             self.skipTest("Require FUSE client")
 

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #if defined(__linux__)

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -23,6 +23,10 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <libgen.h>
+#include <sys/vfs.h>
+#include <sys/xattr.h>
+#include <linux/magic.h>
 
 // ceph
 #include "common/errno.h"
@@ -52,6 +56,12 @@
 #define MAJOR(dev)	((unsigned int) ((dev) >> MINORBITS))
 #define MINOR(dev)	((unsigned int) ((dev) & MINORMASK))
 #define MKDEV(ma,mi)	(((ma) << MINORBITS) | (mi))
+
+#ifndef FUSE_SUPER_MAGIC
+#define FUSE_SUPER_MAGIC 0x65735546
+#endif
+
+#define _CEPH_CLIENT_ID	"ceph.client_id"
 
 static const ceph::unordered_map<int,int> cephfs_errno_to_system_errno = {
   {CEPHFS_EBLOCKLISTED,    ESHUTDOWN},
@@ -160,6 +170,76 @@ public:
 
   struct fuse_args args;
 };
+
+static int already_fuse_mounted(const char *path, bool &already_mounted)
+{
+  struct statx path_statx;
+  struct statx parent_statx;
+  char path_copy[PATH_MAX] = {0};
+  char *parent_path = NULL;
+  int err = 0;
+
+  already_mounted = false;
+
+  strncpy(path_copy, path, sizeof(path_copy)-1);
+  parent_path = dirname(path_copy);
+
+  // get stat information for original path
+  if (-1 == statx(AT_FDCWD, path, AT_STATX_DONT_SYNC, STATX_INO, &path_statx)) {
+    err = errno;
+    derr << "fuse_ll: already_fuse_mounted: statx(" << path << ") failed with error "
+      << cpp_strerror(err) << dendl;
+    return err;
+  }
+
+  // if path isn't directory, then it can't be a mountpoint.
+  if (!(path_statx.stx_mode & S_IFDIR)) {
+    err = EINVAL;
+    derr << "fuse_ll: already_fuse_mounted: "
+      << path << " is not a directory" << dendl;
+    return err;
+  }
+
+  // get stat information for parent path
+  if (-1 == statx(AT_FDCWD, parent_path, AT_STATX_DONT_SYNC, STATX_INO, &parent_statx)) {
+    err = errno;
+    derr << "fuse_ll: already_fuse_mounted: statx(" << parent_path << ") failed with error "
+      << cpp_strerror(err) << dendl;
+    return err;
+  }
+
+  // if original path and parent have different device ids,
+  // then the path is a mount point
+  // or, if they refer to the same path, then it's probably
+  // the root directory '/' and therefore path is a mountpoint
+  if( path_statx.stx_dev_major != parent_statx.stx_dev_major ||
+      path_statx.stx_dev_minor != parent_statx.stx_dev_minor ||
+      ( path_statx.stx_dev_major == parent_statx.stx_dev_major &&
+	path_statx.stx_dev_minor == parent_statx.stx_dev_minor &&
+	path_statx.stx_ino == parent_statx.stx_ino
+      )
+    ) {
+    struct statfs path_statfs;
+    if (-1 == statfs(path, &path_statfs)) {
+      err = errno;
+      derr << "fuse_ll: already_fuse_mounted: statfs(" << path << ") failed with error "
+        << cpp_strerror(err) << dendl;
+      return err;
+    }
+
+    if(FUSE_SUPER_MAGIC == path_statfs.f_type) {
+      // if getxattr returns positive length means value exist for ceph.client_id
+      // then ceph fuse is already mounted on path
+      char client_id[128] = {0};
+      if (getxattr(path, _CEPH_CLIENT_ID, &client_id, sizeof(client_id)) > 0) {
+	already_mounted = true;
+	derr << path << " already mounted by " << client_id << dendl;
+      }
+    }
+  }
+
+  return err;
+}
 
 static int getgroups(fuse_req_t req, gid_t **sgids)
 {
@@ -1321,6 +1401,20 @@ int CephFuse::Handle::init(int argc, const char *argv[])
 
 int CephFuse::Handle::start()
 {
+  bool is_mounted = false;
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  int err = already_fuse_mounted(opts.mountpoint, is_mounted);
+#else
+  int err = already_fuse_mounted(mountpoint, is_mounted);
+#endif
+  if (err) {
+    return err;
+  }
+
+  if (is_mounted) {
+    return EBUSY;
+  }
+
 #if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
   se = fuse_session_new(&args, &fuse_ll_oper, sizeof(fuse_ll_oper), this);
   if (!se) {

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -23,10 +23,13 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
+
+#if defined(__linux__)
 #include <libgen.h>
 #include <sys/vfs.h>
 #include <sys/xattr.h>
 #include <linux/magic.h>
+#endif
 
 // ceph
 #include "common/errno.h"
@@ -57,11 +60,13 @@
 #define MINOR(dev)	((unsigned int) ((dev) & MINORMASK))
 #define MKDEV(ma,mi)	(((ma) << MINORBITS) | (mi))
 
+#if defined(__linux__)
 #ifndef FUSE_SUPER_MAGIC
 #define FUSE_SUPER_MAGIC 0x65735546
 #endif
 
 #define _CEPH_CLIENT_ID	"ceph.client_id"
+#endif
 
 static const ceph::unordered_map<int,int> cephfs_errno_to_system_errno = {
   {CEPHFS_EBLOCKLISTED,    ESHUTDOWN},
@@ -171,6 +176,7 @@ public:
   struct fuse_args args;
 };
 
+#if defined(__linux__)
 static int already_fuse_mounted(const char *path, bool &already_mounted)
 {
   struct statx path_statx;
@@ -240,6 +246,13 @@ static int already_fuse_mounted(const char *path, bool &already_mounted)
 
   return err;
 }
+#else // non-linux platforms
+static int already_fuse_mounted(const char *path, bool &already_mounted)
+{
+  already_mounted = false;
+  return 0;
+}
+#endif
 
 static int getgroups(fuse_req_t req, gid_t **sgids)
 {

--- a/src/mount.fuse.ceph
+++ b/src/mount.fuse.ceph
@@ -28,6 +28,7 @@ id=myuser,conf=/etc/ceph/foo.conf  /mnt/ceph   fuse.ceph   defaults   0 0
 import sys
 import argparse
 import errno
+import platform
 from subprocess import Popen
 
 def ceph_options(mntops):
@@ -74,7 +75,10 @@ def main(arguments):
     mount_cmd.communicate()
 
     if (mount_cmd.returncode != 0):
-        if (mount_cmd.returncode != errno.EBUSY):
+        if (platform.system() == "Linux"):
+            if (mount_cmd.returncode != errno.EBUSY):
+                print("Mount failed with status code: {}".format(mount_cmd.returncode))
+        else:
             print("Mount failed with status code: {}".format(mount_cmd.returncode))
 
 if __name__ == '__main__':

--- a/src/mount.fuse.ceph
+++ b/src/mount.fuse.ceph
@@ -27,6 +27,7 @@ id=myuser,conf=/etc/ceph/foo.conf  /mnt/ceph   fuse.ceph   defaults   0 0
 
 import sys
 import argparse
+import errno
 from subprocess import Popen
 
 def ceph_options(mntops):
@@ -73,7 +74,8 @@ def main(arguments):
     mount_cmd.communicate()
 
     if (mount_cmd.returncode != 0):
-        print("Mount failed with status code: {}".format(mount_cmd.returncode))
+        if (mount_cmd.returncode != errno.EBUSY):
+            print("Mount failed with status code: {}".format(mount_cmd.returncode))
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55040

---

backport of https://github.com/ceph/ceph/pull/44491
parent tracker: https://tracker.ceph.com/issues/46075

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh