### PR TITLE
Enable RocksFB SingleDelete for PGLOG objects

### DIFF
--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1660,7 +1660,8 @@ void RocksDBStore::RocksDBTransactionImpl::rm_single_key(const string &prefix,
 {
   auto cf = db->get_cf_handle(prefix, k);
   if (cf) {
-    bat.SingleDelete(cf, k);
+    //bat.SingleDelete(cf, k);
+    bat.SingleDelete(cf, rocksdb::Slice(k));
   } else {
     bat.SingleDelete(db->default_cf, combine_strings(prefix, k));
   }

--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -131,7 +131,7 @@ public:
     OP_COLL_RMATTR =  25,  // cid, attrname
     OP_COLL_SETATTRS = 26,  // cid, attrset
     OP_COLL_MOVE =    8,   // newcid, oldcid, oid
-
+    OP_OMAP_SINGLE_RMKEYS = 27,  // cid, keyset
     OP_RMATTRS =      28,  // cid, oid
     OP_COLL_RENAME =       29,  // cid, newcid
 
@@ -415,6 +415,7 @@ public:
     case OP_OMAP_CLEAR:
     case OP_OMAP_SETKEYS:
     case OP_OMAP_RMKEYS:
+    case OP_OMAP_SINGLE_RMKEYS:
     case OP_OMAP_RMKEYRANGE:
     case OP_OMAP_SETHEADER:
     case OP_WRITE:
@@ -1115,6 +1116,21 @@ public:
     data.ops = data.ops + 1;
   }
 
+  /// Remove keys single from oid omap (keys must be added only once and never be updated/merged)
+  void __omap_single_rmkeys(
+    const coll_t &cid,             ///< [in] Collection containing oid
+    const ghobject_t &oid,  ///< [in] Object from which to remove the omap
+    const std::set<std::string> &keys ///< [in] Keys to clear
+			  ) {
+    using ceph::encode;
+    Op* _op = _get_next_op();
+    _op->op = OP_OMAP_SINGLE_RMKEYS;
+    _op->cid = _get_coll_id(cid);
+    _op->oid = _get_object_id(oid);
+    encode(keys, data_bl);
+    data.ops = data.ops + 1;
+  }
+
   /// Remove keys from oid omap
   void omap_rmkeys(
     const coll_t &cid,             ///< [in] Collection containing oid
@@ -1127,6 +1143,22 @@ public:
     _op->cid = _get_coll_id(cid);
     _op->oid = _get_object_id(oid);
     encode(keys, data_bl);
+    data.ops = data.ops + 1;
+  }
+
+  /// Remove single key from oid omap (key must be added only once and never be updated/merged)
+  void omap_single_rmkey(
+    const coll_t &cid,             ///< [in] Collection containing oid
+    const ghobject_t &oid,  ///< [in] Object from which to remove the omap
+    const std::string& key ///< [in] Keys to clear
+			 ) {
+    Op* _op = _get_next_op();
+    _op->op = OP_OMAP_SINGLE_RMKEYS;
+    _op->cid = _get_coll_id(cid);
+    _op->oid = _get_object_id(oid);
+    using ceph::encode;
+    encode((uint32_t)1, data_bl);
+    encode(key, data_bl);
     data.ops = data.ops + 1;
   }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3519,6 +3519,10 @@ private:
 		      CollectionRef& c,
 		      OnodeRef& o,
 		      ceph::buffer::list& header);
+  int _omap_single_rmkeys(TransContext *txc,
+			  CollectionRef& c,
+			  OnodeRef& o,
+			  bufferlist& bl);
   int _omap_rmkeys(TransContext *txc,
 		   CollectionRef& c,
 		   OnodeRef& o,

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -950,8 +950,16 @@ void PGLog::_write_log_and_missing(
       (*km)["rollback_info_trimmed_to"]);
   }
 
-  if (!to_remove.empty())
-    t.omap_rmkeys(coll, log_oid, to_remove);
+  if (!to_remove.empty()) {
+#if 0
+    int counter = 0;
+    for (auto& key : to_remove) {
+      t.omap_single_rmkey(coll, log_oid, key);
+    }
+#else
+    t.__omap_single_rmkeys(coll, log_oid, to_remove);
+#endif
+  }
 }
 
 void PGLog::rebuild_missing_set_with_deletes(


### PR DESCRIPTION
Use SingleDelete for PG-LOgs in RocksDB

Signed-off-by: Gabriel BenHanokh <gbenhano@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
