### PR TITLE
crimson/seastore: enlarge omap_leaf_node size

### DIFF
--- a/src/crimson/os/seastore/omap_manager.h
+++ b/src/crimson/os/seastore/omap_manager.h
@@ -14,7 +14,8 @@
 #include "crimson/os/seastore/seastore_types.h"
 #include "crimson/os/seastore/transaction_manager.h"
 
-#define OMAP_BLOCK_SIZE 4096
+#define OMAP_INNER_BLOCK_SIZE 4096
+#define OMAP_LEAF_BLOCK_SIZE 8192
 
 namespace crimson::os::seastore {
 

--- a/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
@@ -26,7 +26,7 @@ BtreeOMapManager::initialize_omap(Transaction &t, laddr_t hint)
 {
 
   logger().debug("{}", __func__);
-  return tm.alloc_extent<OMapLeafNode>(t, hint, OMAP_BLOCK_SIZE)
+  return tm.alloc_extent<OMapLeafNode>(t, hint, OMAP_LEAF_BLOCK_SIZE)
     .si_then([hint](auto&& root_extent) {
       root_extent->set_size(0);
       omap_node_meta_t meta{1};
@@ -51,7 +51,8 @@ BtreeOMapManager::handle_root_split(
   omap_root_t &omap_root,
   const OMapNode::mutation_result_t& mresult)
 {
-  return oc.tm.alloc_extent<OMapInnerNode>(oc.t, omap_root.hint, OMAP_BLOCK_SIZE)
+  return oc.tm.alloc_extent<OMapInnerNode>(oc.t, omap_root.hint,
+                                           OMAP_INNER_BLOCK_SIZE)
     .si_then([&omap_root, mresult](auto&& nroot) -> handle_root_split_ret {
     auto [left, right, pivot] = *(mresult.split_tuple);
     omap_node_meta_t meta{omap_root.depth + 1};

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -268,7 +268,8 @@ OMapInnerNode::split_children_ret
 OMapInnerNode:: make_split_children(omap_context_t oc)
 {
   logger().debug("OMapInnerNode: {}", __func__);
-  return oc.tm.alloc_extents<OMapInnerNode>(oc.t, oc.hint, OMAP_BLOCK_SIZE, 2)
+  return oc.tm.alloc_extents<OMapInnerNode>(oc.t, oc.hint,
+    OMAP_INNER_BLOCK_SIZE, 2)
     .si_then([this] (auto &&ext_pair) {
       auto left = ext_pair.front();
       auto right = ext_pair.back();
@@ -282,7 +283,8 @@ OMapInnerNode::full_merge_ret
 OMapInnerNode::make_full_merge(omap_context_t oc, OMapNodeRef right)
 {
   logger().debug("OMapInnerNode: {}", __func__);
-  return oc.tm.alloc_extent<OMapInnerNode>(oc.t, oc.hint, OMAP_BLOCK_SIZE)
+  return oc.tm.alloc_extent<OMapInnerNode>(oc.t, oc.hint,
+    OMAP_INNER_BLOCK_SIZE)
     .si_then([this, right] (auto &&replacement) {
       replacement->merge_from(*this, *right->cast<OMapInnerNode>());
       return full_merge_ret(
@@ -296,7 +298,8 @@ OMapInnerNode::make_balanced(omap_context_t oc, OMapNodeRef _right)
 {
   logger().debug("OMapInnerNode: {}", __func__);
   ceph_assert(_right->get_type() == TYPE);
-  return oc.tm.alloc_extents<OMapInnerNode>(oc.t, oc.hint, OMAP_BLOCK_SIZE, 2)
+  return oc.tm.alloc_extents<OMapInnerNode>(oc.t, oc.hint,
+    OMAP_INNER_BLOCK_SIZE, 2)
     .si_then([this, _right] (auto &&replacement_pair){
       auto replacement_left = replacement_pair.front();
       auto replacement_right = replacement_pair.back();
@@ -557,7 +560,7 @@ OMapLeafNode::split_children_ret
 OMapLeafNode::make_split_children(omap_context_t oc)
 {
   logger().debug("OMapLeafNode: {}", __func__);
-  return oc.tm.alloc_extents<OMapLeafNode>(oc.t, oc.hint, OMAP_BLOCK_SIZE, 2)
+  return oc.tm.alloc_extents<OMapLeafNode>(oc.t, oc.hint, OMAP_LEAF_BLOCK_SIZE, 2)
     .si_then([this] (auto &&ext_pair) {
       auto left = ext_pair.front();
       auto right = ext_pair.back();
@@ -572,7 +575,7 @@ OMapLeafNode::make_full_merge(omap_context_t oc, OMapNodeRef right)
 {
   ceph_assert(right->get_type() == TYPE);
   logger().debug("OMapLeafNode: {}", __func__);
-  return oc.tm.alloc_extent<OMapLeafNode>(oc.t, oc.hint, OMAP_BLOCK_SIZE)
+  return oc.tm.alloc_extent<OMapLeafNode>(oc.t, oc.hint, OMAP_LEAF_BLOCK_SIZE)
     .si_then([this, right] (auto &&replacement) {
       replacement->merge_from(*this, *right->cast<OMapLeafNode>());
       return full_merge_ret(
@@ -586,7 +589,7 @@ OMapLeafNode::make_balanced(omap_context_t oc, OMapNodeRef _right)
 {
   ceph_assert(_right->get_type() == TYPE);
   logger().debug("OMapLeafNode: {}",  __func__);
-  return oc.tm.alloc_extents<OMapLeafNode>(oc.t, oc.hint, OMAP_BLOCK_SIZE, 2)
+  return oc.tm.alloc_extents<OMapLeafNode>(oc.t, oc.hint, OMAP_LEAF_BLOCK_SIZE, 2)
     .si_then([this, _right] (auto &&replacement_pair) {
       auto replacement_left = replacement_pair.front();
       auto replacement_right = replacement_pair.back();
@@ -607,8 +610,9 @@ omap_load_extent(omap_context_t oc, laddr_t laddr, depth_t depth)
 {
   ceph_assert(depth > 0);
   if (depth > 1) {
-    return oc.tm.read_extent<OMapInnerNode>(oc.t, laddr, OMAP_BLOCK_SIZE
-    ).handle_error_interruptible(
+    return oc.tm.read_extent<OMapInnerNode>(oc.t, laddr,
+      OMAP_INNER_BLOCK_SIZE)
+      .handle_error_interruptible(
       omap_load_extent_iertr::pass_further{},
       crimson::ct_error::assert_all{ "Invalid error in omap_load_extent" }
     ).si_then(
@@ -616,7 +620,7 @@ omap_load_extent(omap_context_t oc, laddr_t laddr, depth_t depth)
       return seastar::make_ready_future<OMapNodeRef>(std::move(e));
     });
   } else {
-    return oc.tm.read_extent<OMapLeafNode>(oc.t, laddr, OMAP_BLOCK_SIZE
+    return oc.tm.read_extent<OMapLeafNode>(oc.t, laddr, OMAP_LEAF_BLOCK_SIZE
     ).handle_error_interruptible(
       omap_load_extent_iertr::pass_further{},
       crimson::ct_error::assert_all{ "Invalid error in omap_load_extent" }

--- a/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
+++ b/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
@@ -401,7 +401,7 @@ public:
       return get_node_key().key_off;
     }
     auto get_node_val_ptr() const {
-      auto tail = node->buf + OMAP_BLOCK_SIZE;
+      auto tail = node->buf + OMAP_INNER_BLOCK_SIZE;
       if (*this == node->iter_end())
         return tail;
       else {
@@ -416,7 +416,7 @@ public:
         return (*this - 1)->get_node_val_offset();
     }
     auto get_right_ptr_end() const {
-      return node->buf + OMAP_BLOCK_SIZE - get_right_offset_end();
+      return node->buf + OMAP_INNER_BLOCK_SIZE - get_right_offset_end();
     }
 
     void update_offset(int offset) {
@@ -438,8 +438,8 @@ public:
       static_assert(!is_const);
       assert(str.size() == get_node_key().key_len);
       assert(get_node_key().key_off >= str.size());
-      assert(get_node_key().key_off < OMAP_BLOCK_SIZE);
-      assert(str.size() < OMAP_BLOCK_SIZE);
+      assert(get_node_key().key_off < OMAP_INNER_BLOCK_SIZE);
+      assert(str.size() < OMAP_INNER_BLOCK_SIZE);
       ::memcpy(get_node_val_ptr(), str.data(), str.size());
     }
 
@@ -656,8 +656,9 @@ public:
   }
 
   uint16_t capacity() const {
-    return OMAP_BLOCK_SIZE - (reinterpret_cast<char*>(layout.template Pointer<2>(buf))-
-                        reinterpret_cast<char*>(layout.template Pointer<0>(buf)));
+    return OMAP_INNER_BLOCK_SIZE
+      - (reinterpret_cast<char*>(layout.template Pointer<2>(buf))
+      - reinterpret_cast<char*>(layout.template Pointer<0>(buf)));
   }
 
   bool is_overflow(size_t ksize) const {
@@ -1007,7 +1008,7 @@ public:
       return get_node_key().key_off;
     }
     auto get_node_val_ptr() const {
-      auto tail = node->buf + OMAP_BLOCK_SIZE;
+      auto tail = node->buf + OMAP_LEAF_BLOCK_SIZE;
       if (*this == node->iter_end())
         return tail;
       else {
@@ -1022,7 +1023,7 @@ public:
         return (*this - 1)->get_node_val_offset();
     }
     auto get_right_ptr_end() const {
-      return node->buf + OMAP_BLOCK_SIZE - get_right_offset_end();
+      return node->buf + OMAP_LEAF_BLOCK_SIZE - get_right_offset_end();
     }
 
     void update_offset(int offset) {
@@ -1262,8 +1263,9 @@ public:
   }
 
   uint32_t capacity() const {
-    return OMAP_BLOCK_SIZE - (reinterpret_cast<char*>(layout.template Pointer<2>(buf))-
-                        reinterpret_cast<char*>(layout.template Pointer<0>(buf)));
+    return OMAP_LEAF_BLOCK_SIZE
+      - (reinterpret_cast<char*>(layout.template Pointer<2>(buf))
+      - reinterpret_cast<char*>(layout.template Pointer<0>(buf)));
   }
 
   bool is_overflow(size_t ksize, size_t vsize) const {


### PR DESCRIPTION
to avoid double split when key size around 2K.

Signed-off-by: chunmei-liu <chunmei.liu@intel.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
