### PR TITLE
pacific: grafana/Makefile: don't push to docker

### DIFF
--- a/monitoring/grafana/build/Makefile
+++ b/monitoring/grafana/build/Makefile
@@ -72,24 +72,13 @@ providers: \\n\
 	sudo buildah commit --format docker --squash $(CONTAINER) $(LOCALTAG)
 
 push:
-	# this transition-through-oci image is a workaround for
-	# https://github.com/containers/buildah/issues/3253 and
-	# can be removed when that is fixed and released.  The
-	# --format v2s2 on push is to convert oci back to docker format.
-	sudo podman push $(LOCALTAG) --format=oci dir://tmp/oci-image
-	sudo podman pull dir://tmp/oci-image
-	sudo rm -rf /tmp/oci-image
-	sudo podman tag localhost/tmp/oci-image docker.io/${TAG}
-	sudo podman tag localhost/tmp/oci-image quay.io/${TAG}
+	sudo podman tag ${LOCALTAG} quay.io/${TAG}
 	# sudo podman has issues with auth.json; just override it
-	sudo podman login --authfile=auth.json -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_PASSWORD} docker.io
 	sudo podman login --authfile=auth.json -u $(CONTAINER_REPO_USERNAME) -p $(CONTAINER_REPO_PASSWORD) quay.io
-	sudo podman push --authfile=auth.json --format v2s2 docker.io/${TAG}
 	sudo podman push --authfile=auth.json --format v2s2 quay.io/${TAG}
 
 clean:
 	sudo podman rmi ${LOCALTAG} || true
-	sudo podman rmi docker.io/${TAG} || true
 	sudo podman rmi quay.io/${TAG} || true
 	sudo podman rmi localhost/tmp/oci-image || true
 	rm -f grafana-*.rpm* auth.json


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55373
---

backport of https://github.com/ceph/ceph/pull/45739
Also includes backport of https://github.com/ceph/ceph/pull/45578
parent tracker: https://tracker.ceph.com/issues/55367

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh