### PR TITLE
pacific: mgr/dashboard: upgrade grafana pie-chart and vonage-status-panel versions

### DIFF
--- a/monitoring/grafana/build/Makefile
+++ b/monitoring/grafana/build/Makefile
@@ -1,10 +1,10 @@
 
-GRAFANA_VERSION ?= 6.7.4-1
-PIECHART_VERSION ?= "1.4.0"
-STATUS_PANEL_VERSION ?= "1.0.9"
+GRAFANA_VERSION ?= 8.3.5-1
+PIECHART_VERSION ?= "1.6.2"
+STATUS_PANEL_VERSION ?= "1.0.11"
 DASHBOARD_DIR := "../dashboards"
 DASHBOARD_PROVISIONING := "ceph-dashboard.yml"
-IMAGE := "docker.io/centos:8"
+IMAGE := "docker.io/redhat/ubi8:8.5"
 PKGMGR := "dnf"
 GF_CONFIG := "/etc/grafana/grafana.ini"
 # clip off "-<whatever> from the end of GRAFANA_VERSION


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55199

---

backport of https://github.com/ceph/ceph/pull/45793
parent tracker: https://tracker.ceph.com/issues/55195

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh