### PR TITLE
pacific: osd/scrub: expose PGs scrubbing info to the operator

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -81,6 +81,11 @@
   unsuitable for hyperconverged infrastructures. For hyperconverged Ceph, please refer
   to the documentation or set ``mgr/cephadm/autotune_memory_target_ratio`` to ``0.2``.
 
+* The ``ceph pg dump`` command now prints two additional columns:
+  `LAST_SCRUB_DURATION` shows the duration (in seconds) of the last completed scrub;
+  `SCRUB_SCHEDULING` conveys whether a PG is scheduled to be scrubbed at a specified
+  time, queued for scrubbing, or being scrubbed.
+
 >=16.0.0
 --------
 

--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -449,6 +449,43 @@ function TEST_scrub_permit_time() {
     teardown $dir || return 1
 }
 
+function TEST_pg_dump_scrub_duration() {
+    local dir=$1
+    local poolname=test
+    local OSDS=3
+    local objects=15
+
+    TESTDATA="testdata.$$"
+
+    setup $dir || return 1
+    run_mon $dir a --osd_pool_default_size=$OSDS || return 1
+    run_mgr $dir x || return 1
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      run_osd $dir $osd || return 1
+    done
+
+    # Create a pool with a single pg
+    create_pool $poolname 1 1
+    wait_for_clean || return 1
+    poolid=$(ceph osd dump | grep "^pool.*[']${poolname}[']" | awk '{ print $2 }')
+
+    dd if=/dev/urandom of=$TESTDATA bs=1032 count=1
+    for i in `seq 1 $objects`
+    do
+        rados -p $poolname put obj${i} $TESTDATA
+    done
+    rm -f $TESTDATA
+
+    local pgid="${poolid}.0"
+    pg_scrub $pgid || return 1
+
+    ceph pg $pgid query | jq '.info.stats.scrub_duration'
+    test "$(ceph pg $pgid query | jq '.info.stats.scrub_duration')" '>' "0" || return 1
+
+    teardown $dir || return 1
+}
+
 main osd-scrub-test "$@"
 
 # Local Variables:

--- a/src/common/hobject_fmt.h
+++ b/src/common/hobject_fmt.h
@@ -1,0 +1,58 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+
+/**
+ * \file fmtlib formatters for some hobject.h classes
+ */
+#include <fmt/format.h>
+
+#include "common/hobject.h"
+#include "include/types_fmt.h"
+#include "msg/msg_fmt.h"
+
+// \todo reimplement
+static inline void append_out_escaped(const std::string& in, std::string* out)
+{
+  for (auto i = in.cbegin(); i != in.cend(); ++i) {
+    if (*i == '%' || *i == ':' || *i == '/' || *i < 32 || *i >= 127) {
+      char buf[4];
+      snprintf(buf, sizeof(buf), "%%%02x", (int)(unsigned char)*i);
+      out->append(buf);
+    } else {
+      out->push_back(*i);
+    }
+  }
+}
+
+template <>
+struct fmt::formatter<hobject_t> {
+
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const hobject_t& ho, FormatContext& ctx)
+  {
+    if (ho == hobject_t{}) {
+      return fmt::format_to(ctx.out(), "MIN");
+    }
+
+    if (ho.is_max()) {
+      return fmt::format_to(ctx.out(), "MAX");
+    }
+
+    std::string v;
+    append_out_escaped(ho.nspace, &v);
+    v.push_back(':');
+    append_out_escaped(ho.get_key(), &v);
+    v.push_back(':');
+    append_out_escaped(ho.oid.name, &v);
+
+    return fmt::format_to(ctx.out(),
+                          "{}:{:08x}:{}:{}",
+                          static_cast<uint64_t>(ho.pool),
+                          ho.get_bitwise_key_u32(),
+                          v,
+                          ho.snap);
+  }
+};

--- a/src/include/types_fmt.h
+++ b/src/include/types_fmt.h
@@ -1,0 +1,28 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+/**
+ * \file fmtlib formatters for some types.h classes
+ */
+
+#include <fmt/format.h>
+
+#include <string_view>
+
+#include "include/types.h"
+
+template <class A, class B, class Comp, class Alloc>
+struct fmt::formatter<std::map<A, B, Comp, Alloc>> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const std::map<A, B, Comp, Alloc>& m, FormatContext& ctx)
+  {
+    std::string_view sep = "{";
+    for (const auto& [k, v] : m) {
+      fmt::format_to(ctx.out(), "{}{}={}", sep, k, v);
+      sep = ",";
+    }
+    return fmt::format_to(ctx.out(), "}}");
+  }
+};

--- a/src/include/utime_fmt.h
+++ b/src/include/utime_fmt.h
@@ -1,0 +1,38 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+/**
+ * \file fmtlib formatter for utime_t
+ */
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+
+#include <string_view>
+
+#include "include/utime.h"
+
+template <>
+struct fmt::formatter<utime_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const utime_t& utime, FormatContext& ctx)
+  {
+    if (utime.sec() < ((time_t)(60 * 60 * 24 * 365 * 10))) {
+      // raw seconds.  this looks like a relative time.
+      return fmt::format_to(ctx.out(),
+                            "{}.{:06}",
+                            (long)utime.sec(),
+                            utime.usec());
+    }
+
+    // this looks like an absolute time.
+    // conform to http://en.wikipedia.org/wiki/ISO_8601
+    auto asgmt = fmt::gmtime(utime.sec());
+    return fmt::format_to(ctx.out(),
+                          "{:%FT%T}.{:06}{:%z}",
+                          asgmt,
+                          utime.usec(),
+                          asgmt);
+  }
+};

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1705,6 +1705,7 @@ void PGMap::dump_pg_stats_plain(
     tab.define_column("LAST_DEEP_SCRUB", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("DEEP_SCRUB_STAMP", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("SNAPTRIMQ_LEN", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("SCRUB_DURATION", TextTable::LEFT, TextTable::RIGHT);
   }
 
   for (auto i = pg_stats.begin();
@@ -1746,6 +1747,7 @@ void PGMap::dump_pg_stats_plain(
           << st.last_deep_scrub
           << st.last_deep_scrub_stamp
           << st.snaptrimq_len
+          << st.scrub_duration
           << TextTable::endrow;
     }
   }
@@ -2327,6 +2329,7 @@ void PGMap::dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs) const
   tab.define_column("ACTING", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("SCRUB_STAMP", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("DEEP_SCRUB_STAMP", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("SCRUB_DURATION", TextTable::LEFT, TextTable::RIGHT);
 
   for (auto i = pgs.begin(); i != pgs.end(); ++i) {
     const pg_stat_t& st = pg_stat.at(*i);
@@ -2354,6 +2357,7 @@ void PGMap::dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs) const
         << actingstr.str()
         << st.last_scrub_stamp
         << st.last_deep_scrub_stamp
+        << st.scrub_duration
         << TextTable::endrow;
   }
 

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1705,7 +1705,8 @@ void PGMap::dump_pg_stats_plain(
     tab.define_column("LAST_DEEP_SCRUB", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("DEEP_SCRUB_STAMP", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("SNAPTRIMQ_LEN", TextTable::LEFT, TextTable::RIGHT);
-    tab.define_column("SCRUB_DURATION", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("LAST_SCRUB_DURATION", TextTable::LEFT, TextTable::RIGHT);
+    tab.define_column("SCRUB_SCHEDULING", TextTable::LEFT, TextTable::LEFT);
   }
 
   for (auto i = pg_stats.begin();
@@ -1747,7 +1748,8 @@ void PGMap::dump_pg_stats_plain(
           << st.last_deep_scrub
           << st.last_deep_scrub_stamp
           << st.snaptrimq_len
-          << st.scrub_duration
+          << st.last_scrub_duration
+          << st.dump_scrub_schedule()
           << TextTable::endrow;
     }
   }
@@ -2329,7 +2331,8 @@ void PGMap::dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs) const
   tab.define_column("ACTING", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("SCRUB_STAMP", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("DEEP_SCRUB_STAMP", TextTable::LEFT, TextTable::RIGHT);
-  tab.define_column("SCRUB_DURATION", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("LAST_SCRUB_DURATION", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("SCRUB_SCHEDULING", TextTable::LEFT, TextTable::LEFT);
 
   for (auto i = pgs.begin(); i != pgs.end(); ++i) {
     const pg_stat_t& st = pg_stat.at(*i);
@@ -2357,8 +2360,9 @@ void PGMap::dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs) const
         << actingstr.str()
         << st.last_scrub_stamp
         << st.last_deep_scrub_stamp
-        << st.scrub_duration
-        << TextTable::endrow;
+        << st.last_scrub_duration
+        << st.dump_scrub_schedule()
+      << TextTable::endrow;
   }
 
   ss << tab;

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1707,6 +1707,7 @@ void PGMap::dump_pg_stats_plain(
     tab.define_column("SNAPTRIMQ_LEN", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("LAST_SCRUB_DURATION", TextTable::LEFT, TextTable::RIGHT);
     tab.define_column("SCRUB_SCHEDULING", TextTable::LEFT, TextTable::LEFT);
+    tab.define_column("OBJECTS_SCRUBBED", TextTable::LEFT, TextTable::RIGHT);
   }
 
   for (auto i = pg_stats.begin();
@@ -1750,6 +1751,7 @@ void PGMap::dump_pg_stats_plain(
           << st.snaptrimq_len
           << st.last_scrub_duration
           << st.dump_scrub_schedule()
+          << st.objects_scrubbed
           << TextTable::endrow;
     }
   }

--- a/src/msg/msg_fmt.h
+++ b/src/msg/msg_fmt.h
@@ -1,0 +1,26 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+
+/**
+ * \file fmtlib formatters for some msg_types.h classes
+ */
+
+#include <fmt/format.h>
+
+#include "include/types_fmt.h"
+#include "msg/msg_types.h"
+
+template <>
+struct fmt::formatter<entity_name_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const entity_name_t& addr, FormatContext& ctx)
+  {
+    if (addr.is_new() || addr.num() < 0) {
+      return fmt::format_to(ctx.out(), "{}.?", addr.type_str());
+    }
+    return fmt::format_to(ctx.out(), "{}.{}", addr.type_str(), addr.num());
+  }
+};

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -821,6 +821,14 @@ void PG::publish_stats_to_osd()
   if (!is_primary())
     return;
 
+  if (m_scrubber) {
+    recovery_state.update_stats_wo_resched(
+      [scrubber = m_scrubber.get()](pg_history_t& hist,
+                                    pg_stat_t& info) mutable -> void {
+        info.scrub_sched_status = scrubber->get_schedule();
+      });
+  }
+
   std::lock_guard l{pg_stats_publish_lock};
   auto stats = recovery_state.prepare_stats_for_publish(
     pg_stats_publish_valid,
@@ -2520,12 +2528,6 @@ void PG::handle_query_state(Formatter *f)
   dout(10) << "handle_query_state" << dendl;
   PeeringState::QueryState q(f);
   recovery_state.handle_event(q, 0);
-
-  // This code has moved to after the close of recovery_state array.
-  // I don't think that scrub is a recovery state
-  if (is_primary() && is_active() && m_scrubber && m_scrubber->is_scrub_active()) {
-    m_scrubber->handle_query_state(f);
-  }
 }
 
 void PG::init_collection_pool_opts()

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -271,6 +271,31 @@ public:
       });
   }
 
+  static void add_objects_scrubbed_count(
+    int64_t count, pg_stat_t &stats) {
+    stats.objects_scrubbed += count;
+  }
+
+  void add_objects_scrubbed_count(int64_t count) {
+    recovery_state.update_stats(
+      [=](auto &history, auto &stats) {
+	add_objects_scrubbed_count(count, stats);
+	return true;
+      });
+  }
+
+  static void reset_objects_scrubbed(pg_stat_t &stats) {
+    stats.objects_scrubbed = 0;
+  }
+
+  void reset_objects_scrubbed() {
+    recovery_state.update_stats(
+      [=](auto &history, auto &stats) {
+  reset_objects_scrubbed(stats);
+  return true;
+      });
+  }
+
   bool is_deleting() const {
     return recovery_state.is_deleting();
   }

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4067,6 +4067,13 @@ void PeeringState::update_stats(
   }
 }
 
+void PeeringState::update_stats_wo_resched(
+  std::function<void(pg_history_t &, pg_stat_t &)> f)
+{
+  f(info.history, info.stats);
+}
+
+
 bool PeeringState::append_log_entries_update_missing(
   const mempool::osd_pglog::list<pg_log_entry_t> &entries,
   ObjectStore::Transaction &t, std::optional<eversion_t> trim_to,

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1796,6 +1796,9 @@ public:
     std::function<bool(pg_history_t &, pg_stat_t &)> f,
     ObjectStore::Transaction *t = nullptr);
 
+  void update_stats_wo_resched(
+    std::function<void(pg_history_t &, pg_stat_t &)> f);
+
   /**
    * adjust_purged_snaps
    *

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1015,7 +1015,7 @@ void PrimaryLogPG::do_command(
     f->close_section();
 
     if (is_primary() && is_active() && m_scrubber) {
-      m_scrubber->dump(f.get());
+      m_scrubber->dump_scrubber(f.get(), m_planned_scrub);
     }
 
     f->open_object_section("agent_state");

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2851,6 +2851,7 @@ void pg_stat_t::dump(Formatter *f) const
   f->dump_stream("last_deep_scrub") << last_deep_scrub;
   f->dump_stream("last_deep_scrub_stamp") << last_deep_scrub_stamp;
   f->dump_stream("last_clean_scrub_stamp") << last_clean_scrub_stamp;
+  f->dump_int("objects_scrubbed", objects_scrubbed);
   f->dump_int("log_size", log_size);
   f->dump_int("ondisk_log_size", ondisk_log_size);
   f->dump_bool("stats_invalid", stats_invalid);
@@ -3013,6 +3014,7 @@ void pg_stat_t::encode(ceph::buffer::list &bl) const
   encode(scrub_sched_status.m_is_active, bl);
   encode((scrub_sched_status.m_is_deep==scrub_level_t::deep), bl);
   encode(scrub_sched_status.m_is_periodic, bl);
+  encode(objects_scrubbed, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -3100,6 +3102,7 @@ void pg_stat_t::decode(ceph::buffer::list::const_iterator &bl)
       scrub_sched_status.m_is_deep = tmp ? scrub_level_t::deep : scrub_level_t::shallow;
       decode(tmp, bl);
       scrub_sched_status.m_is_periodic = tmp;
+      decode(objects_scrubbed, bl);
     }
   }
   DECODE_FINISH(bl);
@@ -3135,6 +3138,7 @@ void pg_stat_t::generate_test_instances(list<pg_stat_t*>& o)
   a.last_clean_scrub_stamp = utime_t(17, 18);
   a.last_scrub_duration = 3617;
   a.snaptrimq_len = 1048576;
+  a.objects_scrubbed = 0;
   list<object_stat_collection_t*> l;
   object_stat_collection_t::generate_test_instances(l);
   a.stats = *l.back();
@@ -3209,7 +3213,8 @@ bool operator==(const pg_stat_t& l, const pg_stat_t& r)
     l.purged_snaps == r.purged_snaps &&
     l.snaptrimq_len == r.snaptrimq_len &&
     l.last_scrub_duration == r.last_scrub_duration &&
-    l.scrub_sched_status == r.scrub_sched_status;
+    l.scrub_sched_status == r.scrub_sched_status &&
+    l.objects_scrubbed == r.objects_scrubbed;
 }
 
 // -- store_statfs_t --

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2859,6 +2859,7 @@ void pg_stat_t::dump(Formatter *f) const
   f->dump_bool("pin_stats_invalid", pin_stats_invalid);
   f->dump_bool("manifest_stats_invalid", manifest_stats_invalid);
   f->dump_unsigned("snaptrimq_len", snaptrimq_len);
+  f->dump_float("scrub_duration", scrub_duration);
   stats.dump(f);
   f->open_array_section("up");
   for (auto p = up.cbegin(); p != up.cend(); ++p)
@@ -2913,7 +2914,7 @@ void pg_stat_t::dump_brief(Formatter *f) const
 
 void pg_stat_t::encode(ceph::buffer::list &bl) const
 {
-  ENCODE_START(26, 22, bl);
+  ENCODE_START(27, 22, bl);
   encode(version, bl);
   encode(reported_seq, bl);
   encode(reported_epoch, bl);
@@ -2961,6 +2962,7 @@ void pg_stat_t::encode(ceph::buffer::list &bl) const
   encode(manifest_stats_invalid, bl);
   encode(avail_no_missing, bl);
   encode(object_location_counts, bl);
+  encode(scrub_duration, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -3035,6 +3037,9 @@ void pg_stat_t::decode(ceph::buffer::list::const_iterator &bl)
       decode(avail_no_missing, bl);
       decode(object_location_counts, bl);
     }
+    if (struct_v >= 27) {
+      decode(scrub_duration, bl);
+    }
   }
   DECODE_FINISH(bl);
 }
@@ -3067,6 +3072,7 @@ void pg_stat_t::generate_test_instances(list<pg_stat_t*>& o)
   a.last_deep_scrub = eversion_t(13, 14);
   a.last_deep_scrub_stamp = utime_t(15, 16);
   a.last_clean_scrub_stamp = utime_t(17, 18);
+  a.scrub_duration = 0.003;
   a.snaptrimq_len = 1048576;
   list<object_stat_collection_t*> l;
   object_stat_collection_t::generate_test_instances(l);
@@ -3140,7 +3146,8 @@ bool operator==(const pg_stat_t& l, const pg_stat_t& r)
     l.pin_stats_invalid == r.pin_stats_invalid &&
     l.manifest_stats_invalid == r.manifest_stats_invalid &&
     l.purged_snaps == r.purged_snaps &&
-    l.snaptrimq_len == r.snaptrimq_len;
+    l.snaptrimq_len == r.snaptrimq_len &&
+    l.scrub_duration == r.scrub_duration;
 }
 
 // -- store_statfs_t --

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -36,8 +36,10 @@ extern "C" {
 
 #include "common/Formatter.h"
 #include "common/StackStringStream.h"
+#include "include/utime_fmt.h"
 #include "OSDMap.h"
 #include "osd_types.h"
+#include "osd_types_fmt.h"
 #include "os/Transaction.h"
 
 using std::list;
@@ -2859,7 +2861,8 @@ void pg_stat_t::dump(Formatter *f) const
   f->dump_bool("pin_stats_invalid", pin_stats_invalid);
   f->dump_bool("manifest_stats_invalid", manifest_stats_invalid);
   f->dump_unsigned("snaptrimq_len", snaptrimq_len);
-  f->dump_float("scrub_duration", scrub_duration);
+  f->dump_int("last_scrub_duration", last_scrub_duration);
+  f->dump_string("scrub_schedule", dump_scrub_schedule());
   stats.dump(f);
   f->open_array_section("up");
   for (auto p = up.cbegin(); p != up.cend(); ++p)
@@ -2912,6 +2915,47 @@ void pg_stat_t::dump_brief(Formatter *f) const
   f->dump_int("acting_primary", acting_primary);
 }
 
+std::string pg_stat_t::dump_scrub_schedule() const
+{
+  if (scrub_sched_status.m_is_active) {
+    return fmt::format(
+      "{}scrubbing for {}s",
+      ((scrub_sched_status.m_is_deep == scrub_level_t::deep) ? "deep " : ""),
+      scrub_sched_status.m_duration_seconds);
+  }
+  switch (scrub_sched_status.m_sched_status) {
+    case pg_scrub_sched_status_t::unknown:
+      // no reported scrub schedule yet
+      return "--"s;
+    case pg_scrub_sched_status_t::not_queued:
+      return "no scrub is scheduled"s;
+    case pg_scrub_sched_status_t::scheduled:
+      return fmt::format(
+        "{} {}scrub scheduled @ {}",
+        (scrub_sched_status.m_is_periodic ? "periodic" : "user requested"),
+        ((scrub_sched_status.m_is_deep == scrub_level_t::deep) ? "deep " : ""),
+        scrub_sched_status.m_scheduled_at);
+    case pg_scrub_sched_status_t::queued:
+      return fmt::format(
+        "queued for {}scrub",
+        ((scrub_sched_status.m_is_deep == scrub_level_t::deep) ? "deep " : ""));
+    default:
+      // a bug!
+      return "SCRUB STATE MISMATCH!"s;
+  }
+}
+
+bool operator==(const pg_scrubbing_status_t& l, const pg_scrubbing_status_t& r)
+{
+  return
+    l.m_sched_status == r.m_sched_status &&
+    l.m_scheduled_at == r.m_scheduled_at &&
+    l.m_duration_seconds == r.m_duration_seconds &&
+    l.m_is_active == r.m_is_active &&
+    l.m_is_deep == r.m_is_deep &&
+    l.m_is_periodic == r.m_is_periodic;
+}
+
 void pg_stat_t::encode(ceph::buffer::list &bl) const
 {
   ENCODE_START(27, 22, bl);
@@ -2962,7 +3006,13 @@ void pg_stat_t::encode(ceph::buffer::list &bl) const
   encode(manifest_stats_invalid, bl);
   encode(avail_no_missing, bl);
   encode(object_location_counts, bl);
-  encode(scrub_duration, bl);
+  encode(last_scrub_duration, bl);
+  encode(scrub_sched_status.m_scheduled_at, bl);
+  encode(scrub_sched_status.m_duration_seconds, bl);
+  encode((__u16)scrub_sched_status.m_sched_status, bl);
+  encode(scrub_sched_status.m_is_active, bl);
+  encode((scrub_sched_status.m_is_deep==scrub_level_t::deep), bl);
+  encode(scrub_sched_status.m_is_periodic, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -2970,7 +3020,7 @@ void pg_stat_t::decode(ceph::buffer::list::const_iterator &bl)
 {
   bool tmp;
   uint32_t old_state;
-  DECODE_START(26, bl);
+  DECODE_START(27, bl);
   decode(version, bl);
   decode(reported_seq, bl);
   decode(reported_epoch, bl);
@@ -3038,7 +3088,18 @@ void pg_stat_t::decode(ceph::buffer::list::const_iterator &bl)
       decode(object_location_counts, bl);
     }
     if (struct_v >= 27) {
-      decode(scrub_duration, bl);
+      decode(last_scrub_duration, bl);
+      decode(scrub_sched_status.m_scheduled_at, bl);
+      decode(scrub_sched_status.m_duration_seconds, bl);
+      __u16 scrub_sched_as_u16;
+      decode(scrub_sched_as_u16, bl);
+      scrub_sched_status.m_sched_status = (pg_scrub_sched_status_t)(scrub_sched_as_u16);
+      decode(tmp, bl);
+      scrub_sched_status.m_is_active = tmp;
+      decode(tmp, bl);
+      scrub_sched_status.m_is_deep = tmp ? scrub_level_t::deep : scrub_level_t::shallow;
+      decode(tmp, bl);
+      scrub_sched_status.m_is_periodic = tmp;
     }
   }
   DECODE_FINISH(bl);
@@ -3072,7 +3133,7 @@ void pg_stat_t::generate_test_instances(list<pg_stat_t*>& o)
   a.last_deep_scrub = eversion_t(13, 14);
   a.last_deep_scrub_stamp = utime_t(15, 16);
   a.last_clean_scrub_stamp = utime_t(17, 18);
-  a.scrub_duration = 0.003;
+  a.last_scrub_duration = 3617;
   a.snaptrimq_len = 1048576;
   list<object_stat_collection_t*> l;
   object_stat_collection_t::generate_test_instances(l);
@@ -3147,7 +3208,8 @@ bool operator==(const pg_stat_t& l, const pg_stat_t& r)
     l.manifest_stats_invalid == r.manifest_stats_invalid &&
     l.purged_snaps == r.purged_snaps &&
     l.snaptrimq_len == r.snaptrimq_len &&
-    l.scrub_duration == r.scrub_duration;
+    l.last_scrub_duration == r.last_scrub_duration &&
+    l.scrub_sched_status == r.scrub_sched_status;
 }
 
 // -- store_statfs_t --

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2210,6 +2210,7 @@ struct pg_stat_t {
 
   int64_t log_size;
   int64_t ondisk_log_size;    // >= active_log_size
+  int64_t objects_scrubbed; // part of v.27 of the structure
 
   std::vector<int32_t> up, acting;
   std::vector<pg_shard_t> avail_no_missing;
@@ -2250,6 +2251,7 @@ struct pg_stat_t {
       created(0), last_epoch_clean(0),
       parent_split_bits(0),
       log_size(0), ondisk_log_size(0),
+      objects_scrubbed(0),
       mapping_epoch(0),
       up_primary(-1),
       acting_primary(-1),

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2218,6 +2218,8 @@ struct pg_stat_t {
   bool pin_stats_invalid:1;
   bool manifest_stats_invalid:1;
 
+  double scrub_duration;
+
   pg_stat_t()
     : reported_seq(0),
       reported_epoch(0),
@@ -2235,7 +2237,8 @@ struct pg_stat_t {
       hitset_stats_invalid(false),
       hitset_bytes_stats_invalid(false),
       pin_stats_invalid(false),
-      manifest_stats_invalid(false)
+      manifest_stats_invalid(false),
+      scrub_duration(0)
   { }
 
   epoch_t get_effective_last_epoch_clean() const {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2148,6 +2148,28 @@ inline bool operator==(const object_stat_collection_t& l,
   return l.sum == r.sum;
 }
 
+enum class scrub_level_t : bool { shallow = false, deep = true };
+enum class scrub_type_t : bool { not_repair = false, do_repair = true };
+
+/// is there a scrub in our future?
+enum class pg_scrub_sched_status_t : uint16_t {
+  unknown,         ///< status not reported yet
+  not_queued,	   ///< not in the OSD's scrub queue. Probably not active.
+  active,          ///< scrubbing
+  scheduled,	   ///< scheduled for a scrub at an already determined time
+  queued	   ///< queued to be scrubbed
+};
+
+struct pg_scrubbing_status_t {
+  utime_t m_scheduled_at{};
+  int32_t m_duration_seconds{0}; // relevant when scrubbing
+  pg_scrub_sched_status_t m_sched_status{pg_scrub_sched_status_t::unknown};
+  bool m_is_active{false};
+  scrub_level_t m_is_deep{scrub_level_t::shallow};
+  bool m_is_periodic{true};
+};
+
+bool operator==(const pg_scrubbing_status_t& l, const pg_scrubbing_status_t& r);
 
 /** pg_stat
  * aggregate stats for a single PG.
@@ -2182,6 +2204,7 @@ struct pg_stat_t {
   utime_t last_scrub_stamp;
   utime_t last_deep_scrub_stamp;
   utime_t last_clean_scrub_stamp;
+  int32_t last_scrub_duration{0};
 
   object_stat_collection_t stats;
 
@@ -2208,6 +2231,8 @@ struct pg_stat_t {
   // absurd already, so cap it to 2^32 and save 4 bytes at  the same time
   uint32_t snaptrimq_len;
 
+  pg_scrubbing_status_t scrub_sched_status;
+
   bool stats_invalid:1;
   /// true if num_objects_dirty is not accurate (because it was not
   /// maintained starting from pool creation)
@@ -2217,8 +2242,6 @@ struct pg_stat_t {
   bool hitset_bytes_stats_invalid:1;
   bool pin_stats_invalid:1;
   bool manifest_stats_invalid:1;
-
-  double scrub_duration;
 
   pg_stat_t()
     : reported_seq(0),
@@ -2237,8 +2260,7 @@ struct pg_stat_t {
       hitset_stats_invalid(false),
       hitset_bytes_stats_invalid(false),
       pin_stats_invalid(false),
-      manifest_stats_invalid(false),
-      scrub_duration(0)
+      manifest_stats_invalid(false)
   { }
 
   epoch_t get_effective_last_epoch_clean() const {
@@ -2298,6 +2320,7 @@ struct pg_stat_t {
   bool is_acting_osd(int32_t osd, bool primary) const;
   void dump(ceph::Formatter *f) const;
   void dump_brief(ceph::Formatter *f) const;
+  std::string dump_scrub_schedule() const;
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   static void generate_test_instances(std::list<pg_stat_t*>& o);
@@ -6023,9 +6046,6 @@ struct PushOp {
 };
 WRITE_CLASS_ENCODER_FEATURES(PushOp)
 std::ostream& operator<<(std::ostream& out, const PushOp &op);
-
-enum class scrub_level_t : bool { shallow = false, deep = true };
-enum class scrub_type_t : bool { not_repair = false, do_repair = true };
 
 /*
  * summarize pg contents for purposes of a scrub

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -1,0 +1,121 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+/**
+ * \file fmtlib formatters for some types.h classes
+ */
+
+#include "common/hobject_fmt.h"
+#include "osd/osd_types.h"
+#include "include/types_fmt.h"
+
+template <>
+struct fmt::formatter<osd_reqid_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const osd_reqid_t& req_id, FormatContext& ctx)
+  {
+    return fmt::format_to(ctx.out(),
+                          "{}.{}:{}",
+                          req_id.name,
+                          req_id.inc,
+                          req_id.tid);
+  }
+};
+
+template <>
+struct fmt::formatter<pg_shard_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const pg_shard_t& shrd, FormatContext& ctx)
+  {
+    if (shrd.is_undefined()) {
+      return fmt::format_to(ctx.out(), "?");
+    }
+    if (shrd.shard == shard_id_t::NO_SHARD) {
+      return fmt::format_to(ctx.out(), "{}", shrd.get_osd());
+    }
+    return fmt::format_to(ctx.out(), "{}({})", shrd.get_osd(), shrd.shard);
+  }
+};
+
+template <>
+struct fmt::formatter<eversion_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const eversion_t& ev, FormatContext& ctx)
+  {
+    return fmt::format_to(ctx.out(), "{}'{}", ev.epoch, ev.version);
+  }
+};
+
+template <>
+struct fmt::formatter<chunk_info_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const chunk_info_t& ci, FormatContext& ctx)
+  {
+    return fmt::format_to(ctx.out(),
+                          "(len: {} oid: {} offset: {} flags: {})",
+                          ci.length,
+                          ci.oid,
+                          ci.offset,
+                          ci.get_flag_string(ci.flags));
+  }
+};
+
+template <>
+struct fmt::formatter<object_manifest_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const object_manifest_t& om, FormatContext& ctx)
+  {
+    fmt::format_to(ctx.out(), "manifest({}", om.get_type_name());
+    if (om.is_redirect()) {
+      fmt::format_to(ctx.out(), " {}", om.redirect_target);
+    } else if (om.is_chunked()) {
+      fmt::format_to(ctx.out(), " {}", om.chunk_map);
+    }
+    return fmt::format_to(ctx.out(), ")");
+  }
+};
+
+template <>
+struct fmt::formatter<object_info_t> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const object_info_t& oi, FormatContext& ctx)
+  {
+    fmt::format_to(ctx.out(),
+                   "{}({} {} {} s {} uv {}",
+                   oi.soid,
+                   oi.version,
+                   oi.last_reqid,
+                   (oi.flags ? oi.get_flag_string() : ""),
+                   oi.size,
+                   oi.user_version);
+    if (oi.is_data_digest()) {
+      fmt::format_to(ctx.out(), " dd {:x}", oi.data_digest);
+    }
+    if (oi.is_omap_digest()) {
+      fmt::format_to(ctx.out(), " od {:x}", oi.omap_digest);
+    }
+
+    fmt::format_to(ctx.out(),
+                   " alloc_hint [{} {} {}]",
+                   oi.expected_object_size,
+                   oi.expected_write_size,
+                   oi.alloc_hint_flags);
+
+    if (oi.has_manifest()) {
+      fmt::format_to(ctx.out(), " {}", oi.manifest);
+    }
+    return fmt::format_to(ctx.out(), ")");
+  }
+};

--- a/src/osd/pg_scrubber.cc
+++ b/src/osd/pg_scrubber.cc
@@ -1898,6 +1898,20 @@ PgScrubber::PgScrubber(PG* pg)
   m_fsm->initiate();
 }
 
+void PgScrubber::set_scrub_begin_time() {
+  scrub_begin_stamp = ceph_clock_now();
+}
+
+void PgScrubber::set_scrub_duration() {
+   utime_t stamp = ceph_clock_now();
+   utime_t duration = stamp - scrub_begin_stamp;
+   m_pg->recovery_state.update_stats(
+      [=](auto &history, auto &stats) {
+       stats.scrub_duration = double(duration);
+  return true;
+    });
+}
+
 void PgScrubber::reserve_replicas()
 {
   dout(10) << __func__ << dendl;

--- a/src/osd/pg_scrubber.cc
+++ b/src/osd/pg_scrubber.cc
@@ -479,6 +479,23 @@ void PgScrubber::unreg_next_scrub()
   }
 }
 
+// a backported & modified version of Qnincy's ScrubQueue::scheduling_state()
+std::string PgScrubber::scheduling_state(utime_t now_is,
+                                         bool is_deep_expected) const
+{
+  if (!is_scrub_registered()) {
+    return "no scrub is scheduled";
+  }
+
+  // if the time has passed, we are surely in the queue
+  if (now_is > m_scrub_reg_stamp) {
+    // we are never sure that the next scrub will indeed be shallow:
+    return "queued for "s + (is_deep_expected ? "deep "s : ""s) + "scrub"s;
+  }
+
+  return "scrub is scheduled @"s + stringify(m_scrub_reg_stamp);
+}
+
 void PgScrubber::scrub_requested(scrub_level_t scrub_level,
 				 scrub_type_t scrub_type,
 				 requested_scrub_t& req_flags)
@@ -501,6 +518,7 @@ void PgScrubber::scrub_requested(scrub_level_t scrub_level,
   dout(20) << __func__ << " pg(" << m_pg_id << ") planned:" << req_flags << dendl;
 
   reg_next_scrub(req_flags);
+  m_pg->publish_stats_to_osd();
 }
 
 void PgScrubber::request_rescrubbing(requested_scrub_t& req_flags)
@@ -892,6 +910,7 @@ void PgScrubber::on_init()
 
   m_start = m_pg->info.pgid.pgid.get_hobj_start();
   m_active = true;
+  m_pg->publish_stats_to_osd();
 }
 
 void PgScrubber::on_replica_init()
@@ -1823,42 +1842,122 @@ void PgScrubber::on_digest_updates()
  * is cleared once scrubbing starts; Some of the values dumped here are
  * thus transitory.
  */
-void PgScrubber::dump(ceph::Formatter* f) const
+void PgScrubber::dump_scrubber(ceph::Formatter* f,
+                               const requested_scrub_t& request_flags) const
 {
   f->open_object_section("scrubber");
-  f->dump_stream("epoch_start") << m_interval_start;
-  f->dump_bool("active", m_active);
-  if (m_active) {
-    f->dump_stream("start") << m_start;
-    f->dump_stream("end") << m_end;
-    f->dump_stream("m_max_end") << m_max_end;
-    f->dump_stream("subset_last_update") << m_subset_last_update;
-    f->dump_bool("deep", m_is_deep);
-    f->dump_bool("must_scrub", (m_pg->m_planned_scrub.must_scrub || m_flags.required));
-    f->dump_bool("must_deep_scrub", m_pg->m_planned_scrub.must_deep_scrub);
-    f->dump_bool("must_repair", m_pg->m_planned_scrub.must_repair);
-    f->dump_bool("need_auto", m_pg->m_planned_scrub.need_auto);
-    f->dump_bool("req_scrub", m_flags.required);
-    f->dump_bool("time_for_deep", m_pg->m_planned_scrub.time_for_deep);
-    f->dump_bool("auto_repair", m_flags.auto_repair);
-    f->dump_bool("check_repair", m_flags.check_repair);
-    f->dump_bool("deep_scrub_on_error", m_flags.deep_scrub_on_error);
-    f->dump_stream("scrub_reg_stamp") << m_scrub_reg_stamp;  // utime_t
-    f->dump_unsigned("priority", m_flags.priority);
-    f->dump_int("shallow_errors", m_shallow_errors);
-    f->dump_int("deep_errors", m_deep_errors);
-    f->dump_int("fixed", m_fixed_count);
-    {
-      f->open_array_section("waiting_on_whom");
-      for (const auto& p : m_maps_status.get_awaited()) {
-	f->dump_stream("shard") << p;
-      }
-      f->close_section();
-    }
+
+  if (m_active) {  // TBD replace with PR#42780's test
+    f->dump_bool("active", true);
+    dump_active_scrubber(f, state_test(PG_STATE_DEEP_SCRUB));
+  } else {
+    f->dump_bool("active", false);
+    f->dump_bool("must_scrub",
+                 (m_pg->m_planned_scrub.must_scrub || m_flags.required));
+    f->dump_bool("must_deep_scrub", request_flags.must_deep_scrub);
+    f->dump_bool("must_repair", request_flags.must_repair);
+    f->dump_bool("need_auto", request_flags.need_auto);
+
+    f->dump_stream("scrub_reg_stamp") << m_scrub_reg_stamp;
+
+    // note that we are repeating logic that is coded elsewhere (currently
+    // PG.cc). This is not optimal.
+    bool deep_expected =
+      (ceph_clock_now() >= m_pg->next_deepscrub_interval()) ||
+      request_flags.must_deep_scrub || request_flags.need_auto;
+    auto sched_state = scheduling_state(ceph_clock_now(), deep_expected);
+    f->dump_string("schedule", sched_state);
   }
+
   f->close_section();
 }
 
+void PgScrubber::dump_active_scrubber(ceph::Formatter* f, bool is_deep) const
+{
+  f->dump_stream("epoch_start") << m_interval_start;
+  f->dump_stream("start") << m_start;
+  f->dump_stream("end") << m_end;
+  f->dump_stream("max_end") << m_max_end;
+  f->dump_stream("subset_last_update") << m_subset_last_update;
+  // note that m_is_deep will be set some time after PG_STATE_DEEP_SCRUB is
+  // asserted. Thus, using the latter.
+  f->dump_bool("deep", is_deep);
+
+  // dump the scrub-type flags
+  f->dump_bool("req_scrub", m_flags.required);
+  f->dump_bool("auto_repair", m_flags.auto_repair);
+  f->dump_bool("check_repair", m_flags.check_repair);
+  f->dump_bool("deep_scrub_on_error", m_flags.deep_scrub_on_error);
+  f->dump_unsigned("priority", m_flags.priority);
+
+  f->dump_int("shallow_errors", m_shallow_errors);
+  f->dump_int("deep_errors", m_deep_errors);
+  f->dump_int("fixed", m_fixed_count);
+  {
+    f->open_array_section("waiting_on_whom");
+    for (const auto& p : m_maps_status.get_awaited()) {
+      f->dump_stream("shard") << p;
+    }
+    f->close_section();
+  }
+  f->dump_string("schedule", "scrubbing");
+}
+
+pg_scrubbing_status_t PgScrubber::get_schedule() const
+{
+  dout(25) << __func__ << dendl;
+  auto now_is = ceph_clock_now();
+
+  if (m_active) {
+    // report current scrub info, including updated duration
+    int32_t duration = (utime_t{now_is} - scrub_begin_stamp).sec();
+
+    return pg_scrubbing_status_t{
+      utime_t{},
+      duration,
+      pg_scrub_sched_status_t::active,
+      true,  // active
+      (m_is_deep ? scrub_level_t::deep : scrub_level_t::shallow),
+      false /* is periodic? unknown, actually */};
+  }
+  if (!is_scrub_registered()) {
+    return pg_scrubbing_status_t{utime_t{},
+                                 0,
+                                 pg_scrub_sched_status_t::not_queued,
+                                 false,
+                                 scrub_level_t::shallow,
+                                 false};
+  }
+
+  // Will next scrub surely be a deep one? note that deep-scrub might be
+  // selected even if we report a regular scrub here.
+  bool deep_expected = (now_is >= m_pg->next_deepscrub_interval()) ||
+                       m_pg->m_planned_scrub.must_deep_scrub ||
+                       m_pg->m_planned_scrub.need_auto;
+  scrub_level_t expected_level =
+    deep_expected ? scrub_level_t::deep : scrub_level_t::shallow;
+  bool periodic = !m_pg->m_planned_scrub.must_scrub &&
+                  !m_pg->m_planned_scrub.need_auto &&
+                  !m_pg->m_planned_scrub.must_deep_scrub;
+
+  // are we ripe for scrubbing?
+  if (now_is > m_scrub_reg_stamp) {
+    // we are waiting for our turn at the OSD.
+    return pg_scrubbing_status_t{m_scrub_reg_stamp,
+                                 0,
+                                 pg_scrub_sched_status_t::queued,
+                                 false,
+                                 expected_level,
+                                 periodic};
+  }
+
+  return pg_scrubbing_status_t{m_scrub_reg_stamp,
+                               0,
+                               pg_scrub_sched_status_t::scheduled,
+                               false,
+                               expected_level,
+                               periodic};
+}
 
 void PgScrubber::handle_query_state(ceph::Formatter* f)
 {
@@ -1869,8 +1968,8 @@ void PgScrubber::handle_query_state(ceph::Formatter* f)
   f->dump_bool("scrubber.active", m_active);
   f->dump_stream("scrubber.start") << m_start;
   f->dump_stream("scrubber.end") << m_end;
-  f->dump_stream("scrubber.m_max_end") << m_max_end;
-  f->dump_stream("scrubber.m_subset_last_update") << m_subset_last_update;
+  f->dump_stream("scrubber.max_end") << m_max_end;
+  f->dump_stream("scrubber.subset_last_update") << m_subset_last_update;
   f->dump_bool("scrubber.deep", m_is_deep);
   {
     f->open_array_section("scrubber.waiting_on_whom");
@@ -1902,14 +2001,14 @@ void PgScrubber::set_scrub_begin_time() {
   scrub_begin_stamp = ceph_clock_now();
 }
 
-void PgScrubber::set_scrub_duration() {
-   utime_t stamp = ceph_clock_now();
-   utime_t duration = stamp - scrub_begin_stamp;
-   m_pg->recovery_state.update_stats(
-      [=](auto &history, auto &stats) {
-       stats.scrub_duration = double(duration);
-  return true;
-    });
+void PgScrubber::set_scrub_duration()
+{
+  utime_t stamp = ceph_clock_now();
+  utime_t duration = stamp - scrub_begin_stamp;
+  m_pg->recovery_state.update_stats([=](auto& history, auto& stats) {
+    stats.last_scrub_duration = ceill(duration.to_msec()/1000.0);
+    return true;
+  });
 }
 
 void PgScrubber::reserve_replicas()

--- a/src/osd/pg_scrubber.cc
+++ b/src/osd/pg_scrubber.cc
@@ -892,7 +892,7 @@ void PgScrubber::on_init()
 {
   // going upwards from 'inactive'
   ceph_assert(!is_scrub_active());
-
+  m_pg->reset_objects_scrubbed();
   preemption_data.reset();
   m_pg->publish_stats_to_osd();
   m_interval_start = m_pg->get_history().same_interval_since;
@@ -1327,6 +1327,7 @@ void PgScrubber::scrub_compare_maps()
 
     dout(2) << __func__ << ": primary (" << m_pg->get_primary() << ") has "
 	    << m_primary_scrubmap.objects.size() << " items" << dendl;
+    m_pg->add_objects_scrubbed_count(m_primary_scrubmap.objects.size());
 
     ss.str("");
     ss.clear();

--- a/src/osd/pg_scrubber.h
+++ b/src/osd/pg_scrubber.h
@@ -409,6 +409,11 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
   std::string dump_awaited_maps() const final;
 
   std::ostream& gen_prefix(std::ostream& out) const final;
+  void set_scrub_begin_time() final;
+
+  void set_scrub_duration() final;
+
+  utime_t scrub_begin_stamp;
 
  protected:
   bool state_test(uint64_t m) const { return m_pg->state_test(m); }

--- a/src/osd/pg_scrubber.h
+++ b/src/osd/pg_scrubber.h
@@ -275,6 +275,12 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
 		       requested_scrub_t& req_flags) final;
 
   /**
+   * a text description of the "scheduling intentions" of this PG:
+   * are we already scheduled for a scrub/deep scrub? when?
+   */
+  std::string scheduling_state(utime_t now_is, bool is_deep_expected) const;
+
+  /**
    * Reserve local scrub resources (managed by the OSD)
    *
    * Fails if OSD's local-scrubs budget was exhausted
@@ -284,7 +290,10 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
 
   void handle_query_state(ceph::Formatter* f) final;
 
-  void dump(ceph::Formatter* f) const override;
+  pg_scrubbing_status_t get_schedule() const final;
+
+  void dump_scrubber(ceph::Formatter* f,
+		     const requested_scrub_t& request_flags) const final;
 
   // used if we are a replica
 
@@ -464,6 +473,9 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
   void reset_epoch(epoch_t epoch_queued);
 
   void run_callbacks();
+
+  // 'query' command data for an active scrub
+  void dump_active_scrubber(ceph::Formatter* f, bool is_deep) const;
 
   // -----     methods used to verify the relevance of incoming events:
 

--- a/src/osd/scrub_machine.cc
+++ b/src/osd/scrub_machine.cc
@@ -103,6 +103,14 @@ sc::result NotActive::react(const StartScrub&)
   return transit<ReservingReplicas>();
 }
 
+sc::result NotActive::react(const AfterRepairScrub&)
+{
+  dout(10) << "NotActive::react(const AfterRepairScrub&)" << dendl;
+  DECLARE_LOCALS;
+  scrbr->set_scrub_begin_time();
+  return transit<ReservingReplicas>();
+}
+
 // ----------------------- ReservingReplicas ---------------------------------
 
 ReservingReplicas::ReservingReplicas(my_context ctx) : my_base(ctx)

--- a/src/osd/scrub_machine.cc
+++ b/src/osd/scrub_machine.cc
@@ -95,6 +95,14 @@ NotActive::NotActive(my_context ctx) : my_base(ctx)
   dout(10) << "-- state -->> NotActive" << dendl;
 }
 
+sc::result NotActive::react(const StartScrub&)
+{
+  dout(10) << "NotActive::react(const StartScrub&)" << dendl;
+  DECLARE_LOCALS;
+  scrbr->set_scrub_begin_time();
+  return transit<ReservingReplicas>();
+}
+
 // ----------------------- ReservingReplicas ---------------------------------
 
 ReservingReplicas::ReservingReplicas(my_context ctx) : my_base(ctx)
@@ -428,6 +436,14 @@ sc::result WaitDigestUpdate::react(const DigestUpdate&)
 
   scrbr->on_digest_updates();
   return discard_event();
+}
+
+sc::result WaitDigestUpdate::react(const ScrubFinished&)
+{
+  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
+  dout(10) << "WaitDigestUpdate::react(const ScrubFinished&)" << dendl;
+  scrbr->set_scrub_duration();
+  return transit<NotActive>();
 }
 
 ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub)

--- a/src/osd/scrub_machine.h
+++ b/src/osd/scrub_machine.h
@@ -153,12 +153,12 @@ struct NotActive : sc::state<NotActive, ScrubMachine> {
   explicit NotActive(my_context ctx);
 
   using reactions = mpl::list<sc::custom_reaction<StartScrub>,
-			      // a scrubbing that was initiated at recovery completion,
-			      // and requires no resource reservations:
-			      sc::transition<AfterRepairScrub, ReservingReplicas>,
+			      // a scrubbing that was initiated at recovery completion
+			      sc::custom_reaction<AfterRepairScrub>,
 			      sc::transition<StartReplica, ReplicaWaitUpdates>,
 			      sc::transition<StartReplicaNoWait, ActiveReplica>>;
   sc::result react(const StartScrub&);
+  sc::result react(const AfterRepairScrub&);
 };
 
 struct ReservingReplicas : sc::state<ReservingReplicas, ScrubMachine> {

--- a/src/osd/scrub_machine.h
+++ b/src/osd/scrub_machine.h
@@ -152,12 +152,13 @@ class ScrubMachine : public sc::state_machine<ScrubMachine, NotActive> {
 struct NotActive : sc::state<NotActive, ScrubMachine> {
   explicit NotActive(my_context ctx);
 
-  using reactions = mpl::list<sc::transition<StartScrub, ReservingReplicas>,
+  using reactions = mpl::list<sc::custom_reaction<StartScrub>,
 			      // a scrubbing that was initiated at recovery completion,
 			      // and requires no resource reservations:
 			      sc::transition<AfterRepairScrub, ReservingReplicas>,
 			      sc::transition<StartReplica, ReplicaWaitUpdates>,
 			      sc::transition<StartReplicaNoWait, ActiveReplica>>;
+  sc::result react(const StartScrub&);
 };
 
 struct ReservingReplicas : sc::state<ReservingReplicas, ScrubMachine> {
@@ -306,9 +307,10 @@ struct WaitDigestUpdate : sc::state<WaitDigestUpdate, ActiveScrubbing> {
   explicit WaitDigestUpdate(my_context ctx);
 
   using reactions = mpl::list<sc::custom_reaction<DigestUpdate>,
-			      sc::transition<NextChunk, PendingTimer>,
-			      sc::transition<ScrubFinished, NotActive>>;
+                            sc::custom_reaction<ScrubFinished>,
+                            sc::transition<NextChunk, PendingTimer>>;
   sc::result react(const DigestUpdate&);
+  sc::result react(const ScrubFinished&);
 };
 
 // ----------------------------- the "replica active" states -----------------------

--- a/src/osd/scrub_machine_lstnr.h
+++ b/src/osd/scrub_machine_lstnr.h
@@ -134,6 +134,10 @@ struct ScrubMachineListener {
 
   virtual void unreserve_replicas() = 0;
 
+  virtual void set_scrub_begin_time() = 0;
+
+  virtual void set_scrub_duration() = 0;
+
   /**
    * the FSM interface into the "are we waiting for maps, either our own or from
    * replicas" state.

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -184,7 +184,10 @@ struct ScrubPgIF {
 
   virtual void handle_query_state(ceph::Formatter* f) = 0;
 
-  virtual void dump(ceph::Formatter* f) const = 0;
+  virtual pg_scrubbing_status_t get_schedule() const = 0;
+
+  virtual void dump_scrubber(ceph::Formatter* f,
+			     const requested_scrub_t& request_flags) const = 0;
 
   /**
    * Return true if soid is currently being scrubbed and pending IOs should block.


### PR DESCRIPTION
Adding the scrub duration, scrub scheduling status and (by necessity - see below)
number-of-objects-scrubbed to the pg_dump (and query) outputs). 

Backport of https://github.com/ceph/ceph/pull/43403 and
https://github.com/ceph/ceph/pull/42977 with follow-up fixes in
https://github.com/ceph/ceph/pull/45599

The pg_stat_t version is set to 27 (Q will be released with 28)
   
    pg_stat_t versions (past and future):
    |------------------------+--------+--------+----------+---------++-------------
    | version                | master | quincy | Pacific  | pacific ||   pacific
    |                        |        |        |    RC1   |  as is  || after patch
    |------------------------+--------+--------+----------+---------++-------------
    | encode:                |   28   |   28   |     27   |   26    ||     27
    | decode:                |   28   |   28   |     26   |   26    ||     27
    |                        |        |        |          |         ||
    | avail_no_missing       |   26   |   26   |     26   |   26    ||     26
    | object_location_counts |   26   |   26   |     26   |   26    ||     26
    | last_scrub_duration    |   27   |   27   |     27   |         ||     27
    | scrub_sched_status     |        |        |          |         ||
    | > m_scheduled_at       |   27   |   27   |     27   |         ||     27
    | > m_duration_seconds   |   27   |   27   |     27   |         ||     27
    | > m_sched_status       |   27   |   27   |     27   |         ||     27
    | > m_is_active          |   27   |   27   |     27   |         ||     27
    | > m_is_deep            |   27   |   27   |     27   |         ||     27
    | > m_is_periodic        |   27   |   27   |     27   |         ||     27
    | objects_scrubbed       |   27   |   27   |      X   |         ||     27
    | scrub_duration         |   28   |   28   |          |         ||    XXXX
    | objects_trimmed        |   28   |   28   |          |         ||
    | snaptrim_duration      |   28   |   28   |          |         ||


Fixes: https://tracker.ceph.com/issues/52609
Co-Authored-By: Aishwarya Mathuria [amathuri@redhat.com](mailto:amathuri@redhat.com)