### PR TITLE
quincy: mgr/dashboard: Imrove error message of '/api/grafana/validation' API endpoint 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/grafana.py
+++ b/src/pybind/mgr/dashboard/controllers/grafana.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from .. import mgr
-from ..exceptions import DashboardException
 from ..grafana import GrafanaRestClient, push_local_dashboards
 from ..security import Scope
+from ..services.exception import handle_error
 from ..settings import Settings
 from . import APIDoc, APIRouter, BaseController, Endpoint, EndpointDoc, \
     ReadPermission, UpdatePermission
@@ -31,6 +31,7 @@ class Grafana(BaseController):
 
     @Endpoint()
     @ReadPermission
+    @handle_error('grafana')
     def validation(self, params):
         grafana = GrafanaRestClient()
         method = 'GET'
@@ -41,14 +42,8 @@ class Grafana(BaseController):
 
     @Endpoint(method='POST')
     @UpdatePermission
+    @handle_error('grafana', 500)
     def dashboards(self):
         response = dict()
-        try:
-            response['success'] = push_local_dashboards()
-        except Exception as e:  # pylint: disable=broad-except
-            raise DashboardException(
-                msg=str(e),
-                component='grafana',
-                http_status_code=500,
-            )
+        response['success'] = push_local_dashboards()
         return response

--- a/src/pybind/mgr/dashboard/services/exception.py
+++ b/src/pybind/mgr/dashboard/services/exception.py
@@ -112,3 +112,11 @@ def handle_request_error(component):
                 raise DashboardException(
                     msg=content_message, component=component)
         raise DashboardException(e=e, component=component)
+
+
+@contextmanager
+def handle_error(component, http_status_code=None):
+    try:
+        yield
+    except Exception as e:  # pylint: disable=broad-except
+        raise DashboardException(e, component=component, http_status_code=http_status_code)

--- a/src/pybind/mgr/dashboard/tests/test_grafana.py
+++ b/src/pybind/mgr/dashboard/tests/test_grafana.py
@@ -53,6 +53,14 @@ class GrafanaTest(ControllerTestCase, KVStoreMockMixin):
         self.assertStatus(200)
         self.assertBody(b'"404"')
 
+    @patch('dashboard.controllers.grafana.GrafanaRestClient.url_validation')
+    def test_validation_endpoint_fails(self, url_validation):
+        url_validation.side_effect = RequestException
+        self.server_settings()
+        self._get('/api/grafana/validation/bar')
+        self.assertStatus(400)
+        self.assertJsonBody({'detail': '', 'code': 'Error', 'component': 'grafana'})
+
     def test_dashboards_unavailable_no_url(self):
         self.server_settings(url="")
         self._post('/api/grafana/dashboards')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55379

---

backport of https://github.com/ceph/ceph/pull/45708
parent tracker: https://tracker.ceph.com/issues/55133

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh