### PR TITLE
qa/cephfs: upgrade xfstests_dev.py to run more tests

### DIFF
--- a/qa/suites/fs/functional/tasks/xfstests-dev.yaml
+++ b/qa/suites/fs/functional/tasks/xfstests-dev.yaml
@@ -1,0 +1,5 @@
+tasks:
+  - cephfs_test_runner:
+      fail_on_skip: false
+      modules:
+        - tasks.cephfs.tests_from_xfstests_dev

--- a/qa/tasks/cephfs/tests_from_xfstests_dev.py
+++ b/qa/tasks/cephfs/tests_from_xfstests_dev.py
@@ -1,0 +1,12 @@
+from logging import getLogger
+
+from tasks.cephfs.xfstests_dev import XFSTestsDev
+
+
+log = getLogger(__name__)
+
+
+class TestXFSTestsDev(XFSTestsDev):
+
+    def test_generic(self):
+        self.run_generic_tests()

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -13,7 +13,6 @@ from tasks.cephfs.kernel_mount import KernelMount
 log = getLogger(__name__)
 
 
-# TODO: add code to run non-ACL tests too.
 # TODO: make xfstests-dev tests running without running `make install`.
 class XFSTestsDev(CephFSTestCase):
 

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -17,6 +17,11 @@ log = getLogger(__name__)
 # TODO: make xfstests-dev tests running without running `make install`.
 class XFSTestsDev(CephFSTestCase):
 
+    #
+    # Following are the methods that download xfstests-dev repo and get it
+    # ready to run tests from it.
+    #
+
     RESULTS_DIR = "results"
 
     def setUp(self):
@@ -34,6 +39,7 @@ class XFSTestsDev(CephFSTestCase):
         # deletion.
         #self.xfstests_repo_path = '/path/to/xfstests-dev'
 
+        self.total_tests_failed = 0
         self.get_repos()
         self.get_test_and_scratch_dirs_ready()
         self.install_deps()
@@ -299,3 +305,100 @@ class XFSTestsDev(CephFSTestCase):
 
         self.mount_a.client_remote.write_file(join(self.xfstests_repo_path, 'ceph.exclude'),
                                               xfstests_exclude_contents, sudo=True)
+
+
+    #
+    # Following are helper methods that launch individual and groups of tests
+    # from xfstests-dev repo that is ready.
+    #
+
+    # generic helper methods
+
+    def run_test(self, cmdargs, exit_on_err=False):
+        """
+        1. exit_on_err is same as check_status in terms of functionality, a
+           different name is used to prevent confusion.
+        2. exit_on_err is set to False to make sure all tests run whether or
+           not all tests pass.
+        """
+        cmd = 'sudo env DIFF_LENGTH=0 ./check ' + cmdargs
+        # XXX: some tests can take pretty long (more than 180 or 300 seconds),
+        # let's be explicit about timeout to save troubles later.
+        timeout = None
+        p = self.mount_a.run_shell(args=cmd, cwd=self.xfstests_repo_path,
+            stdout=StringIO(), stderr=StringIO(), check_status=False,
+            omit_sudo=False, timeout=timeout)
+
+        if p.returncode != 0:
+            log.info('Command failed')
+        log.info(f'Command return value: {p.returncode}')
+
+        stdout, stderr = p.stdout.getvalue(), p.stderr.getvalue()
+
+        try:
+            self.assertEqual(p.returncode, 0)
+            # failure line that is printed some times.
+            line = 'Passed all 0 tests'
+            self.assertNotIn(line, stdout)
+            # "line" isn't printed here normally, but let's have an extra check.
+            self.assertNotIn(line, stderr)
+        except AssertionError:
+            if exit_on_err:
+                raise
+            else:
+                self.total_tests_failed += 1
+
+        return p.returncode
+
+    def run_testfile(self, testdir, testfile, exit_on_err=False):
+        return self.run_test(f'{testdir}/{testfile}', exit_on_err)
+
+    def run_testdir(self, testdir, exit_on_err=False):
+        testfiles = self.mount_a.run_shell(
+            args=f'ls tests/{testdir}', cwd=self.xfstests_repo_path).stdout.\
+            getvalue().split()
+
+        testfiles = [f for f in testfiles if f.isdigit()]
+
+        for testfile in testfiles:
+            self.run_testfile(testdir, testfile)
+
+        log.info('========================================================='
+                 f'Total number of tests failed = {self.total_tests_failed}'
+                 '=========================================================')
+
+        self.assertEqual(self.total_tests_failed, 0)
+
+    def run_testgroup(self, testgroup):
+        return self.run_test(f'-g {testgroup}')
+
+    # Running tests by directory.
+
+    def run_generic_tests(self):
+        return self.run_testdir('generic')
+
+    def run_ceph_tests(self):
+        return self.run_testdir('ceph')
+
+    def run_overlay_tests(self):
+        return self.run_testdir('overlay')
+
+    def run_shared_tests(self):
+        return self.run_testdir('shared')
+
+    # Run tests by group.
+
+    def run_auto_tests(self):
+        return self.run_testgroup('auto')
+
+    def run_quick_tests(self):
+        return self.run_testgroup('quick')
+
+    def run_rw_tests(self):
+        return self.run_testgroup('rw')
+
+    def run_acl_tests(self):
+        return self.run_testgroup('acl')
+
+    def run_stress_tests(self):
+        return self.run_testgroup('stress')


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/18475






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>