### PR TITLE
qa/cephfs: bug fix and some cleanup for test_cephfs_shell.py

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -336,7 +336,9 @@ class TestGetAndPut(TestCephFSShell):
         self.mount_a.run_shell_payload(f"rm -rf {tempdir}")
 
         self.run_cephfs_shell_cmd('get ' + tempdirname)
-        pwd = self.get_cephfs_shell_cmd_output('!pwd')
+        # NOTE: cwd=None because we want to run it at CWD, not at cephfs mntpt.
+        pwd = self.mount_a.run_shell('pwd', cwd=None).stdout.getvalue().\
+            strip()
         for file_ in files:
             if file_ == tempdirname:
                self.mount_a.run_shell_payload(f"stat {path.join(pwd, file_)}")
@@ -359,7 +361,9 @@ class TestGetAndPut(TestCephFSShell):
         o = self.get_cephfs_shell_cmd_output("get dump4 .")
         log.info("cephfs-shell output:\n{}".format(o))
 
-        o = self.get_cephfs_shell_cmd_output("!cat dump4")
+        # NOTE: cwd=None because we want to run it at CWD, not at cephfs mntpt.
+        o = self.mount_a.run_shell('cat dump4', cwd=None).stdout.getvalue().\
+            strip()
         o_hash = crypt.crypt(o, '.A')
 
         # s_hash must be equal to o_hash
@@ -381,7 +385,9 @@ class TestGetAndPut(TestCephFSShell):
 
         # get dump5 should fail
         o = self.get_cephfs_shell_cmd_output("get dump5")
-        o = self.get_cephfs_shell_cmd_output("!stat dump5 || echo $?")
+        # NOTE: cwd=None because we want to run it at CWD, not at cephfs mntpt.
+        o = self.mount_a.run_shell('stat dump5 || echo $?', cwd=None).stdout.\
+                getvalue().strip()
         log.info("cephfs-shell output:\n{}".format(o))
         l = o.split('\n')
         try:

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -383,23 +383,10 @@ class TestGetAndPut(TestCephFSShell):
         o = self.mount_a.stat('dump5')
         log.info("mount_a output:\n{}".format(o))
 
-        # get dump5 should fail
         o = self.get_cephfs_shell_cmd_output("get dump5")
         # NOTE: cwd=None because we want to run it at CWD, not at cephfs mntpt.
-        o = self.mount_a.run_shell('stat dump5 || echo $?', cwd=None).stdout.\
-                getvalue().strip()
-        log.info("cephfs-shell output:\n{}".format(o))
-        l = o.split('\n')
-        try:
-            ret = int(l[1])
-            # verify that stat dump5 passes
-            # if ret == 1, then that implies the stat failed
-            # which implies that there was a problem with "get dump5"
-            assert(ret != 1)
-        except ValueError:
-            # we have a valid stat output; so this is good
-            # if the int() fails then that means there's a valid stat output
-            pass
+        # NOTE: following command must run successfully.
+        self.mount_a.run_shell('stat dump5', cwd=None)
 
     def test_get_to_console(self):
         """


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/55394






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>