### PR TITLE
rgw: allow Arrow Flight to be built and linked into ceph components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,6 +423,7 @@ option(WITH_RADOSGW_LUA_PACKAGES "Rados Gateway's support for dynamically adding
 option(WITH_RADOSGW_DBSTORE "DBStore backend for Rados Gateway" ON)
 option(WITH_RADOSGW_MOTR "CORTX-Motr backend for Rados Gateway" OFF)
 option(WITH_RADOSGW_SELECT_PARQUET "Support for s3 select on parquet objects" ON)
+option(WITH_RADOSGW_ARROW_FLIGHT "Build arrow flight when not using system-provided arrow" OFF)
 
 option(WITH_SYSTEM_ARROW "Use system-provided arrow" OFF)
 option(WITH_SYSTEM_UTF8PROC "Use system-provided utf8proc" OFF)

--- a/cmake/modules/BuildArrow.cmake
+++ b/cmake/modules/BuildArrow.cmake
@@ -42,6 +42,15 @@ function(build_arrow)
   list(APPEND arrow_CMAKE_ARGS -DARROW_WITH_SNAPPY=ON) # required
   list(APPEND arrow_INTERFACE_LINK_LIBRARIES snappy::snappy)
 
+  if(WITH_RADOSGW_ARROW_FLIGHT)
+    message("building arrow flight; make sure grpc-plugins is installed on the system")
+    list(APPEND arrow_CMAKE_ARGS
+      -DARROW_FLIGHT=ON -DARROW_WITH_RE2=OFF)
+    find_package(gRPC REQUIRED)
+    find_package(Protobuf REQUIRED)
+    find_package(c-ares 1.13.0 QUIET REQUIRED)
+  endif(WITH_RADOSGW_ARROW_FLIGHT)
+
   list(APPEND arrow_CMAKE_ARGS -DARROW_WITH_ZLIB=ON) # required
   list(APPEND arrow_INTERFACE_LINK_LIBRARIES ZLIB::ZLIB)
 
@@ -102,6 +111,11 @@ function(build_arrow)
   set(arrow_BYPRODUCTS ${arrow_LIBRARY})
   list(APPEND arrow_BYPRODUCTS ${parquet_LIBRARY})
 
+  if(WITH_RADOSGW_ARROW_FLIGHT)
+    set(arrow_flight_LIBRARY "${arrow_LIBRARY_DIR}/libarrow_flight.a")
+    list(APPEND arrow_BYPRODUCTS ${arrow_flight_LIBRARY})
+  endif(WITH_RADOSGW_ARROW_FLIGHT)
+
   if(CMAKE_MAKE_PROGRAM MATCHES "make")
     # try to inherit command line arguments passed by parent "make" job
     set(make_cmd $(MAKE))
@@ -140,4 +154,14 @@ function(build_arrow)
   set_target_properties(Arrow::Parquet PROPERTIES
     IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
     IMPORTED_LOCATION "${parquet_LIBRARY}")
+
+  if(WITH_RADOSGW_ARROW_FLIGHT)
+    add_library(Arrow::Flight STATIC IMPORTED)
+    add_dependencies(Arrow::Flight arrow_ext)
+    target_link_libraries(Arrow::Flight INTERFACE Arrow::Arrow gRPC::grpc++)
+    set_target_properties(Arrow::Flight PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${arrow_INCLUDE_DIR}" # flight is accessed via "arrow/flight"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+      IMPORTED_LOCATION "${arrow_flight_LIBRARY}")
+  endif(WITH_RADOSGW_ARROW_FLIGHT)
 endfunction()

--- a/cmake/modules/Findc-ares.cmake
+++ b/cmake/modules/Findc-ares.cmake
@@ -21,10 +21,18 @@ find_package_handle_standard_args(c-ares
     c-ares_LIBRARY
   VERSION_VAR c-ares_VERSION)
 
-if(c-ares_FOUND AND NOT (TARGET c-ares::c-ares))
-  add_library(c-ares::c-ares UNKNOWN IMPORTED)
-  set_target_properties(c-ares::c-ares PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${c-ares_INCLUDE_DIR}"
-    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-    IMPORTED_LOCATION "${c-ares_LIBRARY}")
+if(c-ares_FOUND)
+  if(NOT TARGET c-ares)
+    add_library(c-ares UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(c-ares PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${c-ares_INCLUDE_DIR}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${c-ares_LIBRARY}")
+  endif()
+  if(NOT TARGET c-ares::c-ares)
+    add_library(c-ares::c-ares ALIAS c-ares)
+  endif()
+  if(NOT TARGET c-ares::cares)
+    add_library(c-ares::cares ALIAS c-ares)
+  endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -871,8 +871,8 @@ if(WITH_RADOSGW)
 
       include(BuildArrow)
       build_arrow()
-    endif()
-  endif()
+    endif(WITH_SYSTEM_ARROW)
+  endif(WITH_RADOSGW_SELECT_PARQUET)
 
   add_subdirectory(libkmip)
   add_subdirectory(rgw)


### PR DESCRIPTION
Arrow Flight integration is triggered by adding
-DWITH_RADOWGW_ARROW_FLIGHT=ON to the cmake invocation.
    
For now this assumes that grpc-plugins is installed on the system and
won't be built internally.
    
Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
