### PR TITLE
pacific: run-make-check.sh: enable RBD persistent caches

### DIFF
--- a/cmake/modules/Buildpmem.cmake
+++ b/cmake/modules/Buildpmem.cmake
@@ -29,7 +29,7 @@ function(build_pmem)
       # build system tests statically linking to librbd (which uses
       # libpmemobj) will not link (because we don't build the ndctl
       # static library here).
-      BUILD_COMMAND ${make_cmd} CC=${CMAKE_C_COMPILER} NDCTL_ENABLE=n BUILD_EXAMPLES=n BUILD_BENCHMARKS=n DOC=n
+      BUILD_COMMAND ${make_cmd} CC=${CMAKE_C_COMPILER} EXTRA_CFLAGS=-Wno-error NDCTL_ENABLE=n BUILD_EXAMPLES=n BUILD_BENCHMARKS=n DOC=n
       BUILD_IN_SOURCE 1
       BUILD_BYPRODUCTS "<SOURCE_DIR>/src/${PMDK_LIB_DIR}/libpmem.a" "<SOURCE_DIR>/src/${PMDK_LIB_DIR}/libpmemobj.a"
       INSTALL_COMMAND "")

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -74,6 +74,10 @@ function main() {
     if [ $WITH_ZBD ]; then
         cmake_opts+=" -DWITH_ZBD=ON"
     fi
+    if [ $WITH_RBD_RWL ]; then
+        cmake_opts+=" -DWITH_RBD_RWL=ON"
+    fi
+    cmake_opts+=" -DWITH_RBD_SSD_CACHE=ON"
     in_jenkins && echo "CI_DEBUG: Our cmake_opts are: $cmake_opts
                         CI_DEBUG: Running ./configure"
     configure $cmake_opts $@

--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -1418,7 +1418,7 @@ void AbstractWriteLog<I>::dispatch_deferred_writes(void)
       if (allocated_req && front_req && allocated) {
         /* Push dispatch of the first allocated req to a wq */
         m_work_queue.queue(new LambdaContext(
-          [this, allocated_req](int r) {
+          [allocated_req](int r) {
             allocated_req->dispatch();
           }), 0);
         allocated_req = nullptr;
@@ -1909,7 +1909,7 @@ void AbstractWriteLog<I>::new_sync_point(DeferredContexts &later) {
     /* This sync point will acquire no more sub-ops. Activation needs
      * to acquire m_lock, so defer to later*/
     later.add(new LambdaContext(
-      [this, old_sync_point](int r) {
+      [old_sync_point](int r) {
         old_sync_point->prior_persisted_gather_activate();
       }));
   }
@@ -1966,7 +1966,7 @@ void AbstractWriteLog<I>::flush_new_sync_point(C_FlushRequestT *flush_req,
    * now has its finisher. If the sub is already complete, activation will
    * complete the Gather. The finisher will acquire m_lock, so we'll activate
    * this when we release m_lock.*/
-  later.add(new LambdaContext([this, to_append](int r) {
+  later.add(new LambdaContext([to_append](int r) {
     to_append->persist_gather_activate();
   }));
 

--- a/src/librbd/cache/pwl/Request.cc
+++ b/src/librbd/cache/pwl/Request.cc
@@ -250,7 +250,7 @@ bool C_WriteRequest<T>::append_write_request(std::shared_ptr<SyncPoint> sync_poi
   std::lock_guard locker(m_lock);
   auto write_req_sp = this;
   if (sync_point->earlier_sync_point) {
-    Context *schedule_append_ctx = new LambdaContext([this, write_req_sp](int r) {
+    Context *schedule_append_ctx = new LambdaContext([write_req_sp](int r) {
         write_req_sp->schedule_append();
       });
     sync_point->earlier_sync_point->on_sync_point_appending.push_back(schedule_append_ctx);

--- a/src/librbd/cache/pwl/Types.cc
+++ b/src/librbd/cache/pwl/Types.cc
@@ -71,7 +71,7 @@ void WriteLogCacheEntry::dump(Formatter *f) const {
 }
 
 void WriteLogCacheEntry::generate_test_instances(list<WriteLogCacheEntry*>& ls) {
-  ls.push_back(new WriteLogCacheEntry);
+  ls.push_back(new WriteLogCacheEntry());
   ls.push_back(new WriteLogCacheEntry);
   ls.back()->sync_gen_number = 1;
   ls.back()->write_sequence_number = 1;
@@ -96,10 +96,11 @@ void WriteLogPoolRoot::dump(Formatter *f) const {
   f->dump_unsigned("block_size", block_size);
   f->dump_unsigned("num_log_entries", num_log_entries);
   f->dump_unsigned("first_free_entry", first_free_entry);
-  f->dump_unsigned("first_valid_entry", first_valid_entry); }
+  f->dump_unsigned("first_valid_entry", first_valid_entry);
+}
 
 void WriteLogPoolRoot::generate_test_instances(list<WriteLogPoolRoot*>& ls) {
-  ls.push_back(new WriteLogPoolRoot);
+  ls.push_back(new WriteLogPoolRoot());
   ls.push_back(new WriteLogPoolRoot);
   ls.back()->layout_version = 2;
   ls.back()->cur_sync_gen = 1;

--- a/src/librbd/cache/pwl/Types.h
+++ b/src/librbd/cache/pwl/Types.h
@@ -221,7 +221,7 @@ struct WriteLogCacheEntry {
   uint64_t write_data_pos = 0; /* SSD data offset */
   #endif
   union {
-    uint8_t flags;
+    uint8_t flags = 0;
     struct {
       uint8_t entry_valid :1; /* if 0, this entry is free */
       uint8_t sync_point :1;  /* No data. No write sequence number. Marks sync
@@ -236,9 +236,7 @@ struct WriteLogCacheEntry {
   uint32_t entry_index = 0; /* For debug consistency check. Can be removed if
                              * we need the space */
   WriteLogCacheEntry(uint64_t image_offset_bytes=0, uint64_t write_bytes=0)
-    : image_offset_bytes(image_offset_bytes), write_bytes(write_bytes),
-      entry_valid(0), sync_point(0), sequenced(0), has_data(0), discard(0), writesame(0) {
-  }
+      : image_offset_bytes(image_offset_bytes), write_bytes(write_bytes) {}
   BlockExtent block_extent();
   uint64_t get_offset_bytes();
   uint64_t get_write_bytes();

--- a/src/librbd/cache/pwl/ssd/LogOperation.cc
+++ b/src/librbd/cache/pwl/ssd/LogOperation.cc
@@ -20,7 +20,7 @@ void DiscardLogOperation::init_op(
   log_entry->init(current_sync_gen, persist_on_flush, last_op_sequence_num);
   if (persist_on_flush) {
     this->on_write_append = new LambdaContext(
-        [this, write_persist, write_append] (int r) {
+        [write_persist, write_append] (int r) {
         write_append->complete(r);
         write_persist->complete(r);
         });

--- a/src/librbd/cache/pwl/ssd/Types.h
+++ b/src/librbd/cache/pwl/ssd/Types.h
@@ -28,8 +28,15 @@ struct SuperBlock{
   }
 
   static void generate_test_instances(list<SuperBlock*>& ls) {
+    ls.push_back(new SuperBlock());
     ls.push_back(new SuperBlock);
-    ls.push_back(new SuperBlock);
+    ls.back()->root.layout_version = 3;
+    ls.back()->root.cur_sync_gen = 1;
+    ls.back()->root.pool_size = 10737418240;
+    ls.back()->root.flushed_sync_gen = 1;
+    ls.back()->root.block_size = 4096;
+    ls.back()->root.num_log_entries = 0;
+    ls.back()->root.first_free_entry = 30601;
     ls.back()->root.first_valid_entry = 2;
   }
 };

--- a/src/test/encoding/check-generated.sh
+++ b/src/test/encoding/check-generated.sh
@@ -83,7 +83,7 @@ while read type; do
 		echo "**** $type test $n binary reencode check failed ****"
 		echo "   ceph-dencoder type $type select_test $n encode export $tmp1"
 		echo "   ceph-dencoder type $type select_test $n encode decode encode export $tmp2"
-		echo "   cmp $tmp1 $tmp2"
+		diff <(hexdump -C $tmp1) <(hexdump -C $tmp2)
 		failed=$(($failed + 1))
 	    fi
 	fi


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55392

---

backport of https://github.com/ceph/ceph/pull/45872 and https://github.com/ceph/ceph/pull/46600
parent tracker: https://tracker.ceph.com/issues/55285