### PR TITLE
upgrade/pacific-x/parallel: Add prometheus metrics test

### DIFF
--- a/qa/suites/upgrade/pacific-x/stress-split/2-first-half-tasks/prometheus-metrics.yaml
+++ b/qa/suites/upgrade/pacific-x/stress-split/2-first-half-tasks/prometheus-metrics.yaml
@@ -1,0 +1,9 @@
+meta:
+- desc: |
+   run ceph mon daemon version check on prometheus metrics
+first-half-tasks:
+- workunit:
+    clients:
+      client.0:
+        - mgr/test_prometheus_metrics.sh
+- print: "**** done end prometheus-metrics.yaml"

--- a/qa/suites/upgrade/pacific-x/stress-split/4-second-half-tasks/prometheus-metrics.yaml
+++ b/qa/suites/upgrade/pacific-x/stress-split/4-second-half-tasks/prometheus-metrics.yaml
@@ -1,0 +1,9 @@
+meta:
+- desc: |
+   run ceph mon daemon version check on prometheus metrics
+second-half-tasks:
+- workunit:
+    clients:
+      client.0:
+        - mgr/test_prometheus_metrics.sh
+- print: "**** done end prometheus-metrics.yaml"

--- a/qa/workunits/mgr/test_mgr_prometheus_metrics.py
+++ b/qa/workunits/mgr/test_mgr_prometheus_metrics.py
@@ -1,0 +1,69 @@
+#! /usr/bin/env python3
+
+import errno
+import requests
+import time
+import sys
+import json
+from typing import Dict
+
+def get_mon_metadata(metadata_string: str) -> Dict[str, str]:
+    result = dict((item.strip(), str(value.strip()))
+                     for item, value in (element.split('=')
+                                  for element in metadata_string.split(',')))
+    return result
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: %s <url> <mon-metadata>" % sys.argv[0])
+        sys.exit(1)
+
+    addr = sys.argv[1]
+    json_file = sys.argv[2]
+    headers = {'Content-type': 'application/json'}
+
+    request = None
+
+    try:
+        from requests.packages.urllib3.exceptions import InsecureRequestWarning
+        requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+    except:
+        pass
+
+    try:
+        temp_file = open(json_file, 'r+')
+    except IOError as err:
+        if err.errno == errno.ENOENT:
+            assert False, \
+                "error opening '{fp}': {e}".format(fp=json_file, e=err)
+        else:
+            assert False, \
+                'some error occurred: {e}'.format(e=err)
+
+    try:
+        metadata_dump = json.load(temp_file)
+    except ValueError:
+        assert False, \
+            "{jf} content is not a valid JSON object".format(jf=json_file)
+
+    mon_metadata = {}
+    for metadata in metadata_dump:
+         mon_metadata[metadata.get('name')] = metadata.get('ceph_version')
+
+    request = requests.get(addr + '/metrics', verify=False)
+    assert(request.status_code == 200)
+    metrics_data = request.text
+    for line in str(metrics_data).split("\n"):
+        if ("ceph_mon_metadata" in line) and ("#" not in line):
+            metrics_metadata_string = line.replace('ceph_mon_metadata{','').split('}', 1)[0]
+            print(f"metrics_metadata_string : {metrics_metadata_string}")
+            metrics_mon_metadata = get_mon_metadata(metrics_metadata_string)
+            assert('ceph_version' in metrics_mon_metadata)
+            mon_name = eval(metrics_mon_metadata.get('ceph_daemon').replace('mon.',''))
+            mon_version = eval(metrics_mon_metadata.get('ceph_version'))
+            assert(mon_version != '')
+            assert(mon_version == mon_metadata[mon_name])
+            print(f"mon_metadata[{mon_name}] : {mon_version}")
+
+if __name__ == '__main__':
+    main()

--- a/qa/workunits/mgr/test_prometheus_metrics.sh
+++ b/qa/workunits/mgr/test_prometheus_metrics.sh
@@ -1,0 +1,39 @@
+#!/bin/sh -ex
+
+mydir=`dirname $0`
+
+TMP_FILE="/tmp/mon_metadata.json"
+
+function wait_for() {
+    local sec=$1
+    local cmd=$2
+
+    while true ; do
+	$cmd
+        if bash -c "$cmd" ; then
+            break
+        fi
+        sec=$(( $sec - 1 ))
+        if [ $sec -eq 0 ]; then
+            echo failed
+            return 1
+        fi
+        sleep 1
+    done
+    return 0
+}
+
+if ! ceph mgr module ls|jq '.enabled_modules'|grep -q '"prometheus"'; then
+    echo "enabling prometheus module"
+    ceph mgr module enable prometheus
+    wait_for 60 "ceph mgr module ls|jq '.enabled_modules'|grep -q '\"prometheus\"'"
+    sleep 10
+fi
+url=$(ceph mgr dump|jq -r .services.prometheus|sed -e 's/\/$//')
+test $url != null
+ceph mon metadata --format=json-pretty > $TMP_FILE
+echo "url $url $TMP_FILE"
+$mydir/test_mgr_prometheus_metrics.py $url $TMP_FILE
+rm -f $TMP_FILE
+
+echo $0 OK


### PR DESCRIPTION
On partial/full cluster upgrade, the prometheus metrics
was not reflecting the correct ceph version for the
upgraded MONs. This upgrade testcase will verify
that metrics reflecting correct ceph version for MONs.

Signed-off-by: Prashant D <pdhange@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
