### PR TITLE
rgw: fix compilation warnings in cls_fifo_legacy

### DIFF
--- a/src/rgw/cls_fifo_legacy.cc
+++ b/src/rgw/cls_fifo_legacy.cc
@@ -575,7 +575,7 @@ void FIFO::_update_meta(const DoutPrefixProvider *dpp, const fifo::update& updat
   update_meta(&op, info.version, update);
   auto updater = std::make_unique<Updater>(dpp, this, c, update, version, pcanceled,
 					   tid);
-  auto r = ioctx.aio_operate(oid, Updater::call(std::move(updater)), &op);
+  [[maybe_unused]] auto r = ioctx.aio_operate(oid, Updater::call(std::move(updater)), &op);
   assert(r >= 0);
 }
 
@@ -1289,8 +1289,8 @@ void FIFO::read_meta(const DoutPrefixProvider *dpp, std::uint64_t tid, lr::AioCo
   encode(gm, in);
   auto reader = std::make_unique<Reader>(dpp, this, c, tid);
   auto rp = reader.get();
-  auto r = ioctx.aio_exec(oid, Reader::call(std::move(reader)), fifo::op::CLASS,
-			  fifo::op::GET_META, in, &rp->bl);
+  [[maybe_unused]] auto r = ioctx.aio_exec(oid, Reader::call(std::move(reader)), fifo::op::CLASS,
+					   fifo::op::GET_META, in, &rp->bl);
   assert(r >= 0);
 }
 


### PR DESCRIPTION
```
[2045/2146] Building CXX object src/rgw/CMakeFiles/rgw_common.dir/cls_fifo_legacy.cc.o
../src/rgw/cls_fifo_legacy.cc: In member function ‘void rgw::cls::fifo::FIFO::_update_meta(const DoutPrefixProvider*, const rados::cls::fifo::update&, rados::cls::fifo::objv, bool*, uint64_t, librados::v14_2_0::AioCompletion*)’:
../src/rgw/cls_fifo_legacy.cc:578:8: warning: unused variable ‘r’ [-Wunused-variable]
  578 |   auto r = ioctx.aio_operate(oid, Updater::call(std::move(updater)), &op);
      |        ^
../src/rgw/cls_fifo_legacy.cc: In member function ‘void rgw::cls::fifo::FIFO::read_meta(const DoutPrefixProvider*, uint64_t, librados::v14_2_0::AioCompletion*)’:
../src/rgw/cls_fifo_legacy.cc:1292:8: warning: unused variable ‘r’ [-Wunused-variable]
 1292 |   auto r = ioctx.aio_exec(oid, Reader::call(std::move(reader)), fifo::op::CLASS,
      |        ^
```

Signed-off-by: Radosław Zarzyński <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
