### PR TITLE
librgw: teach librgw about rgw_backend_store

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -538,8 +538,44 @@ namespace rgw {
       g_conf()->rgw_run_sync_thread &&
       g_conf()->rgw_nfs_run_sync_thread;
 
+    bool rgw_d3n_datacache_enabled =
+        cct->_conf->rgw_d3n_l1_local_datacache_enabled;
+    if (rgw_d3n_datacache_enabled &&
+        (cct->_conf->rgw_max_chunk_size != cct->_conf->rgw_obj_stripe_size)) {
+      lsubdout(cct, rgw_datacache, 0)
+          << "rgw_d3n:  WARNING: D3N DataCache disabling (D3N requires that "
+             "the chunk_size equals stripe_size)"
+          << dendl;
+      rgw_d3n_datacache_enabled = false;
+    }
+    if (rgw_d3n_datacache_enabled && !cct->_conf->rgw_beast_enable_async) {
+      lsubdout(cct, rgw_datacache, 0)
+          << "rgw_d3n:  WARNING: D3N DataCache disabling (D3N requires yield "
+             "context - rgw_beast_enable_async=true)"
+          << dendl;
+      rgw_d3n_datacache_enabled = false;
+    }
+    lsubdout(cct, rgw, 1) << "D3N datacache enabled: "
+                          << rgw_d3n_datacache_enabled << dendl;
+
+    std::string rgw_store = (!rgw_d3n_datacache_enabled) ? "rados" : "d3n";
+
+    const auto &config_store =
+        g_conf().get_val<std::string>("rgw_backend_store");
+#ifdef WITH_RADOSGW_DBSTORE
+    if (config_store == "dbstore") {
+      rgw_store = "dbstore";
+    }
+#endif
+
+#ifdef WITH_RADOSGW_MOTR
+    if (config_store == "motr") {
+      rgw_store = "motr";
+    }
+#endif
+
     store = StoreManager::get_storage(this, g_ceph_context,
-					 "rados",
+					 rgw_store,
 					 run_gc,
 					 run_lc,
 					 run_quota,


### PR DESCRIPTION
With this change, basic i/o against dbstore works in the primary
librgw_file tests.

Fixes: https://tracker.ceph.com/issues/55430

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
