### PR TITLE
doc/radosgw/STS: sts_key and user capabilities

### DIFF
--- a/doc/radosgw/STS.rst
+++ b/doc/radosgw/STS.rst
@@ -92,20 +92,28 @@ STS Configuration
 
 The following configurable options have to be added for STS integration::
 
-  [client.radosgw.gateway]
-  rgw sts key = {sts key for encrypting the session token}
-  rgw s3 auth use sts = true
+  [client.{your-rgw-name}]
+  rgw_sts_key = {sts key for encrypting the session token}
+  rgw_s3_auth_use_sts = true
 
-Note: By default, STS and S3 APIs co-exist in the same namespace, and both S3
-and STS APIs can be accessed via the same endpoint in Ceph Object Gateway.
+Notes: 
+
+* By default, STS and S3 APIs co-exist in the same namespace, and both S3
+  and STS APIs can be accessed via the same endpoint in Ceph Object Gateway.
+* The ``rgw_sts_key`` needs to be a hex-string consisting of exactly 16 characters.
 
 Examples
 ========
+1. In order to get the example to work, make sure that the user TESTER has the ``roles`` capability assigned:
 
-1. The following is an example of AssumeRole API call, which shows steps to create a role, assign a policy to it
-(that allows access to S3 resources), assuming a role to get temporary credentials and accessing s3 resources using
-those credentials. In this example, TESTER1 assumes a role created by TESTER, to access S3 resources owned by TESTER,
-according to the permission policy attached to the role.
+.. code-block:: console
+
+   radosgw-admin caps add --uid="TESTER" --caps="roles=*"
+
+2. The following is an example of AssumeRole API call, which shows steps to create a role, assign a policy to it
+   (that allows access to S3 resources), assuming a role to get temporary credentials and accessing s3 resources using
+   those credentials. In this example, TESTER1 assumes a role created by TESTER, to access S3 resources owned by TESTER,
+   according to the permission policy attached to the role.
 
 .. code-block:: python
 

--- a/doc/radosgw/STSLite.rst
+++ b/doc/radosgw/STSLite.rst
@@ -60,9 +60,9 @@ The above STS configurables can be used with the Keystone configurables if one
 needs to use STS Lite in conjunction with Keystone. The complete set of
 configurable options will be::
 
-  [client.radosgw.gateway]
-  rgw sts key = {sts key for encrypting/ decrypting the session token}
-  rgw s3 auth use sts = true
+  [client.{your-rgw-name}]
+  rgw_sts_key = {sts key for encrypting/ decrypting the session token, exactly 16 hex characters}
+  rgw_s3_auth_use_sts = true
 
   rgw keystone url = {keystone server url:keystone server admin port}
   rgw keystone admin project = {keystone admin project name}
@@ -81,9 +81,9 @@ The details of the integrating ldap with Ceph Object Gateway can be found here:
 
 The complete set of configurables to use STS Lite with LDAP are::
 
-  [client.radosgw.gateway]
-  rgw sts key = {sts key for encrypting/ decrypting the session token}
-  rgw s3 auth use sts = true
+  [client.{your-rgw-name}]
+  rgw_sts_key = {sts key for encrypting/ decrypting the session token, exactly 16 hex characters}
+  rgw_s3_auth_use_sts = true
 
   rgw_s3_auth_use_ldap = true
   rgw_ldap_uri = {LDAP server to use}


### PR DESCRIPTION
- Mention that the `rgw_sts_key` must be exactly 16 characters long and in hex format
- Mention that the `roles` capability is needed for TESTER (the role and policy creator)

This seems to be a source of confusion for quite some time:
- https://www.mail-archive.com/search?l=ceph-users@lists.ceph.com&q=subject:%22Re%5C%3A+%5C%5Bceph%5C-users%5C%5D+How+to+use+STS+Lite+correctly%5C%3F%22&o=newest&f=1
- https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/thread/CVXNFL5VFJQQ37X3VXFQMQI5PIQA5JNF/
- https://stackoverflow.com/questions/65420090/how-to-config-ceph-rgw-sts-key

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>
- `jenkins test docs`
- `jenkins render docs`
</details>
