### PR TITLE
os/bluestore: skip SlowFastCoDel tests when CEPH_DEBUG_MUTEX is defined

### DIFF
--- a/src/test/os/bluestore/TestBlueStoreSlowFastCoDel.cc
+++ b/src/test/os/bluestore/TestBlueStoreSlowFastCoDel.cc
@@ -186,6 +186,9 @@ public:
 };
 
 TEST_F(TestSlowFastCoDel, test1) {
+  #ifdef CEPH_DEBUG_MUTEX
+  GTEST_SKIP() << "WARNING: CEPH_DEBUG_MUTEX is defined, codel will not work";
+  #endif
   create_bluestore_slow_fast_codel();
   test_codel();
 }


### PR DESCRIPTION
It seems that when the CEPH_DEBUG_MUTEX is defined, the timer fails due to an assert checking the timer lock is acquired. Skipping the test (when CEPH_DEBUG_MUTEX is defined)  should fix the problem for now.

Fixes: https://tracker.ceph.com/issues/55433
Signed-off-by: Esmaeil Mirvakili <smirvaki@ucsc.edu>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
