### PR TITLE
rgw: OpsLogFile::stop() signals under mutex

### DIFF
--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -410,6 +410,7 @@ void OpsLogFile::start() {
 
 void OpsLogFile::stop() {
   {
+    std::unique_lock lock(log_mutex);
     cond_flush.notify_one();
     stopped = true;
   }

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -398,6 +398,7 @@ void* OpsLogFile::entry() {
     }
     cond.wait(lock);
   }
+  lock.unlock();
   flush();
   return NULL;
 }

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -165,11 +165,10 @@ public:
 
 class OpsLogFile : public JsonOpsLogSink, public Thread, public DoutPrefixProvider {
   CephContext* cct;
-  ceph::mutex log_mutex = ceph::make_mutex("OpsLogFile_log");
-  ceph::mutex flush_mutex = ceph::make_mutex("OpsLogFile_flush");
+  ceph::mutex mutex = ceph::make_mutex("OpsLogFile");
   std::vector<bufferlist> log_buffer;
   std::vector<bufferlist> flush_buffer;
-  ceph::condition_variable cond_flush;
+  ceph::condition_variable cond;
   std::ofstream file;
   bool stopped;
   uint64_t data_size;


### PR DESCRIPTION
this shuts up `ceph::debug_condition_variable`'s assertion that the associated mutex is held during `notify_one()`. this is not strictly required for correct use, but is a common source of bugs

Fixes: https://tracker.ceph.com/issues/55432

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
