### PR TITLE
quincy: rgw: OpsLogFile::stop() signals under mutex

### DIFF
--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -389,6 +389,7 @@ void* OpsLogFile::entry() {
     }
     cond.wait(lock);
   }
+  lock.unlock();
   flush();
   return NULL;
 }

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -401,6 +401,7 @@ void OpsLogFile::start() {
 
 void OpsLogFile::stop() {
   {
+    std::unique_lock lock(log_mutex);
     cond_flush.notify_one();
     stopped = true;
   }

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -350,9 +350,8 @@ OpsLogFile::OpsLogFile(CephContext* cct, std::string& path, uint64_t max_data_si
 
 void OpsLogFile::flush()
 {
-  std::scoped_lock flush_lock(flush_mutex);
   {
-    std::scoped_lock log_lock(log_mutex);
+    std::scoped_lock log_lock(mutex);
     assert(flush_buffer.empty());
     flush_buffer.swap(log_buffer);
     data_size = 0;
@@ -380,7 +379,7 @@ void OpsLogFile::flush()
 }
 
 void* OpsLogFile::entry() {
-  std::unique_lock lock(log_mutex);
+  std::unique_lock lock(mutex);
   while (!stopped) {
     if (!log_buffer.empty()) {
       lock.unlock();
@@ -388,7 +387,7 @@ void* OpsLogFile::entry() {
       lock.lock();
       continue;
     }
-    cond_flush.wait(lock);
+    cond.wait(lock);
   }
   flush();
   return NULL;
@@ -401,8 +400,8 @@ void OpsLogFile::start() {
 
 void OpsLogFile::stop() {
   {
-    std::unique_lock lock(log_mutex);
-    cond_flush.notify_one();
+    std::unique_lock lock(mutex);
+    cond.notify_one();
     stopped = true;
   }
   join();
@@ -418,14 +417,14 @@ OpsLogFile::~OpsLogFile()
 
 int OpsLogFile::log_json(struct req_state* s, bufferlist& bl)
 {
-  std::unique_lock lock(log_mutex);
+  std::unique_lock lock(mutex);
   if (data_size + bl.length() >= max_data_size) {
     ldout(s->cct, 0) << "ERROR: RGW ops log file buffer too full, dropping log for txn: " << s->trans_id << dendl;
     return -1;
   }
   log_buffer.push_back(bl);
   data_size += bl.length();
-  cond_flush.notify_all();
+  cond.notify_all();
   return 0;
 }
 

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -165,11 +165,10 @@ public:
 
 class OpsLogFile : public JsonOpsLogSink, public Thread, public DoutPrefixProvider {
   CephContext* cct;
-  ceph::mutex log_mutex = ceph::make_mutex("OpsLogFile_log");
-  ceph::mutex flush_mutex = ceph::make_mutex("OpsLogFile_flush");
+  ceph::mutex mutex = ceph::make_mutex("OpsLogFile");
   std::vector<bufferlist> log_buffer;
   std::vector<bufferlist> flush_buffer;
-  ceph::condition_variable cond_flush;
+  ceph::condition_variable cond;
   std::ofstream file;
   bool stopped;
   uint64_t data_size;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55455

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
