### PR TITLE
pacific: rgw: RGWCoroutine::set_sleeping() checks for null stack

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -142,15 +142,20 @@ RGWCoroutine::~RGWCoroutine() {
 
 void RGWCoroutine::init_new_io(RGWIOProvider *io_provider)
 {
+  ceph_assert(stack); // if there's no stack, io_provider won't be uninitialized
   stack->init_new_io(io_provider);
 }
 
 void RGWCoroutine::set_io_blocked(bool flag) {
-  stack->set_io_blocked(flag);
+  if (stack) {
+    stack->set_io_blocked(flag);
+  }
 }
 
 void RGWCoroutine::set_sleeping(bool flag) {
-  stack->set_sleeping(flag);
+  if (stack) {
+    stack->set_sleeping(flag);
+  }
 }
 
 int RGWCoroutine::io_block(int ret, int64_t io_id) {
@@ -158,6 +163,9 @@ int RGWCoroutine::io_block(int ret, int64_t io_id) {
 }
 
 int RGWCoroutine::io_block(int ret, const rgw_io_id& io_id) {
+  if (!stack) {
+    return 0;
+  }
   if (stack->consume_io_finish(io_id)) {
     return 0;
   }
@@ -167,7 +175,9 @@ int RGWCoroutine::io_block(int ret, const rgw_io_id& io_id) {
 }
 
 void RGWCoroutine::io_complete(const rgw_io_id& io_id) {
-  stack->io_complete(io_id);
+  if (stack) {
+    stack->io_complete(io_id);
+  }
 }
 
 void RGWCoroutine::StatusItem::dump(Formatter *f) const {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55457

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
