### PR TITLE
tests/rgw-multi: zonegroup_data_checkpoint needs to do it twice in test_datalog_autotrim case.

### DIFF
--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -950,7 +950,9 @@ def test_datalog_autotrim():
 
     # wait for metadata and data sync to catch up
     zonegroup_meta_checkpoint(zonegroup)
-    zonegroup_data_checkpoint(zonegroup_conns)
+    # double check for every zone's data-sync completely synchronized
+    for _ in range(2):
+    	zonegroup_data_checkpoint(zonegroup_conns)
 
     # trim each datalog
     for zone, _ in zone_bucket:


### PR DESCRIPTION
Otherwise data sync may not be caught up.

Fixes: https://tracker.ceph.com/issues/56398
Signed-off-by: WeiGuo Ren <weiguo.ren@xtaotech.com>
