### PR TITLE
mount/conf: Fix IPv6 parsing

### DIFF
--- a/src/mount/conf.cc
+++ b/src/mount/conf.cc
@@ -71,9 +71,7 @@ extern "C" void mount_ceph_get_config_info(const char *config_file,
     }
 
     std::string addr;
-    addr += eaddr.ip_only_to_str();
-    addr += ":";
-    addr += std::to_string(eaddr.get_port());
+    addr += eaddr.ip_n_port_to_str();
     /* If this will overrun cci_mons, stop here */
     if (monaddrs.length() + 1 + addr.length() + 1 > sizeof(cci->cci_mons))
       break;

--- a/src/msg/msg_types.cc
+++ b/src/msg/msg_types.cc
@@ -410,3 +410,16 @@ std::string entity_addr_t::ip_only_to_str() const
   }
   return host_ip ? host_ip : "";
 }
+
+std::string entity_addr_t::ip_n_port_to_str() const
+{
+  std::string addr;
+  addr += ip_only_to_str();
+  if (is_ipv6()) {
+    addr = '[' + addr + ']';
+  }
+  addr += ':';
+  addr += std::to_string(get_port());
+  return addr;
+}
+

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -420,6 +420,7 @@ struct entity_addr_t {
   }
 
   std::string ip_only_to_str() const;
+  std::string ip_n_port_to_str() const;
 
   std::string get_legacy_str() const {
     std::ostringstream ss;


### PR DESCRIPTION
When obtaining addresses from the MonClient's monmap, IPv4/6 different parsing wasn't taken into account.
Fixes: https://tracker.ceph.com/issues/47300

Reproduced locally:
```
address from monmap: 1:2:3:4:5:6:7:8:5678,
name '1:2:3:4:5:6:7:8:5678' port '(null)'
server name not found: 1:2:3:4:5:6:7:8:5678 (Name or service not known)
```
After fix:
```
address from monmap: [1:2:3:4:5:6:7:8]:5678,
name '1:2:3:4:5:6:7:8' port '5678'
```

Signed-off-by: Matan Breizman <mbreizma@redhat.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
