### PR TITLE
OpTracker: rename osd_num_op_tracker_shard to num_op_tracker_shard

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,5 +1,6 @@
 >=18.0.0
-
+* Rename config option `osd_num_op_tracker_shard` to `num_op_tracker_shard` since it
+  also applies to mds.
 * RGW's default backend for `rgw_enable_ops_log` changed from RADOS to file.
   The default value of `rgw_ops_log_rados` is now false, and `rgw_ops_log_file_path`
   defaults to "/var/log/ceph/ops-log-$cluster-$name.log".

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3228,7 +3228,7 @@ options:
   default: true
   with_legacy: true
 # The number of shards for holding the ops
-- name: osd_num_op_tracker_shard
+- name: num_op_tracker_shard
   type: uint
   level: advanced
   default: 32

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -499,7 +499,7 @@ MDSRank::MDSRank(
     objecter(new Objecter(g_ceph_context, msgr, monc_, ioc)),
     damage_table(whoami_), sessionmap(this),
     op_tracker(g_ceph_context, g_conf()->mds_enable_op_tracker,
-               g_conf()->osd_num_op_tracker_shard),
+               g_conf()->num_op_tracker_shard),
     progress_thread(this), whoami(whoami_),
     purge_queue(g_ceph_context, whoami_,
       mdsmap_->get_metadata_pool(), objecter,

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2230,7 +2230,7 @@ OSD::OSD(CephContext *cct_,
   heartbeat_thread(this),
   heartbeat_dispatcher(this),
   op_tracker(cct, cct->_conf->osd_enable_op_tracker,
-                  cct->_conf->osd_num_op_tracker_shard),
+                  cct->_conf->num_op_tracker_shard),
   test_ops_hook(NULL),
   op_shardedwq(
     this,


### PR DESCRIPTION
since it also applies to mds.

Both mds and osd use osd_num_op_tracker_shard as op_tracker shards, so rename it as num_op_tracker_shard to remove the osd prefix.

Signed-off-by: haoyixing <haoyixing@kuaishou.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
