### PR TITLE
ceph-volume: only warn when config file isn't found

### DIFF
--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -147,8 +147,8 @@ Ceph Conf: {ceph_path}
             # we warn only here, because it is possible that the configuration
             # file is not needed, or that it will be loaded by some other means
             # (like reading from lvm tags)
-            logger.exception('ignoring inability to load ceph.conf')
-            terminal.red(error)
+            logger.warning('ignoring inability to load ceph.conf', exc_info=1)
+            terminal.yellow(error)
         # dispatch to sub-commands
         terminal.dispatch(self.mapper, subcommand_args)
 

--- a/src/ceph-volume/ceph_volume/tests/test_main.py
+++ b/src/ceph-volume/ceph_volume/tests/test_main.py
@@ -39,7 +39,7 @@ class TestVolume(object):
         assert error.value.code == 0
         log = caplog.records[-1]
         assert log.message == 'ignoring inability to load ceph.conf'
-        assert log.levelname == 'ERROR'
+        assert log.levelname == 'WARNING'
 
     def test_logs_current_command(self, caplog):
         with pytest.raises(SystemExit) as error:
@@ -50,15 +50,15 @@ class TestVolume(object):
         assert log.message == 'Running command: ceph-volume --cluster barnacle lvm --help'
         assert log.levelname == 'INFO'
 
-    def test_logs_set_level_error(self, caplog):
+    def test_logs_set_level_warning(self, caplog):
         with pytest.raises(SystemExit) as error:
-            main.Volume(argv=['ceph-volume', '--log-level', 'error', '--cluster', 'barnacle', 'lvm', '--help'])
+            main.Volume(argv=['ceph-volume', '--log-level', 'warning', '--cluster', 'barnacle', 'lvm', '--help'])
         # make sure we aren't causing an actual error
         assert error.value.code == 0
         assert caplog.records
-        # only log levels of 'ERROR' or above should be captured
+        # only log levels of 'WARNING'
         for log in caplog.records:
-            assert log.levelname in ['ERROR', 'CRITICAL']
+            assert log.levelname == 'WARNING'
 
     def test_logs_incorrect_log_level(self, capsys):
         with pytest.raises(SystemExit) as error:


### PR DESCRIPTION
According to [1], this should only be a warning.

[1] https://github.com/ceph/ceph/commit/0487a9ac60c5ba289b7dd7c730b014a298c5998f

Fixes: https://tracker.ceph.com/issues/47633

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
