### PR TITLE
doc/cephadm/services: Add missing ceph command to orch apply commands

### DIFF
--- a/doc/cephadm/services/index.rst
+++ b/doc/cephadm/services/index.rst
@@ -252,7 +252,7 @@ Daemons can be explicitly placed on hosts by simply specifying them:
 
    .. prompt:: bash #
 
-    orch apply prometheus --placement="host1 host2 host3"
+    ceph orch apply prometheus --placement="host1 host2 host3"
 
 Or in YAML:
 
@@ -269,7 +269,7 @@ MONs and other services may require some enhanced network specifications:
 
    .. prompt:: bash #
 
-    orch daemon add mon --placement="myhost:[v2:1.2.3.4:3300,v1:1.2.3.4:6789]=name"
+    ceph orch daemon add mon --placement="myhost:[v2:1.2.3.4:3300,v1:1.2.3.4:6789]=name"
 
 where ``[v2:1.2.3.4:3300,v1:1.2.3.4:6789]`` is the network address of the monitor
 and ``=name`` specifies the name of the new monitor.
@@ -315,7 +315,7 @@ this command:
 
    .. prompt:: bash #
 
-    orch apply prometheus --placement="label:mylabel"
+    ceph orch apply prometheus --placement="label:mylabel"
 
 Or in YAML:
 
@@ -334,7 +334,7 @@ Daemons can be placed on hosts as well:
 
    .. prompt:: bash #
 
-    orch apply prometheus --placement='myhost[1-3]'
+    ceph orch apply prometheus --placement='myhost[1-3]'
 
 Or in YAML:
 
@@ -348,7 +348,7 @@ To place a service on *all* hosts, use ``"*"``:
 
    .. prompt:: bash #
 
-    orch apply node-exporter --placement='*'
+    ceph orch apply node-exporter --placement='*'
 
 Or in YAML:
 
@@ -366,19 +366,19 @@ By specifying ``count``, only the number of daemons specified will be created:
 
    .. prompt:: bash #
 
-    orch apply prometheus --placement=3
+    ceph orch apply prometheus --placement=3
 
 To deploy *daemons* on a subset of hosts, specify the count:
 
    .. prompt:: bash #
 
-    orch apply prometheus --placement="2 host1 host2 host3"
+    ceph orch apply prometheus --placement="2 host1 host2 host3"
 
 If the count is bigger than the amount of hosts, cephadm deploys one per host:
 
    .. prompt:: bash #
 
-    orch apply prometheus --placement="3 host1 host2"
+    ceph orch apply prometheus --placement="3 host1 host2"
 
 The command immediately above results in two Prometheus daemons.
 


### PR DESCRIPTION
In cephadm service management documentation several of the
`ceph orch` commands are missing the `ceph ` part, mostly in
`ceph orch apply` commands but not all of them.

Add `ceph ` in the front of the command to make them consistent
with all other commands.

Signed-off-by: Ville Ojamo <14869000+bluikko@users.noreply.github.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
