### PR TITLE
rgw_rest_user_policy: Fix GetUserPolicy & ListUserPolicies responses

### DIFF
--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -25,9 +25,9 @@ using rgw::IAM::Policy;
 
 void RGWRestUserPolicy::dump(Formatter *f) const
 {
-  encode_json("Policyname", policy_name , f);
-  encode_json("Username", user_name , f);
-  encode_json("Policydocument", policy, f);
+  encode_json("PolicyName", policy_name , f);
+  encode_json("UserName", user_name , f);
+  encode_json("PolicyDocument", policy, f);
 }
 
 void RGWRestUserPolicy::send_response()
@@ -292,11 +292,11 @@ void RGWListUserPolicies::execute(optional_yield y)
         op_ret = -EIO;
         return;
       }
+      s->formatter->open_object_section("PolicyNames");
       for (const auto& p : policies) {
-        s->formatter->open_object_section("PolicyNames");
         s->formatter->dump_string("member", p.first);
-        s->formatter->close_section();
       }
+      s->formatter->close_section();
       s->formatter->close_section();
       s->formatter->close_section();
     } else {


### PR DESCRIPTION
GetUserPolicy & ListUserPolicies responses has few mistakes/typos when compared with aws documentation.
Due to this mistake, when `aws iam get-user-policy/list-user-policies` command is called it causes a blank/incorrect response.
Correcting the following mistakes with the patch.

**References**
* https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetUserPolicy.html#API_GetUserPolicy_ResponseElements
* https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListUserPolicies.html#API_ListUserPolicies_ResponseElements

**Incorrect / Empty Output**
<details> <summary>get-user-policy</summary>

```
// No response output

╰─➤  aws iam get-user-policy --endpoint-url http://localhost:8000 --user-name mgwuser --policy-name putBktDeny

```

</details>
<details> <summary>list-user-policies</summary>

```
// Incorrect response output

╰─➤  aws iam list-user-policies --endpoint-url http://localhost:8000 --user-name mgwuser
...
{2022-04-27 23:13:24,641 - MainThread - botocore.parsers - DEBUG - Response body:
b'<ListUserPoliciesResponse><ResponseMetadata><RequestId></RequestId></ResponseMetadata><ListUserPoliciesResult><PolicyNames><member>delObjDeny</member></PolicyNames><PolicyNames><member>putBktDeny</member></PolicyNames></ListUserPoliciesResult></ListUserPoliciesResponse>'
2022-04-27 23:13:24,642 - MainThread - botocore.hooks - DEBUG - Event needs-retry.iam.ListUserPolicies: calling handler <botocore.retryhandler.RetryHandler object at 0x7fa588d37128>
2022-04-27 23:13:24,642 - MainThread - botocore.retryhandler - DEBUG - No retry needed.
2022-04-27 23:13:24,642 - MainThread - botocore.hooks - DEBUG - Event after-call.iam.ListUserPolicies: calling handler <function json_decode_policies at 0x7fa58b589bf8>
{
    "PolicyNames": [
        "",
        ""
    ]
}
```

</details>

**Miskates In the Response Schema**
<details><summary>get-user-policy</summary>

```xml
<GetUserPolicyResponse>
    <ResponseMetadata>
        <RequestId></RequestId>
    </ResponseMetadata>
    <GetUserPolicyResult>
        <Policyname>putBktDeny</Policyname>  // **Tag name should be PolicyName**
	<Username>mgwuser</Username>         // **Tag name should be UserName**
	<Policydocument>                     // **Tag name should be PolicyDocument**
          {
            &quot;Version&quot; : &quot;2012-10-17&quot;,
            &quot;Statement&quot; : 
            [{
              &quot;Effect&quot; : &quot;Deny&quot;,
              &quot;Action&quot; : [ &quot;s3:CreateBucket&quot; ],
              &quot;Resource&quot; : &quot;arn:aws:s3:::*&quot;
            }]
          }\n
        </Policydocument>
    </GetUserPolicyResult>
</GetUserPolicyResponse>
```

</details>
<details><summary>list-user-policies</summary>

```xml
<ListUserPoliciesResponse>
	<ResponseMetadata>
		<RequestId></RequestId>
	</ResponseMetadata>
	<ListUserPoliciesResult> 
                ** All the member tags should enclosed in a single PolicyNames tag.**
		<PolicyNames>
			<member>delObjDeny</member>
		</PolicyNames>
		<PolicyNames>
			<member>putBktDeny</member>
		</PolicyNames>
	</ListUserPoliciesResult>
</ListUserPoliciesResponse>
```

</details>

**After the changes from the patch**
<details><summary>get-user-policy</summary>

```json
╰─➤  aws iam get-user-policy --endpoint-url http://localhost:8000 --user-name testid --policy-name putBktDeny --profile sumedh
{
    "UserName": "testid",
    "PolicyName": "putBktDeny",
    "PolicyDocument": {
        "Version": "2012-10-17",
        "Statement": [
            {
                "Effect": "Deny",
                "Action": [
                    "s3:CreateBucket"
                ],
                "Resource": "arn:aws:s3:::*"
            }
        ]
    }
}
```

</details>

<details><summary>get-user-policy</summary>

```json
╰─➤  aws iam list-user-policies --endpoint-url http://localhost:8000 --user-name testid --profile sumedh
{
    "PolicyNames": [
        "delObjDeny",
        "putBktDeny"
    ]
}
```

</details>


Signed-off-by: Sumedh A. Kulkarni <sumedh.a.kulkarni@seagate.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
