### PR TITLE
common: make LogChannel mockable

### DIFF
--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -60,7 +60,7 @@ struct clog_targets_conf_t {
  * Past queueing the LogEntry, the LogChannel is done with the whole thing.
  * LogClient will deal with sending and handling of LogEntries.
  */
-class LogChannel : public OstreamTemp::OstreamTempSink
+class LogChannel : public LoggerSinksSet
 {
 public:
 
@@ -70,10 +70,10 @@ public:
              const std::string &facility,
              const std::string &prio);
 
-  OstreamTemp debug() {
+  OstreamTemp debug() final {
     return OstreamTemp(CLOG_DEBUG, this);
   }
-  void debug(std::stringstream &s) {
+  void debug(std::stringstream &s) final {
     do_log(CLOG_DEBUG, s);
   }
   /**
@@ -93,28 +93,28 @@ public:
         ceph_abort();
     }
   }
-  OstreamTemp info() {
+  OstreamTemp info() final {
     return OstreamTemp(CLOG_INFO, this);
   }
-  void info(std::stringstream &s) {
+  void info(std::stringstream &s) final {
     do_log(CLOG_INFO, s);
   }
-  OstreamTemp warn() {
+  OstreamTemp warn() final {
     return OstreamTemp(CLOG_WARN, this);
   }
-  void warn(std::stringstream &s) {
+  void warn(std::stringstream &s) final {
     do_log(CLOG_WARN, s);
   }
-  OstreamTemp error() {
+  OstreamTemp error() final {
     return OstreamTemp(CLOG_ERROR, this);
   }
-  void error(std::stringstream &s) {
+  void error(std::stringstream &s) final {
     do_log(CLOG_ERROR, s);
   }
-  OstreamTemp sec() {
+  OstreamTemp sec() final {
     return OstreamTemp(CLOG_SEC, this);
   }
-  void sec(std::stringstream &s) {
+  void sec(std::stringstream &s) final {
     do_log(CLOG_SEC, s);
   }
 
@@ -162,8 +162,8 @@ public:
    */
   clog_targets_conf_t parse_client_options(CephContext* conf_cct);
 
-  void do_log(clog_type prio, std::stringstream& ss);
-  void do_log(clog_type prio, const std::string& s);
+  void do_log(clog_type prio, std::stringstream& ss) final;
+  void do_log(clog_type prio, const std::string& s) final;
 
 private:
   CephContext *cct;

--- a/src/common/ostream_temp.h
+++ b/src/common/ostream_temp.h
@@ -37,3 +37,20 @@ private:
   OstreamTempSink *parent;
   std::stringstream ss;
 };
+
+class LoggerSinksSet : public OstreamTemp::OstreamTempSink {
+public:
+  virtual void info(std::stringstream &s) = 0;
+  virtual void warn(std::stringstream &s) = 0;
+  virtual void error(std::stringstream &s) = 0;
+  virtual void sec(std::stringstream &s) = 0;
+  virtual void debug(std::stringstream &s) = 0;
+  virtual OstreamTemp info() = 0;
+  virtual OstreamTemp warn() = 0;
+  virtual OstreamTemp error() = 0;
+  virtual OstreamTemp sec() = 0;
+  virtual OstreamTemp debug() = 0;
+  virtual void do_log(clog_type prio, std::stringstream& ss) = 0;
+  virtual void do_log(clog_type prio, const std::string& ss) = 0;
+  virtual ~LoggerSinksSet() {};
+};

--- a/src/crimson/common/logclient.h
+++ b/src/crimson/common/logclient.h
@@ -58,7 +58,7 @@ int parse_log_client_options(CephContext *cct,
  * Past queueing the LogEntry, the LogChannel is done with the whole thing.
  * LogClient will deal with sending and handling of LogEntries.
  */
-class LogChannel : public OstreamTemp::OstreamTempSink
+class LogChannel : public LoggerSinksSet
 {
 public:
   LogChannel(LogClient *lc, const std::string &channel);
@@ -68,7 +68,7 @@ public:
   OstreamTemp debug() {
     return OstreamTemp(CLOG_DEBUG, this);
   }
-  void debug(std::stringstream &s) {
+  void debug(std::stringstream &s) final {
     do_log(CLOG_DEBUG, s);
   }
   /**
@@ -88,28 +88,28 @@ public:
         ceph_abort();
     }
   }
-  OstreamTemp info() {
+  OstreamTemp info() final {
     return OstreamTemp(CLOG_INFO, this);
   }
-  void info(std::stringstream &s) {
+  void info(std::stringstream &s) final {
     do_log(CLOG_INFO, s);
   }
-  OstreamTemp warn() {
+  OstreamTemp warn() final {
     return OstreamTemp(CLOG_WARN, this);
   }
-  void warn(std::stringstream &s) {
+  void warn(std::stringstream &s) final {
     do_log(CLOG_WARN, s);
   }
-  OstreamTemp error() {
+  OstreamTemp error() final {
     return OstreamTemp(CLOG_ERROR, this);
   }
-  void error(std::stringstream &s) {
+  void error(std::stringstream &s) final {
     do_log(CLOG_ERROR, s);
   }
-  OstreamTemp sec() {
+  OstreamTemp sec() final {
     return OstreamTemp(CLOG_SEC, this);
   }
-  void sec(std::stringstream &s) {
+  void sec(std::stringstream &s) final {
     do_log(CLOG_SEC, s);
   }
 
@@ -163,8 +163,8 @@ public:
 		     uuid_d &fsid,
 		     std::string &host);
 
-  void do_log(clog_type prio, std::stringstream& ss);
-  void do_log(clog_type prio, const std::string& s);
+  void do_log(clog_type prio, std::stringstream& ss) final;
+  void do_log(clog_type prio, const std::string& s) final;
 
 private:
   LogClient *parent;


### PR DESCRIPTION
Adding LoggerSinksSet, an abstract API that enables unit-testing
of OSD components that emit log messages, and trapping the
logs.


Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
