### PR TITLE
pacific: tooling: Change mrun to use bash

### DIFF
--- a/src/mrun
+++ b/src/mrun
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 [ $# -lt 2 ] && echo "usage: $0 <name> <command> [params...]" && exit 1
 


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/45975 to pacific to avoid
```
../src/mrun: 24: [: unexpected operator
```
errors interfering with output captures.