### PR TITLE
cmake/rgw: add missing dependency on Arrow::Arrow

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -4,7 +4,7 @@ if(NOT GPERF)
 endif()
 
 if(WITH_RADOSGW_SELECT_PARQUET)
-  set(ARROW_LIBRARIES Arrow::Parquet)
+  set(ARROW_LIBRARIES Arrow::Arrow Arrow::Parquet)
   add_definitions(-D_ARROW_EXIST)
   message("-- arrow is installed, radosgw/s3select-op is able to process parquet objects")
 endif(WITH_RADOSGW_SELECT_PARQUET)


### PR DESCRIPTION
when WITH_SYSTEM_ARROW is disabled, BuildArrow.cmake creates an Arrow::Parquet target that depends on Arrow::Arrow:
```cmake
  target_link_libraries(Arrow::Parquet INTERFACE Arrow::Arrow)
```
but when WITH_SYSTEM_ARROW is enabled, the targets we get from find_package() do not carry this dependency. so rgw's cmake needs to depend on both targets

Fixes: https://tracker.ceph.com/issues/55420

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
