### PR TITLE
rgw: fix segfault inside RGWRESTConn constructor

### DIFF
--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -21,7 +21,7 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct, rgw::sal::Store* store,
     api_name(_api_name),
     host_style(_host_style)
 {
-  if (store) {
+  if (store && store->get_zone()) {
     key = store->get_zone()->get_system_key();
     self_zone_group = store->get_zone()->get_zonegroup().get_id();
   }


### PR DESCRIPTION
fix segfault inside RGWRESTConn constructor
Fix [45623](https://github.com/ceph/ceph/pull/45623)

While configuring multisite, the primary site is getting segfault
Signed-off-by: Or Friedmann <ofriedma@redhat.com>



