### PR TITLE
global/global_init: set keepcaps flag before switching UID

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -27,6 +27,16 @@ options:
   - osd_numa_auto_affinity
   flags:
   - startup
+- name: set_keepcaps
+  type: bool
+  level: advanced
+  desc: set the keepcaps flag before changing UID, preserving the permitted capability set
+  long_desc: When ceph switches from root to the ceph uid, all capabilities in all sets are eraseed. If
+    a component that is capability aware needs a specific capability, the keepcaps flag maintains
+     the permitted capability set, allowing the capabilities in the effective set to be activated as needed.
+  default: false
+  flags:
+  - startup
 - name: osd_smart_report_timeout
   type: uint
   level: advanced

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -313,6 +313,13 @@ global_init(const std::map<std::string,std::string> *defaults,
 	     << std::endl;
 	exit(1);
       }
+#if defined(HAVE_SYS_PRCTL_H)
+      if (g_conf().get_val<bool>("set_keepcaps")) {
+	if (prctl(PR_SET_KEEPCAPS, 1) == -1) {
+	  cerr << "warning: unable to set keepcaps flag: " << cpp_strerror(errno) << std::endl;
+	}
+      }
+#endif
       if (setuid(uid) != 0) {
 	cerr << "unable to setuid " << uid << ": " << cpp_strerror(errno)
 	     << std::endl;


### PR DESCRIPTION
Plugins running under ceph communicating with devices via vendor specific
NVME commands may need additional capabilities to communicate with the
device. This patch allows, when configured via an option, to maintain
the permitted capbility set across an setuid switch from root to ceph user.
It allows capability aware plugins to add capabilities to the effective
set when needed while preventing capability unaware code from accidentally
making use of these capabilities.

Signed-off-by: Martin Ohmacht <mohmacht@us.ibm.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
