### PR TITLE
mgr/cephadm: filtering out /32 net masks for ipv4

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4741,6 +4741,10 @@ def infer_mon_network(ctx: CephadmContext, mon_eps: List[EndPoint]) -> Optional[
     # Make sure IP is configured locally, and then figure out the CIDR network
     mon_networks = []
     for net, ifaces in list_networks(ctx).items():
+
+        if '/' not in net:  # discard /32 single host Ipv4 nets
+            continue
+
         # build local_ips list for the specified network
         local_ips: List[str] = []
         for _, ls in ifaces.items():


### PR DESCRIPTION
On Ubuntu 18.04 (and I guess in general when system-networkd detects dhcp) `ip route ls` lists /32 (single host) subnets without the mask `/XX`. As consequence, we could end up with these subnets in the` public_network` list and causing a failure later on the monitor. The solution consists in filtering out these subnets for ipv4 (as it doesn't make sense to have the monitor picking its up from a single host net!).

```
root@ubuntu1804:~# ip route ls
default via 192.168.122.1 dev ens3 proto dhcp src 192.168.122.236 metric 100 
192.168.122.0/24 dev ens3 proto kernel scope link src 192.168.122.236 
192.168.122.1 dev ens3 proto dhcp scope link src 192.168.122.236 metric 100 
root@ubuntu1804:~# 

```
**Note:** 
UT is fixed as well as it was listing as valid these kind of subnets.

Fixes: https://tracker.ceph.com/issues/55492
Signed-off-by: Redouane Kachach <rkachach@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
