### PR TITLE
systest: fix race with pool delete after socket injection

### DIFF
--- a/src/test/system/rados_delete_pools_parallel.cc
+++ b/src/test/system/rados_delete_pools_parallel.cc
@@ -68,12 +68,14 @@ int main(int argc, const char **argv)
   RETURN1_IF_NONZERO(CrossProcessSem::create(0, &pool_setup_sem));
   CrossProcessSem *delete_pool_sem = NULL;
   RETURN1_IF_NONZERO(CrossProcessSem::create(0, &delete_pool_sem));
+  CrossProcessSem *deleted_pool_sem = NULL;
+  RETURN1_IF_NONZERO(CrossProcessSem::create(0, &deleted_pool_sem));
 
   // first test: create a pool, then delete that pool
   {
     StRadosCreatePool r1(argc, argv, NULL, pool_setup_sem, NULL,
 			 pool, 50, ".obj");
-    StRadosDeletePool r2(argc, argv, pool_setup_sem, NULL, pool);
+    StRadosDeletePool r2(argc, argv, pool_setup_sem, deleted_pool_sem, pool);
     vector < SysTestRunnable* > vec;
     vec.push_back(&r1);
     vec.push_back(&r2);
@@ -89,7 +91,7 @@ int main(int argc, const char **argv)
   RETURN1_IF_NONZERO(pool_setup_sem->reinit(0));
   RETURN1_IF_NONZERO(delete_pool_sem->reinit(0));
   {
-    StRadosCreatePool r1(argc, argv, NULL, pool_setup_sem, NULL,
+    StRadosCreatePool r1(argc, argv, deleted_pool_sem, pool_setup_sem, NULL,
 			 pool, g_num_objects, ".obj");
     StRadosDeletePool r2(argc, argv, delete_pool_sem, NULL, pool);
     StRadosListObjects r3(argc, argv, pool, true, g_num_objects / 2,


### PR DESCRIPTION
Adding another semaphore for the second test to create pools only after the
first test delete complete.

Fixes: https://tracker.ceph.com/issues/43887
Signed-off-by: Nitzan Mordechai <nmordec@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
