### PR TITLE
tool: modify object-dedup command to run on manifest object

### DIFF
--- a/qa/workunits/rados/test_dedup_tool.sh
+++ b/qa/workunits/rados/test_dedup_tool.sh
@@ -323,6 +323,17 @@ function test_dedup_object()
     $CEPH_TOOL osd pool delete $CHUNK_POOL $CHUNK_POOL --yes-i-really-really-mean-it
     die "Scrub failed expecting bar is removed"
   fi
+  # rerun tier-flush
+
+  RESULT=$($DEDUP_TOOL --pool $POOL --op object-dedup --object bar --chunk-pool $CHUNK_POOL --fingerprint-algorithm sha1 --dedup-cdc-chunk-size 4096)
+
+  CHUNK_OID=$(echo -n "There HIHIHI" | sha1sum | awk '{print $1}')
+  RESULT=$($DEDUP_TOOL --op dump-chunk-refs --chunk-pool $CHUNK_POOL --object $CHUNK_OID | grep bar)
+  if [ -z "$RESULT" ] ; then
+    $CEPH_TOOL osd pool delete $POOL $POOL --yes-i-really-really-mean-it
+    $CEPH_TOOL osd pool delete $CHUNK_POOL $CHUNK_POOL --yes-i-really-really-mean-it
+    die "Scrub failed expecting bar is removed"
+  fi
 
   $CEPH_TOOL osd pool delete $CHUNK_POOL $CHUNK_POOL --yes-i-really-really-mean-it
 

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -758,8 +758,11 @@ inline namespace v14_2_0 {
     void set_chunk(uint64_t src_offset, uint64_t src_length, const IoCtx& tgt_ioctx,
                    std::string tgt_oid, uint64_t tgt_offset, int flag = 0);
     /**
-     * flush a manifest tier object to backing tier; will block racing
-     * updates.
+     * flush a manifest tier object to backing tier, performing deduplication;
+     * will block racing updates.
+     *
+     * Invoking tier_flush() implicitly makes a manifest object even if
+     * the target object is not manifest. 
      */
     void tier_flush();
     /**

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7430,6 +7430,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	oi.clear_data_digest();
 	ctx->delta_stats.num_wr++;
 	ctx->cache_operation = true;
+	ctx->undirty = true;
 	osd->logger->inc(l_osd_tier_evict);
       }
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7388,13 +7388,9 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  result = -EOPNOTSUPP;
 	  break;
 	}
-	if (!obs.oi.has_manifest()) {
-	  result = 0;
-	  break;
-	}
 
-	if (oi.is_dirty()) {
-	  result = start_flush(ctx->op, ctx->obc, true, NULL, std::nullopt);
+	if (oi.is_dirty() || !obs.oi.has_manifest()) {
+	  result = start_flush(ctx->op, ctx->obc, true, NULL, std::nullopt, true);
 	  if (result == -EINPROGRESS)
 	    result = -EAGAIN;
 	} else {
@@ -10675,6 +10671,11 @@ int PrimaryLogPG::finish_set_dedup(hobject_t oid, int r, ceph_tid_t tid, uint64_
     ctx->new_obs = obc->obs;
     ctx->new_obs.oi.clear_flag(object_info_t::FLAG_DIRTY);
     --ctx->delta_stats.num_objects_dirty;
+    if (!ctx->obs->oi.has_manifest()) {
+      ctx->delta_stats.num_objects_manifest++;
+      ctx->new_obs.oi.set_flag(object_info_t::FLAG_MANIFEST);
+      ctx->new_obs.oi.manifest.type = object_manifest_t::TYPE_CHUNKED;
+    }
 
     /* 
     * Let's assume that there is a manifest snapshotted object, and we issue tier_flush() to head.
@@ -10756,7 +10757,8 @@ int PrimaryLogPG::finish_set_manifest_refcount(hobject_t oid, int r, ceph_tid_t 
 int PrimaryLogPG::start_flush(
   OpRequestRef op, ObjectContextRef obc,
   bool blocking, hobject_t *pmissing,
-  std::optional<std::function<void()>> &&on_flush)
+  std::optional<std::function<void()>> &&on_flush,
+  bool force_dedup)
 {
   const object_info_t& oi = obc->obs.oi;
   const hobject_t& soid = oi.soid;
@@ -10778,7 +10780,8 @@ int PrimaryLogPG::start_flush(
     snapset = obc->ssc->snapset;
   }
 
-  if (obc->obs.oi.has_manifest() && obc->obs.oi.manifest.is_chunked()) {
+  if ((obc->obs.oi.has_manifest() && obc->obs.oi.manifest.is_chunked())
+      || force_dedup) {
     // current dedup tier only supports blocking operation
     if (!blocking) {
       return -EOPNOTSUPP;
@@ -10854,7 +10857,8 @@ int PrimaryLogPG::start_flush(
     osd->objecter->op_cancel(tids, -ECANCELED);
   }
 
-  if (obc->obs.oi.has_manifest() && obc->obs.oi.manifest.is_chunked()) {
+  if ((obc->obs.oi.has_manifest() && obc->obs.oi.manifest.is_chunked())
+      || force_dedup) {
     int r = start_dedup(op, obc);
     if (r != -EINPROGRESS) {
       if (blocking)

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1356,7 +1356,8 @@ protected:
   int start_flush(
     OpRequestRef op, ObjectContextRef obc,
     bool blocking, hobject_t *pmissing,
-    std::optional<std::function<void()>> &&on_flush);
+    std::optional<std::function<void()>> &&on_flush,
+    bool force_dedup = false);
   void finish_flush(hobject_t oid, ceph_tid_t tid, int r);
   int try_flush_mark_clean(FlushOpRef fop);
   void cancel_flush(FlushOpRef fop, bool requeue, std::vector<ceph_tid_t> *tids);


### PR DESCRIPTION
Existing object-dedup command always creates temporary object and
perform set-chunk---this is because the object-dedup  assumes that
a target object is not manifest. However, object-dedup should work
even if the target object is already manifest object (Without this
change, this probably works. But, it entails unnecessary overhead)

To do so, this commit makes tier-flush simple by changing
the object's attribute to manifest implicitly if the target object is not manifest. 

As a result, object-dedup can run on either manifest or non-manifest objects.

Signed-off-by: Myoungwon Oh <myoungwon.oh@samsung.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
