### PR TITLE
doc/rados/api: fix invalid RST syntax and don't sudo for vim

### DIFF
--- a/doc/rados/api/python.rst
+++ b/doc/rados/api/python.rst
@@ -20,10 +20,11 @@ perform object operations as a ``client.admin`` user.
 .. note:: To use the Ceph Python bindings, you must have access to a
    running Ceph cluster. To set one up quickly, see `Getting Started`_.
 
-First, create a Python source file for your Ceph client. ::
-   :linenos:
+First, create a Python source file for your Ceph client.
 
-	sudo vim client.py
+.. prompt:: bash
+
+	vim client.py
 
 
 Import the Module

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -2994,7 +2994,7 @@ returned %d, but should return zero on success." % (self.name, ret))
 
             - ``num_object_copies`` (int) - number of object copies
 
-            - ``num_objects_missing_on_primary`` (int) - number of objets
+            - ``num_objects_missing_on_primary`` (int) - number of objects
                 missing on primary
 
             - ``num_objects_unfound`` (int) - number of unfound objects


### PR DESCRIPTION
Fix invalid syntax where "linenos:" was printed in the
final rendered documentation instead of being used as
formatting syntax.

There is no need to use sudo for editing a source file
so run vim without sudo.

Change the whole block to use bash prompt since it is
a command.

Also modify the preceding text to hopefully not bold it
so it is consistent with other such blocks in the doc.

This PR also includes a single-letter fix to pybind/rados
to add missing "c" in "objects" to the documentation
block of Ioctx.get_stats()


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
