### PR TITLE
pacific: rgw: Avoid segfault when OPA authz is enabled

### DIFF
--- a/src/rgw/rgw_opa.cc
+++ b/src/rgw/rgw_opa.cc
@@ -44,10 +44,18 @@ int rgw_opa_authorize(RGWOp *& op,
   jf.dump_string("decoded_uri", s->decoded_uri.c_str());
   jf.dump_string("params", s->info.request_params.c_str());
   jf.dump_string("request_uri_aws4", s->info.request_uri_aws4.c_str());
-  jf.dump_string("object_name", s->object->get_name().c_str());
-  jf.dump_string("subuser", s->auth.identity->get_subuser().c_str());
-  jf.dump_object("user_info", s->user->get_info());
-  jf.dump_object("bucket_info", s->bucket->get_info());
+  if (s->object) {
+    jf.dump_string("object_name", s->object->get_name().c_str());
+  }
+  if (s->auth.identity) {
+    jf.dump_string("subuser", s->auth.identity->get_subuser().c_str());
+  }
+  if (s->user) {
+    jf.dump_object("user_info", s->user->get_info());
+  }
+  if (s->bucket) {
+    jf.dump_object("bucket_info", s->bucket->get_info());
+  }
   jf.close_section();
   jf.close_section();
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55500

---

backport of https://github.com/ceph/ceph/pull/45873
parent tracker: https://tracker.ceph.com/issues/55286

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh