### PR TITLE
cephfs-shell: make onecmd() print proper error msg

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -18,6 +18,7 @@ import errno
 
 from cmd2 import Cmd
 from cmd2 import __version__ as cmd2_version
+from cmd2.exceptions import Cmd2ArgparseError
 from distutils.version import LooseVersion
 
 if sys.version_info.major < 3:
@@ -466,7 +467,13 @@ class CephFSShell(Cmd):
         except (libcephfs.Error, Exception) as e:
             if shell.debug:
                 traceback.print_exc(file=sys.stdout)
-            set_exit_code_msg(msg=e)
+            if isinstance(e, Cmd2ArgparseError):
+                # NOTE: In case of Cmd2ArgparseError the error message is
+                # already printed beforehand (plus Cmd2ArgparseError
+                # instances have empty message)
+                pass
+            else:
+                set_exit_code_msg(msg=f'{type(e).__name__}: {e}')
 
     class path_to_bytes(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):


### PR DESCRIPTION
Rationale: Whenever a python exception occurred in cephfs-shell,
           it would often only be the exception message but doesn't
           say anything about the type of exception. For example if
           `ZeroDivisionError: division by zero` occurred, the onecmd()
           would print `division by zero` but will omit the type of
           exception. In this case it's easy to understand but let's
           say an `KeyError` exception occurred for a key `9999` which
           is not existent in the dictionary, onecmd() would print
           just `9999` in this scenario and it would be very difficult
           to interpret what type of error it is.

Fixes: https://tracker.ceph.com/issues/55536

Signed-off-by: Dhairya Parmar <dparmar@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
