### PR TITLE
quincy: mount/conf: Fix IPv6 parsing

### DIFF
--- a/src/mount/conf.cc
+++ b/src/mount/conf.cc
@@ -71,9 +71,7 @@ extern "C" void mount_ceph_get_config_info(const char *config_file,
     }
 
     std::string addr;
-    addr += eaddr.ip_only_to_str();
-    addr += ":";
-    addr += std::to_string(eaddr.get_port());
+    addr += eaddr.ip_n_port_to_str();
     /* If this will overrun cci_mons, stop here */
     if (monaddrs.length() + 1 + addr.length() + 1 > sizeof(cci->cci_mons))
       break;

--- a/src/msg/msg_types.cc
+++ b/src/msg/msg_types.cc
@@ -410,3 +410,16 @@ std::string entity_addr_t::ip_only_to_str() const
   }
   return host_ip ? host_ip : "";
 }
+
+std::string entity_addr_t::ip_n_port_to_str() const
+{
+  std::string addr;
+  addr += ip_only_to_str();
+  if (is_ipv6()) {
+    addr = '[' + addr + ']';
+  }
+  addr += ':';
+  addr += std::to_string(get_port());
+  return addr;
+}
+

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -400,6 +400,7 @@ struct entity_addr_t {
   }
 
   std::string ip_only_to_str() const;
+  std::string ip_n_port_to_str() const;
 
   std::string get_legacy_str() const {
     std::ostringstream ss;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55513

---

backport of https://github.com/ceph/ceph/pull/46051
parent tracker: https://tracker.ceph.com/issues/47300

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh