### PR TITLE
mgr/dashboard: Throughput optimized osd deployment option.

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -86,7 +86,20 @@ predefined_drive_groups = {
         },
         'encrypted': False
     },
-    OsdDeploymentOptions.THROUGHPUT: {},
+    OsdDeploymentOptions.THROUGHPUT: {
+        'service_type': 'osd',
+        'service_id': 'throughput_optimized',
+        'placement': {
+            'host_pattern': '*'
+        },
+        'data_devices': {
+            'rotational': 1
+        },
+        'db_devices': {
+            'rotational': 0
+        },
+        'encrypted': False
+    },
     OsdDeploymentOptions.IOPS: {},
 }
 
@@ -337,12 +350,13 @@ class Osd(RESTController):
 
     def _create_predefined_drive_group(self, data):
         orch = OrchClient.instance()
-        if OsdDeploymentOptions(data[0]['option']) == OsdDeploymentOptions.COST_CAPACITY:
+        option = OsdDeploymentOptions(data[0]['option'])
+        if option in list(OsdDeploymentOptions):
             try:
                 predefined_drive_groups[
-                    OsdDeploymentOptions.COST_CAPACITY]['encrypted'] = data[0]['encrypted']
+                    option]['encrypted'] = data[0]['encrypted']
                 orch.osds.create([DriveGroupSpec.from_json(
-                    predefined_drive_groups[OsdDeploymentOptions.COST_CAPACITY])])
+                    predefined_drive_groups[option])])
             except (ValueError, TypeError, DriveGroupValidationError) as e:
                 raise DashboardException(e, component='osd')
 
@@ -490,6 +504,10 @@ class OsdUi(Osd):
         if hdds:
             res.options[OsdDeploymentOptions.COST_CAPACITY].available = True
             res.recommended_option = OsdDeploymentOptions.COST_CAPACITY
+        if ssds:
+            res.options[OsdDeploymentOptions.THROUGHPUT].available = True
+            res.recommended_option = OsdDeploymentOptions.THROUGHPUT
+
         return res.as_dict()
 
 


### PR DESCRIPTION
With this deployment option we inlcude `db_devices` with `rotational: 0` (ssd) when there are ssds in the host. `wal_devices` are not included as it [looks like](https://docs.ceph.com/en/quincy/rados/configuration/bluestore-config-ref/#:~:text=If%20there%20is,the%20faster%20device.) `db_devices` impilcitly include `wal_devices`.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
