### PR TITLE
rgw/dbstore: Support user creation via `radosgw-admin`

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3456,6 +3456,20 @@ options:
   - rados
   - dbstore
   - motr
+- name: dbstore_db_dir
+  type: str
+  level: advanced
+  desc: path for the directory for storing the db backend store data
+  default: /var/run/ceph
+  services:
+  - rgw
+- name: dbstore_db_name_prefix
+  type: str
+  level: advanced
+  desc: prefix to the file names created by db backend store
+  default: dbstore
+  services:
+  - rgw
 - name: motr_profile_fid
   type: str
   level: advanced

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -156,7 +156,7 @@ namespace rgw::sal {
   int DBUser::read_attrs(const DoutPrefixProvider* dpp, optional_yield y)
   {
     int ret;
-    ret = store->getDB()->get_user(dpp, string("user_id"), "", info, &attrs,
+    ret = store->getDB()->get_user(dpp, string("user_id"), get_id().id, info, &attrs,
         &objv_tracker);
     return ret;
   }
@@ -196,7 +196,7 @@ namespace rgw::sal {
   {
     int ret = 0;
 
-    ret = store->getDB()->get_user(dpp, string("user_id"), "", info, &attrs,
+    ret = store->getDB()->get_user(dpp, string("user_id"), get_id().id, info, &attrs,
         &objv_tracker);
 
     return ret;
@@ -1660,7 +1660,7 @@ namespace rgw::sal {
   int DBStore::get_user_by_swift(const DoutPrefixProvider *dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user)
   {
     /* Swift keys and subusers are not supported for now */
-    return 0;
+    return -ENOTSUP;
   }
 
   std::string DBStore::get_cluster_id(const DoutPrefixProvider* dpp,  optional_yield y)

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -421,6 +421,11 @@ void RGWUserAdminOpState::set_user_info(RGWUserInfo& user_info)
   user->get_info() = user_info;
 }
 
+void RGWUserAdminOpState::set_user_version_tracker(RGWObjVersionTracker& objv_tracker)
+{
+  user->get_version_tracker() = objv_tracker;
+}
+
 const rgw_user& RGWUserAdminOpState::get_user_id()
 {
   return user->get_id();
@@ -1515,6 +1520,7 @@ int RGWUser::init(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state, 
     op_state.set_user_info(user->get_info());
     op_state.set_populated();
     op_state.objv = user->get_version_tracker();
+    op_state.set_user_version_tracker(user->get_version_tracker());
 
     old_info = user->get_info();
     set_populated();
@@ -1568,6 +1574,8 @@ int RGWUser::update(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state
 
   ret = user->store_user(dpp, y, false, pold_info);
   op_state.objv = user->get_version_tracker();
+  op_state.set_user_version_tracker(user->get_version_tracker());
+
   if (ret < 0) {
     set_err_msg(err_msg, "unable to store user info");
     return ret;
@@ -1717,6 +1725,7 @@ int RGWUser::execute_rename(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
   RGWUserInfo& user_info = op_state.get_user_info();
   user_info.user_id = new_user->get_id();
   op_state.objv = user->get_version_tracker();
+  op_state.set_user_version_tracker(user->get_version_tracker());
 
   rename_swift_keys(new_user->get_id(), user_info.swift_keys);
 

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -299,6 +299,8 @@ struct RGWUserAdminOpState {
 
   void set_user_info(RGWUserInfo& user_info);
 
+  void set_user_version_tracker(RGWObjVersionTracker& objv_tracker);
+
   void set_max_buckets(int32_t mb) {
     max_buckets = mb;
     max_buckets_specified = true;

--- a/src/rgw/store/dbstore/README.md
+++ b/src/rgw/store/dbstore/README.md
@@ -26,7 +26,12 @@ Restart vstart cluster or just RGW server
 
 The above configuration brings up RGW server on dbstore and creates testid user to be used for s3 operations.
 
-By default, dbstore creates .db file named 'default_ns.db' where in the data is stored.
+
+By default, dbstore creates .db file *'/var/run/ceph/dbstore-default_ns.db'* to store the data. This can be configured using below options in ceph.conf
+
+    [client]
+        dbstore db dir = <path for the directory for storing the db backend store data>
+        dbstore db name prefix = <prefix to the file names created by db backend store>
 
 
 ## DBStore Unit Tests

--- a/src/rgw/store/dbstore/README.md
+++ b/src/rgw/store/dbstore/README.md
@@ -20,11 +20,13 @@ Edit ceph.conf to add below option
     [client]
         rgw backend store = dbstore
 
-Restart vstart cluster or just RGW server
+Start vstart cluster
 
-    [..] RGW=1 ../src/vstart.sh -d
+    [..] RGW=1 ../src/vstart.sh -o rgw_backend_store=dbstore -n -d
 
-The above configuration brings up RGW server on dbstore and creates testid user to be used for s3 operations.
+The above vstart command brings up RGW server on dbstore and creates few default users (eg., testid) to be used for s3 operations.
+
+`radosgw-admin` can be used to create and remove other users.
 
 
 By default, dbstore creates .db file *'/var/run/ceph/dbstore-default_ns.db'* to store the data. This can be configured using below options in ceph.conf

--- a/src/rgw/store/dbstore/dbstore_mgr.cc
+++ b/src/rgw/store/dbstore/dbstore_mgr.cc
@@ -37,15 +37,20 @@ not_found:
 }
 
 /* Create DBStore instance */
-DB *DBStoreManager::createDB(string tenant) {
+DB *DBStoreManager::createDB(std::string tenant) {
   DB *dbs = nullptr;
   pair<map<string, DB*>::iterator,bool> ret;
+  const auto& db_path = g_conf().get_val<std::string>("dbstore_db_dir");
+  const auto& db_name = g_conf().get_val<std::string>("dbstore_db_name_prefix");
+
+  std::string db_full_path = db_path + "/" + db_name + "-" + tenant;
+   ldout(cct, 0) << "DB initialization full db_path("<<db_full_path<<")" << dendl;
 
   /* Create the handle */
 #ifdef SQLITE_ENABLED
-  dbs = new SQLiteDB(tenant, cct);
+  dbs = new SQLiteDB(db_full_path, cct);
 #else
-  dbs = new DB(tenant, cct);
+  dbs = new DB(db_full_path, cct);
 #endif
 
   /* API is DB::Initialize(string logfile, int loglevel);

--- a/src/rgw/store/dbstore/sqlite/sqliteDB.cc
+++ b/src/rgw/store/dbstore/sqlite/sqliteDB.cc
@@ -369,9 +369,9 @@ static int list_user(const DoutPrefixProvider *dpp, DBOpInfo &op, sqlite3_stmt *
   op.user.uinfo.display_name = (const char*)sqlite3_column_text(stmt, DisplayName); // user_name
   op.user.uinfo.user_email = (const char*)sqlite3_column_text(stmt, UserEmail);
 
-  SQL_DECODE_BLOB_PARAM(dpp, stmt, AccessKeys, op.user.uinfo.access_keys, sdb);
   SQL_DECODE_BLOB_PARAM(dpp, stmt, SwiftKeys, op.user.uinfo.swift_keys, sdb);
   SQL_DECODE_BLOB_PARAM(dpp, stmt, SubUsers, op.user.uinfo.subusers, sdb);
+  SQL_DECODE_BLOB_PARAM(dpp, stmt, AccessKeys, op.user.uinfo.access_keys, sdb);
 
   op.user.uinfo.suspended = sqlite3_column_int(stmt, Suspended);
   op.user.uinfo.max_buckets = sqlite3_column_int(stmt, MaxBuckets);
@@ -1144,9 +1144,9 @@ int SQLInsertUser::Bind(const DoutPrefixProvider *dpp, struct DBOpParams *params
     SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.access_keys_secret, sdb);
     SQL_BIND_TEXT(dpp, stmt, index, key.c_str(), sdb);
 
-    SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.access_keys, sdb);
-    SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.uinfo.access_keys, sdb);
   }
+  SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.access_keys, sdb);
+  SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.uinfo.access_keys, sdb);
 
   SQL_BIND_INDEX(dpp, stmt, index, p_params.op.user.swift_keys, sdb);
   SQL_ENCODE_BLOB_PARAM(dpp, stmt, index, params->op.user.uinfo.swift_keys, sdb);

--- a/src/rgw/store/dbstore/tests/dbstore_tests.cc
+++ b/src/rgw/store/dbstore/tests/dbstore_tests.cc
@@ -268,7 +268,7 @@ TEST_F(DBStoreTest, StoreUser) {
   uinfo.access_keys["id2"] = k2;
 
   /* non exclusive create..should create new one */
-  ret = db->store_user(dpp, uinfo, true, &attrs, &objv_tracker, &old_uinfo);
+  ret = db->store_user(dpp, uinfo, false, &attrs, &objv_tracker, &old_uinfo);
   ASSERT_EQ(ret, 0);
   ASSERT_EQ(old_uinfo.user_email, "");
   ASSERT_EQ(objv_tracker.read_version.ver, 1);
@@ -305,7 +305,7 @@ TEST_F(DBStoreTest, GetUserQueryByUserID) {
   uinfo.user_id.tenant = "tenant";
   uinfo.user_id.id = "user_id2";
 
-  ret = db->get_user(dpp, "user_id", "", uinfo, &attrs, &objv);
+  ret = db->get_user(dpp, "user_id", "user_id2", uinfo, &attrs, &objv);
   ASSERT_EQ(ret, 0);
   ASSERT_EQ(uinfo.user_id.tenant, "tenant");
   ASSERT_EQ(uinfo.user_email, "user2_new@dbstore.com");
@@ -629,7 +629,6 @@ TEST_F(DBStoreTest, RemoveUserAPI) {
   ret = db->remove_user(dpp, uinfo, &objv);
   ASSERT_EQ(ret, -125);
 
-  /* invalid version number...should fail */
   objv.read_version.ver = 2;
   ret = db->remove_user(dpp, uinfo, &objv);
   ASSERT_EQ(ret, 0);


### PR DESCRIPTION
With the changes in https://github.com/ceph/ceph/pull/45987 ,  'radosgw-admin' command can be used to execute few admin operations on other stores.

This PR include changes to support  user creation/remove via `radosgw-admin` command in dbstore.

Also to run teuthology tests on dbstore, .db file should be accessible by radosgw server on teuthology machines. Hence added options to configure dbstore db file path & name_prefix
        
    'dbstore_db_dir':
        - path of the .db file
        - default: /var/run/ceph
    'dbstore_db_name_prefix':
        - prefix to be used for .db file name
        - default: dbstore
    
    For eg., by default the full path of the file shall be
    eg., /var/run/ceph/dbstore-default_ns.db

In addition, there was an issue in RGWUser::init() where in obv_tracker of new sal::User created is not updated, which results in obj_version mismatch error for few operations. Fixed the same.

Fixes: https://tracker.ceph.com/issues/55528
Signed-off-by: Soumya Koduri <skoduri@redhat.com>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
