### PR TITLE
add test attribute checksum

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3926,6 +3926,11 @@ void RGWPutObj::execute(optional_yield y)
     op_ret = upload->get_info(this, s->yield, &pdest_placement);
 
     s->trace->SetAttribute(tracing::rgw::UPLOAD_ID, multipart_upload_id);
+
+    // set an attribute called "upload_id", 
+    // initialize it with value 0 (implement the algo later)
+    s->trace->SetAttribute(tracing::rgw::UPLOAD_CHECKSUM, 0); 
+
     multipart_trace = tracing::rgw::tracer.add_span(name(), upload->get_trace());
 
     if (op_ret < 0) {
@@ -6189,6 +6194,11 @@ void RGWInitMultipart::execute(optional_yield y)
     upload_id = upload->get_upload_id();
   }
   s->trace->SetAttribute(tracing::rgw::UPLOAD_ID, upload_id);
+
+  // set an attribute called "upload_id", 
+  // initialize it with value 0 (implement the algo later)
+  s->trace->SetAttribute(tracing::rgw::UPLOAD_CHECKSUM, 0);
+
   multipart_trace->UpdateName(tracing::rgw::MULTIPART + upload_id);
 
 }
@@ -6352,6 +6362,11 @@ void RGWCompleteMultipart::execute(optional_yield y)
     return;
   }
   s->trace->SetAttribute(tracing::rgw::UPLOAD_ID, upload_id);
+
+  // set an attribute called "upload_id",
+  // initialize it with value 0 (implement the algo later)
+  s->trace->SetAttribute(tracing::rgw::UPLOAD_CHECKSUM, 0);
+
   jspan_context trace_ctx(false, false);
   extract_span_context(meta_obj->get_attrs(), trace_ctx);
   multipart_trace = tracing::rgw::tracer.add_span(name(), trace_ctx);

--- a/src/rgw/rgw_tracer.h
+++ b/src/rgw/rgw_tracer.h
@@ -17,6 +17,7 @@ const auto UPLOAD_ID = "upload_id";
 const auto TYPE = "type";
 const auto REQUEST = "request";
 const auto MULTIPART = "multipart_upload ";
+const auto UPLOAD_CHECKSUM = "upload_checksum";
 
 #ifdef HAVE_JAEGER
 extern thread_local tracing::Tracer tracer;


### PR DESCRIPTION
rgw/tracer: Multipart upload checksum (test attribute draft)

In this PR I added a test attribute to the source code of raw (multipart upload). At present it's just a test attribute and I have not implement some real function of it yet.
(I mainly changes the source code in `rgw/rgw_tracer.h` and `rgw/rgw_op.cc`.)

It starts on `InitMultipartUpload` Op, and on each `PutObj` Op related to the same multipart upload will be added. So is for the `CompleteMultipartUpload` Op.

I successfully built and run it locally and here is the screenshot.
![image](https://user-images.githubusercontent.com/98803843/166427712-166d79fb-b3ed-45f1-9427-9c7130f2dfaa.png)
In the tags, a new attribute `upload_checksum` is included.
- It will be initialized to `0` value.

The environment of development:
- Fedora 35 (Linux fedora 5.16.16-200.fc35.x86_64)

## Checklist
- [ ] References tracker ticket
- [ ] Doc update (no ticket needed)