### PR TITLE
os/bluestore: fix empty store divide by 0 runtime error

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2460,7 +2460,8 @@ private:
         return (2 > onode_num) ? 2 : onode_num;
       }
       double get_bytes_per_onode() const {
-        return (double)_get_used_bytes() / (double)_get_num_onodes();
+        return std::max((double)_get_used_bytes(), 1.0) /
+	  (double)_get_num_onodes();
       }
     };
     std::shared_ptr<MetaCache> meta_cache;


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
