### PR TITLE
crimson/common/format: remove ceph::coarse_real_clock format speciali…

### DIFF
--- a/src/crimson/common/formatter.cc
+++ b/src/crimson/common/formatter.cc
@@ -29,34 +29,10 @@ struct fmt::formatter<seastar::lowres_system_clock::time_point> {
   }
 };
 
-template <>
-struct fmt::formatter<ceph::coarse_real_clock::time_point> {
-  // ignore the format string
-  template <typename ParseContext>
-  constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
-
-  template <typename FormatContext>
-  auto format(const ceph::coarse_real_clock::time_point& t,
-              FormatContext& ctx) {
-    std::time_t tt = std::chrono::duration_cast<std::chrono::seconds>(
-      t.time_since_epoch()).count();
-    auto milliseconds = (t.time_since_epoch() %
-                         std::chrono::seconds(1)).count();
-    return fmt::format_to(ctx.out(), "{:%Y-%m-%d %H:%M:%S} {:03d}",
-                          fmt::localtime(tt), milliseconds);
-  }
-};
-
 namespace std {
 
 ostream& operator<<(ostream& out,
                     const seastar::lowres_system_clock::time_point& t)
-{
-  return out << fmt::format("{}", t);
-}
-
-ostream& operator<<(ostream& out,
-                    const ceph::coarse_real_clock::time_point& t)
 {
   return out << fmt::format("{}", t);
 }

--- a/src/crimson/common/formatter.h
+++ b/src/crimson/common/formatter.h
@@ -9,7 +9,5 @@ namespace std {
 
 ostream& operator<<(ostream& out,
                     const seastar::lowres_system_clock::time_point& t);
-ostream& operator<<(ostream& out,
-                    const ceph::coarse_real_clock::time_point& t);
 
 }


### PR DESCRIPTION
…zation

...
..., value=..., loc=...) at /usr/include/fmt/ostream.h:114
...

Fixes: https://tracker.ceph.com/issues/55326
Signed-off-by: Samuel Just <sjust@redhat.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
