### PR TITLE
crimson: misc typos

### DIFF
--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -197,8 +197,8 @@ public:
 template std::unique_ptr<AdminSocketHook> make_asok_hook<AssertAlwaysHook>();
 
 /**
-* A Seastar admin hook: fetching the values of configured metrics
-*/
+ * A Seastar admin hook: fetching the values of configured metrics
+ */
 class DumpMetricsHook : public AdminSocketHook {
 public:
   DumpMetricsHook() :

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -174,7 +174,7 @@ auto call_with_interruption_impl(
     typename futurator_t::type>();
   INTR_FUT_DEBUG(
     "call_with_interruption_impl: may_interrupt: {}, "
-    "local interrupt_condintion: {}, "
+    "local interrupt_condition: {}, "
     "global interrupt_cond: {},{}",
     interrupt,
     (void*)interrupt_condition.get(),

--- a/src/crimson/common/operation.h
+++ b/src/crimson/common/operation.h
@@ -427,11 +427,11 @@ public:
   PipelineHandle &operator=(PipelineHandle&&) = default;
 
   /**
-     * Returns a future which unblocks when the handle has entered the passed
-     * OrderedPipelinePhase.  If already in a phase, enter will also release
-     * that phase after placing itself in the queue for the next one to preserve
-     * ordering.
-     */
+   * Returns a future which unblocks when the handle has entered the passed
+   * OrderedPipelinePhase.  If already in a phase, enter will also release
+   * that phase after placing itself in the queue for the next one to preserve
+   * ordering.
+   */
   template <typename T>
   blocking_future<> enter(T &t) {
     /* Strictly speaking, we probably want the blocker to be registered on


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
