### PR TITLE
cmake: s/--prod/--configuration=production/

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -138,9 +138,9 @@ build_dashboard_frontend() {
   . $TEMP_DIR/bin/activate
   NG_CLI_ANALYTICS=false timeout 1h npm ci
   echo "Building ceph-dashboard frontend with build:localize script";
-  # we need to use "--" because so that "--prod" survives accross all
-  # scripts redirections inside package.json
-  npm run build:localize -- --prod
+  # we need to use "--" because so that "--configuration production"
+  # survives accross all scripts redirections inside package.json
+  npm run build:localize -- --configuration production
   deactivate
   cd $CURR_DIR
   rm -rf $TEMP_DIR

--- a/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
@@ -64,7 +64,7 @@ if [[ -n "$JENKINS_HOME" ]]; then
     npm cache clean --force
 fi
 npm ci
-FRONTEND_BUILD_OPTS='-- --prod'
+FRONTEND_BUILD_OPTS='-- --configuration production'
 if [[ -n "${DEV_MODE}" ]]; then
     FRONTEND_BUILD_OPTS+=' --deleteOutputPath=false --watch'
 fi

--- a/src/pybind/mgr/dashboard/frontend/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/frontend/CMakeLists.txt
@@ -109,7 +109,7 @@ execute_process(
 set(frontend_dist_dir "${CMAKE_CURRENT_BINARY_DIR}/dist")
 set(npm_args "--output-path ${frontend_dist_dir}")
 if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
-  string(APPEND npm_args " --prod --progress=false")
+  string(APPEND npm_args " --configuration=production --progress=false")
 else()
   string(APPEND npm_args " --progress=false")
 endif()

--- a/src/pybind/mgr/dashboard/run-frontend-unittests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-unittests.sh
@@ -11,7 +11,7 @@ if [ `uname` != "FreeBSD" ]; then
 fi
 
 # Build
-npm run build -- --prod --progress=false || failed=true
+npm run build -- --configuration=production --progress=false || failed=true
 
 # Unit Tests
 npm run test:ci || failed=true


### PR DESCRIPTION
to silence the warning from Angular 12.0 and up, which complains like:

Option "--prod" is deprecated: Use "--configuration production" instead

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
