### PR TITLE
rgw: remove cerr config_store from rgw_common.cc

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -3016,7 +3016,6 @@ rgw_global_init(const std::map<std::string,std::string> *defaults,
   // Get the store backend
   const auto& config_store = g_conf().get_val<std::string>("rgw_backend_store");
 
-  cerr << "config_store: " << config_store << std::endl;
   if ((config_store == "dbstore") ||
       (config_store == "motr")) {
     // These stores don't use the mon


### PR DESCRIPTION
cleanup from https://github.com/ceph/ceph/pull/45987

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
