### PR TITLE
doc/rados/operations: Add missing required parameters to stretch-mode CRUSH rule example

### DIFF
--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -82,6 +82,8 @@ named ``site1`` and ``site2``::
 
   rule stretch_rule {
           id 1
+          min_size 1
+          max_size 10
           type replicated
           step take site1
           step chooseleaf firstn 2 type host


### PR DESCRIPTION
Rule example is missing min_size and max_size, both are required.