### PR TITLE
rgw: add 'rgw_access' log subsys for frontend http access log

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -43,6 +43,9 @@
   * system
   * truncated
   * user_stats_sync
+* RGW: The beast frontend's HTTP access log line uses a new debug_rgw_access
+  configurable. This has the same defaults as debug_rgw, but can now be controlled
+  independently.
 
 >=17.2.1
 

--- a/src/common/subsys.h
+++ b/src/common/subsys.h
@@ -61,6 +61,7 @@ SUBSYS(perfcounter, 1, 5)
 SUBSYS(rgw, 1, 5)                 // log level for the Rados gateway
 SUBSYS(rgw_sync, 1, 5)
 SUBSYS(rgw_datacache, 1, 5)
+SUBSYS(rgw_access, 1, 5)
 SUBSYS(javaclient, 1, 5)
 SUBSYS(asok, 1, 5)
 SUBSYS(throttle, 1, 1)

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -273,7 +273,7 @@ void handle_connection(boost::asio::io_context& context,
 
       if (cct->_conf->subsys.should_gather(dout_subsys, 1)) {
         // access log line elements begin per Apache Combined Log Format with additions following
-        ldout(cct, 1) << "beast: " << std::hex << &req << std::dec << ": "
+        lsubdout(cct, rgw_access, 1) << "beast: " << std::hex << &req << std::dec << ": "
             << remote_endpoint.address() << " - " << user << " [" << log_apache_time{started} << "] \""
             << message.method_string() << ' ' << message.target() << ' '
             << http_version{message.version()} << "\" " << http_ret << ' '


### PR DESCRIPTION
this allows the log level of this http access log to be configured separately from the 'rgw' subsystem, though the defaults are the same

Fixes: https://tracker.ceph.com/issues/54405

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
