### PR TITLE
rgw: support full object encryption stack on compression

### DIFF
--- a/qa/suites/rgw/crypt/3-rgw/rgw.yaml
+++ b/qa/suites/rgw/crypt/3-rgw/rgw.yaml
@@ -6,6 +6,8 @@ overrides:
         setgroup: ceph
         rgw crypt require ssl: false
         debug rgw: 20
+  rgw:
+    compression type: random
 
 tasks:
 - rgw:

--- a/src/rgw/rgw_compression.h
+++ b/src/rgw/rgw_compression.h
@@ -47,6 +47,7 @@ class RGWPutObj_Compress : public rgw::putobj::Pipe
   CompressorRef compressor;
   std::optional<int32_t> compressor_message;
   std::vector<compression_block> blocks;
+  uint64_t compressed_ofs{0};
 public:
   RGWPutObj_Compress(CephContext* cct_, CompressorRef compressor,
                      rgw::sal::DataProcessor *next)

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2265,6 +2265,10 @@ void RGWGetObj::execute(optional_yield y)
     goto done_err;
   total_len = (ofs <= end ? end + 1 - ofs : 0);
 
+  ofs_x = ofs;
+  end_x = end;
+  filter->fixup_range(ofs_x, end_x);
+
   /* Check whether the object has expired. Swift API documentation
    * stands that we should return 404 Not Found in such case. */
   if (need_object_expiration() && s->object->is_expired()) {
@@ -2282,6 +2286,7 @@ void RGWGetObj::execute(optional_yield y)
                                     attr_iter != attrs.end() ? &(attr_iter->second) : nullptr);
   if (decrypt != nullptr) {
     filter = decrypt.get();
+    filter->fixup_range(ofs_x, end_x);
   }
   if (op_ret < 0) {
     goto done_err;
@@ -2294,9 +2299,6 @@ void RGWGetObj::execute(optional_yield y)
 
   perfcounter->inc(l_rgw_get_b, end - ofs);
 
-  ofs_x = ofs;
-  end_x = end;
-  filter->fixup_range(ofs_x, end_x);
   op_ret = read_op->iterate(this, ofs_x, end_x, filter, s->yield);
 
   if (op_ret >= 0)
@@ -4050,7 +4052,8 @@ void RGWPutObj::execute(optional_yield y)
     }
     if (encrypt != nullptr) {
       filter = &*encrypt;
-    } else if (compression_type != "none") {
+    }
+    if (compression_type != "none") {
       plugin = get_compressor_plugin(s, compression_type);
       if (!plugin) {
         ldpp_dout(this, 1) << "Cannot load plugin for compression type "


### PR DESCRIPTION
replace #36539
add implementation for full object encryption stack on compression. Compressing first and then encrypting.

Security and trustworthiness framework of ceph is important for data storage. Now, cephx and https base on openssl enhance the security of transport layer, and rgw encrytion implementation supports data protection for object store.
Nevertheless, as issues said, [issues19988](https://tracker.ceph.com/issues/19988), space usage and data security are exclusive.
**New compression and encryption filters do not stack, but logically could do so. Users must choose between at rest data reduction and data  security.**
The pr solves this problem. Why compressing first and then encrypting, discussion about data encryption and compression has answer
https://crypto.stackexchange.com/questions/33737/is-it-better-to-encrypt-before-compression-or-vice-versa

Fixed: https://tracker.ceph.com/issues/19988
Signed-off-by: Dai Zhiwei <daizhiwei3@huawei.com>
Signed-off-by: luo rixin <luorixin@huawei.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
