### PR TITLE
crimson: fix op tracking related bugs

### DIFF
--- a/src/crimson/common/operation.h
+++ b/src/crimson/common/operation.h
@@ -262,7 +262,7 @@ struct AggregateBlockingEvent {
   };
 
 private:
-  std::vector<T> events;
+  std::list<T> events;
   template <class OpT>
   friend class Trigger;
 };

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -156,8 +156,7 @@ size_t PGRecovery::start_primary_recovery_ops(
     // TODO: handle lost/unfound
     if (pg->get_recovery_backend()->is_recovering(soid)) {
       auto& recovery_waiter = pg->get_recovery_backend()->get_recovering(soid);
-      out->emplace_back(recovery_waiter.wait_for_recovered(
-	*trigger.create_part_trigger()));
+      out->emplace_back(recovery_waiter.wait_for_recovered(trigger));
       ++started;
     } else if (pg->get_recovery_backend()->is_recovering(head)) {
       ++skipped;
@@ -225,8 +224,7 @@ size_t PGRecovery::start_replica_recovery_ops(
       if (pg->get_recovery_backend()->is_recovering(soid)) {
 	logger().debug("{}: already recovering object {}", __func__, soid);
 	auto& recovery_waiter = pg->get_recovery_backend()->get_recovering(soid);
-	out->emplace_back(recovery_waiter.wait_for_recovered(
-	  *trigger.create_part_trigger()));
+	out->emplace_back(recovery_waiter.wait_for_recovered(trigger));
 	started++;
 	continue;
       }

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -272,11 +272,11 @@ PGRecovery::recover_missing(
   const hobject_t &soid, eversion_t need)
 {
   if (pg->get_peering_state().get_missing_loc().is_deleted(soid)) {
-    return pg->get_recovery_backend()->add_recovering(soid).track_blocking(
+    return pg->get_recovery_backend()->add_recovering(soid).wait_track_blocking(
       trigger,
       pg->get_recovery_backend()->recover_delete(soid, need));
   } else {
-    return pg->get_recovery_backend()->add_recovering(soid).track_blocking(
+    return pg->get_recovery_backend()->add_recovering(soid).wait_track_blocking(
       trigger,
       pg->get_recovery_backend()->recover_object(soid, need)
       .handle_exception_interruptible(
@@ -293,7 +293,7 @@ RecoveryBackend::interruptible_future<> PGRecovery::prep_object_replica_deletes(
   const hobject_t& soid,
   eversion_t need)
 {
-  return pg->get_recovery_backend()->add_recovering(soid).track_blocking(
+  return pg->get_recovery_backend()->add_recovering(soid).wait_track_blocking(
     trigger,
     pg->get_recovery_backend()->push_delete(soid, need).then_interruptible(
       [=] {
@@ -310,7 +310,7 @@ RecoveryBackend::interruptible_future<> PGRecovery::prep_object_replica_pushes(
   const hobject_t& soid,
   eversion_t need)
 {
-  return pg->get_recovery_backend()->add_recovering(soid).track_blocking(
+  return pg->get_recovery_backend()->add_recovering(soid).wait_track_blocking(
     trigger,
     pg->get_recovery_backend()->recover_object(soid, need)
     .handle_exception_interruptible(

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -51,9 +51,7 @@ PGRecovery::start_recovery_ops(
   assert(!pg->is_backfilling());
   assert(!pg->get_peering_state().is_deleting());
 
-  std::vector<RecoveryBackend::interruptible_future<>> new_started;
   std::vector<interruptible_future<>> started;
-  new_started.reserve(max_to_start);
   started.reserve(max_to_start);
   max_to_start -= start_primary_recovery_ops(trigger, max_to_start, &started);
   if (max_to_start > 0) {
@@ -61,7 +59,7 @@ PGRecovery::start_recovery_ops(
   }
   using interruptor =
     crimson::interruptible::interruptor<crimson::osd::IOInterruptCondition>;
-  return interruptor::parallel_for_each(std::move(new_started),
+  return interruptor::parallel_for_each(std::move(started),
 					[] (auto&& ifut) {
     return std::move(ifut);
   }).then_interruptible([this] {

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -80,14 +80,6 @@ private:
 				eversion_t last_complete);
   friend class ReplicatedRecoveryBackend;
   friend class crimson::osd::UrgentRecovery;
-  seastar::future<> handle_pull(Ref<MOSDPGPull> m);
-  seastar::future<> handle_push(Ref<MOSDPGPush> m);
-  seastar::future<> handle_push_reply(Ref<MOSDPGPushReply> m);
-  seastar::future<> handle_recovery_delete(Ref<MOSDPGRecoveryDelete> m);
-  seastar::future<> handle_recovery_delete_reply(
-      Ref<MOSDPGRecoveryDeleteReply> m);
-  seastar::future<> handle_pull_response(Ref<MOSDPGPush> m);
-  seastar::future<> handle_scan(MOSDPGScan& m);
 
   // backfill begin
   std::unique_ptr<crimson::osd::BackfillState> backfill_state;

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -41,13 +41,13 @@ void RecoveryBackend::clean_up(ceph::os::Transaction& t,
   temp_contents.clear();
 
   for (auto& [soid, recovery_waiter] : recovering) {
-    if ((recovery_waiter.pi && recovery_waiter.pi->is_complete())
-	|| (!recovery_waiter.pi
-	  && recovery_waiter.obc && recovery_waiter.obc->obs.exists)) {
-      recovery_waiter.obc->interrupt(
+    if ((recovery_waiter->pi && recovery_waiter->pi->is_complete())
+	|| (!recovery_waiter->pi
+	  && recovery_waiter->obc && recovery_waiter->obc->obs.exists)) {
+      recovery_waiter->obc->interrupt(
 	  ::crimson::common::actingset_changed(
 	      pg.is_primary()));
-      recovery_waiter.interrupt(why);
+      recovery_waiter->interrupt(why);
     }
   }
   recovering.clear();

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -150,7 +150,8 @@ public:
 	std::forward<F>(fut)
       ).finally([ref] {});
     }
-    seastar::future<> wait_for_recovered(BlockingEvent::TriggerI& trigger) {
+    template <typename T>
+    seastar::future<> wait_for_recovered(T &trigger) {
       WaitForObjectRecoveryRef ref = this;
       return wait_track_blocking(trigger, recovered.get_shared_future());
     }


### PR DESCRIPTION
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
