### PR TITLE
doc: Disable double dashes "--" smartquotes conversion to en-dashes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -112,6 +112,8 @@ build_with_rtd = os.environ.get('READTHEDOCS') == 'True'
 
 sys.path.insert(0, os.path.abspath('_ext'))
 
+smartquotes_action = "qe"
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.graphviz',


### PR DESCRIPTION
Double dashes ("--") are converted to [en]dash ("–") which is looks like a single dash.
It's because of docutils smartquotes which is enabled by default by sphinx.
I think it's better to display commands like ```radosgw bucket radoslist --bucket=<bucket>``` instead of ```radosgw bucket radoslist –bucket=<bucket>```.
I just changed the smartquotes_action (added in 1.6.6 version) configuration from default value ("qDe") to "qe" to disable only em- and en-Dashes transformation.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
