### PR TITLE
mgr/selftest: mgr module, pdb server debugger

### DIFF
--- a/src/pybind/mgr/selftest/plugins/__init__.py
+++ b/src/pybind/mgr/selftest/plugins/__init__.py
@@ -1,0 +1,15 @@
+class Plugin:
+    def __init__(self, mgr):
+        self.mgr = mgr
+
+    def serve(self):
+        pass
+
+    def shutdown(self):
+        pass
+
+
+__all__ = []
+
+plugin_names = ['debug_server']
+__all__.extend(plugin_names)

--- a/src/pybind/mgr/selftest/plugins/debug_server.py
+++ b/src/pybind/mgr/selftest/plugins/debug_server.py
@@ -1,0 +1,24 @@
+import sys
+import threading
+from . import Plugin
+
+try:
+    import epdb
+except:
+    pass
+    
+
+class DebugServer(Plugin):
+    def __init__(self, mgr):
+        super(DebugServer, self).__init__(mgr)
+        self.port = mgr.get_module_option('epdb_port', default=7777)
+        self.epdb_thread = None
+
+    def serve(self):
+        if 'epdb' not in sys.modules:
+            raise RuntimeError('epdb module couldn\'t be imported, please install epdb.')
+        self.epdb_thread = threading.Thread(target=epdb.serve, args=(self.port,))
+        self.epdb_thread.start()
+
+    def shutdown(self):
+        del(self.epdb_thread)


### PR DESCRIPTION
This module acts as a epdb server so that you can debug python with a gdb like interface. It is a bit clumsy still, but well, it could be better than reading mgr.x.log again.

https://user-images.githubusercontent.com/30913090/167317876-6f5c03df-ea69-45a1-ad7a-6f1cc4c3d845.mp4
(I apologise for the low video quality)


Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->
## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
