### PR TITLE
crimson/osd, rgw: implement the new Objclass API methods for cls_rgw

### DIFF
--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -7,6 +7,7 @@
 #include "common/ceph_context.h"
 #include "common/ceph_releases.h"
 #include "common/config.h"
+#include "crimson/common/config_proxy.h"
 #include "common/debug.h"
 
 #include "crimson/osd/exceptions.h"
@@ -498,16 +499,12 @@ ceph_release_t cls_get_min_compatible_client(cls_method_context_t hctx)
 
 const ConfigProxy& cls_get_config(cls_method_context_t hctx)
 {
-  // FIXME ; segfault if ever called
-  static ConfigProxy* dummy = nullptr;
-  return *dummy;
+  return crimson::common::local_conf();
 }
 
 const object_info_t& cls_get_object_info(cls_method_context_t hctx)
 {
-  // FIXME ; segfault if ever called
-  static object_info_t* dummy = nullptr;
-  return *dummy;
+  return reinterpret_cast<crimson::osd::OpsExecuter*>(hctx)->get_object_info();
 }
 
 int cls_get_snapset_seq(cls_method_context_t hctx, uint64_t *snap_seq)

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -273,8 +273,11 @@ public:
     const std::vector<OSDOp>& ops);
   void fill_op_params_bump_pg_version();
 
+  const object_info_t &get_object_info() const {
+    return obc->obs.oi;
+  }
   const hobject_t &get_target() const {
-    return obc->obs.oi.soid;
+    return get_object_info().soid;
   }
 
   const auto& get_message() const {


### PR DESCRIPTION
They were introduced by 3877c1e37f2fa4e1574b57f05132288f210835a7.

Signed-off-by: Radosław Zarzyński <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
