### PR TITLE
mgr/dashboard: Creating and editing Prometheus AlertManager silences is buggy

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.spec.ts
@@ -85,7 +85,7 @@ describe('SilenceFormComponent', () => {
   const changeAction = (action: string) => {
     const modes = {
       add: '/monitoring/silences/add',
-      alertAdd: '/monitoring/silences/add/someAlert',
+      alertAdd: '/monitoring/silences/add/alert0',
       recreate: '/monitoring/silences/recreate/someExpiredId',
       edit: '/monitoring/silences/edit/someNotExpiredId'
     };
@@ -99,9 +99,10 @@ describe('SilenceFormComponent', () => {
 
     prometheus = new PrometheusHelper();
     prometheusService = TestBed.inject(PrometheusService);
-    spyOn(prometheusService, 'getAlerts').and.callFake(() =>
-      of([prometheus.createAlert('alert0')])
-    );
+    spyOn(prometheusService, 'getAlerts').and.callFake(() => {
+      const name = _.split(router.url, '/').pop();
+      return of([prometheus.createAlert(name)]);
+    });
     ifPrometheusSpy = spyOn(prometheusService, 'ifPrometheusConfigured').and.callFake((fn) => fn());
     rulesSpy = spyOn(prometheusService, 'getRules').and.callFake(() =>
       of({
@@ -231,9 +232,10 @@ describe('SilenceFormComponent', () => {
     };
 
     beforeEach(() => {
-      spyOn(prometheusService, 'getSilences').and.callFake((p) =>
-        of([prometheus.createSilence(p.id)])
-      );
+      spyOn(prometheusService, 'getSilences').and.callFake(() => {
+        const id = _.split(router.url, '/').pop();
+        return of([prometheus.createSilence(id)]);
+      });
     });
 
     it('should have no special action activate by default', () => {
@@ -251,7 +253,7 @@ describe('SilenceFormComponent', () => {
     it('should be in edit action if route includes edit', () => {
       params = { id: 'someNotExpiredId' };
       expectMode('edit', true, false, 'Edit');
-      expect(prometheusService.getSilences).toHaveBeenCalledWith(params);
+      expect(prometheusService.getSilences).toHaveBeenCalled();
       expect(component.form.value).toEqual({
         comment: `A comment for ${params.id}`,
         createdBy: `Creator of ${params.id}`,
@@ -265,7 +267,7 @@ describe('SilenceFormComponent', () => {
     it('should be in recreation action if route includes recreate', () => {
       params = { id: 'someExpiredId' };
       expectMode('recreate', false, true, 'Recreate');
-      expect(prometheusService.getSilences).toHaveBeenCalledWith(params);
+      expect(prometheusService.getSilences).toHaveBeenCalled();
       expect(component.form.value).toEqual({
         comment: `A comment for ${params.id}`,
         createdBy: `Creator of ${params.id}`,
@@ -277,7 +279,7 @@ describe('SilenceFormComponent', () => {
     });
 
     it('adds matchers based on the label object of the alert with the given id', () => {
-      params = { id: 'someAlert' };
+      params = { id: 'alert0' };
       expectMode('alertAdd', false, false, 'Create');
       expect(prometheusService.getSilences).not.toHaveBeenCalled();
       expect(prometheusService.getAlerts).toHaveBeenCalled();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.ts
@@ -217,12 +217,18 @@ export class SilenceFormComponent {
         return;
       }
       if (this.edit || this.recreate) {
-        this.prometheusService.getSilences(params).subscribe((silences) => {
-          this.fillFormWithSilence(silences[0]);
+        this.prometheusService.getSilences().subscribe((silences) => {
+          const silence = _.find(silences, ['id', params.id]);
+          if (!_.isUndefined(silence)) {
+            this.fillFormWithSilence(silence);
+          }
         });
       } else {
-        this.prometheusService.getAlerts(params).subscribe((alerts) => {
-          this.fillFormByAlert(alerts[0]);
+        this.prometheusService.getAlerts().subscribe((alerts) => {
+          const alert = _.find(alerts, ['fingerprint', params.id]);
+          if (!_.isUndefined(alert)) {
+            this.fillFormByAlert(alert);
+          }
         });
       }
     });


### PR DESCRIPTION
When creating a new monitoring silence the form is pre-filled with the wrong alert data. It is always used the alert data from the very first object in the list of the API response but not the specified alert identified by the 'fingerprint' property.

The same problem applies to editing silences. The selected silence is not edited, it's always the first one in the list returned API response but not that with the specified 'id' property.

The main problem of the origin implementation is that the Prometheus Alertmanager API endpoints /api/v1/[alerts/silences] do not support querying. To fix that, filtering is done in the frontend.

Fixes: https://tracker.ceph.com/issues/55578

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
