### PR TITLE
mgr/nfs: use object_format decorators to simplify response handling

### DIFF
--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -165,12 +165,13 @@ class TestNFS(MgrTestCase):
         it checks for expected cluster id. Otherwise checks nothing is listed.
         :param empty: If true it denotes no cluster is deployed.
         '''
+        nfs_output = self._nfs_cmd('cluster', 'ls')
+        jdata = json.loads(nfs_output)
         if empty:
-            cluster_id = ''
+            self.assertEqual(len(jdata), 0)
         else:
             cluster_id = self.cluster_id
-        nfs_output = self._nfs_cmd('cluster', 'ls')
-        self.assertEqual(cluster_id, nfs_output.strip())
+            self.assertEqual([cluster_id], jdata)
 
     def _create_export(self, export_id, create_fs=False, extra_cmd=None):
         '''

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -736,7 +736,11 @@ class TestNFS(MgrTestCase):
         """
         Test that cluster info doesn't throw junk data for non-existent cluster
         """
-        cluseter_ls = self._nfs_cmd('cluster', 'ls')
-        self.assertNotIn('foo', cluseter_ls, 'cluster foo exists')
-        cluster_info = self._nfs_cmd('cluster', 'info', 'foo')
-        self.assertIn('cluster does not exist', cluster_info)
+        cluster_ls = self._nfs_cmd('cluster', 'ls')
+        self.assertNotIn('foo', cluster_ls, 'cluster foo exists')
+        try:
+            self._nfs_cmd('cluster', 'info', 'foo')
+            self.fail("nfs cluster info foo returned successfully for non-existent cluster")
+        except CommandFailedError as e:
+            if e.exitstatus != errno.ENOENT:
+                raise

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -7,6 +7,7 @@ from typing import cast, Dict, List, Any, Union, Optional, TYPE_CHECKING, Tuple
 
 from mgr_module import NFS_POOL_NAME as POOL_NAME
 from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec, IngressSpec
+from object_format import ErrorResponse
 
 import orchestrator
 
@@ -148,11 +149,12 @@ class NFSCluster:
         except Exception as e:
             return exception_handler(e, f"Failed to delete NFS Cluster {cluster_id}")
 
-    def list_nfs_cluster(self) -> Tuple[int, str, str]:
+    def list_nfs_cluster(self) -> List[str]:
         try:
-            return 0, '\n'.join(available_clusters(self.mgr)), ""
+            return available_clusters(self.mgr)
         except Exception as e:
-            return exception_handler(e, "Failed to list NFS Cluster")
+            log.exception("Failed to list NFS Cluster")
+            raise ErrorResponse.wrap(e)
 
     def _show_nfs_cluster_info(self, cluster_id: str) -> Dict[str, Any]:
         completion = self.mgr.list_daemons(daemon_type='nfs')

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -137,7 +137,7 @@ class NFSCluster:
             log.exception(f"NFS Cluster {cluster_id} could not be created")
             raise ErrorResponse.wrap(e)
 
-    def delete_nfs_cluster(self, cluster_id: str) -> Tuple[int, str, str]:
+    def delete_nfs_cluster(self, cluster_id: str) -> None:
         try:
             cluster_list = available_clusters(self.mgr)
             if cluster_id in cluster_list:
@@ -147,10 +147,11 @@ class NFSCluster:
                 completion = self.mgr.remove_service('nfs.' + cluster_id)
                 orchestrator.raise_if_exception(completion)
                 self.delete_config_obj(cluster_id)
-                return 0, "", ""
-            return 0, "", "Cluster does not exist"
+                return
+            raise NonFatalError("Cluster does not exist")
         except Exception as e:
-            return exception_handler(e, f"Failed to delete NFS Cluster {cluster_id}")
+            log.exception(f"Failed to delete NFS Cluster {cluster_id}")
+            raise ErrorResponse.wrap(e)
 
     def list_nfs_cluster(self) -> List[str]:
         try:

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -1,6 +1,5 @@
 import ipaddress
 import logging
-import json
 import re
 import socket
 from typing import cast, Dict, List, Any, Union, Optional, TYPE_CHECKING, Tuple
@@ -203,7 +202,7 @@ class NFSCluster:
         log.debug("Successfully fetched %s info: %s", cluster_id, r)
         return r
 
-    def show_nfs_cluster_info(self, cluster_id: Optional[str] = None) -> Tuple[int, str, str]:
+    def show_nfs_cluster_info(self, cluster_id: Optional[str] = None) -> Dict[str, Any]:
         try:
             if cluster_id and cluster_id not in available_clusters(self.mgr):
                 raise ClusterNotFound()
@@ -217,9 +216,10 @@ class NFSCluster:
                 res = self._show_nfs_cluster_info(cluster_id)
                 if res:
                     info_res[cluster_id] = res
-            return (0, json.dumps(info_res, indent=4), '')
+            return info_res
         except Exception as e:
-            return exception_handler(e, "Failed to show info for cluster")
+            log.exception("Failed to show info for cluster")
+            raise ErrorResponse.wrap(e)
 
     def get_nfs_cluster_config(self, cluster_id: str) -> Tuple[int, str, str]:
         try:

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -2,7 +2,7 @@ import ipaddress
 import logging
 import re
 import socket
-from typing import cast, Dict, List, Any, Union, Optional, TYPE_CHECKING, Tuple
+from typing import cast, Dict, List, Any, Union, Optional, TYPE_CHECKING
 
 from mgr_module import NFS_POOL_NAME as POOL_NAME
 from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec, IngressSpec
@@ -18,7 +18,7 @@ from .utils import (
     conf_obj_name,
     restart_nfs_service,
     user_conf_obj_name)
-from .export import NFSRados, exception_handler
+from .export import NFSRados
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -227,15 +227,16 @@ class NFSCluster:
             log.exception("Failed to show info for cluster")
             raise ErrorResponse.wrap(e)
 
-    def get_nfs_cluster_config(self, cluster_id: str) -> Tuple[int, str, str]:
+    def get_nfs_cluster_config(self, cluster_id: str) -> str:
         try:
             if cluster_id in available_clusters(self.mgr):
                 rados_obj = self._rados(cluster_id)
                 conf = rados_obj.read_obj(user_conf_obj_name(cluster_id))
-                return 0, conf or "", ""
+                return conf or ""
             raise ClusterNotFound()
         except Exception as e:
-            return exception_handler(e, f"Fetching NFS-Ganesha Config failed for {cluster_id}")
+            log.exception(f"Fetching NFS-Ganesha Config failed for {cluster_id}")
+            raise ErrorResponse.wrap(e)
 
     def set_nfs_cluster_config(self, cluster_id: str, nfs_config: str) -> None:
         try:

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -411,7 +411,8 @@ class ExportMgr:
                 return self.create_rgw_export(**kwargs)
             raise NotImplementedError()
         except Exception as e:
-            log.exception(f"Failed to create {kwargs['pseudo_path']} export for {kwargs['cluster_id']}")
+            log.exception(
+                f"Failed to create {kwargs['pseudo_path']} export for {kwargs['cluster_id']}")
             raise ErrorResponse.wrap(e)
 
     def delete_export(self,

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -5,7 +5,6 @@ from typing import (
     List,
     Any,
     Dict,
-    Tuple,
     Optional,
     TYPE_CHECKING,
     TypeVar,
@@ -54,15 +53,6 @@ def known_cluster_ids(mgr: 'Module') -> Set[str]:
     except NoOrchestrator:
         clusters = nfs_rados_configs(mgr.rados)
     return clusters
-
-
-def exception_handler(
-        exception_obj: Exception,
-        log_msg: str = ""
-) -> Tuple[int, str, str]:
-    if log_msg:
-        log.exception(log_msg)
-    return getattr(exception_obj, 'errno', -1), "", str(exception_obj)
 
 
 def _check_rados_notify(ioctx: Any, obj: str) -> None:

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -462,20 +462,19 @@ class ExportMgr:
         log.warning(f"No {pseudo_path} export to show for {cluster_id}")
         return None
 
-    @export_cluster_checker
     def get_export(
             self,
             cluster_id: str,
             pseudo_path: str,
-    ) -> Tuple[int, str, str]:
+    ) -> Dict[str, Any]:
+        self._validate_cluster_id(cluster_id)
         try:
             export_dict = self._get_export_dict(cluster_id, pseudo_path)
-            if export_dict:
-                return 0, json.dumps(export_dict, indent=2), ''
-            log.warning("No %s export to show for %s", pseudo_path, cluster_id)
-            return 0, '', ''
+            log.info(f"Fetched {export_dict!r} for {cluster_id!r}, {pseudo_path!r}")
+            return export_dict if export_dict else {}
         except Exception as e:
-            return exception_handler(e, f"Failed to get {pseudo_path} export for {cluster_id}")
+            log.exception(f"Failed to get {pseudo_path} export for {cluster_id}")
+            raise ErrorResponse.wrap(e)
 
     def get_export_by_id(
             self,

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -56,25 +56,6 @@ def known_cluster_ids(mgr: 'Module') -> Set[str]:
     return clusters
 
 
-def export_cluster_checker(func: FuncT) -> FuncT:
-    def cluster_check(
-            export: 'ExportMgr',
-            *args: Any,
-            **kwargs: Any
-    ) -> Tuple[int, str, str]:
-        """
-        This method checks if cluster exists
-        """
-        clusters = known_cluster_ids(export.mgr)
-        cluster_id: str = kwargs['cluster_id']
-        log.debug("checking for %r in known nfs clusters: %r",
-                  cluster_id, clusters)
-        if cluster_id not in clusters:
-            return -errno.ENOENT, "", "Cluster does not exist"
-        return func(export, *args, **kwargs)
-    return cast(FuncT, cluster_check)
-
-
 def exception_handler(
         exception_obj: Exception,
         log_msg: str = ""

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -158,7 +158,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @CLICommand('nfs cluster config set', perm='rw')
     @CLICheckNonemptyFileInput(desc='NFS-Ganesha Configuration')
-    def _cmd_nfs_cluster_config_set(self, cluster_id: str, inbuf: str) -> Tuple[int, str, str]:
+    @object_format.EmptyResponder()
+    def _cmd_nfs_cluster_config_set(self, cluster_id: str, inbuf: str) -> None:
         """Set NFS-Ganesha config by `-i <config_file>`"""
         return self.nfs.set_nfs_cluster_config(cluster_id=cluster_id, nfs_config=inbuf)
 

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -3,6 +3,7 @@ import threading
 from typing import Tuple, Optional, List, Dict, Any
 
 from mgr_module import MgrModule, CLICommand, Option, CLICheckNonemptyFileInput
+import object_format
 import orchestrator
 
 from .export import ExportMgr
@@ -85,7 +86,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.export_mgr.delete_export(cluster_id=cluster_id, pseudo_path=pseudo_path)
 
     @CLICommand('nfs export ls', perm='r')
-    def _cmd_nfs_export_ls(self, cluster_id: str, detailed: bool = False) -> Tuple[int, str, str]:
+    @object_format.Responder()
+    def _cmd_nfs_export_ls(self, cluster_id: str, detailed: bool = False) -> List[Any]:
         """List exports of a NFS cluster"""
         return self.export_mgr.list_exports(cluster_id=cluster_id, detailed=detailed)
 

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -114,12 +114,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.export_mgr.apply_export(cluster_id, export_config=inbuf)
 
     @CLICommand('nfs cluster create', perm='rw')
+    @object_format.EmptyResponder()
     def _cmd_nfs_cluster_create(self,
                                 cluster_id: str,
                                 placement: Optional[str] = None,
                                 ingress: Optional[bool] = None,
                                 virtual_ip: Optional[str] = None,
-                                port: Optional[int] = None) -> Tuple[int, str, str]:
+                                port: Optional[int] = None) -> None:
         """Create an NFS Cluster"""
         return self.nfs.create_nfs_cluster(cluster_id=cluster_id, placement=placement,
                                            virtual_ip=virtual_ip, ingress=ingress,

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -132,7 +132,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.nfs.delete_nfs_cluster(cluster_id=cluster_id)
 
     @CLICommand('nfs cluster ls', perm='r')
-    def _cmd_nfs_cluster_ls(self) -> Tuple[int, str, str]:
+    @object_format.Responder()
+    def _cmd_nfs_cluster_ls(self) -> List[str]:
         """List NFS Clusters"""
         return self.nfs.list_nfs_cluster()
 

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -127,12 +127,14 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                            port=port)
 
     @CLICommand('nfs cluster rm', perm='rw')
-    def _cmd_nfs_cluster_rm(self, cluster_id: str) -> Tuple[int, str, str]:
+    @object_format.EmptyResponder()
+    def _cmd_nfs_cluster_rm(self, cluster_id: str) -> None:
         """Removes an NFS Cluster"""
         return self.nfs.delete_nfs_cluster(cluster_id=cluster_id)
 
     @CLICommand('nfs cluster delete', perm='rw')
-    def _cmd_nfs_cluster_delete(self, cluster_id: str) -> Tuple[int, str, str]:
+    @object_format.EmptyResponder()
+    def _cmd_nfs_cluster_delete(self, cluster_id: str) -> None:
         """Removes an NFS Cluster (DEPRECATED)"""
         return self.nfs.delete_nfs_cluster(cluster_id=cluster_id)
 

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -152,9 +152,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.nfs.show_nfs_cluster_info(cluster_id=cluster_id)
 
     @CLICommand('nfs cluster config get', perm='r')
+    @object_format.ErrorResponseHandler()
     def _cmd_nfs_cluster_config_get(self, cluster_id: str) -> Tuple[int, str, str]:
         """Fetch NFS-Ganesha config"""
-        return self.nfs.get_nfs_cluster_config(cluster_id=cluster_id)
+        conf = self.nfs.get_nfs_cluster_config(cluster_id=cluster_id)
+        return 0, conf, ""
 
     @CLICommand('nfs cluster config set', perm='rw')
     @CLICheckNonemptyFileInput(desc='NFS-Ganesha Configuration')

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -26,6 +26,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             self.inited = True
 
     @CLICommand('nfs export create cephfs', perm='rw')
+    @object_format.Responder()
     def _cmd_nfs_export_create_cephfs(
             self,
             cluster_id: str,
@@ -36,7 +37,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             client_addr: Optional[List[str]] = None,
             squash: str = 'none',
             sectype: Optional[List[str]] = None,
-    ) -> Tuple[int, str, str]:
+    ) -> Dict[str, Any]:
         """Create a CephFS export"""
         return self.export_mgr.create_export(
             fsal_type='cephfs',
@@ -51,6 +52,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         )
 
     @CLICommand('nfs export create rgw', perm='rw')
+    @object_format.Responder()
     def _cmd_nfs_export_create_rgw(
             self,
             cluster_id: str,
@@ -61,7 +63,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             client_addr: Optional[List[str]] = None,
             squash: str = 'none',
             sectype: Optional[List[str]] = None,
-    ) -> Tuple[int, str, str]:
+    ) -> Dict[str, Any]:
         """Create an RGW export"""
         return self.export_mgr.create_export(
             fsal_type='rgw',

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -138,7 +138,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.nfs.list_nfs_cluster()
 
     @CLICommand('nfs cluster info', perm='r')
-    def _cmd_nfs_cluster_info(self, cluster_id: Optional[str] = None) -> Tuple[int, str, str]:
+    @object_format.Responder()
+    def _cmd_nfs_cluster_info(self, cluster_id: Optional[str] = None) -> Dict[str, Any]:
         """Displays NFS Cluster info"""
         return self.nfs.show_nfs_cluster_info(cluster_id=cluster_id)
 

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -164,7 +164,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.nfs.set_nfs_cluster_config(cluster_id=cluster_id, nfs_config=inbuf)
 
     @CLICommand('nfs cluster config reset', perm='rw')
-    def _cmd_nfs_cluster_config_reset(self, cluster_id: str) -> Tuple[int, str, str]:
+    @object_format.EmptyResponder()
+    def _cmd_nfs_cluster_config_reset(self, cluster_id: str) -> None:
         """Reset NFS-Ganesha Config to default"""
         return self.nfs.reset_nfs_cluster_config(cluster_id=cluster_id)
 

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -6,7 +6,7 @@ from mgr_module import MgrModule, CLICommand, Option, CLICheckNonemptyFileInput
 import object_format
 import orchestrator
 
-from .export import ExportMgr
+from .export import ExportMgr, AppliedExportResults
 from .cluster import NFSCluster
 from .utils import available_clusters
 
@@ -109,7 +109,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @CLICommand('nfs export apply', perm='rw')
     @CLICheckNonemptyFileInput(desc='Export JSON or Ganesha EXPORT specification')
-    def _cmd_nfs_export_apply(self, cluster_id: str, inbuf: str) -> Tuple[int, str, str]:
+    @object_format.Responder()
+    def _cmd_nfs_export_apply(self, cluster_id: str, inbuf: str) -> AppliedExportResults:
         """Create or update an export by `-i <json_or_ganesha_export_file>`"""
         return self.export_mgr.apply_export(cluster_id, export_config=inbuf)
 

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -78,12 +78,14 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         )
 
     @CLICommand('nfs export rm', perm='rw')
-    def _cmd_nfs_export_rm(self, cluster_id: str, pseudo_path: str) -> Tuple[int, str, str]:
+    @object_format.EmptyResponder()
+    def _cmd_nfs_export_rm(self, cluster_id: str, pseudo_path: str) -> None:
         """Remove a cephfs export"""
         return self.export_mgr.delete_export(cluster_id=cluster_id, pseudo_path=pseudo_path)
 
     @CLICommand('nfs export delete', perm='rw')
-    def _cmd_nfs_export_delete(self, cluster_id: str, pseudo_path: str) -> Tuple[int, str, str]:
+    @object_format.EmptyResponder()
+    def _cmd_nfs_export_delete(self, cluster_id: str, pseudo_path: str) -> None:
         """Delete a cephfs export (DEPRECATED)"""
         return self.export_mgr.delete_export(cluster_id=cluster_id, pseudo_path=pseudo_path)
 

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -92,12 +92,14 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.export_mgr.list_exports(cluster_id=cluster_id, detailed=detailed)
 
     @CLICommand('nfs export info', perm='r')
-    def _cmd_nfs_export_info(self, cluster_id: str, pseudo_path: str) -> Tuple[int, str, str]:
+    @object_format.Responder()
+    def _cmd_nfs_export_info(self, cluster_id: str, pseudo_path: str) -> Dict[str, Any]:
         """Fetch a export of a NFS cluster given the pseudo path/binding"""
         return self.export_mgr.get_export(cluster_id=cluster_id, pseudo_path=pseudo_path)
 
     @CLICommand('nfs export get', perm='r')
-    def _cmd_nfs_export_get(self, cluster_id: str, pseudo_path: str) -> Tuple[int, str, str]:
+    @object_format.Responder()
+    def _cmd_nfs_export_get(self, cluster_id: str, pseudo_path: str) -> Dict[str, Any]:
         """Fetch a export of a NFS cluster given the pseudo path/binding (DEPRECATED)"""
         return self.export_mgr.get_export(cluster_id=cluster_id, pseudo_path=pseudo_path)
 

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1088,9 +1088,8 @@ NFS_CORE_PARAM {
         nfs_mod = Module('nfs', '', '')
         cluster = NFSCluster(nfs_mod)
 
-        rc, out, err = cluster.show_nfs_cluster_info(self.cluster_id)
-        assert rc == 0
-        assert json.loads(out) == {"foo": {"virtual_ip": None, "backend": []}}
+        out = cluster.show_nfs_cluster_info(self.cluster_id)
+        assert out == {"foo": {"virtual_ip": None, "backend": []}}
 
     def test_cluster_info(self):
         self._do_mock_test(self._do_test_cluster_info)

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1101,20 +1101,17 @@ NFS_CORE_PARAM {
         nfs_mod = Module('nfs', '', '')
         cluster = NFSCluster(nfs_mod)
 
-        rc, out, err = cluster.get_nfs_cluster_config(self.cluster_id)
-        assert rc == 0
+        out = cluster.get_nfs_cluster_config(self.cluster_id)
         assert out == ""
 
         cluster.set_nfs_cluster_config(self.cluster_id, '# foo\n')
 
-        rc, out, err = cluster.get_nfs_cluster_config(self.cluster_id)
-        assert rc == 0
+        out = cluster.get_nfs_cluster_config(self.cluster_id)
         assert out == "# foo\n"
 
         cluster.reset_nfs_cluster_config(self.cluster_id)
 
-        rc, out, err = cluster.get_nfs_cluster_config(self.cluster_id)
-        assert rc == 0
+        out = cluster.get_nfs_cluster_config(self.cluster_id)
         assert out == ""
 
     def test_cluster_config(self):

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1105,15 +1105,13 @@ NFS_CORE_PARAM {
         assert rc == 0
         assert out == ""
 
-        rc, out, err = cluster.set_nfs_cluster_config(self.cluster_id, '# foo\n')
-        assert rc == 0
+        cluster.set_nfs_cluster_config(self.cluster_id, '# foo\n')
 
         rc, out, err = cluster.get_nfs_cluster_config(self.cluster_id)
         assert rc == 0
         assert out == "# foo\n"
 
-        rc, out, err = cluster.reset_nfs_cluster_config(self.cluster_id)
-        assert rc == 0
+        cluster.reset_nfs_cluster_config(self.cluster_id)
 
         rc, out, err = cluster.get_nfs_cluster_config(self.cluster_id)
         assert rc == 0

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -912,8 +912,7 @@ NFS_CORE_PARAM {
         nfs_mod = Module('nfs', '', '')
         conf = ExportMgr(nfs_mod)
 
-        exports = conf.list_exports(cluster_id=self.cluster_id)
-        ls = json.loads(exports[1])
+        ls = conf.list_exports(cluster_id=self.cluster_id)
         assert len(ls) == 2
 
         r = conf.create_export(
@@ -927,8 +926,7 @@ NFS_CORE_PARAM {
         )
         assert r[0] == 0
 
-        exports = conf.list_exports(cluster_id=self.cluster_id)
-        ls = json.loads(exports[1])
+        ls = conf.list_exports(cluster_id=self.cluster_id)
         assert len(ls) == 3
 
         export = conf._fetch_export('foo', '/mybucket')
@@ -956,8 +954,7 @@ NFS_CORE_PARAM {
         nfs_mod = Module('nfs', '', '')
         conf = ExportMgr(nfs_mod)
 
-        exports = conf.list_exports(cluster_id=self.cluster_id)
-        ls = json.loads(exports[1])
+        ls = conf.list_exports(cluster_id=self.cluster_id)
         assert len(ls) == 2
 
         r = conf.create_export(
@@ -972,8 +969,7 @@ NFS_CORE_PARAM {
         )
         assert r[0] == 0
 
-        exports = conf.list_exports(cluster_id=self.cluster_id)
-        ls = json.loads(exports[1])
+        ls = conf.list_exports(cluster_id=self.cluster_id)
         assert len(ls) == 3
 
         export = conf._fetch_export('foo', '/mybucket')
@@ -1001,8 +997,7 @@ NFS_CORE_PARAM {
         nfs_mod = Module('nfs', '', '')
         conf = ExportMgr(nfs_mod)
 
-        exports = conf.list_exports(cluster_id=self.cluster_id)
-        ls = json.loads(exports[1])
+        ls = conf.list_exports(cluster_id=self.cluster_id)
         assert len(ls) == 2
 
         r = conf.create_export(
@@ -1016,8 +1011,7 @@ NFS_CORE_PARAM {
         )
         assert r[0] == 0
 
-        exports = conf.list_exports(cluster_id=self.cluster_id)
-        ls = json.loads(exports[1])
+        ls = conf.list_exports(cluster_id=self.cluster_id)
         assert len(ls) == 3
 
         export = conf._fetch_export('foo', '/mybucket')
@@ -1045,8 +1039,7 @@ NFS_CORE_PARAM {
         nfs_mod = Module('nfs', '', '')
         conf = ExportMgr(nfs_mod)
 
-        exports = conf.list_exports(cluster_id=self.cluster_id)
-        ls = json.loads(exports[1])
+        ls = conf.list_exports(cluster_id=self.cluster_id)
         assert len(ls) == 2
 
         r = conf.create_export(
@@ -1061,8 +1054,7 @@ NFS_CORE_PARAM {
         )
         assert r[0] == 0
 
-        exports = conf.list_exports(cluster_id=self.cluster_id)
-        ls = json.loads(exports[1])
+        ls = conf.list_exports(cluster_id=self.cluster_id)
         assert len(ls) == 3
 
         export = conf._fetch_export('foo', '/cephfs2')

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1078,9 +1078,8 @@ NFS_CORE_PARAM {
         nfs_mod = Module('nfs', '', '')
         cluster = NFSCluster(nfs_mod)
 
-        rc, out, err = cluster.list_nfs_cluster()
-        assert rc == 0
-        assert out == self.cluster_id
+        out = cluster.list_nfs_cluster()
+        assert out[0] == self.cluster_id
 
     def test_cluster_ls(self):
         self._do_mock_test(self._do_test_cluster_ls)

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -924,7 +924,7 @@ NFS_CORE_PARAM {
             squash='root',
             addr=["192.168.0.0/16"]
         )
-        assert r[0] == 0
+        assert r["bind"] == "/mybucket"
 
         ls = conf.list_exports(cluster_id=self.cluster_id)
         assert len(ls) == 3
@@ -967,7 +967,7 @@ NFS_CORE_PARAM {
             squash='root',
             addr=["192.168.0.0/16"]
         )
-        assert r[0] == 0
+        assert r["bind"] == "/mybucket"
 
         ls = conf.list_exports(cluster_id=self.cluster_id)
         assert len(ls) == 3
@@ -1009,7 +1009,7 @@ NFS_CORE_PARAM {
             squash='root',
             addr=["192.168.0.0/16"]
         )
-        assert r[0] == 0
+        assert r["bind"] == "/mybucket"
 
         ls = conf.list_exports(cluster_id=self.cluster_id)
         assert len(ls) == 3
@@ -1052,7 +1052,7 @@ NFS_CORE_PARAM {
             squash='root',
             addr=["192.168.1.0/8"],
         )
-        assert r[0] == 0
+        assert r["bind"] == "/cephfs2"
 
         ls = conf.list_exports(cluster_id=self.cluster_id)
         assert len(ls) == 3

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -899,8 +899,8 @@ NFS_CORE_PARAM {
         nfs_mod = Module('nfs', '', '')
         conf = ExportMgr(nfs_mod)
         assert len(conf.exports[self.cluster_id]) == 2
-        assert conf.delete_export(cluster_id=self.cluster_id,
-                                  pseudo_path="/rgw") == (0, "Successfully deleted export", "")
+        conf.delete_export(cluster_id=self.cluster_id,
+                           pseudo_path="/rgw")
         exports = conf.exports[self.cluster_id]
         assert len(exports) == 1
         assert exports[0].export_id == 1

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -610,7 +610,7 @@ NFS_CORE_PARAM {
                 'secret_access_key': 'the_secret_key',
             }
         }))
-        assert r[0] == 0
+        assert len(r.changes) == 1
 
         export = conf._fetch_export('foo', '/rgw/bucket')
         assert export.export_id == 2
@@ -651,7 +651,7 @@ NFS_CORE_PARAM {
                 'secret_access_key': 'the_secret_key',
             }
         }))
-        assert r[0] == 0
+        assert len(r.changes) == 1
 
         export = conf._fetch_export('foo', '/rgw/bucket')
         assert export.export_id == 2
@@ -691,7 +691,7 @@ NFS_CORE_PARAM {
                 'secret_access_key': 'the_secret_key',
             }
         }))
-        assert r[0] == 0
+        assert len(r.changes) == 1
 
         export = conf._fetch_export(self.cluster_id, '/rgw/bucket')
         assert export.export_id == 2
@@ -737,7 +737,7 @@ NFS_CORE_PARAM {
                 'secret_access_key': 'the_secret_key',
             }
         }))
-        assert r[0] == 0
+        assert len(r.changes) == 1
 
         # no sectype was given, key not present
         info = conf._get_export_dict(self.cluster_id, "/rgw/bucket")
@@ -768,7 +768,7 @@ NFS_CORE_PARAM {
                 'secret_access_key': 'the_secret_key',
             }
         }))
-        assert r[0] == 0
+        assert len(r.changes) == 1
 
         # assert sectype matches new value(s)
         info = conf._get_export_dict(self.cluster_id, "/rgw/bucket")
@@ -783,7 +783,7 @@ NFS_CORE_PARAM {
         nfs_mod = Module('nfs', '', '')
         conf = ExportMgr(nfs_mod)
         r = conf.apply_export(self.cluster_id, self.export_3)
-        assert r[0] == 0
+        assert len(r.changes) == 1
 
     def test_update_export_with_ganesha_conf_sectype(self):
         self._do_mock_test(
@@ -800,7 +800,7 @@ NFS_CORE_PARAM {
         nfs_mod = Module('nfs', '', '')
         conf = ExportMgr(nfs_mod)
         r = conf.apply_export(self.cluster_id, export_conf)
-        assert r[0] == 0
+        assert len(r.changes) == 1
 
         # assert sectype matches new value(s)
         info = conf._get_export_dict(self.cluster_id, "/secure1")
@@ -858,7 +858,10 @@ NFS_CORE_PARAM {
                 }
             },
         ]))
-        assert r[0] == 0
+        # The input object above contains TWO items (two different pseudo paths)
+        # therefore we expect the result to report that two changes have been
+        # applied, rather than the typical 1 change.
+        assert len(r.changes) == 2
 
         export = conf._fetch_export('foo', '/rgw/bucket')
         assert export.export_id == 3

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -241,7 +241,7 @@ EXPORT {
             return OrchResult([])
 
         with mock.patch('nfs.module.Module.describe_service', mock_describe_service) as describe_service, \
-             mock.patch('nfs.module.Module.list_daemons', mock_list_daemons) as list_daemons, \
+            mock.patch('nfs.module.Module.list_daemons', mock_list_daemons) as list_daemons, \
                 mock.patch('nfs.module.Module.rados') as rados, \
                 mock.patch('nfs.export.available_clusters',
                            return_value=[self.cluster_id]), \
@@ -992,7 +992,7 @@ NFS_CORE_PARAM {
         assert export.clients[0].access_type == 'rw'
         assert export.clients[0].addresses == ["192.168.0.0/16"]
         assert export.cluster_id == self.cluster_id
-        
+
     def test_create_export_rgw_user(self):
         self._do_mock_test(self._do_test_create_export_rgw_user)
 
@@ -1034,7 +1034,7 @@ NFS_CORE_PARAM {
         assert export.clients[0].access_type == 'rw'
         assert export.clients[0].addresses == ["192.168.0.0/16"]
         assert export.cluster_id == self.cluster_id
-        
+
     def test_create_export_cephfs(self):
         self._do_mock_test(self._do_test_create_export_cephfs)
 

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -26,6 +26,15 @@ class NonFatalError(ErrorResponseBase):
         return 0, "", self.msg
 
 
+class ManualRestartRequired(NonFatalError):
+    """Raise this exception type if all other changes were successful but
+    user needs to manually restart nfs services.
+    """
+
+    def __init__(self, msg: str) -> None:
+        super().__init__(" ".join((msg, "(Manual Restart of NFS Pods required)")))
+
+
 def export_obj_name(export_id: int) -> str:
     """Return a rados object name for the export."""
     return f"{EXPORT_PREFIX}{export_id}"

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -1,5 +1,6 @@
-from typing import List, TYPE_CHECKING
+from typing import List, Tuple, TYPE_CHECKING
 
+from object_format import ErrorResponseBase
 import orchestrator
 
 if TYPE_CHECKING:
@@ -8,6 +9,21 @@ if TYPE_CHECKING:
 EXPORT_PREFIX: str = "export-"
 CONF_PREFIX: str = "conf-nfs."
 USER_CONF_PREFIX: str = "userconf-nfs."
+
+
+class NonFatalError(ErrorResponseBase):
+    """Raise this exception when you want to interrupt the flow of a function
+    and return an informative message to the user. In certain situations the
+    NFS MGR module wants to indicate an action was or was not taken but still
+    return a success code so that non-interactive scripts continue as if the
+    overall action was completed.
+    """
+    def __init__(self, msg: str) -> None:
+        super().__init__(msg)
+        self.msg = msg
+
+    def format_response(self) -> Tuple[int, str, str]:
+        return 0, "", self.msg
 
 
 def export_obj_name(export_id: int) -> str:


### PR DESCRIPTION

Depends on: #45467 

The changes above add a new python module to the mgr - a general way to handle mgr command responses and formatting. As yet it is unused. This series of changes converts the nfs mgr module to use the object_format decorators. This serves as both a demonstration of how the decorators can be used and how they benefit a mgr module - the code within the module becomes simpler and more pythonic. Only at the "outermost" layer do we concern ourselves with creating mgr response tuples.  Because the nfs module is one of sufficient complexity and history not all existing APIs can use the simplest object_format.Responder decorator.  A few edge cases (discussed below) were found and this required the addition of two simpler decorators "EmptyResponder" and "ErrorResponseHandler".

There are approximately three kinds of conversion that were done:
* A function already returned JSON and could be mapped directly to Responder
* A function makes changes to system state and (usually) returned no information were mapped to EmptyResponder
* A function passed raw data stored in a rados object to the client. The one case of this we used the ErrorResponseHandler to ensure exceptions of the right base class are converted to response tuples. Otherwise the only other change was to isolate the mgr response logic to the CLICommand function.


I am filing this PR in draft state until the predecessor pr is merged. As it'll be in draft, discussion of things like the general approach and naming are quite welcome.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
