### PR TITLE
pacific: rpm: use system libpmem on Centos 9 Stream

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -29,7 +29,11 @@
 %else
 %bcond_without tcmalloc
 %endif
+%if 0%{?rhel} >= 9
+%bcond_without system_pmdk
+%else
 %bcond_with system_pmdk
+%endif
 %if 0%{?fedora} || 0%{?rhel}
 %bcond_without selinux
 %ifarch x86_64 ppc64le


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55560

---

backport of https://github.com/ceph/ceph/pull/45341
parent tracker: https://tracker.ceph.com/issues/54473