### PR TITLE
quincy: rpm: use system libpmem on Centos 9 Stream

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -36,7 +36,11 @@
 %bcond_with rbd_rwl_cache
 %endif
 %if 0%{?fedora} || 0%{?rhel}
+%if 0%{?rhel} < 9
 %bcond_with system_pmdk
+%else
+%bcond_without system_pmdk
+%endif
 %bcond_without selinux
 %if 0%{?rhel} >= 8
 %bcond_with cephfs_java


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55561

---

backport of https://github.com/ceph/ceph/pull/45341
parent tracker: https://tracker.ceph.com/issues/54473