### PR TITLE
pacific: test/bufferlist: ensure rebuild_aligned_size_and_memory() always rebuilds.

### DIFF
--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1744,8 +1744,9 @@ TEST(BufferList, rebuild_aligned_size_and_memory) {
     bl.append(ptr, 0, 0);
     EXPECT_EQ(bl.get_num_buffers(), 2);
     EXPECT_EQ(bl.back().length(), 0);
-    /* rebuild_aligned() calls rebuild_aligned_size_and_memory() */
-    bl.rebuild_aligned(4096);
+    /* rebuild_aligned() calls rebuild_aligned_size_and_memory().
+     * we assume the rebuild always happens. */
+    EXPECT_TRUE(bl.rebuild_aligned(4096));
     EXPECT_EQ(bl.get_num_buffers(), 1);
   }
 }

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1737,13 +1737,14 @@ TEST(BufferList, rebuild_aligned_size_and_memory) {
      * scenario where the first bptr is both size and memory aligned and
      * the second is 0-length */
     bl.clear();
-    bufferptr ptr1(buffer::create_aligned(4096, 4096));
-    bl.append(ptr1);
-    bufferptr ptr(10);
-    /* bl.back().length() must be 0 */
-    bl.append(ptr, 0, 0);
+    bl.append(bufferptr{buffer::create_aligned(4096, 4096)});
+    bufferptr ptr(buffer::create_aligned(42, 4096));
+    /* bl.back().length() must be 0. offset set to 42 guarantees
+     * the entire list is unaligned. */
+    bl.append(ptr, 42, 0);
     EXPECT_EQ(bl.get_num_buffers(), 2);
     EXPECT_EQ(bl.back().length(), 0);
+    EXPECT_FALSE(bl.is_aligned(4096));
     /* rebuild_aligned() calls rebuild_aligned_size_and_memory().
      * we assume the rebuild always happens. */
     EXPECT_TRUE(bl.rebuild_aligned(4096));


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/53972

---

backport of https://github.com/ceph/ceph/pull/44706
parent tracker: https://tracker.ceph.com/issues/53969

clean cherry-pick required additional commit from https://github.com/ceph/ceph/pull/44675