### PR TITLE
cls/rgw: avoid double-encoding cls_rgw_obj's name

### DIFF
--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1123,16 +1123,22 @@ struct cls_rgw_obj {
   cls_rgw_obj(std::string& _p, cls_rgw_obj_key& _k) : pool(_p), key(_k) {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 2, bl);
     encode(pool, bl);
-    encode(key.name, bl);
+    {
+      // v1 and v2 encoded 'key.name' here. v2 duplicated this in 'key'. v3
+      // encodes an empty string here so that v2 can still decode it, but
+      // is no longer compatible with v1 encodings that don't include 'key'
+      std::string empty;
+      encode(empty, bl);
+    }
     encode(loc, bl);
     encode(key, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     decode(pool, bl);
     decode(key.name, bl);
     decode(loc, bl);


### PR DESCRIPTION
update cls_rgw_obj's encoder to avoid encoding 'key.name', which is already being encoded as 'key'

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
