### PR TITLE
quincy: mgr/dashboard: fix wrong pg status processing

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/pg-category.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/pg-category.service.spec.ts
@@ -35,6 +35,7 @@ describe('PgCategoryService', () => {
 
     it(PgCategory.CATEGORY_WORKING, () => {
       testMethod('clean+scrubbing', PgCategory.CATEGORY_WORKING);
+      testMethod('active+clean+snaptrim_wait', PgCategory.CATEGORY_WORKING);
       testMethod(
         '  8 active+clean+scrubbing+deep, 255 active+clean  ',
         PgCategory.CATEGORY_WORKING

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/pg-category.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/pg-category.service.ts
@@ -54,7 +54,7 @@ export class PgCategoryService {
 
   private getPgStatesFromText(pgStatesText: string) {
     const pgStates = pgStatesText
-      .replace(/[^a-z]+/g, ' ')
+      .replace(/[^a-z_]+/g, ' ')
       .trim()
       .split(' ');
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55416

---

backport of https://github.com/ceph/ceph/pull/45360
parent tracker: https://tracker.ceph.com/issues/54481

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh