### PR TITLE
qa/rgw: use 'with-sse-s3' override for s3tests

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
+++ b/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
@@ -13,6 +13,8 @@ overrides:
   rgw:
     client.0:
       use-vault-role: client.0
+  s3tests:
+    with-sse-s3: true
 
 tasks:
 - vault:

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -14,7 +14,6 @@ import logging
 import threading
 import traceback
 import os
-import re
 import shlex
 
 from io import BytesIO, StringIO
@@ -70,14 +69,6 @@ def toolbox(ctx, cluster_name, args, **kwargs):
 def write_conf(ctx, conf_path=DEFAULT_CONF_PATH, cluster='ceph'):
     conf_fp = BytesIO()
     ctx.ceph[cluster].conf.write(conf_fp)
-    conf_fp.seek(0)
-    lines = conf_fp.readlines()
-    m = None
-    for l in lines:
-     m = re.search("rgw.crypt.sse.s3.backend *= *(.*)", l.decode())
-     if m:
-      break
-    ctx.ceph[cluster].rgw_crypt_sse_s3_backend = m.expand("\\1") if m else None
     conf_fp.seek(0)
     writes = ctx.cluster.run(
         args=[

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -432,7 +432,7 @@ def run_tests(ctx, config):
         attrs = ["!fails_on_rgw", "!lifecycle_expiration", "!fails_strict_rfc2616","!test_of_sts","!webidentity_test"]
         if client_config.get('calling-format') != 'ordinary':
             attrs += ['!fails_with_subdomain']
-        if client_config.get('without-sse-s3'):
+        if not client_config.get('with-sse-s3'):
             attrs += ['!sse-s3']
        
         if 'extra_attrs' in client_config:

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -416,7 +416,6 @@ def run_tests(ctx, config):
     testdir = teuthology.get_testdir(ctx)
     for client, client_config in config.items():
         client_config = client_config or {}
-        (cluster_name,_,_) = teuthology.split_role(client)
         (remote,) = ctx.cluster.only(client).remotes.keys()
         args = [
             'S3TEST_CONF={tdir}/archive/s3-tests.{client}.conf'.format(tdir=testdir, client=client),
@@ -434,10 +433,6 @@ def run_tests(ctx, config):
         if client_config.get('calling-format') != 'ordinary':
             attrs += ['!fails_with_subdomain']
         if client_config.get('without-sse-s3'):
-            attrs += ['!sse-s3']
-        elif client_config.get('with-sse-s3'):
-            pass
-        elif ctx.ceph[cluster_name].rgw_crypt_sse_s3_backend is None:
             attrs += ['!sse-s3']
        
         if 'extra_attrs' in client_config:


### PR DESCRIPTION
don't rely on the ceph manager task to parse a config file. each rgw could be using a different config. instead, revert to an s3tests override called 'with-sse-s3'

this way, the only job that enables sse-s3, vault_transit.yaml, contains both the 'rgw crypt sse s3' configurables, and the flag to enable the associated test cases


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
