### PR TITLE
quincy: rgw: remove rgw_rados_pool_pg_num_min and its use on pool creation use the cluster defaults for pg_num_min

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1157,15 +1157,6 @@ options:
   - rgw
   min: 0.01
   max: 100000
-- name: rgw_rados_pool_pg_num_min
-  type: uint
-  level: advanced
-  desc: pg_num_min value for RGW metadata (omap-heavy) pools
-  default: 8
-  services:
-  - rgw
-  min: 1
-  max: 1_K
 - name: rgw_rados_pool_recovery_priority
   type: uint
   level: advanced

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -80,17 +80,6 @@ int rgw_init_ioctx(const DoutPrefixProvider *dpp,
 	ldpp_dout(dpp, 10) << __func__ << " warning: failed to set pg_autoscale_bias on "
 		 << pool.name << dendl;
       }
-      // set pg_num_min
-      int min = g_conf().get_val<uint64_t>("rgw_rados_pool_pg_num_min");
-      r = rados->mon_command(
-	"{\"prefix\": \"osd pool set\", \"pool\": \"" +
-	pool.name + "\", \"var\": \"pg_num_min\", \"val\": \"" +
-	stringify(min) + "\"}",
-	inbl, NULL, NULL);
-      if (r < 0) {
-	ldpp_dout(dpp, 10) << __func__ << " warning: failed to set pg_num_min on "
-		 << pool.name << dendl;
-      }
       // set recovery_priority
       int p = g_conf().get_val<uint64_t>("rgw_rados_pool_recovery_priority");
       r = rados->mon_command(


### PR DESCRIPTION

Fixes: https://tracker.ceph.com/issues/52673

Signed-off-by: Casey Bodley <cbodley@redhat.com>
(cherry picked from commit 8cc82b6fe8ee266a45ffae36202b0f168bec9788)

Backport: https://tracker.ceph.com/issues/54277
