### PR TITLE
pacific: rgw: remove rgw_rados_pool_pg_num_min and its use on pool creation use the cluster defaults for pg_num_min

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6399,11 +6399,6 @@ std::vector<Option> get_rgw_options() {
     .set_min_max(0.01, 100000.0)
     .set_description("pg_autoscale_bias value for RGW metadata (omap-heavy) pools"),
 
-    Option("rgw_rados_pool_pg_num_min", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(8)
-    .set_min_max(1, 1024)
-    .set_description("pg_num_min value for RGW metadata (omap-heavy) pools"),
-
     Option("rgw_rados_pool_recovery_priority", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(5)
     .set_min_max(-10, 10)

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -78,17 +78,6 @@ int rgw_init_ioctx(const DoutPrefixProvider *dpp,
 	ldpp_dout(dpp, 10) << __func__ << " warning: failed to set pg_autoscale_bias on "
 		 << pool.name << dendl;
       }
-      // set pg_num_min
-      int min = g_conf().get_val<uint64_t>("rgw_rados_pool_pg_num_min");
-      r = rados->mon_command(
-	"{\"prefix\": \"osd pool set\", \"pool\": \"" +
-	pool.name + "\", \"var\": \"pg_num_min\", \"val\": \"" +
-	stringify(min) + "\"}",
-	inbl, NULL, NULL);
-      if (r < 0) {
-	ldpp_dout(dpp, 10) << __func__ << " warning: failed to set pg_num_min on "
-		 << pool.name << dendl;
-      }
       // set recovery_priority
       int p = g_conf().get_val<uint64_t>("rgw_rados_pool_recovery_priority");
       r = rados->mon_command(


### PR DESCRIPTION

Fixes: https://tracker.ceph.com/issues/52673

Signed-off-by: Casey Bodley <cbodley@redhat.com>
(cherry picked from commit 8cc82b6fe8ee266a45ffae36202b0f168bec9788)

 Conflicts:
	src/common/options/rgw.yaml.in
        - not part of pacific branch
        src/common/options.cc
        - changes for src/common/options/rgw.yaml.in are present in
          this file.

Backport: https://tracker.ceph.com/issues/54278

