### PR TITLE
quincy: qa: fix is_addr_blocklisted() to get blocklisted clients from 'osd dump'

### DIFF
--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -263,18 +263,12 @@ class CephCluster(object):
             log.debug("_json_asok output empty")
             return None
 
-    def is_addr_blocklisted(self, addr=None):
-        if addr is None:
-            log.warn("Couldn't get the client address, so the blocklisted "
-                     "status undetermined")
-            return False
-
-        blocklist = json.loads(self.mon_manager.run_cluster_cmd(
-            args=["osd", "blocklist", "ls", "--format=json"],
-            stdout=StringIO()).stdout.getvalue())
-        for b in blocklist:
-            if addr == b["addr"]:
-                return True
+    def is_addr_blocklisted(self, addr):
+        blocklist = json.loads(self.mon_manager.raw_cluster_cmd(
+            "osd", "dump", "--format=json"))['blocklist']
+        if addr in blocklist:
+            return True
+        log.warn(f'The address {addr} is not blocklisted')
         return False
 
 

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -217,10 +217,6 @@ class TestMirroring(CephFSTestCase):
                                          'fs', 'mirror', 'status', f'{fs_name}@{fs_id}')
         return res['rados_inst']
 
-    def get_blocklisted_instances(self):
-        return json.loads(self.mds_cluster.mon_manager.raw_cluster_cmd(
-            "osd", "dump", "--format=json-pretty"))['blocklist']
-
     def mirror_daemon_command(self, cmd_label, *args):
         asok_path = self.get_daemon_admin_socket()
         try:
@@ -451,8 +447,7 @@ class TestMirroring(CephFSTestCase):
         self.mount_a.run_shell(['kill', '-SIGCONT', pid])
 
         # check if the rados addr is blocklisted
-        blocklist = self.get_blocklisted_instances()
-        self.assertTrue(rados_inst in blocklist)
+        self.assertTrue(self.mds_cluster.is_addr_blocklisted(rados_inst))
 
         # wait enough so that the mirror daemon restarts blocklisted instances
         time.sleep(40)
@@ -619,8 +614,7 @@ class TestMirroring(CephFSTestCase):
         self.mount_a.run_shell(['kill', '-SIGCONT', pid])
 
         # check if the rados addr is blocklisted
-        blocklist = self.get_blocklisted_instances()
-        self.assertTrue(rados_inst in blocklist)
+        self.assertTrue(self.mds_cluster.is_addr_blocklisted(rados_inst))
 
         time.sleep(500)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
@@ -893,8 +887,7 @@ class TestMirroring(CephFSTestCase):
         time.sleep(40)
 
         # make sure the rados addr is blocklisted
-        blocklist = self.get_blocklisted_instances()
-        self.assertTrue(rados_inst in blocklist)
+        self.assertTrue(self.mds_cluster.is_addr_blocklisted(rados_inst))
 
         # now we are sure that there are no "active" mirror daemons -- add a directory path.
         dir_path_p = "/d0/d1"


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/55621

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>