### PR TITLE
mgr/dashboard:Cancel button leads to the previous page in browser history 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/back-button/back-button.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/back-button/back-button.component.ts
@@ -1,5 +1,4 @@
-
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
@@ -13,17 +12,16 @@ export class BackButtonComponent {
   @Output() backAction = new EventEmitter();
   @Input() name: string = this.actionLabels.CANCEL;
   
-  previousNavigation: string; 
+   
 
-  constructor(private router: Router, private actionLabels: ActionLabelsI18n) {
-    this.previousNavigation = this.router.getCurrentNavigation().previousNavigation.finalUrl.toString();
-  }
+  constructor(private router: Router, private route: ActivatedRoute, private actionLabels: ActionLabelsI18n) {}
 
   back() {
-    if (this.backAction.observers.length === 0) {   
-      this.router.navigateByUrl(this.previousNavigation);     
+    if(this.backAction.observers.length === 0){
+      this.router.navigate(['../'], {relativeTo: this.route})
     } else {
       this.backAction.emit();
     }
+     
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/back-button/back-button.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/back-button/back-button.component.ts
@@ -1,4 +1,5 @@
-import { Location } from '@angular/common';
+
+import { Router } from '@angular/router';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
@@ -11,12 +12,16 @@ import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 export class BackButtonComponent {
   @Output() backAction = new EventEmitter();
   @Input() name: string = this.actionLabels.CANCEL;
+  
+  previousNavigation: string; 
 
-  constructor(private location: Location, private actionLabels: ActionLabelsI18n) {}
+  constructor(private router: Router, private actionLabels: ActionLabelsI18n) {
+    this.previousNavigation = this.router.getCurrentNavigation().previousNavigation.finalUrl.toString();
+  }
 
   back() {
-    if (this.backAction.observers.length === 0) {
-      this.location.back();
+    if (this.backAction.observers.length === 0) {   
+      this.router.navigateByUrl(this.previousNavigation);     
     } else {
       this.backAction.emit();
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.ts
@@ -1,6 +1,6 @@
-import { Location } from '@angular/common';
 import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { FormGroup, NgForm } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { ModalService } from '~/app/shared/services/modal.service';
@@ -35,10 +35,12 @@ export class FormButtonPanelComponent {
   @Input()
   disabled = false;
 
+  previousRoute: string;
   constructor(
-    private location: Location,
+    private router: Router,
+    private route: ActivatedRoute,
     private actionLabels: ActionLabelsI18n,
-    private modalService: ModalService
+    private modalService: ModalService,
   ) {}
 
   submitAction() {
@@ -50,7 +52,7 @@ export class FormButtonPanelComponent {
       if (this.modalService.hasOpenModals()) {
         this.modalService.dismissAll();
       } else {
-        this.location.back();
+        this.router.navigate(['../'], {relativeTo: this.route});
       }
     } else {
       this.backActionEvent.emit();


### PR DESCRIPTION

This commit changes the behavior of the Cancel button from relying on browser history to rely on the
router hierarchy.

Fixes: https://tracker.ceph.com/issues/39121
Signed-off-by: Seremba Patrick <pserembae@gmail.com>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
