### PR TITLE
quincy: ceph.in: clarify the usage of `--format` in the ceph command

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -1615,9 +1615,9 @@ Options
 
 	Make less verbose.
 
-.. option:: -f {json,json-pretty,xml,xml-pretty,plain}, --format
+.. option:: -f {json,json-pretty,xml,xml-pretty,plain,yaml}, --format
 
-	Format of output.
+	Format of output. Note: yaml is only valid for orch commands. 
 
 .. option:: --connect-timeout CLUSTER_TIMEOUT
 

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -336,7 +336,8 @@ def parse_cmdargs(args=None, target='') -> Tuple[argparse.ArgumentParser,
                         help="make less verbose")
 
     parser.add_argument('-f', '--format', choices=['json', 'json-pretty',
-                        'xml', 'xml-pretty', 'plain', 'yaml'], dest='output_format')
+                        'xml', 'xml-pretty', 'plain', 'yaml'],
+                        help="Note: yaml is only valid for orch commands", dest='output_format')
 
     parser.add_argument('--connect-timeout', dest='cluster_timeout',
                         type=int,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55624

---

backport of https://github.com/ceph/ceph/pull/45802
parent tracker: https://tracker.ceph.com/issues/53895

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh