### PR TITLE
exporter: daemon cpu and memory metrics. 

### DIFF
--- a/src/exporter/CMakeLists.txt
+++ b/src/exporter/CMakeLists.txt
@@ -2,6 +2,7 @@ set(exporter_srcs
   ceph_exporter.cc
   DaemonMetricCollector.cc
   http_server.cc
+  util.cc
   )
 add_executable(ceph-exporter ${exporter_srcs})
 target_link_libraries(ceph-exporter

--- a/src/exporter/DaemonMetricCollector.h
+++ b/src/exporter/DaemonMetricCollector.h
@@ -12,12 +12,16 @@
 #include <string>
 #include <vector>
 
-static const int STATM_SIZE = 0;
-static const int STATM_RESIDENT = 1;
-static const int STAT_UTIME = 13;
-static const int STAT_STIME = 14;
-static const int STAT_START_TIME = 21;
-static const int UPTIME_SYSTEM = 0;
+struct pstat {
+  unsigned long utime;
+  unsigned long stime;
+  unsigned long minflt;
+  unsigned long majflt;
+  unsigned long start_time;
+  int num_threads;
+  unsigned long vm_size;
+  int resident_size;
+};
 
 class DaemonMetricCollector {
 public:

--- a/src/exporter/DaemonMetricCollector.h
+++ b/src/exporter/DaemonMetricCollector.h
@@ -12,6 +12,13 @@
 #include <string>
 #include <vector>
 
+static const int STATM_SIZE = 0;
+static const int STATM_RESIDENT = 1;
+static const int STAT_UTIME = 13;
+static const int STAT_STIME = 14;
+static const int STAT_START_TIME = 21;
+static const int UPTIME_SYSTEM = 0;
+
 class DaemonMetricCollector {
 public:
   void main();
@@ -30,6 +37,7 @@ private:
                         std::string labels);
   std::pair<std::string, std::string>
   get_labels_and_metric_name(std::string daemon_name, std::string metric_name);
+  std::string get_process_metrics(std::vector<std::pair<std::string, int>> daemon_pids);
   std::string asok_request(AdminSocketClient &asok, std::string command);
 };
 

--- a/src/exporter/util.cc
+++ b/src/exporter/util.cc
@@ -1,0 +1,45 @@
+#include "util.h"
+#include <boost/algorithm/string/classification.hpp>
+#include <cctype>
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+BlockTimer::BlockTimer(std::string file, std::string function)
+	: file(file), function(function), stopped(false) {
+	t1 = std::chrono::high_resolution_clock::now();
+}
+BlockTimer::~BlockTimer() {
+	std::cout << file << ":" << function << ": " << ms.count() << "ms\n";
+}
+
+// useful with stop
+double BlockTimer::get_ms() {
+	return ms.count();
+}
+
+// Manually stop the timer as you might want to get the time
+void BlockTimer::stop() {
+	if (!stopped) {
+		stopped = true;
+		t2 = std::chrono::high_resolution_clock::now();
+		ms = t2 - t1;
+	}
+}
+
+bool string_is_digit(std::string s) {
+	size_t i = 0;
+	while (std::isdigit(s[i]) && i < s.size()) {
+		i++;
+	}
+	return i >= s.size();
+}
+
+std::string read_file_to_string(std::string path) {
+	// FIXME: snails are faster than this
+	std::ifstream is(path);
+	std::stringstream buffer;
+	buffer << is.rdbuf();
+	return buffer.str();
+}

--- a/src/exporter/util.h
+++ b/src/exporter/util.h
@@ -1,0 +1,22 @@
+#include "common/hostname.h"
+#include <chrono>
+#include <string>
+
+#define TIMED_FUNCTION() BlockTimer timer(__FILE__, __FUNCTION__) 
+
+class BlockTimer {
+ public:
+	BlockTimer(std::string file, std::string function);
+	~BlockTimer();
+	void stop();
+	double get_ms();
+ private:
+	std::chrono::duration<double, std::milli> ms;
+	std::string file, function;
+	bool stopped;
+	std::chrono::time_point<std::chrono::high_resolution_clock> t1, t2;
+};
+
+bool string_is_digit(std::string s);
+std::string read_file_to_string(std::string path);
+std::string get_hostname(std::string path);


### PR DESCRIPTION
With the exporter we can add daemon specific cpu/mem stats. This first iteration I've added cpu usage and memory usage, nevertheless, I'm not sure wether I should add more metrics. Is it worth adding metrics with regards to paging, swapping, OOM and Working Set Size, load averages...?

List of metrics added as of now:
- ceph_exporter_minflt
- ceph_exporter_majflt
- ceph_exporter_num_threads
- ceph_exporter_vm_size
- ceph_exporter_resident_size
- ceph_exporter_cpu_usage
- ceph_exporter_scrape_time

Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
