### PR TITLE
octopus: mon,auth: fix proposal (and mon db rebuild) of rotating secrets

### DIFF
--- a/qa/suites/rados/singleton/all/rebuild-mondb.yaml
+++ b/qa/suites/rados/singleton/all/rebuild-mondb.yaml
@@ -24,6 +24,9 @@ tasks:
       - \(OSDMAP_FLAGS\)
       - \(OSD_
       - \(PG_
+    conf:
+      mon:
+        debug auth: 30
 - full_sequential:
   - radosbench:
       clients: [client.0]

--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -145,7 +145,6 @@ int KeyServer::start_server()
 {
   std::scoped_lock l{lock};
 
-  _check_rotating_secrets();
   _dump_rotating_secrets();
   return 0;
 }
@@ -153,30 +152,6 @@ int KeyServer::start_server()
 void KeyServer::dump()
 {
   _dump_rotating_secrets();
-}
-
-bool KeyServer::_check_rotating_secrets()
-{
-  ldout(cct, 10) << "_check_rotating_secrets" << dendl;
-
-  int added = 0;
-  added += _rotate_secret(CEPH_ENTITY_TYPE_AUTH);
-  added += _rotate_secret(CEPH_ENTITY_TYPE_MON);
-  added += _rotate_secret(CEPH_ENTITY_TYPE_OSD);
-  added += _rotate_secret(CEPH_ENTITY_TYPE_MDS);
-  added += _rotate_secret(CEPH_ENTITY_TYPE_MGR);
-
-  if (added) {
-    data.rotating_ver++;
-    ldout(cct, 10) << __func__ << " added " << added
-		   << ", rotating_ver=" << data.rotating_ver
-		   << dendl;
-    //data.next_rotating_time = ceph_clock_now(cct);
-    //data.next_rotating_time += std::min(cct->_conf->auth_mon_ticket_ttl, cct->_conf->auth_service_ticket_ttl);
-    _dump_rotating_secrets();
-    return true;
-  }
-  return false;
 }
 
 void KeyServer::_dump_rotating_secrets()
@@ -195,9 +170,9 @@ void KeyServer::_dump_rotating_secrets()
   }
 }
 
-int KeyServer::_rotate_secret(uint32_t service_id)
+int KeyServer::_rotate_secret(uint32_t service_id, KeyServerData &pending_data)
 {
-  RotatingSecrets& r = data.rotating_secrets[service_id];
+  RotatingSecrets& r = pending_data.rotating_secrets[service_id];
   int added = 0;
   utime_t now = ceph_clock_now();
   double ttl = service_id == CEPH_ENTITY_TYPE_AUTH ? cct->_conf->auth_mon_ticket_ttl : cct->_conf->auth_service_ticket_ttl;
@@ -363,26 +338,30 @@ void KeyServer::encode_plaintext(bufferlist &bl)
   bl.append(os.str());
 }
 
-bool KeyServer::updated_rotating(bufferlist& rotating_bl, version_t& rotating_ver)
+bool KeyServer::prepare_rotating_update(bufferlist& rotating_bl)
 {
   std::scoped_lock l{lock};
   ldout(cct, 20) << __func__ << " before: data.rotating_ver=" << data.rotating_ver
-		 << " vs rotating_ver " << rotating_ver << dendl;
+		 << dendl;
 
-  bool r = _check_rotating_secrets();
-  
-  ldout(cct, 20) << __func__ << " after: data.rotating_ver=" << data.rotating_ver
-		 << " vs rotating_ver " << rotating_ver << dendl;
+  KeyServerData pending_data(nullptr);
+  pending_data.rotating_ver = data.rotating_ver + 1;
+  pending_data.rotating_secrets = data.rotating_secrets;
 
-  if (data.rotating_ver <= rotating_ver) {
-    ceph_assert(!r);
+  int added = 0;
+  added += _rotate_secret(CEPH_ENTITY_TYPE_AUTH, pending_data);
+  added += _rotate_secret(CEPH_ENTITY_TYPE_MON, pending_data);
+  added += _rotate_secret(CEPH_ENTITY_TYPE_OSD, pending_data);
+  added += _rotate_secret(CEPH_ENTITY_TYPE_MDS, pending_data);
+  added += _rotate_secret(CEPH_ENTITY_TYPE_MGR, pending_data);
+  if (!added) {
     return false;
   }
- 
-  data.encode_rotating(rotating_bl);
 
-  rotating_ver = data.rotating_ver;
-
+  ldout(cct, 20) << __func__ << " after: pending_data.rotating_ver="
+		 << pending_data.rotating_ver
+		 << dendl;
+  pending_data.encode_rotating(rotating_bl);
   return true;
 }
 

--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -65,10 +65,12 @@ bool KeyServerData::get_service_secret(CephContext *cct, uint32_t service_id,
 bool KeyServerData::get_service_secret(CephContext *cct, uint32_t service_id,
 				uint64_t secret_id, CryptoKey& secret) const
 {
-  map<uint32_t, RotatingSecrets>::const_iterator iter =
-      rotating_secrets.find(service_id);
-  if (iter == rotating_secrets.end())
+  auto iter = rotating_secrets.find(service_id);
+  if (iter == rotating_secrets.end()) {
+    ldout(cct, 10) << __func__ << " no rotating_secrets for service " << service_id
+		   << " " << ceph_entity_type_name(service_id) << dendl;
     return false;
+  }
 
   const RotatingSecrets& secrets = iter->second;
   map<uint64_t, ExpiringCryptoKey>::const_iterator riter = 
@@ -148,6 +150,11 @@ int KeyServer::start_server()
   return 0;
 }
 
+void KeyServer::dump()
+{
+  _dump_rotating_secrets();
+}
+
 bool KeyServer::_check_rotating_secrets()
 {
   ldout(cct, 10) << "_check_rotating_secrets" << dendl;
@@ -160,8 +167,10 @@ bool KeyServer::_check_rotating_secrets()
   added += _rotate_secret(CEPH_ENTITY_TYPE_MGR);
 
   if (added) {
-    ldout(cct, 10) << __func__ << " added " << added << dendl;
     data.rotating_ver++;
+    ldout(cct, 10) << __func__ << " added " << added
+		   << ", rotating_ver=" << data.rotating_ver
+		   << dendl;
     //data.next_rotating_time = ceph_clock_now(cct);
     //data.next_rotating_time += std::min(cct->_conf->auth_mon_ticket_ttl, cct->_conf->auth_service_ticket_ttl);
     _dump_rotating_secrets();
@@ -357,11 +366,18 @@ void KeyServer::encode_plaintext(bufferlist &bl)
 bool KeyServer::updated_rotating(bufferlist& rotating_bl, version_t& rotating_ver)
 {
   std::scoped_lock l{lock};
+  ldout(cct, 20) << __func__ << " before: data.rotating_ver=" << data.rotating_ver
+		 << " vs rotating_ver " << rotating_ver << dendl;
 
-  _check_rotating_secrets(); 
+  bool r = _check_rotating_secrets();
+  
+  ldout(cct, 20) << __func__ << " after: data.rotating_ver=" << data.rotating_ver
+		 << " vs rotating_ver " << rotating_ver << dendl;
 
-  if (data.rotating_ver <= rotating_ver)
+  if (data.rotating_ver <= rotating_ver) {
+    ceph_assert(!r);
     return false;
+  }
  
   data.encode_rotating(rotating_bl);
 

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -216,6 +216,8 @@ public:
   int start_server();
   void rotate_timeout(double timeout);
 
+  void dump();
+  
   int build_session_auth_info(uint32_t service_id,
 			      const AuthTicket& parent_ticket,
 			      CephXSessionAuthInfo& info);

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -196,8 +196,7 @@ class KeyServer : public KeyStore {
   KeyServerData data;
   mutable ceph::mutex lock;
 
-  int _rotate_secret(uint32_t service_id);
-  bool _check_rotating_secrets();
+  int _rotate_secret(uint32_t service_id, KeyServerData &pending_data);
   void _dump_rotating_secrets();
   int _build_session_auth_info(uint32_t service_id, 
 			       const AuthTicket& parent_ticket,
@@ -302,7 +301,7 @@ public:
     }
   }
 
-  bool updated_rotating(bufferlist& rotating_bl, version_t& rotating_ver);
+  bool prepare_rotating_update(ceph::buffer::list& rotating_bl);
 
   bool get_rotating_encrypted(const EntityName& name, bufferlist& enc_bl) const;
 

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -331,7 +331,10 @@ void AuthMonitor::update_from_paxos(bool *need_bootstrap)
 
   dout(10) << __func__ << " max_global_id=" << max_global_id
 	   << " format_version " << format_version
+	   << ", last_rotating_ver " << last_rotating_ver
 	   << dendl;
+
+  mon.key_server.dump();
 }
 
 bool AuthMonitor::_should_increase_max_global_id()

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -56,11 +56,12 @@ bool AuthMonitor::check_rotate()
 {
   KeyServerData::Incremental rot_inc;
   rot_inc.op = KeyServerData::AUTH_INC_SET_ROTATING;
-  if (!mon->key_server.updated_rotating(rot_inc.rotating_bl, last_rotating_ver))
-    return false;
-  dout(10) << __func__ << " updated rotating" << dendl;
-  push_cephx_inc(rot_inc);
-  return true;
+  if (mon->key_server.prepare_rotating_update(rot_inc.rotating_bl)) {
+    dout(10) << __func__ << " updating rotating" << dendl;
+    push_cephx_inc(rot_inc);
+    return true;
+  }
+  return false;
 }
 
 /*
@@ -112,16 +113,26 @@ void AuthMonitor::on_active()
 
   if (!mon->is_leader())
     return;
+
   mon->key_server.start_server();
 
-  bool increase;
-  {
-    std::lock_guard l(mon->auth_lock);
-    increase = _should_increase_max_global_id();
-  }
-  if (is_writeable() && increase) {
-    increase_max_global_id();
-    propose_pending();
+  if (is_writeable()) {
+    bool propose = false;
+    if (check_rotate()) {
+      propose = true;
+    }
+    bool increase;
+    {
+      std::lock_guard l(mon->auth_lock);
+      increase = _should_increase_max_global_id();
+    }
+    if (increase) {
+      increase_max_global_id();
+      propose = true;
+    }
+    if (propose) {
+      propose_pending();
+    }
   }
 }
 
@@ -214,7 +225,6 @@ void AuthMonitor::create_initial()
 
   // initialize rotating keys
   mon->key_server.clear_secrets();
-  last_rotating_ver = 0;
   check_rotate();
   ceph_assert(pending_auth.size() == 1);
 
@@ -331,10 +341,9 @@ void AuthMonitor::update_from_paxos(bool *need_bootstrap)
 
   dout(10) << __func__ << " max_global_id=" << max_global_id
 	   << " format_version " << format_version
-	   << ", last_rotating_ver " << last_rotating_ver
 	   << dendl;
 
-  mon.key_server.dump();
+  mon->key_server.dump();
 }
 
 bool AuthMonitor::_should_increase_max_global_id()

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -96,8 +96,7 @@ public:
 
 
 private:
-  vector<Incremental> pending_auth;
-  version_t last_rotating_ver;
+  std::vector<Incremental> pending_auth;
   uint64_t max_global_id;
   uint64_t last_allocated_id;
 
@@ -185,7 +184,6 @@ private:
  public:
   AuthMonitor(Monitor *mn, Paxos *p, const string& service_name)
     : PaxosService(mn, p, service_name),
-      last_rotating_ver(0),
       max_global_id(0),
       last_allocated_id(0)
   {}

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -40,6 +40,7 @@ install(TARGETS ceph-osdomap-tool DESTINATION bin)
 
 add_executable(ceph-monstore-tool
   ceph_monstore_tool.cc
+  ../auth/cephx/CephxKeyServer.cc
   ../mgr/mgr_commands.cc)
 target_link_libraries(ceph-monstore-tool os global Boost::program_options)
 install(TARGETS ceph-monstore-tool DESTINATION bin)

--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -494,6 +494,20 @@ static int update_auth(MonitorDBStore& st, const string& keyring_path)
     inc.encode(bl, CEPH_FEATURES_ALL);
   }
 
+  // prime rotating secrets
+  {
+    KeyServer ks(g_ceph_context, nullptr);
+    KeyServerData::Incremental auth_inc;
+    auth_inc.op = KeyServerData::AUTH_INC_SET_ROTATING;
+    bool r = ks.prepare_rotating_update(auth_inc.rotating_bl);
+    ceph_assert(r);
+    AuthMonitor::Incremental inc;
+    inc.inc_type = AuthMonitor::AUTH_DATA;
+    encode(auth_inc, inc.auth_data);
+    inc.auth_type = CEPH_AUTH_CEPHX;
+    inc.encode(bl, CEPH_FEATURES_ALL);
+  }
+
   const string prefix("auth");
   auto last_committed = st.get(prefix, "last_committed") + 1;
   auto t = make_shared<MonitorDBStore::Transaction>();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55634

---

backport of https://github.com/ceph/ceph/pull/43335
parent tracker: https://tracker.ceph.com/issues/51815

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh