### PR TITLE
mgr/dashboard: rbd mirroring snapshot support

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rbd.py
+++ b/qa/tasks/mgr/dashboard/test_rbd.py
@@ -205,6 +205,7 @@ class RbdTest(DashboardTestCase):
         {
             "size": 1073741824,
             "obj_size": 4194304,
+            "mirror_mode": "journal",
             "num_objs": 256,
             "order": 22,
             "block_name_prefix": "rbd_data.10ae2ae8944a",
@@ -245,6 +246,7 @@ class RbdTest(DashboardTestCase):
                 'source': JLeaf(int),
                 'value': JLeaf(str),
             })),
+            'mirror_mode': JLeaf(str),
         })
         self.assertSchema(img, schema)
 

--- a/src/pybind/mgr/dashboard/__init__.py
+++ b/src/pybind/mgr/dashboard/__init__.py
@@ -48,5 +48,13 @@ else:
         os.path.dirname(__file__),
         'frontend/dist'))
 
+    import rbd
+
+    # Api tests do not mock rbd as opposed to dashboard unit tests. Both
+    # use UNITTEST env variable.
+    if isinstance(rbd, mock.Mock):
+        rbd.RBD_MIRROR_IMAGE_MODE_JOURNAL = 0
+        rbd.RBD_MIRROR_IMAGE_MODE_SNAPSHOT = 1
+
 # DO NOT REMOVE: required for ceph-mgr to load a module
 from .module import Module, StandbyModule  # noqa: F401

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -21,6 +21,7 @@ import { IscsiTargetListComponent } from './iscsi-target-list/iscsi-target-list.
 import { IscsiComponent } from './iscsi/iscsi.component';
 import { MirroringModule } from './mirroring/mirroring.module';
 import { OverviewComponent as RbdMirroringComponent } from './mirroring/overview/overview.component';
+import { PoolEditModeModalComponent } from './mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component';
 import { RbdConfigurationFormComponent } from './rbd-configuration-form/rbd-configuration-form.component';
 import { RbdConfigurationListComponent } from './rbd-configuration-list/rbd-configuration-list.component';
 import { RbdDetailsComponent } from './rbd-details/rbd-details.component';
@@ -139,7 +140,14 @@ const routes: Routes = [
     path: 'mirroring',
     component: RbdMirroringComponent,
     canActivate: [FeatureTogglesGuardService],
-    data: { breadcrumbs: 'Mirroring' }
+    data: { breadcrumbs: 'Mirroring' },
+    children: [
+      {
+        path: `${URLVerbs.EDIT}/:pool_name`,
+        component: PoolEditModeModalComponent,
+        outlet: 'modal'
+      }
+    ]
   },
   // iSCSI
   {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.html
@@ -1,4 +1,5 @@
-<cd-modal [modalRef]="activeModal">
+<cd-modal [modalRef]="activeModal"
+          pageURL="mirroring">
   <ng-container i18n
                 class="modal-title">Edit pool mirror mode</ng-container>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
@@ -10,6 +11,7 @@ import { of } from 'rxjs';
 import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { SharedModule } from '~/app/shared/shared.module';
+import { ActivatedRouteStub } from '~/testing/activated-route-stub';
 import { configureTestBed, FormHelper } from '~/testing/unit-test-helper';
 import { PoolEditModeModalComponent } from './pool-edit-mode-modal.component';
 
@@ -19,6 +21,7 @@ describe('PoolEditModeModalComponent', () => {
   let notificationService: NotificationService;
   let rbdMirroringService: RbdMirroringService;
   let formHelper: FormHelper;
+  let activatedRoute: ActivatedRouteStub;
 
   configureTestBed({
     declarations: [PoolEditModeModalComponent],
@@ -29,7 +32,13 @@ describe('PoolEditModeModalComponent', () => {
       SharedModule,
       ToastrModule.forRoot()
     ],
-    providers: [NgbActiveModal]
+    providers: [
+      NgbActiveModal,
+      {
+        provide: ActivatedRoute,
+        useValue: new ActivatedRouteStub({ pool_name: 'somePool' })
+      }
+    ]
   });
 
   beforeEach(() => {
@@ -41,6 +50,7 @@ describe('PoolEditModeModalComponent', () => {
     spyOn(notificationService, 'show').and.stub();
 
     rbdMirroringService = TestBed.inject(RbdMirroringService);
+    activatedRoute = <ActivatedRouteStub>TestBed.inject(ActivatedRoute);
 
     formHelper = new FormHelper(component.editModeForm);
     fixture.detectChanges();
@@ -55,11 +65,8 @@ describe('PoolEditModeModalComponent', () => {
       spyOn(component.activeModal, 'close').and.callThrough();
     });
 
-    afterEach(() => {
-      expect(component.activeModal.close).toHaveBeenCalledTimes(1);
-    });
-
     it('should call updatePool', () => {
+      activatedRoute.setParams({ pool_name: 'somePool' });
       spyOn(rbdMirroringService, 'updatePool').and.callFake(() => of(''));
 
       component.editModeForm.patchValue({ mirrorMode: 'disabled' });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.ts
@@ -1,5 +1,7 @@
+import { Location } from '@angular/common';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { AbstractControl, FormControl, Validators } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Subscription } from 'rxjs';
@@ -40,7 +42,9 @@ export class PoolEditModeModalComponent implements OnInit, OnDestroy {
     public activeModal: NgbActiveModal,
     public actionLabels: ActionLabelsI18n,
     private rbdMirroringService: RbdMirroringService,
-    private taskWrapper: TaskWrapperService
+    private taskWrapper: TaskWrapperService,
+    private route: ActivatedRoute,
+    private location: Location
   ) {
     this.createForm();
   }
@@ -54,6 +58,9 @@ export class PoolEditModeModalComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.route.params.subscribe((params: { pool_name: string }) => {
+      this.poolName = params.pool_name;
+    });
     this.pattern = `${this.poolName}`;
     this.rbdMirroringService.getPool(this.poolName).subscribe((resp: PoolEditModeResponseModel) => {
       this.setResponse(resp);
@@ -97,7 +104,7 @@ export class PoolEditModeModalComponent implements OnInit, OnDestroy {
       error: () => this.editModeForm.setErrors({ cdSubmitButton: true }),
       complete: () => {
         this.rbdMirroringService.refresh();
-        this.activeModal.close();
+        this.location.back();
       }
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-list/pool-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-list/pool-list.component.html
@@ -20,3 +20,4 @@
              let-value="value">
   <span [ngClass]="row.health_color | mirrorHealthColor">{{ value }}</span>
 </ng-template>
+<router-outlet name="modal"></router-outlet>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-list/pool-list.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { Observable, Subscriber, Subscription } from 'rxjs';
@@ -6,6 +7,7 @@ import { Observable, Subscriber, Subscription } from 'rxjs';
 import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
 import { TableStatusViewCache } from '~/app/shared/classes/table-status-view-cache';
 import { CriticalConfirmationModalComponent } from '~/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
+import { URLVerbs } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
@@ -14,9 +16,9 @@ import { Permission } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { ModalService } from '~/app/shared/services/modal.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
-import { PoolEditModeModalComponent } from '../pool-edit-mode-modal/pool-edit-mode-modal.component';
 import { PoolEditPeerModalComponent } from '../pool-edit-peer-modal/pool-edit-peer-modal.component';
 
+const BASE_URL = '/block/mirroring';
 @Component({
   selector: 'cd-mirroring-pools',
   templateUrl: './pool-list.component.html',
@@ -43,7 +45,8 @@ export class PoolListComponent implements OnInit, OnDestroy {
     private authStorageService: AuthStorageService,
     private rbdMirroringService: RbdMirroringService,
     private modalService: ModalService,
-    private taskWrapper: TaskWrapperService
+    private taskWrapper: TaskWrapperService,
+    private router: Router
   ) {
     this.data = [];
     this.permission = this.authStorageService.getPermissions().rbdMirroring;
@@ -111,10 +114,10 @@ export class PoolListComponent implements OnInit, OnDestroy {
   }
 
   editModeModal() {
-    const initialState = {
-      poolName: this.selection.first().name
-    };
-    this.modalRef = this.modalService.show(PoolEditModeModalComponent, initialState);
+    this.router.navigate([
+      BASE_URL,
+      { outlets: { modal: [URLVerbs.EDIT, this.selection.first().name] } }
+    ]);
   }
 
   editPeersModal(mode: string) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
@@ -133,6 +133,7 @@
                               [featuresName]="selection.features_name"
                               [poolName]="selection.pool_name"
                               [namespace]="selection.namespace"
+                              [mirroring]="selection.mirror_mode"
                               [rbdName]="selection.name"></cd-rbd-snapshot-list>
       </ng-template>
     </li>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form-edit-request.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form-edit-request.model.ts
@@ -5,4 +5,9 @@ export class RbdFormEditRequestModel {
   size: number;
   features: Array<string> = [];
   configuration: RbdConfigurationEntry[];
+
+  enable_mirror?: boolean;
+  mirror_mode?: string;
+  schedule_interval: string;
+  remove_scheduling? = false;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -68,7 +68,8 @@
                     name="pool"
                     class="form-control"
                     formControlName="pool"
-                    *ngIf="mode !== 'editing' && poolPermission.read">
+                    *ngIf="mode !== 'editing' && poolPermission.read"
+                    (change)="setPoolMirrorMode()">
               <option *ngIf="pools === null"
                       [ngValue]="null"
                       i18n>Loading...</option>
@@ -235,6 +236,62 @@
                          html="{{ feature.helperHtml }}">
               </cd-helper>
             </div>
+          </div>
+        </div>
+
+        <!-- Mirroring -->
+        <div class="form-group row">
+          <div class="cd-col-form-offset">
+            <div class="custom-control custom-checkbox">
+              <input type="checkbox"
+                     class="custom-control-input"
+                     id="mirroring"
+                     name="mirroring"
+                     (change)="setMirrorMode()"
+                     formControlName="mirroring">
+              <label class="custom-control-label"
+                     for="mirroring">Mirroring</label>
+              <cd-helper *ngIf="mirroring === false && this.currentPoolName">
+                <span i18n>You need to enable a <b>mirror mode</b> in the selected pool. Please <a [routerLink]="['/block/mirroring', {outlets: {modal: ['edit', currentPoolName]}}]">click here to select a mode and enable it in this pool.</a></span>
+              </cd-helper>
+            </div>
+            <div *ngIf="mirroring">
+              <div class="custom-control custom-radio ml-2"
+                   *ngFor="let option of mirroringOptions">
+                <input type="radio"
+                       class="custom-control-input"
+                       [id]="option"
+                       [value]="option"
+                       name="mirroringMode"
+                       (change)="setExclusiveLock()"
+                       formControlName="mirroringMode"
+                       [attr.disabled]="(poolMirrorMode === 'pool' && option === 'snapshot') ? true : null">
+                <label class="custom-control-label"
+                       [for]="option">{{ option | titlecase }}</label>
+                <cd-helper *ngIf="poolMirrorMode === 'pool' && option === 'snapshot'">
+                  <span i18n>You need to enable <b>image mirror mode</b> in the selected pool. Please <a [routerLink]="['/block/mirroring', {outlets: {modal: ['edit', currentPoolName]}}]">click here to select a mode and enable it in this pool.</a></span>
+                </cd-helper>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="form-group row"
+             *ngIf="rbdForm.getValue('mirroringMode') === 'snapshot' && mirroring">
+          <label class="cd-col-form-label"
+                 i18n>Schedule Interval
+          <cd-helper i18n-html
+                     html="Create Mirror-Snapshots automatically on a periodic basis. The interval can be specified in days, hours, or minutes using d, h, m suffix respectively.">
+          </cd-helper></label>
+          <div class="cd-col-form-input">
+            <input id="schedule"
+                   name="schedule"
+                   class="form-control"
+                   type="text"
+                   formControlName="schedule"
+                   i18n-placeholder
+                   placeholder="e.g., 12h or 1d or 10m"
+                   [attr.disabled]="(mode === rbdFormMode.editing) ? true : null">
           </div>
         </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
@@ -304,12 +304,7 @@ describe('RbdFormComponent', () => {
   });
 
   describe('tests for feature flags', () => {
-    let deepFlatten: any,
-      layering: any,
-      exclusiveLock: any,
-      objectMap: any,
-      journaling: any,
-      fastDiff: any;
+    let deepFlatten: any, layering: any, exclusiveLock: any, objectMap: any, fastDiff: any;
     const defaultFeatures = [
       // Supposed to be enabled by default
       'deep-flatten',
@@ -323,7 +318,6 @@ describe('RbdFormComponent', () => {
       'layering',
       'exclusive-lock',
       'object-map',
-      'journaling',
       'fast-diff'
     ];
     const setFeatures = (features: Record<string, RbdImageFeature>) => {
@@ -359,14 +353,7 @@ describe('RbdFormComponent', () => {
         spyOn(rbdService, 'defaultFeatures').and.returnValue(of(defaultFeatures));
         setRouterUrl('edit', pool, image);
         fixture.detectChanges();
-        [
-          deepFlatten,
-          layering,
-          exclusiveLock,
-          objectMap,
-          journaling,
-          fastDiff
-        ] = getFeatureNativeElements();
+        [deepFlatten, layering, exclusiveLock, objectMap, fastDiff] = getFeatureNativeElements();
       };
 
       it('should have the interlock feature for flags disabled, if one feature is not set', () => {
@@ -409,14 +396,7 @@ describe('RbdFormComponent', () => {
         spyOn(rbdService, 'defaultFeatures').and.returnValue(of(defaultFeatures));
         setRouterUrl('create');
         fixture.detectChanges();
-        [
-          deepFlatten,
-          layering,
-          exclusiveLock,
-          objectMap,
-          journaling,
-          fastDiff
-        ] = getFeatureNativeElements();
+        [deepFlatten, layering, exclusiveLock, objectMap, fastDiff] = getFeatureNativeElements();
       });
 
       it('should initialize the checkboxes correctly', () => {
@@ -424,27 +404,58 @@ describe('RbdFormComponent', () => {
         expect(layering.disabled).toBe(false);
         expect(exclusiveLock.disabled).toBe(false);
         expect(objectMap.disabled).toBe(false);
-        expect(journaling.disabled).toBe(false);
         expect(fastDiff.disabled).toBe(false);
 
         expect(deepFlatten.checked).toBe(true);
         expect(layering.checked).toBe(true);
         expect(exclusiveLock.checked).toBe(true);
         expect(objectMap.checked).toBe(true);
-        expect(journaling.checked).toBe(false);
         expect(fastDiff.checked).toBe(true);
       });
 
       it('should disable features if their requirements are not met (exclusive-lock)', () => {
         exclusiveLock.click(); // unchecks exclusive-lock
         expect(objectMap.disabled).toBe(true);
-        expect(journaling.disabled).toBe(true);
         expect(fastDiff.disabled).toBe(true);
       });
 
       it('should disable features if their requirements are not met (object-map)', () => {
         objectMap.click(); // unchecks object-map
         expect(fastDiff.disabled).toBe(true);
+      });
+    });
+
+    describe('test mirroring options', () => {
+      beforeEach(() => {
+        component.ngOnInit();
+        fixture.detectChanges();
+        const mirroring = fixture.debugElement.query(By.css('#mirroring')).nativeElement;
+        mirroring.click();
+        fixture.detectChanges();
+      });
+
+      it('should verify two mirroring options are shown', () => {
+        const journal = fixture.debugElement.query(By.css('#journal')).nativeElement;
+        const snapshot = fixture.debugElement.query(By.css('#snapshot')).nativeElement;
+        expect(journal).not.toBeNull();
+        expect(snapshot).not.toBeNull();
+      });
+
+      it('should verify only snapshot is disabled for pools that are in pool mirror mode', () => {
+        component.poolMirrorMode = 'pool';
+        fixture.detectChanges();
+        const journal = fixture.debugElement.query(By.css('#journal')).nativeElement;
+        const snapshot = fixture.debugElement.query(By.css('#snapshot')).nativeElement;
+        expect(journal.disabled).toBe(false);
+        expect(snapshot.disabled).toBe(true);
+      });
+
+      it('should set and disable exclusive-lock only for the journal mode', () => {
+        component.poolMirrorMode = 'pool';
+        fixture.detectChanges();
+        const exclusiveLocks = fixture.debugElement.query(By.css('#exclusive-lock')).nativeElement;
+        expect(exclusiveLocks.checked).toBe(true);
+        expect(exclusiveLocks.disabled).toBe(true);
       });
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.model.ts
@@ -17,4 +17,10 @@ export class RbdFormModel {
 
   /* Deletion process */
   source?: string;
+
+  enable_mirror?: boolean;
+  mirror_mode?: string;
+
+  schedule_interval: string;
+  start_time: string;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -24,7 +24,7 @@
   </cd-rbd-details>
 </cd-table>
 
-<ng-template #usageNotAvailableTooltipTpl>
+<ng-template #scheduleStatus>
   <div i18n
        [innerHtml]="'Only available for RBD images with <strong>fast-diff</strong> enabled'"></div>
 </ng-template>
@@ -54,6 +54,18 @@
   <span *ngIf="value">{{ value.pool_name }}<span
           *ngIf="value.pool_namespace">/{{ value.pool_namespace }}</span>/{{ value.image_name }}@{{ value.snap_name }}</span>
   <span *ngIf="!value">-</span>
+</ng-template>
+
+<ng-template #mirroringTpl
+             let-value="value">
+  <span *ngIf="value.length === 3; else probb"
+        class="badge badge-info">{{ value[0] }}</span>&nbsp;
+  <span *ngIf="value.length === 3"
+        class="badge badge-info"
+        [ngbTooltip]="'Next scheduled snapshot on' + ' ' + (value[2] | cdDate)">{{ value[1] }}</span>
+  <ng-template #probb>
+    <span class="badge badge-info">{{ value }}</span>
+  </ng-template>
 </ng-template>
 
 <ng-template #flattenTpl

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -314,11 +314,19 @@ describe('RbdListComponent', () => {
 
     expect(tableActions).toEqual({
       'create,update,delete': {
-        actions: ['Create', 'Edit', 'Copy', 'Flatten', 'Delete', 'Move to Trash'],
+        actions: [
+          'Create',
+          'Edit',
+          'Copy',
+          'Flatten',
+          'Delete',
+          'Move to Trash',
+          'Remove Scheduling'
+        ],
         primary: { multiple: 'Create', executing: 'Edit', single: 'Edit', no: 'Create' }
       },
       'create,update': {
-        actions: ['Create', 'Edit', 'Copy', 'Flatten'],
+        actions: ['Create', 'Edit', 'Copy', 'Flatten', 'Remove Scheduling'],
         primary: { multiple: 'Create', executing: 'Edit', single: 'Edit', no: 'Create' }
       },
       'create,delete': {
@@ -330,11 +338,11 @@ describe('RbdListComponent', () => {
         primary: { multiple: 'Create', executing: 'Copy', single: 'Copy', no: 'Create' }
       },
       'update,delete': {
-        actions: ['Edit', 'Flatten', 'Delete', 'Move to Trash'],
+        actions: ['Edit', 'Flatten', 'Delete', 'Move to Trash', 'Remove Scheduling'],
         primary: { multiple: 'Edit', executing: 'Edit', single: 'Edit', no: 'Edit' }
       },
       update: {
-        actions: ['Edit', 'Flatten'],
+        actions: ['Edit', 'Flatten', 'Remove Scheduling'],
         primary: { multiple: 'Edit', executing: 'Edit', single: 'Edit', no: 'Edit' }
       },
       delete: {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form-modal.component.html
@@ -19,11 +19,14 @@
                    placeholder="Snapshot name..."
                    id="snapshotName"
                    name="snapshotName"
+                   [attr.disabled]="(mirroring === 'snapshot') ? true : null"
                    formControlName="snapshotName"
                    autofocus>
             <span class="invalid-feedback"
                   *ngIf="snapshotForm.showError('snapshotName', formDir, 'required')"
-                  i18n>This field is required.</span>
+                  i18n>This field is required.</span><br><br>
+            <span *ngIf="mirroring === 'snapshot'"
+                  i18n>Snapshot mode is enabled on image <b>{{ imageName }}</b>: snapshot names are auto generated</span>
           </div>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form-modal.component.ts
@@ -22,6 +22,7 @@ export class RbdSnapshotFormModalComponent {
   namespace: string;
   imageName: string;
   snapName: string;
+  mirroring: string;
 
   snapshotForm: CdFormGroup;
 
@@ -53,7 +54,11 @@ export class RbdSnapshotFormModalComponent {
 
   setSnapName(snapName: string) {
     this.snapName = snapName;
-    this.snapshotForm.get('snapshotName').setValue(snapName);
+    if (this.mirroring !== 'snapshot') {
+      this.snapshotForm.get('snapshotName').setValue(snapName);
+    } else {
+      this.snapshotForm.get('snapshotName').clearValidators();
+    }
   }
 
   /**

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-actions.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-actions.model.ts
@@ -34,27 +34,31 @@ export class RbdSnapshotActionsModel {
     this.rename = {
       permission: 'update',
       icon: Icons.edit,
-      name: actionLabels.RENAME
+      name: actionLabels.RENAME,
+      disable: (selection: CdTableSelection) => this.disableForMirrorSnapshot(selection)
     };
     this.protect = {
       permission: 'update',
       icon: Icons.lock,
       visible: (selection: CdTableSelection) =>
         selection.hasSingleSelection && !selection.first().is_protected,
-      name: actionLabels.PROTECT
+      name: actionLabels.PROTECT,
+      disable: (selection: CdTableSelection) => this.disableForMirrorSnapshot(selection)
     };
     this.unprotect = {
       permission: 'update',
       icon: Icons.unlock,
       visible: (selection: CdTableSelection) =>
         selection.hasSingleSelection && selection.first().is_protected,
-      name: actionLabels.UNPROTECT
+      name: actionLabels.UNPROTECT,
+      disable: (selection: CdTableSelection) => this.disableForMirrorSnapshot(selection)
     };
     this.clone = {
       permission: 'create',
       canBePrimary: (selection: CdTableSelection) => selection.hasSingleSelection,
       disable: (selection: CdTableSelection) =>
-        this.getCloneDisableDesc(selection, this.featuresName),
+        this.getCloneDisableDesc(selection, this.featuresName) ||
+        this.disableForMirrorSnapshot(selection),
       icon: Icons.clone,
       name: actionLabels.CLONE
     };
@@ -62,21 +66,29 @@ export class RbdSnapshotActionsModel {
       permission: 'create',
       canBePrimary: (selection: CdTableSelection) => selection.hasSingleSelection,
       disable: (selection: CdTableSelection) =>
-        !selection.hasSingleSelection || selection.first().cdExecuting,
+        !selection.hasSingleSelection ||
+        selection.first().cdExecuting ||
+        this.disableForMirrorSnapshot(selection),
       icon: Icons.copy,
       name: actionLabels.COPY
     };
     this.rollback = {
       permission: 'update',
       icon: Icons.undo,
-      name: actionLabels.ROLLBACK
+      name: actionLabels.ROLLBACK,
+      disable: (selection: CdTableSelection) => this.disableForMirrorSnapshot(selection)
     };
     this.deleteSnap = {
       permission: 'delete',
       icon: Icons.destroy,
       disable: (selection: CdTableSelection) => {
         const first = selection.first();
-        return !selection.hasSingleSelection || first.cdExecuting || first.is_protected;
+        return (
+          !selection.hasSingleSelection ||
+          first.cdExecuting ||
+          first.is_protected ||
+          this.disableForMirrorSnapshot(selection)
+        );
       },
       name: actionLabels.DELETE
     };
@@ -107,5 +119,13 @@ export class RbdSnapshotActionsModel {
     }
 
     return true;
+  }
+
+  disableForMirrorSnapshot(selection: CdTableSelection) {
+    return (
+      selection.hasSingleSelection &&
+      selection.first().mirror_mode === 'snapshot' &&
+      selection.first().name.includes('.mirror.')
+    );
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
@@ -56,6 +56,8 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
   @Input()
   namespace: string;
   @Input()
+  mirroring: string;
+  @Input()
   rbdName: string;
   @ViewChild('nameTpl')
   nameTpl: TemplateRef<any>;
@@ -210,7 +212,10 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
   }
 
   private openSnapshotModal(taskName: string, snapName: string = null) {
-    this.modalRef = this.modalService.show(RbdSnapshotFormModalComponent);
+    const modalVariables = {
+      mirroring: this.mirroring
+    };
+    this.modalRef = this.modalService.show(RbdSnapshotFormModalComponent, modalVariables);
     this.modalRef.componentInstance.poolName = this.poolName;
     this.modalRef.componentInstance.imageName = this.rbdName;
     this.modalRef.componentInstance.namespace = this.namespace;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
@@ -127,6 +127,7 @@ export class ActionLabelsI18n {
   FLAGS: string;
   ENTER_MAINTENANCE: string;
   EXIT_MAINTENANCE: string;
+  REMOVE_SCHEDULING: string;
   START_DRAIN: string;
   STOP_DRAIN: string;
   START: string;
@@ -186,6 +187,7 @@ export class ActionLabelsI18n {
     this.FLAGS = $localize`Flags`;
     this.ENTER_MAINTENANCE = $localize`Enter Maintenance`;
     this.EXIT_MAINTENANCE = $localize`Exit Maintenance`;
+
     this.START_DRAIN = $localize`Start Drain`;
     this.STOP_DRAIN = $localize`Stop Drain`;
 
@@ -197,6 +199,8 @@ export class ActionLabelsI18n {
     this.STOP = $localize`Stop`;
     this.REDEPLOY = $localize`Redeploy`;
     this.RESTART = $localize`Restart`;
+
+    this.REMOVE_SCHEDULING = $localize`Remove Scheduling`;
   }
 }
 

--- a/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_forms.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_forms.scss
@@ -27,6 +27,10 @@
   padding-top: 7px;
 }
 
+.custom-radio {
+  padding-top: 5px;
+}
+
 .cd-col-form {
   @extend .col-12;
   @extend .col-lg-8;

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -206,6 +206,8 @@ paths:
                   type: string
                 features:
                   type: string
+                mirror_mode:
+                  type: string
                 name:
                   type: string
                 namespace:
@@ -213,6 +215,9 @@ paths:
                 obj_size:
                   type: integer
                 pool_name:
+                  type: string
+                schedule_interval:
+                  default: ''
                   type: string
                 size:
                   type: integer
@@ -549,6 +554,9 @@ paths:
                   type: string
                 primary:
                   type: string
+                remove_scheduling:
+                  default: false
+                  type: boolean
                 resync:
                   default: false
                   type: boolean
@@ -557,9 +565,6 @@ paths:
                   type: string
                 size:
                   type: integer
-                start_time:
-                  default: ''
-                  type: string
               type: object
       responses:
         '200':

--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unused-argument
 import errno
+import json
+from enum import IntEnum
 
 import cherrypy
 import rbd
 
 from .. import mgr
+from ..exceptions import DashboardException
 from ..tools import ViewCache
 from .ceph_service import CephService
 
@@ -26,6 +29,20 @@ RBD_FEATURES_NAME_MAPPING = {
     rbd.RBD_FEATURE_DATA_POOL: "data-pool",
     rbd.RBD_FEATURE_OPERATIONS: "operations",
 }
+
+
+class MIRROR_IMAGE_MODE(IntEnum):
+    journal = rbd.RBD_MIRROR_IMAGE_MODE_JOURNAL
+    snapshot = rbd.RBD_MIRROR_IMAGE_MODE_SNAPSHOT
+
+
+def _rbd_support_remote(method_name: str, *args, **kwargs):
+    try:
+        return mgr.remote('rbd_support', method_name, *args, **kwargs)
+    except ImportError as ie:
+        raise DashboardException(f'rbd_support module not found {ie}')
+    except RuntimeError as ie:
+        raise DashboardException(f'rbd_support.{method_name} error: {ie}')
 
 
 def format_bitmask(features):
@@ -245,10 +262,22 @@ class RbdService(object):
         return total_used_size, snap_map
 
     @classmethod
-    def _rbd_image(cls, ioctx, pool_name, namespace, image_name):
+    def _rbd_image(cls, ioctx, pool_name, namespace, image_name):  # pylint: disable=R0912
         with rbd.Image(ioctx, image_name) as img:
-
             stat = img.stat()
+            mirror_mode = img.mirror_image_get_mode()
+            if mirror_mode == rbd.RBD_MIRROR_IMAGE_MODE_JOURNAL:
+                stat['mirror_mode'] = 'journal'
+            elif mirror_mode == rbd.RBD_MIRROR_IMAGE_MODE_SNAPSHOT:
+                stat['mirror_mode'] = 'snapshot'
+                schedule_status = json.loads(_rbd_support_remote(
+                    'mirror_snapshot_schedule_status')[1])
+                for scheduled_image in schedule_status['scheduled_images']:
+                    if scheduled_image['image'] == get_image_spec(pool_name, namespace, image_name):
+                        stat['schedule_info'] = scheduled_image
+            else:
+                stat['mirror_mode'] = 'unknown'
+
             stat['name'] = image_name
             if img.old_format():
                 stat['unique_id'] = get_image_spec(pool_name, namespace, stat['block_name_prefix'])
@@ -286,23 +315,34 @@ class RbdService(object):
             # snapshots
             stat['snapshots'] = []
             for snap in img.list_snaps():
+                try:
+                    snap['mirror_mode'] = MIRROR_IMAGE_MODE(img.mirror_image_get_mode()).name
+                except ValueError as ex:
+                    raise DashboardException(f'Unknown RBD Mirror mode: {ex}')
+
                 snap['timestamp'] = "{}Z".format(
                     img.get_snap_timestamp(snap['id']).isoformat())
-                snap['is_protected'] = img.is_protected_snap(snap['name'])
+
+                snap['is_protected'] = None
+                if mirror_mode != rbd.RBD_MIRROR_IMAGE_MODE_SNAPSHOT:
+                    snap['is_protected'] = img.is_protected_snap(snap['name'])
                 snap['used_bytes'] = None
                 snap['children'] = []
-                img.set_snap(snap['name'])
-                for child_pool_name, child_image_name in img.list_children():
-                    snap['children'].append({
-                        'pool_name': child_pool_name,
-                        'image_name': child_image_name
-                    })
+
+                if mirror_mode != rbd.RBD_MIRROR_IMAGE_MODE_SNAPSHOT:
+                    img.set_snap(snap['name'])
+                    for child_pool_name, child_image_name in img.list_children():
+                        snap['children'].append({
+                            'pool_name': child_pool_name,
+                            'image_name': child_image_name
+                        })
                 stat['snapshots'].append(snap)
 
             # disk usage
             img_flags = img.flags()
             if 'fast-diff' in stat['features_name'] and \
-                    not rbd.RBD_FLAG_FAST_DIFF_INVALID & img_flags:
+                    not rbd.RBD_FLAG_FAST_DIFF_INVALID & img_flags and \
+                    mirror_mode != rbd.RBD_MIRROR_IMAGE_MODE_SNAPSHOT:
                 snaps = [(s['id'], s['size'], s['name'])
                          for s in stat['snapshots']]
                 snaps.sort(key=lambda s: s[0])
@@ -431,7 +471,7 @@ class RBDSchedulerInterval:
 class RbdMirroringService:
 
     @classmethod
-    def enable_image(cls, image_name: str, pool_name: str, namespace: str, mode: str):
+    def enable_image(cls, image_name: str, pool_name: str, namespace: str, mode: MIRROR_IMAGE_MODE):
         rbd_image_call(pool_name, namespace, image_name,
                        lambda ioctx, image: image.mirror_image_enable(mode))
 
@@ -456,6 +496,10 @@ class RbdMirroringService:
                        lambda ioctx, image: image.mirror_image_resync())
 
     @classmethod
-    def snapshot_schedule(cls, image_spec: str, interval: str, start_time: str = ''):
-        mgr.remote('rbd_support', 'mirror_snapshot_schedule_add', image_spec,
-                   str(RBDSchedulerInterval(interval)), start_time)
+    def snapshot_schedule_add(cls, image_spec: str, interval: str):
+        _rbd_support_remote('mirror_snapshot_schedule_add', image_spec,
+                            str(RBDSchedulerInterval(interval)))
+
+    @classmethod
+    def snapshot_schedule_remove(cls, image_spec: str):
+        _rbd_support_remote('mirror_snapshot_schedule_remove', image_spec)


### PR DESCRIPTION
When parsing images if an image has the snapshot mode enabled, it will try to  run commands 
that don't work with that mode. The solution was not running those for now and appending the mode in the get call.


e2e tests are not done here!

Things to consider:

**backend**
* Can we get the rbd disk usage from snapshot mirroring image mode?
* Is an image protected in snapshot mode?
* set_snap doesn't work with snapshot mode.

**frontend**
* disable performing actions snapshots with snapshot mode
* 1 joint table for all modes or 2 different ones?
![Screenshot from 2022-05-18 19-47-01](https://user-images.githubusercontent.com/71764184/169270356-6a7ec4a0-560b-4b5a-9b24-c3ee78be49f0.png)

**Image List**
![Screenshot from 2022-05-19 16-42-19](https://user-images.githubusercontent.com/71764184/169282564-6b7a64f6-e70e-4e64-9b55-3032bf823d81.png)

**Mirror snapshots (the one starts with `.mirror`) is created implicitly when enabling an image snapshot mirroring and is handled differently. So all of the snapshot actions (like clone, protect etc) doesn't work. Hence disabling those.**
![Screenshot from 2022-05-16 15-27-10](https://user-images.githubusercontent.com/71764184/168568014-79b8b34b-f718-4239-86d9-cf72018a27b0.png)

![Screenshot from 2022-05-19 16-45-13](https://user-images.githubusercontent.com/71764184/169282557-71d859c4-fc21-43da-8af2-6863fdb86731.png)

![Screenshot from 2022-05-19 16-41-37](https://user-images.githubusercontent.com/71764184/169282567-81ae8a70-368d-4f65-bd3d-1f10dca36217.png)

![Screenshot from 2022-05-19 16-41-14](https://user-images.githubusercontent.com/71764184/169282569-578f3fdb-a854-415a-a819-1992842a42fd.png)

![Screenshot from 2022-05-30 14-39-13](https://user-images.githubusercontent.com/66050535/170960964-050a99b3-25d5-4050-ac3f-1db43a23aac3.png)

![Screenshot from 2022-05-30 14-39-23](https://user-images.githubusercontent.com/66050535/170961152-1dc11b58-8093-42c9-8f58-49a5a698e608.png)

![Screenshot from 2022-05-27 17-33-01](https://user-images.githubusercontent.com/66050535/170961333-e51a03f7-8aaf-4450-8b65-8283013293b6.png)

![Screenshot from 2022-05-26 17-38-18](https://user-images.githubusercontent.com/66050535/170961499-6e077b47-854b-42cb-8200-75880925a6f6.png)

![Screenshot from 2022-05-26 17-59-29](https://user-images.githubusercontent.com/66050535/170961617-fe88dc8d-e745-4758-98e7-f2a9ea10fa05.png)



### Known Issues so far

* Disk usage is not there for snapshot mirror images
* Deleting is not possible from frontend for snapshot mirror enabled images. If we disable the snapshot mirroring then we can delete.


Fixes: https://tracker.ceph.com/issues/55648
Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>
Signed-off-by: Nizamudeen A <nia@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
