### PR TITLE
add some types from cls_rgw_ops.h to ceph-dencoder

### DIFF
--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -388,6 +388,65 @@ void rgw_cls_bucket_update_stats_op::dump(Formatter *f) const
   encode_json("stats", s, f);
 }
 
+void rgw_cls_obj_remove_op::dump(Formatter *f) const {
+  list<std::string> k;
+  for (auto& entry : keep_attr_prefixes) {
+    k.push_back(entry);
+  }
+  ::encode_json("keep_attr_prefix", k, f);
+}
+
+void rgw_cls_obj_remove_op::generate_test_instances(list<rgw_cls_obj_remove_op *>& o) {
+  rgw_cls_obj_remove_op *r = new rgw_cls_obj_remove_op;
+  r->keep_attr_prefixes.push_back("111");
+  r->keep_attr_prefixes.push_back("222");
+  o.push_back(r);
+
+  o.push_back(new rgw_cls_obj_remove_op);
+}
+
+void rgw_cls_obj_store_pg_ver_op::dump(Formatter *f) const {
+  ::encode_json("attr", attr, f);
+}
+
+void rgw_cls_obj_store_pg_ver_op::generate_test_instances(list<rgw_cls_obj_store_pg_ver_op *>& o){
+  rgw_cls_obj_store_pg_ver_op *r = new rgw_cls_obj_store_pg_ver_op;
+  r->attr = "test";
+  o.push_back(r);
+
+  o.push_back(new rgw_cls_obj_store_pg_ver_op);
+}
+
+void rgw_cls_obj_check_attrs_prefix::dump(Formatter *f) const {
+  ::encode_json("check_prefix", check_prefix, f);
+  ::encode_json("fail_if_exist", fail_if_exist, f);
+}
+
+void rgw_cls_obj_check_attrs_prefix::generate_test_instances(list<rgw_cls_obj_check_attrs_prefix *>& o){
+  rgw_cls_obj_check_attrs_prefix *r = new rgw_cls_obj_check_attrs_prefix;
+  r->check_prefix = "test_prefix";
+  r->fail_if_exist = true;
+  o.push_back(r);
+
+  o.push_back(new rgw_cls_obj_check_attrs_prefix);
+}
+
+void rgw_cls_obj_check_mtime::dump(Formatter *f) const {
+  ::encode_json("mtime", mtime, f);
+  ::encode_json("type", int(type), f);
+  ::encode_json("high_precision_time", high_precision_time, f);
+}
+
+void rgw_cls_obj_check_mtime::generate_test_instances(list<rgw_cls_obj_check_mtime *>& o) {
+  rgw_cls_obj_check_mtime *r = new rgw_cls_obj_check_mtime;
+  r->mtime = ceph::real_clock::now();
+  r->type = RGWCheckMTimeType::CLS_RGW_CHECK_TIME_MTIME_LT;
+  r->high_precision_time = true;
+  o.push_back(r);
+
+  o.push_back(new rgw_cls_obj_check_mtime);
+}
+
 void cls_rgw_bi_log_list_op::dump(Formatter *f) const
 {
   f->dump_string("marker", marker);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -527,6 +527,9 @@ struct rgw_cls_obj_remove_op {
     decode(keep_attr_prefixes, bl);
     DECODE_FINISH(bl);
   }
+
+  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_obj_remove_op *>& o);
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_remove_op)
 
@@ -544,6 +547,9 @@ struct rgw_cls_obj_store_pg_ver_op {
     decode(attr, bl);
     DECODE_FINISH(bl);
   }
+
+  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_obj_store_pg_ver_op *>& o);
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_store_pg_ver_op)
 
@@ -566,6 +572,9 @@ struct rgw_cls_obj_check_attrs_prefix {
     decode(fail_if_exist, bl);
     DECODE_FINISH(bl);
   }
+
+  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_obj_check_attrs_prefix *>& o);
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_check_attrs_prefix)
 
@@ -595,6 +604,9 @@ struct rgw_cls_obj_check_mtime {
     }
     DECODE_FINISH(bl);
   }
+
+  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_cls_obj_check_mtime *>& o);
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_check_mtime)
 

--- a/src/tools/ceph-dencoder/rgw_types.h
+++ b/src/tools/ceph-dencoder/rgw_types.h
@@ -83,6 +83,12 @@ TYPE(cls_rgw_reshard_remove_op)
 TYPE(cls_rgw_set_bucket_resharding_op)
 TYPE(cls_rgw_clear_bucket_resharding_op)
 TYPE(cls_rgw_lc_obj_head)
+TYPE(rgw_cls_bucket_update_stats_op)
+TYPE(rgw_cls_obj_remove_op)
+TYPE(rgw_cls_obj_store_pg_ver_op)
+TYPE(rgw_cls_obj_check_attrs_prefix)
+TYPE(rgw_cls_obj_check_mtime)
+
 
 #include "cls/rgw/cls_rgw_client.h"
 TYPE(rgw_bi_log_entry)


### PR DESCRIPTION
New classes are declared in #include "cls/rgw/cls_rgw_ops.h"
Missing memeber functions are declared and defined
Fixes: https://tracker.ceph.com/issues/54054
Signed-off-by: zhengp570 <zhengp570@gmail.com>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
