### PR TITLE
osd: limit the number of send immediate osd_failure

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3114,6 +3114,13 @@ options:
   desc: Turn up debug levels during shutdown
   default: false
   with_legacy: true
+# debug osd_failure send to mon messages
+- name: osd_debug_osd_failure
+  type: bool
+  level: dev
+  desc: print log when osd send osd_failures to mon
+  default: false
+  with_legacy: true
 # crash osd if client ignores a backoff; useful for debugging
 - name: osd_debug_crash_on_ignored_backoff
   type: bool
@@ -3307,6 +3314,13 @@ options:
     crashed OSD host survives). Disable it to restore old
     behavior, at the expense of possible long I/O stalls when
     OSDs crash in the middle of I/O operations.
+  with_legacy: true
+- name: osd_limit_fast_fail_on_connection_refused
+  type: bool
+  level: advanced
+  default: true
+  fmt_desc: If this option is enabled, limit the number of
+    send immediate osd_failure.
   with_legacy: true
 - name: osd_pg_object_context_cache_count
   type: int

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1866,8 +1866,13 @@ protected:
   void got_full_map(epoch_t e);
 
   // -- failures --
-  std::map<int,utime_t> failure_queue;
-  std::map<int,std::pair<utime_t,entity_addrvec_t> > failure_pending;
+  struct failure_pending_t {
+    utime_t time;
+    entity_addrvec_t addrs;
+    int flags;
+  };
+  std::map<int,std::pair<utime_t,int> > failure_queue; //{osd:<time,flags>}
+  std::map<int,failure_pending_t> failure_pending;
 
   void requeue_failures();
   void send_failures();


### PR DESCRIPTION
```
Problem:
hardware environment: 3 nodes, 98 * 3 = 294 OSDs, 3mon, 3mgr
For osd_fast_fail_on_connection_refused=true/false,
Comparison of the number of failures sent

osd_fast_fail_on_connection_refused = true
reboot node2
[node1]# grep 2022-05-13T14:2 ceph-osd.*.log|grep osd_failure|wc -l
109150
[node3]# grep 2022-05-13T14:2 ceph-osd.*.log|grep osd_failure|wc -l
94852

osd_fast_fail_on_connection_refused = false
reboot node1
[node2]# grep 2022-05-13T15:2. ceph-osd.*.log|grep osd_failure|wc -l
1386
[node3]# grep 2022-05-13T15:2. ceph-osd.*.log|grep osd_failure|wc -l
808

Comparing the test results, we can see
osd_fast_fail_on_connection_refused = true Report osd_failure 160,000 to 200,000 times to mon
osd_fast_fail_on_connection_refused = false Report osd_failure 2000 times to mon
100 times difference

osd_fast_fail_on_connection_refused = true, It can lead to mon's constant elections.

Solution:
when osd_fast_fail_on_connection_refused is true,
we need to limit the number of osd_failure that send the same osd

add osd_debug_osd_failure option for debug osd_failure log

Reuse the existing failure_pending queue

When the connection refused osd_failure has been sent, it records in the failure_pending,
and the osd-osd heartbeat timeout osd_failure will no longer be sent.

When the osd-osd heartbeat timeout osd_failure has been sent,
but the connection refused osd_failure has not been sent,
the connection refused osd_failure will be sent again
and overwrite the existing osd-osd heartbeat timeout osd_failure in the failure_pending.

Fix : https://tracker.ceph.com/issues/55665

Signed-off-by: Jianwei Zhang <jianwei1216@qq.com>


```