### PR TITLE
osd: add command ceph pg <pgid> find_unfound_object <objname> for rec…

### DIFF
--- a/src/messages/MOSDPGQueryObjectInfo.h
+++ b/src/messages/MOSDPGQueryObjectInfo.h
@@ -1,0 +1,132 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_MOSDPGQueryObjectInfo_H
+#define CEPH_MOSDPGQueryObjectInfo_H
+
+#include "MOSDFastDispatchOp.h"
+
+class MOSDPGQueryObjectInfo: public MOSDFastDispatchOp {
+private:
+  static constexpr int HEAD_VERSION = 2;
+  static constexpr int COMPAT_VERSION = 2;
+
+public:
+  enum {
+    OP_GET_OBJECT_INFO = 1,      // just objects and versions
+    OP_OBJECT_INFO = 2,          // result
+  };
+  const char *get_op_name(int o) const {
+    switch (o) {
+    case OP_GET_OBJECT_INFO: return "get_object_info";
+    case OP_OBJECT_INFO: return "object_info";
+    default: return "???";
+    }
+  }
+
+  __u32 op = 0;
+  ceph_tid_t rep_tid = 0;
+  epoch_t map_epoch = 0, query_epoch = 0;
+  pg_shard_t from;
+  spg_t pgid;
+  hobject_t object;
+  int32_t result;
+
+  epoch_t get_map_epoch() const override {
+    return map_epoch;
+  }
+  epoch_t get_min_epoch() const override {
+    return query_epoch;
+  }
+  spg_t get_spg() const override {
+    return pgid;
+  }
+
+  ceph_tid_t get_tid() const {
+    return rep_tid;
+  }
+
+  void decode_payload() override {
+    auto p = payload.cbegin();
+    decode(op, p);
+    decode(rep_tid, p);
+    decode(map_epoch, p);
+    decode(query_epoch, p);
+    decode(pgid.pgid, p);
+    decode(object, p);
+    decode(from, p);
+    decode(pgid.shard, p);
+    decode(result, p);
+  }
+
+  void encode_payload(uint64_t features) override {
+    using ceph::encode;
+    encode(op, payload);
+    encode(rep_tid, payload);
+    encode(map_epoch, payload);
+    if (!HAVE_FEATURE(features, SERVER_NAUTILUS)) {
+      // pre-nautilus OSDs do not set last_peering_reset properly
+      encode(map_epoch, payload);
+    } else {
+      encode(query_epoch, payload);
+    }
+    encode(pgid.pgid, payload);
+    encode(object, payload);
+    encode(from, payload);
+    encode(pgid.shard, payload);
+    encode(result, payload);
+  }
+
+  MOSDPGQueryObjectInfo()
+    : MOSDFastDispatchOp{MSG_OSD_PG_QUERY_OBJECT_INFO, HEAD_VERSION, COMPAT_VERSION} {}
+
+  MOSDPGQueryObjectInfo(
+    __u32 o,
+    ceph_tid_t tid,
+    pg_shard_t from,
+    epoch_t e,
+    epoch_t qe,
+    spg_t p,
+    hobject_t obj,
+    int32_t res)
+    : MOSDFastDispatchOp{MSG_OSD_PG_QUERY_OBJECT_INFO, HEAD_VERSION, COMPAT_VERSION},
+      op(o),
+      rep_tid(tid),
+      map_epoch(e),
+      query_epoch(qe),
+      from(from),
+      pgid(p),
+      object(obj),
+      result(res) {
+  }
+private:
+  ~MOSDPGQueryObjectInfo() override {}
+
+public:
+  std::string_view get_type_name() const override { return "pg_query_object_info"; }
+  void print(ostream& out) const override {
+    out << "pg_query_object_info(" << get_op_name(op)
+	<< " " << rep_tid
+	<< " " << pgid
+	<< " " << object
+	<< " result=" << result
+	<< " e " << map_epoch << "/" << query_epoch
+	<< ")";
+  }
+private:
+  template<class T, typename... Args>
+  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+};
+
+#endif

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -95,6 +95,7 @@
 #include "messages/MOSDRepScrubMap.h"
 #include "messages/MOSDForceRecovery.h"
 #include "messages/MOSDPGScan.h"
+#include "messages/MOSDPGQueryObjectInfo.h"
 #include "messages/MOSDPGBackfill.h"
 #include "messages/MOSDBackoff.h"
 #include "messages/MOSDPGBackfillRemove.h"
@@ -588,6 +589,9 @@ Message *decode_message(CephContext *cct,
     break;
   case MSG_OSD_PG_SCAN:
     m = make_message<MOSDPGScan>();
+    break;
+  case MSG_OSD_PG_QUERY_OBJECT_INFO:
+    m = make_message<MOSDPGQueryObjectInfo>();
     break;
   case MSG_OSD_PG_BACKFILL:
     m = make_message<MOSDPGBackfill>();

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -143,6 +143,8 @@
 #define MSG_OSD_PG_LEASE        133
 #define MSG_OSD_PG_LEASE_ACK    134
 
+#define MSG_OSD_PG_QUERY_OBJECT_INFO 135
+
 // *** MDS ***
 
 #define MSG_MDS_BEACON             100  // to monitor

--- a/src/osd/MissingLoc.h
+++ b/src/osd/MissingLoc.h
@@ -253,6 +253,11 @@ class MissingLoc {
     it->second.need = need;
   }
 
+  bool add_source_info_for_one_unfound(
+    const pg_shard_t fromosd,
+    const hobject_t &soid,
+    const pg_missing_item &missing);
+
   /// Adds info about a possible recovery source
   bool add_source_info(
     pg_shard_t source,           ///< [in] source

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -108,6 +108,7 @@
 #include "messages/MOSDPGCreated.h"
 #include "messages/MOSDPGUpdateLogMissing.h"
 #include "messages/MOSDPGUpdateLogMissingReply.h"
+#include "messages/MOSDPGQueryObjectInfo.h"
 
 #include "messages/MOSDPeeringOp.h"
 
@@ -2392,6 +2393,7 @@ void OSD::asok_command(
   if (prefix == "pg" ||
       prefix == "query" ||
       prefix == "mark_unfound_lost" ||
+      prefix == "find_unfound_object" ||
       prefix == "list_unfound" ||
       prefix == "scrub" ||
       prefix == "deep_scrub"
@@ -3968,6 +3970,14 @@ void OSD::final_init()
   r = admin_socket->register_command(
     "pg "			   \
     "name=pgid,type=CephPgid "	   \
+    "name=cmd,type=CephChoices,strings=find_unfound_object " \
+    "name=objname,type=CephString,req=true",
+    asok_hook,
+    "");
+  ceph_assert(r == 0);
+  r = admin_socket->register_command(
+    "pg "			   \
+    "name=pgid,type=CephPgid "	   \
     "name=cmd,type=CephChoices,strings=list_unfound " \
     "name=offset,type=CephString,req=false",
     asok_hook,
@@ -4001,6 +4011,14 @@ void OSD::final_init()
     "name=mulcmd,type=CephChoices,strings=revert|delete",
     asok_hook,
     "mark all unfound objects in this pg as lost, either removing or reverting to a prior version if one is available");
+  ceph_assert(r == 0);
+  r = admin_socket->register_command(
+    "find_unfound_object "					\
+    "name=pgid,type=CephPgid,req=false "			\
+    "name=objname,type=CephString,req=true",
+    asok_hook,
+    "find specific unfound object in this pg " \
+    "find source osd for current need version if one is available");
   ceph_assert(r == 0);
   r = admin_socket->register_command(
     "list_unfound "					\

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1946,6 +1946,7 @@ private:
     case MSG_OSD_PG_PULL:
     case MSG_OSD_PG_PUSH_REPLY:
     case MSG_OSD_PG_SCAN:
+    case MSG_OSD_PG_QUERY_OBJECT_INFO:
     case MSG_OSD_PG_BACKFILL:
     case MSG_OSD_PG_BACKFILL_REMOVE:
     case MSG_OSD_EC_WRITE:

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1489,6 +1489,7 @@ protected:
 
   // OpRequest queueing
   bool can_discard_op(OpRequestRef& op);
+  bool can_discard_query_object_info(OpRequestRef op);
   bool can_discard_scan(OpRequestRef op);
   bool can_discard_backfill(OpRequestRef op);
   bool can_discard_request(OpRequestRef& op);

--- a/src/osd/PGPeeringEvent.cc
+++ b/src/osd/PGPeeringEvent.cc
@@ -15,3 +15,16 @@ void MLogRec::print(std::ostream *out) const
   *out << "MLogRec from " << from << " ";
   msg->inner_print(*out);
 }
+
+RecoverUnfoundObject::RecoverUnfoundObject(
+  set<pg_shard_t> peers,
+  const hobject_t object,
+  const pg_missing_item missing)
+  : peers(peers), object(object), missing(missing) {}
+
+void RecoverUnfoundObject::print(std::ostream *out) const
+{
+  *out << "RecoverUnfoundObject object " << object
+       << " missing " << missing
+       << " peers " << peers << " ";
+}

--- a/src/osd/PGPeeringEvent.h
+++ b/src/osd/PGPeeringEvent.h
@@ -98,6 +98,16 @@ struct MLogRec : boost::statechart::event< MLogRec > {
   void print(std::ostream *out) const;
 };
 
+struct RecoverUnfoundObject : boost::statechart::event< RecoverUnfoundObject > {
+  set<pg_shard_t> peers;
+  hobject_t object;
+  pg_missing_item missing;
+  RecoverUnfoundObject(set<pg_shard_t> peers,
+		       const hobject_t object,
+		       const pg_missing_item missing);
+  void print(std::ostream *out) const;
+};
+
 struct MNotifyRec : boost::statechart::event< MNotifyRec > {
   spg_t pgid;
   pg_shard_t from;


### PR DESCRIPTION
Author: Jianwei Zhang <jianwei1216@qq.com>
Date:   Mon May 16 15:46:57 2022 +0800

    osd: add command ceph pg <pgid> find_unfound_object <objname> for recovery_unfound
    
    problem:
    ec(4+2) The original 3 nodes, open ec folding, the ratio is 2, expand 2 nodes to the cluster
    ec(2+1) The original 3 nodes, open ec folding, the ratio is 2, expand 2 nodes to the cluster
    all osds status of ceph cluster are exists&up&in
    but some PGs have been stuck in recovery_unfound state and cannot be recovered
    note: after one-by-one adding a new osd to the ceph cluster, pg stuck recovery_unfound
    
    root cause:
    1. The pg acting set has missing objects that needs to recover.
    2. But the source osd of the missing objects is in the backfill_targets(up) set,
    3. Since the source osd in the backfill_targets(up) set needs to restart backfill, set the pg info.last_backfill to MIN,
    4. Since the pg info.last_backfill of source osd is MIN, when MissingLoc::add_source_info, filter the source osd that has missing object,
    5. These missing objects cannot recover and the pg status changes to recovery_unfound.
    
    Solution:
    <pgid> : pg.id
    <objname> : ceph pg <pgid> list_unfound

    example:
    ceph pg 3.20 list_unfound
    {
        "num_missing": 1,
        "num_unfound": 1,
        "objects": [
            {
                "oid": {
                    "oid": "202000000000095.00000005",
                    "key": "",
                    "snapid": -2,
                    "hash": 1807777312,
                    "max": 0,
                    "pool": 3,
                    "namespace": ""
                },
                "need": "303'1222",
                "have": "0'0",
                "flags": "none",
                "clean_regions": "clean_offsets: [], clean_omap: 0, new_object: 1",
                "locations": [
                    "1(5)",
                    "46(1)"
                ]
            }
        ],
        "more": false
    }
    
    ceph pg 3.20 find_unfound_object 202000000000095.00000005
    pg has 3:047e03d6:::202000000000095.00000005:head object unfound
            missing 303'1222 flags = none clean_offsets: [], clean_omap: 0, new_object: 1
            old_location 1(5),46(1)
            new_location 1(5),32(2),34(0),42(4),46(1)
            and find all might have unfound source
    
    Signed-off-by: Jianwei Zhang <jianwei1216@qq.com>
