### PR TITLE
osd: add log for pg peering and activiting complete

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -6227,6 +6227,8 @@ boost::statechart::result PeeringState::Active::react(const AllReplicasActivated
     pl->send_pg_created(pgid);
   }
 
+  psdout(1) << __func__ << " AllReplicasActivated Activating complete" << dendl;
+
   ps->info.history.last_epoch_started = ps->info.last_epoch_started;
   ps->info.history.last_interval_started = ps->info.last_interval_started;
   ps->dirty_info = true;


### PR DESCRIPTION
This log is added to PeeringState::Active::react(const AllReplicasActivated &evt)
to pair with the PeeringState::start_peering_interval() log,
So that under the default log level of debug_osd(1/5),
the completion of each pg peering can be traced back through ceph-osd.x.log

Because under some exceptions, we need to know clearly
whether pg has completed peering at the time when the exception occurs,
and whether it can handle client IO.

Signed-off-by: Jianwei Zhang <jianwei1216@qq.com>