### PR TITLE
osd: optimize pg peering latency when add new osd that need backfill

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -2758,6 +2758,14 @@ options:
   flags:
   - startup
   with_legacy: true
+- name: osd_pg_init_with_backfill
+  type: bool
+  level: advanced
+  default: true
+  long_desc: This happens when the newly created(caused by adding or deleting osd)
+    pg has its pglog (head, tail) that is emtpy pglog (0,0), but it still continuous
+    with the authoritative log(0, 3000), In this case, we use backfill instead of recovery.
+  with_legacy: true
 - name: osd_map_dedup
   type: bool
   level: advanced

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1041,6 +1041,7 @@ seastar::future<Ref<PG>> OSD::handle_pg_create_info(
           acting_primary,
           info->history,
           info->past_intervals,
+          false,
           rctx.transaction);
 
         return shard_services.start_operation<PGAdvanceMap>(

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -415,11 +415,12 @@ void PG::init(
   const vector<int>& newacting, int new_acting_primary,
   const pg_history_t& history,
   const PastIntervals& pi,
+  bool backfill,
   ObjectStore::Transaction &t)
 {
   peering_state.init(
     role, newup, new_up_primary, newacting,
-    new_acting_primary, history, pi, t);
+    new_acting_primary, history, pi, backfill, t);
 }
 
 seastar::future<> PG::read_state(crimson::os::FuturizedStore* store)

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -478,6 +478,7 @@ public:
     int acting_primary,
     const pg_history_t& history,
     const PastIntervals& pim,
+    bool backfill,
     ceph::os::Transaction &t);
 
   seastar::future<> read_state(crimson::os::FuturizedStore* store);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5100,7 +5100,7 @@ PGRef OSD::handle_pg_create_info(const OSDMapRef& osdmap,
     acting_primary,
     info->history,
     info->past_intervals,
-    false,
+    cct->_conf->osd_pg_init_with_backfill,
     rctx.transaction);
 
   pg->init_collection_pool_opts();
@@ -9498,6 +9498,9 @@ void OSD::handle_pg_query_nopg(const MQuery& q)
 
   dout(10) << " pg " << pgid << " dne" << dendl;
   pg_info_t empty(spg_t(pgid.pgid, q.query.to));
+  if (cct->_conf->osd_pg_init_with_backfill)
+    empty.set_last_backfill(hobject_t());
+
   ConnectionRef con = service.get_con_osd_cluster(q.from.osd, osdmap->get_epoch());
   if (con) {
     Message *m;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5100,6 +5100,7 @@ PGRef OSD::handle_pg_create_info(const OSDMapRef& osdmap,
     acting_primary,
     info->history,
     info->past_intervals,
+    false,
     rctx.transaction);
 
   pg->init_collection_pool_opts();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -861,11 +861,12 @@ void PG::init(
   const vector<int>& newacting, int new_acting_primary,
   const pg_history_t& history,
   const PastIntervals& pi,
+  bool backfill,
   ObjectStore::Transaction &t)
 {
   recovery_state.init(
     role, newup, new_up_primary, newacting,
-    new_acting_primary, history, pi, t);
+    new_acting_primary, history, pi, backfill, t);
 }
 
 void PG::shutdown()

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -383,6 +383,7 @@ public:
     int acting_primary,
     const pg_history_t& history,
     const PastIntervals& pim,
+    bool backfill,
     ObjectStore::Transaction &t);
 
   /// read existing pg state off disk

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3893,6 +3893,7 @@ void PeeringState::init(
   const vector<int>& newacting, int new_acting_primary,
   const pg_history_t& history,
   const PastIntervals& pi,
+  bool backfill,
   ObjectStore::Transaction &t)
 {
   psdout(10) << "init role " << role << " up "
@@ -3919,6 +3920,13 @@ void PeeringState::init(
 
   if (!perform_deletes_during_peering()) {
     pg_log.set_missing_may_contain_deletes();
+  }
+
+  if (backfill) {
+    psdout(10) << __func__ << ": Setting backfill" << dendl;
+    info.set_last_backfill(hobject_t());
+    info.last_complete = info.last_update;
+    pg_log.mark_log_for_rewrite();
   }
 
   on_new_interval();

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1737,6 +1737,7 @@ public:
     const std::vector<int>& newacting, int new_acting_primary,
     const pg_history_t& history,
     const PastIntervals& pi,
+    bool backfill,
     ObjectStore::Transaction &t);
 
   /// Init pg instance from disk state


### PR DESCRIPTION
https://tracker.ceph.com/issues/52884
first description : https://github.com/ceph/ceph/pull/43482

```
    osd: optimize pg peering latency when add new osd that need backfill
    
    set last_backfill to MIN when creating pg
    
    This happens when the newly created(caused by adding or deleting osd)
    pg has its pglog (head, tail) that is empty pglog(0,0),
    but it still continuous with the authoritative log(0, 3000),
    In this case, we use backfill instead of recovery.
    
    If the authoritative log (6000,9000), that is, tail > 3000,
    then the newly created pg (0,0) will naturally go directly to the backfill path,
    because there is no intersection between the two.
    
    If the osd is offline for a short time,
    the pg on it will still be continuous with the authoritative log.
    In this case, the recovery path will still be taken, not backfill.
    
    There are 2 benefits
    1. Backfill has lower latency than recovery in processing pglog during peering
    2. When choose_acting, the backfill osd will not be considered,
       when osd is continuously added/deleted, the number of acting changes can be reduced.
    
    Fix : https://tracker.ceph.com/issues/52884
    
    Signed-off-by: Jianwei Zhang <jianwei1216@qq.com>
```
