### PR TITLE
multisite reshard: update test_rgw_bucket_sync_cache with nullopt

### DIFF
--- a/src/test/rgw/test_rgw_bucket_sync_cache.cc
+++ b/src/test/rgw/test_rgw_bucket_sync_cache.cc
@@ -61,6 +61,16 @@ TEST(BucketSyncCache, DistinctShards)
   EXPECT_EQ(0, cache->get(key2, std::nullopt)->counter);
 }
 
+TEST(BucketSyncCache, DistinctGen)
+{
+  auto cache = Cache::create(2);
+  const auto key = make_key("", "bucket", 0);
+  std::optional<uint64_t> gen1; // empty
+  std::optional<uint64_t> gen2 = 5;
+  cache->get(key, gen1)->counter = 1;
+  EXPECT_EQ(0, cache->get(key, gen2)->counter);
+}
+
 TEST(BucketSyncCache, DontEvictPinned)
 {
   auto cache = Cache::create(0);


### PR DESCRIPTION
fixes compilation after https://github.com/ceph/ceph/pull/45122:
```
src/test/rgw/test_rgw_bucket_sync_cache.cc:32:27: error: too few arguments to function call, expected 2, have 1
  auto h1 = cache->get(key); // pin
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
