### PR TITLE
rgw/lua: don't create the script manager per request

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -10394,7 +10394,8 @@ next:
       cerr << "ERROR: cannot specify tenant in background context" << std::endl;
       return EINVAL;
     }
-    rc = rgw::lua::write_script(dpp(), store, tenant, null_yield, script_ctx, script);
+    auto lua_manager = store->get_lua_manager();
+    rc = rgw::lua::write_script(dpp(), lua_manager.get(), tenant, null_yield, script_ctx, script);
     if (rc < 0) {
       cerr << "ERROR: failed to put script. error: " << rc << std::endl;
       return -rc;
@@ -10411,8 +10412,9 @@ next:
       cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: preRequest, postRequest, background" << std::endl;
       return EINVAL;
     }
+    auto lua_manager = store->get_lua_manager();
     std::string script;
-    const auto rc = rgw::lua::read_script(dpp(), store, tenant, null_yield, script_ctx, script);
+    const auto rc = rgw::lua::read_script(dpp(), lua_manager.get(), tenant, null_yield, script_ctx, script);
     if (rc == -ENOENT) {
       std::cout << "no script exists for context: " << *str_script_ctx << 
         (tenant.empty() ? "" : (" in tenant: " + tenant)) << std::endl;
@@ -10434,7 +10436,8 @@ next:
       cerr << "ERROR: invalid script context: " << *str_script_ctx << ". must be one of: preRequest, postRequest, background" << std::endl;
       return EINVAL;
     }
-    const auto rc = rgw::lua::delete_script(dpp(), store, tenant, null_yield, script_ctx);
+    auto lua_manager = store->get_lua_manager();
+    const auto rc = rgw::lua::delete_script(dpp(), lua_manager.get(), tenant, null_yield, script_ctx);
     if (rc < 0) {
       cerr << "ERROR: failed to remove script. error: " << rc << std::endl;
       return -rc;

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -183,6 +183,7 @@ void handle_connection(boost::asio::io_context& context,
                        parse_buffer& buffer, bool is_ssl,
                        SharedMutex& pause_mutex,
                        rgw::dmclock::Scheduler *scheduler,
+                       std::unique_ptr<rgw::sal::LuaManager>& lua_manager,
                        boost::system::error_code& ec,
                        yield_context yield)
 {
@@ -269,7 +270,9 @@ void handle_connection(boost::asio::io_context& context,
                       *env.auth_registry, &client, env.olog, y,
                       scheduler, &user, &latency,
                       env.ratelimiting->get_active(),
-                      &http_ret, env.lua_background);
+                      env.lua_background,
+                      lua_manager,
+                      &http_ret);
 
       if (cct->_conf->subsys.should_gather(ceph_subsys_rgw_access, 1)) {
         // access log line elements begin per Apache Combined Log Format with additions following
@@ -383,6 +386,7 @@ class AsioFrontend {
 #endif
   SharedMutex pause_mutex;
   std::unique_ptr<rgw::dmclock::Scheduler> scheduler;
+  std::unique_ptr<rgw::sal::LuaManager> lua_manager;
 
   struct Listener {
     tcp::endpoint endpoint;
@@ -413,7 +417,8 @@ class AsioFrontend {
  public:
   AsioFrontend(const RGWProcessEnv& env, RGWFrontendConfig* conf,
 	       dmc::SchedulerCtx& sched_ctx)
-    : env(env), conf(conf), pause_mutex(context.get_executor())
+    : env(env), conf(conf), pause_mutex(context.get_executor()),
+    lua_manager(env.store->get_lua_manager())
   {
     auto sched_t = dmc::get_scheduler_t(ctx());
     switch(sched_t){
@@ -1004,6 +1009,7 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
         conn->buffer.consume(bytes);
         handle_connection(context, env, stream, timeout, header_limit,
                           conn->buffer, true, pause_mutex, scheduler.get(),
+                          lua_manager,
                           ec, yield);
         if (!ec) {
           // ssl shutdown (ignoring errors)
@@ -1023,6 +1029,7 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
         boost::system::error_code ec;
         handle_connection(context, env, conn->socket, timeout, header_limit,
                           conn->buffer, false, pause_mutex, scheduler.get(),
+                          lua_manager,
                           ec, yield);
         conn->socket.shutdown(tcp_socket::shutdown_both, ec);
       }, make_stack_allocator());
@@ -1108,6 +1115,7 @@ void AsioFrontend::unpause(rgw::sal::Store* const store,
 {
   env.store = store;
   env.auth_registry = std::move(auth_registry);
+  lua_manager = store->get_lua_manager();
 
   // unpause to unblock connections
   pause_mutex.unlock();

--- a/src/rgw/rgw_loadgen_process.cc
+++ b/src/rgw/rgw_loadgen_process.cc
@@ -137,7 +137,9 @@ void RGWLoadGenProcess::handle_request(const DoutPrefixProvider *dpp, RGWRequest
   int ret = process_request(store, rest, req, uri_prefix,
                             *auth_registry, &client_io, olog,
                             null_yield, nullptr, nullptr, nullptr,
-                            ratelimit.get_active(), nullptr);
+                            ratelimit.get_active(),
+                            nullptr,
+                            lua_manager);
   if (ret < 0) {
     /* we don't really care about return code */
     dout(20) << "process_request() returned " << ret << dendl;

--- a/src/rgw/rgw_lua.cc
+++ b/src/rgw/rgw_lua.cc
@@ -67,25 +67,21 @@ std::string script_oid(context ctx, const std::string& tenant) {
 }
 
 
-int read_script(const DoutPrefixProvider *dpp, rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx, std::string& script)
+int read_script(const DoutPrefixProvider *dpp, sal::LuaManager* manager, const std::string& tenant, optional_yield y, context ctx, std::string& script)
 {
-  auto lua_mgr = store->get_lua_manager();
 
-  return lua_mgr->get_script(dpp, y, script_oid(ctx, tenant), script);
+  return manager->get_script(dpp, y, script_oid(ctx, tenant), script);
+
 }
 
-int write_script(const DoutPrefixProvider *dpp, rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx, const std::string& script)
+int write_script(const DoutPrefixProvider *dpp, sal::LuaManager* manager, const std::string& tenant, optional_yield y, context ctx, const std::string& script)
 {
-  auto lua_mgr = store->get_lua_manager();
-
-  return lua_mgr->put_script(dpp, y, script_oid(ctx, tenant), script);
+  return manager->put_script(dpp, y, script_oid(ctx, tenant), script);
 }
 
-int delete_script(const DoutPrefixProvider *dpp, rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx)
+int delete_script(const DoutPrefixProvider *dpp, sal::LuaManager* manager, const std::string& tenant, optional_yield y, context ctx)
 {
-  auto lua_mgr = store->get_lua_manager();
-
-  return lua_mgr->del_script(dpp, y, script_oid(ctx, tenant));
+  return manager->del_script(dpp, y, script_oid(ctx, tenant));
 }
 
 #ifdef WITH_RADOSGW_LUA_PACKAGES

--- a/src/rgw/rgw_lua.h
+++ b/src/rgw/rgw_lua.h
@@ -9,8 +9,10 @@
 
 class lua_State;
 class rgw_user;
+class DoutPrefixProvider;
 namespace rgw::sal {
   class RadosStore;
+  class LuaManager;
 }
 
 namespace rgw::lua {
@@ -31,13 +33,13 @@ context to_context(const std::string& s);
 bool verify(const std::string& script, std::string& err_msg);
 
 // store a lua script in a context
-int write_script(const DoutPrefixProvider *dpp, rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx, const std::string& script);
+int write_script(const DoutPrefixProvider *dpp, rgw::sal::LuaManager* manager, const std::string& tenant, optional_yield y, context ctx, const std::string& script);
 
 // read the stored lua script from a context
-int read_script(const DoutPrefixProvider *dpp, rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx, std::string& script);
+int read_script(const DoutPrefixProvider *dpp, rgw::sal::LuaManager* manager, const std::string& tenant, optional_yield y, context ctx, std::string& script);
 
 // delete the stored lua script from a context
-int delete_script(const DoutPrefixProvider *dpp, rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx);
+int delete_script(const DoutPrefixProvider *dpp, rgw::sal::LuaManager* manager, const std::string& tenant, optional_yield y, context ctx);
 
 using packages_t = std::set<std::string>;
 

--- a/src/rgw/rgw_lua_background.h
+++ b/src/rgw/rgw_lua_background.h
@@ -189,7 +189,7 @@ private:
   bool paused = false;
   int execute_interval;
   const DoutPrefix dp;
-  rgw::sal::Store* store;
+  std::unique_ptr<rgw::sal::LuaManager> lua_manager; 
   CephContext* const cct;
   const std::string luarocks_path;
   std::thread runner;

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -63,6 +63,7 @@ protected:
   int sock_fd;
   std::string uri_prefix;
   rgw::lua::Background* lua_background;
+  std::unique_ptr<rgw::sal::LuaManager> lua_manager;
 
   struct RGWWQ : public DoutPrefixProvider, public ThreadPool::WorkQueue<RGWRequest> {
     RGWProcess* process;
@@ -115,6 +116,7 @@ public:
       sock_fd(-1),
       uri_prefix(pe->uri_prefix),
       lua_background(pe->lua_background),
+      lua_manager(store->get_lua_manager()),
       req_wq(this,
 	     ceph::make_timespan(g_conf()->rgw_op_thread_timeout),
 	     ceph::make_timespan(g_conf()->rgw_op_thread_suicide_timeout),
@@ -134,6 +136,7 @@ public:
                                rgw_auth_registry_ptr_t auth_registry) {
     this->store = store;
     this->auth_registry = std::move(auth_registry);
+    lua_manager = store->get_lua_manager();
     m_tp.unpause();
   }
 
@@ -183,8 +186,9 @@ extern int process_request(rgw::sal::Store* store,
                            std::string* user,
                            ceph::coarse_real_clock::duration* latency,
                            std::shared_ptr<RateLimiter> ratelimit,
-                           int* http_ret = nullptr,
-                           rgw::lua::Background* lua_background = nullptr);
+                           rgw::lua::Background* lua_background,
+                           std::unique_ptr<rgw::sal::LuaManager>& lua_manager,
+                           int* http_ret = nullptr);
 
 extern int rgw_process_authenticated(RGWHandler_REST* handler,
                                      RGWOp*& op,

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -879,7 +879,7 @@ public:
 };
 
 class RadosLuaManager : public StoreLuaManager {
-  RadosStore* store;
+  RadosStore* const store;
   rgw_pool pool;
 
 public:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/53810

Signed-off-by: yuval Lifshitz <ylifshit@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
