### PR TITLE
crimson/os/seastore: increase journal size and decrease rewrite-dirty size

### DIFF
--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -510,6 +510,20 @@ public:
 
     static config_t get_default() {
       return config_t{
+	  12,   // target_journal_segments
+	  16,   // max_journal_segments
+	  .9,   // available_ratio_gc_max
+	  .2,   // available_ratio_hard_limit
+	  .8,   // reclaim_ratio_hard_limit
+	  .6,   // reclaim_ratio_gc_threshold
+	  1<<20,// reclaim_bytes_per_cycle
+	  1<<17,// rewrite_dirty_bytes_per_cycle
+	  1<<24 // rewrite_backref_bytes_per_cycle
+	};
+    }
+
+    static config_t get_test() {
+      return config_t{
 	  2,    // target_journal_segments
 	  4,    // max_journal_segments
 	  .9,   // available_ratio_gc_max
@@ -517,7 +531,7 @@ public:
 	  .8,   // reclaim_ratio_hard_limit
 	  .6,   // reclaim_ratio_gc_threshold
 	  1<<20,// reclaim_bytes_per_cycle
-	  1<<20,// rewrite_dirty_bytes_per_cycle
+	  1<<17,// rewrite_dirty_bytes_per_cycle
 	  1<<24 // rewrite_backref_bytes_per_cycle
 	};
     }

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -644,12 +644,23 @@ TransactionManagerRef make_transaction_manager(tm_make_config_t config)
   auto lba_manager = lba_manager::create_lba_manager(*cache);
   auto sms = std::make_unique<SegmentManagerGroup>();
   auto backref_manager = create_backref_manager(*sms, *cache);
+
+  bool cleaner_is_detailed;
+  SegmentCleaner::config_t cleaner_config;
+  if (config.is_test) {
+    cleaner_is_detailed = true;
+    cleaner_config = SegmentCleaner::config_t::get_test();
+  } else {
+    cleaner_is_detailed = false;
+    cleaner_config = SegmentCleaner::config_t::get_default();
+  }
   auto segment_cleaner = std::make_unique<SegmentCleaner>(
-    SegmentCleaner::config_t::get_default(),
+    cleaner_config,
     std::move(sms),
     *backref_manager,
     *cache,
-    config.detailed);
+    cleaner_is_detailed);
+
   JournalRef journal;
   if (config.j_type == journal_type_t::SEGMENT_JOURNAL) {
     journal = journal::make_segmented(*segment_cleaner);

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -35,7 +35,7 @@ namespace crimson::os::seastore {
 class Journal;
 
 struct tm_make_config_t {
-  bool detailed = true;
+  bool is_test = true;
   journal_type_t j_type = journal_type_t::SEGMENT_JOURNAL;
   placement_hint_t default_placement_hint = placement_hint_t::HOT;
 
@@ -65,10 +65,10 @@ struct tm_make_config_t {
   tm_make_config_t &operator=(const tm_make_config_t &) = default;
 private:
   tm_make_config_t(
-    bool detailed,
+    bool is_test,
     journal_type_t j_type,
     placement_hint_t default_placement_hint)
-    : detailed(detailed), j_type(j_type),
+    : is_test(is_test), j_type(j_type),
       default_placement_hint(default_placement_hint)
   {}
 };


### PR DESCRIPTION
In short, by increasing the journal size:
* The conflicts between user and trim transactions drop from 4x to only 0.15x;
* The invalid write from trim decreases from 2x to 0.25x due to less conflicts;
* The data required to trim also decreases from 3x to 1.75x due to longer buffer;
* The overall internal write amplification drops from 7x to 4x (note: reclaim was not involved yet);
* Trimming become faster, no more IO throttling due to trimming;
* The end performance become more stable and better -- 13.5% better in the first 600 seconds;

By decreasing the rewrite-dirty size (with pros and cons):
* Pros: invalid write from trim further decreases from 0.25x to nearly 0;
* Cons: trimming become slower and can cause IO throttling;

### 600s RADOS random write performance results
A. Original
```
Total time run:         600.042
Total writes made:      1421290
Write size:             4096
Object size:            4096
Bandwidth (MB/sec):     9.25255
Stddev Bandwidth:       1.98603
Max bandwidth (MB/sec): 15.5469
Min bandwidth (MB/sec): 0.460938
Average IOPS:           2368
Stddev IOPS:            508.424
Max IOPS:               3980
Min IOPS:               118
Average Latency(s):     0.0270172
Stddev Latency(s):      0.0278056
Max latency(s):         1.10713
Min latency(s):         0.000898385
```
B. Increase the number of journal segments
```
Total time run:         600.045
Total writes made:      1613820
Write size:             4096
Object size:            4096
Bandwidth (MB/sec):     10.5059
Stddev Bandwidth:       1.21455
Max bandwidth (MB/sec): 15.332
Min bandwidth (MB/sec): 7.90625
Average IOPS:           2689
Stddev IOPS:            310.925
Max IOPS:               3925
Min IOPS:               2024
Average Latency(s):     0.0237941
Stddev Latency(s):      0.0165314
Max latency(s):         0.224455
Min latency(s):         0.000851744
```
C. Then decrease rewrite-dirty size
```
Total time run:         600.042
Total writes made:      1603626
Write size:             4096
Object size:            4096
Bandwidth (MB/sec):     10.4395
Stddev Bandwidth:       1.30485
Max bandwidth (MB/sec): 15.0664
Min bandwidth (MB/sec): 7.86719
Average IOPS:           2672
Stddev IOPS:            334.04
Max IOPS:               3857
Min IOPS:               2014
Average Latency(s):     0.0239452
Stddev Latency(s):      0.0170661
Max latency(s):         0.248981
Min latency(s):         0.000616932
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
