### PR TITLE
rgw: add SetAttribute and AddEvent functions for TraceMetaTable in Lua

### DIFF
--- a/doc/radosgw/lua-scripting.rst
+++ b/doc/radosgw/lua-scripting.rst
@@ -320,6 +320,19 @@ during execution so that it may be read and used later during other executions, 
 - The maximum number of entries in the table is 100,000. Each entry has a key and string value with a combined length of no more than 1KB. 
   A Lua script will abort with an error if the number of entries or entry size exceeds these limits.
 
+Tracing
+~~~~~~~
+Tracing functions can be used only in `postRequest` context.
+
+- ``Request.Trace.SetAttribute()`` - sets the attribute for the request's trace.
+  Takes two arguments. The first is the `key`, which should be a string. The second is the value, which can either be a string or a number.
+  Using the attribute, you can locate specific traces.
+
+- ``Request.Trace.AddEvent()`` - adds an event to the first span of the request's trace
+  An event is defined by event name, event time, and zero or more event attributes.
+  Therefore, the function accepts one or two arguments. A string containing the event name should be the first argument, followed by the event attributes, which is optional for events without attributes.
+  An event's attributes must be a table of strings.
+
 Lua Code Samples
 ----------------
 - Print information on source and destination objects in case of copy:
@@ -469,4 +482,22 @@ In the `preRequest` context:
   end
 
 Note that changing `Request.Trace.Enable` does not change the tracer's state, but disables or enables the tracing for the request only.
+
+
+- Add Information for requests traces
+
+in `postRequest` context, we can add attributes and events to the request's trace.
+
+.. code-block:: lua
+
+  Request.Trace.AddEvent("lua script execution started")
+
+  Request.Trace.SetAttribute("HTTPStatusCode", Request.Response.HTTPStatusCode)
+
+  event_attrs = {}
+  for k,v in pairs(Request.GenericAttributes) do
+    event_attrs[k] = v
+  end
+
+  Request.Trace.AddEvent("second event", event_attrs)
 

--- a/src/common/tracer.h
+++ b/src/common/tracer.h
@@ -11,6 +11,7 @@
 
 using jspan = opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>;
 using jspan_context = opentelemetry::trace::SpanContext;
+using jspan_attribute = opentelemetry::common::AttributeValue;
 
 namespace tracing {
 
@@ -54,11 +55,12 @@ void decode(jspan_context& span_ctx, ceph::buffer::list::const_iterator& bl);
 
 #include <string_view>
 
-
 class Value {
  public:
   template <typename T> Value(T val) {}
 };
+
+using jspan_attribute = Value;
 
 struct jspan_context {
   jspan_context() {}
@@ -69,9 +71,12 @@ struct span_stub {
   jspan_context _ctx;
   template <typename T>
   void SetAttribute(std::string_view key, const T& value) const noexcept {}
-  void AddEvent(std::string_view, std::initializer_list<std::pair<std::string_view, Value>> fields) {}
+  void AddEvent(std::string_view) {}
+  void AddEvent(std::string_view, std::initializer_list<std::pair<std::string_view, jspan_attribute>> fields) {}
+  template <typename T> void AddEvent(std::string_view name, const T& fields = {}) {}
   const jspan_context& GetContext() { return _ctx; }
   void UpdateName(std::string_view) {}
+  bool IsRecording() { return false; }
 };
 
 class jspan {

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -16,6 +16,10 @@ if(WITH_RADOSGW_LUA_PACKAGES)
   list(APPEND rgw_libs Boost::filesystem)
 endif()
 
+if(WITH_JAEGER)
+  list(APPEND rgw_libs ${jaeger_base})
+endif()
+
 #unittest_rgw_bencode
 add_executable(unittest_rgw_bencode test_rgw_bencode.cc)
 add_ceph_unittest(unittest_rgw_bencode)

--- a/src/test/rgw/test_rgw_lua.cc
+++ b/src/test/rgw/test_rgw_lua.cc
@@ -157,7 +157,11 @@ auto g_cct = new CephContext(CEPH_ENTITY_TYPE_CLIENT);
 
 CctCleaner cleaner(g_cct);
 
+tracing::Tracer tracer;
+
 #define DEFINE_REQ_STATE RGWEnv e; req_state s(g_cct, &e, 0);
+#define INIT_TRACE tracer.init("test"); \
+                   s.trace = tracer.start_trace("test", true);
 
 TEST(TestRGWLua, EmptyScript)
 {
@@ -849,3 +853,50 @@ TEST(TestRGWLuaBackground, MultipleStarts)
   EXPECT_GT(lua_background.get_table_value("hello").size(), value_len);
 }
 
+TEST(TestRGWLua, TracingSetAttribute)
+{
+  const std::string script = R"(
+    Request.Trace.SetAttribute("str-attr", "value")
+    Request.Trace.SetAttribute("int-attr", 42)
+    Request.Trace.SetAttribute("double-attr", 42.5)
+  )";
+
+  DEFINE_REQ_STATE;
+  INIT_TRACE;
+  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "put_obj", script);
+  ASSERT_EQ(rc, 0);
+}
+
+TEST(TestRGWLua, TracingSetBadAttribute)
+{
+  const std::string script = R"(
+    Request.Trace.SetAttribute("attr", nil)
+  )";
+
+  DEFINE_REQ_STATE;
+  INIT_TRACE;
+  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "put_obj", script);
+  #ifdef HAVE_JAEGER
+   ASSERT_NE(rc, 0);
+  #else
+   ASSERT_EQ(rc, 0);
+  #endif
+}
+
+TEST(TestRGWLua, TracingAddEvent)
+{
+  const std::string script = R"(
+    event_attrs = {}
+    event_attrs["x"] = "value-x"
+    event_attrs[42] = 42
+    event_attrs[42.5] = 42.5
+    event_attrs["y"] = "value-y"
+
+    Request.Trace.AddEvent("my_event", event_attrs)
+  )";
+
+  DEFINE_REQ_STATE;
+  INIT_TRACE;
+  const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "put_obj", script);
+  ASSERT_EQ(rc, 0);
+}


### PR DESCRIPTION
This PR adds two functions, `SetAttribute` and `AddEvent` for TraceMetaTable in lua

**SetAttribute** - attribute is a key-value pair that tags a trace,  this k-v can be used later for searching.

**AddEvent** - we can record an event of a span. the event can be a string (like a simple log), or string and k-v pairs. 

using those 2 functions we can add new information to an existing trace on-demand, without code changes.

those functions can be used in the postRequest context only. since it is required to create the trace before



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
