### PR TITLE
mgr/rook: fix error when trying to get the list of nfs services

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -351,8 +351,10 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             all_nfs = self.rook_cluster.get_resource("cephnfses")
             nfs_pods = self.rook_cluster.describe_pods('nfs', None, None)
             for nfs in all_nfs:
-                if nfs['spec']['rados']['pool'] != NFS_POOL_NAME:
-                    continue
+                # Starting with V.17.2.0, the 'rados' spec part in 'cephnfs' resources does not contain the 'pool' item
+                if 'pool' in nfs['spec']['rados']:
+                    if nfs['spec']['rados']['pool'] != NFS_POOL_NAME:
+                        continue
                 nfs_name = nfs['metadata']['name']
                 svc = 'nfs.' + nfs_name
                 if svc in spec:


### PR DESCRIPTION
Resolves: https://tracker.ceph.com/issues/55605

Starting with Ceph V16.2.7, Rook does not use the information in the "rados" part of the cephnfs resources. Previously we had the name of the pool used by the nfs resource, and if the name of the pool was ".nfs" then we identified the service as nfs service.
IMHO this is really redundant, because the list of resources  "cephnfses" , already provide the list of right services to list. so it has no sense to "double check" if the service uses a ".nfs" pool. 
In any case, and to avoid unexpected problems with nfs resources created previously I have preferred to add a check instead to delete the complete verification.

With the modification the execution of commands that require to get the list of nfs services is working properly:
```
[rook@rook-ceph-tools-d6d7c985c-x58c5 /]$ ceph orch ls
NAME        PORTS  RUNNING  REFRESHED  AGE  PLACEMENT    
mds.myfs               0/2  0s ago     -    count:1      
mgr                    1/1  0s ago     60m  count:1      
mon                    1/1  0s ago     60m  count:1      
nfs.my-nfs             1/1  0s ago     53m  count:1      
osd                      4  0s ago     59m  <unmanaged>

[rook@rook-ceph-tools-d6d7c985c-x58c5 /]$ ceph nfs cluster ls
my-nfs

[rook@rook-ceph-tools-d6d7c985c-x58c5 /]$  ceph nfs export ls my-nfs
[]
```

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

