### PR TITLE
quincy: mgr/dashboard: unselect rows in datatables 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/block/mirroring.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/block/mirroring.po.ts
@@ -13,7 +13,7 @@ export class MirroringPageHelper extends PageHelper {
    */
   @PageHelper.restrictTo(pages.index.url)
   editMirror(name: string, option: string) {
-    // Clicks the pool in the table
+    // Select the pool in the table
     this.getFirstTableCell(name).click();
 
     // Clicks the Edit Mode button
@@ -28,5 +28,8 @@ export class MirroringPageHelper extends PageHelper {
     cy.contains('.modal-dialog', 'Edit pool mirror mode').should('not.exist');
     const val = option.toLowerCase(); // used since entries in table are lower case
     this.getFirstTableCell(val).should('be.visible');
+
+    // unselect the pool in the table
+    this.getFirstTableCell(name).click();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
@@ -127,8 +127,8 @@ export class HostsPageHelper extends PageHelper {
   @PageHelper.restrictTo(pages.index.url)
   maintenance(hostname: string, exit = false, force = false) {
     this.clearTableSearchInput();
+    this.getTableCell(this.columnIndex.hostname, hostname).click();
     if (force) {
-      this.getTableCell(this.columnIndex.hostname, hostname).click();
       this.clickActionButton('enter-maintenance');
 
       cy.get('cd-modal').within(() => {
@@ -145,7 +145,6 @@ export class HostsPageHelper extends PageHelper {
     }
     if (exit) {
       this.getTableCell(this.columnIndex.hostname, hostname)
-        .click()
         .parent()
         .find(`datatable-body-cell:nth-child(${this.columnIndex.status})`)
         .then(($ele) => {
@@ -163,7 +162,6 @@ export class HostsPageHelper extends PageHelper {
           expect(status).to.not.include('maintenance');
         });
     } else {
-      this.getTableCell(this.columnIndex.hostname, hostname).click();
       this.clickActionButton('enter-maintenance');
 
       this.getTableCell(this.columnIndex.hostname, hostname)
@@ -187,5 +185,9 @@ export class HostsPageHelper extends PageHelper {
       cy.wait(20000);
       this.expectTableCount('total', 0);
     });
+
+    // unselect it to avoid colliding with any other selection
+    // in different steps
+    this.getTableCell(this.columnIndex.hostname, hostname).click();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/services.po.ts
@@ -166,6 +166,10 @@ export class ServicesPageHelper extends PageHelper {
     cy.get('cd-service-daemon-list').within(() => {
       this.getTableRow(daemon).click();
       this.clickActionButton(action);
+
+      // unselect it to avoid colliding with any other selection
+      // in different steps
+      this.getTableRow(daemon).click();
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -568,12 +568,30 @@ describe('TableComponent', () => {
       expect(executingElement.nativeElement.textContent.trim()).toBe(`(${state})`);
     };
 
-    it.only('should display executing template', () => {
+    it('should display executing template', () => {
       testExecutingTemplate();
     });
 
-    it.only('should display executing template with custom classes', () => {
+    it('should display executing template with custom classes', () => {
       testExecutingTemplate({ valueClass: 'a b', executingClass: 'c d' });
+    });
+  });
+
+  describe('test unselect functionality of rows', () => {
+    beforeEach(() => {
+      component.autoReload = -1;
+      component.selectionType = 'single';
+      fixture.detectChanges();
+    });
+
+    it('should unselect row on clicking on it again', () => {
+      const rowCellDebugElement = fixture.debugElement.query(By.css('datatable-body-cell'));
+
+      rowCellDebugElement.triggerEventHandler('click', null);
+      expect(component.selection.selected.length).toEqual(1);
+
+      rowCellDebugElement.triggerEventHandler('click', null);
+      expect(component.selection.selected.length).toEqual(0);
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -308,6 +308,10 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
     } else {
       this.useData();
     }
+
+    if (this.selectionType === 'single') {
+      this.table.selectCheck = this.singleSelectCheck.bind(this);
+    }
   }
 
   initUserConfig() {
@@ -705,6 +709,10 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
       this.selection.selected = $event['selected'];
     }
     this.updateSelection.emit(_.clone(this.selection));
+  }
+
+  private singleSelectCheck(row: any) {
+    return this.selection.selected.indexOf(row) === -1;
   }
 
   toggleColumn(column: CdTableColumn) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55691

---

backport of https://github.com/ceph/ceph/pull/45313
parent tracker: https://tracker.ceph.com/issues/53244

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh