### PR TITLE
build: Silence deprecation warnings from OpenSSL 3

### DIFF
--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -33,12 +33,19 @@
 #include "common/debug.h"
 #include <errno.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 using std::ostringstream;
 using std::string;
 
 using ceph::bufferlist;
 using ceph::bufferptr;
 using ceph::Formatter;
+
 
 // use getentropy() if available. it uses the same source of randomness
 // as /dev/urandom without the filesystem overhead
@@ -603,3 +610,6 @@ CryptoHandler *CryptoHandler::create(int type)
     return NULL;
   }
 }
+
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop

--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -27,6 +27,12 @@
 #  include <openssl/err.h>
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 namespace TOPNSPC::crypto::ssl {
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -213,3 +219,6 @@ void ssl::OpenSSLDigest::Final(unsigned char *digest) {
 }
 
 }
+
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -22,6 +22,12 @@
 
 #include "include/ceph_assert.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 extern "C" {
   const EVP_MD *EVP_md5(void);
   const EVP_MD *EVP_sha1(void);
@@ -201,5 +207,8 @@ auto digest(const ceph::buffer::list& bl)
   return sha_digest_t<Digest::digest_size>{fingerprint};
 }
 }
+
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
 #endif

--- a/src/common/openssl_opts_handler.cc
+++ b/src/common/openssl_opts_handler.cc
@@ -113,7 +113,14 @@ void load_module(const string &engine_conf)
   }
 
   OPENSSL_load_builtin_modules();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   ENGINE_load_builtin_engines();
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
   if (CONF_modules_load(
           conf, nullptr,

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -8,8 +8,16 @@
 #include "rgw_rest.h"
 #include "rgw_sts.h"
 #include "rgw_web_idp.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include "jwt-cpp/jwt.h"
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 #include "rgw_oidc_provider.h"
+
 
 namespace rgw::auth::sts {
 
@@ -227,3 +235,4 @@ public:
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override;
 };
+


### PR DESCRIPTION
The OpenSSL developers suggest that anyone wishing to continue using
low-level functions may either live with the warnings, silence them,
or switch to high level functions.

As high level functions do their own memory allocation, switching to
them may lead to performance regressions.

We do not wish to have deprecation warnings filling up our compiler
outputs when searching for other messages.

So silencing the warnings, at least for now, seems the least bad option.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
