### PR TITLE
crimson: clarify use of tm_make_config_t

### DIFF
--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1692,9 +1692,7 @@ seastar::future<std::unique_ptr<SeaStore>> make_seastore(
   return Device::make_device(
     device
   ).then([&device](DeviceRef device_obj) {
-    tm_make_config_t config;
-    config.detailed = false;
-    auto tm = make_transaction_manager(config);
+    auto tm = make_transaction_manager(tm_make_config_t::get_default());
     auto cm = std::make_unique<collection_manager::FlatCollectionManager>(*tm);
     return std::make_unique<SeaStore>(
       device,

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -37,15 +37,40 @@ class Journal;
 struct tm_make_config_t {
   bool detailed = true;
   journal_type_t j_type = journal_type_t::SEGMENT_JOURNAL;
-  placement_hint_t default_placement_hint =
-    placement_hint_t::HOT;
+  placement_hint_t default_placement_hint = placement_hint_t::HOT;
+
   static tm_make_config_t get_default() {
+    return tm_make_config_t {
+      false,
+      journal_type_t::SEGMENT_JOURNAL,
+      placement_hint_t::HOT
+    };
+  }
+  static tm_make_config_t get_test_segmented_journal() {
     return tm_make_config_t {
       true,
       journal_type_t::SEGMENT_JOURNAL,
       placement_hint_t::HOT
     };
   }
+  static tm_make_config_t get_test_cb_journal() {
+    return tm_make_config_t {
+      true,
+      journal_type_t::CIRCULARBOUNDED_JOURNAL,
+      placement_hint_t::REWRITE
+    };
+  }
+
+  tm_make_config_t(const tm_make_config_t &) = default;
+  tm_make_config_t &operator=(const tm_make_config_t &) = default;
+private:
+  tm_make_config_t(
+    bool detailed,
+    journal_type_t j_type,
+    placement_hint_t default_placement_hint)
+    : detailed(detailed), j_type(j_type),
+      default_placement_hint(default_placement_hint)
+  {}
 };
 
 template <typename F>

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -131,9 +131,7 @@ seastar::future<bufferlist> TMDriver::read(
 
 void TMDriver::init()
 {
-  tm_make_config_t config;
-  config.detailed = false;
-  tm = make_transaction_manager(config);
+  tm = make_transaction_manager(tm_make_config_t::get_default());
   tm->add_device(device.get(), true);
 }
 

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -58,7 +58,6 @@ struct transaction_manager_test_t :
 
   std::random_device rd;
   std::mt19937 gen;
-  tm_make_config_t tm_config;
 
   transaction_manager_test_t(std::size_t num_devices)
     : TMTestState(num_devices), gen(rd()) {
@@ -76,11 +75,9 @@ struct transaction_manager_test_t :
   seastar::future<> set_up_fut() final {
     std::string j_type = GetParam();
     if (j_type == "segmented") {
-      return tm_setup(tm_config);
+      return tm_setup(tm_make_config_t::get_test_segmented_journal());
     } else if (j_type == "circularbounded") {
-      tm_config.j_type = journal_type_t::CIRCULARBOUNDED_JOURNAL;
-      tm_config.default_placement_hint = placement_hint_t::REWRITE;
-      return tm_setup(tm_config);
+      return tm_setup(tm_make_config_t::get_test_cb_journal());
     } else {
       ceph_assert(0 == "no support");
     }

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -26,7 +26,7 @@ protected:
   segment_manager::EphemeralSegmentManagerRef segment_manager;
   std::list<segment_manager::EphemeralSegmentManagerRef> secondary_segment_managers;
   std::unique_ptr<nvme_device::NVMeBlockDevice> rb_device;
-  tm_make_config_t tm_config;
+  tm_make_config_t tm_config = tm_make_config_t::get_test_segmented_journal();
 
   EphemeralTestState(std::size_t num_segment_managers) {
     assert(num_segment_managers > 0);
@@ -63,7 +63,7 @@ protected:
   }
 
   seastar::future<> tm_setup(
-    tm_make_config_t config = tm_make_config_t::get_default()) {
+    tm_make_config_t config = tm_make_config_t::get_test_segmented_journal()) {
     tm_config = config;
     segment_manager = segment_manager::create_test_ephemeral();
     for (auto &sec_sm : secondary_segment_managers) {
@@ -128,7 +128,7 @@ protected:
 };
 
 auto get_seastore(SeaStore::MDStoreRef mdstore, SegmentManagerRef sm) {
-  auto tm = make_transaction_manager(tm_make_config_t::get_default());
+  auto tm = make_transaction_manager(tm_make_config_t::get_test_segmented_journal());
   auto cm = std::make_unique<collection_manager::FlatCollectionManager>(*tm);
   return std::make_unique<SeaStore>(
     "",


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/55706
Introduced: 9fe59429fc2ef17e2bec329109713eb63ffc74c9
Signed-off-by: Samuel Just <sjust@redhat.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
