### PR TITLE
crimson/onode-staged-tree: fix unaligned reference to shard_pool_t::pool

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -58,24 +58,26 @@ struct node_offset_packed_t {
 // TODO: consider alignments
 struct shard_pool_t {
   bool operator==(const shard_pool_t& x) const {
-    return (shard == x.shard && pool == x.pool);
+    return (shard == x.shard && pool() == x.pool());
   }
   bool operator!=(const shard_pool_t& x) const { return !(*this == x); }
+
+  pool_t pool() const { return _pool; }
 
   template <KeyT KT>
   static shard_pool_t from_key(const full_key_t<KT>& key);
 
   shard_t shard;
-  pool_t pool;
+  pool_t _pool;
 } __attribute__((packed));
 inline std::ostream& operator<<(std::ostream& os, const shard_pool_t& sp) {
-  return os << (int)sp.shard << "," << sp.pool;
+  return os << (int)sp.shard << "," << sp.pool();
 }
 inline MatchKindCMP compare_to(const shard_pool_t& l, const shard_pool_t& r) {
   auto ret = toMatchKindCMP(l.shard, r.shard);
   if (ret != MatchKindCMP::EQ)
     return ret;
-  return toMatchKindCMP(l.pool, r.pool);
+  return toMatchKindCMP(l.pool(), r.pool());
 }
 
 // Note: this is the reversed version of the object hash
@@ -621,7 +623,7 @@ class key_view_t {
     return shard_pool_packed().shard;
   }
   pool_t pool() const {
-    return shard_pool_packed().pool;
+    return shard_pool_packed().pool();
   }
   crush_hash_t crush() const {
     return crush_packed().crush;
@@ -841,7 +843,7 @@ MatchKindCMP compare_to(const full_key_t<Type>& key, const shard_pool_t& target)
   auto ret = toMatchKindCMP(key.shard(), target.shard);
   if (ret != MatchKindCMP::EQ)
     return ret;
-  return toMatchKindCMP(key.pool(), target.pool);
+  return toMatchKindCMP(key.pool(), target.pool());
 }
 
 template <KeyT Type>


### PR DESCRIPTION
../src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h:844:44:
runtime error: reference binding to misaligned address 0x6250013ee905
for type 'const crimson::os::seastore::onode::pool_t' (aka 'const
  long'), which requires 8 byte alignment

from UndefinedBehaviorSanitizer

Signed-off-by: Yingxin Cheng <yingxin.cheng@intel.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
