### PR TITLE
ceph-volume/ceph_volume/util: ceph-volume multi-actuator drive attribute

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -286,6 +286,16 @@ class TestGetDevices(object):
         result = disk.get_devices()
         assert rbd_path not in result
 
+    @patch('ceph_volume.util.disk.is_locked_raw_device', lambda x: False)
+    def test_actuator_device(self, patched_get_block_devs_sysfs, fake_filesystem):
+        sda_path = '/dev/sda'
+        fake_actuator_nb = 2
+        patched_get_block_devs_sysfs.return_value = [[sda_path, sda_path, 'disk']]
+        for actuator in range(0, fake_actuator_nb):
+            fake_filesystem.create_dir(f'/sys/block/sda/queue/independent_access_ranges/{actuator}')
+        result = disk.get_devices()
+        assert result[sda_path]['actuators'] == fake_actuator_nb
+
 
 class TestSizeCalculations(object):
 

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -85,6 +85,7 @@ class Device(object):
         'lsm_data',
     ]
     pretty_report_sys_fields = [
+        'actuators',
         'human_readable_size',
         'model',
         'removable',

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -872,6 +872,13 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         else:
             metadata['device_nodes'] = devname
 
+        metadata['actuators'] = ""
+        if os.path.isdir(sysdir + "/queue/independent_access_ranges/"):
+            actuators = 0
+            while os.path.isdir(sysdir + "/queue/independent_access_ranges/" + str(actuators)):
+                actuators += 1
+            metadata['actuators'] = actuators
+
         metadata['scheduler_mode'] = ""
         scheduler = get_file_contents(sysdir + "/queue/scheduler")
         if scheduler is not None:


### PR DESCRIPTION
As storage capacities grow, multi-actuator technology introduced by Seagate addresses the downward pressure on performance that comes with growing drive capacities and areal densities. Having multiple actuators enables drives to maintain the performance needs of customers with data-intensive applications. However, this innovation requires storage stack changes because a single hard drive is now represented by two or more independent actuators (independent_access_ranges) that transfer data concurrently and are represented by a single LBA address space.

This code addition to the `ceph-volume` command assists Ceph administrators in identifying drives with multiple actuators by utilizing the Linux kernel's multi-actuator support introduced in version 5.16. Dual-actuator hard drives are gaining market share and becoming more important to Ceph deployments on large discs.

The code has been tested with Seagate Osprey Exos 2X18 with Mach.2 technology.

$ sudo ceph-volume inventory /dev/sdd

====== Device report /dev/sdd ======

     path                      /dev/sdd
     ceph device               None
     lsm data                  {}
     available                 False
     rejected reasons          Has GPT headers
     device id                 ST18000NM0092-3CX103_MVV00H3J
     removable                 0
     ro                        0
     vendor                    ATA
     model                     ST18000NM0092-3C
     sas address
     rotational                1
     actuators                 2
     scheduler mode            mq-deadline
     human readable size       16.37 TB

Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates

Signed-off-by: Michael English <michael.english@seagate.com>
