### PR TITLE
crimson/os/seastore/segment_cleaner: add dedicated backref trimming process

### DIFF
--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -710,6 +710,15 @@ SegmentCleaner::gc_cycle_ret SegmentCleaner::do_gc_cycle()
 	"GCProcess::run encountered invalid error in gc_trim_journal"
       }
     );
+  } else if (gc_should_trim_backref()) {
+    return gc_trim_backref(get_backref_tail()
+    ).safe_then([](auto) {
+      return seastar::now();
+    }).handle_error(
+      crimson::ct_error::assert_all{
+	"GCProcess::run encountered invalid error in gc_trim_backref"
+      }
+    );
   } else if (gc_should_reclaim_space()) {
     return gc_reclaim_space(
     ).handle_error(
@@ -722,35 +731,45 @@ SegmentCleaner::gc_cycle_ret SegmentCleaner::do_gc_cycle()
   }
 }
 
+SegmentCleaner::gc_trim_backref_ret
+SegmentCleaner::gc_trim_backref(journal_seq_t limit) {
+  return seastar::do_with(
+    journal_seq_t(),
+    [this, limit=std::move(limit)](auto &seq) mutable {
+    return repeat_eagain([this, limit=std::move(limit), &seq] {
+      return ecb->with_transaction_intr(
+	Transaction::src_t::TRIM_BACKREF,
+	"trim_backref",
+	[this, limit](auto &t) {
+	return trim_backrefs(
+	  t,
+	  limit
+	).si_then([this, &t, limit](auto trim_backrefs_to)
+	  -> ExtentCallbackInterface::submit_transaction_direct_iertr::future<
+	    journal_seq_t> {
+	  if (trim_backrefs_to != JOURNAL_SEQ_NULL) {
+	    return ecb->submit_transaction_direct(
+	      t, std::make_optional<journal_seq_t>(trim_backrefs_to)
+	    ).si_then([trim_backrefs_to=std::move(trim_backrefs_to)]() mutable {
+	      return seastar::make_ready_future<
+		journal_seq_t>(std::move(trim_backrefs_to));
+	    });
+	  }
+	  return seastar::make_ready_future<journal_seq_t>(std::move(limit));
+	});
+      }).safe_then([&seq](auto trim_backrefs_to) {
+	seq = std::move(trim_backrefs_to);
+      });
+    }).safe_then([&seq] {
+      return gc_trim_backref_ertr::make_ready_future<
+	journal_seq_t>(std::move(seq));
+    });
+  });
+}
+
 SegmentCleaner::gc_trim_journal_ret SegmentCleaner::gc_trim_journal()
 {
-  return ecb->with_transaction_intr(
-    Transaction::src_t::TRIM_BACKREF,
-    "trim_backref",
-    [this](auto &t) {
-    return seastar::do_with(
-      get_dirty_tail(),
-      [this, &t](auto &limit) {
-      return trim_backrefs(t, limit).si_then(
-	[this, &t, &limit](auto trim_backrefs_to)
-	-> ExtentCallbackInterface::submit_transaction_direct_iertr::future<
-	     journal_seq_t> {
-	if (trim_backrefs_to != JOURNAL_SEQ_NULL) {
-	  return ecb->submit_transaction_direct(
-	    t, std::make_optional<journal_seq_t>(trim_backrefs_to)
-	  ).si_then([trim_backrefs_to=std::move(trim_backrefs_to)]() mutable {
-	    return seastar::make_ready_future<
-	      journal_seq_t>(std::move(trim_backrefs_to));
-	  });
-	}
-	return seastar::make_ready_future<journal_seq_t>(std::move(limit));
-      });
-    });
-  }).handle_error(
-    crimson::ct_error::eagain::handle([](auto) {
-      ceph_abort("unexpected eagain");
-    }),
-    crimson::ct_error::pass_further_all()
+  return gc_trim_backref(get_dirty_tail()
   ).safe_then([this](auto seq) {
     return repeat_eagain([this, seq=std::move(seq)]() mutable {
       return ecb->with_transaction_intr(


### PR DESCRIPTION
Space reclamation needs to merge backrefs up to the point where the latest
release of extents within the scope of the reclamation process happened. When the
journal size is large, that merge may generate a transaction record with
size exceeds the max record size threshold. So we need have a backref
trimming process that merge most of the backrefs before the space
reclamation happens.

This commit also fixes issue: https://tracker.ceph.com/issues/55692, by
repeating the inflight backrefs trimming transaction when it's
invalidated by other trans on the ROOT block

Fixes: https://tracker.ceph.com/issues/55692
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
