### PR TITLE
mon/LogMonitor, MgrStat: Report logm and mgrstat committed version

### DIFF
--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -1038,6 +1038,11 @@ bool LogMonitor::prepare_command(MonOpRequestRef op)
   return false;
 }
 
+void LogMonitor::dump_info(Formatter *f)
+{
+  f->dump_unsigned("logm_first_committed", get_first_committed());
+  f->dump_unsigned("logm_last_committed", get_last_committed());
+}
 
 int LogMonitor::sub_name_to_id(const string& n)
 {

--- a/src/mon/LogMonitor.h
+++ b/src/mon/LogMonitor.h
@@ -164,6 +164,7 @@ private:
   
   void tick() override;  // check state, take actions
 
+  void dump_info(Formatter *f);
   void check_subs();
   void check_sub(Subscription *s);
 

--- a/src/mon/MgrStatMonitor.h
+++ b/src/mon/MgrStatMonitor.h
@@ -94,6 +94,8 @@ public:
   void dump_info(ceph::Formatter *f) const {
     digest.dump(f);
     f->dump_object("servicemap", get_service_map());
+    f->dump_unsigned("mgrstat_first_committed", get_first_committed());
+    f->dump_unsigned("mgrstat_last_committed", get_last_committed());
   }
   void dump_cluster_stats(std::stringstream *ss,
 			  ceph::Formatter *f,

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3710,6 +3710,7 @@ void Monitor::handle_command(MonOpRequestRef op)
     mdsmon()->dump_info(f.get());
     authmon()->dump_info(f.get());
     mgrstatmon()->dump_info(f.get());
+    logmon()->dump_info(f.get());
 
     paxos->dump_info(f.get());
 


### PR DESCRIPTION
Only way to get the first and last committed version for logm and
mgrstat is through the monstore db dump. Reporting first and last
committed version for logm and mgrstat in ceph report will help in
debugging monstore is too big issues.

Signed-off-by: Prashant D <pdhange@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
