### PR TITLE
rgw multisite: fix build for MotrStore

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -554,7 +554,8 @@ int MotrBucket::unlink_user(const DoutPrefixProvider* dpp, User* new_user, optio
 }
 
 /* stats - Not for first pass */
-int MotrBucket::read_stats(const DoutPrefixProvider *dpp, int shard_id,
+int MotrBucket::read_stats(const DoutPrefixProvider *dpp,
+    const bucket_index_layout_generation& idx_layout, int shard_id,
     std::string *bucket_ver, std::string *master_ver,
     std::map<RGWObjCategory, RGWStorageStats>& stats,
     std::string *max_marker, bool *syncstopped)
@@ -590,7 +591,9 @@ int MotrBucket::create_multipart_indices()
 }
 
 
-int MotrBucket::read_stats_async(const DoutPrefixProvider *dpp, int shard_id, RGWGetBucketStats_CB *ctx)
+int MotrBucket::read_stats_async(const DoutPrefixProvider *dpp,
+                                 const bucket_index_layout_generation& idx_layout,
+                                 int shard_id, RGWGetBucketStats_CB *ctx)
 {
   return 0;
 }

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -306,12 +306,15 @@ class MotrBucket : public Bucket {
     int unlink_user(const DoutPrefixProvider* dpp, User* new_user, optional_yield y);
     int create_bucket_index();
     int create_multipart_indices();
-    virtual int read_stats(const DoutPrefixProvider *dpp, int shard_id,
+    virtual int read_stats(const DoutPrefixProvider *dpp,
+        const bucket_index_layout_generation& idx_layout, int shard_id,
         std::string *bucket_ver, std::string *master_ver,
         std::map<RGWObjCategory, RGWStorageStats>& stats,
         std::string *max_marker = nullptr,
         bool *syncstopped = nullptr) override;
-    virtual int read_stats_async(const DoutPrefixProvider *dpp, int shard_id, RGWGetBucketStats_CB* ctx) override;
+    virtual int read_stats_async(const DoutPrefixProvider *dpp,
+                                 const bucket_index_layout_generation& idx_layout,
+                                 int shard_id, RGWGetBucketStats_CB* ctx) override;
     virtual int sync_user_stats(const DoutPrefixProvider *dpp, optional_yield y) override;
     virtual int update_container_stats(const DoutPrefixProvider *dpp) override;
     virtual int check_bucket_shards(const DoutPrefixProvider *dpp) override;
@@ -940,7 +943,7 @@ class MotrStore : public Store {
         optional_yield y) override;
     virtual RGWDataSyncStatusManager* get_data_sync_manager(const rgw_zone_id& source_zone) override;
     virtual void wakeup_meta_sync_shards(std::set<int>& shard_ids) override { return; }
-    virtual void wakeup_data_sync_shards(const DoutPrefixProvider *dpp, const rgw_zone_id& source_zone, std::map<int, std::set<std::string> >& shard_ids) override { return; }
+    virtual void wakeup_data_sync_shards(const DoutPrefixProvider *dpp, const rgw_zone_id& source_zone, boost::container::flat_map<int, boost::container::flat_set<rgw_data_notify_entry>>& shard_ids) override {}
     virtual int clear_usage(const DoutPrefixProvider *dpp) override { return 0; }
     virtual int read_all_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch,
         uint32_t max_entries, bool *is_truncated,


### PR DESCRIPTION
fixes 'make check' failures in https://github.com/ceph/ceph/pull/39002:
```
In file included from ../src/rgw/rgw_sal.cc:33:
../src/rgw/rgw_sal_motr.h:309:17: error: 'read_stats' marked 'override' but does not override any member functions
    virtual int read_stats(const DoutPrefixProvider *dpp, int shard_id,
                ^
../src/rgw/rgw_sal_motr.h:314:17: error: 'read_stats_async' marked 'override' but does not override any member functions
    virtual int read_stats_async(const DoutPrefixProvider *dpp, int shard_id, RGWGetBucketStats_CB* ctx) override;
                ^
../src/rgw/rgw_sal_motr.h:309:17: error: 'rgw::sal::MotrBucket::read_stats' hides overloaded virtual function [-Werror,-Woverloaded-virtual]
    virtual int read_stats(const DoutPrefixProvider *dpp, int shard_id,
                ^
../src/rgw/rgw_sal.h:708:17: note: hidden overloaded virtual function 'rgw::sal::Bucket::read_stats' declared here: different number of parameters (8 vs 7)
    virtual int read_stats(const DoutPrefixProvider *dpp,
                ^
In file included from ../src/rgw/rgw_sal.cc:33:
../src/rgw/rgw_sal_motr.h:314:17: error: 'rgw::sal::MotrBucket::read_stats_async' hides overloaded virtual function [-Werror,-Woverloaded-virtual]
    virtual int read_stats_async(const DoutPrefixProvider *dpp, int shard_id, RGWGetBucketStats_CB* ctx) override;
                ^
../src/rgw/rgw_sal.h:715:17: note: hidden overloaded virtual function 'rgw::sal::Bucket::read_stats_async' declared here: different number of parameters (4 vs 3)
    virtual int read_stats_async(const DoutPrefixProvider *dpp,
                ^
In file included from ../src/rgw/rgw_sal.cc:33:
../src/rgw/rgw_sal_motr.h:943:18: error: 'wakeup_data_sync_shards' marked 'override' but does not override any member functions
    virtual void wakeup_data_sync_shards(const DoutPrefixProvider *dpp, const rgw_zone_id& source_zone, std::map<int, std::set<std::string> >& shard_ids) override { return; }
                 ^
../src/rgw/rgw_sal_motr.h:943:18: error: 'rgw::sal::MotrStore::wakeup_data_sync_shards' hides overloaded virtual function [-Werror,-Woverloaded-virtual]
../src/rgw/rgw_sal.h:378:18: note: hidden overloaded virtual function 'rgw::sal::Store::wakeup_data_sync_shards' declared here: type mismatch at 3rd parameter ('boost::container::flat_map<int, boost::container::flat_set<rgw_data_notify_entry>> &' vs 'std::map<int, std::set<std::string>> &' (aka 'map<int, set<basic_string<char>>> &'))
    virtual void wakeup_data_sync_shards(const DoutPrefixProvider *dpp, const rgw_zone_id& source_zone, boost::container::flat_map<int, boost::container::flat_set<rgw_data_notify_entry>>& shard_ids) = 0;
                 ^
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
