### PR TITLE
octopus: qa/suites/rados/thrash-erasure-code-big/thrashers: add `osd max backfills` setting to mapgap and pggrow

### DIFF
--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/mapgap.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/mapgap.yaml
@@ -11,6 +11,7 @@ overrides:
         osd map cache size: 1
         osd scrub min interval: 60
         osd scrub max interval: 120
+        osd max backfills: 6
 tasks:
 - thrashosds:
     timeout: 1800

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/pggrow.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/pggrow.yaml
@@ -7,6 +7,7 @@ overrides:
       osd:
         osd scrub min interval: 60
         osd scrub max interval: 120
+        osd max backfills: 6
 tasks:
 - thrashosds:
     timeout: 1200


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55743

---

backport of https://github.com/ceph/ceph/pull/46346
parent tracker: https://tracker.ceph.com/issues/51076

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh