### PR TITLE
backport-create-issue: copy 'Assignee' of original issue to backports

### DIFF
--- a/src/script/backport-create-issue
+++ b/src/script/backport-create-issue
@@ -34,6 +34,7 @@ import os
 import re
 import time
 from redminelib import Redmine  # https://pypi.org/project/python-redmine/
+from redminelib.exceptions import ResourceAttrError
 
 redmine_endpoint = "https://tracker.ceph.com"
 project_name = "Ceph"
@@ -216,6 +217,11 @@ def update_relations(r, issue, dry_run):
                 "unknown release " + release)
             break
         subject = (release + ": " + issue['subject'])[:255]
+        assigned_to_id = None
+        try:
+            assigned_to_id = issue.assigned_to.id
+        except ResourceAttrError: # not assigned
+            pass
         if dry_run:
             logging.info(url(issue) + " add backport to " + release)
             continue
@@ -223,6 +229,7 @@ def update_relations(r, issue, dry_run):
                                tracker_id=backport_tracker_id,
                                subject=subject,
                                priority_id=issue['priority']['id'],
+                               assigned_to_id=assigned_to_id,
                                target_version=None,
                                custom_fields=[{
                                    "id": release_id,


### PR DESCRIPTION
following up on discussion from today's leadership call about who's responsible for preparing backport PRs. i think it would be useful to copy the 'Assignee' field from the original tracker issue, so that person is aware that backports are needed

~~TODO: actually test that this works, both for tracker issues with/without an Assignee field~~

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
