### PR TITLE
crimson/os/seastore/backref: don't merge in-cache backrefs that has already been released

### DIFF
--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -376,8 +376,9 @@ BtreeBackrefManager::remove_mapping(
 		-> remove_mapping_ret {
 	if (iter.is_end() || iter.get_key() != addr) {
 	  LOG_PREFIX(BtreeBackrefManager::remove_mapping);
-	  ERRORT("paddr={} doesn't exist", c.trans, addr);
-	  return crimson::ct_error::enoent::make();
+	  DEBUGT("paddr={} doesn't exist", c.trans, addr);
+	  return remove_mapping_iertr::make_ready_future<
+	    remove_mapping_result_t>(remove_mapping_result_t());
 	}
 
 	auto ret = remove_mapping_result_t{

--- a/src/crimson/os/seastore/backref/btree_backref_manager.h
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.h
@@ -126,6 +126,8 @@ public:
 
   void cache_new_backref_extent(paddr_t paddr, extent_types_t type) final;
 
+  bool backref_should_be_removed(paddr_t paddr) final;
+
 private:
   SegmentManagerGroup &sm_group;
   Cache &cache;

--- a/src/crimson/os/seastore/backref_manager.h
+++ b/src/crimson/os/seastore/backref_manager.h
@@ -128,9 +128,9 @@ public:
     const uint64_t max) = 0;
 
   struct remove_mapping_result_t {
-    paddr_t offset;
-    extent_len_t len;
-    laddr_t laddr;
+    paddr_t offset = P_ADDR_NULL;
+    extent_len_t len = 0;
+    laddr_t laddr = L_ADDR_NULL;
   };
 
   /**

--- a/src/crimson/os/seastore/backref_manager.h
+++ b/src/crimson/os/seastore/backref_manager.h
@@ -102,6 +102,8 @@ public:
     paddr_t start,
     paddr_t end) = 0;
 
+  virtual bool backref_should_be_removed(paddr_t paddr) = 0;
+
   using retrieve_backref_extents_iertr = trans_iertr<
     crimson::errorator<
       crimson::ct_error::input_output_error>

--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -1271,11 +1271,10 @@ void SegmentCleaner::mark_space_used(
 
 void SegmentCleaner::mark_space_free(
   paddr_t addr,
-  extent_len_t len,
-  bool force)
+  extent_len_t len)
 {
   LOG_PREFIX(SegmentCleaner::mark_space_free);
-  if (!init_complete && !force) {
+  if (!init_complete) {
     return;
   }
   if (addr.get_addr_type() != addr_types_t::SEGMENT) {

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -796,8 +796,7 @@ public:
 
   void mark_space_free(
     paddr_t addr,
-    extent_len_t len,
-    bool force = false);
+    extent_len_t len);
 
   SpaceTrackerIRef get_empty_space_tracker() const {
     return space_tracker->make_empty();

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -134,7 +134,8 @@ TransactionManager::mount_ertr::future<> TransactionManager::mount()
 		    t,
 		    addr,
 		    len);
-		  if (addr.is_real()) {
+		  if (addr.is_real() &&
+		      !backref_manager->backref_should_be_removed(addr)) {
 		    segment_cleaner->mark_space_used(
 		      addr,
 		      len ,
@@ -161,14 +162,6 @@ TransactionManager::mount_ertr::future<> TransactionManager::mount()
 		      backref.len,
 		      seastar::lowres_system_clock::time_point(),
 		      seastar::lowres_system_clock::time_point(),
-		      true);
-		  }
-		  auto &del_backrefs = backref_manager->get_cached_backref_removals();
-		  DEBUG("marking {} backrefs free", del_backrefs.size());
-		  for (auto &del_backref : del_backrefs) {
-		    segment_cleaner->mark_space_free(
-		      del_backref.paddr,
-		      del_backref.len,
 		      true);
 		  }
 		  return seastar::now();


### PR DESCRIPTION
This pr avoids merging backrefs the paddr of which has already been released, which also drops the requirement that retired extents and fresh extents within the same transaction can't have same paddrs. This will save the backref manager from unnecessary work and offer more flexibility to future development, for example, extent splitting.

Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
