### PR TITLE
mgr/cephadm: adding dynamic prometheus configuration based on http_sd_config

### DIFF
--- a/doc/cephadm/services/monitoring.rst
+++ b/doc/cephadm/services/monitoring.rst
@@ -71,10 +71,10 @@ steps below:
 
      ceph orch apply prometheus
 
-   or 
+   or
 
    .. prompt:: bash #
-     
+
      ceph orch apply prometheus --placement 'count:2'
 
 #. Deploy grafana:
@@ -193,12 +193,26 @@ configuration files for monitoring services.
 
 Internally, cephadm already uses `Jinja2
 <https://jinja.palletsprojects.com/en/2.11.x/>`_ templates to generate the
-configuration files for all monitoring components. To be able to customize the
-configuration of Prometheus, Grafana or the Alertmanager it is possible to store
-a Jinja2 template for each service that will be used for configuration
-generation instead. This template will be evaluated every time a service of that
-kind is deployed or reconfigured. That way, the custom configuration is
-preserved and automatically applied on future deployments of these services.
+configuration files for all monitoring components. Starting from version x.x.x,
+cephadm uses Prometheus http service discovery support `http_sd_config
+<https://prometheus.io/docs/prometheus/2.28/configuration/configuration/#http_sd_config>`
+in order to get the currently configured targets from Ceph. Internally, `ceph-mgr`
+provides a service discovery endpoint at `<https://<mgr-ip>:8765/sd/` (port is
+configurable through the variable `service_discovery_port`) which is used by
+Prometheus to get the needed targets.
+
+Customers with external monitoring stack can use `ceph-mgr` service discovery endpoint
+to get scraping configuration. Root certificate of the server can be obtained by the
+following command:
+
+   .. prompt:: bash #
+
+     ceph orch sd dump cert
+
+The configuration of Prometheus, Grafana, or Alertmanager may be customized by storing
+a Jinja2 template for each service. This template will be evaluated every time a service
+of that kind is deployed or reconfigured. That way, the custom configuration is preserved
+and automatically applied on future deployments of these services.
 
 .. note::
 
@@ -281,6 +295,12 @@ cluster.
 
   By default, ceph-mgr presents prometheus metrics on port 9283 on each host
   running a ceph-mgr daemon.  Configure prometheus to scrape these.
+
+To make this integration easier, Ceph provides by means of `ceph-mgr` a service
+discovery endpoint at `<https://<mgr-ip>:8765/sd/` which can be used by an external
+Prometheus to retrieve targets information. Information reported by this EP used
+the format specified by `http_sd_config
+<https://prometheus.io/docs/prometheus/2.28/configuration/configuration/#http_sd_config>`
 
 * To enable the dashboard's prometheus-based alerting, see :ref:`dashboard-alerting`.
 

--- a/doc/cephadm/services/monitoring.rst
+++ b/doc/cephadm/services/monitoring.rst
@@ -193,7 +193,7 @@ configuration files for monitoring services.
 
 Internally, cephadm already uses `Jinja2
 <https://jinja.palletsprojects.com/en/2.11.x/>`_ templates to generate the
-configuration files for all monitoring components. Starting from version x.x.x,
+configuration files for all monitoring components. Starting from version 17.2.3,
 cephadm uses Prometheus http service discovery support `http_sd_config
 <https://prometheus.io/docs/prometheus/2.28/configuration/configuration/#http_sd_config>`
 in order to get the currently configured targets from Ceph. Internally, `ceph-mgr`

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4403,7 +4403,7 @@ WantedBy=ceph-{fsid}.target
                                'port': self.listener_port})
             data = data.encode('ascii')
 
-            url = f'https://{self.target_ip}:{self.target_port}/data'
+            url = f'https://{self.target_ip}:{self.target_port}/data/'
             try:
                 req = Request(url, data, {'Content-Type': 'application/json'})
                 send_time = time.monotonic()
@@ -5177,7 +5177,7 @@ def create_mgr(
     # Note:the default port used by the Prometheus node exporter is opened in fw
     ctx.meta_json = json.dumps({'service_name': 'mgr'})
     deploy_daemon(ctx, fsid, 'mgr', mgr_id, mgr_c, uid, gid,
-                  config=config, keyring=mgr_keyring, ports=[9283])
+                  config=config, keyring=mgr_keyring, ports=[9283, 8765])
 
     # wait for the service to become available
     logger.info('Waiting for mgr to start...')

--- a/src/pybind/mgr/cephadm/http_server.py
+++ b/src/pybind/mgr/cephadm/http_server.py
@@ -1,0 +1,63 @@
+import cherrypy
+import threading
+import logging
+from typing import TYPE_CHECKING
+
+from cephadm.agent import AgentEndpoint
+from cephadm.service_discovery import ServiceDiscovery
+
+
+if TYPE_CHECKING:
+    from cephadm.module import CephadmOrchestrator
+
+
+def cherrypy_filter(record: logging.LogRecord) -> int:
+    blocked = [
+        'TLSV1_ALERT_DECRYPT_ERROR'
+    ]
+    msg = record.getMessage()
+    return not any([m for m in blocked if m in msg])
+
+
+logging.getLogger('cherrypy.error').addFilter(cherrypy_filter)
+cherrypy.log.access_log.propagate = False
+
+
+class CephadmHttpServer(threading.Thread):
+    def __init__(self, mgr: "CephadmOrchestrator") -> None:
+        self.mgr = mgr
+        self.agent = AgentEndpoint(mgr)
+        self.service_discovery = ServiceDiscovery(mgr)
+        self.cherrypy_shutdown_event = threading.Event()
+        super().__init__(target=self.run)
+
+    def configure_cherrypy(self) -> None:
+        cherrypy.config.update({
+            'environment': 'production',
+            'engine.autoreload.on': False,
+        })
+
+    def run(self) -> None:
+        try:
+            self.configure_cherrypy()
+            self.agent.configure()
+            self.service_discovery.configure()
+
+            self.mgr.log.debug('Starting cherrypy engine...')
+            cherrypy.server.unsubscribe()  # disable default server
+            cherrypy.engine.start()
+            self.mgr.log.debug('Cherrypy engine started.')
+
+            self.mgr._kick_serve_loop()
+            # wait for the shutdown event
+            self.cherrypy_shutdown_event.wait()
+            self.cherrypy_shutdown_event.clear()
+            cherrypy.engine.stop()
+            cherrypy.server.httpserver = None
+            self.mgr.log.debug('Cherrypy engine stopped.')
+        except Exception as e:
+            self.mgr.log.error(f'Failed to run cephadm http server: {e}')
+
+    def shutdown(self) -> None:
+        self.mgr.log.debug('Stopping cherrypy engine...')
+        self.cherrypy_shutdown_event.set()

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -580,8 +580,8 @@ class CephadmServe:
 
         if service_type == 'agent':
             try:
-                assert self.mgr.cherrypy_thread
-                assert self.mgr.cherrypy_thread.ssl_certs.get_root_cert()
+                assert self.mgr.http_server.agent
+                assert self.mgr.http_server.agent.ssl_certs.get_root_cert()
             except Exception:
                 self.log.info(
                     'Delaying applying agent spec until cephadm endpoint root cert created')

--- a/src/pybind/mgr/cephadm/service_discovery.py
+++ b/src/pybind/mgr/cephadm/service_discovery.py
@@ -1,0 +1,197 @@
+try:
+    import cherrypy
+    from cherrypy._cpserver import Server
+except ImportError:
+    # to avoid sphinx build crash
+    class Server:  # type: ignore
+        pass
+
+import logging
+import tempfile
+from typing import Dict, List, TYPE_CHECKING, cast, Collection
+
+from orchestrator import OrchestratorError
+from mgr_module import ServiceInfoT
+from mgr_util import verify_tls_files, build_url
+from cephadm.services.ingress import IngressSpec
+from cephadm.ssl_cert_utils import SSLCerts
+
+if TYPE_CHECKING:
+    from cephadm.module import CephadmOrchestrator
+
+
+def cherrypy_filter(record: logging.LogRecord) -> int:
+    blocked = [
+        'TLSV1_ALERT_DECRYPT_ERROR'
+    ]
+    msg = record.getMessage()
+    return not any([m for m in blocked if m in msg])
+
+
+logging.getLogger('cherrypy.error').addFilter(cherrypy_filter)
+cherrypy.log.access_log.propagate = False
+
+
+class ServiceDiscovery:
+
+    KV_STORE_SD_ROOT_CERT = 'service_discovery/root/cert'
+    KV_STORE_SD_ROOT_KEY = 'service_discovery/root/key'
+
+    def __init__(self, mgr: "CephadmOrchestrator") -> None:
+        self.mgr = mgr
+        self.ssl_certs = SSLCerts()
+        self.server_port = self.mgr.service_discovery_port
+        self.server_addr = '::'
+
+    def configure_routes(self) -> None:
+
+        root_server = Root(self.mgr,
+                           self.server_port,
+                           self.server_addr,
+                           self.cert_file.name,
+                           self.key_file.name)
+
+        # configure routes
+        d = cherrypy.dispatch.RoutesDispatcher()
+        d.connect(name='index', route='/', controller=root_server.index)
+        d.connect(name='index', route='/sd', controller=root_server.index)
+        d.connect(name='index', route='/sd/', controller=root_server.index)
+        d.connect(name='sd-config', route='/sd/prometheus/sd-config',
+                  controller=root_server.get_sd_config)
+        d.connect(name='rules', route='/sd/prometheus/rules',
+                  controller=root_server.get_prometheus_rules)
+        cherrypy.tree.mount(None, '/', config={'/': {'request.dispatch': d}})
+
+    def configure_tls(self) -> None:
+        try:
+            old_cert = self.mgr.get_store(self.KV_STORE_SD_ROOT_CERT)
+            old_key = self.mgr.get_store(self.KV_STORE_SD_ROOT_KEY)
+            if not old_key or not old_cert:
+                raise OrchestratorError('No old credentials for service discovery found')
+            self.ssl_certs.load_root_credentials(old_cert, old_key)
+        except (OrchestratorError, KeyError, ValueError):
+            self.ssl_certs.generate_root_cert(self.mgr.get_mgr_ip())
+            self.mgr.set_store(self.KV_STORE_SD_ROOT_CERT, self.ssl_certs.get_root_cert())
+            self.mgr.set_store(self.KV_STORE_SD_ROOT_KEY, self.ssl_certs.get_root_key())
+
+        cert, key = self.ssl_certs.generate_cert(self.mgr.get_mgr_ip())
+        self.key_file = tempfile.NamedTemporaryFile()
+        self.key_file.write(key.encode('utf-8'))
+        self.key_file.flush()  # pkey_tmp must not be gc'ed
+        self.cert_file = tempfile.NamedTemporaryFile()
+        self.cert_file.write(cert.encode('utf-8'))
+        self.cert_file.flush()  # cert_tmp must not be gc'ed
+        verify_tls_files(self.cert_file.name, self.key_file.name)
+
+    def configure(self) -> None:
+        self.configure_tls()
+        self.configure_routes()
+
+
+class Root(Server):
+
+    # collapse everything to '/'
+    def _cp_dispatch(self, vpath: str) -> 'Root':
+        cherrypy.request.path = ''
+        return self
+
+    def __init__(self, mgr: "CephadmOrchestrator",
+                 port: int = 0,
+                 host: str = '',
+                 ssl_ca_cert: str = '',
+                 ssl_priv_key: str = ''):
+        self.mgr = mgr
+        super().__init__()
+        self.socket_port = port
+        self._socket_host = host
+        self.ssl_certificate = ssl_ca_cert
+        self.ssl_private_key = ssl_priv_key
+        self.subscribe()
+
+    @cherrypy.expose
+    def index(self) -> str:
+        return '''<!DOCTYPE html>
+<html>
+<head><title>Cephadm HTTP Endpoint</title></head>
+<body>
+<h2>Cephadm Service Discovery Endpoints</h2>
+<p><a href='prometheus/sd-config?service=mgr-prometheus'>mgr/Prometheus http sd-config</a></p>
+<p><a href='prometheus/sd-config?service=alertmanager'>Alertmanager http sd-config</a></p>
+<p><a href='prometheus/sd-config?service=node-exporter'>Node exporter http sd-config</a></p>
+<p><a href='prometheus/sd-config?service=haproxy'>HAProxy http sd-config</a></p>
+<p><a href='prometheus/rules'>Prometheus rules</a></p>
+</body>
+</html>'''
+
+    @cherrypy.expose
+    @cherrypy.tools.json_out()
+    def get_sd_config(self, service: str) -> List[Dict[str, Collection[str]]]:
+        """Return <http_sd_config> compatible prometheus config for the specified service."""
+        if service == 'mgr-prometheus':
+            return self.prometheus_sd_config()
+        elif service == 'alertmanager':
+            return self.alertmgr_sd_config()
+        elif service == 'node-exporter':
+            return self.node_exporter_sd_config()
+        elif service == 'haproxy':
+            return self.haproxy_sd_config()
+        else:
+            return []
+
+    def prometheus_sd_config(self) -> List[Dict[str, Collection[str]]]:
+        """Return <http_sd_config> compatible prometheus config for prometheus service."""
+        servers = self.mgr.list_servers()
+        targets = []
+        for server in servers:
+            hostname = server.get('hostname', '')
+            for service in cast(List[ServiceInfoT], server.get('services', [])):
+                if service['type'] != 'mgr':
+                    continue
+                port = self.mgr.get_module_option_ex('prometheus', 'server_port', 9283)
+                targets.append(f'{hostname}:{port}')
+        return [{"targets": targets, "labels": {}}]
+
+    def alertmgr_sd_config(self) -> List[Dict[str, Collection[str]]]:
+        """Return <http_sd_config> compatible prometheus config for mgr alertmanager service."""
+        srv_entries = []
+        for dd in self.mgr.cache.get_daemons_by_service('alertmanager'):
+            assert dd.hostname is not None
+            addr = dd.ip if dd.ip else self.mgr.inventory.get_addr(dd.hostname)
+            port = dd.ports[0] if dd.ports else 9093
+            srv_entries.append('{}'.format(build_url(host=addr, port=port).lstrip('/')))
+        return [{"targets": srv_entries, "labels": {}}]
+
+    def node_exporter_sd_config(self) -> List[Dict[str, Collection[str]]]:
+        """Return <http_sd_config> compatible prometheus config for node-exporter service."""
+        srv_entries = []
+        for dd in self.mgr.cache.get_daemons_by_service('node-exporter'):
+            assert dd.hostname is not None
+            addr = dd.ip if dd.ip else self.mgr.inventory.get_addr(dd.hostname)
+            port = dd.ports[0] if dd.ports else 9100
+            srv_entries.append({
+                'targets': [build_url(host=addr, port=port).lstrip('/')],
+                'labels': {'instance': dd.hostname}
+            })
+        return srv_entries
+
+    def haproxy_sd_config(self) -> List[Dict[str, Collection[str]]]:
+        """Return <http_sd_config> compatible prometheus config for haproxy service."""
+        srv_entries = []
+        for dd in self.mgr.cache.get_daemons_by_type('ingress'):
+            if dd.service_name() in self.mgr.spec_store:
+                spec = cast(IngressSpec, self.mgr.spec_store[dd.service_name()].spec)
+                assert dd.hostname is not None
+                if dd.daemon_type == 'haproxy':
+                    addr = self.mgr.inventory.get_addr(dd.hostname)
+                    srv_entries.append({
+                        'targets': [f"{build_url(host=addr, port=spec.monitor_port).lstrip('/')}"],
+                        'labels': {'instance': dd.service_name()}
+                    })
+        return srv_entries
+
+    @cherrypy.expose(alias='prometheus/rules')
+    def get_prometheus_rules(self) -> str:
+        """Return currently configured prometheus rules as Yaml."""
+        cherrypy.response.headers['Content-Type'] = 'text/plain'
+        with open(self.mgr.prometheus_alerts_path, 'r', encoding='utf-8') as f:
+            return f.read()

--- a/src/pybind/mgr/cephadm/ssl_cert_utils.py
+++ b/src/pybind/mgr/cephadm/ssl_cert_utils.py
@@ -1,0 +1,123 @@
+
+from typing import Any, Tuple
+import ipaddress
+
+from datetime import datetime, timedelta
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.backends import default_backend
+
+from orchestrator import OrchestratorError
+
+
+class SSLCerts:
+    def __init__(self) -> None:
+        self.root_cert: Any
+        self.root_key: Any
+
+    def generate_root_cert(self, host: str) -> Tuple[str, str]:
+        self.root_key = rsa.generate_private_key(
+            public_exponent=65537, key_size=4096, backend=default_backend())
+        root_public_key = self.root_key.public_key()
+        root_builder = x509.CertificateBuilder()
+        root_builder = root_builder.subject_name(x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, u'cephadm-root'),
+        ]))
+        root_builder = root_builder.issuer_name(x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, u'cephadm-root'),
+        ]))
+        root_builder = root_builder.not_valid_before(datetime.now())
+        root_builder = root_builder.not_valid_after(datetime.now() + timedelta(days=(365 * 10 + 3)))
+        root_builder = root_builder.serial_number(x509.random_serial_number())
+        root_builder = root_builder.public_key(root_public_key)
+        root_builder = root_builder.add_extension(
+            x509.SubjectAlternativeName(
+                [x509.IPAddress(ipaddress.IPv4Address(host))]
+            ),
+            critical=False
+        )
+        root_builder = root_builder.add_extension(
+            x509.BasicConstraints(ca=True, path_length=None), critical=True,
+        )
+
+        self.root_cert = root_builder.sign(
+            private_key=self.root_key, algorithm=hashes.SHA256(), backend=default_backend()
+        )
+
+        cert_str = self.root_cert.public_bytes(encoding=serialization.Encoding.PEM).decode('utf-8')
+        key_str = self.root_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption()
+        ).decode('utf-8')
+
+        return (cert_str, key_str)
+
+    def generate_cert(self, addr: str) -> Tuple[str, str]:
+        have_ip = True
+        try:
+            ip = x509.IPAddress(ipaddress.IPv4Address(addr))
+        except Exception:
+            try:
+                ip = x509.IPAddress(ipaddress.IPv6Address(addr))
+            except Exception:
+                have_ip = False
+
+        private_key = rsa.generate_private_key(
+            public_exponent=65537, key_size=4096, backend=default_backend())
+        public_key = private_key.public_key()
+
+        builder = x509.CertificateBuilder()
+        builder = builder.subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, addr), ]))
+        builder = builder.issuer_name(
+            x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, u'cephadm-root'), ]))
+        builder = builder.not_valid_before(datetime.now())
+        builder = builder.not_valid_after(datetime.now() + timedelta(days=(365 * 10 + 3)))
+        builder = builder.serial_number(x509.random_serial_number())
+        builder = builder.public_key(public_key)
+        if have_ip:
+            builder = builder.add_extension(
+                x509.SubjectAlternativeName(
+                    [ip]
+                ),
+                critical=False
+            )
+        builder = builder.add_extension(x509.BasicConstraints(
+            ca=False, path_length=None), critical=True,)
+
+        cert = builder.sign(private_key=self.root_key,
+                            algorithm=hashes.SHA256(), backend=default_backend())
+        cert_str = cert.public_bytes(encoding=serialization.Encoding.PEM).decode('utf-8')
+        key_str = private_key.private_bytes(encoding=serialization.Encoding.PEM,
+                                            format=serialization.PrivateFormat.TraditionalOpenSSL,
+                                            encryption_algorithm=serialization.NoEncryption()
+                                            ).decode('utf-8')
+
+        return (cert_str, key_str)
+
+    def get_root_cert(self) -> str:
+        try:
+            return self.root_cert.public_bytes(encoding=serialization.Encoding.PEM).decode('utf-8')
+        except AttributeError:
+            return ''
+
+    def get_root_key(self) -> str:
+        try:
+            return self.root_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.NoEncryption(),
+            ).decode('utf-8')
+        except AttributeError:
+            return ''
+
+    def load_root_credentials(self, cert: str, priv_key: str) -> None:
+        given_cert = x509.load_pem_x509_certificate(cert.encode('utf-8'), backend=default_backend())
+        tz = given_cert.not_valid_after.tzinfo
+        if datetime.now(tz) >= given_cert.not_valid_after:
+            raise OrchestratorError('Given cert is expired')
+        self.root_cert = given_cert
+        self.root_key = serialization.load_pem_private_key(
+            data=priv_key.encode('utf-8'), backend=default_backend(), password=None)

--- a/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
@@ -4,38 +4,37 @@ global:
   evaluation_interval: 10s
 rule_files:
   - /etc/prometheus/alerting/*
-{% if alertmgr_targets %}
+
+{% if alertmanager_sd_url %}
 alerting:
   alertmanagers:
     - scheme: http
-      static_configs:
-        - targets: [{{ alertmgr_targets|join(', ') }}]
+      http_sd_configs:
+        - url: {{ alertmanager_sd_url }}
+          tls_config:
+            ca_file: root_cert.pem
 {% endif %}
+
 scrape_configs:
   - job_name: 'ceph'
     honor_labels: true
-    static_configs:
-    - targets:
-{% for mgr in mgr_scrape_list %}
-      - '{{ mgr }}'
-{% endfor %}
+    http_sd_configs:
+    - url: {{ mgr_prometheus_sd_url }}
+      tls_config:
+        ca_file: root_cert.pem
 
-{% if nodes %}
+{% if node_exporter_sd_url %}
   - job_name: 'node'
-    static_configs:
-{% for node in nodes %}
-    - targets: ['{{ node.url }}']
-      labels:
-        instance: '{{ node.hostname }}'
-{% endfor %}
+    http_sd_configs:
+    - url: {{ node_exporter_sd_url }}
+      tls_config:
+        ca_file: root_cert.pem
 {% endif %}
 
-{% if haproxy_targets %}
+{% if haproxy_sd_url %}
   - job_name: 'haproxy'
-    static_configs:
-{% for haproxy in haproxy_targets %}
-      - targets: [{{ haproxy.url }}]
-        labels:
-          instance: '{{ haproxy.service }}'
-{% endfor %}
+    http_sd_configs:
+    - url: {{ haproxy_sd_url }}
+      tls_config:
+        ca_file: root_cert.pem
 {% endif %}

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -98,9 +98,9 @@ def with_cephadm_module(module_options=None, store=None):
             mock.patch("cephadm.agent.CephadmAgentHelpers._request_agent_acks"), \
             mock.patch("cephadm.agent.CephadmAgentHelpers._apply_agent", return_value=False), \
             mock.patch("cephadm.agent.CephadmAgentHelpers._agent_down", return_value=False), \
-            mock.patch('cephadm.agent.CherryPyThread.run'), \
             mock.patch('cephadm.offline_watcher.OfflineHostWatcher.run'), \
-            mock.patch('cephadm.tuned_profiles.TunedProfileUtils._remove_stray_tuned_profiles'):
+            mock.patch('cephadm.tuned_profiles.TunedProfileUtils._remove_stray_tuned_profiles'),\
+            mock.patch('cephadm.offline_watcher.OfflineHostWatcher.run'):
 
         m = CephadmOrchestrator.__new__(CephadmOrchestrator)
         if module_options is not None:

--- a/src/pybind/mgr/cephadm/tests/test_service_discovery.py
+++ b/src/pybind/mgr/cephadm/tests/test_service_discovery.py
@@ -1,5 +1,5 @@
 from unittest.mock import MagicMock
-from cephadm.agent import Root
+from cephadm.service_discovery import Root
 
 
 class FakeDaemonDescription:
@@ -88,7 +88,7 @@ class FakeMgr:
         return "9283"
 
 
-class TestCephadmService:
+class TestServiceDiscovery:
 
     def test_get_sd_config_prometheus(self):
         mgr = FakeMgr()

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -401,18 +401,21 @@ class TestMonitoring:
                   evaluation_interval: 10s
                 rule_files:
                   - /etc/prometheus/alerting/*
+
+
                 scrape_configs:
                   - job_name: 'ceph'
                     honor_labels: true
-                    static_configs:
-                    - targets:
-                      - '[::1]:9283'
+                    http_sd_configs:
+                    - url: https://[::1]:8765/sd/prometheus/sd-config?service=mgr-prometheus
+                      tls_config:
+                        ca_file: root_cert.pem
 
                   - job_name: 'node'
-                    static_configs:
-                    - targets: ['[1::4]:9100']
-                      labels:
-                        instance: 'test'
+                    http_sd_configs:
+                    - url: https://[::1]:8765/sd/prometheus/sd-config?service=node-exporter
+                      tls_config:
+                        ca_file: root_cert.pem
 
                 """).lstrip()
 
@@ -427,7 +430,7 @@ class TestMonitoring:
                         '--config-json', '-',
                         '--tcp-ports', '9095'
                     ],
-                    stdin=json.dumps({"files": {"prometheus.yml": y}}),
+                    stdin=json.dumps({"files": {"prometheus.yml": y, "root_cert.pem": ''}}),
                     image='')
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -437,6 +437,14 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def service_discovery_dump_cert(self) -> OrchResult:
+        """
+        Returns service discovery server root certificate
+
+        :return: service discovery root certificate
+        """
+        raise NotImplementedError()
+
     def describe_service(self, service_type: Optional[str] = None, service_name: Optional[str] = None, refresh: bool = False) -> OrchResult[List['ServiceDescription']]:
         """
         Describe a service (of any kind) that is already configured in

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -573,6 +573,15 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
+    @_cli_write_command('orch sd dump cert')
+    def _service_discovery_dump_cert(self) -> HandleCommandResult:
+        """
+        Returns service discovery server root certificate
+        """
+        completion = self.service_discovery_dump_cert()
+        raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
     @_cli_read_command('orch ls')
     def _list_services(self,
                        service_type: Optional[str] = None,


### PR DESCRIPTION
https://tracker.ceph.com/issues/52602

Now that we have the basis for service discovery (introduced by the PR https://github.com/ceph/ceph/pull/45425)
 we can use it in order to make prometheus daemon configuration fully dynamic by using [prometheus http service direcovery feature](https://github.com/ceph/ceph/pull/45425)

The changes on this PR basically includes:

- Moving the service discovery code to its own file `service_discovery.py` (so keep it separated from the agent)
- Change the template used for prometehus so we use `http_sd_config` to get it dynamically
- Include `active manager` as prometheus dependency (since mgr ip is used in the dynamic url we have to redeploy when the mgr fails over)
- Use cherrypy._cpserver to create a separate http servers for agent and service discovery
- Refactor the code a little bit (moving TLS/SSL support to its own file, ...)

Performed testing:

- deploy a ceph a cluster running the new code
- check the deployed `prometheus` daemon to make sure its configuration file is correct
- check the deployed `prometheus` daemon to make sure the `root_cert.pem` is correct (since we have two roots certificates)
- connect using a web browser to `http://ceph-node-0:9095/targets` and check:
   > the configuration (should point to the active mgr IP)
   > the dynamic targets
- force a mgr fail over by `ceph mgr fail` and make sure prometheus daemon y re-deployed and points to the new active mgr ip
- connect using a web browser to `http://ceph-node-0:9095/targets` and check the conf is updated accordingly and targets are correct

**Regression testing:**

- change `mgr/prometheus/server_port`  and make sure prometheus daemon is re-deployed
- force a mgr fail over and make sure mgr-prometheus is listening on the new port

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
