### PR TITLE
quincy: osd/scrub: restart snap trimming after a failed scrub

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -441,7 +441,6 @@ void PG::queue_scrub_after_repair()
   m_scrubber->set_op_parameters(m_planned_scrub);
   dout(15) << __func__ << ": queueing" << dendl;
 
-  m_scrubber->set_queued_or_active();
   osd->queue_scrub_after_repair(this, Scrub::scrub_prio_t::high_priority);
 }
 
@@ -1371,7 +1370,6 @@ Scrub::schedule_result_t PG::sched_scrub()
   m_scrubber->set_op_parameters(m_planned_scrub);
 
   dout(10) << __func__ << ": queueing" << dendl;
-  m_scrubber->set_queued_or_active();
   osd->queue_for_scrub(this, Scrub::scrub_prio_t::low_priority);
   return Scrub::schedule_result_t::scrub_initiated;
 }

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -429,6 +429,7 @@ class PgScrubber : public ScrubPgIF, public ScrubMachineListener {
   [[nodiscard]] bool was_epoch_changed() const final;
 
   void set_queued_or_active() final;
+  /// Clears `m_queued_or_active` and restarts snaptrimming
   void clear_queued_or_active() final;
 
   void mark_local_map_ready() final;

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -191,6 +191,8 @@ struct ScrubPgIF {
   /**
    * Manipulate the 'scrubbing request has been queued, or - we are
    * actually scrubbing' Scrubber's flag
+   *
+   * clear_queued_or_active() will also restart any blocked snaptrimming.
    */
   virtual void set_queued_or_active() = 0;
   virtual void clear_queued_or_active() = 0;


### PR DESCRIPTION
A followup to PR#45640.
In PR#45640 snap trimming was restarted (if blocked) after all
successful scrubs, and after most scrub failures. Still, a few
failure scenarios did not handle snaptrim restart correctly.

The current PR cleans up and fixes the interaction between
scrub initiation/termination (for whatever cause) and snap
trimming.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
(cherry picked from commit 290e744a9b6c64f3da805056625b963f0eedaf33)
