### PR TITLE
doc/dev: remove -R from command for running tests for first time

### DIFF
--- a/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-workflow.rst
+++ b/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-workflow.rst
@@ -67,7 +67,6 @@ teuthology. This procedure explains how to run tests using teuthology.
         -p 110 \
         --filter "cephfs-shell" \
         -e foo@gmail.com \
-        -R fail
 
    The options in the above command are defined here: 
 
@@ -86,10 +85,6 @@ teuthology. This procedure explains how to run tests using teuthology.
         -e <email>    When tests finish or time out, send an email to the
                       specified address. Can also be specified in 
                       ~/.teuthology.yaml as 'results_email'
-        -R            A comma-separated list of statuses to be used
-                      with --rerun. Supported statuses: 'dead',
-                      'fail', 'pass', 'queued', 'running', 'waiting'
-                      [default: fail,dead]
       =============  =========================================================
 
    .. note:: The priority number present in the command above is a placeholder. 
@@ -239,10 +234,13 @@ example, for the above test ID, the link is - http://pulpito.front.sepia.ceph.co
 Re-running Tests
 ----------------
 
-The ``teuthology-suite`` command has a ``--rerun`` option, which allows you to
-re-run tests. This is handy when your test has failed or is dead. The
-``--rerun`` option takes the name of a teuthology run as an argument, as you
-can see in the example below:
+The ``teuthology-suite`` command has a ``-r`` (or ``--rerun``) option, which
+allows you to re-run tests. This is handy when your tests have failed or end
+up dead. The ``--rerun`` option takes the name of a teuthology run as an
+argument. Option ``-R`` (or ``--rerun-statuses``) can be passed along with
+``-r`` to choose which kind of tests should be picked from the run. For
+example, you can re-run only those tests from previous run which had ended up
+as dead. Following is a practical example:
 
 .. prompt:: bash $ 
 
@@ -250,12 +248,23 @@ can see in the example below:
     -m smithi \
     -c wip-rishabh-fs-test_cephfs_shell-fix \
     -p 50 \
-    --rerun teuthology-2019-12-10_05:00:03-smoke-master-testing-basic-smithi \
-    -R fail,dead,queued,running \
+    --r teuthology-2019-12-10_05:00:03-smoke-master-testing-basic-smithi \
+    -R fail,dead,queued \
     -e $CEPH_QA_MAIL
 
-The meaning and function of the other options is covered in the table in the
-`Triggering Tests`_ section.
+Following's the definition of new options introduced in this section:
+
+      =======================  ===============================================
+         Option                     Meaning
+      =======================  ===============================================
+        -r, --rerun             Attempt to reschedule a run, selecting only
+                                those jobs whose status are mentioned by
+                                --rerun-status.
+        -R, --rerun-statuses    A comma-separated list of statuses to be used
+                                with --rerun. Supported statuses: 'dead',
+                                'fail', 'pass', 'queued', 'running' and
+                                'waiting'. Default value: 'fail,dead'
+      =======================  ===============================================
 
 Naming the ceph-ci branch
 -------------------------


### PR DESCRIPTION
It's incorrect to pass option "-R fail" to the teuthology-suite command
meant for triggering tests for first time. teuthology-suite command will
fail if "-R" is passed without "-r". Therefore, remove this option from
the command as well as from the description of options right after the
command.







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>