### PR TITLE
Use ObjectStore tests for FuturizedStore

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -429,6 +429,21 @@ set(ceph_common_objs
   $<TARGET_OBJECTS:common-objs>
   $<TARGET_OBJECTS:common_mountcephfs_objs>
   $<TARGET_OBJECTS:crush_objs>)
+
+if(WITH_SEASTAR)
+  set(ceph_common_minor_objs
+    $<TARGET_OBJECTS:common-auth-objs>
+    $<TARGET_OBJECTS:common-common-minor-objs>
+    $<TARGET_OBJECTS:common-options-objs>
+    $<TARGET_OBJECTS:common-msg-objs>
+    $<TARGET_OBJECTS:common_buffer_obj>
+    $<TARGET_OBJECTS:common_texttable_obj>
+    $<TARGET_OBJECTS:compressor_objs>
+    $<TARGET_OBJECTS:common-objs>
+    $<TARGET_OBJECTS:common_mountcephfs_objs>
+    $<TARGET_OBJECTS:crush_objs>)
+endif()
+
 set(ceph_common_deps
   json_spirit erasure_code arch crc32
   ${LIB_RESOLV}
@@ -509,6 +524,11 @@ else()
 endif()
 
 target_link_libraries(ceph-common ${ceph_common_deps})
+if(WITH_SEASTAR)
+  add_library(ceph-common-minor ${CEPH_SHARED} ${ceph_common_minor_objs})
+  target_link_libraries(ceph-common-minor ${ceph_common_deps})
+endif()
+
 if(ENABLE_COVERAGE)
   target_link_libraries(ceph-common gcov)
 endif(ENABLE_COVERAGE)
@@ -529,6 +549,12 @@ if(NOT APPLE AND NOT FREEBSD)
     TARGET ceph-common
     APPEND APPEND_STRING
     PROPERTY LINK_FLAGS "-Wl,-Bsymbolic -Wl,-Bsymbolic-functions")
+  if(WITH_SEASTAR)
+    set_property(
+      TARGET ceph-common-minor
+      APPEND APPEND_STRING
+      PROPERTY LINK_FLAGS "-Wl,-Bsymbolic -Wl,-Bsymbolic-functions")
+  endif()
 endif()
 
 if(MINGW)
@@ -539,6 +565,14 @@ if(MINGW)
 else()
   install(
     TARGETS ceph-common
+    LIBRARY
+    DESTINATION ${CEPH_INSTALL_PKGLIBDIR}
+    NAMELINK_SKIP)
+endif()
+
+if(WITH_SEASTAR)
+  install(
+    TARGETS ceph-common-minor
     LIBRARY
     DESTINATION ${CEPH_INSTALL_PKGLIBDIR}
     NAMELINK_SKIP)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -102,6 +102,11 @@ set(common_srcs
   util.cc
   version.cc)
 
+if(WITH_SEASTAR)
+  set(common_minor_srcs ${common_srcs})
+  remove_exported(common_minor_srcs "^common/" crimson_ceph_exported_srcs)
+endif()
+
 if(WITH_SYSTEMD)
   list(APPEND common_srcs
     Journald.cc)
@@ -150,6 +155,13 @@ else()
     dns_resolve.cc
     linux_version.c
     SubProcess.cc)
+  if(WITH_SEASTAR)
+    list(APPEND common_minor_srcs
+      blkdev.cc
+      dns_resolve.cc
+      linux_version.c
+      SubProcess.cc)
+  endif()
 endif()
 
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/common/version.cc
@@ -180,6 +192,11 @@ endif()
 
 add_library(common-common-objs OBJECT
   ${common_srcs})
+if(WITH_SEASTAR)
+  add_library(common-common-minor-objs OBJECT
+    ${common_minor_srcs})
+endif()
+
 # Let's not rely on the default system headers and point Cmake to the
 # retrieved OpenSSL location. This is especially important when cross
 # compiling (e.g. targeting Windows).

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(crimson::cflags INTERFACE IMPORTED)
+add_library(crimson::cflags INTERFACE IMPORTED GLOBAL)
 set(crimson_cflag_definitions "WITH_SEASTAR=1")
 # disable concepts to address https://github.com/boostorg/asio/issues/312
 if((CMAKE_CXX_COMPILER_ID STREQUAL GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10) OR
@@ -24,102 +24,132 @@ set(crimson_common_srcs
   common/throttle.cc
   common/tri_mutex.cc)
 
+# Components of vanilla ceph imported to crimson.
+# These sources will be removed from a ceph-common library to form ceph-common-minor library.
+# The ceph-common-minor library is used when making crimson binaries, that links also crimson-common.
+# The ceph-common library is used when making non-crimson binaries.
+set(crimson_ceph_imported_srcs
+  auth/Crypto.cc
+  common/admin_socket_client.cc
+  common/bit_str.cc
+  common/bloom_filter.cc
+  common/buffer.cc
+  common/buffer_seastar.cc
+  common/ceph_argparse.cc
+  common/ceph_context.cc
+  common/ceph_crypto.cc
+  common/ceph_hash.cc
+  common/ceph_time.cc
+  common/ceph_strings.cc
+  common/ceph_releases.cc
+  common/cmdparse.cc
+  common/compat.cc
+  common/code_environment.cc
+  common/config_values.cc
+  common/dout.cc
+  common/entity_name.cc
+  common/environment.cc
+  common/errno.cc
+  common/escape.cc
+  common/hex.cc
+  common/fs_types.cc
+  common/ceph_json.cc
+  common/histogram.cc
+  common/hobject.cc
+  common/hostname.cc
+  common/ipaddr.cc
+  common/mempool.cc
+  common/options.cc
+  common/perf_counters.cc
+  common/perf_histogram.cc
+  common/page.cc
+  common/pick_address.cc
+  common/snap_types.cc
+  common/signal.cc
+  common/str_list.cc
+  common/str_map.cc
+  common/strtol.cc
+  common/reverse.c
+  common/types.cc
+  common/utf8.c
+  common/version.cc
+  common/BackTrace.cc
+  common/ConfUtils.cc
+  common/DecayCounter.cc
+  common/HTMLFormatter.cc
+  common/Formatter.cc
+  common/Graylog.cc
+  common/Journald.cc
+  common/ostream_temp.cc
+  common/LogEntry.cc
+  common/TextTable.cc
+  common/Thread.cc
+  common/PluginRegistry.cc
+  common/RefCountedObj.cc
+  common/util.cc
+  compressor/Compressor.cc
+  crush/builder.c
+  crush/mapper.c
+  crush/crush.c
+  crush/hash.c
+  crush/CrushWrapper.cc
+  crush/CrushCompiler.cc
+  crush/CrushTester.cc
+  crush/CrushLocation.cc
+  global/global_context.cc
+  global/pidfile.cc
+  librbd/Features.cc
+  librbd/io/IoOperations.cc
+  log/Log.cc
+  mgr/ServiceMap.cc
+  mds/inode_backtrace.cc
+  mds/mdstypes.cc
+  mds/cephfs_features.cc
+  mds/FSMap.cc
+  mds/FSMapUser.cc
+  mds/MDSMap.cc
+  msg/msg_types.cc
+  msg/Message.cc
+  mon/PGMap.cc
+  mon/MonCap.cc
+  mon/MonMap.cc
+  osd/osd_types.cc
+  osd/ECMsgTypes.cc
+  osd/HitSet.cc
+  osd/OSDMap.cc
+  osd/PGPeeringEvent.cc
+  xxHash/xxhash.c
+)
+
+#Sources that are compiled for both libcrimson-common libceph-common.
+#This is necessary when we replace ceph:: classes with crimson:: counterparts
+set(crimson_ceph_used_twice_srcs
+  common/config.cc
+  common/common_init.cc
+)
+
+#Switch name from "imported" to "exported" to make better sense for other modules.
+set(crimson_ceph_exported_srcs "${crimson_ceph_imported_srcs}" PARENT_SCOPE)
+
+#cuts out from variable 'local_srcs' values that are present in 'exported_srcs'
+#it selects only those that match 'filter', removing 'filter' prefix
+function(remove_exported local_srcs filter exported_srcs)
+  set(to_remove ${${exported_srcs}})
+  list(FILTER to_remove INCLUDE REGEX ${filter})
+  list(TRANSFORM to_remove REPLACE ${filter} "")
+  list(REMOVE_ITEM ${local_srcs} ${to_remove})
+endfunction()
+
+#we compile from crimson subdir, so we need to prepend full path
+list(TRANSFORM crimson_ceph_imported_srcs PREPEND "${PROJECT_SOURCE_DIR}/src/")
+list(TRANSFORM crimson_ceph_used_twice_srcs PREPEND "${PROJECT_SOURCE_DIR}/src/")
+
 # the specialized version of ceph-common, where
 #  - the logging is sent to Seastar backend
 #  - and the template parameter of lock_policy is SINGLE
 add_library(crimson-common STATIC
-  ${PROJECT_SOURCE_DIR}/src/auth/Crypto.cc
-  ${PROJECT_SOURCE_DIR}/src/common/admin_socket_client.cc
-  ${PROJECT_SOURCE_DIR}/src/common/bit_str.cc
-  ${PROJECT_SOURCE_DIR}/src/common/bloom_filter.cc
-  ${PROJECT_SOURCE_DIR}/src/common/buffer.cc
-  ${PROJECT_SOURCE_DIR}/src/common/buffer_seastar.cc
-  ${PROJECT_SOURCE_DIR}/src/common/ceph_argparse.cc
-  ${PROJECT_SOURCE_DIR}/src/common/ceph_context.cc
-  ${PROJECT_SOURCE_DIR}/src/common/ceph_crypto.cc
-  ${PROJECT_SOURCE_DIR}/src/common/ceph_hash.cc
-  ${PROJECT_SOURCE_DIR}/src/common/ceph_time.cc
-  ${PROJECT_SOURCE_DIR}/src/common/ceph_strings.cc
-  ${PROJECT_SOURCE_DIR}/src/common/ceph_releases.cc
-  ${PROJECT_SOURCE_DIR}/src/common/cmdparse.cc
-  ${PROJECT_SOURCE_DIR}/src/common/common_init.cc
-  ${PROJECT_SOURCE_DIR}/src/common/compat.cc
-  ${PROJECT_SOURCE_DIR}/src/common/code_environment.cc
-  ${PROJECT_SOURCE_DIR}/src/common/config.cc
-  ${PROJECT_SOURCE_DIR}/src/common/config_values.cc
-  ${PROJECT_SOURCE_DIR}/src/common/dout.cc
-  ${PROJECT_SOURCE_DIR}/src/common/entity_name.cc
-  ${PROJECT_SOURCE_DIR}/src/common/environment.cc
-  ${PROJECT_SOURCE_DIR}/src/common/errno.cc
-  ${PROJECT_SOURCE_DIR}/src/common/escape.cc
-  ${PROJECT_SOURCE_DIR}/src/common/hex.cc
-  ${PROJECT_SOURCE_DIR}/src/common/fs_types.cc
-  ${PROJECT_SOURCE_DIR}/src/common/ceph_json.cc
-  ${PROJECT_SOURCE_DIR}/src/common/histogram.cc
-  ${PROJECT_SOURCE_DIR}/src/common/hobject.cc
-  ${PROJECT_SOURCE_DIR}/src/common/hostname.cc
-  ${PROJECT_SOURCE_DIR}/src/common/ipaddr.cc
-  ${PROJECT_SOURCE_DIR}/src/common/mempool.cc
-  ${PROJECT_SOURCE_DIR}/src/common/options.cc
-  ${PROJECT_SOURCE_DIR}/src/common/perf_counters.cc
-  ${PROJECT_SOURCE_DIR}/src/common/perf_histogram.cc
-  ${PROJECT_SOURCE_DIR}/src/common/page.cc
-  ${PROJECT_SOURCE_DIR}/src/common/pick_address.cc
-  ${PROJECT_SOURCE_DIR}/src/common/snap_types.cc
-  ${PROJECT_SOURCE_DIR}/src/common/signal.cc
-  ${PROJECT_SOURCE_DIR}/src/common/str_list.cc
-  ${PROJECT_SOURCE_DIR}/src/common/str_map.cc
-  ${PROJECT_SOURCE_DIR}/src/common/strtol.cc
-  ${PROJECT_SOURCE_DIR}/src/common/reverse.c
-  ${PROJECT_SOURCE_DIR}/src/common/types.cc
-  ${PROJECT_SOURCE_DIR}/src/common/utf8.c
-  ${PROJECT_SOURCE_DIR}/src/common/version.cc
-  ${PROJECT_SOURCE_DIR}/src/common/BackTrace.cc
-  ${PROJECT_SOURCE_DIR}/src/common/ConfUtils.cc
-  ${PROJECT_SOURCE_DIR}/src/common/DecayCounter.cc
-  ${PROJECT_SOURCE_DIR}/src/common/HTMLFormatter.cc
-  ${PROJECT_SOURCE_DIR}/src/common/Formatter.cc
-  ${PROJECT_SOURCE_DIR}/src/common/Graylog.cc
-  ${PROJECT_SOURCE_DIR}/src/common/Journald.cc
-  ${PROJECT_SOURCE_DIR}/src/common/ostream_temp.cc
-  ${PROJECT_SOURCE_DIR}/src/common/LogEntry.cc
-  ${PROJECT_SOURCE_DIR}/src/common/TextTable.cc
-  ${PROJECT_SOURCE_DIR}/src/common/Thread.cc
-  ${PROJECT_SOURCE_DIR}/src/common/PluginRegistry.cc
-  ${PROJECT_SOURCE_DIR}/src/common/RefCountedObj.cc
-  ${PROJECT_SOURCE_DIR}/src/common/util.cc
-  ${PROJECT_SOURCE_DIR}/src/compressor/Compressor.cc
-  ${PROJECT_SOURCE_DIR}/src/crush/builder.c
-  ${PROJECT_SOURCE_DIR}/src/crush/mapper.c
-  ${PROJECT_SOURCE_DIR}/src/crush/crush.c
-  ${PROJECT_SOURCE_DIR}/src/crush/hash.c
-  ${PROJECT_SOURCE_DIR}/src/crush/CrushWrapper.cc
-  ${PROJECT_SOURCE_DIR}/src/crush/CrushCompiler.cc
-  ${PROJECT_SOURCE_DIR}/src/crush/CrushTester.cc
-  ${PROJECT_SOURCE_DIR}/src/crush/CrushLocation.cc
-  ${PROJECT_SOURCE_DIR}/src/global/global_context.cc
-  ${PROJECT_SOURCE_DIR}/src/global/pidfile.cc
-  ${PROJECT_SOURCE_DIR}/src/librbd/Features.cc
-  ${PROJECT_SOURCE_DIR}/src/librbd/io/IoOperations.cc
-  ${PROJECT_SOURCE_DIR}/src/log/Log.cc
-  ${PROJECT_SOURCE_DIR}/src/mgr/ServiceMap.cc
-  ${PROJECT_SOURCE_DIR}/src/mds/inode_backtrace.cc
-  ${PROJECT_SOURCE_DIR}/src/mds/mdstypes.cc
-  ${PROJECT_SOURCE_DIR}/src/mds/cephfs_features.cc
-  ${PROJECT_SOURCE_DIR}/src/mds/FSMap.cc
-  ${PROJECT_SOURCE_DIR}/src/mds/FSMapUser.cc
-  ${PROJECT_SOURCE_DIR}/src/mds/MDSMap.cc
-  ${PROJECT_SOURCE_DIR}/src/msg/msg_types.cc
-  ${PROJECT_SOURCE_DIR}/src/msg/Message.cc
-  ${PROJECT_SOURCE_DIR}/src/mon/PGMap.cc
-  ${PROJECT_SOURCE_DIR}/src/mon/MonCap.cc
-  ${PROJECT_SOURCE_DIR}/src/mon/MonMap.cc
-  ${PROJECT_SOURCE_DIR}/src/osd/osd_types.cc
-  ${PROJECT_SOURCE_DIR}/src/osd/ECMsgTypes.cc
-  ${PROJECT_SOURCE_DIR}/src/osd/HitSet.cc
-  ${PROJECT_SOURCE_DIR}/src/osd/OSDMap.cc
-  ${PROJECT_SOURCE_DIR}/src/osd/PGPeeringEvent.cc
-  ${PROJECT_SOURCE_DIR}/src/xxHash/xxhash.c
+  ${crimson_ceph_imported_srcs}
+  ${crimson_ceph_used_twice_srcs}
   ${crimson_common_srcs}
   $<TARGET_OBJECTS:common_mountcephfs_objs>
   $<TARGET_OBJECTS:common-options-objs>)

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -159,8 +159,10 @@ seastar::future<> AlienStore::umount()
     return tp->submit([this] {
       return store->umount();
     });
-  }).then([] (int r) {
+  }).then([this] (int r) {
     assert(r == 0);
+    // revive op_gate in case we would like to mount again
+    op_gate = seastar::gate();
     return seastar::now();
   });
 }

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -202,7 +202,7 @@ AlienStore::list_objects(CollectionRef ch,
       [=, &objects, &next] {
       auto c = static_cast<AlienCollection*>(ch.get());
       return store->collection_list(c->collection, start, end,
-                                    store->get_ideal_list_max(),
+                                    limit,
                                     &objects, &next);
     }).then([&objects, &next] (int r) {
       assert(r == 0);

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -194,7 +194,10 @@ AlienStore::list_objects(CollectionRef ch,
   assert(tp);
   return do_with_op_gate(std::vector<ghobject_t>(), ghobject_t(),
                          [=] (auto &objects, auto &next) {
-    objects.reserve(limit);
+    if (limit <= 100) {
+      //reserve if limit is reasonably small
+      objects.reserve(limit);
+    }
     return tp->submit(ch->get_cid().hash_to_shard(tp->size()),
       [=, &objects, &next] {
       auto c = static_cast<AlienCollection*>(ch.get());

--- a/src/global/CMakeLists.txt
+++ b/src/global/CMakeLists.txt
@@ -17,3 +17,8 @@ target_link_libraries(global-static common)
 add_library(global STATIC
   $<TARGET_OBJECTS:libglobal_objs>)
 target_link_libraries(global ceph-common ${EXTRALIBS})
+
+#global that does not include ceph-common
+add_library(global-raw STATIC
+  $<TARGET_OBJECTS:libglobal_objs>)
+target_link_libraries(global ${EXTRALIBS})

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -723,14 +723,15 @@ public:
     std::map<std::string, ceph::buffer::list> *out ///< [out] Returned keys and values
     ) = 0;
 
-#ifdef WITH_SEASTAR
+  /// Used only in implementation of AlienStore(BlueStore)
   virtual int omap_get_values(
     CollectionHandle &c,         ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
     const std::optional<std::string> &start_after,     ///< [in] Keys to get
     std::map<std::string, ceph::buffer::list> *out ///< [out] Returned keys and values
-    ) = 0;
-#endif
+  ) {
+    return -ENOTSUP;
+  }
 
   /// Filters keys into out which are defined on oid
   virtual int omap_check_keys(

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -42,7 +42,9 @@
 namespace ceph {
   class Formatter;
 }
-
+namespace ceph::common {
+  class CephContext;
+}
 /*
  * low-level interface to the local OSD file system
  */
@@ -67,7 +69,7 @@ protected:
 public:
   using Transaction = ceph::os::Transaction;
 
-  CephContext* cct;
+  ceph::common::CephContext* cct;
   /**
    * create - create an ObjectStore instance.
    *
@@ -80,14 +82,14 @@ public:
    */
 #ifndef WITH_SEASTAR
   static std::unique_ptr<ObjectStore> create(
-    CephContext *cct,
+    ceph::common::CephContext *cct,
     const std::string& type,
     const std::string& data,
     const std::string& journal,
     osflagbits_t flags = 0);
 #endif
   static std::unique_ptr<ObjectStore> create(
-    CephContext *cct,
+    ceph::common::CephContext *cct,
     const std::string& type,
     const std::string& data);
 
@@ -99,7 +101,7 @@ public:
    * @param fsid [out] osd uuid
    */
   static int probe_block_device_fsid(
-    CephContext *cct,
+    ceph::common::CephContext *cct,
     const std::string& path,
     uuid_d *fsid);
 
@@ -130,7 +132,7 @@ public:
    * ObjectStore users may get collection handles with open_collection() (or,
    * for bootstrapping a new collection, create_new_collection()).
    */
-  struct CollectionImpl : public RefCountedObject {
+  struct CollectionImpl : public ceph::common::RefCountedObject {
     const coll_t cid;
 
     /// wait for any queued transactions to apply
@@ -156,7 +158,7 @@ public:
     }
   protected:
     CollectionImpl() = delete;
-    CollectionImpl(CephContext* cct, const coll_t& c) : RefCountedObject(cct), cid(c) {}
+    CollectionImpl(ceph::common::CephContext* cct, const coll_t& c) : ceph::common::RefCountedObject(cct), cid(c) {}
     ~CollectionImpl() = default;
   };
   using CollectionHandle = ceph::ref_t<CollectionImpl>;
@@ -236,7 +238,7 @@ public:
 
 
  public:
-  ObjectStore(CephContext* cct,
+  ObjectStore(ceph::common::CephContext* cct,
 	      const std::string& path_) : path(path_), cct(cct) {}
   virtual ~ObjectStore() {}
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12054,7 +12054,6 @@ int BlueStore::omap_get_values(
   return r;
 }
 
-#ifdef WITH_SEASTAR
 int BlueStore::omap_get_values(
   CollectionHandle &c_,        ///< [in] Collection containing oid
   const ghobject_t &oid,       ///< [in] Object containing omap
@@ -12096,7 +12095,6 @@ out:
           << dendl;
   return r;
 }
-#endif
 
 int BlueStore::omap_check_keys(
   CollectionHandle &c_,    ///< [in] Collection containing oid

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12083,7 +12083,9 @@ int BlueStore::omap_get_values(
       r = -ENOENT;
       goto out;
     }
-    iter->upper_bound(*start_after);
+    if (start_after) {
+      iter->upper_bound(*start_after);
+    }
     for (; iter->valid(); iter->next()) {
       output->insert(make_pair(iter->key(), iter->value()));
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4617,6 +4617,7 @@ BlueStore::~BlueStore()
   ceph_assert(bluefs == NULL);
   ceph_assert(fsid_fd < 0);
   ceph_assert(path_fd < 0);
+  new_coll_map.clear();
   for (auto i : onode_cache_shards) {
     delete i;
   }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3118,14 +3118,12 @@ public:
     std::map<std::string, ceph::buffer::list> *out ///< [out] Returned keys and values
     ) override;
 
-#ifdef WITH_SEASTAR
   int omap_get_values(
     CollectionHandle &c,         ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
     const std::optional<std::string> &start_after,     ///< [in] Keys to get
     std::map<std::string, ceph::buffer::list> *out ///< [out] Returned keys and values
     ) override;
-#endif
 
   /// Filters keys into out which are defined on oid
   int omap_check_keys(

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -11,6 +11,12 @@ target_include_directories(store_test_fixture PRIVATE
 add_executable(ceph_test_objectstore
   store_test.cc
   $<TARGET_OBJECTS:store_test_fixture>)
+
+if(WITH_SEASTAR)
+target_compile_definitions(ceph_test_objectstore PUBLIC WITH_XSTORE=1)
+target_compile_definitions(store_test_fixture PUBLIC WITH_XSTORE=1)
+endif()
+
 target_link_libraries(ceph_test_objectstore
   os
   ceph-common
@@ -22,6 +28,24 @@ target_link_libraries(ceph_test_objectstore
   )
 install(TARGETS ceph_test_objectstore
   DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+if(WITH_SEASTAR)
+add_library(xstore-crimson STATIC
+  xstore-crimson.cc
+  )
+target_link_libraries(xstore-crimson
+  PRIVATE
+  crimson-os
+  crimson-common
+  crimson
+  crimson::cflags)
+
+add_library(xstore-classic STATIC
+  xstore.cc)
+target_link_libraries(xstore-classic PRIVATE
+  xstore-crimson
+  os)
+endif()
 
 add_executable(ceph_test_keyvaluedb
   test_kv.cc)

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -19,13 +19,21 @@ endif()
 
 target_link_libraries(ceph_test_objectstore
   os
-  ceph-common
   ${UNITTEST_LIBS}
-  global
+  global-raw
   ${EXTRALIBS}
   ${BLKID_LIBRARIES}
   ${CMAKE_DL_LIBS}
   )
+if(WITH_SEASTAR)
+  target_link_libraries(ceph_test_objectstore
+    xstore-classic
+    ceph-common-minor
+)
+else()
+  target_link_libraries(ceph_test_objectstore
+    ceph-common)
+endif()
 install(TARGETS ceph_test_objectstore
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -7,10 +7,12 @@ install(TARGETS ceph_perf_objectstore
 add_library(store_test_fixture OBJECT store_test_fixture.cc)
 target_include_directories(store_test_fixture PRIVATE
   $<TARGET_PROPERTY:GTest::GTest,INTERFACE_INCLUDE_DIRECTORIES>)
+if(WITH_SEASTAR)
+  target_link_libraries(store_test_fixture xstore-crimson)
+endif()
 
 add_executable(ceph_test_objectstore
-  store_test.cc
-  $<TARGET_OBJECTS:store_test_fixture>)
+  store_test.cc)
 
 if(WITH_SEASTAR)
 target_compile_definitions(ceph_test_objectstore PUBLIC WITH_XSTORE=1)
@@ -24,10 +26,11 @@ target_link_libraries(ceph_test_objectstore
   ${EXTRALIBS}
   ${BLKID_LIBRARIES}
   ${CMAKE_DL_LIBS}
+  store_test_fixture
   )
 if(WITH_SEASTAR)
   target_link_libraries(ceph_test_objectstore
-    xstore-classic
+    xstore-crimson
     ceph-common-minor
 )
 else()
@@ -47,12 +50,6 @@ target_link_libraries(xstore-crimson
   crimson-common
   crimson
   crimson::cflags)
-
-add_library(xstore-classic STATIC
-  xstore.cc)
-target_link_libraries(xstore-classic PRIVATE
-  xstore-crimson
-  os)
 endif()
 
 add_executable(ceph_test_keyvaluedb
@@ -189,10 +186,9 @@ target_link_libraries(unittest_transaction os ceph-common)
 
 # unittest_memstore_clone
 add_executable(unittest_memstore_clone
-  test_memstore_clone.cc
-  $<TARGET_OBJECTS:store_test_fixture>)
+  test_memstore_clone.cc)
 add_ceph_unittest(unittest_memstore_clone)
-target_link_libraries(unittest_memstore_clone os global)
+target_link_libraries(unittest_memstore_clone os global store_test_fixture)
 
 if(WITH_BLUESTORE)
   add_executable(ceph_test_alloc_replay

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -46,7 +46,9 @@
 #include "include/unordered_map.h"
 #include "os/kv.h"
 #include "store_test_fixture.h"
-
+#if defined(WITH_XSTORE)
+#include "xstore-crimson.h"
+#endif
 
 using namespace std;
 using namespace std::placeholders;
@@ -6843,7 +6845,12 @@ INSTANTIATE_TEST_SUITE_P(
 #if defined(WITH_BLUESTORE)
     "bluestore",
 #endif
-    "kstore"));
+    "kstore"
+#if defined(WITH_XSTORE)
+    ,
+    "xstore-bluestore"
+#endif
+  ));
 
 // Note: instantiate all stores to preserve store numbering order only
 INSTANTIATE_TEST_SUITE_P(
@@ -10616,6 +10623,10 @@ TEST_P(StoreTestOmapUpgrade, LargeLegacyToPG) {
 #endif  // WITH_BLUESTORE
 
 int main(int argc, char **argv) {
+#ifdef WITH_XSTORE
+  XStore__save_args(argc, argv);
+#endif
+
   auto args = argv_to_vec(argc, argv);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
@@ -10671,7 +10682,8 @@ int main(int argc, char **argv) {
   g_ceph_context->_conf.apply_changes(nullptr);
 
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int gtest_result = RUN_ALL_TESTS();
+  return gtest_result;
 }
 
 /*

--- a/src/test/objectstore/store_test_fixture.cc
+++ b/src/test/objectstore/store_test_fixture.cc
@@ -12,6 +12,9 @@
 #include "os/bluestore/BlueStore.h"
 #endif
 #include "store_test_fixture.h"
+#if defined(WITH_XSTORE)
+#include "xstore-crimson.h"
+#endif
 
 using namespace std;
 

--- a/src/test/objectstore/store_test_fixture.cc
+++ b/src/test/objectstore/store_test_fixture.cc
@@ -44,11 +44,21 @@ void StoreTestFixture::SetUp()
     cerr << __func__ << ": unable to create " << data_dir << ": " << cpp_strerror(r) << std::endl;
   }
   ASSERT_EQ(0, r);
-
-  store = ObjectStore::create(g_ceph_context,
-                              type,
-                              data_dir,
-                              "store_test_temp_journal");
+#if defined(WITH_XSTORE)
+  if (type.find("xstore-") == 0) {
+    string sub_type = type.substr(7);
+    store = XStore__create(g_ceph_context,
+                           g_ceph_context->_conf.get_config_values(),
+                           sub_type,
+                           data_dir);
+  } else
+#endif
+  {
+    store = ObjectStore::create(g_ceph_context,
+                                type,
+                                data_dir,
+                                "store_test_temp_journal");
+  }
   if (!store) {
     cerr << __func__ << ": objectstore type " << type << " doesn't exist yet!" << std::endl;
   }
@@ -118,10 +128,21 @@ void StoreTestFixture::CloseAndReopen() {
   EXPECT_EQ(0, r);
   ch.reset(nullptr);
   store.reset(nullptr);
-  store = ObjectStore::create(g_ceph_context,
-                              type,
-                              data_dir,
-                              "store_test_temp_journal");
+#if defined(WITH_XSTORE)
+  if (type.find("xstore-") == 0) {
+    string sub_type = type.substr(7);
+    store = XStore__create(g_ceph_context,
+                           g_ceph_context->_conf.get_config_values(),
+                           sub_type,
+                           data_dir);
+  } else
+#endif
+  {
+    store = ObjectStore::create(g_ceph_context,
+                                type,
+                                data_dir,
+                                "store_test_temp_journal");
+  }
   if (!store) {
     cerr << __func__ << ": objectstore type " << type << " failed to reopen!" << std::endl;
   }

--- a/src/test/objectstore/store_test_fixture.h
+++ b/src/test/objectstore/store_test_fixture.h
@@ -14,11 +14,9 @@ class StoreTestFixture : virtual public ::testing::Test {
   ConfigProxy* conf = nullptr;
 
   std::string orig_death_test_style;
-
 public:
   std::unique_ptr<ObjectStore> store;
   ObjectStore::CollectionHandle ch;
-
   explicit StoreTestFixture(const std::string& type)
     : type(type), data_dir(type + ".test_temp_dir")
   {}

--- a/src/test/objectstore/xstore-crimson.cc
+++ b/src/test/objectstore/xstore-crimson.cc
@@ -1,0 +1,814 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#include "xstore-crimson.h"
+
+#include "common/ceph_argparse.h"
+#include "messages/MPing.h"
+#include "messages/MCommand.h"
+#include "crimson/auth/DummyAuth.h"
+#include "crimson/common/log.h"
+#include "crimson/net/Connection.h"
+#include "crimson/net/Dispatcher.h"
+#include "crimson/net/Messenger.h"
+
+#include <map>
+#include <random>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <seastar/core/app-template.hh>
+#include <seastar/core/do_with.hh>
+#include <seastar/core/future-util.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/with_timeout.hh>
+#include <seastar/core/alien.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/core/thread.hh>
+#include <os/ObjectStore.h>
+#include "crimson/os/futurized_collection.h"
+#include <crimson/os/futurized_store.h>
+#include <crimson/os/alienstore/semaphore.h>
+
+using namespace std::chrono_literals;
+namespace bpo = boost::program_options;
+using crimson::common::local_conf;
+
+using crimson::os::FuturizedStore;
+
+namespace ceph::common {
+class CephContext;
+}
+
+class XStore : public ObjectStore
+{
+  struct FinalizeThread : public Thread {
+    XStore *store;
+    static constexpr unsigned QUEUE_SIZE = 128;
+    crimson::counting_semaphore<QUEUE_SIZE> sem{0};
+    boost::lockfree::queue<Context*> pending{QUEUE_SIZE};
+
+    explicit FinalizeThread(XStore *s) : store(s) {}
+    void *entry() override {
+      // When semaphore is signalled but no element means stop processing.
+      bool popped = true;
+      do {
+	sem.acquire();
+	Context* c = nullptr;
+	popped = pending.pop(c);
+	if (popped) {
+	  c->complete(0);
+	}
+      } while (popped);
+      return nullptr;
+    }
+    void stop_signal() {
+      sem.release();
+    }
+    void stop_wait() {
+      join();
+    }
+  };
+
+  class OnCommit final: public Context
+  {
+    XStore* store;
+    Context *oncommit;
+  public:
+    OnCommit(
+      XStore* store,
+      Context *oncommit)
+      : store(store)
+      , oncommit(oncommit) {
+    }
+    void finish(int) override {
+      ceph_assert(oncommit);
+      store->finalize_thread.pending.push(oncommit);
+      store->finalize_thread.sem.release();
+    }
+  };
+
+  struct ReactorThread : public Thread {
+    XStore *xstore;
+    std::mutex lock;              // this is compiled with seastar, ceph::mutex
+    std::condition_variable cond; // and ceph::cond are dummies
+    seastar::semaphore stop;
+    explicit ReactorThread(XStore *s)
+      : xstore(s)
+      , stop(0) {}
+    void *entry() override {
+      std::vector<char*> xargs;
+      xargs.push_back(strdup("/me"));
+      xargs.push_back(strdup("-c"));
+      xargs.push_back(strdup("2"));
+      std::string cluster_name{"ceph"};
+      std::string conf_file_list;
+      auto ceph_args = argv_to_vec(xargs.size(), xargs.data());
+      auto init_params =
+	ceph_argparse_early_args(args, CEPH_ENTITY_TYPE_CLIENT,
+				 &cluster_name, &conf_file_list);
+      using crimson::common::sharded_conf;
+      xstore->app.add_options()
+	("verbose,v", bpo::value<bool>()->default_value(false),
+	 "chatty if true");
+      xstore->app.run(xargs.size(), xargs.data(), [&] {
+	return seastar::async([&] {
+	  sharded_conf().start(init_params.name, cluster_name).get();
+	  local_conf().parse_config_files(conf_file_list).get();
+	  local_conf().parse_env().get();
+	  local_conf().parse_argv(ceph_args).get();
+	  return;
+	}).then([&] {
+	  {
+	    // signal started
+	    std::unique_lock l{lock};
+	    cond.notify_all();
+	  }
+	  return stop.wait(1).then([] {
+	    return sharded_conf().stop();
+	  });
+	});
+      });
+      for (auto x : xargs) {
+	free(x);
+      }
+      return nullptr;
+    }
+
+    bool wait_start() {
+      std::unique_lock l{lock};
+      cond.wait(l);
+      return true;
+    }
+
+    void stop_signal() {
+      using crimson::common::sharded_conf;
+      seastar::alien::submit_to(xstore->app.alien(), 0, [this] {
+	stop.signal(1);
+	return seastar::make_ready_future<>();
+      }).wait();
+    }
+    void stop_wait() {
+      join();
+    }
+  };
+
+  seastar::app_template app;
+  FinalizeThread finalize_thread;
+  ReactorThread reactor;
+  std::unique_ptr<FuturizedStore> fstore;
+  std::string type; //FuturizedStore does not have type, save it for us
+  uuid_d osd_fsid;
+public:
+  static inline std::vector<const char*> args;
+
+  XStore(ceph::common::CephContext *cct,
+	 const std::string& type,
+	 const std::string& path)
+    : ObjectStore(cct, path)
+    , finalize_thread(this)
+    , reactor(this)
+    , type(type) {
+    finalize_thread.create("xstore-fin");
+    reactor.create("xstore-reactor");
+    reactor.wait_start();
+  }
+
+  // Actual creation moved away from constructor to give
+  // FuturizedStore::create a chance to fail.
+  bool init(const ConfigValues& cv) {
+    seastar::alien::submit_to(app.alien(), 0, [&] {
+      return crimson::os::FuturizedStore::create(type, path, cv).
+	then([&] (auto&& fstore) {
+	  this->fstore = std::move(fstore);
+	  return seastar::make_ready_future<>();
+	});
+    }).wait();
+    return bool(fstore);
+  }
+
+  ~XStore() {
+    finalize_thread.stop_signal();
+    reactor.stop_signal();
+    finalize_thread.stop_wait();
+    reactor.stop_wait();
+  }
+
+
+  objectstore_perf_stat_t get_cur_stats() override {
+    ceph_assert(0 && "not implemented");
+    return objectstore_perf_stat_t{};
+  }
+
+  const PerfCounters* get_perf_counters() const override {
+    ceph_assert(0 && "not implemented");
+    return nullptr;
+  }
+
+  std::string get_type() override {
+    //todo improve
+    return "xstore";
+  }
+
+  bool test_mount_in_use() override {
+    return true;
+  }
+
+  int mount() override {
+    seastar::alien::submit_to(app.alien(), 0, [this]
+    {
+      return fstore->start().then([this] {
+	return fstore->mount().handle_error(
+	  crimson::stateful_ec::handle([] (const auto& ec) {
+	    std::exit(EXIT_FAILURE);
+	  }));
+      });
+    }).wait();
+    return 0;
+  }
+
+  int umount() override {
+    seastar::alien::submit_to(app.alien(), 0, [this] {
+      return fstore->umount().then([this] {
+	return fstore->stop();
+      });
+    }).wait();
+    return 0;
+  }
+
+  int validate_hobject_key(const hobject_t &obj) const override {
+    ceph_assert(0 && "not implemented");
+    return 0;
+  }
+
+  unsigned get_max_attr_name_length() override {
+    ceph_assert(0 && "not implemented");
+    return 256;
+  }
+
+  int mkfs() override {
+    seastar::alien::submit_to(app.alien(), 0, [this] {
+      return fstore->start().then([this] {
+	return fstore->mkfs(osd_fsid).handle_error(
+	  crimson::stateful_ec::handle([] (const auto& ec) {
+	    std::exit(EXIT_FAILURE);
+	  })).then([this] {
+	    return fstore->stop();
+	  });
+      });
+    }).wait();
+    return 0;
+  }
+
+  int mkjournal() override {
+    return 0;
+  }
+
+  bool needs_journal() override {
+    return false;
+  }
+
+  bool wants_journal() override {
+    return false;
+  }
+
+  bool allows_journal() override {
+    return false;
+  }
+
+  int statfs(struct store_statfs_t *buf,
+	     osd_alert_list_t* alerts) override {
+    ceph_assert(0 && "not implemented");
+    return 0;
+  }
+
+  int pool_statfs(uint64_t pool_id, struct store_statfs_t *buf,
+		  bool *per_pool_omap) override {
+    ceph_assert(0 && "not implemented");
+    return 0;
+  }
+
+  struct Collection : public ObjectStore::CollectionImpl {
+    XStore* xstore;
+    crimson::os::FuturizedStore::CollectionRef col;
+    Collection(XStore* xstore,
+	       const coll_t &cid,
+	       crimson::os::FuturizedStore::CollectionRef col)
+      :CollectionImpl(xstore->cct, cid)
+      ,xstore(xstore)
+      ,col(col) {
+    }
+    ~Collection() override {
+    }
+    void flush() override {
+      seastar::alien::submit_to(xstore->app.alien(), 0, [this] {
+	  return xstore->fstore->flush(col);
+	}).wait();
+    }
+    bool flush_commit(Context *c) override {
+      seastar::alien::submit_to(xstore->app.alien(), 0, [this] {
+	  return xstore->fstore->flush(col);
+	}).wait();
+      return true;
+    }
+  };
+
+  inline const crimson::os::FuturizedStore::CollectionRef get_coll(const CollectionHandle& h) const {
+    Collection* c = static_cast<Collection*>(h.get());
+    return c->col;
+  }
+
+  ObjectStore::CollectionHandle open_collection(const coll_t &cid) override {
+    auto fcoll = seastar::alien::submit_to(app.alien(), 0, [this, cid]
+    {
+      return fstore->open_collection(cid);
+    });
+    fcoll.wait();
+    auto coll = fcoll.get();
+    if (coll) {
+      return ceph::make_ref<Collection>(this, cid, coll);
+    } else {
+      return CollectionHandle{};
+    }
+  }
+
+  ObjectStore::CollectionHandle create_new_collection(const coll_t &cid) override {
+    auto fcoll = seastar::alien::submit_to(app.alien(), 0, [this, cid]
+    {
+      return fstore->create_new_collection(cid);
+    });
+    fcoll.wait();
+    return ceph::make_ref<Collection>(this, cid, fcoll.get());
+  }
+
+  int queue_transactions(CollectionHandle& c, std::vector<Transaction>& tls,
+			 TrackedOpRef op, ThreadPool::TPHandle *handle) override {
+    auto res = seastar::alien::submit_to(app.alien(), 0, [this, &tls, &c] {
+      return seastar::do_with(tls.begin(), [this, &tls, &c] (auto&& p) {
+	return seastar::do_until(
+	  [&tls, &p] { return p == tls.end(); },
+	  [this, &p, &c ] {
+	    auto& txn = *p;
+	    p++;
+	    Context *crimson_wrapper = ceph::os::Transaction::collect_all_contexts(txn);
+	    if (crimson_wrapper)
+	      txn.register_on_commit(new OnCommit(this, crimson_wrapper));
+	    return fstore->do_transaction(get_coll(c), std::move(txn));
+	  });
+      });
+    });
+    res.wait();
+    return 0;
+  }
+
+  void set_collection_commit_queue(const coll_t &cid, ContextQueue *commit_queue) override {
+    ceph_assert(0 && "not implemented");
+  }
+
+  bool exists(CollectionHandle& c, const ghobject_t& oid) override {
+    // FuturizeStore does not have exists call.
+    // We use get_attr instead.
+    auto res = seastar::alien::submit_to(app.alien(), 0, [this, c, &oid] {
+      return fstore->get_attr(get_coll(c), oid, "=====").
+	safe_then([] (ceph::buffer::list&& attr_val) {
+	  // strangely, object does have '=====' attribute
+	  return seastar::make_ready_future<bool>(true);
+	}).
+	handle_error(
+	  crimson::ct_error::enoent::handle([] {
+	    // ENOENT means that object does not exist
+	    return seastar::make_ready_future<bool>(false);
+	  }),
+	  crimson::ct_error::enodata::handle([] {
+	    // ENODATA means that object existed only did not have attribute
+	    // It is expected result, we select attribute so it most likely did not exist
+	    return seastar::make_ready_future<bool>(true);
+	  })
+	);
+    });
+    res.wait();
+    return res.get();
+  }
+
+  int set_collection_opts(
+    CollectionHandle& c, const pool_opts_t& opts) override {
+    ceph_assert(0 && "not implemented");
+    return 0;
+  }
+
+  int stat(CollectionHandle &c, const ghobject_t& oid,
+	   struct stat *st, bool allow_eio) override {
+    auto res = seastar::alien::submit_to(app.alien(), 0, [this, c, &oid] {
+      return fstore->stat(get_coll(c), oid);
+    });
+    res.wait();
+    *st = res.get();
+    // TODO: either modify this function to check for oid existence
+    // or modify FuturizedStore::stat call
+    return 0;
+  }
+
+  int read(CollectionHandle &c, const ghobject_t& oid,
+	   uint64_t offset, size_t len,
+	   ceph::buffer::list& result_bl, uint32_t op_flags) override {
+    auto res = seastar::alien::submit_to(app.alien(), 0,
+      [=, &result_bl, &oid] () -> seastar::future<int> {
+	return fstore->read(get_coll(c), oid, offset, len, op_flags).
+	  safe_then([&result_bl] (ceph::buffer::list&& b) {
+	  result_bl = std::move(b);
+	  return seastar::make_ready_future<int>(result_bl.length());
+	}).
+	handle_error(
+	  crimson::ct_error::input_output_error::handle([] {
+	    return seastar::make_ready_future<int>(-EIO);
+	  }),
+	  crimson::ct_error::enoent::handle([] {
+	    return seastar::make_ready_future<int>(-ENOENT);
+	  })
+	);
+      });
+    res.wait();
+    return res.get();
+  }
+
+  int fiemap(CollectionHandle& c, const ghobject_t& oid,
+	     uint64_t offset, size_t len, ceph::buffer::list& bl) override {
+    std::map<uint64_t, uint64_t> destmap;
+    int r = fiemap(c, oid, offset, len, destmap);
+    encode(destmap, bl);
+    return r;
+  }
+
+  int fiemap(CollectionHandle& c, const ghobject_t& oid,
+	     uint64_t offset, size_t len, std::map<uint64_t, uint64_t>& destmap) override {
+  using crimson::ct_error::input_output_error;
+    auto res = seastar::alien::submit_to(app.alien(), 0, [=, &oid, &destmap] {
+      return fstore->fiemap(get_coll(c), oid, offset, len).
+	safe_then([&destmap] (std::map<uint64_t, uint64_t>&& fmap) {
+	  destmap = std::move(fmap);
+	  return seastar::make_ready_future<int>(0);
+	}).
+	handle_error(
+	  input_output_error::handle([] {
+	    return seastar::make_ready_future<int>(-EIO);
+	  }),
+	  crimson::ct_error::enoent::handle([] {
+	    return seastar::make_ready_future<int>(-ENOENT);
+	  })
+	);
+    });
+    res.wait();
+    return res.get();
+  }
+
+  int readv(CollectionHandle &c, const ghobject_t& oid,
+	    interval_set<uint64_t>& m, ceph::buffer::list& bl,
+	    uint32_t op_flags) override {
+    ceph_assert(0 && "not implemented");
+    return 0;
+  }
+
+  int dump_onode(CollectionHandle &c, const ghobject_t& oid,
+		 const std::string& section_name, ceph::Formatter *f) override {
+    ceph_assert(0 && "not implemented");
+    return 0;
+  }
+
+  int getattr(CollectionHandle &c, const ghobject_t& oid,
+	      const char *name, ceph::buffer::ptr& value) override {
+    auto res = seastar::alien::submit_to(app.alien(), 0, [=, &oid, &value] {
+      return fstore->get_attr(get_coll(c), oid, name).
+	safe_then([&value] (ceph::bufferlist&& v) {
+	  // convert buffer::list to buffer::ptr
+	  // TODO maybe just extract first buffer::ptr from the buffer::list ?
+	  ceph::buffer::ptr value1(v.c_str(), v.length());
+	  value = std::move(value1);
+	  return seastar::make_ready_future<int>(0);
+	}).
+	handle_error(
+	  crimson::ct_error::enodata::handle([] {
+	    return seastar::make_ready_future<int>(-ENODATA);
+	  }),
+	  crimson::ct_error::enoent::handle([] {
+	    return seastar::make_ready_future<int>(-ENOENT);
+	  })
+	);
+    });
+    res.wait();
+    return res.get();
+  }
+
+  int getattrs(CollectionHandle &c, const ghobject_t& oid,
+	       std::map<std::string,ceph::buffer::ptr, std::less<>>& aset) override {
+    auto res = seastar::alien::submit_to(app.alien(), 0, [=, &oid, &aset] {
+      return fstore->get_attrs(get_coll(c), oid).
+	safe_then([&aset] (std::map<std::string, ceph::bufferlist, std::less<>>&& fset) {
+	  aset.clear();
+	  auto hint = aset.begin();
+	  for (auto& [n, v] : fset) {
+	    hint = aset.emplace_hint(hint, n, ceph::buffer::ptr(v.c_str(), v.length()));
+	  }
+	  return seastar::make_ready_future<int>(0);
+	}).
+	handle_error(
+	  crimson::ct_error::enoent::handle([] {
+	    return seastar::make_ready_future<int>(-ENOENT);
+	  })
+	);
+    });
+    res.wait();
+    return res.get();
+  }
+
+  int list_collections(std::vector<coll_t>& ls) override {
+    ceph_assert(0 && "not implemented");
+    return 0;
+  }
+
+  bool collection_exists(const coll_t& cid) override {
+    auto res = seastar::alien::submit_to(app.alien(), 0, [this, cid]
+    {
+      return fstore->open_collection(cid);
+    });
+    res.wait();
+    return bool(res.get());
+  }
+
+  int collection_empty(CollectionHandle& c, bool *empty) override {
+    ghobject_t next;
+    std::vector<ghobject_t> ls;
+    int r = collection_list(c, ghobject_t(), ghobject_t::get_max(), 1, &ls, &next);
+    *empty = ls.size() == 0;
+    return r;
+  }
+
+  int collection_bits(CollectionHandle& c) override {
+    ceph_assert(0 && "not implemented");
+    return 0;
+  }
+
+  int collection_list(CollectionHandle &c, const ghobject_t& start,
+		      const ghobject_t& end, int max,
+		      std::vector<ghobject_t> *ls, ghobject_t *next) override {
+    auto res = seastar::alien::submit_to(app.alien(), 0, [=, &start, &end] {
+      return fstore->list_objects(get_coll(c), start, end, max).
+	then([ls, next] (std::tuple<std::vector<ghobject_t>, ghobject_t>&& list_next) {
+	  *ls = std::get<0>(list_next);
+	  if (next) {
+	    *next = std::get<1>(list_next);
+	  }
+	  return seastar::make_ready_future<>();
+	});
+    });
+    res.wait();
+    return 0;
+  }
+
+  int omap_get(CollectionHandle &c, const ghobject_t &oid, ceph::buffer::list *header,
+	       std::map<std::string, ceph::buffer::list> *k_v) override {
+    auto res = seastar::alien::submit_to(app.alien(), 0, [=, &oid] {
+      std::optional<std::string> start; //uninitialized, list from begin
+      std::function<FuturizedStore::read_errorator::future<>(const std::optional<std::string>&& start)> more_omaps;
+      // Strangely, defining and setting of more_omaps must be in separate statements.
+      // Assignment in definition "std::function<...> more_omaps = [] ...;" compiles, but gives faulty code.
+      more_omaps = [=, &oid] (const std::optional<std::string>&& start) -> FuturizedStore::read_errorator::future<> {
+	return fstore->omap_get_values(get_coll(c), oid, start).
+	safe_then([k_v, more_omaps] (std::tuple<bool, FuturizedStore::omap_values_t>&& done_omaps) {
+	  bool done = std::get<0>(done_omaps);
+	  auto& kvs = std::get<1>(done_omaps);
+	  auto hint = k_v->end();
+	  for (auto i = kvs.begin(); i != kvs.end(); ++i) {
+	    hint = k_v->emplace_hint(hint, i->first, i->second);
+	  }
+	  if (!done) {
+	    return more_omaps(kvs.rbegin()->first);
+	  }
+	  return FuturizedStore::read_errorator::now();
+	});
+      };
+      return more_omaps(std::optional<std::string>()). /*string not present - start from beginning*/
+	safe_then([=, &oid] () {
+	  return fstore->omap_get_header(get_coll(c), oid).
+	    safe_then([header] (ceph::bufferlist&& v) {
+	      *header = std::move(v);
+	      return seastar::make_ready_future<int>(0);
+	    });
+	}).
+	handle_error(
+	  crimson::ct_error::input_output_error::handle([] {
+	    return seastar::make_ready_future<int>(-EIO);
+	  }),
+	  crimson::ct_error::enodata::handle([] {
+	    return seastar::make_ready_future<int>(-ENODATA);
+	  }),
+	  crimson::ct_error::enoent::handle([] {
+	    return seastar::make_ready_future<int>(-ENOENT);
+	  })
+	);
+    });
+    res.wait();
+    return res.get();
+  }
+
+  int omap_get_header(CollectionHandle &c, const ghobject_t &oid,
+		      ceph::buffer::list *header, bool allow_eio) override {
+    auto res = seastar::alien::submit_to(app.alien(), 0, [=, &oid] {
+      return fstore->omap_get_header(get_coll(c), oid).
+	safe_then([header] (ceph::bufferlist&& v) {
+	  *header = v;
+	  return seastar::make_ready_future<int>(0);
+	}).
+	handle_error(
+	  crimson::ct_error::enodata::handle([] {
+	    return seastar::make_ready_future<int>(-ENODATA);
+	  }),
+	  crimson::ct_error::enoent::handle([] {
+	    return seastar::make_ready_future<int>(-ENOENT);
+	  })
+	);
+    });
+    res.wait();
+    return res.get();
+  }
+
+  int omap_get_keys(CollectionHandle &c, const ghobject_t &oid,
+		    std::set<std::string> *keys) override {
+    keys->clear();
+    auto res = seastar::alien::submit_to(app.alien(), 0, [=, &oid] {
+      std::function<FuturizedStore::read_errorator::future<>(const std::optional<std::string>&& start)> more_omaps;
+      more_omaps = [=, &oid] (const std::optional<std::string>&& start) -> FuturizedStore::read_errorator::future<> {
+	return fstore->omap_get_values(get_coll(c), oid, start).
+	safe_then([keys, more_omaps] (std::tuple<bool, FuturizedStore::omap_values_t>&& done_omaps) {
+	  bool done = std::get<0>(done_omaps);
+	  auto k_v = std::get<1>(done_omaps);
+	  auto hint = keys->end();
+	  for (auto& [k, v] : k_v) {
+	    hint = keys->emplace_hint(hint, k);
+	  }
+	  if (!done) {
+	    return more_omaps(k_v.rbegin()->first);
+	  }
+	  return FuturizedStore::read_errorator::now();
+	});
+      };
+
+      return
+	more_omaps(std::optional<std::string>()).
+	safe_then([] {
+	  return seastar::make_ready_future<int>(0);
+	}).
+	handle_error(
+	  crimson::ct_error::input_output_error::handle([] {
+	    return seastar::make_ready_future<int>(-EIO);
+	  }),
+	  crimson::ct_error::enoent::handle([] {
+	    return seastar::make_ready_future<int>(-ENOENT);
+	  })
+	);
+    });
+    res.wait();
+    return res.get();
+  }
+
+  int omap_get_values(CollectionHandle &c, const ghobject_t &oid,
+		      const std::set<std::string> &keys,
+		      std::map<std::string, ceph::buffer::list> *out) override {
+    auto res = seastar::alien::submit_to(app.alien(), 0,
+      [=, &oid, &keys]() -> seastar::future<int> {
+	return fstore->omap_get_values(get_coll(c), oid, keys).
+	  safe_then([=] (FuturizedStore::omap_values_t&& values) {
+	    for (auto& i : values) {
+	      out->emplace(i);
+	    }
+	    return seastar::make_ready_future<int>(0);
+	  }).
+	  handle_error(
+	    crimson::ct_error::input_output_error::handle([] {
+	      return seastar::make_ready_future<int>(-EIO);
+	    }),
+	    crimson::ct_error::enoent::handle([] {
+	      return seastar::make_ready_future<int>(-ENOENT);
+	    })
+	  );
+      });
+    res.wait();
+    return res.get();
+  }
+
+  int omap_get_values(CollectionHandle &c, const ghobject_t &oid,
+		      const std::optional<std::string> &start_after,
+		      std::map<std::string, ceph::buffer::list> *out) override {
+    return -ENOTSUP;
+  }
+
+  int omap_check_keys(CollectionHandle &c, const ghobject_t &oid,
+		      const std::set<std::string> &keys, std::set<std::string> *out) override {
+    ceph_assert(0 && "not implemented");
+    return 0;
+  }
+
+  class OmapIteratorImpl : public ObjectMap::ObjectMapIteratorImpl {
+    crimson::os::FuturizedStore::OmapIteratorRef oit;
+    XStore* xstore;
+  public:
+    OmapIteratorImpl(XStore* xstore,
+		     crimson::os::FuturizedStore::CollectionRef col,
+		     const ghobject_t &oid)
+      :xstore(xstore)
+    {
+      seastar::alien::submit_to(xstore->app.alien(), 0, [&]
+      {
+	return xstore->fstore->get_omap_iterator(col, oid).
+	  then([&] (auto oit) {
+	    this->oit = std::move(oit);
+	    return seastar::make_ready_future<>();
+	  });
+      }).wait();
+    }
+    ~OmapIteratorImpl() override {
+    }
+    int seek_to_first() override {
+      auto res = seastar::alien::submit_to(xstore->app.alien(), 0, [this]
+      {
+	return oit->seek_to_first();
+      });
+      res.wait();
+      return 0;
+    }
+    int upper_bound(const std::string &after) override {
+      seastar::alien::submit_to(xstore->app.alien(), 0, [this, &after]
+      {
+	return oit->upper_bound(after);
+      }).wait();
+      return 0;
+    }
+    int lower_bound(const std::string &to) override {
+      seastar::alien::submit_to(xstore->app.alien(), 0, [this, &to]
+      {
+	return oit->lower_bound(to);
+      }).wait();
+      return 0;
+    }
+    bool valid() override {
+      return oit->valid();
+    }
+    int next() override {
+      seastar::alien::submit_to(xstore->app.alien(), 0, [this]
+      {
+	return oit->next();
+      }).wait();
+      return 0;
+    }
+    std::string key() override {
+      return oit->key();
+    }
+    ceph::buffer::list value() override {
+      return oit->value();
+    }
+    std::string tail_key() override {
+      ceph_assert(0 && "unable to calculate tail_key");
+      return "";
+    }
+    int status() override {
+      return oit->status();
+    }
+  };
+
+  ObjectMap::ObjectMapIterator
+  get_omap_iterator(CollectionHandle &c, const ghobject_t &oid) override {
+    return ObjectMap::ObjectMapIterator(new OmapIteratorImpl(this, get_coll(c), oid));
+  }
+
+  void set_fsid(uuid_d u) override {
+    osd_fsid = u;
+  }
+
+  uuid_d get_fsid() override {
+    return osd_fsid;
+  }
+
+  uint64_t estimate_objects_overhead(uint64_t num_objects) override {
+    ceph_assert(0 && "not implemented");
+    return 0;
+  }
+};
+
+std::unique_ptr<ObjectStore> XStore__create(
+  ceph::common::CephContext *cct,
+  const ConfigValues& cv,
+  const std::string& type,
+  const std::string& data)
+{
+  XStore* xstore = new XStore(cct, type, data);
+  if (!xstore->init(cv)) {
+    delete xstore;
+    xstore = nullptr;
+  }
+  return std::unique_ptr<ObjectStore>(xstore);
+}
+
+void XStore__save_args(int argc, char** argv) {
+  for (int i = 0; i < argc; i++) {
+    XStore::args.push_back(argv[i]);
+  }
+}
+

--- a/src/test/objectstore/xstore-crimson.h
+++ b/src/test/objectstore/xstore-crimson.h
@@ -1,0 +1,20 @@
+#include <common/config_values.h>
+#include "os/ObjectStore.h"
+
+
+// Functions
+// - XStore__create
+// - XStore__save_args
+// are not part of XStore class to avoid type definition collision.
+// Nothing here depends on WITH_SEASTAR define. This file can be included by crimson and classic.
+// But even the declaration of XStore class requires crimson.
+
+std::unique_ptr<ObjectStore> XStore__create(
+  ceph::common::CephContext *cct,
+  const ConfigValues& cf,
+  const std::string& type,
+  const std::string& data);
+
+// Saves args used to start ceph_test_objectstore for initialization of the reactor.
+void XStore__save_args(int argc, char** argv);
+

--- a/src/test/osd/CMakeLists.txt
+++ b/src/test/osd/CMakeLists.txt
@@ -87,10 +87,10 @@ target_link_libraries(unittest_scrub_sched osd os global ${CMAKE_DL_LIBS} mon ${
 add_executable(unittest_pglog
   TestPGLog.cc
   $<TARGET_OBJECTS:unit-main>
-  $<TARGET_OBJECTS:store_test_fixture>
   )
 add_ceph_unittest(unittest_pglog)
-target_link_libraries(unittest_pglog osd os global ${CMAKE_DL_LIBS} ${BLKID_LIBRARIES})
+target_link_libraries(unittest_pglog
+  osd os global ${CMAKE_DL_LIBS} ${BLKID_LIBRARIES} store_test_fixture)
 
 # unittest_hitset
 add_executable(unittest_hitset


### PR DESCRIPTION
This PR intends to provide a way to reuse functional test made for ObjectStore `ceph_test_objectstore` to be applied for any FuturizedStore.
The gist of it is that new Objectstore `xstore` that is implemented using FuturizedStore interface.
On creation `xstore` gets name of FuturizedStore to instantiate. 
Reactor is created for a lifetime of the futurized store.

`ceph_test_objectstore` is extended with ObjectStore index 4 = xstore-objectstore.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
