### PR TITLE
mgr/dashboard: move replaying images to Syncing tab

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -4,7 +4,7 @@ import json
 import logging
 import re
 from functools import partial
-from typing import no_type_check
+from typing import NamedTuple, Optional, no_type_check
 
 import cherrypy
 import rbd
@@ -199,6 +199,13 @@ def get_daemons_and_pools():  # pylint: disable=R0915
     }
 
 
+class ReplayingData(NamedTuple):
+    bytes_per_second: Optional[int] = None
+    seconds_until_synced: Optional[int] = None
+    syncing_percent: Optional[float] = None
+    entries_behind_primary: Optional[int] = None
+
+
 @ViewCache()
 @no_type_check
 def _get_pool_datum(pool_name):
@@ -250,8 +257,9 @@ def _get_pool_datum(pool_name):
         rbd.MIRROR_IMAGE_STATUS_STATE_STOPPED: {
             'health': 'ok',
             'state_color': 'info',
-            'state': 'Primary'
+            'state': 'Stopped'
         }
+
     }
 
     rbdctx = rbd.RBD()
@@ -271,6 +279,29 @@ def _get_pool_datum(pool_name):
         raise
 
     return data
+
+
+def _update_syncing_image_data(mirror_image, image):
+    if mirror_image['state'] == 'Replaying':
+        p = re.compile("replaying, ({.*})")
+        replaying_data = p.findall(mirror_image['description'])
+        assert len(replaying_data) == 1
+        replaying_data = json.loads(replaying_data[0])
+        if 'replay_state' in replaying_data and replaying_data['replay_state'] == 'idle':
+            image.update({
+                'state_color': 'info',
+                'state': 'Idle'
+            })
+        for field in ReplayingData._fields:
+            try:
+                image[field] = replaying_data[field]
+            except KeyError:
+                pass
+    else:
+        p = re.compile("bootstrapping, IMAGE_COPY/COPY_OBJECT (.*)%")
+        image.update({
+            'progress': (p.findall(mirror_image['description']) or [0])[0]
+        })
 
 
 @ViewCache()
@@ -309,22 +340,7 @@ def _get_content_data():  # pylint: disable=R0914
                 })
                 image_ready.append(image)
             elif mirror_image['health'] == 'syncing':
-                if mirror_image['state'] == 'Replaying':
-                    p = re.compile("replaying, ({.*})")
-                    replaying_data = p.findall(mirror_image['description'])
-                    assert len(replaying_data) == 1
-                    replaying_data = json.loads(replaying_data[0])
-                    seconds_until_synced = 0
-                    if 'seconds_until_synced' in replaying_data:
-                        seconds_until_synced = replaying_data['seconds_until_synced']
-                    image.update({
-                        'seconds_until_synced': seconds_until_synced
-                    })
-                else:
-                    p = re.compile("bootstrapping, IMAGE_COPY/COPY_OBJECT (.*)%")
-                    image.update({
-                        'progress': (p.findall(mirror_image['description']) or [0])[0]
-                    })
+                _update_syncing_image_data(mirror_image, image)
                 image_syncing.append(image)
             else:
                 image.update({

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/block/mirroring.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/block/mirroring.e2e-spec.ts
@@ -20,9 +20,9 @@ describe('Mirroring page', () => {
   });
 
   it('should show text for all tabs', () => {
-    mirroring.getTabText(0).should('eq', 'Issues');
-    mirroring.getTabText(1).should('eq', 'Syncing');
-    mirroring.getTabText(2).should('eq', 'Ready');
+    mirroring.getTabText(0).should('eq', 'Issues (0)');
+    mirroring.getTabText(1).should('eq', 'Syncing (0)');
+    mirroring.getTabText(2).should('eq', 'Ready (0)');
   });
 
   describe('checks that edit mode functionality shows in the pools table', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.html
@@ -57,7 +57,7 @@
   <div *ngIf="row.state === 'Replaying'">
   </div>
   <ngb-progressbar *ngIf="row.state === 'Syncing'"
-                    type="info"
+                   type="info"
                    [value]="value"
                    [showValue]="true"></ngb-progressbar>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.html
@@ -4,7 +4,7 @@
     cdStatefulTab="image-list">
   <li ngbNavItem="issues">
     <a ngbNavLink
-       i18n>Issues</a>
+       i18n>Issues ({{ image_error.data.length }})</a>
     <ng-template ngbNavContent>
       <cd-table [data]="image_error.data"
                 columnMode="flex"
@@ -17,7 +17,7 @@
   </li>
   <li ngbNavItem="syncing">
     <a ngbNavLink
-       i18n>Syncing</a>
+       i18n>Syncing ({{ image_syncing.data.length }})</a>
     <ng-template ngbNavContent>
       <cd-table [data]="image_syncing.data"
                 columnMode="flex"
@@ -30,7 +30,7 @@
   </li>
   <li ngbNavItem="ready">
     <a ngbNavLink
-       i18n>Ready</a>
+       i18n>Ready ({{ image_ready.data.length }})</a>
     <ng-template ngbNavContent>
       <cd-table [data]="image_ready.data"
                 columnMode="flex"
@@ -51,14 +51,19 @@
   <span [ngClass]="row.state_color | mirrorHealthColor">{{ value }}</span>
 </ng-template>
 
-<ng-template #syncTmpl>
-  <span class="badge badge-info"
-        i18n>Syncing</span>
-</ng-template>
-
 <ng-template #progressTmpl
+             let-row="row"
              let-value="value">
-  <ngb-progressbar type="info"
+  <div *ngIf="row.state === 'Replaying'">
+    <span *ngIf="row.seconds_until_synced == 0">
+      synced
+    </span>
+    <span *ngIf="row.seconds_until_synced > 0">
+      {{row.seconds_until_synced | duration }} until synced
+    </span>
+  </div>
+  <ngb-progressbar *ngIf="row.state === 'Syncing'"
+                    type="info"
                    [value]="value"
                    [showValue]="true"></ngb-progressbar>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.html
@@ -55,12 +55,6 @@
              let-row="row"
              let-value="value">
   <div *ngIf="row.state === 'Replaying'">
-    <span *ngIf="row.seconds_until_synced == 0">
-      synced
-    </span>
-    <span *ngIf="row.seconds_until_synced > 0">
-      {{row.seconds_until_synced | duration }} until synced
-    </span>
   </div>
   <ngb-progressbar *ngIf="row.state === 'Syncing'"
                     type="info"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.ts
@@ -41,42 +41,44 @@ export class ImageListComponent implements OnInit, OnDestroy {
     this.image_error.columns = [
       { prop: 'pool_name', name: $localize`Pool`, flexGrow: 2 },
       { prop: 'name', name: $localize`Image`, flexGrow: 2 },
-      { prop: 'description', name: $localize`Issue`, flexGrow: 4 },
       {
         prop: 'state',
         name: $localize`State`,
         cellTemplate: this.stateTmpl,
         flexGrow: 1
-      }
+      },
+      { prop: 'description', name: $localize`Issue`, flexGrow: 4 },
     ];
 
     this.image_syncing.columns = [
       { prop: 'pool_name', name: $localize`Pool`, flexGrow: 2 },
       { prop: 'name', name: $localize`Image`, flexGrow: 2 },
+			{
+        prop: 'state',
+        name: $localize`State`,
+        cellTemplate: this.stateTmpl,
+        flexGrow: 1
+      },
       {
         prop: 'progress',
         name: $localize`Progress`,
         cellTemplate: this.progressTmpl,
         flexGrow: 2
       },
-      {
-        prop: 'state',
-        name: $localize`State`,
-        cellTemplate: this.stateTmpl,
-        flexGrow: 1
-      }
+      { prop: 'bytes_per_second', name: $localize`Bytes per second`, flexGrow: 2 },
+			{ prop: 'entries_behind_primary', name: $localize`Entries behind primary`, flexGrow: 2 },
     ];
 
     this.image_ready.columns = [
       { prop: 'pool_name', name: $localize`Pool`, flexGrow: 2 },
       { prop: 'name', name: $localize`Image`, flexGrow: 2 },
-      { prop: 'description', name: $localize`Description`, flexGrow: 4 },
       {
         prop: 'state',
         name: $localize`State`,
         cellTemplate: this.stateTmpl,
         flexGrow: 1
-      }
+      },
+      { prop: 'description', name: $localize`Description`, flexGrow: 4 },
     ];
 
     this.subs = this.rbdMirroringService.subscribeSummary((data) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.ts
@@ -47,13 +47,13 @@ export class ImageListComponent implements OnInit, OnDestroy {
         cellTemplate: this.stateTmpl,
         flexGrow: 1
       },
-      { prop: 'description', name: $localize`Issue`, flexGrow: 4 },
+      { prop: 'description', name: $localize`Issue`, flexGrow: 4 }
     ];
 
     this.image_syncing.columns = [
       { prop: 'pool_name', name: $localize`Pool`, flexGrow: 2 },
       { prop: 'name', name: $localize`Image`, flexGrow: 2 },
-			{
+      {
         prop: 'state',
         name: $localize`State`,
         cellTemplate: this.stateTmpl,
@@ -66,7 +66,7 @@ export class ImageListComponent implements OnInit, OnDestroy {
         flexGrow: 2
       },
       { prop: 'bytes_per_second', name: $localize`Bytes per second`, flexGrow: 2 },
-			{ prop: 'entries_behind_primary', name: $localize`Entries behind primary`, flexGrow: 2 },
+      { prop: 'entries_behind_primary', name: $localize`Entries behind primary`, flexGrow: 2 }
     ];
 
     this.image_ready.columns = [
@@ -78,7 +78,7 @@ export class ImageListComponent implements OnInit, OnDestroy {
         cellTemplate: this.stateTmpl,
         flexGrow: 1
       },
-      { prop: 'description', name: $localize`Description`, flexGrow: 4 },
+      { prop: 'description', name: $localize`Description`, flexGrow: 4 }
     ];
 
     this.subs = this.rbdMirroringService.subscribeSummary((data) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/image-list/image-list.component.ts
@@ -62,7 +62,7 @@ export class ImageListComponent implements OnInit, OnDestroy {
       {
         prop: 'state',
         name: $localize`State`,
-        cellTemplate: this.syncTmpl,
+        cellTemplate: this.stateTmpl,
         flexGrow: 1
       }
     ];


### PR DESCRIPTION
Images with 'Replaying' state will be displayed in Syncing tab. syncTmpl
removed as it was unnecessary if sate is provided from the backend.


![image](https://user-images.githubusercontent.com/30913090/172450389-35df556b-5b3b-465c-a832-da006aedc199.png)

Fixes: https://tracker.ceph.com/issues/55795
Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
