### PR TITLE
crimson/os/seastore: implement generational GC

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -29,6 +29,8 @@ namespace crimson::os::seastore {
 struct segment_info_t {
   using time_point = seastar::lowres_system_clock::time_point;
 
+  segment_id_t id = NULL_SEG_ID;
+
   // segment_info_t is initiated as set_empty()
   Segment::segment_state_t state = Segment::segment_state_t::EMPTY;
 
@@ -195,6 +197,12 @@ public:
   void reset();
 
   void add_segment_manager(SegmentManager &segment_manager);
+
+  void assign_ids() {
+    for (auto &item : segments) {
+      item.second.id = item.first;
+    }
+  }
 
   // initiate non-empty segments, the others are by default empty
   void init_closed(segment_id_t, segment_seq_t, segment_type_t,
@@ -1156,6 +1164,9 @@ private:
   double get_reclaim_ratio() const {
     if (segments.get_unavailable_bytes() == 0) return 0;
     return (double)get_unavailable_unused_bytes() / (double)segments.get_unavailable_bytes();
+  }
+  double get_alive_ratio() const {
+    return stats.used_bytes / (double)segments.get_total_bytes();
   }
 
   /*

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -546,8 +546,8 @@ public:
 	  12,   // target_journal_segments
 	  16,   // max_journal_segments
 	  2,	// target_backref_inflight_segments
-	  .1,   // available_ratio_gc_max
-	  .05,  // available_ratio_hard_limit
+	  .15,  // available_ratio_gc_max
+	  .1,   // available_ratio_hard_limit
 	  .1,   // reclaim_ratio_gc_threshold
 	  1<<20,// reclaim_bytes_per_cycle
 	  1<<17,// rewrite_dirty_bytes_per_cycle

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1068,7 +1068,7 @@ private:
   } gc_process;
 
   using gc_ertr = work_ertr::extend_ertr<
-    SegmentManagerGroup::scan_extents_ertr
+    SegmentManagerGroup::scan_valid_records_ertr
     >;
 
   gc_cycle_ret do_gc_cycle();
@@ -1241,13 +1241,10 @@ private:
     }
   }
 
-  using scan_extents_ret_bare =
-    std::vector<std::pair<segment_id_t, segment_header_t>>;
-  using scan_extents_ertr = SegmentManagerGroup::scan_extents_ertr;
+  using scan_extents_ertr = SegmentManagerGroup::scan_valid_records_ertr;
   using scan_extents_ret = scan_extents_ertr::future<>;
-  scan_extents_ret scan_nonfull_segment(
+  scan_extents_ret scan_no_tail_segment(
     const segment_header_t& header,
-    scan_extents_ret_bare& segment_set,
     segment_id_t segment_id);
 
   /**

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -313,7 +313,9 @@ public:
   static mkfs_ret mkfs(op_context_t<node_key_t> c) {
     auto root_leaf = c.cache.template alloc_new_extent<leaf_node_t>(
       c.trans,
-      node_size);
+      node_size,
+      placement_hint_t::HOT,
+      0);
     root_leaf->set_size(0);
     fixed_kv_node_meta_t<node_key_t> meta{min_max_t<node_key_t>::min, min_max_t<node_key_t>::max, 1};
     root_leaf->set_meta(meta);
@@ -814,7 +816,9 @@ public:
         std::remove_reference_t<decltype(fixed_kv_extent)>
         >(
         c.trans,
-        fixed_kv_extent.get_length());
+        fixed_kv_extent.get_length(),
+        fixed_kv_extent.get_user_hint(),
+        fixed_kv_extent.get_reclaim_generation());
       fixed_kv_extent.get_bptr().copy_out(
         0,
         fixed_kv_extent.get_length(),
@@ -1400,7 +1404,7 @@ private:
 
     if (split_from == iter.get_depth()) {
       auto nroot = c.cache.template alloc_new_extent<internal_node_t>(
-        c.trans, node_size);
+        c.trans, node_size, placement_hint_t::HOT, 0);
       fixed_kv_node_meta_t<node_key_t> meta{
         min_max_t<node_key_t>::min, min_max_t<node_key_t>::max, iter.get_depth() + 1};
       nroot->set_meta(meta);

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -823,6 +823,7 @@ public:
         0,
         fixed_kv_extent.get_length(),
         n_fixed_kv_extent->get_bptr().c_str());
+      n_fixed_kv_extent->set_modify_time(fixed_kv_extent.get_modify_time());
       n_fixed_kv_extent->pin.set_range(n_fixed_kv_extent->get_node_meta());
       
       /* This is a bit underhanded.  Any relative addrs here must necessarily

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -154,9 +154,9 @@ struct FixedKVInternalNode
   std::tuple<Ref, Ref, NODE_KEY>
   make_split_children(op_context_t<NODE_KEY> c) {
     auto left = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size);
+      c.trans, node_size, placement_hint_t::HOT, 0);
     auto right = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size);
+      c.trans, node_size, placement_hint_t::HOT, 0);
     auto pivot = this->split_into(*left, *right);
     left->pin.set_range(left->get_meta());
     right->pin.set_range(right->get_meta());
@@ -170,7 +170,7 @@ struct FixedKVInternalNode
     op_context_t<NODE_KEY> c,
     Ref &right) {
     auto replacement = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size);
+      c.trans, node_size, placement_hint_t::HOT, 0);
     replacement->merge_from(*this, *right->template cast<node_type_t>());
     replacement->pin.set_range(replacement->get_meta());
     return replacement;
@@ -184,9 +184,9 @@ struct FixedKVInternalNode
     ceph_assert(_right->get_type() == this->get_type());
     auto &right = *_right->template cast<node_type_t>();
     auto replacement_left = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size);
+      c.trans, node_size, placement_hint_t::HOT, 0);
     auto replacement_right = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size);
+      c.trans, node_size, placement_hint_t::HOT, 0);
 
     auto pivot = this->balance_into_new_nodes(
       *this,
@@ -355,9 +355,9 @@ struct FixedKVLeafNode
   std::tuple<Ref, Ref, NODE_KEY>
   make_split_children(op_context_t<NODE_KEY> c) {
     auto left = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size);
+      c.trans, node_size, placement_hint_t::HOT, 0);
     auto right = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size);
+      c.trans, node_size, placement_hint_t::HOT, 0);
     auto pivot = this->split_into(*left, *right);
     left->pin.set_range(left->get_meta());
     right->pin.set_range(right->get_meta());
@@ -371,7 +371,7 @@ struct FixedKVLeafNode
     op_context_t<NODE_KEY> c,
     Ref &right) {
     auto replacement = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size);
+      c.trans, node_size, placement_hint_t::HOT, 0);
     replacement->merge_from(*this, *right->template cast<node_type_t>());
     replacement->pin.set_range(replacement->get_meta());
     return replacement;
@@ -385,9 +385,9 @@ struct FixedKVLeafNode
     ceph_assert(_right->get_type() == this->get_type());
     auto &right = *_right->template cast<node_type_t>();
     auto replacement_left = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size);
+      c.trans, node_size, placement_hint_t::HOT, 0);
     auto replacement_right = c.cache.template alloc_new_extent<node_type_t>(
-      c.trans, node_size);
+      c.trans, node_size, placement_hint_t::HOT, 0);
 
     auto pivot = this->balance_into_new_nodes(
       *this,

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -712,6 +712,7 @@ void Cache::add_to_dirty(CachedExtentRef ref)
 {
   assert(ref->is_dirty());
   assert(!ref->primary_ref_list_hook.is_linked());
+  ceph_assert(ref->get_modify_time() != NULL_TIME);
   intrusive_ptr_add_ref(&*ref);
   dirty.push_back(*ref);
   stats.dirty_bytes += ref->get_length();
@@ -1025,10 +1026,6 @@ record_t Cache::prepare_record(
 
   record_t record;
   auto commit_time = seastar::lowres_system_clock::now();
-  record.commit_time = commit_time.time_since_epoch().count();
-  record.commit_type = (t.get_src() == Transaction::src_t::MUTATE)
-			? record_commit_type_t::MODIFY
-			: record_commit_type_t::REWRITE;
 
   // Add new copy of mutated blocks, set_io_wait to block until written
   record.deltas.reserve(t.mutated_block_list.size());
@@ -1046,12 +1043,12 @@ record_t Cache::prepare_record(
     auto delta_length = delta_bl.length();
     DEBUGT("mutated extent with {}B delta, commit replace extent ... -- {}, prior={}",
            t, delta_length, *i, *i->prior_instance);
+    i->set_modify_time(commit_time);
     commit_replace_extent(t, i, i->prior_instance);
 
     i->prepare_write();
     i->set_io_wait();
 
-    i->set_last_modified(commit_time);
     assert(i->get_version() > 0);
     auto final_crc = i->get_crc32c();
     if (i->get_type() == extent_types_t::ROOT) {
@@ -1155,14 +1152,11 @@ record_t Cache::prepare_record(
       ceph_assert(0 == "ROOT never gets written as a fresh block");
     }
 
-    if (t.get_src() == Transaction::src_t::MUTATE) {
-      i->set_last_modified(commit_time);
-    } else {
-      assert(is_cleaner_transaction(t.get_src()));
-      i->set_last_rewritten(commit_time);
-    }
-
     assert(bl.length() == i->get_length());
+    auto modify_time = i->get_modify_time();
+    if (modify_time == NULL_TIME) {
+      modify_time = commit_time;
+    }
     record.push_back(extent_t{
 	i->get_type(),
 	i->is_logical()
@@ -1170,9 +1164,9 @@ record_t Cache::prepare_record(
 	: (is_lba_node(i->get_type())
 	  ? i->cast<lba_manager::btree::LBANode>()->get_node_meta().begin
 	  : L_ADDR_NULL),
-	std::move(bl),
-	i->get_last_modified().time_since_epoch().count()
-      });
+	std::move(bl)
+      },
+      modify_time);
     if (i->is_valid()
 	&& is_backref_mapped_extent_node(i)) {
       alloc_delta.alloc_blk_ranges.emplace_back(
@@ -1241,10 +1235,14 @@ record_t Cache::prepare_record(
     assert(ool_stats.is_clear());
   }
 
+  if (record.modify_time == NULL_TIME) {
+    record.modify_time = commit_time;
+  }
+
   SUBDEBUGT(seastore_t,
       "commit H{} dirty_from={}, {} read, {} fresh with {} invalid, "
       "{} delta, {} retire, {}(md={}B, data={}B) ool-records, "
-      "{}B md, {}B data",
+      "{}B md, {}B data, modify_time={}",
       t, (void*)&t.get_handle(),
       get_oldest_dirty_from().value_or(JOURNAL_SEQ_NULL),
       read_stat,
@@ -1256,7 +1254,8 @@ record_t Cache::prepare_record(
       ool_stats.md_bytes,
       ool_stats.get_data_bytes(),
       record.size.get_raw_mdlength(),
-      record.size.dlength);
+      record.size.dlength,
+      sea_time_point_printer_t{record.modify_time});
   if (is_cleaner_transaction(trans_src)) {
     // CLEANER transaction won't contain any onode tree operations
     assert(t.onode_tree_stats.is_clear());
@@ -1399,13 +1398,7 @@ void Cache::complete_commit(
       if (cleaner) {
 	cleaner->mark_space_used(
 	  i->get_paddr(),
-	  i->get_length(),
-	  (t.get_src() == Transaction::src_t::MUTATE)
-	    ? i->last_modified
-	    : seastar::lowres_system_clock::time_point(),
-	  (is_cleaner_transaction(t.get_src()))
-	    ? i->last_rewritten
-	    : seastar::lowres_system_clock::time_point());
+	  i->get_length());
       }
       if (is_backref_mapped_extent_node(i)) {
 	backref_list.emplace_back(
@@ -1547,10 +1540,11 @@ Cache::replay_delta(
   paddr_t record_base,
   const delta_info_t &delta,
   const journal_seq_t &alloc_replay_from,
-  seastar::lowres_system_clock::time_point& last_modified)
+  sea_time_point &modify_time)
 {
   LOG_PREFIX(Cache::replay_delta);
   assert(alloc_replay_from != JOURNAL_SEQ_NULL);
+  ceph_assert(modify_time != NULL_TIME);
   if (delta.type == extent_types_t::ROOT) {
     TRACE("replay root delta at {} {}, remove extent ... -- {}, prv_root={}",
           journal_seq, record_base, delta, *root);
@@ -1560,7 +1554,7 @@ Cache::replay_delta(
     root->state = CachedExtent::extent_state_t::DIRTY;
     DEBUG("replayed root delta at {} {}, add extent -- {}, root={}",
           journal_seq, record_base, delta, *root);
-    root->set_last_modified(last_modified);
+    root->set_modify_time(modify_time);
     add_extent(root);
     return replay_delta_ertr::now();
   } else if (delta.type == extent_types_t::ALLOC_INFO) {
@@ -1642,7 +1636,7 @@ Cache::replay_delta(
 
       assert(extent->last_committed_crc == delta.prev_crc);
       extent->apply_delta_and_adjust_crc(record_base, delta.bl);
-      extent->set_last_modified(last_modified);
+      extent->set_modify_time(modify_time);
       assert(extent->last_committed_crc == delta.final_crc);
 
       extent->version++;

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -798,7 +798,7 @@ public:
     const delta_info_t &delta,
     const journal_seq_t &, // journal seq from which alloc
 			   // delta should be replayed
-    seastar::lowres_system_clock::time_point& last_modified);
+    sea_time_point &modify_time);
 
   /**
    * init_cached_extents

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -101,10 +101,7 @@ class CachedExtent : public boost::intrusive_ref_counter<
   CachedExtentRef prior_instance;
 
   // time of the last modification
-  seastar::lowres_system_clock::time_point last_modified;
-
-  // time of the last rewrite
-  seastar::lowres_system_clock::time_point last_rewritten;
+  sea_time_point modify_time = NULL_TIME;
 
 public:
   void init(extent_state_t _state,
@@ -117,29 +114,14 @@ public:
     reclaim_generation = gen;
   }
 
-  void set_last_modified(seastar::lowres_system_clock::duration d) {
-    last_modified = seastar::lowres_system_clock::time_point(d);
+  void set_modify_time(sea_time_point t) {
+    modify_time = t;
   }
 
-  void set_last_modified(seastar::lowres_system_clock::time_point t) {
-    last_modified = t;
+  sea_time_point get_modify_time() const {
+    return modify_time;
   }
 
-  seastar::lowres_system_clock::time_point get_last_modified() const {
-    return last_modified;
-  }
-
-  void set_last_rewritten(seastar::lowres_system_clock::duration d) {
-    last_rewritten = seastar::lowres_system_clock::time_point(d);
-  }
-
-  void set_last_rewritten(seastar::lowres_system_clock::time_point t) {
-    last_rewritten = t;
-  }
-
-  seastar::lowres_system_clock::time_point get_last_rewritten() const {
-    return last_rewritten;
-  }
   /**
    *  duplicate_for_write
    *
@@ -213,8 +195,7 @@ public:
 	<< ", type=" << get_type()
 	<< ", version=" << version
 	<< ", dirty_from_or_retired_at=" << dirty_from_or_retired_at
-	<< ", last_modified=" << last_modified.time_since_epoch()
-	<< ", last_rewritten=" << last_rewritten.time_since_epoch()
+	<< ", modify_time=" << sea_time_point_printer_t{modify_time}
 	<< ", paddr=" << get_paddr()
 	<< ", length=" << get_length()
 	<< ", state=" << state

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -83,17 +83,7 @@ SegmentedOolWriter::do_write(
   }
   record_t record;
   std::list<LogicalCachedExtentRef> pending_extents;
-
   auto commit_time = seastar::lowres_system_clock::now();
-  record_commit_type_t commit_type;
-  if (t.get_src() == Transaction::src_t::MUTATE) {
-    commit_type = record_commit_type_t::MODIFY;
-  } else {
-    assert(is_cleaner_transaction(t.get_src()));
-    commit_type = record_commit_type_t::REWRITE;
-  }
-  record.commit_time = commit_time.time_since_epoch().count();
-  record.commit_type = commit_type;
 
   for (auto it = extents.begin(); it != extents.end();) {
     auto& extent = *it;
@@ -126,21 +116,20 @@ SegmentedOolWriter::do_write(
     TRACET("{} extents={} add extent to record -- {}",
            t, segment_allocator.get_name(),
            extents.size(), *extent);
-    if (commit_type == record_commit_type_t::MODIFY) {
-      extent->set_last_modified(commit_time);
-    } else {
-      assert(commit_type == record_commit_type_t::REWRITE);
-      extent->set_last_rewritten(commit_time);
-    }
     ceph::bufferlist bl;
     extent->prepare_write();
     bl.append(extent->get_bptr());
     assert(bl.length() == extent->get_length());
-    record.push_back(extent_t{
-      extent->get_type(),
-      extent->get_laddr(),
-      std::move(bl),
-      extent->get_last_modified().time_since_epoch().count()});
+    auto modify_time = extent->get_modify_time();
+    if (modify_time == NULL_TIME) {
+      modify_time = commit_time;
+    }
+    record.push_back(
+      extent_t{
+        extent->get_type(),
+        extent->get_laddr(),
+        std::move(bl)},
+      modify_time);
     pending_extents.push_back(extent);
     it = extents.erase(it);
 

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -10,10 +10,11 @@ SET_SUBSYS(seastore_journal);
 namespace crimson::os::seastore {
 
 SegmentedOolWriter::SegmentedOolWriter(
-  std::string name,
+  data_category_t category,
+  reclaim_gen_t gen,
   SegmentProvider& sp,
   SegmentSeqAllocator &ssa)
-  : segment_allocator(name, segment_type_t::OOL, sp, ssa),
+  : segment_allocator(segment_type_t::OOL, category, gen, sp, ssa),
     record_submitter(crimson::common::get_conf<uint64_t>(
                        "seastore_journal_iodepth_limit"),
                      crimson::common::get_conf<uint64_t>(
@@ -55,7 +56,7 @@ SegmentedOolWriter::write_record(
       TRACET("{} ool extent written at {} -- {}",
              t, segment_allocator.get_name(),
              extent_addr, *extent);
-      extent->hint = placement_hint_t::NUM_HINTS; // invalidate hint
+      extent->invalidate_hints();
       t.mark_delayed_extent_ool(extent, extent_addr);
       extent_addr = extent_addr.as_seg_paddr().add_offset(
           extent->get_length());

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -48,7 +48,8 @@ class SegmentProvider;
  */
 class SegmentedOolWriter : public ExtentOolWriter {
 public:
-  SegmentedOolWriter(std::string name,
+  SegmentedOolWriter(data_category_t category,
+                     reclaim_gen_t gen,
                      SegmentProvider &sp,
                      SegmentSeqAllocator &ssa);
 
@@ -85,26 +86,29 @@ private:
 
 class ExtentPlacementManager {
 public:
-  ExtentPlacementManager() {
+  ExtentPlacementManager(bool prefer_ool)
+    : prefer_ool{prefer_ool} {
     devices_by_id.resize(DEVICE_ID_GLOBAL_MAX, nullptr);
   }
 
   void init_ool_writers(SegmentProvider &sp, SegmentSeqAllocator &ssa) {
-    // Currently only one SegmentProvider is supported, so hardcode the
-    // writers_by_hint for now.
-    writer_seed = 0;
+    // Currently only one SegmentProvider is supported
     writer_refs.clear();
-    writers_by_hint.resize((std::size_t)placement_hint_t::NUM_HINTS, {});
 
-    // ool writer is not supported for placement_hint_t::HOT
-    writer_refs.emplace_back(
-        std::make_unique<SegmentedOolWriter>("COLD", sp, ssa));
-    writers_by_hint[(std::size_t)placement_hint_t::COLD
-                   ].emplace_back(writer_refs.back().get());
-    writer_refs.emplace_back(
-        std::make_unique<SegmentedOolWriter>("REWRITE", sp, ssa));
-    writers_by_hint[(std::size_t)placement_hint_t::REWRITE
-                   ].emplace_back(writer_refs.back().get());
+    ceph_assert(RECLAIM_GENERATIONS > 0);
+    data_writers_by_gen.resize(RECLAIM_GENERATIONS, {});
+    for (reclaim_gen_t gen = 0; gen < RECLAIM_GENERATIONS; ++gen) {
+      writer_refs.emplace_back(std::make_unique<SegmentedOolWriter>(
+            data_category_t::DATA, gen, sp, ssa));
+      data_writers_by_gen[gen] = writer_refs.back().get();
+    }
+
+    md_writers_by_gen.resize(RECLAIM_GENERATIONS - 1, {});
+    for (reclaim_gen_t gen = 1; gen < RECLAIM_GENERATIONS; ++gen) {
+      writer_refs.emplace_back(std::make_unique<SegmentedOolWriter>(
+            data_category_t::METADATA, gen, sp, ssa));
+      md_writers_by_gen[gen - 1] = writer_refs.back().get();
+    }
   }
 
   void add_device(Device* device, bool is_primary) {
@@ -132,8 +136,10 @@ public:
   open_ertr::future<> open() {
     LOG_PREFIX(ExtentPlacementManager::open);
     SUBINFO(seastore_journal, "started");
-    return crimson::do_for_each(writers_by_hint, [](auto& writers) {
-      return crimson::do_for_each(writers, [](auto& writer) {
+    return crimson::do_for_each(data_writers_by_gen, [](auto &writer) {
+      return writer->open();
+    }).safe_then([this] {
+      return crimson::do_for_each(md_writers_by_gen, [](auto &writer) {
         return writer->open();
       });
     });
@@ -142,14 +148,18 @@ public:
   struct alloc_result_t {
     paddr_t paddr;
     bufferptr bp;
+    reclaim_gen_t gen;
   };
   alloc_result_t alloc_new_extent(
     Transaction& t,
     extent_types_t type,
     seastore_off_t length,
-    placement_hint_t hint
+    placement_hint_t hint,
+    reclaim_gen_t gen
   ) {
     assert(hint < placement_hint_t::NUM_HINTS);
+    assert(gen < RECLAIM_GENERATIONS);
+    assert(gen == 0 || hint == placement_hint_t::REWRITE);
 
     // XXX: bp might be extended to point to differnt memory (e.g. PMem)
     // according to the allocator.
@@ -160,19 +170,35 @@ public:
     if (!is_logical_type(type)) {
       // TODO: implement out-of-line strategy for physical extent.
       return {make_record_relative_paddr(0),
-              std::move(bp)};
+              std::move(bp),
+              0};
     }
 
-    // FIXME: set delay for COLD extent and improve GC
-    // NOTE: delay means to delay the decision about whether to write the
-    // extent as inline or out-of-line extents.
-    bool delay = (hint > placement_hint_t::COLD);
-    if (delay) {
+    if (hint == placement_hint_t::COLD) {
+      assert(gen == 0);
       return {make_delayed_temp_paddr(0),
-              std::move(bp)};
+              std::move(bp),
+              COLD_GENERATION};
+    }
+
+    if (get_extent_category(type) == data_category_t::METADATA &&
+        gen == 0) {
+      // gen 0 METADATA writer is the journal writer
+      if (prefer_ool) {
+        return {make_delayed_temp_paddr(0),
+                std::move(bp),
+                1};
+      } else {
+        return {make_record_relative_paddr(0),
+                std::move(bp),
+                0};
+      }
     } else {
-      return {make_record_relative_paddr(0),
-              std::move(bp)};
+      assert(get_extent_category(type) == data_category_t::DATA ||
+             gen > 0);
+      return {make_delayed_temp_paddr(0),
+              std::move(bp),
+              gen};
     }
   }
 
@@ -193,7 +219,10 @@ public:
         [this, &t, &delayed_extents](auto& alloc_map) {
       for (auto& extent : delayed_extents) {
         // For now, just do ool allocation for any delayed extent
-        auto writer_ptr = get_writer(extent->hint);
+        auto writer_ptr = get_writer(
+            extent->get_user_hint(),
+            get_extent_category(extent->get_type()),
+            extent->get_reclaim_generation());
         alloc_map[writer_ptr].emplace_back(extent);
       }
       return trans_intr::do_for_each(alloc_map, [&t](auto& p) {
@@ -208,8 +237,10 @@ public:
   close_ertr::future<> close() {
     LOG_PREFIX(ExtentPlacementManager::close);
     SUBINFO(seastore_journal, "started");
-    return crimson::do_for_each(writers_by_hint, [](auto& writers) {
-      return crimson::do_for_each(writers, [](auto& writer) {
+    return crimson::do_for_each(data_writers_by_gen, [](auto &writer) {
+      return writer->close();
+    }).safe_then([this] {
+      return crimson::do_for_each(md_writers_by_gen, [](auto &writer) {
         return writer->close();
       });
     }).safe_then([this] {
@@ -230,18 +261,27 @@ public:
   }
 
 private:
-  ExtentOolWriter* get_writer(placement_hint_t hint) {
+  ExtentOolWriter* get_writer(placement_hint_t hint,
+                              data_category_t category,
+                              reclaim_gen_t gen) {
     assert(hint < placement_hint_t::NUM_HINTS);
-    auto hint_index = static_cast<std::size_t>(hint);
-    assert(hint_index < writers_by_hint.size());
-    auto& writers = writers_by_hint[hint_index];
-    assert(writers.size() > 0);
-    return writers[writer_seed++ % writers.size()];
+    assert(gen < RECLAIM_GENERATIONS);
+    if (category == data_category_t::DATA) {
+      return data_writers_by_gen[gen];
+    } else {
+      assert(category == data_category_t::METADATA);
+      // gen 0 METADATA writer is the journal writer
+      assert(gen > 0);
+      return md_writers_by_gen[gen - 1];
+    }
   }
 
-  std::size_t writer_seed = 0;
+  bool prefer_ool;
   std::vector<ExtentOolWriterRef> writer_refs;
-  std::vector<std::vector<ExtentOolWriter*>> writers_by_hint;
+  std::vector<ExtentOolWriter*> data_writers_by_gen;
+  // gen 0 METADATA writer is the journal writer
+  std::vector<ExtentOolWriter*> md_writers_by_gen;
+
   std::vector<Device*> devices_by_id;
   Device* primary_device = nullptr;
 };

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -87,7 +87,7 @@ public:
 	       const delta_info_t&,
 	       const journal_seq_t, // journal seq from which
 				    // alloc delta should replayed
-	       seastar::lowres_system_clock::time_point last_modified)>;
+	       sea_time_point modify_time)>;
   virtual replay_ret replay(
     delta_handler_t &&delta_handler) = 0;
 

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.cc
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.cc
@@ -429,14 +429,12 @@ Journal::replay_ret CircularBoundedJournal::replay(
 		record_deltas.deltas,
 		[locator,
 		&d_handler](auto& p) {
-		auto& commit_time = p.first;
+		auto& modify_time = p.first;
 		auto& delta = p.second;
 		return d_handler(locator,
 		  delta,
 		  locator.write_result.start_seq,
-		  seastar::lowres_system_clock::time_point(
-		    seastar::lowres_system_clock::duration(commit_time))
-		  );
+		  modify_time);
 	      });
 	    }).safe_then([this, &cursor_addr]() {
 	      if (cursor_addr >= get_journal_end()) {

--- a/src/crimson/os/seastore/journal/segment_allocator.h
+++ b/src/crimson/os/seastore/journal/segment_allocator.h
@@ -30,8 +30,9 @@ class SegmentAllocator {
       crimson::ct_error::input_output_error>;
 
  public:
-  SegmentAllocator(std::string name,
-                   segment_type_t type,
+  SegmentAllocator(segment_type_t type,
+                   data_category_t category,
+                   reclaim_gen_t gen,
                    SegmentProvider &sp,
                    SegmentSeqAllocator &ssa);
 
@@ -111,11 +112,12 @@ class SegmentAllocator {
   using close_segment_ertr = base_ertr;
   close_segment_ertr::future<> close_segment();
 
-  const std::string name;
   // device id is not available during construction,
   // so generate the print_name later.
   std::string print_name;
   const segment_type_t type; // JOURNAL or OOL
+  const data_category_t category;
+  const reclaim_gen_t gen;
   SegmentProvider &segment_provider;
   SegmentManagerGroup &sm_group;
   SegmentRef current_segment;

--- a/src/crimson/os/seastore/journal/segment_allocator.h
+++ b/src/crimson/os/seastore/journal/segment_allocator.h
@@ -40,6 +40,10 @@ class SegmentAllocator {
     return print_name;
   }
 
+  SegmentProvider &get_provider() {
+    return segment_provider;
+  }
+
   seastore_off_t get_block_size() const {
     return sm_group.get_block_size();
   }

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -31,8 +31,9 @@ SegmentedJournal::SegmentedJournal(
   : segment_provider(segment_provider),
     segment_seq_allocator(
       new SegmentSeqAllocator(segment_type_t::JOURNAL)),
-    journal_segment_allocator("JOURNAL",
-                              segment_type_t::JOURNAL,
+    journal_segment_allocator(segment_type_t::JOURNAL,
+                              data_category_t::METADATA,
+                              0, // generation
                               segment_provider,
                               *segment_seq_allocator),
     record_submitter(crimson::common::get_conf<uint64_t>(

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -195,7 +195,7 @@ SegmentedJournal::replay_segment(
              FNAME,
              &handler](auto &p)
           {
-	    auto& commit_time = p.first;
+	    auto& modify_time = p.first;
 	    auto& delta = p.second;
             /* The journal may validly contain deltas for extents in
              * since released segments.  We can detect those cases by
@@ -225,8 +225,7 @@ SegmentedJournal::replay_segment(
 	      locator,
 	      delta,
 	      segment_provider.get_alloc_info_replay_from(),
-	      seastar::lowres_system_clock::time_point(
-		seastar::lowres_system_clock::duration(commit_time)));
+              modify_time);
           });
         });
       });

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -196,6 +196,22 @@ std::ostream &operator<<(std::ostream &out, data_category_t c)
   }
 }
 
+std::ostream &operator<<(std::ostream &out, sea_time_point_printer_t tp)
+{
+  if (tp.tp == NULL_TIME) {
+    return out << "tp(NULL)";
+  }
+  auto time = seastar::lowres_system_clock::to_time_t(tp.tp);
+  char buf[32];
+  std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&time));
+  return out << "tp(" << buf << ")";
+}
+
+std::ostream &operator<<(std::ostream &out, mod_time_point_printer_t tp) {
+  auto time = mod_to_timepoint(tp.tp);
+  return out << "mod_" << sea_time_point_printer_t{time};
+}
+
 std::ostream &operator<<(std::ostream &out, const laddr_list_t &rhs)
 {
   bool first = false;
@@ -259,8 +275,8 @@ std::ostream &operator<<(std::ostream &out, const segment_tail_t &tail)
 	     << ", segment_id=" << tail.physical_segment_id
 	     << ", journal_tail=" << tail.journal_tail
 	     << ", segment_nonce=" << tail.segment_nonce
-	     << ", last_modified=" << tail.last_modified
-	     << ", last_rewritten=" << tail.last_rewritten
+	     << ", modify_time=" << mod_time_point_printer_t{tail.modify_time}
+	     << ", num_extents=" << tail.num_extents
 	     << ")";
 }
 
@@ -297,6 +313,7 @@ std::ostream &operator<<(std::ostream& out, const record_t& r)
   return out << "record_t("
              << "num_extents=" << r.extents.size()
              << ", num_deltas=" << r.deltas.size()
+             << ", modify_time=" << sea_time_point_printer_t{r.modify_time}
              << ")";
 }
 
@@ -305,6 +322,7 @@ std::ostream &operator<<(std::ostream& out, const record_header_t& r)
   return out << "record_header_t("
              << "num_extents=" << r.extents
              << ", num_deltas=" << r.deltas
+             << ", modify_time=" << mod_time_point_printer_t{r.modify_time}
              << ")";
 }
 
@@ -404,8 +422,7 @@ ceph::bufferlist encode_records(
     record_header_t rheader{
       (extent_len_t)r.deltas.size(),
       (extent_len_t)r.extents.size(),
-      r.commit_time,
-      r.commit_type
+      timepoint_to_mod(r.modify_time)
     };
     encode(rheader, bl);
   }
@@ -599,7 +616,7 @@ try_decode_deltas(
     for (auto& i: result_iter->deltas) {
       try {
         decode(i.second, bliter);
-	i.first = r.header.commit_time;
+        i.first = mod_to_timepoint(r.header.modify_time);
       } catch (ceph::buffer::error &e) {
         journal_logger().debug(
             "try_decode_deltas: failed, "

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -47,11 +47,11 @@ std::ostream &operator<<(std::ostream &out, const device_id_printer_t &id)
 std::ostream &operator<<(std::ostream &out, const segment_id_t &segment)
 {
   if (segment == NULL_SEG_ID) {
-    return out << "NULL_SEG";
+    return out << "Seg[NULL]";
   } else if (segment == FAKE_SEG_ID) {
-    return out << "FAKE_SEG";
+    return out << "Seg[FAKE]";
   } else {
-    return out << "[" << device_id_printer_t{segment.device_id()}
+    return out << "Seg[" << device_id_printer_t{segment.device_id()}
                << "," << segment.device_segment_id()
                << "]";
   }
@@ -297,6 +297,14 @@ std::ostream &operator<<(std::ostream& out, const record_t& r)
   return out << "record_t("
              << "num_extents=" << r.extents.size()
              << ", num_deltas=" << r.deltas.size()
+             << ")";
+}
+
+std::ostream &operator<<(std::ostream& out, const record_header_t& r)
+{
+  return out << "record_header_t("
+             << "num_extents=" << r.extents
+             << ", num_deltas=" << r.deltas
              << ")";
 }
 

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -173,6 +173,29 @@ std::ostream &operator<<(std::ostream &out, extent_types_t t)
   }
 }
 
+std::ostream &operator<<(std::ostream &out, reclaim_gen_printer_t gen)
+{
+  if (gen.gen == NULL_GENERATION) {
+    return out << "NULL_GEN";
+  } else if (gen.gen >= RECLAIM_GENERATIONS) {
+    return out << "INVALID_GEN(" << (unsigned)gen.gen << ")";
+  } else {
+    return out << "GEN(" << (unsigned)gen.gen << ")";
+  }
+}
+
+std::ostream &operator<<(std::ostream &out, data_category_t c)
+{
+  switch (c) {
+    case data_category_t::METADATA:
+      return out << "MD";
+    case data_category_t::DATA:
+      return out << "DATA";
+    default:
+      return out << "INVALID_CATEGORY!";
+  }
+}
+
 std::ostream &operator<<(std::ostream &out, const laddr_list_t &rhs)
 {
   bool first = false;
@@ -224,6 +247,8 @@ std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
 	     << ", journal_tail=" << header.journal_tail
 	     << ", segment_nonce=" << header.segment_nonce
 	     << ", type=" << header.type
+	     << ", category=" << header.category
+	     << ", generaton=" << (unsigned)header.generation
 	     << ")";
 }
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1586,6 +1586,7 @@ struct record_header_t {
     DENC_FINISH(p);
   }
 };
+std::ostream &operator<<(std::ostream&, const record_header_t&);
 
 struct record_group_header_t {
   uint32_t      records;

--- a/src/crimson/os/seastore/segment_manager_group.h
+++ b/src/crimson/os/seastore/segment_manager_group.h
@@ -91,31 +91,7 @@ public:
     segment_tail_t>;
   read_segment_tail_ret  read_segment_tail(segment_id_t segment);
 
-  struct commit_info_t {
-    mod_time_point_t commit_time;
-    record_commit_type_t commit_type;
-  };
-
-  /**
-   * scan_extents
-   *
-   * Scans records beginning at addr until the first record boundary after
-   * addr + bytes_to_read.
-   *
-   * Returns list<extent, extent_info>
-   * cursor.is_complete() will be true when no further extents exist in segment.
-   */
   using read_ertr = SegmentManager::read_ertr;
-  using scan_extents_cursor = scan_valid_records_cursor;
-  using scan_extents_ertr = read_ertr::extend<crimson::ct_error::enodata>;
-  using scan_extents_ret_bare =
-    std::list<std::pair<paddr_t, std::pair<commit_info_t, extent_info_t>>>;
-  using scan_extents_ret = scan_extents_ertr::future<scan_extents_ret_bare>;
-  scan_extents_ret scan_extents(
-    scan_extents_cursor &cursor,
-    extent_len_t bytes_to_read
-  );
-
   using scan_valid_records_ertr = read_ertr::extend<crimson::ct_error::enodata>;
   using scan_valid_records_ret = scan_valid_records_ertr::future<
     size_t>;

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -28,16 +28,14 @@ TransactionManager::TransactionManager(
   CacheRef _cache,
   LBAManagerRef _lba_manager,
   ExtentPlacementManagerRef &&epm,
-  BackrefManagerRef&& backref_manager,
-  tm_make_config_t config)
+  BackrefManagerRef&& backref_manager)
   : async_cleaner(std::move(_async_cleaner)),
     cache(std::move(_cache)),
     lba_manager(std::move(_lba_manager)),
     journal(std::move(_journal)),
     epm(std::move(epm)),
     backref_manager(std::move(backref_manager)),
-    sm_group(*async_cleaner->get_segment_manager_group()),
-    config(config)
+    sm_group(*async_cleaner->get_segment_manager_group())
 {
   async_cleaner->set_extent_callback(this);
   journal->set_write_pipeline(&write_pipeline);
@@ -473,7 +471,8 @@ TransactionManager::rewrite_logical_extent(
     t,
     lextent->get_type(),
     lextent->get_length(),
-    placement_hint_t::REWRITE)->cast<LogicalCachedExtent>();
+    lextent->get_user_hint(),
+    lextent->get_reclaim_generation())->cast<LogicalCachedExtent>();
   lextent->get_bptr().copy_out(
     0,
     lextent->get_length(),
@@ -497,7 +496,8 @@ TransactionManager::rewrite_logical_extent(
 
 TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(
   Transaction &t,
-  CachedExtentRef extent)
+  CachedExtentRef extent,
+  reclaim_gen_t target_generation)
 {
   LOG_PREFIX(TransactionManager::rewrite_extent);
 
@@ -509,6 +509,13 @@ TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(
     }
     extent = updated;
     ceph_assert(!extent->is_pending_io());
+  }
+
+  assert(extent->is_valid() && !extent->is_initial_pending());
+  if (extent->is_dirty()) {
+    extent->set_reclaim_generation(DIRTY_GENERATION);
+  } else {
+    extent->set_reclaim_generation(target_generation);
   }
 
   t.get_rewrite_version_stats().increment(extent->get_version());
@@ -640,7 +647,7 @@ TransactionManager::~TransactionManager() {}
 TransactionManagerRef make_transaction_manager(tm_make_config_t config)
 {
   LOG_PREFIX(make_transaction_manager);
-  auto epm = std::make_unique<ExtentPlacementManager>();
+  auto epm = std::make_unique<ExtentPlacementManager>(config.epm_prefer_ool);
   auto cache = std::make_unique<Cache>(*epm);
   auto lba_manager = lba_manager::create_lba_manager(*cache);
   auto sms = std::make_unique<SegmentManagerGroup>();
@@ -681,8 +688,7 @@ TransactionManagerRef make_transaction_manager(tm_make_config_t config)
     std::move(cache),
     std::move(lba_manager),
     std::move(epm),
-    std::move(backref_manager),
-    config);
+    std::move(backref_manager));
 }
 
 }

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -443,7 +443,8 @@ public:
   rewrite_extent_ret rewrite_extent(
     Transaction &t,
     CachedExtentRef extent,
-    reclaim_gen_t target_generation) final;
+    reclaim_gen_t target_generation,
+    sea_time_point modify_time) final;
 
   using AsyncCleaner::ExtentCallbackInterface::get_extent_if_live_ret;
   get_extent_if_live_ret get_extent_if_live(

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -60,7 +60,9 @@ struct btree_test_base :
 
   segment_id_t allocate_segment(
     segment_seq_t seq,
-    segment_type_t type
+    segment_type_t type,
+    data_category_t,
+    reclaim_gen_t
   ) final {
     auto ret = next;
     next = segment_id_t{
@@ -111,7 +113,7 @@ struct btree_test_base :
     }).safe_then([this] {
       sms.reset(new SegmentManagerGroup());
       journal = journal::make_segmented(*this);
-      epm.reset(new ExtentPlacementManager());
+      epm.reset(new ExtentPlacementManager(false));
       cache.reset(new Cache(*epm));
 
       block_size = segment_manager->get_block_size();
@@ -368,7 +370,11 @@ struct btree_lba_manager_test : btree_test_base {
       test_lba_mappings
     };
     if (create_fake_extent) {
-      cache->alloc_new_extent<TestBlockPhysical>(*t.t, TestBlockPhysical::SIZE);
+      cache->alloc_new_extent<TestBlockPhysical>(
+          *t.t,
+          TestBlockPhysical::SIZE,
+          placement_hint_t::HOT,
+          0);
     };
     return t;
   }

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -79,6 +79,8 @@ struct btree_test_base :
 
   void update_segment_avail_bytes(segment_type_t, paddr_t) final {}
 
+  void update_modify_time(segment_id_t, sea_time_point, std::size_t) final {}
+
   SegmentManagerGroup* get_segment_manager_group() final { return sms.get(); }
 
   journal_seq_t get_dirty_extents_replay_from() const final {

--- a/src/test/crimson/seastore/test_cbjournal.cc
+++ b/src/test/crimson/seastore/test_cbjournal.cc
@@ -135,7 +135,7 @@ struct cbjournal_test_t : public seastar_test_suite_t
 
   cbjournal_test_t() :
       segment_manager(segment_manager::create_test_ephemeral()),
-      epm(new ExtentPlacementManager()),
+      epm(new ExtentPlacementManager(true)),
       cache(*epm)
   {
     device = new nvme_device::TestMemory(CBTEST_DEFAULT_TEST_SIZE);

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -88,7 +88,7 @@ struct cache_test_t : public seastar_test_suite_t {
       return segment_manager->mkfs(
         segment_manager::get_ephemeral_device_config(0, 1));
     }).safe_then([this] {
-      epm.reset(new ExtentPlacementManager());
+      epm.reset(new ExtentPlacementManager(false));
       cache.reset(new Cache(*epm));
       current = paddr_t::make_seg_paddr(segment_id_t(segment_manager->get_device_id(), 0), 0);
       epm->add_device(segment_manager.get(), true);
@@ -131,7 +131,9 @@ TEST_F(cache_test_t, test_addr_fixup)
       auto t = get_transaction();
       auto extent = cache->alloc_new_extent<TestBlockPhysical>(
 	*t,
-	TestBlockPhysical::SIZE);
+	TestBlockPhysical::SIZE,
+	placement_hint_t::HOT,
+	0);
       extent->set_contents('c');
       csum = extent->get_crc32c();
       submit_transaction(std::move(t)).get0();
@@ -160,7 +162,9 @@ TEST_F(cache_test_t, test_dirty_extent)
       auto t = get_transaction();
       auto extent = cache->alloc_new_extent<TestBlockPhysical>(
 	*t,
-	TestBlockPhysical::SIZE);
+	TestBlockPhysical::SIZE,
+	placement_hint_t::HOT,
+	0);
       extent->set_contents('c');
       csum = extent->get_crc32c();
       auto reladdr = extent->get_paddr();

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -128,6 +128,8 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
 
   void update_segment_avail_bytes(segment_type_t, paddr_t) final {}
 
+  void update_modify_time(segment_id_t, sea_time_point, std::size_t) final {}
+
   SegmentManagerGroup* get_segment_manager_group() final { return sms.get(); }
 
   seastar::future<> set_up_fut() final {

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -109,7 +109,9 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider {
 
   segment_id_t allocate_segment(
     segment_seq_t seq,
-    segment_type_t type
+    segment_type_t type,
+    data_category_t,
+    reclaim_gen_t
   ) final {
     auto ret = next;
     next = segment_id_t{


### PR DESCRIPTION
This PR has 2 parts: generational-GC and policy-improvements.

## I. Generational GC

Classify segments into 2 dimensions --- data category (data, metadata) and generation (0, 1, 2), totally 6 types of segments --- to improve the locality of block placements. This is the foundation to form a desired bimodal distribution of
segment utilizations for more efficient GC.

The profiling with rbd-fio (zipf-0.6) proves that the desired bimodal distribution has been formed. Note that reclaiming has been delayed as late as possible (see https://github.com/ceph/ceph/pull/46437), so that the first ~1500 seconds won't involve reclaiming, and the utility distribution below is accurate before 1500s:
* Before[^1]: all the blocks are mixed together so segment utilities are around 20~30%, which is not bimodal.
* After[^2]: nearly 55% of the segments have utilities below 10%, and another half have utilities around 55%, which is bimodal.

## II. Policy improvements

* `record_header_t` to store the average modify time instead of the commit time to consider dirty extents.
* Drop tracking rewrite-time, consider rewriting seems to have negative impacts: 0.55 WAF from reclaiming that considers rewrite-time or modify-time, and 0.33 WAF that only considers modify-time, in rbd-fio(zipf-0.6, 5400s).
* Drop the last-modify field in `extent_info_t`, which seems unnecessary right now.
* Make sure the information of modify-time won't be lost during rewriting.
* Introduce 3 GC policies to select from: greedy, benefit, and cost-benefit.

## Final performance improvements with rbd-fio, zipf-0.6, 5400s

* WAF from trimming is reduced from 2.03 to 1.32.
* WAF from reclaiming is reduced from 0.90 to 0.33.
* Overall conflict ratio are reduced, see before[^3] and after[^4].
* Overall throughput in the steady state is improved 11%.

## Policy selection

There are 3 GC policies available:
* GREEDY: always select the least utilized segment to reclaim.
* COST_BENEFIT: revise base on sprite-lfs's cost-benefit formula, and revise from the original version.
* BENEFIT: a revised version of GREEDY policy that considers the age factor, so that the aged segment has larger benefit:
![benefit-formula](https://user-images.githubusercontent.com/7736006/174752085-9ce7b6a6-8dc4-465c-8e66-d3a06ae64c69.png)

In theory, GREEDY policy should be the least efficient as it only considers segment utility. The result reclaim WAFs in rbd-fio(zipf-0.6, 5400s) are:
* GREEDY: 0.586
* COSY_BENEFIT: 0.328
* BENEFIT: 0.372

For reference, the original reclaim WAFs were:
* Before generational GC: 0.896
* After generational GC, before policy improvements: 0.553

[^1]: ![before-gen-dist](https://user-images.githubusercontent.com/7736006/174697816-e9705230-adb0-47e3-96a5-5d9a81df78a8.png)

[^2]: ![after-gen-dist](https://user-images.githubusercontent.com/7736006/174698322-9840c08b-628a-4ed8-b9d3-ccf711b2774e.png)

[^3]: ![before-gen-conflicts](https://user-images.githubusercontent.com/7736006/174703387-76125c93-d95c-4f0d-b37e-1e89c3292a19.png)

[^4]: ![after-gen-conflicts](https://user-images.githubusercontent.com/7736006/174703550-55f271a8-ad3c-4b00-814a-37ac63cbe966.png)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
