### PR TITLE
crimson/os/seastore/segment_cleaner: tune and fixes around reclaiming

### DIFF
--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -351,14 +351,6 @@ BtreeBackrefManager::rewrite_extent(
   Transaction &t,
   CachedExtentRef extent)
 {
-  LOG_PREFIX(BtreeBackrefManager::rewrite_extent);
-  auto updated = cache.update_extent_from_transaction(t, extent);
-  if (!updated) {
-    DEBUGT("extent is already retired, skipping -- {}", t, *extent);
-    return rewrite_extent_iertr::now();
-  }
-  extent = updated;
-
   auto c = get_context(t);
   return with_btree<BackrefBtree>(
     cache,

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -695,13 +695,13 @@ void Cache::mark_dirty(CachedExtentRef ref)
   }
 
   lru.remove_from_lru(*ref);
-  add_to_dirty(ref);
   ref->state = CachedExtent::extent_state_t::DIRTY;
+  add_to_dirty(ref);
 }
 
 void Cache::add_to_dirty(CachedExtentRef ref)
 {
-  assert(ref->is_valid());
+  assert(ref->is_dirty());
   assert(!ref->primary_ref_list_hook.is_linked());
   intrusive_ptr_add_ref(&*ref);
   dirty.push_back(*ref);
@@ -746,6 +746,7 @@ void Cache::commit_replace_extent(
     CachedExtentRef next,
     CachedExtentRef prev)
 {
+  assert(next->is_dirty());
   assert(next->get_paddr() == prev->get_paddr());
   assert(next->version == prev->version + 1);
   extents.replace(*next, *prev);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -667,8 +667,8 @@ public:
     auto ret = CachedExtent::make_cached_extent_ref<T>(std::move(result.bp));
     ret->set_paddr(result.paddr);
     ret->hint = hint;
-    t.add_fresh_extent(ret);
     ret->state = CachedExtent::extent_state_t::INITIAL_WRITE_PENDING;
+    t.add_fresh_extent(ret);
     SUBDEBUGT(seastore_cache, "allocated {} {}B extent at {}, hint={} -- {}",
               t, T::TYPE, length, result.paddr, hint, *ret);
     return ret;

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1692,7 +1692,12 @@ seastar::future<std::unique_ptr<SeaStore>> make_seastore(
   return Device::make_device(
     device
   ).then([&device](DeviceRef device_obj) {
+#ifndef NDEBUG
+    auto tm = make_transaction_manager(
+        tm_make_config_t::get_test_segmented_journal());
+#else
     auto tm = make_transaction_manager(tm_make_config_t::get_default());
+#endif
     auto cm = std::make_unique<collection_manager::FlatCollectionManager>(*tm);
     return std::make_unique<SeaStore>(
       device,

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -946,6 +946,8 @@ constexpr bool is_logical_type(extent_types_t type) {
   case extent_types_t::ROOT:
   case extent_types_t::LADDR_INTERNAL:
   case extent_types_t::LADDR_LEAF:
+  case extent_types_t::BACKREF_INTERNAL:
+  case extent_types_t::BACKREF_LEAF:
     return false;
   default:
     return true;

--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -582,7 +582,12 @@ void SegmentCleaner::update_journal_tail_target(
               journal_head >= target);
   if (journal_tail_target == JOURNAL_SEQ_NULL ||
       target > journal_tail_target) {
-    DEBUG("journal_tail_target={} => {}", journal_tail_target, target);
+    if (!init_complete ||
+        journal_tail_target.segment_seq == target.segment_seq) {
+      DEBUG("journal_tail_target={} => {}", journal_tail_target, target);
+    } else {
+      INFO("journal_tail_target={} => {}", journal_tail_target, target);
+    }
     journal_tail_target = target;
   }
   gc_process.maybe_wake_on_space_used();

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -516,10 +516,10 @@ public:
 	  12,   // target_journal_segments
 	  16,   // max_journal_segments
 	  2,	// target_backref_inflight_segments
-	  .9,   // available_ratio_gc_max
-	  .2,   // available_ratio_hard_limit
-	  .8,   // reclaim_ratio_hard_limit
-	  .6,   // reclaim_ratio_gc_threshold
+	  .1,   // available_ratio_gc_max
+	  .05,  // available_ratio_hard_limit
+	  .9,   // reclaim_ratio_hard_limit
+	  .1,   // reclaim_ratio_gc_threshold
 	  1<<20,// reclaim_bytes_per_cycle
 	  1<<17,// rewrite_dirty_bytes_per_cycle
 	  1<<24 // rewrite_backref_bytes_per_cycle

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -47,6 +47,8 @@ struct tm_make_config_t {
     };
   }
   static tm_make_config_t get_test_segmented_journal() {
+    LOG_PREFIX(get_test_segmented_journal);
+    SUBWARN(seastore_tm, "test mode enabled!");
     return tm_make_config_t {
       true,
       journal_type_t::SEGMENT_JOURNAL,
@@ -54,6 +56,8 @@ struct tm_make_config_t {
     };
   }
   static tm_make_config_t get_test_cb_journal() {
+    LOG_PREFIX(get_test_cb_journal);
+    SUBWARN(seastore_tm, "test mode enabled!");
     return tm_make_config_t {
       true,
       journal_type_t::CIRCULARBOUNDED_JOURNAL,

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -131,7 +131,12 @@ seastar::future<bufferlist> TMDriver::read(
 
 void TMDriver::init()
 {
+#ifndef NDEBUG
+  tm = make_transaction_manager(
+      tm_make_config_t::get_test_segmented_journal());
+#else
   tm = make_transaction_manager(tm_make_config_t::get_default());
+#endif
   tm->add_device(device.get(), true);
 }
 


### PR DESCRIPTION
It should be generically better to delay reclaim as late as possible, so
that:
* unalive/unavailable ratio can become higher to reduce reclaim efforts, see before[^1] to after[^2], and more effective in case of before[^5] to after[^6] from https://github.com/ceph/ceph/pull/46436, down to ~1/3 reclaim efforts;
* less conflicts between mutate and reclaim transactions, see before[^3] to after[^4], down to ~1% conflicts from reclaim transactions;

Please note,
* in the non-generational version[^1][^2][^3][^4], reclaiming is too slow so that unavailable/total ratio will reach the original hard limit 80%, **not** significantly lower than the tuned 95% limit, so that the end performance is **not** significantly impacted, from 11.9MB/s to 11.95MB/s.
* in the generational version[^5][^6] from https://github.com/ceph/ceph/pull/46436, due to the improved bimodal distribution of segment utilizations, reclaiming is much faster so that the unavailable/total ratio ends up to ~45%, significantly lower than the tuned 95% limit, so that the end performance is improved from 9.95MB/s to 12.31MB/s.

Another change is `crimson/os/seastore/transaction_manager: set to test mode under debug build`, please refer to its commit message.

[^1]: ![before-waf](https://user-images.githubusercontent.com/7736006/171078335-bb381415-f72c-493b-b2e4-1d1aebb05bfe.png)
[^2]: ![after-waf](https://user-images.githubusercontent.com/7736006/171078388-1a8298ab-745a-4dcf-a539-4fd074ccf628.png)
[^3]: ![before-conflicts](https://user-images.githubusercontent.com/7736006/171078508-0233aec9-e2ce-4eb8-b6af-67213504dff3.png)
[^4]: ![after-conflicts](https://user-images.githubusercontent.com/7736006/171078541-d9c5b080-870f-4ea8-8d16-ea147d868f57.png)
[^5]: ![before2-waf](https://user-images.githubusercontent.com/7736006/171078581-9884a20a-50f4-451f-93d2-f995945d6686.png)
[^6]: ![after2-waf](https://user-images.githubusercontent.com/7736006/171078629-a42e85d5-15f4-4b95-81ea-43ca37be8e70.png)




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
