### PR TITLE
rgw: The error reported in the "rgw_s3_prepare_decrypt" function is unreasonable

### DIFF
--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -1387,7 +1387,7 @@ int rgw_s3_prepare_decrypt(struct req_state* s,
       ldpp_dout(s, 0) << "ERROR: key obtained from key_id:" <<
           key_id << " is not 256 bit size" << dendl;
       s->err.message = "KMS provided an invalid key for the given kms-keyid.";
-      return -ERR_INVALID_ACCESS_KEY;
+      return -EINVAL;
     }
 
     auto aes = std::unique_ptr<AES_256_CBC>(new AES_256_CBC(s, s->cct));
@@ -1457,7 +1457,7 @@ int rgw_s3_prepare_decrypt(struct req_state* s,
       ldpp_dout(s, 0) << "ERROR: key obtained " <<
           "is not 256 bit size" << dendl;
       s->err.message = "SSE-S3 provided an invalid key for the given keyid.";
-      return -ERR_INVALID_ACCESS_KEY;
+      return -EINVAL;
     }
 
     auto aes = std::unique_ptr<AES_256_CBC>(new AES_256_CBC(s, s->cct));

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -873,7 +873,7 @@ static int get_actual_key_from_conf(const DoutPrefixProvider* dpp,
 
   map<string, string>::iterator it = str_map.find(std::string(key_id));
   if (it == str_map.end())
-    return -ERR_INVALID_ACCESS_KEY;
+    return -EINVAL;
 
   std::string master_key;
   try {


### PR DESCRIPTION
When decrypting the data encrypted with the "SSE-KMS" method, the "InvalidAccessKeyId" error is reported when the KMS key is unavailable, which is unreasonable. Therefore, we added the "InvalidKmsKeyId" error code to correct this problem.

Fixes: https://tracker.ceph.com/issues/55799
Signed-off-by: wangyingbin <ybwang0211@163.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
