### PR TITLE
quincy: mgr/dashboard:  don't log 3xx as errors

### DIFF
--- a/src/pybind/mgr/dashboard/services/exception.py
+++ b/src/pybind/mgr/dashboard/services/exception.py
@@ -51,6 +51,9 @@ def dashboard_exception_handler(handler, *args, **kwargs):
         cherrypy.response.headers['Content-Type'] = 'application/json'
         cherrypy.response.status = getattr(error, 'status', 400)
         return json.dumps(serialize_dashboard_exception(error)).encode('utf-8')
+    except cherrypy.HTTPRedirect:
+        # No internal errors
+        raise
     except Exception as error:
         logger.exception('Internal Server Error')
         raise error


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55115

---

backport of https://github.com/ceph/ceph/pull/45563
parent tracker: https://tracker.ceph.com/issues/54991

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh