### PR TITLE
mgr/dashboard: ordered metrics with metric classes

### DIFF
--- a/src/common/options/ceph-exporter.yaml.in
+++ b/src/common/options/ceph-exporter.yaml.in
@@ -43,3 +43,12 @@ options:
   - ceph-exporter
   flags:
   - runtime
+- name: exporter_sort_metrics
+  type: bool
+  level: advanced
+  desc: If true it will sort the metrics and group them.
+  default: true
+  services:
+  - ceph-exporter
+  flags:
+  - runtime

--- a/src/exporter/DaemonMetricCollector.h
+++ b/src/exporter/DaemonMetricCollector.h
@@ -23,6 +23,13 @@ struct pstat {
   int resident_size;
 };
 
+class MetricsBuilder;
+class OrderedMetricsBuilder;
+class UnorderedMetricsBuilder;
+class Metric;
+
+typedef std::map<std::string, std::string> labels_t;
+
 class DaemonMetricCollector {
 public:
   void main();
@@ -32,17 +39,66 @@ private:
   std::map<std::string, AdminSocketClient> clients;
   std::string metrics;
   std::mutex metrics_mutex;
+  std::unique_ptr<MetricsBuilder> builder;
   void update_sockets();
   void request_loop(boost::asio::steady_timer &timer);
 
   void dump_asok_metrics();
-  void dump_asok_metric(std::stringstream &ss, boost::json::object perf_info,
+  void dump_asok_metric(boost::json::object perf_info,
                         boost::json::value perf_values, std::string name,
-                        std::string labels);
-  std::pair<std::string, std::string>
+                        labels_t labels);
+  std::pair<labels_t, std::string>
   get_labels_and_metric_name(std::string daemon_name, std::string metric_name);
-  std::string get_process_metrics(std::vector<std::pair<std::string, int>> daemon_pids);
+  void get_process_metrics(std::vector<std::pair<std::string, int>> daemon_pids);
   std::string asok_request(AdminSocketClient &asok, std::string command);
+};
+
+class Metric {
+private:
+  struct metric_entry {
+    labels_t labels;
+    std::string value;
+  };
+  std::string name;
+  std::string mtype;
+  std::string description;
+  std::vector<metric_entry> entries;
+
+public:
+  Metric(std::string name, std::string mtype, std::string description)
+      : name(name), mtype(mtype), description(description) {}
+  Metric(const Metric &) = default;
+  Metric() = default;
+  void add(labels_t labels, std::string value);
+  std::string dump();
+};
+
+class MetricsBuilder {
+public:
+  virtual ~MetricsBuilder() = default;
+  virtual std::string dump() = 0;
+  virtual void add(std::string value, std::string name, std::string description,
+                   std::string mtype, labels_t labels) = 0;
+
+protected:
+  std::string out;
+};
+
+class OrderedMetricsBuilder : public MetricsBuilder {
+private:
+  std::map<std::string, Metric> metrics;
+
+public:
+  std::string dump();
+  void add(std::string value, std::string name, std::string description,
+           std::string mtype, labels_t labels);
+};
+
+class UnorderedMetricsBuilder : public MetricsBuilder {
+public:
+  std::string dump();
+  void add(std::string value, std::string name, std::string description,
+           std::string mtype, labels_t labels);
 };
 
 DaemonMetricCollector &collector_instance();


### PR DESCRIPTION
It is common seeing prometheus metrics grouped instead of sparsed. With these changes 2 main classes were added: Metric and MetricBuilder. Metric is the representation of a prometheus metric where you can have more than one labels-value pairs.

Furthermore, two types of MetricBuilders, OrderedMetricBuilder and UnorderedMetric builder exists. OrderedMetricBuillder constructs the /metrics string in the usual prometheus way. UnorderedMetricBuilder does not sort metric label-value pairs so you'll see more than one TYPE definition but it skips having to store metrics to sort them later.

Ordered:
-----------
![image](https://user-images.githubusercontent.com/30913090/175938947-419c1f81-5ca6-4e37-aecc-aec316b40219.png)

Unordered:
---------------
![image](https://user-images.githubusercontent.com/30913090/175939067-73317e8f-6f16-49b5-b055-bc1e0c37ef32.png)

Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
