### PR TITLE
rgw multisite: restore empty-olh-name fix and update test case

### DIFF
--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -858,6 +858,13 @@ int RGWBucketReshard::do_reshard(const rgw::bucket_index_layout_generation& curr
 	rgw_bucket_category_stats stats;
 	bool account = entry.get_info(&cls_key, &category, &stats);
 	rgw_obj_key key(cls_key);
+	if (entry.type == BIIndexType::OLH && key.empty()) {
+	  // bogus entry created by https://tracker.ceph.com/issues/46456
+	  // to fix, skip so it doesn't get include in the new bucket instance
+	  total_entries--;
+	  ldpp_dout(dpp, 10) << "Dropping entry with empty name, idx=" << marker << dendl;
+	  continue;
+	}
 	rgw_obj obj(bucket_info.bucket, key);
 	RGWMPObj mp;
 	if (key.ns == RGW_OBJ_NS_MULTIPART && mp.from_meta(key.name)) {


### PR DESCRIPTION
the fix from https://github.com/ceph/ceph/pull/45304 got lost in a rebase, so i added it back

the test was also broken by the addition of index generations, because it does surgery directly on a bucket index shard object. it now looks up the bucket's current index generation, and uses that generation number in the index object name

resolves test_rgw_reshard.py failure:
```
Traceback (most recent call last):
  File "/home/ubuntu/cephtest/clone.client.0/qa/workunits/rgw/test_rgw_reshard.py", line 316, in <module>
    main()
  File "/home/ubuntu/cephtest/clone.client.0/qa/workunits/rgw/test_rgw_reshard.py", line 296, in main
    assert len(json_op) == 1
AssertionError
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
