### PR TITLE
quincy -- sse s3 changes

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -229,6 +229,22 @@ HashiCorp Vault Settings
 .. confval:: rgw_crypt_vault_secret_engine
 .. confval:: rgw_crypt_vault_namespace
 
+SSE-S3 Settings
+===============
+
+.. confval:: rgw_crypt_sse_s3_backend
+.. confval:: rgw_crypt_sse_s3_vault_secret_engine
+.. confval:: rgw_crypt_sse_s3_key_template
+.. confval:: rgw_crypt_sse_s3_vault_auth
+.. confval:: rgw_crypt_sse_s3_vault_token_file
+.. confval:: rgw_crypt_sse_s3_vault_addr
+.. confval:: rgw_crypt_sse_s3_vault_prefix
+.. confval:: rgw_crypt_sse_s3_vault_namespace
+.. confval:: rgw_crypt_sse_s3_vault_verify_ssl
+.. confval:: rgw_crypt_sse_s3_vault_ssl_cacert
+.. confval:: rgw_crypt_sse_s3_vault_ssl_clientcert
+.. confval:: rgw_crypt_sse_s3_vault_ssl_clientkey
+
 
 QoS settings
 ------------

--- a/doc/radosgw/encryption.rst
+++ b/doc/radosgw/encryption.rst
@@ -25,13 +25,14 @@ keys and remember which key was used to encrypt each object.
 
 This is implemented in S3 according to the `Amazon SSE-C`_ specification.
 
-As all key management is handled by the client, no special configuration is
-needed to support this encryption mode.
+As all key management is handled by the client, no special Ceph configuration
+is needed to support this encryption mode.
 
 Key Management Service
 ======================
 
-This mode allows keys to be stored in a secure key management service and
+In this mode, an administrator stores keys in a secure key management service.
+These keys are then
 retrieved on demand by the Ceph Object Gateway to serve requests to encrypt
 or decrypt data.
 
@@ -43,12 +44,26 @@ integration with `Barbican`_, `Vault`_, and `KMIP`_ are implemented.
 See `OpenStack Barbican Integration`_, `HashiCorp Vault Integration`_,
 and `KMIP Integration`_.
 
+SSE-S3
+======
+
+This makes key management invisible to the user.  They are still stored
+in vault, but they are automatically created and deleted by Ceph. and
+retrieved as required to serve requests to encrypt
+or decrypt data.
+
+This is implemented in S3 according to the `Amazon SSE-S3`_ specification.
+
+In principle, any key management service could be used here.  Currently
+only integration with `Vault`_, is implemented.
+
+See `HashiCorp Vault Integration`_.
+
 Bucket Encryption APIs
 ======================
 
 Bucket Encryption APIs to support server-side encryption with Amazon
 S3-managed keys (SSE-S3) or AWS KMS customer master keys (SSE-KMS). 
-SSE-KMS implementation via BucketEncryption APIs is not supported yet.
 
 See `PutBucketEncryption`_, `GetBucketEncryption`_, `DeleteBucketEncryption`_
 
@@ -69,6 +84,7 @@ The configuration expects a base64-encoded 256 bit key. For example::
 
 .. _Amazon SSE-C: https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html
 .. _Amazon SSE-KMS: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
+.. _Amazon SSE-S3: https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html
 .. _Barbican: https://wiki.openstack.org/wiki/Barbican
 .. _Vault: https://www.vaultproject.io/docs/
 .. _KMIP: http://www.oasis-open.org/committees/kmip/

--- a/doc/radosgw/vault.rst
+++ b/doc/radosgw/vault.rst
@@ -111,7 +111,7 @@ Token policies for the object gateway
 
 All Vault tokens have powers as specified by the polices attached
 to that token.  Multiple policies may be associated with one
-token.  You should only use the policy necessary for your
+token.  You should only use the policies necessary for your
 configuration.
 
 When using the kv secret engine with the object gateway::
@@ -156,6 +156,18 @@ transit secret engine, you might need the following policy::
     }
   EOF
 
+If you are using both sse-kms and sse-s3, then you should point
+each to separate containers.  You could either use separate
+vault instances, or you could use either separately mounted
+transit instances, or different branches under a common transit
+pointpoint.  If you are not using separate vault instances, you can
+Use these to point kms and sse-s3 to separate containers:
+``rgw_crypt_vault_prefix``
+and/or
+``rgw_crypt_sse_s3_vault_prefix``.
+When granting vault permissions to sse-kms bucket owners, you should
+not give them permission to muck around with sse-s3 keys;
+only ceph itself should be doing that.
 
 Token authentication
 --------------------

--- a/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
+++ b/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
@@ -13,6 +13,8 @@ overrides:
   rgw:
     client.0:
       use-vault-role: client.0
+  s3tests:
+    with-sse-s3: true
 
 tasks:
 - vault:

--- a/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
+++ b/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
@@ -13,8 +13,6 @@ overrides:
   rgw:
     client.0:
       use-vault-role: client.0
-  s3tests:
-    with-sse-s3: true
 
 tasks:
 - vault:

--- a/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
+++ b/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
@@ -6,6 +6,10 @@ overrides:
         rgw crypt vault auth: token
         rgw crypt vault secret engine: transit
         rgw crypt vault prefix: /v1/transit/
+        rgw crypt sse s3 backend: vault
+        rgw crypt sse s3 vault auth: token
+        rgw crypt sse s3 vault secret engine: transit
+        rgw crypt sse s3 vault prefix: /v1/transit/
   rgw:
     client.0:
       use-vault-role: client.0

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -14,6 +14,7 @@ import logging
 import threading
 import traceback
 import os
+import re
 import shlex
 
 from io import BytesIO, StringIO
@@ -69,6 +70,14 @@ def toolbox(ctx, cluster_name, args, **kwargs):
 def write_conf(ctx, conf_path=DEFAULT_CONF_PATH, cluster='ceph'):
     conf_fp = BytesIO()
     ctx.ceph[cluster].conf.write(conf_fp)
+    conf_fp.seek(0)
+    lines = conf_fp.readlines()
+    m = None
+    for l in lines:
+     m = re.search("rgw.crypt.sse.s3.backend *= *(.*)", l.decode())
+     if m:
+      break
+    ctx.ceph[cluster].rgw_crypt_sse_s3_backend = m.expand("\\1") if m else None
     conf_fp.seek(0)
     writes = ctx.cluster.run(
         args=[

--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -138,9 +138,12 @@ def start_rgw(ctx, config, clients):
             ctx.cluster.only(client).run(args=['sudo', 'chmod', '600', token_path])
             ctx.cluster.only(client).run(args=['sudo', 'chown', 'ceph', token_path])
 
+            vault_addr = "{}:{}".format(*ctx.vault.endpoints[vault_role])
             rgw_cmd.extend([
-                '--rgw_crypt_vault_addr', "{}:{}".format(*ctx.vault.endpoints[vault_role]),
-                '--rgw_crypt_vault_token_file', token_path
+                '--rgw_crypt_vault_addr', vault_addr,
+                '--rgw_crypt_vault_token_file', token_path,
+                '--rgw_crypt_sse_s3_vault_addr', vault_addr,
+                '--rgw_crypt_sse_s3_vault_token_file', token_path,
             ])
         elif pykmip_role is not None:
             if not hasattr(ctx, 'pykmip'):

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -432,6 +432,8 @@ def run_tests(ctx, config):
         attrs = ["!fails_on_rgw", "!lifecycle_expiration", "!fails_strict_rfc2616","!test_of_sts","!webidentity_test"]
         if client_config.get('calling-format') != 'ordinary':
             attrs += ['!fails_with_subdomain']
+        if not client_config.get('with-sse-s3'):
+            attrs += ['!sse-s3']
        
         if 'extra_attrs' in client_config:
             attrs = client_config.get('extra_attrs') 

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -432,7 +432,7 @@ def run_tests(ctx, config):
         attrs = ["!fails_on_rgw", "!lifecycle_expiration", "!fails_strict_rfc2616","!test_of_sts","!webidentity_test"]
         if client_config.get('calling-format') != 'ordinary':
             attrs += ['!fails_with_subdomain']
-        if not client_config.get('with-sse-s3'):
+        if client_config.get('without-sse-s3'):
             attrs += ['!sse-s3']
        
         if 'extra_attrs' in client_config:

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -416,6 +416,7 @@ def run_tests(ctx, config):
     testdir = teuthology.get_testdir(ctx)
     for client, client_config in config.items():
         client_config = client_config or {}
+        (cluster_name,_,_) = teuthology.split_role(client)
         (remote,) = ctx.cluster.only(client).remotes.keys()
         args = [
             'S3TEST_CONF={tdir}/archive/s3-tests.{client}.conf'.format(tdir=testdir, client=client),
@@ -433,6 +434,10 @@ def run_tests(ctx, config):
         if client_config.get('calling-format') != 'ordinary':
             attrs += ['!fails_with_subdomain']
         if client_config.get('without-sse-s3'):
+            attrs += ['!sse-s3']
+        elif client_config.get('with-sse-s3'):
+            pass
+        elif ctx.ceph[cluster_name].rgw_crypt_sse_s3_backend is None:
             attrs += ['!sse-s3']
        
         if 'extra_attrs' in client_config:

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -433,7 +433,7 @@ def run_tests(ctx, config):
         attrs = ["!fails_on_rgw", "!lifecycle_expiration", "!fails_strict_rfc2616","!test_of_sts","!webidentity_test"]
         if client_config.get('calling-format') != 'ordinary':
             attrs += ['!fails_with_subdomain']
-        if client_config.get('without-sse-s3'):
+        if not client_config.get('with-sse-s3'):
             attrs += ['!sse-s3']
         elif client_config.get('with-sse-s3'):
             pass

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2743,6 +2743,155 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_crypt_sse_s3_backend
+  type: str
+  level: advanced
+  desc: Where the SSE-S3 encryption keys are stored. The only valid choice here is
+    HashiCorp Vault ('vault').
+  fmt_desc: Where the SSE-S3 encryption keys are stored. The only valid
+    choice is HashiCorp Vault (``vault``).
+  default: vault
+  services:
+  - rgw
+  enum_values:
+  - vault
+  with_legacy: true
+
+- name: rgw_crypt_sse_s3_vault_secret_engine
+  type: str
+  level: advanced
+  desc: Vault Secret Engine to be used to retrieve encryption keys.
+  fmt_desc: |
+    Vault Secret Engine to be used to retrieve encryption keys.  The
+    only valid choice here is transit.
+  default: transit
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_sse_s3_backend
+  - rgw_crypt_sse_s3_vault_auth
+  - rgw_crypt_sse_s3_vault_addr
+  with_legacy: true
+- name: rgw_crypt_sse_s3_key_template
+  type: str
+  level: advanced
+  desc: template for per-bucket sse-s3 keys in vault.
+  long_desc: This is the template for per-bucket sse-s3 keys.
+    This string may include ``%bucket_id`` which will be expanded out to
+    the bucket marker, a unique uuid assigned to that bucket.
+    It could contain ``%owner_id``, which will expand out to the owner's id.
+    Any other use of % is reserved and should not be used.
+    If the template contains ``%bucket_id``, associated bucket keys
+    will be automatically removed when the bucket is removed.
+  services:
+  - rgw
+  default: "%bucket_id"
+  see_also:
+  - rgw_crypt_sse_s3_backend
+  - rgw_crypt_sse_s3_vault_auth
+  - rgw_crypt_sse_s3_vault_addr
+  with_legacy: true
+- name: rgw_crypt_sse_s3_vault_auth
+  type: str
+  level: advanced
+  desc: Type of authentication method to be used with SSE-S3 and Vault.
+  fmt_desc: Type of authentication method to be used. The only method
+    currently supported is ``token``.
+  default: token
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_sse_s3_backend
+  - rgw_crypt_sse_s3_vault_addr
+  - rgw_crypt_sse_s3_vault_token_file
+  enum_values:
+  - token
+  - agent
+  with_legacy: true
+- name: rgw_crypt_sse_s3_vault_token_file
+  type: str
+  level: advanced
+  desc: If authentication method is 'token', provide a path to the token file, which
+    for security reasons should readable only by Rados Gateway.
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_sse_s3_backend
+  - rgw_crypt_sse_s3_vault_auth
+  - rgw_crypt_sse_s3_vault_addr
+  with_legacy: true
+- name: rgw_crypt_sse_s3_vault_addr
+  type: str
+  level: advanced
+  desc: SSE-S3 Vault server base address.
+  fmt_desc: Vault server base address, e.g. ``http://vaultserver:8200``.
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_sse_s3_backend
+  - rgw_crypt_sse_s3_vault_auth
+  - rgw_crypt_sse_s3_vault_prefix
+  with_legacy: true
+# Optional URL prefix to Vault secret path
+- name: rgw_crypt_sse_s3_vault_prefix
+  type: str
+  level: advanced
+  desc: SSE-S3 Vault secret URL prefix, which can be used to restrict access to a particular
+    subset of the Vault secret space.
+  fmt_desc: The Vault secret URL prefix, which can be used to restrict access
+    to a particular subset of the secret space, e.g. ``/v1/secret/data``.
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_sse_s3_backend
+  - rgw_crypt_sse_s3_vault_addr
+  - rgw_crypt_sse_s3_vault_auth
+  with_legacy: true
+#  Vault Namespace (only availabe in Vault Enterprise Version)
+- name: rgw_crypt_sse_s3_vault_namespace
+  type: str
+  level: advanced
+  desc: Vault Namespace to be used to select your tenant
+  fmt_desc: If set, Vault Namespace provides tenant isolation for teams and individuals
+    on the same Vault Enterprise instance, e.g. ``acme/tenant1``
+  services:
+  - rgw
+  see_also:
+  - rgw_crypt_sse_s3_backend
+  - rgw_crypt_sse_s3_vault_auth
+  - rgw_crypt_sse_s3_vault_addr
+  with_legacy: true
+# Enable TLS authentication rgw and vault
+- name: rgw_crypt_sse_s3_vault_verify_ssl
+  type: bool
+  level: advanced
+  desc: Should RGW verify the vault server SSL certificate.
+  default: true
+  services:
+  - rgw
+  with_legacy: true
+# TLS certs options
+- name: rgw_crypt_sse_s3_vault_ssl_cacert
+  type: str
+  level: advanced
+  desc: Path for custom ca certificate for accessing vault server
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_crypt_sse_s3_vault_ssl_clientcert
+  type: str
+  level: advanced
+  desc: Path for custom client certificate for accessing vault server
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_crypt_sse_s3_vault_ssl_clientkey
+  type: str
+  level: advanced
+  desc: Path for private key required for client cert
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_list_bucket_min_readahead
   type: int
   level: advanced

--- a/src/rgw/rgw_bucket_encryption.h
+++ b/src/rgw/rgw_bucket_encryption.h
@@ -12,7 +12,10 @@ class ApplyServerSideEncryptionByDefault
   std::string sseAlgorithm;
 
 public:
-  ApplyServerSideEncryptionByDefault(): kmsMasterKeyID(""), sseAlgorithm("") {};
+  ApplyServerSideEncryptionByDefault() {};
+  ApplyServerSideEncryptionByDefault(const std::string &algorithm,
+     const std::string &key_id)
+   : kmsMasterKeyID(key_id), sseAlgorithm(algorithm) {};
 
   const std::string& kms_master_key_id() const {
     return kmsMasterKeyID;
@@ -49,6 +52,10 @@ protected:
 
 public:
   ServerSideEncryptionConfiguration(): bucketKeyEnabled(false) {};
+  ServerSideEncryptionConfiguration(const std::string &algorithm,
+    const std::string &keyid="", bool enabled = false)
+      : applyServerSideEncryptionByDefault(algorithm, keyid),
+        bucketKeyEnabled(enabled) {}
 
   const std::string& kms_master_key_id() const {
     return applyServerSideEncryptionByDefault.kms_master_key_id();
@@ -89,6 +96,9 @@ protected:
 
 public:
   RGWBucketEncryptionConfig(): rule_exist(false) {}
+  RGWBucketEncryptionConfig(const std::string &algorithm,
+    const std::string &keyid = "", bool enabled = false)
+      : rule_exist(true), rule(algorithm, keyid, enabled) {}
 
   const std::string& kms_master_key_id() const {
     return rule.kms_master_key_id();
@@ -126,5 +136,7 @@ public:
 
   void decode_xml(XMLObj *obj);
   void dump_xml(Formatter *f) const;
+  void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<RGWBucketEncryptionConfig*>& o);
 };
 WRITE_CLASS_ENCODER(RGWBucketEncryptionConfig)

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1225,6 +1225,7 @@ struct req_info {
   const RGWEnv *env;
   RGWHTTPArgs args;
   meta_map_t x_meta_map;
+  meta_map_t crypt_attribute_map;
 
   std::string host;
   const char *method;
@@ -2051,6 +2052,15 @@ void rgw_add_amz_meta_header(
   meta_map_t& x_meta_map,
   const std::string& k,
   const std::string& v);
+
+enum rgw_set_action_if_set {
+  DISCARD=0, OVERWRITE, APPEND
+};
+
+bool rgw_set_amz_meta_header(
+  meta_map_t& x_meta_map,
+  const std::string& k,
+  const std::string& v, rgw_set_action_if_set f);
 
 extern std::string rgw_string_unquote(const std::string& s);
 extern void parse_csv_string(const std::string& ival, std::vector<std::string>& ovals);

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -1189,17 +1189,8 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
         return -EINVAL;
       }
     } else {
-      /* x-amz-server-side-encryption not present or empty */
-      std::string_view key_id =
-	crypt_attributes.get(X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID);
-      if (!key_id.empty()) {
-        ldpp_dout(s, 5) << "ERROR: SSE-KMS encryption request is missing the header "
-                         << "x-amz-server-side-encryption"
-                         << dendl;
-        s->err.message = "Server Side Encryption with KMS managed key requires "
-                         "HTTP header x-amz-server-side-encryption : aws:kms";
-        return -EINVAL;
-      }
+  /*no encryption*/
+      return 0;
     }
 
     /* from here on we are only handling SSE-S3 (req_sse=="AES256") */
@@ -1289,9 +1280,10 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
       ::ceph::crypto::zeroize_for_security(actual_key, sizeof(actual_key));
       return 0;
     }
+    s->err.message = "Request specifies Server Side Encryption "
+                     "but server configuration does not support this.";
+    return -EINVAL;
   }
-  /*no encryption*/
-  return 0;
 }
 
 

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -1103,7 +1103,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
     }
 
     /* Checking bucket attributes if SSE is enabled. Currently only supporting SSE-S3 */
-    rgw::sal::Attrs buck_attrs(s->bucket_attrs);
+    const auto& buck_attrs = s->bucket_attrs;
     auto aiter = buck_attrs.find(RGW_ATTR_BUCKET_ENCRYPTION_POLICY);
     if (aiter != buck_attrs.end()) {
       ldpp_dout(s, 5) << "Found RGW_ATTR_BUCKET_ENCRYPTION_POLICY on "

--- a/src/rgw/rgw_crypt.h
+++ b/src/rgw/rgw_crypt.h
@@ -141,9 +141,6 @@ public:
 
 int rgw_s3_prepare_encrypt(struct req_state* s,
                            std::map<std::string, ceph::bufferlist>& attrs,
-                           std::map<std::string,
-                                    RGWPostObj_ObjStore::post_form_part,
-                                    const ltstr_nocase>* parts,
                            std::unique_ptr<BlockCrypt>* block_crypt,
                            std::map<std::string,
                                     std::string>& crypt_http_responses);

--- a/src/rgw/rgw_crypt.h
+++ b/src/rgw/rgw_crypt.h
@@ -173,4 +173,6 @@ static inline std::string get_str_attribute(std::map<std::string, bufferlist>& a
   return iter->second.to_str();
 }
 
+int rgw_remove_sse_s3_bucket_key(req_state *s);
+
 #endif

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -11,6 +11,7 @@
 #include "rgw_meta_sync_status.h"
 #include "rgw_data_sync.h"
 #include "rgw_multi.h"
+#include "rgw_bucket_encryption.h"
 
 #include "common/Formatter.h"
 
@@ -26,4 +27,15 @@ void obj_version::generate_test_instances(list<obj_version*>& o)
 
   o.push_back(v);
   o.push_back(new obj_version);
+}
+
+void RGWBucketEncryptionConfig::generate_test_instances(std::list<RGWBucketEncryptionConfig*>& o)
+{
+  auto *bc = new RGWBucketEncryptionConfig("aws:kms", "some:key", true);
+  o.push_back(bc);
+
+  bc = new RGWBucketEncryptionConfig("AES256");
+  o.push_back(bc);
+
+  o.push_back(new RGWBucketEncryptionConfig);
 }

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -185,17 +185,17 @@ class SSEContext {
 protected:
   virtual ~SSEContext(){};
 public:
-  virtual std::string & backend() = 0;
-  virtual std::string & addr() = 0;
-  virtual std::string & auth() = 0;
-  virtual std::string & k_namespace() = 0;
-  virtual std::string & prefix() = 0;
+  virtual const std::string & backend() = 0;
+  virtual const std::string & addr() = 0;
+  virtual const std::string & auth() = 0;
+  virtual const std::string & k_namespace() = 0;
+  virtual const std::string & prefix() = 0;
   virtual const std::string & secret_engine() = 0;
-  virtual std::string & ssl_cacert() = 0;
-  virtual std::string & ssl_clientcert() = 0;
-  virtual std::string & ssl_clientkey() = 0;
-  virtual std::string & token_file() = 0;
-  virtual bool verify_ssl() = 0;
+  virtual const std::string & ssl_cacert() = 0;
+  virtual const std::string & ssl_clientcert() = 0;
+  virtual const std::string & ssl_clientkey() = 0;
+  virtual const std::string & token_file() = 0;
+  virtual const bool verify_ssl() = 0;
 };
 
 class VaultSecretEngine: public SecretEngine {
@@ -1085,37 +1085,37 @@ class KMSContext : public SSEContext {
 public:
   KMSContext(CephContext*_cct) : cct{_cct} {};
   ~KMSContext() override {};
-  std::string & backend() override {
+  const std::string & backend() override {
     return cct->_conf->rgw_crypt_s3_kms_backend;
   };
-  std::string & addr() override {
+  const std::string & addr() override {
     return cct->_conf->rgw_crypt_vault_addr;
   };
-  std::string & auth() override {
+  const std::string & auth() override {
     return cct->_conf->rgw_crypt_vault_auth;
   };
-  std::string & k_namespace() override {
+  const std::string & k_namespace() override {
     return cct->_conf->rgw_crypt_vault_namespace;
   };
-  std::string & prefix() override {
+  const std::string & prefix() override {
     return cct->_conf->rgw_crypt_vault_prefix;
   };
   const std::string & secret_engine() override {
     return cct->_conf->rgw_crypt_vault_secret_engine;
   };
-  std::string & ssl_cacert() override {
+  const std::string & ssl_cacert() override {
     return cct->_conf->rgw_crypt_vault_ssl_cacert;
   };
-  std::string & ssl_clientcert() override {
+  const std::string & ssl_clientcert() override {
     return cct->_conf->rgw_crypt_vault_ssl_clientcert;
   };
-  std::string & ssl_clientkey() override {
+  const std::string & ssl_clientkey() override {
     return cct->_conf->rgw_crypt_vault_ssl_clientkey;
   };
-  std::string & token_file() override {
+  const std::string & token_file() override {
     return cct->_conf->rgw_crypt_vault_token_file;
   };
-  bool verify_ssl() override {
+  const bool verify_ssl() override {
     return cct->_conf->rgw_crypt_vault_verify_ssl;
   };
 };
@@ -1126,37 +1126,37 @@ public:
   static const std::string sse_s3_secret_engine;
   SseS3Context(CephContext*_cct) : cct{_cct} {};
   ~SseS3Context(){};
-  std::string & backend() override {
+  const std::string & backend() override {
    return cct->_conf->rgw_crypt_sse_s3_backend;
   };
-  std::string & addr() override {
+  const std::string & addr() override {
     return cct->_conf->rgw_crypt_sse_s3_vault_addr;
   };
-  std::string & auth() override {
+  const std::string & auth() override {
     return cct->_conf->rgw_crypt_sse_s3_vault_auth;
   };
-  std::string & k_namespace() override {
+  const std::string & k_namespace() override {
     return cct->_conf->rgw_crypt_sse_s3_vault_namespace;
   };
-  std::string & prefix() override {
+  const std::string & prefix() override {
     return cct->_conf->rgw_crypt_sse_s3_vault_prefix;
   };
   const std::string & secret_engine() override {
     return sse_s3_secret_engine;
   };
-  std::string & ssl_cacert() override {
+  const std::string & ssl_cacert() override {
     return cct->_conf->rgw_crypt_sse_s3_vault_ssl_cacert;
   };
-  std::string & ssl_clientcert() override {
+  const std::string & ssl_clientcert() override {
     return cct->_conf->rgw_crypt_sse_s3_vault_ssl_clientcert;
   };
-  std::string & ssl_clientkey() override {
+  const std::string & ssl_clientkey() override {
     return cct->_conf->rgw_crypt_sse_s3_vault_ssl_clientkey;
   };
-  std::string & token_file() override {
+  const std::string & token_file() override {
     return cct->_conf->rgw_crypt_sse_s3_vault_token_file;
   };
-  bool verify_ssl() override {
+  const bool verify_ssl() override {
     return cct->_conf->rgw_crypt_sse_s3_vault_verify_ssl;
   };
 };
@@ -1168,7 +1168,7 @@ int reconstitute_actual_key_from_kms(const DoutPrefixProvider *dpp, CephContext 
 {
   std::string key_id = get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYID);
   KMSContext kctx { cct };
-  std::string &kms_backend { kctx.backend() };
+  const std::string &kms_backend { kctx.backend() };
 
   ldpp_dout(dpp, 20) << "Getting KMS encryption key for key " << key_id << dendl;
   ldpp_dout(dpp, 20) << "SSE-KMS backend is " << kms_backend << dendl;
@@ -1199,7 +1199,7 @@ int make_actual_key_from_kms(const DoutPrefixProvider *dpp, CephContext *cct,
                             std::string& actual_key)
 {
   KMSContext kctx { cct };
-  std::string &kms_backend { kctx.backend() };
+  const std::string &kms_backend { kctx.backend() };
   if (RGW_SSE_KMS_BACKEND_VAULT == kms_backend)
     return make_actual_key_from_vault(dpp, cct, kctx, attrs, actual_key);
   return reconstitute_actual_key_from_kms(dpp, cct, attrs, actual_key);
@@ -1212,7 +1212,7 @@ int reconstitute_actual_key_from_sse_s3(const DoutPrefixProvider *dpp,
 {
   std::string key_id = get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYID);
   SseS3Context kctx { cct };
-  std::string &kms_backend { kctx.backend() };
+  const std::string &kms_backend { kctx.backend() };
 
   ldpp_dout(dpp, 20) << "Getting SSE-S3  encryption key for key " << key_id << dendl;
   ldpp_dout(dpp, 20) << "SSE-KMS backend is " << kms_backend << dendl;
@@ -1231,7 +1231,7 @@ int make_actual_key_from_sse_s3(const DoutPrefixProvider *dpp,
                             std::string& actual_key)
 {
   SseS3Context kctx { cct };
-  std::string kms_backend { kctx.backend() };
+  const std::string kms_backend { kctx.backend() };
   if (RGW_SSE_KMS_BACKEND_VAULT != kms_backend) {
     ldpp_dout(dpp, 0) << "ERROR: Unsupported rgw_crypt_sse_s3_backend: " << kms_backend << dendl;
     return -EINVAL;

--- a/src/rgw/rgw_kms.h
+++ b/src/rgw/rgw_kms.h
@@ -45,7 +45,6 @@ int make_actual_key_from_sse_s3(const DoutPrefixProvider *dpp, CephContext *cct,
 int reconstitute_actual_key_from_sse_s3(const DoutPrefixProvider *dpp, CephContext *cct,
                             std::map<std::string, bufferlist>& attrs,
                             std::string& actual_key);
-int generate_kek_sse_s3(CephContext *cct, string kek_id);
 
 int create_sse_s3_bucket_key(const DoutPrefixProvider *dpp, CephContext *cct,
                             const std::string& actual_key);

--- a/src/rgw/rgw_kms.h
+++ b/src/rgw/rgw_kms.h
@@ -39,6 +39,18 @@ int make_actual_key_from_kms(const DoutPrefixProvider *dpp, CephContext *cct,
 int reconstitute_actual_key_from_kms(const DoutPrefixProvider *dpp, CephContext *cct,
                             std::map<std::string, bufferlist>& attrs,
                             std::string& actual_key);
+int make_actual_key_from_sse_s3(const DoutPrefixProvider *dpp, CephContext *cct,
+                            std::map<std::string, bufferlist>& attrs,
+                            std::string& actual_key);
+int reconstitute_actual_key_from_sse_s3(const DoutPrefixProvider *dpp, CephContext *cct,
+                            std::map<std::string, bufferlist>& attrs,
+                            std::string& actual_key);
+
+int create_sse_s3_bucket_key(const DoutPrefixProvider *dpp, CephContext *cct,
+                            const std::string& actual_key);
+
+int remove_sse_s3_bucket_key(const DoutPrefixProvider *dpp, CephContext *cct,
+                            const std::string& actual_key);
 
 /**
  * SecretEngine Interface

--- a/src/rgw/rgw_kms.h
+++ b/src/rgw/rgw_kms.h
@@ -45,6 +45,7 @@ int make_actual_key_from_sse_s3(const DoutPrefixProvider *dpp, CephContext *cct,
 int reconstitute_actual_key_from_sse_s3(const DoutPrefixProvider *dpp, CephContext *cct,
                             std::map<std::string, bufferlist>& attrs,
                             std::string& actual_key);
+int generate_kek_sse_s3(CephContext *cct, string kek_id);
 
 int create_sse_s3_bucket_key(const DoutPrefixProvider *dpp, CephContext *cct,
                             const std::string& actual_key);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3637,15 +3637,15 @@ int RGWPutObj::verify_permission(optional_yield y)
 
     constexpr auto encrypt_attr = "x-amz-server-side-encryption";
     constexpr auto s3_encrypt_attr = "s3:x-amz-server-side-encryption";
-    auto enc_header = s->info.x_meta_map.find(encrypt_attr);
-    if (enc_header != s->info.x_meta_map.end()){
+    auto enc_header = s->info.crypt_attribute_map.find(encrypt_attr);
+    if (enc_header != s->info.crypt_attribute_map.end()){
       rgw_add_to_iam_environment(s->env, s3_encrypt_attr, enc_header->second);
     }
 
     constexpr auto kms_attr = "x-amz-server-side-encryption-aws-kms-key-id";
     constexpr auto s3_kms_attr = "s3:x-amz-server-side-encryption-aws-kms-key-id";
-    auto kms_header = s->info.x_meta_map.find(kms_attr);
-    if (kms_header != s->info.x_meta_map.end()){
+    auto kms_header = s->info.crypt_attribute_map.find(kms_attr);
+    if (kms_header != s->info.crypt_attribute_map.end()){
       rgw_add_to_iam_environment(s->env, s3_kms_attr, kms_header->second);
     }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -8656,20 +8656,6 @@ void RGWPutBucketEncryption::execute(optional_yield y)
     return;
   }
 
-  if(bucket_encryption_conf.kms_master_key_id().compare("") != 0) {
-    ldpp_dout(this, 5) << "encryption not supported with sse-kms" << dendl;
-    op_ret = -ERR_NOT_IMPLEMENTED;
-    s->err.message = "SSE-KMS support is not provided";
-    return;
-  }
-
-  if(bucket_encryption_conf.sse_algorithm().compare("AES256") != 0) {
-    ldpp_dout(this, 5) << "only aes256 algorithm is supported for encryption" << dendl;
-    op_ret = -ERR_NOT_IMPLEMENTED;
-    s->err.message = "Encryption is supported only with AES256 algorithm";
-    return;
-  }
-
   op_ret = store->forward_request_to_master(this, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << "forward_request_to_master returned ret=" << op_ret << dendl;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3428,6 +3428,11 @@ void RGWDeleteBucket::execute(optional_yield y)
     return;
   }
 
+  op_ret = rgw_remove_sse_s3_bucket_key(s);
+  if (op_ret != 0) {
+      // do nothing; it will already have been logged
+  }
+
   op_ret = s->bucket->remove_bucket(this, false, false, nullptr, y);
   if (op_ret < 0 && op_ret == -ECANCELED) {
       // lost a race, either with mdlog sync or another delete bucket operation.

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3733,7 +3733,8 @@ void RGWGetBucketEncryption_ObjStore_S3::send_response()
   dump_start(s);
 
   if (!op_ret) {
-    encode_xml("ServerSideEncryptionConfiguration", bucket_encryption_conf, s->formatter);
+    encode_xml("ServerSideEncryptionConfiguration", XMLNS_AWS_S3,
+      bucket_encryption_conf, s->formatter);
     rgw_flush_formatter_and_reset(s, s->formatter);
   }
 }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -141,6 +141,112 @@ static struct response_attr_param resp_attr_params[] = {
   {NULL, NULL},
 };
 
+#define SSE_C_GROUP 1
+#define KMS_GROUP 2
+
+int get_encryption_defaults(req_state *s)
+{
+  int meta_sse_group = 0;
+  constexpr auto sse_c_prefix = "x-amz-server-side-encryption-customer-";
+  constexpr auto encrypt_attr = "x-amz-server-side-encryption";
+  constexpr auto context_attr = "x-amz-server-side-encryption-context";
+  constexpr auto kms_attr = "x-amz-server-side-encryption-aws-kms-key-id";
+  constexpr auto bucket_key_attr = "x-amz-server-side-encryption-bucket-key-enabled";
+  bool bucket_configuration_found { false };
+
+  for (auto& kv : s->info.crypt_attribute_map) {
+    if (kv.first.find(sse_c_prefix) == 0)
+      meta_sse_group |= SSE_C_GROUP;
+    else if (kv.first.find(encrypt_attr) == 0)
+      meta_sse_group |= KMS_GROUP;
+  }
+  if (meta_sse_group == (SSE_C_GROUP|KMS_GROUP)) {
+    s->err.message = "Server side error - can't do sse-c & sse-kms|sse-s3";
+    return -EINVAL;
+  }
+
+  const auto& buck_attrs = s->bucket_attrs;
+  auto aiter = buck_attrs.find(RGW_ATTR_BUCKET_ENCRYPTION_POLICY);
+  RGWBucketEncryptionConfig bucket_encryption_conf;
+  if (aiter != buck_attrs.end()) {
+    ldpp_dout(s, 5) << "Found RGW_ATTR_BUCKET_ENCRYPTION_POLICY on "
+	    << s->bucket_name << dendl;
+
+    bufferlist::const_iterator iter{&aiter->second};
+
+    try {
+      bucket_encryption_conf.decode(iter);
+      bucket_configuration_found = true;
+    } catch (const buffer::error& e) {
+      s->err.message = "Server side error - can't decode bucket_encryption_conf";
+      ldpp_dout(s, 5) << __func__ <<  "decode bucket_encryption_conf failed" << dendl;
+      return -EINVAL;
+    }
+  }
+  if (meta_sse_group & SSE_C_GROUP) {
+    ldpp_dout(s, 20) << "get_encryption_defaults: no defaults cause sse-c forced"
+	<< dendl;
+    return 0;			// sse-c: no defaults here
+  }
+  std::string sse_algorithm { bucket_encryption_conf.sse_algorithm() };
+  auto kms_master_key_id { bucket_encryption_conf.kms_master_key_id() };
+  bool bucket_key_enabled { bucket_encryption_conf.bucket_key_enabled() };
+  bool kms_attr_seen = false;
+  if (bucket_configuration_found) {
+    ldpp_dout(s, 5) << "RGW_ATTR_BUCKET_ENCRYPTION ALGO: "
+	  <<  sse_algorithm << dendl;
+  }
+
+  auto iter = s->info.crypt_attribute_map.find(kms_attr);
+  if (iter != s->info.crypt_attribute_map.end()) {
+ldpp_dout(s, 20) << "get_encryption_defaults: found kms_attr " << kms_attr << " = " << iter->second << ", setting kms_attr_seen" << dendl;
+    kms_attr_seen = true;
+  } else if (kms_master_key_id != "") {
+ldpp_dout(s, 20) << "get_encryption_defaults: no kms_attr, but kms_master_key_id = " << kms_master_key_id << ", settig kms_attr_seen" << dendl;
+    kms_attr_seen = true;
+    rgw_set_amz_meta_header(s->info.crypt_attribute_map, kms_attr, kms_master_key_id, OVERWRITE);
+  }
+
+  iter = s->info.crypt_attribute_map.find(bucket_key_attr);
+  if (iter != s->info.crypt_attribute_map.end()) {
+ldpp_dout(s, 20) << "get_encryption_defaults: found bucket_key_attr " << bucket_key_attr << " = " << iter->second << ", setting kms_attr_seen" << dendl;
+    kms_attr_seen = true;
+  } else if (bucket_key_enabled) {
+ldpp_dout(s, 20) << "get_encryption_defaults: no bucket_key_attr, but bucket_key_enabled,  setting kms_attr_seen" << dendl;
+    kms_attr_seen = true;
+    rgw_set_amz_meta_header(s->info.crypt_attribute_map, bucket_key_attr, "true", OVERWRITE);
+  }
+
+  iter = s->info.crypt_attribute_map.find(context_attr);
+  if (iter != s->info.crypt_attribute_map.end()) {
+ldpp_dout(s, 20) << "get_encryption_defaults: found context_attr " << context_attr << " = " << iter->second << ", setting kms_attr_seen" << dendl;
+    kms_attr_seen = true;
+  }
+
+  if (kms_attr_seen && sse_algorithm == "") {
+ldpp_dout(s, 20) << "get_encryption_defaults: kms_attr but no algorithm, defaulting to aws_kms" << dendl;
+    sse_algorithm = "aws:kms";
+  }
+
+  iter = s->info.crypt_attribute_map.find(encrypt_attr);
+  if (iter != s->info.crypt_attribute_map.end()) {
+ldpp_dout(s, 20) << "get_encryption_defaults: found encrypt_attr " << encrypt_attr << " = " << iter->second << ", setting sse_algorithm to that" << dendl;
+    sse_algorithm = iter->second;
+  } else if (sse_algorithm != "") {
+    rgw_set_amz_meta_header(s->info.crypt_attribute_map, encrypt_attr, sse_algorithm, OVERWRITE);
+  }
+for (const auto& kv: s->info.crypt_attribute_map) {
+ldpp_dout(s, 20) << "get_encryption_defaults:  final map: " << kv.first << " = " << kv.second << dendl;
+}
+ldpp_dout(s, 20) << "get_encryption_defaults:  kms_attr_seen is " << kms_attr_seen << " and sse_algorithm is " << sse_algorithm << dendl;
+  if (kms_attr_seen && sse_algorithm != "aws:kms") {
+    s->err.message = "algorithm <" + sse_algorithm + "> but got sse-kms attributes";
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
 int RGWGetObj_ObjStore_S3Website::send_response_data(bufferlist& bl, off_t bl_ofs, off_t bl_len) {
   map<string, bufferlist>::iterator iter;
   iter = attrs.find(RGW_ATTR_AMZ_WEBSITE_REDIRECT_LOCATION);
@@ -2340,7 +2446,7 @@ void RGWDeleteBucket_ObjStore_S3::send_response()
   end_header(s, this);
 }
 
-static inline void map_qs_metadata(struct req_state* s)
+static inline void map_qs_metadata(struct req_state* s, bool crypto_too)
 {
   /* merge S3 valid user metadata from the query-string into
    * x_meta_map, which maps them to attributes */
@@ -2349,6 +2455,9 @@ static inline void map_qs_metadata(struct req_state* s)
     std::string k = boost::algorithm::to_lower_copy(elt.first);
     if (k.find("x-amz-meta-") == /* offset */ 0) {
       rgw_add_amz_meta_header(s->info.x_meta_map, k, elt.second);
+    }
+    if (crypto_too && k.find("x-amz-server-side-encryption") == /* offset */ 0) {
+      rgw_set_amz_meta_header(s->info.crypt_attribute_map, k, elt.second, OVERWRITE);
     }
   }
 }
@@ -2360,7 +2469,12 @@ int RGWPutObj_ObjStore_S3::get_params(optional_yield y)
 
   int ret;
 
-  map_qs_metadata(s);
+  map_qs_metadata(s, true);
+  ret = get_encryption_defaults(s);
+  if (ret < 0) {
+    ldpp_dout(this, 5) << __func__ << "(): get_encryption_defaults() returned ret=" << ret << dendl;
+    return ret;
+  }
 
   RGWAccessControlPolicy_S3 s3policy(s->cct);
   ret = create_s3_policy(s, store, s3policy, s->owner);
@@ -2640,7 +2754,7 @@ int RGWPostObj_ObjStore_S3::get_params(optional_yield y)
     return op_ret;
   }
 
-  map_qs_metadata(s);
+  map_qs_metadata(s, false);
 
   ldpp_dout(this, 20) << "adding bucket to policy env: " << s->bucket->get_name()
 		    << dendl;
@@ -2695,6 +2809,20 @@ int RGWPostObj_ObjStore_S3::get_params(optional_yield y)
     string part_str(part.data.c_str(), part.data.length());
     env.add_var(part.name, part_str);
   } while (!done);
+
+  for (auto &p: parts) {
+    if (! boost::istarts_with(p.first, "x-amz-server-side-encryption")) {
+      continue;
+    }
+    bufferlist &d { p.second.data };
+    std::string v { rgw_trim_whitespace(std::string_view(d.c_str(), d.length())) };
+    rgw_set_amz_meta_header(s->info.crypt_attribute_map, p.first, v, OVERWRITE);
+  }
+  int r = get_encryption_defaults(s);
+  if (r < 0) {
+    ldpp_dout(this, 5) << __func__ << "(): get_encryption_defaults() returned ret=" << r << dendl;
+    return r;
+  }
 
   string object_str;
   if (!part_str(parts, "key", &object_str)) {
@@ -2768,7 +2896,7 @@ int RGWPostObj_ObjStore_S3::get_params(optional_yield y)
     attrs[attr_name] = attr_bl;
   }
 
-  int r = get_policy(y);
+  r = get_policy(y);
   if (r < 0)
     return r;
 
@@ -3757,7 +3885,7 @@ int RGWCompleteMultipart_ObjStore_S3::get_params(optional_yield y)
     return ret;
   }
 
-  map_qs_metadata(s);
+  map_qs_metadata(s, true);
 
   return do_aws4_auth_completion();
 }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2714,7 +2714,7 @@ int RGWPutObj_ObjStore_S3::get_encrypt_filter(
   else
   {
     std::unique_ptr<BlockCrypt> block_crypt;
-    res = rgw_s3_prepare_encrypt(s, attrs, nullptr, &block_crypt, crypt_http_responses);
+    res = rgw_s3_prepare_encrypt(s, attrs, &block_crypt, crypt_http_responses);
     if (res == 0 && block_crypt != nullptr) {
       filter->reset(new RGWPutObj_BlockEncrypt(s, s->cct, cb, std::move(block_crypt)));
     }
@@ -3261,7 +3261,7 @@ int RGWPostObj_ObjStore_S3::get_encrypt_filter(
     rgw::sal::DataProcessor *cb)
 {
   std::unique_ptr<BlockCrypt> block_crypt;
-  int res = rgw_s3_prepare_encrypt(s, attrs, &parts, &block_crypt,
+  int res = rgw_s3_prepare_encrypt(s, attrs, &block_crypt,
                                    crypt_http_responses);
   if (res == 0 && block_crypt != nullptr) {
     filter->reset(new RGWPutObj_BlockEncrypt(s, s->cct, cb, std::move(block_crypt)));
@@ -3874,7 +3874,7 @@ void RGWInitMultipart_ObjStore_S3::send_response()
 int RGWInitMultipart_ObjStore_S3::prepare_encryption(map<string, bufferlist>& attrs)
 {
   int res = 0;
-  res = rgw_s3_prepare_encrypt(s, attrs, nullptr, nullptr, crypt_http_responses);
+  res = rgw_s3_prepare_encrypt(s, attrs, nullptr, crypt_http_responses);
   return res;
 }
 

--- a/src/tools/ceph-dencoder/rgw_types.h
+++ b/src/tools/ceph-dencoder/rgw_types.h
@@ -128,4 +128,7 @@ TYPE(rgw_data_sync_info)
 TYPE(rgw_data_sync_marker)
 TYPE(rgw_data_sync_status)
 
+#include "rgw/rgw_bucket_encryption.h"
+TYPE(RGWBucketEncryptionConfig)
+
 #endif


### PR DESCRIPTION



sse s3 changes backported to quincy.

No special magic here -- patches applied without issue.  Builds on fc35, not otherwise tested.  Will need corresponding changes to test suites to pass teuthology.

There might still be a build of this at ceph-ci -- look for "mdw-qmk-2"