### PR TITLE
quincy: qa: fix teuthology master branch ref

### DIFF
--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -25,7 +25,7 @@ commands = mypy {posargs:.}
 [testenv:py3]
 basepython = python3
 deps =
-  {env:TEUTHOLOGY_GIT:git+https://github.com/ceph/teuthology.git@master}#egg=teuthology[coverage,orchestra,test]
+  {env:TEUTHOLOGY_GIT:git+https://github.com/ceph/teuthology.git@main}#egg=teuthology[coverage,orchestra,test]
   httplib2
 commands =
   pytest --assert=plain test_import.py


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55831

---

backport of https://github.com/ceph/ceph/pull/46501
parent tracker: https://tracker.ceph.com/issues/55826

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh