### PR TITLE
pacific: qa: fix teuthology master branch ref

### DIFF
--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -15,7 +15,7 @@ commands = mypy {posargs:.}
 
 [testenv:import-tasks]
 basepython = python3
-deps = {env:TEUTHOLOGY_GIT:git+https://github.com/ceph/teuthology.git@master}#egg=teuthology[coverage,orchestra,test]
+deps = {env:TEUTHOLOGY_GIT:git+https://github.com/ceph/teuthology.git@main}#egg=teuthology[coverage,orchestra,test]
 commands = python test_import.py {posargs:tasks/**/*.py}
 
 [testenv:pytest]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55832

---

backport of https://github.com/ceph/ceph/pull/46501
parent tracker: https://tracker.ceph.com/issues/55826

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh