### PR TITLE
mgr/dashboard: rbd force resync from front-end

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -319,6 +319,7 @@ describe('RbdListComponent', () => {
           'Edit',
           'Copy',
           'Flatten',
+          'Resync',
           'Delete',
           'Move to Trash',
           'Remove Scheduling'
@@ -326,7 +327,7 @@ describe('RbdListComponent', () => {
         primary: { multiple: 'Create', executing: 'Edit', single: 'Edit', no: 'Create' }
       },
       'create,update': {
-        actions: ['Create', 'Edit', 'Copy', 'Flatten', 'Remove Scheduling'],
+        actions: ['Create', 'Edit', 'Copy', 'Flatten', 'Resync', 'Remove Scheduling'],
         primary: { multiple: 'Create', executing: 'Edit', single: 'Edit', no: 'Create' }
       },
       'create,delete': {
@@ -338,11 +339,11 @@ describe('RbdListComponent', () => {
         primary: { multiple: 'Create', executing: 'Copy', single: 'Copy', no: 'Create' }
       },
       'update,delete': {
-        actions: ['Edit', 'Flatten', 'Delete', 'Move to Trash', 'Remove Scheduling'],
+        actions: ['Edit', 'Flatten', 'Resync', 'Delete', 'Move to Trash', 'Remove Scheduling'],
         primary: { multiple: 'Edit', executing: 'Edit', single: 'Edit', no: 'Edit' }
       },
       update: {
-        actions: ['Edit', 'Flatten', 'Remove Scheduling'],
+        actions: ['Edit', 'Flatten', 'Resync', 'Remove Scheduling'],
         primary: { multiple: 'Edit', executing: 'Edit', single: 'Edit', no: 'Edit' }
       },
       delete: {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -565,7 +565,7 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
     const first = selection.first();
 
     if (first && this.imageIsPrimary(first)) {
-      return $localize`Primary RBD cannot be resynced`;
+      return $localize`Primary RBD images cannot be resynced`;
     }
 
     return this.getInvalidNameDisable(selection);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
@@ -134,6 +134,7 @@ export class ActionLabelsI18n {
   STOP: string;
   REDEPLOY: string;
   RESTART: string;
+  RESYNC: string;
 
   constructor() {
     /* Create a new item */
@@ -190,7 +191,7 @@ export class ActionLabelsI18n {
 
     this.START_DRAIN = $localize`Start Drain`;
     this.STOP_DRAIN = $localize`Stop Drain`;
-
+    this.RESYNC = $localize`Resync`;
     /* Prometheus wording */
     this.RECREATE = $localize`Recreate`;
     this.EXPIRE = $localize`Expire`;


### PR DESCRIPTION
Adds a new table action to resync rbd images.

To test this feature:
- `docker exec -it ceph /bin/bash`
- `rbd-mirror -d`
- Block>Mirroring change status of rbd mirroring to “pool” (from disabled)
- Create a new rbd image(rbd2) with “Journaling” checked
- `rbd mirror image demote rbd/rbd2`
- now try to "resync" by using table-actions

depends on: https://github.com/ceph/ceph/pull/46479 and https://tracker.ceph.com/issues/55939

![image](https://user-images.githubusercontent.com/48375025/171752617-9dc1ae1e-2d06-493a-aa9f-6bda68dedc61.png)

![image](https://user-images.githubusercontent.com/48375025/171752662-c18c972f-5700-400c-8d7d-f877aa56a11d.png)

Fixes: https://tracker.ceph.com/issues/55839
Signed-off-by: Sarthak0702 <sarthak.dev.0702@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
