### PR TITLE
cephadm: add 'is_paused' field in orch status output

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -147,6 +147,7 @@ class CephadmUpgrade:
             r.target_image = self.target_image
             r.in_progress = True
             r.progress, r.services_complete = self._get_upgrade_info()
+            r.is_paused = self.upgrade_state.paused
 
             if self.upgrade_state.daemon_types is not None:
                 which_str = f'Upgrading daemons of type(s) {",".join(self.upgrade_state.daemon_types)}'

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -783,6 +783,7 @@ class UpgradeStatusSpec(object):
         self.which: str = '<unknown>'  # for if user specified daemon types, services or hosts
         self.progress: Optional[str] = None  # How many of the daemons have we upgraded
         self.message = ""  # Freeform description
+        self.is_paused: bool = False  # Is the upgrade paused?
 
 
 def handle_type_error(method: FuncT) -> FuncT:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1421,6 +1421,7 @@ Usage:
             'services_complete': status.services_complete,
             'progress': status.progress,
             'message': status.message,
+            'is_paused': status.is_paused,
         }
         out = json.dumps(r, indent=4)
         return HandleCommandResult(stdout=out)


### PR DESCRIPTION
it can be convenient for automation tool if `orch status` output reports
whether the upgrade is currently paused.

Fixes: https://tracker.ceph.com/issues/55843

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
