### PR TITLE
rgw multisite: stop broadcasting and receiving data/metadata change notifications

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2304,17 +2304,6 @@ options:
   services:
   - rgw
   with_legacy: true
-- name: rgw_md_notify_interval_msec
-  type: int
-  level: advanced
-  desc: Length of time to aggregate metadata changes
-  long_desc: Length of time (in milliseconds) in which the master zone aggregates
-    all the metadata changes that occurred, before sending notifications to all the
-    other zones.
-  default: 200
-  services:
-  - rgw
-  with_legacy: true
 - name: rgw_run_sync_thread
   type: bool
   level: advanced
@@ -3001,17 +2990,6 @@ options:
   type: str
   level: advanced
   desc: torrent field encoding
-  services:
-  - rgw
-  with_legacy: true
-- name: rgw_data_notify_interval_msec
-  type: int
-  level: advanced
-  desc: data changes notification interval to followers
-  long_desc: In multisite, radosgw will occasionally broadcast new entries in its
-    data changes log to peer zones, so they can prioritize sync of some
-    of the most recent changes. Can be disabled with 0.
-  default: 0
   services:
   - rgw
   with_legacy: true

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -367,9 +367,6 @@ class RGWRemoteDataLog : public RGWCoroutinesManager {
   RGWDataSyncEnv sync_env;
   RGWDataSyncCtx sc;
 
-  ceph::shared_mutex lock = ceph::make_shared_mutex("RGWRemoteDataLog::lock");
-  RGWDataSyncControlCR *data_sync_cr;
-
   RGWSyncTraceNodeRef tn;
 
   bool initialized;
@@ -391,8 +388,6 @@ public:
   int read_shard_status(const DoutPrefixProvider *dpp, int shard_id, std::set<std::string>& lagging_buckets,std::set<std::string>& recovering_buckets, rgw_data_sync_marker* sync_marker, const int max_entries);
   int init_sync_status(const DoutPrefixProvider *dpp, int num_shards);
   int run_sync(const DoutPrefixProvider *dpp, int num_shards);
-
-  void wakeup(int shard_id, bc::flat_set<rgw_data_notify_entry>& entries);
 };
 
 class RGWDataSyncStatusManager : public DoutPrefixProvider {
@@ -458,8 +453,6 @@ public:
   }
 
   int run(const DoutPrefixProvider *dpp) { return source_log.run_sync(dpp, num_shards); }
-
-  void wakeup(int shard_id, bc::flat_set<rgw_data_notify_entry>& entries) { return source_log.wakeup(shard_id, entries); }
 
   void stop() {
     source_log.finish();

--- a/src/rgw/rgw_datalog.h
+++ b/src/rgw/rgw_datalog.h
@@ -249,9 +249,6 @@ class RGWDataChangesLog {
   std::string prefix;
 
   ceph::mutex lock = ceph::make_mutex("RGWDataChangesLog::lock");
-  ceph::shared_mutex modified_lock =
-    ceph::make_shared_mutex("RGWDataChangesLog::modified_lock");
-  bc::flat_map<int, bc::flat_set<rgw_data_notify_entry>> modified_shards;
 
   std::atomic<bool> down_flag = { false };
 
@@ -314,15 +311,6 @@ public:
   int list_entries(const DoutPrefixProvider *dpp, int max_entries,
 		   std::vector<rgw_data_change_log_entry>& entries,
 		   LogMarker& marker, bool* ptruncated);
-
-  void mark_modified(int shard_id, const rgw_bucket_shard& bs, uint64_t gen);
-  auto read_clear_modified() {
-    std::unique_lock wl{modified_lock};
-    decltype(modified_shards) modified;
-    modified.swap(modified_shards);
-    modified_shards.clear();
-    return modified;
-  }
 
   void set_observer(rgw::BucketChangeObserver *observer) {
     this->observer = observer;

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -79,18 +79,13 @@ class RGWMetadataLog {
     return META_LOG_OBJ_PREFIX + period + ".";
   }
 
-  RWLock lock;
-  std::set<int> modified_shards;
-
-  void mark_modified(int shard_id);
 public:
   RGWMetadataLog(CephContext *_cct,
                  RGWSI_Zone *_zone_svc,
                  RGWSI_Cls *_cls_svc,
                  const std::string& period)
     : cct(_cct),
-      prefix(make_prefix(period)),
-      lock("RGWMetaLog::lock") {
+      prefix(make_prefix(period)) {
     svc.zone = _zone_svc;
     svc.cls = _cls_svc;
   }
@@ -137,8 +132,6 @@ public:
   int unlock(const DoutPrefixProvider *dpp, int shard_id, std::string& zone_id, std::string& owner_id);
 
   int update_shards(std::list<int>& shards);
-
-  void read_clear_modified(std::set<int> &modified);
 };
 
 struct LogStatusDump {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -44,8 +44,6 @@ struct D3nDataCache;
 class RGWWatcher;
 class ACLOwner;
 class RGWGC;
-class RGWMetaNotifier;
-class RGWDataNotifier;
 class RGWLC;
 class RGWObjectExpirer;
 class RGWMetaSyncProcessorThread;
@@ -331,8 +329,6 @@ class RGWIndexCompletionManager;
 class RGWRados
 {
   friend class RGWGC;
-  friend class RGWMetaNotifier;
-  friend class RGWDataNotifier;
   friend class RGWObjectExpirer;
   friend class RGWMetaSyncProcessorThread;
   friend class RGWDataSyncProcessorThread;
@@ -369,8 +365,6 @@ class RGWRados
   bool run_sync_thread;
   bool run_reshard_thread;
 
-  RGWMetaNotifier *meta_notifier;
-  RGWDataNotifier *data_notifier;
   RGWMetaSyncProcessorThread *meta_sync_processor_thread;
   RGWSyncTraceManager *sync_tracer = nullptr;
   std::map<rgw_zone_id, RGWDataSyncProcessorThread *> data_sync_processor_threads;
@@ -451,8 +445,7 @@ protected:
 public:
   RGWRados(): timer(NULL),
                gc(NULL), lc(NULL), obj_expirer(NULL), use_gc_thread(false), use_lc_thread(false), quota_threads(false),
-               run_sync_thread(false), run_reshard_thread(false), meta_notifier(NULL),
-               data_notifier(NULL), meta_sync_processor_thread(NULL),
+               run_sync_thread(false), run_reshard_thread(false), meta_sync_processor_thread(NULL),
                bucket_index_max_shards(0),
                max_bucket_id(0), cct(NULL),
                binfo_cache(NULL), obj_tombstone_cache(nullptr),

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1199,10 +1199,6 @@ public:
    */
   int delete_bucket(RGWBucketInfo& bucket_info, RGWObjVersionTracker& objv_tracker, optional_yield y, const DoutPrefixProvider *dpp, bool check_empty = true);
 
-  void wakeup_meta_sync_shards(std::set<int>& shard_ids);
-
-  void wakeup_data_sync_shards(const DoutPrefixProvider *dpp, const rgw_zone_id& source_zone, bc::flat_map<int, bc::flat_set<rgw_data_notify_entry> >& entries);
-
   RGWMetaSyncStatusManager* get_meta_sync_manager();
   RGWDataSyncStatusManager* get_data_sync_manager(const rgw_zone_id& source_zone);
 

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -372,10 +372,6 @@ class Store {
 					optional_yield y) = 0;
     /** Get a status manager for bucket sync */
     virtual RGWDataSyncStatusManager* get_data_sync_manager(const rgw_zone_id& source_zone) = 0;
-    /** Wake up sync threads for bucket metadata sync */
-    virtual void wakeup_meta_sync_shards(std::set<int>& shard_ids) = 0;
-    /** Wake up sync threads for bucket data sync */
-    virtual void wakeup_data_sync_shards(const DoutPrefixProvider *dpp, const rgw_zone_id& source_zone, boost::container::flat_map<int, boost::container::flat_set<rgw_data_notify_entry>>& shard_ids) = 0;
     /** Clear all usage statistics globally */
     virtual int clear_usage(const DoutPrefixProvider *dpp) = 0;
     /** Get usage statistics for all users and buckets */

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -800,12 +800,6 @@ public:
           RGWBucketSyncPolicyHandlerRef *phandler,
           optional_yield y) override;
       virtual RGWDataSyncStatusManager* get_data_sync_manager(const rgw_zone_id& source_zone) override;
-      virtual void wakeup_meta_sync_shards(std::set<int>& shard_ids) override { return; }
-      virtual void wakeup_data_sync_shards(const DoutPrefixProvider *dpp,
-					   const rgw_zone_id& source_zone,
-					   boost::container::flat_map<
-					     int,
-					   boost::container::flat_set<rgw_data_notify_entry>>& shard_ids) override { return; }
       virtual int clear_usage(const DoutPrefixProvider *dpp) override { return 0; }
       virtual int read_all_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch,
           uint32_t max_entries, bool *is_truncated,

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -942,8 +942,6 @@ class MotrStore : public Store {
         RGWBucketSyncPolicyHandlerRef *phandler,
         optional_yield y) override;
     virtual RGWDataSyncStatusManager* get_data_sync_manager(const rgw_zone_id& source_zone) override;
-    virtual void wakeup_meta_sync_shards(std::set<int>& shard_ids) override { return; }
-    virtual void wakeup_data_sync_shards(const DoutPrefixProvider *dpp, const rgw_zone_id& source_zone, boost::container::flat_map<int, boost::container::flat_set<rgw_data_notify_entry>>& shard_ids) override {}
     virtual int clear_usage(const DoutPrefixProvider *dpp) override { return 0; }
     virtual int read_all_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch,
         uint32_t max_entries, bool *is_truncated,

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -169,8 +169,6 @@ class RadosStore : public Store {
 					RGWBucketSyncPolicyHandlerRef* phandler,
 					optional_yield y) override;
     virtual RGWDataSyncStatusManager* get_data_sync_manager(const rgw_zone_id& source_zone) override;
-    virtual void wakeup_meta_sync_shards(std::set<int>& shard_ids) override { rados->wakeup_meta_sync_shards(shard_ids); }
-    virtual void wakeup_data_sync_shards(const DoutPrefixProvider *dpp, const rgw_zone_id& source_zone, boost::container::flat_map<int, boost::container::flat_set<rgw_data_notify_entry>>& shard_ids) override { rados->wakeup_data_sync_shards(dpp, source_zone, shard_ids); }
     virtual int clear_usage(const DoutPrefixProvider *dpp) override { return rados->clear_usage(dpp); }
     virtual int read_all_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch,
 			       uint32_t max_entries, bool* is_truncated,


### PR DESCRIPTION
removes all of the machinery related to multisite's "async notifications"

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
