### PR TITLE
rpm: use system arrow/utf8proc packages by default

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -106,7 +106,6 @@
 %bcond_with cephfs_shell
 %endif
 %bcond_with system_arrow
-%bcond_with system_utf8proc
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel} >= 8
 %global weak_deps 1
 %endif
@@ -324,8 +323,6 @@ BuildRequires:  libpmemobj-devel >= 1.8
 %if 0%{with system_arrow}
 BuildRequires:  libarrow-devel
 BuildRequires:  parquet-libs-devel
-%endif
-%if 0%{with system_utf8proc}
 BuildRequires:  utf8proc-devel
 %endif
 %if 0%{with seastar}
@@ -1420,8 +1417,6 @@ cmake .. \
 %endif
 %if 0%{with system_arrow}
     -DWITH_SYSTEM_ARROW:BOOL=ON \
-%endif
-%if 0%{with system_utf8proc}
     -DWITH_SYSTEM_UTF8PROC:BOOL=ON \
 %endif
 %if 0%{with seastar}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -322,8 +322,8 @@ BuildRequires:  libpmem-devel
 BuildRequires:  libpmemobj-devel >= 1.8
 %endif
 %if 0%{with system_arrow}
-BuildRequires:  arrow-devel
-BuildRequires:  parquet-devel
+BuildRequires:  libarrow-devel
+BuildRequires:  parquet-libs-devel
 %endif
 %if 0%{with system_utf8proc}
 BuildRequires:  utf8proc-devel

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -105,7 +105,13 @@
 # distros that do _not_ ship cmd2/colorama
 %bcond_with cephfs_shell
 %endif
+%if 0%{?fedora} || 0%{?rhel} >= 9
+%bcond_without system_arrow
+%else
+# for centos 8, utf8proc-devel comes from the subversion-devel module which isn't available in EPEL8
+# this is tracked in https://bugzilla.redhat.com/2152265
 %bcond_with system_arrow
+%endif
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel} >= 8
 %global weak_deps 1
 %endif


### PR DESCRIPTION
testing to see whether all arrow dependencies are available through epel on centos stream 8

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
