### PR TITLE
rgw: fix un/signed comparison warnings in rgw_sync.cc

### DIFF
--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1652,7 +1652,7 @@ public:
               pos_to_prev[marker] = marker;
             }
             // limit spawn window
-            while (num_spawned() > cct->_conf->rgw_meta_sync_spawn_window) {
+            while (num_spawned() > static_cast<size_t>(cct->_conf->rgw_meta_sync_spawn_window)) {
               yield wait_for_child();
               collect_children();
             }
@@ -1851,7 +1851,7 @@ public:
                 pos_to_prev[log_iter->id] = marker;
               }
               // limit spawn window
-              while (num_spawned() > cct->_conf->rgw_meta_sync_spawn_window) {
+              while (num_spawned() > static_cast<size_t>(cct->_conf->rgw_meta_sync_spawn_window)) {
                 yield wait_for_child();
                 collect_children();
               }


### PR DESCRIPTION
```
[ 75%] Building CXX object src/rgw/CMakeFiles/rgw_common.dir/rgw_sync.cc.o
src/rgw/rgw_sync.cc: In member function ‘int RGWMetaSyncShardCR::full_sync()’:
src/rgw/rgw_sync.cc:1655:34: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int64_t’ {aka ‘long int’} [-Wsign-compare]
             while (num_spawned() > cct->_conf->rgw_meta_sync_spawn_window) {
                    ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/rgw/rgw_sync.cc: In member function ‘int RGWMetaSyncShardCR::incremental_sync()’:
src/rgw/rgw_sync.cc:1854:36: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int64_t’ {aka ‘long int’} [-Wsign-compare]
               while (num_spawned() > cct->_conf->rgw_meta_sync_spawn_window) {
                      ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Fixes: https://tracker.ceph.com/issues/55898

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
