### PR TITLE
rgw: fix un/signed comparison warnings in rgw_admin.cc

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2576,7 +2576,7 @@ static int bucket_source_sync_status(const DoutPrefixProvider *dpp, rgw::sal::Ra
     return r;
   }
 
-  const size_t total_shards = shard_status.size();
+  const int total_shards = shard_status.size();
 
   out << indented{width} << "incremental sync on " << total_shards << " shards\n";
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/55901

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
