### PR TITLE
rgw/multisite: send full sync obligations to error repo in incremental sync

### DIFF
--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -6,6 +6,7 @@ overrides:
         setuser: ceph
         setgroup: ceph
         debug rgw: 20
+        debug rgw sync: 20
         rgw crypt s3 kms backend: testing
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
         rgw crypt require ssl: false
@@ -15,5 +16,6 @@ overrides:
         rgw data log num shards: 4
         rgw sync obj etag verify: true
         rgw sync meta inject err probability: 0.1
+        rgw sync data inject err probability: 0.1
   rgw:
     compression type: random

--- a/qa/suites/rgw/multisite/tasks/test_multi.yaml
+++ b/qa/suites/rgw/multisite/tasks/test_multi.yaml
@@ -15,5 +15,3 @@ tasks:
 - rgw-multisite-tests:
     config:
       reconfigure_delay: 60
-    args: ['-a', '!bucket_sync_disable,!bucket_reshard'] # filter out disable/enable and reshard tests
-- interactive:

--- a/qa/suites/rgw/multisite/tasks/test_multi.yaml
+++ b/qa/suites/rgw/multisite/tasks/test_multi.yaml
@@ -16,3 +16,4 @@ tasks:
     config:
       reconfigure_delay: 60
     args: ['-a', '!bucket_sync_disable,!bucket_reshard'] # filter out disable/enable and reshard tests
+- interactive:

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2395,7 +2395,7 @@ options:
   services:
   - rgw
   with_legacy: true
-- name: rgw_read_bilog_info_inject_err_probability
+- name: rgw_sync_data_full_inject_err_probability
   type: float
   level: dev
   default: 0

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2395,6 +2395,13 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_read_bilog_info_inject_err_probability
+  type: float
+  level: dev
+  default: 0
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_sync_trace_history_size
   type: size
   level: advanced

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1341,8 +1341,8 @@ public:
           progress = ceph::real_time{};
 
           ldout(cct, 4) << "starting sync on " << bucket_shard_str{state->key.first}
-              << ' ' << *state->obligation << "progress timestamp " << state->progress_timestamp
-              << "progress " << progress << dendl;
+              << ' ' << *state->obligation << " progress timestamp " << state->progress_timestamp
+              << " progress " << progress << dendl;
           yield call(new RGWRunBucketSourcesSyncCR(sc, lease_cr,
                                                    state->key.first, tn,
                                                    state->obligation->gen,
@@ -1608,13 +1608,6 @@ public:
                 return retcode;
               });
       }
-
-      drain_all_cb([&](uint64_t stack_id, int ret) {
-        if (ret < 0) {
-          tn->log(10, SSTR("a sync operation returned error: " << ret));
-        }
-        return ret;
-      });
 
       yield call(marker_tracker->finish(key));
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3986,8 +3986,6 @@ done:
   }
 };
 
-#define BUCKET_SYNC_SPAWN_WINDOW 20
-
 class RGWBucketFullSyncCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
@@ -4787,7 +4785,7 @@ int RGWRunBucketSourcesSyncCR::operate(const DoutPrefixProvider *dpp)
 
       yield_spawn_window(sync_bucket_shard_cr(sc, lease_cr, sync_pair,
                                               gen, tn, &*cur_shard_progress),
-                         BUCKET_SYNC_SPAWN_WINDOW,
+                         cct->_conf->rgw_bucket_sync_spawn_window,
                          [&](uint64_t stack_id, int ret) {
                            if (ret < 0) {
                              tn->log(10, SSTR("ERROR: a sync operation returned error: " << ret));

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -674,7 +674,7 @@ struct rgw_bucket_index_marker_info {
   bool syncstopped{false};
   uint64_t oldest_gen = 0;
   uint64_t latest_gen = 0;
-  std::vector<std::pair<int, int>> gen_numshards;
+  std::vector<std::pair<uint64_t, uint32_t>> gen_numshards;
 
   void decode_json(JSONObj *obj) {
     JSONDecoder::decode_json("bucket_ver", bucket_ver, obj);

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -674,6 +674,7 @@ struct rgw_bucket_index_marker_info {
   bool syncstopped{false};
   uint64_t oldest_gen = 0;
   uint64_t latest_gen = 0;
+  std::vector<std::pair<int, int>> gen_numshards;
 
   void decode_json(JSONObj *obj) {
     JSONDecoder::decode_json("bucket_ver", bucket_ver, obj);

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -667,6 +667,21 @@ struct bilog_status_v2 {
   void decode_json(JSONObj *obj);
 };
 
+struct store_gen_shards {
+  uint64_t gen = 0;
+  uint32_t num_shards = 0;
+
+  void dump(Formatter *f) const {
+    encode_json("gen", gen, f);
+    encode_json("num_shards", num_shards, f);
+  }
+
+  void decode_json(JSONObj *obj) {
+    JSONDecoder::decode_json("gen", gen, obj);
+    JSONDecoder::decode_json("num_shards", num_shards, obj);
+  }
+};
+
 struct rgw_bucket_index_marker_info {
   std::string bucket_ver;
   std::string master_ver;
@@ -674,7 +689,7 @@ struct rgw_bucket_index_marker_info {
   bool syncstopped{false};
   uint64_t oldest_gen = 0;
   uint64_t latest_gen = 0;
-  std::vector<std::pair<uint64_t, uint32_t>> gen_numshards;
+  std::vector<store_gen_shards> generations;
 
   void decode_json(JSONObj *obj) {
     JSONDecoder::decode_json("bucket_ver", bucket_ver, obj);
@@ -683,6 +698,7 @@ struct rgw_bucket_index_marker_info {
     JSONDecoder::decode_json("syncstopped", syncstopped, obj);
     JSONDecoder::decode_json("oldest_gen", oldest_gen, obj);
     JSONDecoder::decode_json("latest_gen", latest_gen, obj);
+    JSONDecoder::decode_json("generations", generations, obj);
   }
 };
 

--- a/src/rgw/rgw_datalog.h
+++ b/src/rgw/rgw_datalog.h
@@ -284,7 +284,6 @@ class RGWDataChangesLog {
   std::thread renew_thread;
 
   std::function<bool(const rgw_bucket& bucket, optional_yield y, const DoutPrefixProvider *dpp)> bucket_filter;
-  int choose_oid(const rgw_bucket_shard& bs);
   bool going_down() const;
   bool filter_bucket(const DoutPrefixProvider *dpp, const rgw_bucket& bucket, optional_yield y) const;
   int renew_entries(const DoutPrefixProvider *dpp);
@@ -296,7 +295,7 @@ public:
 
   int start(const DoutPrefixProvider *dpp, const RGWZone* _zone, const RGWZoneParams& zoneparams,
 	    librados::Rados* lr);
-
+  int choose_oid(const rgw_bucket_shard& bs);
   int add_entry(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
 		const rgw::bucket_log_layout_generation& gen, int shard_id);
   int get_log_shard_id(rgw_bucket& bucket, int shard_id);

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -568,7 +568,7 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
 
   for (auto& log : logs) {
       uint32_t num_shards = log.layout.in_index.layout.num_shards;
-      gen_numshards.push_back(std::make_pair(log.gen, num_shards));
+      generations.push_back({log.gen, num_shards});
   }
 }
 
@@ -587,7 +587,7 @@ void RGWOp_BILog_Info::send_response() {
   encode_json("syncstopped", syncstopped, s->formatter);
   encode_json("oldest_gen", oldest_gen, s->formatter);
   encode_json("latest_gen", latest_gen, s->formatter);
-  //encode_json("gen_numshards", gen_numshards, s->formatter); TODO: add supporting encode/decode for std::pair
+  encode_json("generations", generations, s->formatter);
   s->formatter->close_section();
 
   flusher.flush();

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -565,6 +565,17 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
 
   oldest_gen = logs.front().gen;
   latest_gen = logs.back().gen;
+
+  std::vector<std::pair<int, int>> gen_numshards;
+  for (auto gen = logs.front().gen; gen <= logs.back().gen; gen++) {
+    auto log = std::find_if(logs.begin(), logs.end(), rgw::matches_gen(gen));
+    if (log == logs.end()) {
+      ldpp_dout(s, 5) << "ERROR: no log layout with gen=" << gen << dendl;
+      op_ret = -ENOENT;
+    }
+    const auto& num_shards = log->layout.in_index.layout.num_shards;
+    gen_numshards.push_back(std::make_pair(gen, num_shards));
+  }
 }
 
 void RGWOp_BILog_Info::send_response() {

--- a/src/rgw/rgw_rest_log.h
+++ b/src/rgw/rgw_rest_log.h
@@ -20,6 +20,7 @@
 #include "rgw_rest_s3.h"
 #include "rgw_metadata.h"
 #include "rgw_mdlog.h"
+#include "rgw_data_sync.h"
 
 class RGWOp_BILog_List : public RGWRESTOp {
   bool sent_header;
@@ -53,7 +54,7 @@ class RGWOp_BILog_Info : public RGWRESTOp {
   bool syncstopped;
   uint64_t oldest_gen = 0;
   uint64_t latest_gen = 0;
-  std::vector<std::pair<uint64_t, uint32_t>> gen_numshards;
+  std::vector<store_gen_shards> generations;
 
 public:
   RGWOp_BILog_Info() : bucket_ver(), master_ver(), syncstopped(false) {}

--- a/src/rgw/rgw_rest_log.h
+++ b/src/rgw/rgw_rest_log.h
@@ -53,6 +53,7 @@ class RGWOp_BILog_Info : public RGWRESTOp {
   bool syncstopped;
   uint64_t oldest_gen = 0;
   uint64_t latest_gen = 0;
+  std::vector<std::pair<uint64_t, uint32_t>> gen_numshards;
 
 public:
   RGWOp_BILog_Info() : bucket_ver(), master_ver(), syncstopped(false) {}


### PR DESCRIPTION
After recent changes that introduced layouts and generations in multisite, 'data full sync init' does not work as intended.
When 'data sync init' is run on a bucket that has already made it to incremental sync, we could end up losing track of generations lower than remote's latest generation. Secondly when building full sync index, we only use shard 0 for every bucket. As a result, when we run data sync init, we start an incremental sync of shard 0 alone while the intention was to trigger a bucket full sync. 

In order to preserve generations and their shard information for a bucket, we will write those full sync obligations into error repo for later retry during incremental sync.

Signed-off-by: Shilpa Jagannath <smanjara@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
