### PR TITLE
osd: add option to dump pg log to pg command

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2527,6 +2527,7 @@ void OSD::asok_command(
   // --- PG commands are routed here to PG::do_command ---
   if (prefix == "pg" ||
       prefix == "query" ||
+      prefix == "log" ||
       prefix == "mark_unfound_lost" ||
       prefix == "list_unfound" ||
       prefix == "scrub" ||
@@ -4191,6 +4192,13 @@ void OSD::final_init()
   r = admin_socket->register_command(
     "pg "			   \
     "name=pgid,type=CephPgid "	   \
+    "name=cmd,type=CephChoices,strings=log",
+    asok_hook,
+    "");
+  ceph_assert(r == 0);
+  r = admin_socket->register_command(
+    "pg "			   \
+    "name=pgid,type=CephPgid "	   \
     "name=cmd,type=CephChoices,strings=mark_unfound_lost " \
     "name=mulcmd,type=CephChoices,strings=revert|delete",
     asok_hook,
@@ -4225,6 +4233,11 @@ void OSD::final_init()
     "query",
     asok_hook,
     "show details of a specific pg");
+  ceph_assert(r == 0);
+  r = admin_socket->register_command(
+    "log",
+    asok_hook,
+    "dump pg_log of a specific pg");
   ceph_assert(r == 0);
   r = admin_socket->register_command(
     "mark_unfound_lost "					\

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1038,7 +1038,14 @@ void PrimaryLogPG::do_command(
 
     f->close_section();
   }
-
+  else if (prefix == "log") {
+    
+    f->open_object_section("op_log");
+    f->open_object_section("pg_log_t");
+    recovery_state.get_pg_log().get_log().dump(f.get());
+    f->close_section();
+    f->close_section();
+  }
   else if (prefix == "mark_unfound_lost") {
     string mulcmd;
     cmd_getval(cmdmap, "mulcmd", mulcmd);


### PR DESCRIPTION
Currently we need to stop the cluster and use ceph_objectstore_tool to dump pg log
with that commit we will be able to dump pg logs with PG command

Fixes: https://tracker.ceph.com/issues/56153
Signed-off-by: Nitzan Mordechai <nmordech@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
