### PR TITLE
common/cmdparse: Unsplit crimson/classic

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -552,7 +552,7 @@ AdminSocket::find_matched_hook(std::string& prefix,
   // make sure one of the registered commands with this prefix validates.
   stringstream errss;
   for (auto hook = hooks_begin; hook != hooks_end; ++hook) {
-    if (validate_cmd(m_cct, hook->second.desc, cmdmap, errss)) {
+    if (validate_cmd(hook->second.desc, cmdmap, errss)) {
       in_hook = true;
       return {0, hook->second.hook};
     }

--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -32,7 +32,7 @@ using namespace std::literals;
  * Given a cmddesc like "foo baz name=bar,type=CephString",
  * return the prefix "foo baz".
  */
-namespace TOPNSPC::common {
+namespace ceph::common {
 std::string cmddesc_get_prefix(const std::string_view &cmddesc)
 {
   string tmp(cmddesc); // FIXME: stringstream ctor can't take string_view :(
@@ -571,8 +571,7 @@ bool validate_str_arg(std::string_view value,
   }
 }
 
-bool validate_bool(CephContext *cct,
-		  const cmdmap_t& cmdmap,
+bool validate_bool(const cmdmap_t& cmdmap,
 		  const arg_desc_t& desc,
 		  const std::string_view name,
 		  const std::string_view type,
@@ -600,8 +599,7 @@ template<bool is_vector,
 	 typename Value = std::conditional_t<is_vector,
 					     vector<T>,
 					     T>>
-bool validate_arg(CephContext* cct,
-		  const cmdmap_t& cmdmap,
+bool validate_arg(const cmdmap_t& cmdmap,
 		  const arg_desc_t& desc,
 		  const std::string_view name,
 		  const std::string_view type,
@@ -642,8 +640,7 @@ bool validate_arg(CephContext* cct,
 }
 } // anonymous namespace
 
-bool validate_cmd(CephContext* cct,
-		  const std::string& desc,
+bool validate_cmd(const std::string& desc,
 		  const cmdmap_t& cmdmap,
 		  std::ostream& os)
 {
@@ -658,27 +655,27 @@ bool validate_cmd(CephContext* cct,
     auto type = arg_desc["type"];
     if (arg_desc.count("n")) {
       if (type == "CephInt") {
-	return !validate_arg<true, int64_t>(cct, cmdmap, arg_desc,
+	return !validate_arg<true, int64_t>(cmdmap, arg_desc,
 					    name, type, os);
       } else if (type == "CephFloat") {
-	return !validate_arg<true, double>(cct, cmdmap, arg_desc,
+	return !validate_arg<true, double>(cmdmap, arg_desc,
 					    name, type, os);
       } else {
-	return !validate_arg<true, string>(cct, cmdmap, arg_desc,
+	return !validate_arg<true, string>(cmdmap, arg_desc,
 					   name, type, os);
       }
     } else {
       if (type == "CephInt") {
-	return !validate_arg<false, int64_t>(cct, cmdmap, arg_desc,
+	return !validate_arg<false, int64_t>(cmdmap, arg_desc,
 					    name, type, os);
       } else if (type == "CephFloat") {
-	return !validate_arg<false, double>(cct, cmdmap, arg_desc,
+	return !validate_arg<false, double>(cmdmap, arg_desc,
 					    name, type, os);
       } else if (type == "CephBool") {
-	return !validate_bool(cct, cmdmap, arg_desc,
+	return !validate_bool(cmdmap, arg_desc,
 			      name, type, os);
       } else {
-	return !validate_arg<false, string>(cct, cmdmap, arg_desc,
+	return !validate_arg<false, string>(cmdmap, arg_desc,
 					    name, type, os);
       }
     }

--- a/src/common/cmdparse.h
+++ b/src/common/cmdparse.h
@@ -22,7 +22,7 @@ typedef boost::variant<std::string,
 		       std::vector<double>>  cmd_vartype;
 typedef std::map<std::string, cmd_vartype, std::less<>> cmdmap_t;
 
-namespace TOPNSPC::common {
+namespace ceph::common {
 std::string cmddesc_get_prefix(const std::string_view &cmddesc);
 std::string cmddesc_get_prenautilus_compat(const std::string &cmddesc);
 void dump_cmd_to_json(ceph::Formatter *f, uint64_t features,
@@ -118,8 +118,7 @@ cmd_putval(CephContext *cct, cmdmap_t& cmdmap, std::string_view k, const T& val)
   cmdmap.insert_or_assign(std::string{k}, val);
 }
 
-bool validate_cmd(CephContext* cct,
-		  const std::string& desc,
+bool validate_cmd(const std::string& desc,
 		  const cmdmap_t& cmdmap,
 		  std::ostream& os);
 extern int parse_osd_id(const char *s, std::ostream *pss);

--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -22,6 +22,11 @@
 
 using namespace crimson::common;
 using namespace std::literals;
+using ceph::common::cmdmap_from_json;
+using ceph::common::cmd_getval;
+using ceph::common::bad_cmd_get;
+using ceph::common::validate_cmd;
+using ceph::common::dump_cmd_and_help_to_json;
 
 namespace {
 seastar::logger& logger()
@@ -154,7 +159,7 @@ auto AdminSocket::execute_command(const std::vector<std::string>& cmd,
   if (auto* parsed = std::get_if<parsed_command_t>(&maybe_parsed); parsed) {
     stringstream os;
     string desc{parsed->hook.desc};
-    if (!validate_cmd(nullptr, desc, parsed->params, os)) {
+    if (!validate_cmd(desc, parsed->params, os)) {
       logger().error("AdminSocket::execute_command: "
                      "failed to validate '{}': {}", cmd, os.str());
       ceph::bufferlist out;

--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -30,6 +30,8 @@ using std::unique_ptr;
 using crimson::osd::OSD;
 using crimson::common::local_conf;
 using namespace crimson::common;
+using ceph::common::cmd_getval;
+using ceph::common::cmd_getval_or;
 
 namespace crimson::admin {
 

--- a/src/crimson/admin/pg_commands.cc
+++ b/src/crimson/admin/pg_commands.cc
@@ -18,6 +18,7 @@
 using crimson::osd::OSD;
 using crimson::osd::PG;
 using namespace crimson::common;
+using ceph::common::cmd_getval;
 
 
 namespace crimson::admin::pg {

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -10,7 +10,6 @@ set(crimson_alien_common_srcs
   ${PROJECT_SOURCE_DIR}/src/common/blkdev.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_context.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_crypto.cc
-  ${PROJECT_SOURCE_DIR}/src/common/cmdparse.cc
   ${PROJECT_SOURCE_DIR}/src/common/Finisher.cc
   ${PROJECT_SOURCE_DIR}/src/common/HeartbeatMap.cc
   ${PROJECT_SOURCE_DIR}/src/common/PluginRegistry.cc

--- a/src/messages/MMonCommand.h
+++ b/src/messages/MMonCommand.h
@@ -20,8 +20,8 @@
 #include <vector>
 #include <string>
 
-using TOPNSPC::common::cmdmap_from_json;
-using TOPNSPC::common::cmd_getval;
+using ceph::common::cmdmap_from_json;
+using ceph::common::cmd_getval;
 
 class MMonCommand final : public PaxosServiceMessage {
 public:

--- a/src/messages/MMonCommandAck.h
+++ b/src/messages/MMonCommandAck.h
@@ -17,8 +17,8 @@
 
 #include "messages/PaxosServiceMessage.h"
 
-using TOPNSPC::common::cmdmap_from_json;
-using TOPNSPC::common::cmd_getval;
+using ceph::common::cmdmap_from_json;
+using ceph::common::cmd_getval;
 
 class MMonCommandAck final : public PaxosServiceMessage {
 public:

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -33,9 +33,9 @@ using std::vector;
 
 using ceph::bufferlist;
 using ceph::fixed_u_to_string;
-
-using TOPNSPC::common::cmd_getval;
-using TOPNSPC::common::cmd_getval_or;
+using ceph::common::cmd_getval;
+using ceph::common::cmd_getval_or;
+using ceph::common::cmd_putval;
 
 MEMPOOL_DEFINE_OBJECT_FACTORY(PGMapDigest, pgmap_digest, pgmap);
 MEMPOOL_DEFINE_OBJECT_FACTORY(PGMap, pgmap, pgmap);

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -6487,7 +6487,7 @@ int OSDMap::parse_osd_id_list(const vector<string>& ls, set<int> *out,
       get_all_osds(*out);
       break;
     }
-    long osd = TOPNSPC::common::parse_osd_id(i->c_str(), ss);
+    long osd = ceph::common::parse_osd_id(i->c_str(), ss);
     if (osd < 0) {
       *ss << "invalid osd id '" << *i << "'";
       return -EINVAL;


### PR DESCRIPTION
Merges split of cmdparse functions to ceph::common and crimson::common namespaces.
Now only one implementation is present: ceph::common::(cmdparse funcs).

This modification is a step towards BlueStore(classic) and BlueStore(alienstore) actually be the same code.
The future gain might be to avoid having two BlueStore object definitions with different compilation flags, as we currently have if we join together ObjectStores and FuturizedStores. See #46422.

This PR is part of larger effort to get rid of WITH_ALIEN compilation flag and make BlueStore better connected to outside environment by: 
- admin socket commands 
- dout messages
- config params manipulation

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
