### PR TITLE
qa/cephfs: improvements for xfstests_dev.py

### DIFF
--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -11,7 +11,6 @@ log = getLogger(__name__)
 
 
 # TODO: add code to run non-ACL tests too.
-# TODO: get tests running with SCRATCH_DEV and SCRATCH_DIR.
 # TODO: make xfstests-dev tests running without running `make install`.
 # TODO: make xfstests-dev compatible with ceph-fuse. xfstests-dev remounts
 # CephFS before running tests using kernel, so ceph-fuse mounts are never
@@ -201,18 +200,17 @@ class XFSTestsDev(CephFSTestCase):
         self.test_dev = mon_sock + ':/' + self.test_dirname
         self.scratch_dev = mon_sock + ':/' + self.scratch_dirname
 
-        xfstests_config_contents = dedent('''\
+        xfstests_config_contents = dedent(f'''\
             export FSTYP=ceph
-            export TEST_DEV={}
-            export TEST_DIR={}
-            export SCRATCH_DEV={}
-            export SCRATCH_MNT={}
-            export CEPHFS_MOUNT_OPTIONS="-o name=admin,secret={}{}"
-            ''').format(self.test_dev, self.test_dirs_mount_path, self.scratch_dev,
-                        self.scratch_dirs_mount_path, self.get_admin_key(), _options)
+            export TEST_DEV={self.test_dev}
+            export TEST_DIR={self.test_dirs_mount_path}
+            export SCRATCH_DEV={self.scratch_dev}
+            export SCRATCH_MNT={self.scratch_dirs_mount_path}
+            export CEPHFS_MOUNT_OPTIONS="-o name=admin,secret={self.get_admin_key()}{_options}"
+            ''')
 
-        self.mount_a.client_remote.write_file(join(self.xfstests_repo_path, 'local.config'),
-                                              xfstests_config_contents, sudo=True)
+       self.mount_a.client_remote.write_file(join(self.xfstests_repo_path, 'local.config'),
+                                             xfstests_config_contents, sudo=True)
 
     def write_ceph_exclude(self):
         # These tests will fail or take too much time and will

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -122,18 +122,12 @@ class XFSTestsDev(CephFSTestCase):
         # read var name as "test dir's mount path"
         self.test_dirs_mount_path = self.mount_a.client_remote.mkdtemp(
             suffix=self.test_dirname)
-        self.mount_a.run_shell(['sudo','ln','-s',join(self.mount_a.mountpoint,
-                                                      self.test_dirname),
-                                self.test_dirs_mount_path])
 
         self.scratch_dirname = 'scratch'
         self.mount_a.run_shell(['mkdir', self.scratch_dirname])
         # read var name as "scratch dir's mount path"
         self.scratch_dirs_mount_path = self.mount_a.client_remote.mkdtemp(
             suffix=self.scratch_dirname)
-        self.mount_a.run_shell(['sudo','ln','-s',join(self.mount_a.mountpoint,
-                                                      self.scratch_dirname),
-                                self.scratch_dirs_mount_path])
 
     def install_deps(self):
         from teuthology.misc import get_system_type

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 
 
-logger = getLogger(__name__)
+log = getLogger(__name__)
 
 
 # TODO: add code to run non-ACL tests too.

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -17,6 +17,8 @@ log = getLogger(__name__)
 # actually testsed.
 class XFSTestsDev(CephFSTestCase):
 
+    RESULTS_DIR = "results"
+
     def setUp(self):
         super(XFSTestsDev, self).setUp()
         self.setup_xfsprogs_devs()
@@ -56,12 +58,48 @@ class XFSTestsDev(CephFSTestCase):
                                        omit_sudo=False, check_status=False)
 
     def del_repos(self):
+        self.save_results_dir()
         self.mount_a.client_remote.run(args=f'sudo rm -rf {self.xfstests_repo_path}',
                                        omit_sudo=False, check_status=False)
 
         if self.install_xfsprogs:
             self.mount_a.client_remote.run(args=f'sudo rm -rf {self.xfsprogs_repo_path}',
                                            omit_sudo=False, check_status=False)
+
+    def save_results_dir(self):
+        """
+        When tests in xfstests-dev repo are executed, logs are created and
+        saved, under a directory named "results" that lies at the repo root.
+        In case a test from xfstests-dev repo fails, these logs will help find
+        the cause of the failure.
+
+        Since there's no option in teuthology to copy a directory lying at a
+        custom location in order to save it from teuthology test runner's tear
+        down, let's copy this directory to a standard location that teuthology
+        copies away before erasing all data on the test machine. The standard
+        location chosen in the case here is the Ceph log directory.
+
+        In case of vstart_runner.py, this methods does nothing.
+        """
+        # No need to save results dir in case of vstart_runner.py.
+        for x in ('LocalFuseMount', 'LocalKernelMount'):
+            if x in self.mount_a.__class__.__name__:
+                return
+
+        src = join(self.xfstests_repo_path, self.RESULTS_DIR)
+
+        if self.mount_a.run_shell(f'sudo stat {src}',
+                check_status=False, omit_sudo=False).returncode != 0:
+            log.info(f'xfstests-dev repo contains not directory named '
+                     f'"{self.RESULTS_DIR}". repo location: {self.xfstests_repo_path}')
+            return
+
+        std_loc = '/var/log/ceph' # standard location
+        dst = join(std_loc, 'xfstests-dev-results')
+        self.mount_a.run_shell(f'sudo mkdir -p {dst}', omit_sudo=False)
+        self.mount_a.run_shell(f'sudo cp -r {src} {dst}', omit_sudo=False)
+        log.info(f'results dir from xfstests-dev has been saved; it was '
+                 f'copied from {self.xfstests_repo_path} to {std_loc}.')
 
     def build_and_install(self):
         # NOTE: On teuthology machines it's necessary to run "make" as

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -209,8 +209,10 @@ class XFSTestsDev(CephFSTestCase):
             export CEPHFS_MOUNT_OPTIONS="-o name=admin,secret={self.get_admin_key()}{_options}"
             ''')
 
-       self.mount_a.client_remote.write_file(join(self.xfstests_repo_path, 'local.config'),
-                                             xfstests_config_contents, sudo=True)
+        self.mount_a.client_remote.write_file(
+            join(self.xfstests_repo_path, 'local.config'),
+            xfstests_config_contents, sudo=True)
+        log.info(f'local.config\'s contents -\n{xfstests_config_contents}')
 
     def write_ceph_exclude(self):
         # These tests will fail or take too much time and will

--- a/qa/tasks/cephfs/xfstests_dev.py
+++ b/qa/tasks/cephfs/xfstests_dev.py
@@ -185,9 +185,11 @@ class XFSTestsDev(CephFSTestCase):
         self.mount_a.client_remote.run(args=args, omit_sudo=False)
 
     def create_reqd_users(self):
-        self.mount_a.client_remote.run(args=['sudo', 'useradd', 'fsgqa'],
+        self.mount_a.client_remote.run(args=['sudo', 'useradd', '-m', 'fsgqa'],
                                        omit_sudo=False, check_status=False)
         self.mount_a.client_remote.run(args=['sudo', 'groupadd', 'fsgqa'],
+                                       omit_sudo=False, check_status=False)
+        self.mount_a.client_remote.run(args=['sudo', 'useradd', 'fsgqa2'],
                                        omit_sudo=False, check_status=False)
         self.mount_a.client_remote.run(args=['sudo', 'useradd',
                                              '123456-fsgqa'], omit_sudo=False,


### PR DESCRIPTION
Lots of commits here originally resided at PR #45960.
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>