### PR TITLE
schedule_subset.sh: Default to ceph.git

### DIFF
--- a/qa/machine_types/schedule_subset.sh
+++ b/qa/machine_types/schedule_subset.sh
@@ -17,4 +17,4 @@ shift
 # rest of arguments passed directly to teuthology-suite
 
 echo "Scheduling $branch branch"
-teuthology-suite -v -c "$branch" -m "$machine" -k "$kernel" -s "$suite" --subset "$((RANDOM % partitions))/$partitions" --newest 100 -e "$email" "$@"
+teuthology-suite -v -c "$branch" -m "$machine" -k "$kernel" -s "$suite" --ceph-repo git://git.ceph.com/ceph.git --suite-repo git://git.ceph.com/ceph.git --subset "$((RANDOM % partitions))/$partitions" --newest 100 -e "$email" "$@"


### PR DESCRIPTION
https://github.com/ceph/teuthology/pull/999 never got overridden in ceph.git.  We've been using a years-old checkout of teuthology for the `teuthology` user.

With the master->main change, that checkout needed to go.  Then when trying to schedule new nightlies, teuthology-suite was defaulting to ceph-ci.git which either has very old versions of the release branches (octopus, pacific, etc.) or they don't exist at all.

Signed-off-by: David Galloway <dgallowa@redhat.com>