### PR TITLE
pacific: client/fuse: Fix directory DACs overriding for root

### DIFF
--- a/qa/suites/fs/permission/tasks/cfuse_workunit_misc.yaml
+++ b/qa/suites/fs/permission/tasks/cfuse_workunit_misc.yaml
@@ -9,3 +9,4 @@ tasks:
       all:
         - fs/misc/acl.sh
         - fs/misc/chmod.sh
+        - fs/misc/dac_override.sh

--- a/qa/workunits/fs/misc/dac_override.sh
+++ b/qa/workunits/fs/misc/dac_override.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -x
+
+expect_failure() {
+	if "$@"; then return 1; else return 0; fi
+}
+
+set -e
+
+mkdir -p testdir
+file=test_chmod.$$
+
+echo "foo" > testdir/${file}
+sudo chmod 600 testdir
+
+# only root can read
+expect_failure cat testdir/${file}
+
+# directory read/write DAC override for root should allow read
+sudo cat testdir/${file}

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5615,8 +5615,10 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, const M
 int Client::inode_permission(Inode *in, const UserPerm& perms, unsigned want)
 {
   if (perms.uid() == 0) {
-    // Executable are overridable when there is at least one exec bit set
-    if((want & MAY_EXEC) && !(in->mode & S_IXUGO))
+    // For directories, DACs are overridable.
+    // For files, Read/write DACs are always overridable but executable DACs are
+    // overridable when there is at least one exec bit set
+    if(!S_ISDIR(in->mode) && (want & MAY_EXEC) && !(in->mode & S_IXUGO))
       return -CEPHFS_EACCES;
     return 0;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55927

---

backport of https://github.com/ceph/ceph/pull/46078
parent tracker: https://tracker.ceph.com/issues/55313

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh