### PR TITLE
test/librados: modify LibRadosMiscConnectFailure.ConnectFailure to comply with new seconds unit

### DIFF
--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -58,7 +58,7 @@ TEST(LibRadosMiscConnectFailure, ConnectFailure) {
   ASSERT_EQ(0, rados_conf_read_file(cluster, NULL));
   ASSERT_EQ(0, rados_conf_parse_env(cluster, NULL));
 
-  ASSERT_EQ(0, rados_conf_set(cluster, "client_mount_timeout", "0.000000001"));
+  ASSERT_EQ(0, rados_conf_set(cluster, "client_mount_timeout", "1s"));
   ASSERT_EQ(0, rados_conf_set(cluster, "debug_monc", "20"));
   ASSERT_EQ(0, rados_conf_set(cluster, "debug_ms", "1"));
   ASSERT_EQ(0, rados_conf_set(cluster, "log_to_stderr", "true"));


### PR DESCRIPTION
The unit type for `client_mount_timeout` was changed from "float" to "secs" in 983b10506dc8466a0e47ff0d320d480dd09999ec. To make LibRadosMiscConnectFailure.ConnectFailure comply with the new unit change, we need to change the `client_mount_timeout` value to an integer, as seconds does not accept float values.

For example, on a vstart cluster:
```
[lflores@folio01 build]$ ./bin/ceph config set client client_mount_timeout 0.1
Error EINVAL: error parsing value: unexpected trailing '.1'
```

I tested this fix locally about 20 times with:
```
cd ceph/build
ninja ceph_test_rados_api_misc
./bin/ceph_test_rados_api_misc --gtest_filter=*LibRadosMiscConnectFailure*
```
And it passed all 20 times. The only thing I'm not sure about is that with the change from "float" to "seconds", it will now be impossible to change the `client_mount_timeout` to anything less than 1 second (unless you want to set it for 0 seconds). The LibRadosMiscConnectFailure.ConnectFailure test was using a very small timeout value, and setting the timeout to 1 second is not quite equivalent.

Fixes: https://tracker.ceph.com/issues/55971
Signed-off-by: Laura Flores <lflores@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
