### PR TITLE
[WIP] mgr/cephadm: expose scheduled daemon actions and daemon action history

### DIFF
--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -529,6 +529,32 @@ class Orchestrator(object):
         # assert action in ["start", "stop", "reload, "restart", "redeploy"]
         raise NotImplementedError()
 
+    def daemon_action_ls(self, daemon_name: Optional[str] = None, host: Optional[str] = None) -> OrchResult[List['DaemonActionDescription']]:
+        """
+        View currently scheduled daemon action (start/stop/restart/reconfig/redeploy)
+
+        :param daemon_name: name of specific daemon you only want to see action for
+        :param host: name of specific host you only want to see actions for
+        :rtype: OrchResult
+        """
+        raise NotImplementedError()
+
+    def daemon_action_history(self,
+                              daemon_name: Optional[str] = None,
+                              host: Optional[str] = None,
+                              count: int = 10,
+                              failure_only: bool = False) -> OrchResult[List['DaemonActionDescription']]:
+        """
+        View up to last 100 completed (failed or succeeded) daemon actions
+
+        :param daemon_name: name of specific daemon you only want to see action history for
+        :param host: name of specific host you only want to see action history for
+        :param count: max number of actions in history to be dispayed. Must be less thaan 200
+        :param failure_only: only show actions that failed
+        :rtype: OrchResult
+        """
+        raise NotImplementedError()
+
     def create_osds(self, drive_group: DriveGroupSpec) -> OrchResult[str]:
         """
         Create one or more OSDs within a single Drive Group.
@@ -1268,6 +1294,45 @@ class ServiceDescription(object):
 
 
 yaml.add_representer(ServiceDescription, ServiceDescription.yaml_representer)
+
+
+class DaemonActionDescription(object):
+    """
+    Class used for displaying a daemon action
+    """
+
+    def __init__(self,
+                 host: str,
+                 daemon_name: str,
+                 action: str,
+                 status: str = 'unknown',
+                 timestamp: Optional[str] = None):
+        self.host = host
+        self.daemon_name = daemon_name
+        self.action = action
+        self.status = status
+        self.timestamp = timestamp
+
+    def to_json(self) -> Dict[str, str]:
+        j = {
+            'host': self.host,
+            'daemon_name': self.daemon_name,
+            'action': self.action,
+            'status': self.status,
+        }
+        if self.timestamp:
+            j['timestamp'] = self.timestamp
+        return j
+
+    @classmethod
+    def from_json(cls, dad: Dict[str, str]) -> 'DaemonActionDescription':
+        j: Dict[str, Any] = {'host': '', 'daemon_name': '', 'action': '', 'status': 'unknown'}
+        for val in ['host', 'daemon_name', 'action', 'status']:
+            if val in dad:
+                j[val] = dad[val]
+        if 'timestamp' in dad:
+            j['timestamp'] = dad['timestamp']
+        return cls(**j)
 
 
 class InventoryFilter(object):


### PR DESCRIPTION
Previously scheduled daemon actions were not visible at all
to the user. No reason we can't show them. Some daemon actions
were recorded as events for daemons but it could be annoying
to have to go check inidividual daemons for an event. This allows
a centralized place to look for recent history and the events still
exists to get a more detailed view of what was done and
try to debug failures

Partially fixes: https://tracker.ceph.com/issues/53539

Signed-off-by: Adam King <adking@redhat.com>

Unit tests and docs still TODO

Some sample output on a recently bootstrapped 2 node cluster

```
[ceph: root@vm-00 /]# ceph orch daemon action-history --count 30
mon.vm-01           reconfigured on host vm-01 at 2022-06-09T23:19:35.901443Z
mgr.vm-01.mzgcbl    reconfigured on host vm-01 at 2022-06-09T23:19:34.924333Z
crash.vm-01         reconfigured on host vm-01 at 2022-06-09T23:19:33.963022Z
grafana.vm-00       reconfigured on host vm-00 at 2022-06-09T23:19:32.879146Z
crash.vm-00         reconfigured on host vm-00 at 2022-06-09T23:19:30.109206Z
alertmanager.vm-00  reconfigured on host vm-00 at 2022-06-09T23:19:29.032651Z
mgr.vm-00.jchbhs    reconfigured on host vm-00 at 2022-06-09T23:19:26.374416Z
mon.vm-00           reconfigured on host vm-00 at 2022-06-09T23:19:25.519755Z
prometheus.vm-00    deployed on host vm-00 at 2022-06-09T23:19:18.095334Z
node-exporter.vm-01 deployed on host vm-01 at 2022-06-09T23:19:09.452771Z
mon.vm-01           deployed on host vm-01 at 2022-06-09T23:19:01.781842Z
mgr.vm-01.mzgcbl    deployed on host vm-01 at 2022-06-09T23:18:57.306218Z
crash.vm-01         deployed on host vm-01 at 2022-06-09T23:18:55.039992Z
node-exporter.vm-00 deployed on host vm-00 at 2022-06-09T23:18:07.800723Z
grafana.vm-00       deployed on host vm-00 at 2022-06-09T23:18:04.206876Z
crash.vm-00         deployed on host vm-00 at 2022-06-09T23:17:40.971350Z
alertmanager.vm-00  deployed on host vm-00 at 2022-06-09T23:17:39.022908Z
[ceph: root@vm-00 /]# ceph orch ps
NAME                 HOST   PORTS        STATUS          REFRESHED   AGE  MEM USE  MEM LIM  VERSION                 IMAGE ID      CONTAINER ID  
alertmanager.vm-00   vm-00  *:9093,9094  running (77s)      0s ago    3m    15.7M        -                          ba2b418f427c  aa1ffb80d5d7  
crash.vm-00          vm-00               running (3m)       0s ago    3m    6983k        -  17.0.0-12762-g63f84c50  4aaff0c158c5  caad48fd968c  
crash.vm-01          vm-01               running (111s)     1s ago  111s    7226k        -  17.0.0-12762-g63f84c50  4aaff0c158c5  d410fe6fb893  
grafana.vm-00        vm-00  *:3000       running (73s)      0s ago    2m    43.1M        -  8.3.5                   dad864ee21e9  098dc55242c7  
mgr.vm-00.jchbhs     vm-00  *:9283       running (4m)       0s ago    4m     459M        -  17.0.0-12762-g63f84c50  4aaff0c158c5  332a489067f2  
mgr.vm-01.mzgcbl     vm-01  *:8443,9283  running (109s)     1s ago  108s     426M        -  17.0.0-12762-g63f84c50  4aaff0c158c5  5bdf077614bd  
mon.vm-00            vm-00               running (4m)       0s ago    4m    43.5M    2048M  17.0.0-12762-g63f84c50  4aaff0c158c5  71ed3a3937be  
mon.vm-01            vm-01               running (105s)     1s ago  104s    34.9M    2048M  17.0.0-12762-g63f84c50  4aaff0c158c5  0627a7905cec  
node-exporter.vm-00  vm-00  *:9100       running (2m)       0s ago    2m    21.9M        -                          1dbe0e931976  bc0c429f55c9  
node-exporter.vm-01  vm-01  *:9100       running (97s)      1s ago   96s    21.7M        -                          1dbe0e931976  190a541260fa  
prometheus.vm-00     vm-00  *:9095       running (88s)      0s ago   88s    37.1M        -                          514e6a882f6e  013dd53691b2  
[ceph: root@vm-00 /]# ceph orch daemon get-scheduled-actions
[ceph: root@vm-00 /]# ceph orch redeploy node-exporter
Scheduled to redeploy node-exporter.vm-00 on host 'vm-00'
Scheduled to redeploy node-exporter.vm-01 on host 'vm-01'
[ceph: root@vm-00 /]# ceph orch daemon get-scheduled-actions
node-exporter.vm-00 scheduled for redeploy on host vm-00
node-exporter.vm-01 scheduled for redeploy on host vm-01
[ceph: root@vm-00 /]# ceph orch daemon get-scheduled-actions
[ceph: root@vm-00 /]# ceph orch daemon action-history --count 3 
node-exporter.vm-01 redeployed on host vm-01 at 2022-06-09T23:21:42.627404Z
node-exporter.vm-00 redeployed on host vm-00 at 2022-06-09T23:21:40.365047Z
mon.vm-01           reconfigured on host vm-01 at 2022-06-09T23:19:35.901443Z
[ceph: root@vm-00 /]# ceph orch daemon stop node-exporter.vm-01
Scheduled to stop node-exporter.vm-01 on host 'vm-01'
[ceph: root@vm-00 /]# ceph orch daemon start node-exporter.vm-01
Scheduled to start node-exporter.vm-01 on host 'vm-01'
[ceph: root@vm-00 /]# ceph orch daemon action-history -f yaml --daemon-name node-exporter.vm-01
action: start
daemon_name: node-exporter.vm-01
host: vm-01
status: succeeded
timestamp: '2022-06-09T23:22:34.363077Z'
---
action: reset-failed
daemon_name: node-exporter.vm-01
host: vm-01
status: succeeded
timestamp: '2022-06-09T23:22:33.086062Z'
---
action: stop
daemon_name: node-exporter.vm-01
host: vm-01
status: succeeded
timestamp: '2022-06-09T23:22:22.351637Z'
---
action: redeploy
daemon_name: node-exporter.vm-01
host: vm-01
status: succeeded
timestamp: '2022-06-09T23:21:42.627404Z'
---
action: deploy
daemon_name: node-exporter.vm-01
host: vm-01
status: succeeded
timestamp: '2022-06-09T23:19:09.452771Z'

```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
