### PR TITLE
pacific: rgw: reopen ops log file on sighup

### DIFF
--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -342,8 +342,12 @@ int OpsLogManifold::log(struct req_state* s, struct rgw_log_entry& entry)
 }
 
 OpsLogFile::OpsLogFile(CephContext* cct, std::string& path, uint64_t max_data_size) :
-  cct(cct), file(path, std::ofstream::app), data_size(0), max_data_size(max_data_size)
+  cct(cct), data_size(0), max_data_size(max_data_size), path(path), need_reopen(false)
 {
+}
+
+void OpsLogFile::reopen() {
+  need_reopen = true;
 }
 
 void OpsLogFile::flush()
@@ -357,6 +361,11 @@ void OpsLogFile::flush()
   for (auto bl : flush_buffer) {
     int try_num = 0;
     while (true) {
+      if (!file.is_open() || need_reopen) {
+        need_reopen = false;
+        file.close();
+        file.open(path, std::ofstream::app);
+      }
       bl.write_stream(file);
       if (!file) {
         ldpp_dout(this, 0) << "ERROR: failed to log RGW ops log file entry" << dendl;

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -171,6 +171,8 @@ class OpsLogFile : public JsonOpsLogSink, public Thread, public DoutPrefixProvid
   bool stopped;
   uint64_t data_size;
   uint64_t max_data_size;
+  std::string path;
+  std::atomic_bool need_reopen;
 
   void flush();
 protected:
@@ -182,6 +184,7 @@ public:
   CephContext *get_cct() const override { return cct; }
   unsigned get_subsys() const override { return dout_subsys; }
   std::ostream& gen_prefix(std::ostream& out) const override { return out << "rgw OpsLogFile: "; }
+  void reopen();
   void start();
   void stop();
 };

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -129,6 +129,15 @@ static void handle_sigterm(int signum)
 
 }
 
+static OpsLogFile* ops_log_file = nullptr;
+
+static void rgw_sighup_handler(int signum) {
+    if (ops_log_file != nullptr) {
+        ops_log_file->reopen();
+    }
+    sighup_handler(signum);
+}
+
 static void godown_alarm(int signum)
 {
   _exit(0);
@@ -314,7 +323,6 @@ int radosgw_Main(int argc, const char **argv)
   common_init_finish(g_ceph_context);
 
   init_async_signal_handler();
-  register_async_signal_handler(SIGHUP, sighup_handler);
 
   TracepointProvider::initialize<rgw_rados_tracepoint_traits>(g_ceph_context);
   TracepointProvider::initialize<rgw_op_tracepoint_traits>(g_ceph_context);
@@ -510,12 +518,12 @@ int radosgw_Main(int argc, const char **argv)
     olog_socket->init(g_conf()->rgw_ops_log_socket_path);
     olog->add_sink(olog_socket);
   }
-  OpsLogFile* ops_log_file;
   if (!g_conf()->rgw_ops_log_file_path.empty()) {
     ops_log_file = new OpsLogFile(g_ceph_context, g_conf()->rgw_ops_log_file_path, g_conf()->rgw_ops_log_data_backlog);
     ops_log_file->start();
     olog->add_sink(ops_log_file);
   }
+  register_async_signal_handler(SIGHUP, rgw_sighup_handler);
   olog->add_sink(new OpsLogRados(store));
 
   r = signal_fd_init();
@@ -681,7 +689,7 @@ int radosgw_Main(int argc, const char **argv)
     delete fec;
   }
 
-  unregister_async_signal_handler(SIGHUP, sighup_handler);
+  unregister_async_signal_handler(SIGHUP, rgw_sighup_handler);
   unregister_async_signal_handler(SIGTERM, handle_sigterm);
   unregister_async_signal_handler(SIGINT, handle_sigterm);
   unregister_async_signal_handler(SIGUSR1, handle_sigterm);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55996

---

backport of https://github.com/ceph/ceph/pull/44488
parent tracker: https://tracker.ceph.com/issues/53788

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh