### PR TITLE
pacific: rgw: log access key id in ops logs

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -11,6 +11,7 @@
 #include "rgw_http_client.h"
 #include "rgw_keystone.h"
 #include "rgw_sal.h"
+#include "rgw_log.h"
 
 #include "include/str_list.h"
 
@@ -458,6 +459,9 @@ bool rgw::auth::WebIdentityApplier::is_identity(const idset_t& ids) const
     return false;
 }
 
+const std::string rgw::auth::RemoteApplier::AuthInfo::NO_SUBUSER;
+const std::string rgw::auth::RemoteApplier::AuthInfo::NO_ACCESS_KEY;
+
 /* rgw::auth::RemoteAuthApplier */
 uint32_t rgw::auth::RemoteApplier::get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const
 {
@@ -609,6 +613,12 @@ void rgw::auth::RemoteApplier::create_account(const DoutPrefixProvider* dpp,
   }
 }
 
+void rgw::auth::RemoteApplier::write_ops_log_entry(rgw_log_entry& entry) const
+{
+  entry.access_key_id = info.access_key_id;
+  entry.subuser = info.subuser;
+}
+
 /* TODO(rzarzynski): we need to handle display_name changes. */
 void rgw::auth::RemoteApplier::load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo& user_info) const      /* out */
 {
@@ -664,6 +674,7 @@ void rgw::auth::RemoteApplier::load_acct_info(const DoutPrefixProvider* dpp, RGW
 /* rgw::auth::LocalApplier */
 /* static declaration */
 const std::string rgw::auth::LocalApplier::NO_SUBUSER;
+const std::string rgw::auth::LocalApplier::NO_ACCESS_KEY;
 
 uint32_t rgw::auth::LocalApplier::get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const
 {
@@ -740,6 +751,12 @@ void rgw::auth::LocalApplier::load_acct_info(const DoutPrefixProvider* dpp, RGWU
   /* Load the account that belongs to the authenticated identity. An extra call
    * to RADOS may be safely skipped in this case. */
   user_info = this->user_info;
+}
+
+void rgw::auth::LocalApplier::write_ops_log_entry(rgw_log_entry& entry) const
+{
+  entry.access_key_id = access_key_id;
+  entry.subuser = subuser;
 }
 
 void rgw::auth::RoleApplier::to_str(std::ostream& out) const {
@@ -843,7 +860,7 @@ rgw::auth::AnonymousEngine::authenticate(const DoutPrefixProvider* dpp, const re
     auto apl = \
       apl_factory->create_apl_local(cct, s, user_info,
                                     rgw::auth::LocalApplier::NO_SUBUSER,
-                                    boost::none);
+                                    boost::none, rgw::auth::LocalApplier::NO_ACCESS_KEY);
     return result_t::grant(std::move(apl));
   }
 }

--- a/src/rgw/rgw_auth_filters.h
+++ b/src/rgw/rgw_auth_filters.h
@@ -118,6 +118,10 @@ public:
   void modify_request_state(const DoutPrefixProvider* dpp, req_state * s) const override {     /* in/out */
     return get_decoratee().modify_request_state(dpp, s);
   }
+
+  void write_ops_log_entry(rgw_log_entry& entry) const override {
+    return get_decoratee().write_ops_log_entry(entry);
+  }
 };
 
 

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -133,8 +133,10 @@ TokenEngine::get_creds_info(const TokenEngine::token_envelope_t& token,
      * the access rights through the perm_mask. At least at this layer. */
     RGW_PERM_FULL_CONTROL,
     level,
-    TYPE_KEYSTONE,
-  };
+    rgw::auth::RemoteApplier::AuthInfo::NO_ACCESS_KEY,
+    rgw::auth::RemoteApplier::AuthInfo::NO_SUBUSER,
+    TYPE_KEYSTONE
+};
 }
 
 static inline const std::string
@@ -497,7 +499,8 @@ EC2Engine::get_acl_strategy(const EC2Engine::token_envelope_t&) const
 
 EC2Engine::auth_info_t
 EC2Engine::get_creds_info(const EC2Engine::token_envelope_t& token,
-                          const std::vector<std::string>& admin_roles
+                          const std::vector<std::string>& admin_roles,
+                          const std::string& access_key_id
                          ) const noexcept
 {
   using acct_privilege_t = \
@@ -521,7 +524,9 @@ EC2Engine::get_creds_info(const EC2Engine::token_envelope_t& token,
      * the access rights through the perm_mask. At least at this layer. */
     RGW_PERM_FULL_CONTROL,
     level,
-    TYPE_KEYSTONE,
+    access_key_id,
+    rgw::auth::RemoteApplier::AuthInfo::NO_SUBUSER,
+    TYPE_KEYSTONE
   };
 }
 
@@ -589,7 +594,7 @@ rgw::auth::Engine::result_t EC2Engine::authenticate(
                   << " expires: " << t->get_expires() << dendl;
 
     auto apl = apl_factory->create_apl_remote(cct, s, get_acl_strategy(*t),
-                                              get_creds_info(*t, accepted_roles.admin));
+                                              get_creds_info(*t, accepted_roles.admin, std::string(access_key_id)));
     return result_t::grant(std::move(apl), completer_factory(boost::none));
   }
 }

--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -138,7 +138,8 @@ class EC2Engine : public rgw::auth::s3::AWSEngine {
   /* Helper methods. */
   acl_strategy_t get_acl_strategy(const token_envelope_t& token) const;
   auth_info_t get_creds_info(const token_envelope_t& token,
-                             const std::vector<std::string>& admin_roles
+                             const std::vector<std::string>& admin_roles,
+                             const std::string& access_key_id
                             ) const noexcept;
   std::pair<boost::optional<token_envelope_t>, int>
   get_from_keystone(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -56,9 +56,10 @@ class STSAuthStrategy : public rgw::auth::Strategy,
                             const req_state* const s,
                             const RGWUserInfo& user_info,
                             const std::string& subuser,
-                            const boost::optional<uint32_t>& perm_mask) const override {
+                            const boost::optional<uint32_t>& perm_mask,
+                            const std::string& access_key_id) const override {
     auto apl = rgw::auth::add_sysreq(cct, ctl, s,
-      rgw::auth::LocalApplier(cct, user_info, subuser, perm_mask));
+      rgw::auth::LocalApplier(cct, user_info, subuser, perm_mask, access_key_id));
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }
 
@@ -178,9 +179,10 @@ class AWSAuthStrategy : public rgw::auth::Strategy,
                             const req_state* const s,
                             const RGWUserInfo& user_info,
                             const std::string& subuser,
-                            const boost::optional<uint32_t>& perm_mask) const override {
+                            const boost::optional<uint32_t>& perm_mask,
+                            const std::string& access_key_id) const override {
     auto apl = rgw::auth::add_sysreq(cct, ctl, s,
-      rgw::auth::LocalApplier(cct, user_info, subuser, perm_mask));
+      rgw::auth::LocalApplier(cct, user_info, subuser, perm_mask, access_key_id));
     /* TODO(rzarzynski): replace with static_ptr. */
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -313,7 +313,13 @@ void rgw_format_ops_log_entry(struct rgw_log_entry& entry, Formatter *formatter)
       formatter->close_section();
     }
   }
-
+  if (!entry.access_key_id.empty()) {
+    formatter->dump_string("access_key_id", entry.access_key_id);
+  }
+  if (!entry.subuser.empty()) {
+    formatter->dump_string("subuser", entry.subuser);
+  }
+  formatter->dump_bool("temp_url", entry.temp_url);
   formatter->close_section();
 }
 
@@ -587,6 +593,7 @@ int rgw_log_op(RGWREST* const rest, struct req_state *s, const string& op_name, 
 
   if (s->auth.identity) {
     entry.identity_type = s->auth.identity->get_identity_type();
+    s->auth.identity->write_ops_log_entry(entry);
   } else {
     entry.identity_type = TYPE_NONE;
   }

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -41,9 +41,12 @@ struct rgw_log_entry {
   string trans_id;
   std::vector<string> token_claims;
   uint32_t identity_type;
+  std::string access_key_id;
+  std::string subuser;
+  bool temp_url {false};
 
   void encode(bufferlist &bl) const {
-    ENCODE_START(12, 5, bl);
+    ENCODE_START(13, 5, bl);
     encode(object_owner.id, bl);
     encode(bucket_owner.id, bl);
     encode(bucket, bl);
@@ -69,10 +72,13 @@ struct rgw_log_entry {
     encode(trans_id, bl);
     encode(token_claims, bl);
     encode(identity_type,bl);
+    encode(access_key_id, bl);
+    encode(subuser, bl);
+    encode(temp_url, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &p) {
-    DECODE_START_LEGACY_COMPAT_LEN(12, 5, 5, p);
+    DECODE_START_LEGACY_COMPAT_LEN(13, 5, 5, p);
     decode(object_owner.id, p);
     if (struct_v > 3)
       decode(bucket_owner.id, p);
@@ -126,6 +132,11 @@ struct rgw_log_entry {
     }
     if (struct_v >= 12) {
       decode(identity_type, p);
+    }
+    if (struct_v >= 13) {
+      decode(access_key_id, p);
+      decode(subuser, p);
+      decode(temp_url, p);
     }
     DECODE_FINISH(p);
   }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5667,6 +5667,8 @@ rgw::auth::s3::LDAPEngine::get_creds_info(const rgw::RGWToken& token) const noex
     token.id,
     RGW_PERM_FULL_CONTROL,
     acct_privilege_t::IS_PLAIN_ACCT,
+    rgw::auth::RemoteApplier::AuthInfo::NO_ACCESS_KEY,
+    rgw::auth::RemoteApplier::AuthInfo::NO_SUBUSER,
     TYPE_LDAP
   };
 }
@@ -5776,7 +5778,7 @@ rgw::auth::s3::LocalEngine::authenticate(
     return result_t::deny(-ERR_SIGNATURE_NO_MATCH);
   }
 
-  auto apl = apl_factory->create_apl_local(cct, s, user_info, k.subuser, boost::none);
+  auto apl = apl_factory->create_apl_local(cct, s, user_info, k.subuser, boost::none, access_key_id);
   return result_t::grant(std::move(apl), completer_factory(k.key));
 }
 
@@ -5791,6 +5793,8 @@ rgw::auth::s3::STSEngine::get_creds_info(const STS::SessionToken& token) const n
     token.acct_name,
     token.perm_mask,
     (token.is_admin) ? acct_privilege_t::IS_ADMIN_ACCT: acct_privilege_t::IS_PLAIN_ACCT,
+    token.access_key_id,
+    rgw::auth::RemoteApplier::AuthInfo::NO_SUBUSER,
     token.acct_type
   };
 }
@@ -5950,7 +5954,7 @@ rgw::auth::s3::STSEngine::authenticate(
     return result_t::grant(std::move(apl), completer_factory(token.secret_access_key));
   } else { // This is for all local users of type TYPE_RGW or TYPE_NONE
     string subuser;
-    auto apl = local_apl_factory->create_apl_local(cct, s, user_info, subuser, token.perm_mask);
+    auto apl = local_apl_factory->create_apl_local(cct, s, user_info, subuser, token.perm_mask, std::string(_access_key_id));
     return result_t::grant(std::move(apl), completer_factory(token.secret_access_key));
   }
 }

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -60,6 +60,12 @@ void TempURLApplier::modify_request_state(const DoutPrefixProvider* dpp, req_sta
 
 }
 
+void TempURLApplier::write_ops_log_entry(rgw_log_entry& entry) const
+{
+  LocalApplier::write_ops_log_entry(entry);
+  entry.temp_url = true;
+}
+
 /* TempURL: engine */
 bool TempURLEngine::is_applicable(const req_state* const s) const noexcept
 {
@@ -457,7 +463,8 @@ ExternalTokenEngine::authenticate(const DoutPrefixProvider* dpp,
 
   auto apl = apl_factory->create_apl_local(cct, s, tmp_uinfo,
                                            extract_swift_subuser(swift_user),
-                                           boost::none);
+                                           boost::none,
+                                           rgw::auth::LocalApplier::NO_ACCESS_KEY);
   return result_t::grant(std::move(apl));
 }
 
@@ -611,7 +618,7 @@ SignedTokenEngine::authenticate(const DoutPrefixProvider* dpp,
 
   auto apl = apl_factory->create_apl_local(cct, s, user_info,
                                            extract_swift_subuser(swift_user),
-                                           boost::none);
+                                           boost::none, rgw::auth::LocalApplier::NO_ACCESS_KEY);
   return result_t::grant(std::move(apl));
 }
 

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -24,10 +24,11 @@ class TempURLApplier : public rgw::auth::LocalApplier {
 public:
   TempURLApplier(CephContext* const cct,
                  const RGWUserInfo& user_info)
-    : LocalApplier(cct, user_info, LocalApplier::NO_SUBUSER, boost::none) {
+    : LocalApplier(cct, user_info, LocalApplier::NO_SUBUSER, boost::none, LocalApplier::NO_ACCESS_KEY) {
   };
 
   void modify_request_state(const DoutPrefixProvider* dpp, req_state * s) const override; /* in/out */
+  void write_ops_log_entry(rgw_log_entry& entry) const override;
 
   struct Factory {
     virtual ~Factory() {}
@@ -153,7 +154,7 @@ class SwiftAnonymousApplier : public rgw::auth::LocalApplier {
   public:
     SwiftAnonymousApplier(CephContext* const cct,
                           const RGWUserInfo& user_info)
-      : LocalApplier(cct, user_info, LocalApplier::NO_SUBUSER, boost::none) {
+      : LocalApplier(cct, user_info, LocalApplier::NO_SUBUSER, boost::none, LocalApplier::NO_ACCESS_KEY) {
       };
     bool is_admin_of(const rgw_user& uid) const {return false;}
     bool is_owner_of(const rgw_user& uid) const {return uid.id.compare(RGW_USER_ANON_ID) == 0;}
@@ -225,11 +226,12 @@ class DefaultStrategy : public rgw::auth::Strategy,
                             const req_state* const s,
                             const RGWUserInfo& user_info,
                             const std::string& subuser,
-                            const boost::optional<uint32_t>& perm_mask) const override {
+                            const boost::optional<uint32_t>& perm_mask,
+                            const std::string& access_key_id) const override {
     auto apl = \
       rgw::auth::add_3rdparty(ctl, rgw_user(s->account_name),
         rgw::auth::add_sysreq(cct, ctl, s,
-          rgw::auth::LocalApplier(cct, user_info, subuser, perm_mask)));
+          rgw::auth::LocalApplier(cct, user_info, subuser, perm_mask, access_key_id)));
     /* TODO(rzarzynski): replace with static_ptr. */
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55998

---

backport of https://github.com/ceph/ceph/pull/44052
parent tracker: https://tracker.ceph.com/issues/53367

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh