### PR TITLE
quincy: rgw: reopen ops log file on sighup

### DIFF
--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -344,8 +344,12 @@ int OpsLogManifold::log(struct req_state* s, struct rgw_log_entry& entry)
 }
 
 OpsLogFile::OpsLogFile(CephContext* cct, std::string& path, uint64_t max_data_size) :
-  cct(cct), file(path, std::ofstream::app), data_size(0), max_data_size(max_data_size)
+  cct(cct), data_size(0), max_data_size(max_data_size), path(path), need_reopen(false)
 {
+}
+
+void OpsLogFile::reopen() {
+  need_reopen = true;
 }
 
 void OpsLogFile::flush()
@@ -359,6 +363,11 @@ void OpsLogFile::flush()
   for (auto bl : flush_buffer) {
     int try_num = 0;
     while (true) {
+      if (!file.is_open() || need_reopen) {
+        need_reopen = false;
+        file.close();
+        file.open(path, std::ofstream::app);
+      }
       bl.write_stream(file);
       if (!file) {
         ldpp_dout(this, 0) << "ERROR: failed to log RGW ops log file entry" << dendl;

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -173,6 +173,8 @@ class OpsLogFile : public JsonOpsLogSink, public Thread, public DoutPrefixProvid
   bool stopped;
   uint64_t data_size;
   uint64_t max_data_size;
+  std::string path;
+  std::atomic_bool need_reopen;
 
   void flush();
 protected:
@@ -184,6 +186,7 @@ public:
   CephContext *get_cct() const override { return cct; }
   unsigned get_subsys() const override { return dout_subsys; }
   std::ostream& gen_prefix(std::ostream& out) const override { return out << "rgw OpsLogFile: "; }
+  void reopen();
   void start();
   void stop();
 };


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55997

---

backport of https://github.com/ceph/ceph/pull/44488
parent tracker: https://tracker.ceph.com/issues/53788

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh