### PR TITLE
pacific: client: Inode::hold_caps_until is time from monotonic clock now.

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -349,6 +349,12 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
   _collect_and_send_global_metrics = cct->_conf.get_val<bool>(
     "client_collect_and_send_global_metrics");
 
+  mount_timeout = cct->_conf.get_val<std::chrono::seconds>(
+    "client_mount_timeout");
+
+  caps_release_delay = cct->_conf.get_val<std::chrono::seconds>(
+    "client_caps_release_delay");
+
   if (cct->_conf->client_acl_type == "posix_acl")
     acl_type = POSIX_ACL;
 
@@ -1787,6 +1793,7 @@ int Client::make_request(MetaRequest *request,
 
   // and timestamp
   request->op_stamp = ceph_clock_now();
+  request->created = ceph::coarse_mono_clock::now();
 
   // make note
   mds_requests[tid] = request->get();
@@ -3520,8 +3527,8 @@ int Client::get_caps_used(Inode *in)
 void Client::cap_delay_requeue(Inode *in)
 {
   ldout(cct, 10) << __func__ << " on " << *in << dendl;
-  in->hold_caps_until = ceph_clock_now();
-  in->hold_caps_until += cct->_conf->client_caps_release_delay;
+
+  in->hold_caps_until = ceph::coarse_mono_clock::now() + caps_release_delay;
   delayed_list.push_back(&in->delay_cap_item);
 }
 
@@ -5962,7 +5969,7 @@ int Client::authenticate()
   }
 
   client_lock.unlock();
-  int r = monclient->authenticate(cct->_conf->client_mount_timeout);
+  int r = monclient->authenticate(std::chrono::duration<double>(mount_timeout).count());
   client_lock.lock();
   if (r < 0) {
     return r;
@@ -6573,8 +6580,8 @@ void Client::renew_and_flush_cap_releases()
 
   if (!mount_aborted && mdsmap->get_epoch()) {
     // renew caps?
-    utime_t el = ceph_clock_now() - last_cap_renew;
-    if (unlikely(el > mdsmap->get_session_timeout() / 3.0))
+    auto el = ceph::coarse_mono_clock::now() - last_cap_renew;
+    if (unlikely(utime_t(el) > mdsmap->get_session_timeout() / 3.0))
       renew_caps();
 
     flush_cap_releases();
@@ -6585,7 +6592,7 @@ void Client::tick()
 {
   ldout(cct, 20) << "tick" << dendl;
 
-  utime_t now = ceph_clock_now();
+  auto now = ceph::coarse_mono_clock::now();
 
   /*
    * If the mount() is not finished
@@ -6593,7 +6600,7 @@ void Client::tick()
   if (is_mounting() && !mds_requests.empty()) {
     MetaRequest *req = mds_requests.begin()->second;
 
-    if (req->op_stamp + cct->_conf->client_mount_timeout < now) {
+    if (req->created + mount_timeout < now) {
       req->abort(-CEPHFS_ETIMEDOUT);
       if (req->caller_cond) {
         req->kick = true;
@@ -6627,7 +6634,7 @@ void Client::tick()
   trim_cache(true);
 
   if (blocklisted && (is_mounted() || is_unmounting()) &&
-      last_auto_reconnect + 30 * 60 < now &&
+      last_auto_reconnect + std::chrono::seconds(30 * 60) < now &&
       cct->_conf.get_val<bool>("client_reconnect_stale")) {
     messenger->client_reset();
     fd_gen++; // invalidate open files
@@ -6779,7 +6786,7 @@ void Client::collect_and_send_global_metrics() {
 void Client::renew_caps()
 {
   ldout(cct, 10) << "renew_caps()" << dendl;
-  last_cap_renew = ceph_clock_now();
+  last_cap_renew = ceph::coarse_mono_clock::now();
 
   for (auto &p : mds_sessions) {
     ldout(cct, 15) << "renew_caps requesting from mds." << p.first << dendl;
@@ -15721,6 +15728,8 @@ const char** Client::get_tracked_conf_keys() const
     "client_oc_max_dirty",
     "client_oc_target_dirty",
     "client_oc_max_dirty_age",
+    "client_caps_release_delay",
+    "client_mount_timeout",
     NULL
   };
   return keys;
@@ -15757,6 +15766,14 @@ void Client::handle_conf_change(const ConfigProxy& conf,
   if (changed.count("client_collect_and_send_global_metrics")) {
     _collect_and_send_global_metrics = cct->_conf.get_val<bool>(
       "client_collect_and_send_global_metrics");
+  }    
+  if (changed.count("client_caps_release_delay")) {
+    caps_release_delay = cct->_conf.get_val<std::chrono::seconds>(
+      "client_caps_release_delay");
+  }
+  if (changed.count("client_mount_timeout")) {
+    mount_timeout = cct->_conf.get_val<std::chrono::seconds>(
+      "client_mount_timeout");
   }
 }
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1474,7 +1474,7 @@ private:
   Finisher async_ino_releasor;
   Finisher objecter_finisher;
 
-  utime_t last_cap_renew;
+  ceph::coarse_mono_time last_cap_renew;
 
   CommandHook m_command_hook;
 
@@ -1536,8 +1536,8 @@ private:
   ceph::unordered_map<inodeno_t,SnapRealm*> snap_realms;
   std::map<std::string, std::string> metadata;
 
-  utime_t last_auto_reconnect;
-
+  ceph::coarse_mono_time last_auto_reconnect;
+  std::chrono::seconds caps_release_delay, mount_timeout;
   // trace generation
   ofstream traceout;
 

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -115,6 +115,7 @@ struct CapSnap {
 #define I_ERROR_FILELOCK	(1 << 5)
 
 struct Inode : RefCountedObject {
+  ceph::coarse_mono_time hold_caps_until;
   Client *client;
 
   // -- the actual inode --
@@ -211,7 +212,6 @@ struct Inode : RefCountedObject {
   int cache_gen = 0;
   int snap_caps = 0;
   int snap_cap_refs = 0;
-  utime_t hold_caps_until;
   xlist<Inode*>::item delay_cap_item, dirty_cap_item, flushing_cap_item;
 
   SnapRealm *snaprealm = 0;

--- a/src/client/MetaRequest.h
+++ b/src/client/MetaRequest.h
@@ -25,6 +25,7 @@ private:
   Dentry *_old_dentry; //associated with path2
   int abort_rc;
 public:
+  ceph::coarse_mono_time created = ceph::coarse_mono_clock::zero();
   uint64_t tid;
   utime_t  op_stamp;
   ceph_mds_request_head head;

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -346,7 +346,6 @@ OPTION(mon_client_directed_command_retry, OPT_INT)
 OPTION(client_cache_size, OPT_INT)
 OPTION(client_cache_mid, OPT_FLOAT)
 OPTION(client_use_random_mds, OPT_BOOL)
-OPTION(client_mount_timeout, OPT_DOUBLE)
 OPTION(client_trace, OPT_STR)
 OPTION(client_readahead_min, OPT_LONGLONG)  // readahead at _least_ this much.
 OPTION(client_readahead_max_bytes, OPT_LONGLONG)  // default unlimited
@@ -356,7 +355,6 @@ OPTION(client_mount_uid, OPT_INT)
 OPTION(client_mount_gid, OPT_INT)
 OPTION(client_notify_timeout, OPT_INT) // in seconds
 OPTION(osd_client_watch_timeout, OPT_INT) // in seconds
-OPTION(client_caps_release_delay, OPT_INT) // in seconds
 OPTION(client_quota_df, OPT_BOOL) // use quota for df on subdir mounts
 OPTION(client_oc, OPT_BOOL)
 OPTION(client_oc_size, OPT_INT)    // MB * n

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8954,8 +8954,8 @@ std::vector<Option> get_mds_client_options() {
     .set_default(false)
     .set_description("issue new requests to a random active MDS"),
 
-    Option("client_mount_timeout", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(300.0)
+    Option("client_mount_timeout", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
+    .set_default(300)
     .set_description("timeout for mounting CephFS (seconds)"),
 
     Option("client_tick_interval", Option::TYPE_SECS, Option::LEVEL_DEV)
@@ -9008,7 +9008,7 @@ std::vector<Option> get_mds_client_options() {
     .set_default(30)
     .set_description(""),
 
-    Option("client_caps_release_delay", Option::TYPE_INT, Option::LEVEL_DEV)
+    Option("client_caps_release_delay", Option::TYPE_SECS, Option::LEVEL_DEV)
     .set_default(5)
     .set_description(""),
 

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -278,7 +278,7 @@ int librados::RadosClient::connect()
     goto out;
   }
 
-  err = monclient.authenticate(conf->client_mount_timeout);
+  err = monclient.authenticate(std::chrono::duration<double>(conf.get_val<std::chrono::seconds>("client_mount_timeout")).count());
   if (err) {
     ldout(cct, 0) << conf->name << " authentication error " << cpp_strerror(-err) << dendl;
     shutdown();

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -155,7 +155,7 @@ int MonClient::get_monmap_and_config()
     if (r < 0) {
       return r;
     }
-    r = authenticate(cct->_conf->client_mount_timeout);
+    r = authenticate(std::chrono::duration<double>(cct->_conf.get_val<std::chrono::seconds>("client_mount_timeout")).count());
     if (r == -ETIMEDOUT) {
       shutdown();
       continue;

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -158,7 +158,7 @@ struct MonClientPinger : public Dispatcher,
   int wait_for_reply(double timeout = 0.0) {
     std::unique_lock locker{lock};
     if (timeout <= 0) {
-      timeout = cct->_conf->client_mount_timeout;
+      timeout = std::chrono::duration<double>(cct->_conf.get_val<std::chrono::seconds>("client_mount_timeout")).count();
     }
     done = false;
     if (ping_recvd_cond.wait_for(locker,

--- a/src/neorados/RADOSImpl.cc
+++ b/src/neorados/RADOSImpl.cc
@@ -59,7 +59,7 @@ RADOS::RADOS(boost::asio::io_context& ioctx,
   if (err) {
     throw boost::system::system_error(ceph::to_error_code(err));
   }
-  err = monclient.authenticate(cct->_conf->client_mount_timeout);
+  err = monclient.authenticate(std::chrono::duration<double>(cct->_conf.get_val<std::chrono::seconds>("client_mount_timeout")).count());
   if (err) {
     throw boost::system::system_error(ceph::to_error_code(err));
   }

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -60,7 +60,7 @@ TEST(LibRadosMiscConnectFailure, ConnectFailure) {
   ASSERT_EQ(0, rados_conf_read_file(cluster, NULL));
   ASSERT_EQ(0, rados_conf_parse_env(cluster, NULL));
 
-  ASSERT_EQ(0, rados_conf_set(cluster, "client_mount_timeout", "0.000000001"));
+  ASSERT_EQ(0, rados_conf_set(cluster, "client_mount_timeout", "1s"));
   ASSERT_EQ(0, rados_conf_set(cluster, "debug_monc", "20"));
   ASSERT_EQ(0, rados_conf_set(cluster, "debug_ms", "1"));
   ASSERT_EQ(0, rados_conf_set(cluster, "log_to_stderr", "true"));

--- a/src/tools/cephfs_mirror/Mirror.cc
+++ b/src/tools/cephfs_mirror/Mirror.cc
@@ -238,7 +238,7 @@ int Mirror::init_mon_client() {
     return r;
   }
 
-  r = m_monc->authenticate(m_cct->_conf->client_mount_timeout);
+  r = m_monc->authenticate(std::chrono::duration<double>(m_cct->_conf.get_val<std::chrono::seconds>("client_mount_timeout")).count());
   if (r < 0) {
     derr << ": failed to authenticate to monitor: " << cpp_strerror(r) << dendl;
     return r;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55937

---

backport of https://github.com/ceph/ceph/pull/44247
parent tracker: https://tracker.ceph.com/issues/52982

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh