### PR TITLE
doc/man/8: Tweak formatting and wording in ceph.rst

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -546,16 +546,16 @@ Usage::
 
 Subcommand ``enable_stretch_mode`` enables stretch mode, changing the peering
 rules and failure handling on all pools. For a given PG to successfully peer
-and be marked active, min_size replicas will now need to be active under all
+and be marked active, ``min_size`` replicas will now need to be active under all
 (currently two) CRUSH buckets of type <dividing_bucket>.
 
-`tiebreaker_mon` is the tiebreaker mon to use if a network split happens.
+<tiebreaker_mon> is the tiebreaker mon to use if a network split happens.
 
-`dividing_bucket` is the bucket type to set for locations for stretching across.
-This will typically be datacenter or other CRUSH hierarchy bucket type that
+<dividing_bucket> is the bucket type across which to stretch.
+This will typically be ``datacenter`` or other CRUSH hierarchy bucket type that
 denotes physically or logically distant subdivisions.
 
-`new_crush_rule` will be set as CRUSH rule for all pools.
+<new_crush_rule> will be set as CRUSH rule for all pools.
 
 Usage::
 


### PR DESCRIPTION
Signed-off-by: Anthony D'Atri <anthonyeleven@users.noreply.github.com>

doc/man/8: Tweak formatting and wording in ceph.rst changes from #46195



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
