### PR TITLE
SubmittingPatches.rst: PRs should target "main"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@
 -->
 
 ## Contribution Guidelines
-- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).
+- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).
 
 - If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.
 

--- a/SubmittingPatches.rst
+++ b/SubmittingPatches.rst
@@ -5,7 +5,7 @@ Submitting Patches to Ceph
 Patches to Ceph can be divided into three categories:
 
     1. patches targeting Ceph kernel code
-    2. patches targeting the "master" branch
+    2. patches targeting the "main" branch
     3. patches targeting stable branches (e.g.: "nautilus")
 
 Some parts of Ceph - notably the RBD and CephFS kernel clients - are maintained
@@ -16,7 +16,7 @@ The rest of this document assumes that your patch relates to Ceph code that is
 maintained in the GitHub repository https://github.com/ceph/ceph
 
 If you have a patch that fixes an issue, feel free to open a GitHub pull request
-("PR") targeting the "master" branch, but do read this document first, as it
+("PR") targeting the "main" branch, but do read this document first, as it
 contains important information for ensuring that your PR passes code review
 smoothly.
 
@@ -128,7 +128,7 @@ should start with "doc". For instance, a commit fixing a typo in
 
   doc/mgr/dashboard: fix a typo
 
-More positive examples can be obtained from the git history of the ``master``
+More positive examples can be obtained from the git history of the ``main``
 branch::
 
      git log
@@ -151,7 +151,7 @@ In the body of your commit message, be as specific as possible. If the commit
 message title was too short to fully state what the commit is doing, use the
 body to explain not just the "what", but also the "why".
 
-For positive examples, peruse ``git log`` in the ``master`` branch. A negative
+For positive examples, peruse ``git log`` in the ``main`` branch. A negative
 example would be a commit message that merely states the obvious. For example:
 "this patch includes updates for subsystem X. Please apply."
 
@@ -195,7 +195,7 @@ PRs should be opened on branches contained in your fork of
 https://github.com/ceph/ceph.git - do not push branches directly to
 ``ceph/ceph.git``.
 
-PRs should target "master". If you need to add a patch to a stable branch, such
+PRs should target "main". If you need to add a patch to a stable branch, such
 as "nautilus", see the file ``SubmittingPatches-backports.rst``.
 
 In addition to a base, or "target" branch, PRs have several other components:


### PR DESCRIPTION
PRs should target "main" branch in "SubmittingPatches.rst";
"SubmittingPatches.rst" in "Contribution Guidelines" should jump main branch;

fix: https://tracker.ceph.com/issues/56009
Signed-off-by: Huber-ming <zhangsm01@inspur.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
