### PR TITLE
pacific: Add mapping for ernno:13 and adding path in error msg in opendir()/cephfs.pyx 

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -176,7 +176,8 @@ class NotDirectory(OSError):
 
 class DiskQuotaExceeded(OSError):
     pass
-
+class PermissionDenied(OSError):
+    pass
 
 cdef errno_to_exception =  {
     CEPHFS_EPERM      : PermissionError,
@@ -192,6 +193,7 @@ cdef errno_to_exception =  {
     CEPHFS_ENOTEMPTY  : ObjectNotEmpty,
     CEPHFS_ENOTDIR    : NotDirectory,
     CEPHFS_EDQUOT     : DiskQuotaExceeded,
+    CEPHFS_EACCES     : PermissionDenied,
 }
 
 
@@ -939,7 +941,7 @@ cdef class LibCephFS(object):
         with nogil:
             ret = ceph_opendir(self.cluster, _path, &handle);
         if ret < 0:
-            raise make_ex(ret, "opendir failed")
+            raise make_ex(ret, "opendir failed at {}".format(path.decode('utf-8')))
         d = DirResult()
         d.lib = self
         d.handle = handle


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54577

---

backport of https://github.com/ceph/ceph/pull/45104
parent tracker: https://tracker.ceph.com/issues/54237

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh