### PR TITLE
pacific: mgr/dashboard: fix drain e2e failure 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/hosts.po.ts
@@ -158,14 +158,14 @@ export class HostsPageHelper extends PageHelper {
     this.clickActionButton('start-drain');
     this.checkLabelExists(hostname, ['_no_schedule'], true);
 
+    // unselect it to avoid colliding with any other selection
+    // in different steps
+    this.getTableCell(this.columnIndex.hostname, hostname).click();
+
     this.clickTab('cd-host-details', hostname, 'Daemons');
     cy.get('cd-host-details').within(() => {
       cy.wait(20000);
       this.expectTableCount('total', 0);
     });
-
-    // unselect it to avoid colliding with any other selection
-    // in different steps
-    this.getTableCell(this.columnIndex.hostname, hostname).click();
   }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56036

---

backport of https://github.com/ceph/ceph/pull/46475
parent tracker: https://tracker.ceph.com/issues/55741

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh