### PR TITLE
quincy: mgr/dashboard: stop polling when page is not visible

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -5,7 +5,6 @@ import {
   Component,
   EventEmitter,
   Input,
-  NgZone,
   OnChanges,
   OnDestroy,
   OnInit,
@@ -24,7 +23,7 @@ import {
   TableColumnProp
 } from '@swimlane/ngx-datatable';
 import _ from 'lodash';
-import { Observable, Subject, Subscription, timer as observableTimer } from 'rxjs';
+import { Observable, of, Subject, Subscription } from 'rxjs';
 
 import { TableStatus } from '~/app/shared/classes/table-status';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
@@ -35,6 +34,7 @@ import { CdTableColumnFiltersChange } from '~/app/shared/models/cd-table-column-
 import { CdTableFetchDataContext } from '~/app/shared/models/cd-table-fetch-data-context';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { CdUserConfig } from '~/app/shared/models/cd-user-config';
+import { TimerService } from '~/app/shared/services/timer.service';
 
 @Component({
   selector: 'cd-table',
@@ -234,7 +234,11 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
     });
   }
 
-  constructor(private ngZone: NgZone, private cdRef: ChangeDetectorRef) {}
+  constructor(
+    // private ngZone: NgZone,
+    private cdRef: ChangeDetectorRef,
+    private timerService: TimerService
+  ) {}
 
   static prepareSearch(search: string) {
     search = search.toLowerCase().replace(/,/g, '');
@@ -296,13 +300,11 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
       this.loadingIndicator = true;
     }
     if (_.isInteger(this.autoReload) && this.autoReload > 0) {
-      this.ngZone.runOutsideAngular(() => {
-        this.reloadSubscriber = observableTimer(0, this.autoReload).subscribe(() => {
-          this.ngZone.run(() => {
-            return this.reloadData();
-          });
+      this.reloadSubscriber = this.timerService
+        .get(() => of(0), this.autoReload)
+        .subscribe(() => {
+          this.reloadData();
         });
-      });
     } else if (!this.autoReload) {
       this.reloadData();
     } else {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/rxjs/operators/page-visibilty.operator.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/rxjs/operators/page-visibilty.operator.ts
@@ -1,0 +1,20 @@
+import { fromEvent, Observable, partition } from 'rxjs';
+import { repeatWhen, shareReplay, takeUntil } from 'rxjs/operators';
+
+export function whenPageVisible() {
+  const visibilitychange$ = fromEvent(document, 'visibilitychange').pipe(
+    shareReplay({ refCount: true, bufferSize: 1 })
+  );
+
+  const [pageVisible$, pageHidden$] = partition(
+    visibilitychange$,
+    () => document.visibilityState === 'visible'
+  );
+
+  return function <T>(source: Observable<T>) {
+    return source.pipe(
+      takeUntil(pageHidden$),
+      repeatWhen(() => pageVisible$)
+    );
+  };
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/motd-notification.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/motd-notification.service.ts
@@ -5,6 +5,7 @@ import { BehaviorSubject, EMPTY, Observable, of, Subscription } from 'rxjs';
 import { catchError, delay, mergeMap, repeat, tap } from 'rxjs/operators';
 
 import { Motd, MotdService } from '~/app/shared/api/motd.service';
+import { whenPageVisible } from '../rxjs/operators/page-visibilty.operator';
 
 @Injectable({
   providedIn: 'root'
@@ -31,7 +32,8 @@ export class MotdNotificationService implements OnDestroy {
         }),
         tap((motd: Motd | null) => this.processResponse(motd)),
         delay(60000),
-        repeat()
+        repeat(),
+        whenPageVisible()
       )
       .subscribe();
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/timer.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/timer.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { Observable, timer } from 'rxjs';
 import { observeOn, shareReplay, switchMap } from 'rxjs/operators';
 
+import { whenPageVisible } from '../rxjs/operators/page-visibilty.operator';
 import { NgZoneSchedulerService } from './ngzone-scheduler.service';
 
 @Injectable({
@@ -21,7 +22,8 @@ export class TimerService {
     return timer(dueTime, refreshInterval, this.ngZone.leave).pipe(
       observeOn(this.ngZone.enter),
       switchMap(next),
-      shareReplay({ refCount: true, bufferSize: 1 })
+      shareReplay({ refCount: true, bufferSize: 1 }),
+      whenPageVisible()
     );
   }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56037

---

backport of https://github.com/ceph/ceph/pull/46370
parent tracker: https://tracker.ceph.com/issues/50963

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh