### PR TITLE
pacific: ceph_test_librados_service: wait longer for servicemap to update

### DIFF
--- a/src/test/librados/service.cc
+++ b/src/test/librados/service.cc
@@ -120,7 +120,7 @@ TEST(LibRadosService, StatusFormat) {
     });
   }
 
-  int retry = 15;
+  int retry = 60; // mon thrashing may make this take a long time
   while (retry) {
     rados_t cluster;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51287

---

backport of https://github.com/ceph/ceph/pull/41923
parent tracker: https://tracker.ceph.com/issues/51234

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh