### PR TITLE
pacific: mon/OSDMonitor: Ensure kvmon() is writeable before handling "osd new" cmd

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -12596,6 +12596,14 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       return false;
     }
 
+    // make sure kvmon is writeable.
+    if (!mon.kvmon()->is_writeable()) {
+      dout(10) << __func__ << " waiting for kv mon to be writeable for "
+               << "osd new" << dendl;
+      mon.kvmon()->wait_for_writeable(op, new C_RetryMessage(this, op));
+      return false;
+    }
+
     map<string,string> param_map;
 
     bufferlist bl = m->get_data();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56059

---

backport of https://github.com/ceph/ceph/pull/46428
parent tracker: https://tracker.ceph.com/issues/55773

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh