### PR TITLE
pacific: pybind/mgr: ceph osd status crash with ZeroDivisionError

### DIFF
--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -44,7 +44,7 @@ class Module(MgrModule):
 
         #self.log.error("get_latest {0} data={1}".format(stat, data))
         if data and len(data) > 1 and data[-1][0] != data[-2][0]:
-            return (data[-1][1] - data[-2][1]) / float(data[-1][0] - data[-2][0])
+            return (data[-1][1] - data[-2][1]) // int(data[-1][0] - data[-2][0])
         else:
             return 0
 

--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -43,7 +43,7 @@ class Module(MgrModule):
         data = self.get_counter(daemon_type, daemon_name, stat)[stat]
 
         #self.log.error("get_latest {0} data={1}".format(stat, data))
-        if data and len(data) > 1 and data[-1][0] != data[-2][0]:
+        if data and len(data) > 1 and (int(data[-1][0] - data[-2][0]) != 0):
             return (data[-1][1] - data[-2][1]) // int(data[-1][0] - data[-2][0])
         else:
             return 0


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54281

---

backport of https://github.com/ceph/ceph/pull/44752
parent tracker: https://tracker.ceph.com/issues/53538

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh