### PR TITLE
ceph-volume: do not sensitive details about luks encryption

### DIFF
--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -145,7 +145,8 @@ def get_dmcrypt_key(osd_id, osd_fsid, lockbox_keyring=None):
             'get',
             config_key
         ],
-        show_command=True
+        show_command=True,
+        logfile_verbose=False
     )
     if returncode != 0:
         raise RuntimeError('Unable to retrieve dmcrypt secret')


### PR DESCRIPTION
During osd activation, ceph-volume logs the luks key to its log file.

```
[2022-06-15 12:50:35,180][ceph_volume.process][INFO  ] Running command: /usr/bin/ceph --cluster ceph --name client.osd-lockbox.51d0770d-403d-4f81-93e6-e99f627f246c --keyring /var/lib/ceph/osd/ceph-0/lockbox.keyring config-key get dm-crypt/osd/51d0770d-403d-4f81-93e6-e99f627f246c/luks
[2022-06-15 12:50:35,522][ceph_volume.process][INFO  ] stdout ut9NjMK6YtMh1BLMJZ/mE2A7zTNyrp9pW1kHV8F2ipfz1BIX9MkEWhdYB2Azm1JPZ1d7ahIjBMUbrC/Iqqr2jQhP3MIsDzUYj1enw+sw7LeVvGPf0qNUdKmEGu5tUmvtQ+5pbk4T/9PF36kT6vCHKfNML/3fL6nnY8FDySrI4LY=
[2022-06-15 12:50:35,522][ceph_volume.process][INFO  ] Running command: /usr/sbin/cryptsetup --key-size 512 --key-file - --allow-discards luksOpen /dev/ceph-83c307d3-710b-4197-8ecd-0484e17395e3/osd-block-51d0770d-403d-4f81-93e6-e99f627f246c a9HhDO-MiYD-DtYm-SKJf-nO1d-5O3u-FmcCrd
```

Fixes: https://tracker.ceph.com/issues/56066

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
