### PR TITLE
rgw: When the key_id used by the encrypted file is unavailable, usinghead_obj to view the details of the file will also report an error

### DIFF
--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -1273,7 +1273,7 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
 int rgw_s3_prepare_decrypt(struct req_state* s,
                        map<string, bufferlist>& attrs,
                        std::unique_ptr<BlockCrypt>* block_crypt,
-                       std::map<std::string, std::string>& crypt_http_responses)
+                       std::map<std::string, std::string>& crypt_http_responses, bool get_data)
 {
   int res = 0;
   std::string stored_mode = get_str_attribute(attrs, RGW_ATTR_CRYPT_MODE);
@@ -1376,6 +1376,12 @@ int rgw_s3_prepare_decrypt(struct req_state* s,
     }
     /* try to retrieve actual key */
     std::string key_id = get_str_attribute(attrs, RGW_ATTR_CRYPT_KEYID);
+    if (!get_data) {
+      crypt_http_responses["x-amz-server-side-encryption"] = "aws:kms";
+      crypt_http_responses["x-amz-server-side-encryption-aws-kms-key-id"] = key_id;
+      return 0;
+    }
+
     std::string actual_key;
     res = reconstitute_actual_key_from_kms(s, s->cct, attrs, actual_key);
     if (res != 0) {

--- a/src/rgw/rgw_crypt.h
+++ b/src/rgw/rgw_crypt.h
@@ -149,7 +149,8 @@ int rgw_s3_prepare_decrypt(struct req_state* s,
                            std::map<std::string, ceph::bufferlist>& attrs,
                            std::unique_ptr<BlockCrypt>* block_crypt,
                            std::map<std::string,
-                                    std::string>& crypt_http_responses);
+                           std::string>& crypt_http_responses,
+                           bool get_data = true);
 
 static inline void set_attr(std::map<std::string, bufferlist>& attrs,
                             const char* key,

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2279,7 +2279,7 @@ void RGWGetObj::execute(optional_yield y)
 
   attr_iter = attrs.find(RGW_ATTR_MANIFEST);
   op_ret = this->get_decrypt_filter(&decrypt, filter,
-                                    attr_iter != attrs.end() ? &(attr_iter->second) : nullptr);
+                                    attr_iter != attrs.end() ? &(attr_iter->second) : nullptr, get_data);
   if (decrypt != nullptr) {
     filter = decrypt.get();
   }

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -433,7 +433,7 @@ public:
   /**
    * calculates filter used to decrypt RGW objects data
    */
-  virtual int get_decrypt_filter(std::unique_ptr<RGWGetObj_Filter>* filter, RGWGetObj_Filter* cb, bufferlist* manifest_bl) {
+  virtual int get_decrypt_filter(std::unique_ptr<RGWGetObj_Filter>* filter, RGWGetObj_Filter* cb, bufferlist* manifest_bl, bool get_data) {
     *filter = nullptr;
     return 0;
   }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -567,7 +567,7 @@ send_data:
   return 0;
 }
 
-int RGWGetObj_ObjStore_S3::get_decrypt_filter(std::unique_ptr<RGWGetObj_Filter> *filter, RGWGetObj_Filter* cb, bufferlist* manifest_bl)
+int RGWGetObj_ObjStore_S3::get_decrypt_filter(std::unique_ptr<RGWGetObj_Filter> *filter, RGWGetObj_Filter* cb, bufferlist* manifest_bl, bool get_data)
 {
   if (skip_decrypt) { // bypass decryption for multisite sync requests
     return 0;
@@ -575,7 +575,7 @@ int RGWGetObj_ObjStore_S3::get_decrypt_filter(std::unique_ptr<RGWGetObj_Filter> 
 
   int res = 0;
   std::unique_ptr<BlockCrypt> block_crypt;
-  res = rgw_s3_prepare_decrypt(s, attrs, &block_crypt, crypt_http_responses);
+  res = rgw_s3_prepare_decrypt(s, attrs, &block_crypt, crypt_http_responses, get_data);
   if (res == 0) {
     if (block_crypt != nullptr) {
       auto f = std::make_unique<RGWGetObj_BlockDecrypt>(s, s->cct, cb, std::move(block_crypt));

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -55,7 +55,7 @@ public:
   void set_custom_http_response(int http_ret) { custom_http_ret = http_ret; }
   int get_decrypt_filter(std::unique_ptr<RGWGetObj_Filter>* filter,
                          RGWGetObj_Filter* cb,
-                         bufferlist* manifest_bl) override;
+                         bufferlist* manifest_bl, bool get_data) override;
 };
 
 class RGWGetObjTags_ObjStore_S3 : public RGWGetObjTags_ObjStore


### PR DESCRIPTION

The reason for this phenomenon is that when the head_obj interface is used, it will verify whether the key_id is available in barbican. If it is not available, the interface will return an error. A more reasonable way is that the head_obj interface returns the key_id and encryption method, but does not verify whether the key_id is available.

Fixes:https://tracker.ceph.com/issues/56080

Signed-off-by: wangyingbin <ybwang0211@163.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
