### PR TITLE
quincy: ceph-volume: do not log sensitive details

### DIFF
--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -1,13 +1,14 @@
 import base64
 import os
 import logging
-from ceph_volume import process, conf
+from ceph_volume import process, conf, terminal
 from ceph_volume.util import constants, system
 from ceph_volume.util.device import Device
 from .prepare import write_keyring
 from .disk import lsblk, device_family, get_part_entry_type
 
 logger = logging.getLogger(__name__)
+mlogger = terminal.MultiLogger(__name__)
 
 def get_key_size_from_conf():
     """
@@ -135,6 +136,7 @@ def get_dmcrypt_key(osd_id, osd_fsid, lockbox_keyring=None):
     name = 'client.osd-lockbox.%s' % osd_fsid
     config_key = 'dm-crypt/osd/%s/luks' % osd_fsid
 
+    mlogger.info(f'Running ceph config-key get {config_key}')
     stdout, stderr, returncode = process.call(
         [
             'ceph',
@@ -145,7 +147,8 @@ def get_dmcrypt_key(osd_id, osd_fsid, lockbox_keyring=None):
             'get',
             config_key
         ],
-        show_command=True
+        show_command=True,
+        logfile_verbose=False
     )
     if returncode != 0:
         raise RuntimeError('Unable to retrieve dmcrypt secret')

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -19,7 +19,8 @@ mlogger = terminal.MultiLogger(__name__)
 def create_key():
     stdout, stderr, returncode = process.call(
         ['ceph-authtool', '--gen-print-key'],
-        show_command=True)
+        show_command=True,
+        logfile_verbose=False)
     if returncode != 0:
         raise RuntimeError('Unable to generate a new auth key')
     return ' '.join(stdout).strip()
@@ -40,13 +41,15 @@ def write_keyring(osd_id, secret, keyring_name='keyring', name=None):
     """
     osd_keyring = '/var/lib/ceph/osd/%s-%s/%s' % (conf.cluster, osd_id, keyring_name)
     name = name or 'osd.%s' % str(osd_id)
-    process.run(
+    mlogger.info(f'Creating keyring file for {name}')
+    process.call(
         [
             'ceph-authtool', osd_keyring,
             '--create-keyring',
             '--name', name,
             '--add-key', secret
-        ])
+        ],
+        logfile_verbose=False)
     system.chown(osd_keyring)
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56085

---

backport of https://github.com/ceph/ceph/pull/46698
parent tracker: https://tracker.ceph.com/issues/56071

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh