### PR TITLE
quincy: ceph-volume: make is_valid() optional

### DIFF
--- a/src/ceph-volume/ceph_volume/configuration.py
+++ b/src/ceph-volume/ceph_volume/configuration.py
@@ -86,13 +86,14 @@ class Conf(conf_parentclass):
         s = '_'.join(s.split())
         return s
 
-    def get_safe(self, section, key, default=None):
+    def get_safe(self, section, key, default=None, check_valid=True):
         """
         Attempt to get a configuration value from a certain section
         in a ``cfg`` object but returning None if not found. Avoids the need
         to be doing try/except {ConfigParser Exceptions} every time.
         """
-        self.is_valid()
+        if check_valid:
+            self.is_valid()
         try:
             return self.get(section, key)
         except (configparser.NoSectionError, configparser.NoOptionError):

--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -18,7 +18,7 @@ def get_key_size_from_conf():
     key_size = conf.ceph.get_safe(
         'osd',
         'osd_dmcrypt_key_size',
-        default='512')
+        default='512', check_valid=False)
 
     if key_size not in ['256', '512']:
         logger.warning(("Invalid value set for osd_dmcrypt_key_size ({}). "


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56039

---

backport of https://github.com/ceph/ceph/pull/46588
parent tracker: https://tracker.ceph.com/issues/55970

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh