### PR TITLE
cephadm: improve message when removing osd

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2816,7 +2816,10 @@ Then run the following:
 
         # trigger the serve loop to initiate the removal
         self._kick_serve_loop()
-        return "Scheduled OSD(s) for removal"
+        warning_zap = "" if not zap else ("\nVG/LV for the OSDs won't be zapped (--zap wasn't passed).\n"
+                                          "Run the `ceph-volume lvm zap` command with `--destroy`"
+                                          " against the VG/LV if you want them to be destroyed.")
+        return f"Scheduled OSD(s) for removal.{warning_zap}"
 
     @handle_orch_error
     def stop_remove_osds(self, osd_ids: List[str]) -> str:


### PR DESCRIPTION
make it clearer that not passing --zap will leave VG/LV, therefore all
LVM metadata associated with the osd being removed from the Ceph cluster.

Fixes: https://tracker.ceph.com/issues/56092

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>

