### PR TITLE
log: Make log_max_recent have an effect again.

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -473,6 +473,7 @@ options:
     to the log.  For example, debug_osd=1/5 will write everything <= 1 to the log
     unconditionally but keep entries at levels 2-5 in memory.  If there is a seg fault
     or assertion failure, all entries will be dumped to the log.
+  min: 1
   default: 500
   daemon_default: 10000
   # default changed by common_preinit()

--- a/src/log/Entry.h
+++ b/src/log/Entry.h
@@ -90,7 +90,7 @@ public:
     str.assign(strv.begin(), strv.end());
     return *this;
   }
-  ConcreteEntry(ConcreteEntry&& e) : Entry(e), str(std::move(e.str)) {}
+  ConcreteEntry(ConcreteEntry&& e) noexcept : Entry(e), str(std::move(e.str)) {}
   ConcreteEntry& operator=(ConcreteEntry&& e) {
     Entry::operator=(e);
     str = std::move(e.str);

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -93,7 +93,7 @@ void Log::set_max_new(std::size_t n)
 void Log::set_max_recent(std::size_t n)
 {
   std::scoped_lock lock(m_flush_mutex);
-  m_max_recent = n;
+  m_recent.set_capacity(n);
 }
 
 void Log::set_log_file(std::string_view fn)
@@ -420,8 +420,8 @@ void Log::dump_recent()
 			     tid_to_int(pthread_id), pthread_name), true);
   }
 
-  _log_message(fmt::format("  max_recent {:9}", m_max_recent), true);
-  _log_message(fmt::format("  max_new    {:9}", m_max_recent), true);
+  _log_message(fmt::format("  max_recent {:9}", m_recent.capacity()), true);
+  _log_message(fmt::format("  max_new    {:9}", m_max_new), true);
   _log_message(fmt::format("  log_file {}", m_log_file), true);
 
   _log_message("--- end dump of recent events ---", true);

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -73,7 +73,6 @@ class Log : private Thread
   bool m_stop = false;
 
   std::size_t m_max_new = DEFAULT_MAX_NEW;
-  std::size_t m_max_recent = DEFAULT_MAX_RECENT;
 
   bool m_inject_segv = false;
 


### PR DESCRIPTION
The log improvements in a747aeac13daf3dba43343120659e802cb569f6b unfortunately left log_max_recent broken because m_max_recent wasn't used anymore.

Eliminate m_max_recent and set the capacity of the m_recent ring buffer when log_max_recent changes. In order to call capacity(), ConcreteEntry needed its move constructor set noexcept.

I haven't followed the boost code all the way down but I suspect that setting the ring buffer capacity to anything less than 1 entry will probably cause problems, so restrict log_max_recent to >=1.

Also fix a wrong variable used for printing the max new entries during "log dump".

Fixes: https://tracker.ceph.com/issues/56093

Signed-off-by: Joshua Baergen <jbaergen@digitalocean.com>
