### PR TITLE
src/mon/Paxos: Provide paxos with mon shutdown info

### DIFF
--- a/src/messages/MMonShutdown.h
+++ b/src/messages/MMonShutdown.h
@@ -1,0 +1,39 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+
+
+#ifndef CEPH_MMONSHUTDOWN_H
+#define CEPH_MMONSHUTDOWN_H
+
+#include "msg/Message.h"
+
+class MMonShutdown final : public Message {
+public:
+  std::string name;
+  MMonShutdown() : Message{MSG_MON_SHUTDOWN} {}
+  MMonShutdown(std::string n) : Message{MSG_MON_SHUTDOWN},
+  name(n) {}
+private:
+  ~MMonShutdown() final {}
+
+public:
+  std::string_view get_type_name() const override { return "mon_shutdown"; }
+  void print(std::ostream& o) const override {
+    o << "mon_shutdown: mon." << name;
+  }
+
+  void decode_payload() override {
+    using ceph::decode;
+    auto p = payload.cbegin();
+    decode(name, p);
+  }
+  void encode_payload(uint64_t features) override {
+    using ceph::encode;
+    encode(name, payload);
+  }
+private:
+  template<class T, typename... Args>
+  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+};
+
+#endif

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -624,6 +624,12 @@ public:
       q.push_back(monmap->get_name(*p));
     return q;
   }
+  std::set<std::string> get_quorum_names_set() {
+    std::set<std::string> q;
+    for (auto p = quorum.begin(); p != quorum.end(); ++p)
+      q.insert(monmap->get_name(*p));
+    return q;
+  }
   uint64_t get_quorum_con_features() const {
     return quorum_con_features;
   }

--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -548,6 +548,13 @@ private:
    * (when all the quorum members have accepted the proposal).
    */
   std::set<int>   accepted;
+
+  /**
+   * The same as *accepted* but this set keeps track of the name rather than rank
+   * of the monitor.
+   */
+  std::set<std::string> accepted_name;
+
   /**
    * Callback to trigger a new election if the proposal is not accepted by the
    * full quorum within a given timeframe.
@@ -597,6 +604,12 @@ private:
    * this list.  When it commits, these finishers are notified.
    */
   std::list<Context*> committing_finishers;
+  /**
+   * List of Monitors that have been shutdown.
+   # This gets populated through the function handle_shutdown_mon.
+   * The list will be cleared in every time we restart paxos.
+   */
+  std::set<std::string> shutdown_mons;
   /**
    * This function re-triggers pending_ and committing_finishers
    * safely, so as to maintain existing system invariants. In particular
@@ -1074,6 +1087,13 @@ public:
   }
 
   void dispatch(MonOpRequestRef op);
+  
+  /**
+   * When a monitor gets shutdown, we recieve the name of the
+   * monitor and use this information to make better decision
+   * in the ACCEPT phase of Paxos.
+   */
+  void handle_shutdown_mon(MonOpRequestRef op);
 
   void read_and_prepare_transactions(MonitorDBStore::TransactionRef tx,
 				     version_t from, version_t last);

--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -23,6 +23,7 @@ using std::ostream;
 using std::string;
 
 using ceph::bufferlist;
+using ceph::JSONFormatter;
 
 #define dout_subsys ceph_subsys_paxos
 #undef dout_prefix
@@ -248,6 +249,12 @@ void PaxosService::propose_pending()
 	ceph_abort_msg("bad return value for C_Committed");
     }
   };
+  dout(10) << __func__ << " JR propose_pending" << dendl;
+  dout(10) << __func__ << " transaction dump:\n";
+  JSONFormatter f(true);
+  t->dump(&f);
+  f.flush(*_dout);
+  *_dout << dendl;
   paxos.queue_pending_finisher(new C_Committed(this));
   paxos.trigger_propose();
 }

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -44,6 +44,7 @@
 #include "messages/MMonSync.h"
 #include "messages/MMonPing.h"
 #include "messages/MMonScrub.h"
+#include "messages/MMonShutdown.h"
 
 #include "messages/MLog.h"
 #include "messages/MLogAck.h"
@@ -399,6 +400,9 @@ Message *decode_message(CephContext *cct,
     break;
   case MSG_MON_PAXOS:
     m = make_message<MMonPaxos>();
+    break;
+  case MSG_MON_SHUTDOWN:
+    m = make_message<MMonShutdown>();
     break;
   case MSG_CONFIG:
     m = make_message<MConfig>();

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -47,6 +47,7 @@
 #define MSG_MON_JOIN               68
 #define MSG_MON_SYNC		   69
 #define MSG_MON_PING               140
+#define MSG_MON_SHUTDOWN           141
 
 /* monitor <-> mon admin tool */
 #define MSG_MON_COMMAND            50

--- a/src/msg/MessageRef.h
+++ b/src/msg/MessageRef.h
@@ -124,6 +124,7 @@ class MMonScrub;
 class MMonSubscribeAck;
 class MMonSubscribe;
 class MMonSync;
+class MMonShutdown;
 class MOSDAlive;
 class MOSDBackoff;
 class MOSDBeacon;

--- a/src/tools/ceph-dencoder/common_types.h
+++ b/src/tools/ceph-dencoder/common_types.h
@@ -345,6 +345,9 @@ MESSAGE(MMonSubscribe)
 #include "messages/MMonSubscribeAck.h"
 MESSAGE(MMonSubscribeAck)
 
+#include "messages/MMonShutdown.h"
+MESSAGE(MMonShutdown)
+
 #include "messages/MOSDAlive.h"
 MESSAGE(MOSDAlive)
 


### PR DESCRIPTION
**Problem:**
    
mon.a
mon.b
mon.c
mon.d
mon.e

ceph -a stop mon.d
ceph mon remove d

.
.

mon.d is down but actually did not get removed and monmap still did not get updated.

We shut down mon.d, this blocks mon.a Paxos:: begin (assuming Paxos is updating),
since mon.a (leader) sends out begin message (MMonPaxos::OP_BEGIN) to all peer
monitors including mon.d since mon.get_quorum() still is not updated and still contain mon.d.
Paxos will not proceed to the commit() phase since we did not get a reply
message(MMonPaxos::OP_ACCEPT) from mon.d. The lease of one of the monitors will eventually expire
and will call for an election, now, if the monmap proposal of ("mon remove", "name": "d")
comes in before the election happens, it will get queued to pending_finisher and eventually
be discarded once the election has started. Resulting in the remove command not taking effect.
 
However, if the election finishes before the monmap proposal, then we will be fine
because mon.get_quorum() will get updated and Paxos will not send
(MMonPaxos::OP_BEGIN) to mon.d, hence will not be blocked and will continue to the commit phase,
therefore, this problem is non-deterministic.
    
**Solution:**

The goal is to allow users to successfully shutdown
and remove a monitor without Paxos
rejecting the remove proposal because it needs **all** monitors
in the quorum to accept when we know there is a monitor that was purposely shut down. 
We provide Paxos with the additional information that the
monitor in the quorum might not be relevant if it is already
shut down. Once monmap is changed,  and Paxos is restarted,
the information about shut down monitor will be cleared because
we will start a new election and the quorum will be up to date with
the shutdown monitor being outside the quorum.

Fixes: https://tracker.ceph.com/issues/55695

Signed-off-by: Kamoltat <ksirivad@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
