### PR TITLE
script: CentOS 8 EOL, use archived mirror in ceph-debug-docker.sh

### DIFF
--- a/src/script/ceph-debug-docker.sh
+++ b/src/script/ceph-debug-docker.sh
@@ -134,6 +134,7 @@ EOF
                 base_debuginfo="glibc-debuginfo"
                 ceph_debuginfo="ceph-base-debuginfo"
                 debuginfo=/etc/yum.repos.d/CentOS-Linux-Debuginfo.repo
+                base_url="s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g"
                 ;;
             centos:stream)
                 python_bindings="python3-rados python3-cephfs"
@@ -149,7 +150,8 @@ EOF
 FROM ${env}
 
 WORKDIR /root
-RUN yum update -y && \
+RUN sed -i '${base_url}' /etc/yum.repos.d/CentOS-* && \
+    yum update -y && \
     sed -i 's/enabled=0/enabled=1/' ${debuginfo} && \
     yum update -y && \
     yum install -y tmux epel-release wget psmisc ca-certificates gdb


### PR DESCRIPTION
CentOS 8 is EOL, resulting in:  ```Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist```.
Updates repos to use https://vault.centos.org/.

https://www.centos.org/centos-linux-eol/

Signed-off-by: Matan Breizman <mbreizma@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
