### PR TITLE
[DNM] pacific: mon: verify data pool is already not in use by any file system

### DIFF
--- a/doc/cephfs/createfs.rst
+++ b/doc/cephfs/createfs.rst
@@ -45,7 +45,35 @@ Once the pools are created, you may enable the file system using the ``fs new`` 
 
 .. code:: bash
 
-    $ ceph fs new <fs_name> <metadata> <data>
+    $ ceph fs new <fs_name> <metadata> <data> [--force] [--allow-dangerous-metadata-overlay] [<fscid:int>] [--recover]
+
+This command creates a new file system with specified metadata and data pool.
+The specified data pool is the default data pool and cannot be changed once set.
+Each file system has its own set of MDS daemons assigned to ranks so ensure that
+you have sufficient standby daemons available to accommodate the new file system.
+
+The ``--force`` option is used to achieve any of the following:
+
+- To set an erasure-coded pool for the default data pool. Use of an EC pool for the
+  default data pool is discouraged. Refer to `Creating pools`_ for details.
+- To set non-empty pool (pool already contains some objects) for the metadata pool.
+- To create a file system with a specific file system's ID (fscid).
+  The --force option is required with --fscid option.
+
+The ``--allow-dangerous-metadata-overlay`` option permits the reuse metadata and
+data pools if it is already in-use. This should only be done in emergencies and
+after careful reading of the documentation.
+
+If the ``--fscid`` option is provided then this creates a file system with a
+specific fscid. This can be used when an application expects the file system's ID
+to be stable after it has been recovered, e.g., after monitor databases are
+lost and rebuilt. Consequently, file system IDs don't always keep increasing
+with newer file systems.
+
+The ``--recover`` option sets the state of file system's rank 0 to existing but
+failed. So when a MDS daemon eventually picks up rank 0, the daemon reads the
+existing in-RADOS metadata and doesn't overwrite it. The flag also prevents the
+standby MDS daemons to join the file system.
 
 For example:
 

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -181,6 +181,67 @@ class TestAdminCommands(CephFSTestCase):
         else:
             raise RuntimeError("expected failure")
 
+    def test_add_already_in_use_data_pool(self):
+        """
+        That command try to add data pool which is already in use with another fs.
+        """
+
+        # create first data pool, metadata pool and add with filesystem
+        first_fs = "first_fs"
+        first_metadata_pool = "first_metadata_pool"
+        first_data_pool = "first_data_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_metadata_pool)
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_data_pool)
+        self.fs.mon_manager.raw_cluster_cmd('fs', 'new', first_fs, first_metadata_pool, first_data_pool)
+
+        # create second data pool, metadata pool and add with filesystem
+        second_fs = "second_fs"
+        second_metadata_pool = "second_metadata_pool"
+        second_data_pool = "second_data_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', second_metadata_pool)
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', second_data_pool)
+        self.fs.mon_manager.raw_cluster_cmd('fs', 'new', second_fs, second_metadata_pool, second_data_pool)
+
+        # try to add 'first_data_pool' with 'second_fs'
+        # Expecting EINVAL exit status because 'first_data_pool' is already in use with 'first_fs'
+        try:
+            self.fs.mon_manager.raw_cluster_cmd('fs', 'add_data_pool', second_fs, first_data_pool)
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.EINVAL)
+        else:
+            self.fail("Expected EINVAL because data pool is already in use as data pool for first_fs")
+
+    def test_add_already_in_use_metadata_pool(self):
+        """
+        That command try to add metadata pool which is already in use with another fs.
+        """
+
+        # create first data pool, metadata pool and add with filesystem
+        first_fs = "first_fs"
+        first_metadata_pool = "first_metadata_pool"
+        first_data_pool = "first_data_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_metadata_pool)
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_data_pool)
+        self.fs.mon_manager.raw_cluster_cmd('fs', 'new', first_fs, first_metadata_pool, first_data_pool)
+
+        # create second data pool, metadata pool and add with filesystem
+        second_fs = "second_fs"
+        second_metadata_pool = "second_metadata_pool"
+        second_data_pool = "second_data_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', second_metadata_pool)
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', second_data_pool)
+        self.fs.mon_manager.raw_cluster_cmd('fs', 'new', second_fs, second_metadata_pool, second_data_pool)
+
+        # try to add 'second_metadata_pool' with 'first_fs' as a data pool
+        # Expecting EINVAL exit status because 'second_metadata_pool'
+        # is already in use with 'second_fs' as a metadata pool
+        try:
+            self.fs.mon_manager.raw_cluster_cmd('fs', 'add_data_pool', first_fs, second_metadata_pool)
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.EINVAL)
+        else:
+            self.fail("Expected EINVAL because data pool is already in use as metadata pool for 'second_fs'")
+
     def test_fs_new_pool_application_metadata(self):
         """
         That the application metadata set on the pools of a newly created filesystem are as expected.
@@ -265,6 +326,239 @@ class TestAdminCommands(CephFSTestCase):
         else:
             self.fail("expected creating file system with ID already in use to fail")
 
+    def test_fs_new_metadata_pool_already_in_use(self):
+        """
+        That creating file system with metadata pool already in use.
+        """
+
+        # create first data pool, metadata pool and add with filesystem
+        first_fs = "first_fs"
+        first_metadata_pool = "first_metadata_pool"
+        first_data_pool = "first_data_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_metadata_pool)
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_data_pool)
+        self.fs.mon_manager.raw_cluster_cmd('fs', 'new', first_fs, first_metadata_pool, first_data_pool)
+
+        second_fs = "second_fs"
+        second_data_pool = "second_data_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', second_data_pool)
+
+        # try to create new fs 'second_fs' with following configuration
+        # metadata pool -> 'first_metadata_pool'
+        # data pool -> 'second_data_pool'
+        # Expecting EINVAL exit status because 'first_metadata_pool'
+        # is already in use with 'first_fs'
+        try:
+            self.fs.mon_manager.raw_cluster_cmd('fs', 'new', second_fs, first_metadata_pool, second_data_pool)
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.EINVAL)
+        else:
+            self.fail("Expected EINVAL because metadata  pool is already in use for 'first_fs'")
+
+    def test_fs_new_data_pool_already_in_use(self):
+        """
+        That creating file system with data pool already in use.
+        """
+
+        # create first data pool, metadata pool and add with filesystem
+        first_fs = "first_fs"
+        first_metadata_pool = "first_metadata_pool"
+        first_data_pool = "first_data_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_metadata_pool)
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_data_pool)
+        self.fs.mon_manager.raw_cluster_cmd('fs', 'new', first_fs, first_metadata_pool, first_data_pool)
+
+        second_fs = "second_fs"
+        second_metadata_pool = "second_metadata_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', second_metadata_pool)
+
+        # try to create new fs 'second_fs' with following configuration
+        # metadata pool -> 'second_metadata_pool'
+        # data pool -> 'first_data_pool'
+        # Expecting EINVAL exit status because 'first_data_pool'
+        # is already in use with 'first_fs'
+        try:
+            self.fs.mon_manager.raw_cluster_cmd('fs', 'new', second_fs, second_metadata_pool, first_data_pool)
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.EINVAL)
+        else:
+            self.fail("Expected EINVAL because data pool is already in use for 'first_fs'")
+
+    def test_fs_new_metadata_and_data_pool_in_use_by_another_same_fs(self):
+        """
+        That creating file system with metadata and data pool which is already in use by another same fs.
+        """
+
+        # create first data pool, metadata pool and add with filesystem
+        first_fs = "first_fs"
+        first_metadata_pool = "first_metadata_pool"
+        first_data_pool = "first_data_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_metadata_pool)
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_data_pool)
+        self.fs.mon_manager.raw_cluster_cmd('fs', 'new', first_fs, first_metadata_pool, first_data_pool)
+
+        second_fs = "second_fs"
+
+        # try to create new fs 'second_fs' with following configuration
+        # metadata pool -> 'first_metadata_pool'
+        # data pool -> 'first_data_pool'
+        # Expecting EINVAL exit status because 'first_metadata_pool' and 'first_data_pool'
+        # is already in use with 'first_fs'
+        try:
+            self.fs.mon_manager.raw_cluster_cmd('fs', 'new', second_fs, first_metadata_pool, first_data_pool)
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.EINVAL)
+        else:
+            self.fail("Expected EINVAL because metadata and data pool is already in use for 'first_fs'")
+
+    def test_fs_new_metadata_and_data_pool_in_use_by_different_fs(self):
+        """
+        That creating file system with metadata and data pool which is already in use by different fs.
+        """
+
+        # create first data pool, metadata pool and add with filesystem
+        first_fs = "first_fs"
+        first_metadata_pool = "first_metadata_pool"
+        first_data_pool = "first_data_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_metadata_pool)
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_data_pool)
+        self.fs.mon_manager.raw_cluster_cmd('fs', 'new', first_fs, first_metadata_pool, first_data_pool)
+
+        # create second data pool, metadata pool and add with filesystem
+        second_fs = "second_fs"
+        second_metadata_pool = "second_metadata_pool"
+        second_data_pool = "second_data_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', second_metadata_pool)
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', second_data_pool)
+        self.fs.mon_manager.raw_cluster_cmd('fs', 'new', second_fs, second_metadata_pool, second_data_pool)
+
+        third_fs = "third_fs"
+
+        # try to create new fs 'third_fs' with following configuration
+        # metadata pool -> 'first_metadata_pool'
+        # data pool -> 'second_data_pool'
+        # Expecting EINVAL exit status because 'first_metadata_pool' and 'second_data_pool'
+        # is already in use with 'first_fs' and 'second_fs'
+        try:
+            self.fs.mon_manager.raw_cluster_cmd('fs', 'new', third_fs, first_metadata_pool, second_data_pool)
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.EINVAL)
+        else:
+            self.fail("Expected EINVAL because metadata and data pool is already in use for 'first_fs' and 'second_fs'")
+
+    def test_fs_new_interchange_already_in_use_metadata_and_data_pool_of_same_fs(self):
+        """
+        That creating file system with interchanging metadata and data pool which is already in use by same fs.
+        """
+
+        # create first data pool, metadata pool and add with filesystem
+        first_fs = "first_fs"
+        first_metadata_pool = "first_metadata_pool"
+        first_data_pool = "first_data_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_metadata_pool)
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_data_pool)
+        self.fs.mon_manager.raw_cluster_cmd('fs', 'new', first_fs, first_metadata_pool, first_data_pool)
+
+        second_fs = "second_fs"
+
+        # try to create new fs 'second_fs' with following configuration
+        # metadata pool -> 'first_data_pool' (already used as data pool for 'first_fs')
+        # data pool -> 'first_metadata_pool' (already used as metadata pool for 'first_fs')
+        # Expecting EINVAL exit status because 'first_data_pool' and 'first_metadata_pool'
+        # is already in use with 'first_fs'
+        try:
+            self.fs.mon_manager.raw_cluster_cmd('fs', 'new', second_fs, first_data_pool, first_metadata_pool)
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.EINVAL)
+        else:
+            self.fail("Expected EINVAL because metadata and data pool is already in use for 'first_fs'")
+
+    def test_fs_new_interchange_already_in_use_metadata_and_data_pool_of_different_fs(self):
+        """
+        That creating file system with interchanging metadata and data pool which is already in use by defferent fs.
+        """
+
+        # create first data pool, metadata pool and add with filesystem
+        first_fs = "first_fs"
+        first_metadata_pool = "first_metadata_pool"
+        first_data_pool = "first_data_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_metadata_pool)
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', first_data_pool)
+        self.fs.mon_manager.raw_cluster_cmd('fs', 'new', first_fs, first_metadata_pool, first_data_pool)
+
+        # create second data pool, metadata pool and add with filesystem
+        second_fs = "second_fs"
+        second_metadata_pool = "second_metadata_pool"
+        second_data_pool = "second_data_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', second_metadata_pool)
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', second_data_pool)
+        self.fs.mon_manager.raw_cluster_cmd('fs', 'new', second_fs, second_metadata_pool, second_data_pool)
+
+        third_fs = "third_fs"
+
+        # try to create new fs 'third_fs' with following configuration
+        # metadata pool -> 'first_data_pool' (already used as data pool for 'first_fs')
+        # data pool -> 'second_metadata_pool' (already used as metadata pool for 'second_fs')
+        # Expecting EINVAL exit status because 'first_data_pool' and 'second_metadata_pool'
+        # is already in use with 'first_fs' and 'second_fs'
+        try:
+            self.fs.mon_manager.raw_cluster_cmd('fs', 'new', third_fs, first_data_pool, second_metadata_pool)
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.EINVAL)
+        else:
+            self.fail("Expected EINVAL because metadata and data pool is already in use for 'first_fs' and 'second_fs'")
+
+    def test_fs_new_metadata_pool_already_in_use_with_rbd(self):
+        """
+        That creating new file system with metadata pool already used by rbd.
+        """
+
+        # create pool and initialise with rbd
+        new_pool = "new_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', new_pool)
+        self.ctx.cluster.run(args=['rbd', 'pool', 'init', new_pool])
+
+        new_fs = "new_fs"
+        new_data_pool = "new_data_pool"
+
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', new_data_pool)
+
+        # try to create new fs 'new_fs' with following configuration
+        # metadata pool -> 'new_pool' (already used by rbd app)
+        # data pool -> 'new_data_pool'
+        # Expecting EINVAL exit status because 'new_pool' is already in use with 'rbd' app
+        try:
+            self.fs.mon_manager.raw_cluster_cmd('fs', 'new', new_fs, new_pool, new_data_pool)
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.EINVAL)
+        else:
+            self.fail("Expected EINVAL because metadata pool is already in use for rbd")
+
+    def test_fs_new_data_pool_already_in_use_with_rbd(self):
+        """
+        That creating new file system with data pool already used by rbd.
+        """
+
+        # create pool and initialise with rbd
+        new_pool = "new_pool"
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', new_pool)
+        self.ctx.cluster.run(args=['rbd', 'pool', 'init', new_pool])
+
+        new_fs = "new_fs"
+        new_metadata_pool = "new_metadata_pool"
+
+        self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create', new_metadata_pool)
+
+        # try to create new fs 'new_fs' with following configuration
+        # metadata pool -> 'new_metadata_pool'
+        # data pool -> 'new_pool' (already used by rbd app)
+        # Expecting EINVAL exit status because 'new_pool' is already in use with 'rbd' app
+        try:
+            self.fs.mon_manager.raw_cluster_cmd('fs', 'new', new_fs, new_metadata_pool, new_pool)
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.EINVAL)
+        else:
+            self.fail("Expected EINVAL because data pool is already in use for rbd")
 
 class TestDump(CephFSTestCase):
     CLIENTS_REQUIRED = 0

--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -122,7 +122,8 @@ class TestMisc(CephFSTestCase):
                                             '--pg_num_min', str(self.fs.pg_num_min))
         self.fs.mon_manager.raw_cluster_cmd('fs', 'new', self.fs.name,
                                             self.fs.metadata_pool_name,
-                                            data_pool_name)
+                                            data_pool_name,
+                                            '--allow_dangerous_metadata_overlay')
 
     def test_cap_revoke_nonresponder(self):
         """

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -222,19 +222,17 @@ class FsNewHandler : public FileSystemCommandHandler
       return -EINVAL;
     }
 
+    bool allow_overlay = false;
+    cmd_getval(cmdmap, "allow_dangerous_metadata_overlay", allow_overlay);
+
     for (auto& fs : fsmap.get_filesystems()) {
       const std::vector<int64_t> &data_pools = fs->mds_map.get_data_pools();
-
-      bool sure = false;
-      cmd_getval(cmdmap,
-                 "allow_dangerous_metadata_overlay", sure);
-
       if ((std::find(data_pools.begin(), data_pools.end(), data) != data_pools.end()
 	   || fs->mds_map.get_metadata_pool() == metadata)
-	  && !sure) {
+	  && !allow_overlay) {
 	ss << "Filesystem '" << fs_name
 	   << "' is already using one of the specified RADOS pools. This should ONLY be done in emergencies and after careful reading of the documentation. Pass --allow-dangerous-metadata-overlay to permit this.";
-	return -EEXIST;
+	return -EINVAL;
       }
     }
 
@@ -255,12 +253,12 @@ class FsNewHandler : public FileSystemCommandHandler
     pg_pool_t const *metadata_pool = mon->osdmon()->osdmap.get_pg_pool(metadata);
     ceph_assert(metadata_pool != NULL);  // Checked it existed above
 
-    int r = _check_pool(mon->osdmon()->osdmap, data, POOL_DATA_DEFAULT, force, &ss);
+    int r = _check_pool(mon->osdmon()->osdmap, data, POOL_DATA_DEFAULT, force, &ss, allow_overlay);
     if (r < 0) {
       return r;
     }
 
-    r = _check_pool(mon->osdmon()->osdmap, metadata, POOL_METADATA, force, &ss);
+    r = _check_pool(mon->osdmon()->osdmap, metadata, POOL_METADATA, force, &ss, allow_overlay);
     if (r < 0) {
       return r;
     }
@@ -1419,7 +1417,8 @@ int FileSystemCommandHandler::_check_pool(
     const int64_t pool_id,
     int type,
     bool force,
-    std::ostream *ss) const
+    std::ostream *ss,
+    bool allow_overlay) const
 {
   ceph_assert(ss != NULL);
 
@@ -1430,6 +1429,29 @@ int FileSystemCommandHandler::_check_pool(
   }
 
   const string& pool_name = osd_map.get_pool_name(pool_id);
+  auto app_map = pool->application_metadata;
+
+  if (!allow_overlay && !force && !app_map.empty()) {
+    auto app = app_map.find(pg_pool_t::APPLICATION_NAME_CEPHFS);
+    if (app != app_map.end()) {
+      auto& [app_name, app_metadata] = *app;
+      auto itr = app_metadata.find("data");
+      if (itr == app_metadata.end()) {
+	itr = app_metadata.find("metadata");
+      }
+      if (itr != app_metadata.end()) {
+        auto& [type, filesystem] = *itr;
+        *ss << "RADOS pool '" << pool_name << "' is already used by filesystem '"
+            << filesystem << "' as a '" << type << "' pool for application '"
+            << app_name << "'";
+        return -EINVAL;
+      }
+    } else {
+      *ss << "RADOS pool '" << pool_name
+          << "' has another non-CephFS application enabled.";
+      return -EINVAL;
+    }
+  }
 
   if (pool->is_erasure()) {
     if (type == POOL_METADATA) {

--- a/src/mon/FSCommands.h
+++ b/src/mon/FSCommands.h
@@ -47,7 +47,8 @@ protected:
       const int64_t pool_id,
       int type,
       bool force,
-      std::ostream *ss) const;
+      std::ostream *ss,
+      bool allow_overlay = false) const;
 
   virtual std::string const &get_prefix() const {return prefix;}
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56113

---

backport of https://github.com/ceph/ceph/pull/44900
parent tracker: https://tracker.ceph.com/issues/54111

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh