### PR TITLE
quincy: mon: verify data pool is already not in use by any file system

### DIFF
--- a/doc/cephfs/createfs.rst
+++ b/doc/cephfs/createfs.rst
@@ -45,7 +45,35 @@ Once the pools are created, you may enable the file system using the ``fs new`` 
 
 .. code:: bash
 
-    $ ceph fs new <fs_name> <metadata> <data>
+    $ ceph fs new <fs_name> <metadata> <data> [--force] [--allow-dangerous-metadata-overlay] [<fscid:int>] [--recover]
+
+This command creates a new file system with specified metadata and data pool.
+The specified data pool is the default data pool and cannot be changed once set.
+Each file system has its own set of MDS daemons assigned to ranks so ensure that
+you have sufficient standby daemons available to accommodate the new file system.
+
+The ``--force`` option is used to achieve any of the following:
+
+- To set an erasure-coded pool for the default data pool. Use of an EC pool for the
+  default data pool is discouraged. Refer to `Creating pools`_ for details.
+- To set non-empty pool (pool already contains some objects) for the metadata pool.
+- To create a file system with a specific file system's ID (fscid).
+  The --force option is required with --fscid option.
+
+The ``--allow-dangerous-metadata-overlay`` option permits the reuse metadata and
+data pools if it is already in-use. This should only be done in emergencies and
+after careful reading of the documentation.
+
+If the ``--fscid`` option is provided then this creates a file system with a
+specific fscid. This can be used when an application expects the file system's ID
+to be stable after it has been recovered, e.g., after monitor databases are
+lost and rebuilt. Consequently, file system IDs don't always keep increasing
+with newer file systems.
+
+The ``--recover`` option sets the state of file system's rank 0 to existing but
+failed. So when a MDS daemon eventually picks up rank 0, the daemon reads the
+existing in-RADOS metadata and doesn't overwrite it. The flag also prevents the
+standby MDS daemons to join the file system.
 
 For example:
 

--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -144,7 +144,8 @@ class TestMisc(CephFSTestCase):
                                             '--pg_num_min', str(self.fs.pg_num_min))
         self.fs.mon_manager.raw_cluster_cmd('fs', 'new', self.fs.name,
                                             self.fs.metadata_pool_name,
-                                            data_pool_name)
+                                            data_pool_name,
+                                            '--allow_dangerous_metadata_overlay')
 
     def test_cap_revoke_nonresponder(self):
         """

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -222,19 +222,17 @@ class FsNewHandler : public FileSystemCommandHandler
       return -EINVAL;
     }
 
+    bool allow_overlay = false;
+    cmd_getval(cmdmap, "allow_dangerous_metadata_overlay", allow_overlay);
+
     for (auto& fs : fsmap.get_filesystems()) {
       const std::vector<int64_t> &data_pools = fs->mds_map.get_data_pools();
-
-      bool sure = false;
-      cmd_getval(cmdmap,
-                 "allow_dangerous_metadata_overlay", sure);
-
       if ((std::find(data_pools.begin(), data_pools.end(), data) != data_pools.end()
 	   || fs->mds_map.get_metadata_pool() == metadata)
-	  && !sure) {
+	  && !allow_overlay) {
 	ss << "Filesystem '" << fs_name
 	   << "' is already using one of the specified RADOS pools. This should ONLY be done in emergencies and after careful reading of the documentation. Pass --allow-dangerous-metadata-overlay to permit this.";
-	return -EEXIST;
+	return -EINVAL;
       }
     }
 
@@ -255,12 +253,12 @@ class FsNewHandler : public FileSystemCommandHandler
     pg_pool_t const *metadata_pool = mon->osdmon()->osdmap.get_pg_pool(metadata);
     ceph_assert(metadata_pool != NULL);  // Checked it existed above
 
-    int r = _check_pool(mon->osdmon()->osdmap, data, POOL_DATA_DEFAULT, force, &ss);
+    int r = _check_pool(mon->osdmon()->osdmap, data, POOL_DATA_DEFAULT, force, &ss, allow_overlay);
     if (r < 0) {
       return r;
     }
 
-    r = _check_pool(mon->osdmon()->osdmap, metadata, POOL_METADATA, force, &ss);
+    r = _check_pool(mon->osdmon()->osdmap, metadata, POOL_METADATA, force, &ss, allow_overlay);
     if (r < 0) {
       return r;
     }
@@ -1514,7 +1512,8 @@ int FileSystemCommandHandler::_check_pool(
     const int64_t pool_id,
     int type,
     bool force,
-    std::ostream *ss) const
+    std::ostream *ss,
+    bool allow_overlay) const
 {
   ceph_assert(ss != NULL);
 
@@ -1525,6 +1524,29 @@ int FileSystemCommandHandler::_check_pool(
   }
 
   const string& pool_name = osd_map.get_pool_name(pool_id);
+  auto app_map = pool->application_metadata;
+
+  if (!allow_overlay && !force && !app_map.empty()) {
+    auto app = app_map.find(pg_pool_t::APPLICATION_NAME_CEPHFS);
+    if (app != app_map.end()) {
+      auto& [app_name, app_metadata] = *app;
+      auto itr = app_metadata.find("data");
+      if (itr == app_metadata.end()) {
+	itr = app_metadata.find("metadata");
+      }
+      if (itr != app_metadata.end()) {
+        auto& [type, filesystem] = *itr;
+        *ss << "RADOS pool '" << pool_name << "' is already used by filesystem '"
+            << filesystem << "' as a '" << type << "' pool for application '"
+            << app_name << "'";
+        return -EINVAL;
+      }
+    } else {
+      *ss << "RADOS pool '" << pool_name
+          << "' has another non-CephFS application enabled.";
+      return -EINVAL;
+    }
+  }
 
   if (pool->is_erasure()) {
     if (type == POOL_METADATA) {

--- a/src/mon/FSCommands.h
+++ b/src/mon/FSCommands.h
@@ -47,7 +47,8 @@ protected:
       const int64_t pool_id,
       int type,
       bool force,
-      std::ostream *ss) const;
+      std::ostream *ss,
+      bool allow_overlay = false) const;
 
   virtual std::string const &get_prefix() const {return prefix;}
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56114

---

backport of https://github.com/ceph/ceph/pull/44900
parent tracker: https://tracker.ceph.com/issues/54111

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh