### PR TITLE
ceph-volume: decrease number of `pvs` calls in `lvm list`

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -101,6 +101,8 @@ class List(object):
 
         report = {}
 
+        pvs = api.get_pvs()
+
         for lv in lvs:
             if not api.is_ceph_device(lv):
                 continue
@@ -109,8 +111,7 @@ class List(object):
             report.setdefault(osd_id, [])
             lv_report = lv.as_dict()
 
-            pvs = api.get_pvs(filters={'lv_uuid': lv.lv_uuid})
-            lv_report['devices'] = [pv.name for pv in pvs] if pvs else []
+            lv_report['devices'] = [pv.name for pv in pvs if pv.lv_uuid == lv.lv_uuid] if pvs else []
             report[osd_id].append(lv_report)
 
             phys_devs = self.create_report_non_lv_device(lv)


### PR DESCRIPTION
current implementation of `List.create_report()` implies a lot of calls
to `pvs` process. This could be avoided.

current implementation:
```
>>> import timeit
>>> from ceph_volume.devices.lvm.listing import List
>>> timeit.timeit(List([]).main, number=1000)

...

93.03700458299136
```

new implementation:

```
>>> import timeit
>>> from ceph_volume.devices.lvm.listing import List
>>> timeit.timeit(List([]).main, number=1000)

...

62.16391600697534
```

In this example, it improves performance by ~30%

Fixes: https://tracker.ceph.com/issues/56127

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
