### PR TITLE
.gitmodules: add opentelemetry-cpp as a submodule 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -72,3 +72,6 @@
 [submodule "src/utf8proc"]
 	path = src/utf8proc
 	url = https://github.com/JuliaStrings/utf8proc
+[submodule "src/jaegertracing/opentelemetry-cpp"]
+	path = src/jaegertracing/opentelemetry-cpp
+	url = https://github.com/open-telemetry/opentelemetry-cpp.git

--- a/cmake/modules/BuildOpentelemetry.cmake
+++ b/cmake/modules/BuildOpentelemetry.cmake
@@ -6,7 +6,7 @@ function(target_create _target _lib)
 endfunction()
 
 function(build_opentelemetry)
-  set(opentelemetry_SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/opentelemetry-cpp")
+  set(opentelemetry_SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/jaegertracing/opentelemetry-cpp")
   set(opentelemetry_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/opentelemetry-cpp")
   set(opentelemetry_cpp_targets opentelemetry_trace opentelemetry_exporter_jaeger_trace)
   set(opentelemetry_CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON
@@ -20,7 +20,7 @@ function(build_opentelemetry)
       ${opentelemetry_BINARY_DIR}/sdk/src/resource/libopentelemetry_resources.a
       ${opentelemetry_BINARY_DIR}/sdk/src/common/libopentelemetry_common.a
       ${opentelemetry_BINARY_DIR}/exporters/jaeger/libopentelemetry_exporter_jaeger_trace.a
-      ${opentelemetry_BINARY_DIR}/ext/src/http/client/curl/libhttp_client_curl.a
+      ${opentelemetry_BINARY_DIR}/ext/src/http/client/curl/libopentelemetry_http_client_curl.a
       ${CURL_LIBRARIES}
   )
   set(opentelemetry_include_dir ${opentelemetry_SOURCE_DIR}/api/include/
@@ -48,11 +48,7 @@ function(build_opentelemetry)
   endif()
 
   include(ExternalProject)
-  ExternalProject_Add(
-    opentelemetry-cpp
-    GIT_REPOSITORY https://github.com/ideepika/opentelemetry-cpp.git
-    GIT_TAG wip-ceph
-    GIT_SHALLOW 1
+  ExternalProject_Add(opentelemetry-cpp
     SOURCE_DIR ${opentelemetry_SOURCE_DIR}
     PREFIX "opentelemetry-cpp"
     CMAKE_ARGS ${opentelemetry_CMAKE_ARGS}
@@ -74,7 +70,7 @@ function(build_opentelemetry)
   target_create("opentelemetry_exporter_jaeger_trace"
                 "exporters/jaeger/libopentelemetry_exporter_jaeger_trace.a")
   target_create("http_client_curl"
-                "ext/src/http/client/curl/libhttp_client_curl.a")
+                "ext/src/http/client/curl/libopentelemetry_http_client_curl.a")
 
   # will do all linking and path setting fake include path for
   # interface_include_directories since this happens at build time


### PR DESCRIPTION
- removes compile time fetch for opentelemetry
- updates to use opentelemetry remote instead of unofficial patched remote

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>


with the PR's merged in opentelemetry we do not require to maintain our own
remote:
https://github.com/open-telemetry/opentelemetry-cpp/pull/1100/
https://github.com/open-telemetry/opentelemetry-cpp/pull/1020



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
