### PR TITLE
Crimson: Update zns support

### DIFF
--- a/src/crimson/os/seastore/segment_manager.cc
+++ b/src/crimson/os/seastore/segment_manager.cc
@@ -3,22 +3,13 @@
 
 #include "crimson/os/seastore/segment_manager.h"
 #include "crimson/os/seastore/segment_manager/block.h"
-#include "crimson/common/log.h"
-
+#include "crimson/os/seastore/logging.h"
 
 #ifdef HAVE_ZNS
 #include "crimson/os/seastore/segment_manager/zns.h"
+SET_SUBSYS(seastore_device);
 #endif
 
-namespace{
-
-#ifdef HAVE_ZNS
-seastar::logger &logger(){
-  return crimson::get_logger(ceph_subsys_seastore_device);
-}
-#endif
-
-}
 
 namespace crimson::os::seastore {
 
@@ -56,6 +47,7 @@ SegmentManager::get_segment_manager(
   const std::string &device)
 {
 #ifdef HAVE_ZNS
+LOG_PREFIX(SegmentManager::get_segment_manager);
   return seastar::do_with(
     static_cast<size_t>(0),
     [&](auto &nr_zones) {
@@ -71,7 +63,7 @@ SegmentManager::get_segment_manager(
 	  });
       }).then([&](auto ret) -> crimson::os::seastore::SegmentManagerRef {
 	crimson::os::seastore::SegmentManagerRef sm;
-	logger().error("NR_ZONES: {}", nr_zones);
+	INFO("Found {} zones.", nr_zones);
 	if (nr_zones != 0) {
 	  return std::make_unique<
 	    segment_manager::zns::ZNSSegmentManager

--- a/src/crimson/os/seastore/segment_manager/zns.h
+++ b/src/crimson/os/seastore/segment_manager/zns.h
@@ -164,11 +164,9 @@ namespace crimson::os::seastore::segment_manager::zns {
 
     uint64_t get_offset(paddr_t addr) {
       auto& seg_addr = addr.as_seg_paddr();
-      const auto default_sector_size = 512;
       return (metadata.first_segment_offset +
 	      (seg_addr.get_segment_id().device_segment_id() * 
-	       metadata.zone_size)) * default_sector_size + 
-	seg_addr.get_segment_off();
+	       metadata.zone_size)) + seg_addr.get_segment_off();
     }
   };
 

--- a/src/crimson/os/seastore/segment_manager/zns.h
+++ b/src/crimson/os/seastore/segment_manager/zns.h
@@ -28,7 +28,8 @@ namespace crimson::os::seastore::segment_manager::zns {
     size_t block_size = 0;
     size_t segments = 0;
     size_t zone_size = 0;
-    uint64_t first_segment_offset = 0;
+    size_t first_segment_offset = 0;
+
     seastore_meta_t meta;
     
     bool major_dev = false;
@@ -166,7 +167,7 @@ namespace crimson::os::seastore::segment_manager::zns {
       auto& seg_addr = addr.as_seg_paddr();
       return (metadata.first_segment_offset +
 	      (seg_addr.get_segment_id().device_segment_id() * 
-	       metadata.zone_size)) + seg_addr.get_segment_off();
+	       metadata.segment_size)) + seg_addr.get_segment_off();
     }
   };
 


### PR DESCRIPTION

Fix up zns support related issues. 
Update debug logs.
Get correct zone capacity 
Fix up calculations in ZNSSegmentManager::make_metadata()

These are initial fixes and more patches are needed to make zns support work seamlessly.
I will continue to submit PR's as I make progress.