### PR TITLE
quincy: win32_deps_build.sh: master -> main for wnbd

### DIFF
--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -38,7 +38,7 @@ snappyTag="1.1.9"
 winLibDir="${depsToolsetDir}/windows/lib"
 
 wnbdUrl="https://github.com/cloudbase/wnbd"
-wnbdTag="master"
+wnbdTag="main"
 wnbdSrcDir="${depsSrcDir}/wnbd"
 wnbdLibDir="${depsToolsetDir}/wnbd/lib"
 


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/46760 to quincy.