### PR TITLE
AdminSocket for alien_store

### DIFF
--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -106,7 +106,7 @@ class AdminSocket
 {
 public:
   AdminSocket(CephContext *cct);
-  ~AdminSocket();
+  virtual ~AdminSocket();
 
   AdminSocket(const AdminSocket&) = delete;
   AdminSocket& operator =(const AdminSocket&) = delete;
@@ -132,14 +132,14 @@ public:
    *
    * @return 0 for success, -EEXIST if command already registered.
    */
-  int register_command(std::string_view cmddesc,
+  virtual int register_command(std::string_view cmddesc,
 		       AdminSocketHook *hook,
 		       std::string_view help);
 
   /*
    * unregister all commands belong to hook.
    */
-  void unregister_commands(const AdminSocketHook *hook);
+  virtual void unregister_commands(const AdminSocketHook *hook);
 
   bool init(const std::string& path);
 

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -725,7 +725,11 @@ CephContext::CephContext(uint32_t module_type_,
 #endif
   _perf_counters_collection = new PerfCountersCollection(this);
  
-  _admin_socket = new AdminSocket(this);
+  if (options.create_admin_socket) {
+    _admin_socket = options.create_admin_socket(this);
+  } else {
+    _admin_socket = new AdminSocket(this);
+  }
   _heartbeat_map = new HeartbeatMap(this);
 
   _plugin_registry = new PluginRegistry(this);

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -62,6 +62,7 @@ namespace ceph {
   class HeartbeatMap;
   namespace logging {
     class Log;
+    class SubsystemMap;
   }
 }
 
@@ -114,7 +115,13 @@ public:
   CephContext(uint32_t module_type_,
               enum code_environment_t code_env=CODE_ENVIRONMENT_UTILITY,
               int init_flags_ = 0);
-
+  struct create_options {
+    enum code_environment_t code_env=CODE_ENVIRONMENT_UTILITY;
+    int init_flags = 0;
+    std::function<ceph::logging::Log* (const ceph::logging::SubsystemMap *)> create_log;
+  };
+  CephContext(uint32_t module_type_,
+	      const create_options& options);
   CephContext(const CephContext&) = delete;
   CephContext& operator =(const CephContext&) = delete;
   CephContext(CephContext&&) = delete;

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -119,6 +119,7 @@ public:
     enum code_environment_t code_env=CODE_ENVIRONMENT_UTILITY;
     int init_flags = 0;
     std::function<ceph::logging::Log* (const ceph::logging::SubsystemMap *)> create_log;
+    std::function<AdminSocket* (ceph::common::CephContext*)> create_admin_socket;
   };
   CephContext(uint32_t module_type_,
 	      const create_options& options);

--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -133,16 +133,6 @@ struct is_dynamic<dynamic_marker_t<T>> : public std::true_type {};
                   "{}", _out.str().c_str());    \
     }                                           \
   } while (0)
-#elif defined(WITH_SEASTAR) && defined(WITH_ALIEN)
-#define dout_impl(cct, sub, v)						\
-  do {									\
-  if (0) {							\
-    ceph::logging::MutableEntry _dout_e(v, sub);                        \
-    std::ostream* _dout = &_dout_e.get_ostream();
-
-#define dendl_impl std::flush;                                          \
-  }                                                                     \
-  } while (0)
 #else
 #define dout_impl(cct, sub, v)						\
   do {									\

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -101,7 +101,6 @@ add_library(crimson-common STATIC
   ${PROJECT_SOURCE_DIR}/src/global/pidfile.cc
   ${PROJECT_SOURCE_DIR}/src/librbd/Features.cc
   ${PROJECT_SOURCE_DIR}/src/librbd/io/IoOperations.cc
-  ${PROJECT_SOURCE_DIR}/src/log/Log.cc
   ${PROJECT_SOURCE_DIR}/src/mgr/ServiceMap.cc
   ${PROJECT_SOURCE_DIR}/src/mds/inode_backtrace.cc
   ${PROJECT_SOURCE_DIR}/src/mds/mdstypes.cc

--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -55,7 +55,7 @@ void AdminSocket::register_command(std::unique_ptr<AdminSocketHook>&& hook)
   auto prefix = hook->prefix;
   auto [it, added] = hooks.emplace(prefix, std::move(hook));
   assert(added);
-  logger().info("register_command(): {})", it->first);
+  logger().info("register_command(): {}", it->first);
 }
 
 void AdminSocket::unregister_command(const std::string_view prefix)

--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -58,6 +58,10 @@ void AdminSocket::register_command(std::unique_ptr<AdminSocketHook>&& hook)
   logger().info("register_command(): {})", it->first);
 }
 
+void AdminSocket::unregister_command(const std::string_view prefix)
+{
+  hooks.erase(prefix);
+}
 auto AdminSocket::parse_cmd(const std::vector<std::string>& cmd)
   -> std::variant<parsed_command_t, tell_result_t>
 {

--- a/src/crimson/admin/admin_socket.h
+++ b/src/crimson/admin/admin_socket.h
@@ -117,6 +117,10 @@ class AdminSocket : public seastar::enable_lw_shared_from_this<AdminSocket> {
    */
   void register_admin_commands();
   /**
+   * Unregister command by string prefix.
+   */
+  void unregister_command(const std::string_view);
+  /**
    * handle a command message by replying an MCommandReply with the same tid
    *
    * \param conn connection over which the incoming command message is received

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -7,6 +7,7 @@ set_target_properties(alien::cflags PROPERTIES
 
 set(crimson_alien_common_srcs
   ${PROJECT_SOURCE_DIR}/src/common/admin_socket.cc
+  ${PROJECT_SOURCE_DIR}/src/common/url_escape.cc
   ${PROJECT_SOURCE_DIR}/src/common/blkdev.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_context.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_crypto.cc
@@ -25,6 +26,7 @@ set(crimson_alien_common_srcs
   ${PROJECT_SOURCE_DIR}/src/common/util.cc
   ${PROJECT_SOURCE_DIR}/src/crush/CrushLocation.cc
   ${PROJECT_SOURCE_DIR}/src/global/global_context.cc
+  ${PROJECT_SOURCE_DIR}/src/log/Log.cc
   $<TARGET_OBJECTS:compressor_objs>
   $<TARGET_OBJECTS:common_prioritycache_obj>)
 if(WITH_CEPH_DEBUG_MUTEX)
@@ -44,6 +46,7 @@ target_link_libraries(crimson-alien-common
 set(alien_store_srcs
   alien_store.cc
   thread_pool.cc
+  alien_log.cc
   ${PROJECT_SOURCE_DIR}/src/os/ObjectStore.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/Allocator.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/AvlAllocator.cc

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -47,6 +47,7 @@ set(alien_store_srcs
   alien_store.cc
   thread_pool.cc
   alien_log.cc
+  alien_admin_socket.cc
   ${PROJECT_SOURCE_DIR}/src/os/ObjectStore.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/Allocator.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/AvlAllocator.cc
@@ -81,6 +82,7 @@ target_link_libraries(crimson-alienstore
     kv
     heap_profiler
     crimson-alien-common
+    crimson-admin
     ${BLKID_LIBRARIES}
     ${UDEV_LIBRARIES}
     crimson

--- a/src/crimson/os/alienstore/alien_admin_socket.cc
+++ b/src/crimson/os/alienstore/alien_admin_socket.cc
@@ -1,0 +1,131 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "alien_admin_socket.h"
+#include "crimson/admin/admin_socket.h"
+#include <seastar/core/alien.hh>
+
+using string_prefix = std::string;
+
+static const std::string alien_prefix = "alien ";
+
+// Inheriting from string to preserve initialization order:
+// 1) prefix_str
+// 2) AdminSocketHook
+// We need to store prefix_str, since AdminSocketHook is directly storing string_view (no copy)
+class CnAdminSocketHook : public string_prefix, public crimson::admin::AdminSocketHook
+{
+ public:
+  CnAdminSocketHook(std::string prefix_str,
+                    std::string_view desc,
+                    std::string_view help,
+                    seastar::alien::instance& inst,
+                    unsigned shard,
+                    std::unique_ptr<crimson::os::ThreadPool>& tp,
+                    ::AdminSocketHook* hook)
+    :string_prefix(prefix_str)
+    ,crimson::admin::AdminSocketHook(*static_cast<string_prefix*>(this), desc, help)
+    ,inst(inst)
+    ,shard(shard)
+    ,tp(tp)
+    ,hook(hook)
+  {
+  }
+  ~CnAdminSocketHook()
+  {
+  }
+ private:
+  seastar::alien::instance& inst;
+  unsigned shard;
+  std::unique_ptr<crimson::os::ThreadPool>& tp;
+  ::AdminSocketHook* hook;
+
+  seastar::future<crimson::admin::tell_result_t> call(
+    const cmdmap_t& cmdmap,
+    std::string_view format,
+    ceph::bufferlist&& input) const override
+  {
+    return seastar::do_with(
+      std::stringstream{},
+      ceph::buffer::list{},
+      [=] (std::stringstream& errss, auto& out) {
+        return tp->submit([this, cmdmap = cmdmap, format, &errss, &out] {
+        std::unique_ptr<Formatter> f{Formatter::create(format, "json-pretty", "json-pretty")};
+        int res = hook->call(
+          (*static_cast<const string_prefix*>(this)).substr(alien_prefix.length()),
+          cmdmap, f.get(), errss, out);
+          if (out.length() == 0) {
+            f->flush(out);
+          }
+          return res;
+        }).then([&] (int res) {
+          return seastar::make_ready_future<crimson::admin::tell_result_t>(res, errss.str(), std::move(out));
+        });
+      });
+  };
+};
+
+CnAdminSocket::CnAdminSocket(
+  ceph::common::CephContext* cct,
+  seastar::lw_shared_ptr<crimson::admin::AdminSocket> cn_asok,
+  std::unique_ptr<crimson::os::ThreadPool>& tp,
+  seastar::alien::instance& inst,
+  unsigned shard)
+:AdminSocket(cct)
+,cn_asok(cn_asok)
+,tp(tp)
+,inst(inst)
+,shard(shard)
+{  
+}
+
+CnAdminSocket::~CnAdminSocket()
+{
+  seastar::alien::submit_to(inst, shard, [this] {
+    // deleting admin_socket causes waiting on threads
+    cn_asok = nullptr;
+    return seastar::make_ready_future<>();
+  }).wait();
+}
+
+int CnAdminSocket::register_command(
+  std::string_view cmddesc,
+  AdminSocketHook *hook,
+  std::string_view help)
+{
+  std::string_view prefix;
+  std::string_view desc;
+  // splitting cmddesc(classic) into prefix and desc (crimson)
+  size_t pos = cmddesc.find('=');
+  if (pos != std::string_view::npos) {
+    pos = cmddesc.rfind(' ', pos);
+    ceph_assert(pos != std::string_view::npos);
+    prefix = cmddesc.substr(0, pos);
+    desc = cmddesc.substr(pos + 1);
+  } else {
+    prefix = cmddesc;
+    desc = "";
+  }
+  CnAdminSocketHook* cn_hook = new CnAdminSocketHook(
+    alien_prefix + std::string(prefix), desc, help, inst, shard, tp, hook);
+  seastar::alien::submit_to(inst, shard, [this, hook, cn_hook] {
+    cn_asok->register_command(std::unique_ptr<CnAdminSocketHook>(cn_hook));
+    hook_tracker[hook].push_back(cn_hook);
+    return seastar::make_ready_future<>();
+  }).wait();
+  return 0;
+}
+
+void CnAdminSocket::unregister_commands(
+  const AdminSocketHook *hook)
+{
+  seastar::alien::submit_to(inst, shard, [this, &hook] {
+    auto it = hook_tracker.find(hook);
+    if (it != hook_tracker.end()) {
+      for (auto& i : it->second) {
+        cn_asok->unregister_command(i->prefix);
+      }
+    }
+    return seastar::make_ready_future<>();
+  }).wait();
+}

--- a/src/crimson/os/alienstore/alien_admin_socket.h
+++ b/src/crimson/os/alienstore/alien_admin_socket.h
@@ -1,0 +1,37 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef ALIEN_ADMIN_SOCKET_H
+#define ALIEN_ADMIN_SOCKET_H
+
+#include "common/admin_socket.h"
+#include "crimson/admin/admin_socket.h"
+#include "crimson/os/alienstore/thread_pool.h"
+
+namespace seastar::alien {
+  class instance;
+}
+
+class CnAdminSocketHook;
+
+class CnAdminSocket : public AdminSocket {
+  seastar::lw_shared_ptr<crimson::admin::AdminSocket> cn_asok;
+  std::unique_ptr<crimson::os::ThreadPool>& tp;
+  std::map<const ::AdminSocketHook*, std::vector<CnAdminSocketHook*> > hook_tracker;
+  seastar::alien::instance& inst;
+  unsigned shard;
+
+public:
+  CnAdminSocket(ceph::common::CephContext* cct,
+		seastar::lw_shared_ptr<crimson::admin::AdminSocket> cn_asok,
+		std::unique_ptr<crimson::os::ThreadPool>& tp,
+		seastar::alien::instance& inst,
+		unsigned shard);
+  ~CnAdminSocket() override;
+  int register_command(std::string_view cmddesc,
+		       AdminSocketHook *hook,
+		       std::string_view help) override;
+  void unregister_commands(const AdminSocketHook *hook) override;
+};
+
+#endif

--- a/src/crimson/os/alienstore/alien_log.cc
+++ b/src/crimson/os/alienstore/alien_log.cc
@@ -1,0 +1,33 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "alien_log.h"
+#include "log/SubsystemMap.h"
+#include <seastar/core/alien.hh>
+#include "crimson/common/log.h"
+
+namespace ceph::logging {
+CnLog::CnLog(const SubsystemMap *s, seastar::alien::instance& inst, unsigned shard)
+  :Log(s)
+  ,inst(inst)
+  ,shard(shard) {
+}
+
+CnLog::~CnLog() {
+}
+
+void CnLog::_flush(EntryVector& q, bool crash) {
+  seastar::alien::submit_to(inst, shard, [&q] {
+    for (auto& it : q) {
+      crimson::get_logger(it.m_subsys).log(
+        crimson::to_log_level(it.m_prio),
+        "{}",
+        it.strv());
+    }
+    return seastar::make_ready_future<>();
+  }).wait();
+  q.clear();
+  return;
+}
+
+} //namespace ceph::logging

--- a/src/crimson/os/alienstore/alien_log.h
+++ b/src/crimson/os/alienstore/alien_log.h
@@ -1,0 +1,31 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef ALIEN_LOG_H
+#define ALIEN_LOG_H
+
+#include "log/Log.h"
+
+namespace ceph {
+namespace logging {
+class SubsystemMap;
+}
+}
+
+namespace seastar::alien {
+  class instance;
+}
+namespace ceph::logging
+{
+class CnLog : public ceph::logging::Log
+{
+  seastar::alien::instance& inst;
+  unsigned shard;
+  void _flush(EntryVector& q, bool crash) override;
+public:
+  CnLog(const SubsystemMap *s, seastar::alien::instance& inst, unsigned shard);
+  ~CnLog() override;
+};
+}
+
+#endif

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -702,6 +702,10 @@ int AlienStore::AlienOmapIterator::status() const
   return iter->status();
 }
 
+void AlienStore::set_admin_socket(seastar::lw_shared_ptr<crimson::admin::AdminSocket> asok)
+{
+  this->asok = asok;
+}
 std::vector<uint64_t> AlienStore::_parse_cpu_cores()
 {
   std::vector<uint64_t> cpu_cores;

--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -137,6 +137,7 @@ private:
   mutable std::unique_ptr<crimson::os::ThreadPool> tp;
   const std::string type;
   const std::string path;
+  const ConfigValues values;
   uint64_t used_bytes = 0;
   std::unique_ptr<ObjectStore> store;
   std::unique_ptr<CephContext> cct;

--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -13,6 +13,7 @@
 #include "crimson/os/alienstore/thread_pool.h"
 #include "crimson/os/futurized_collection.h"
 #include "crimson/os/futurized_store.h"
+#include "crimson/admin/admin_socket.h"
 
 namespace ceph::os {
 class Transaction;
@@ -118,6 +119,7 @@ public:
     CollectionRef ch,
     const ghobject_t& oid) final;
 
+  void set_admin_socket(seastar::lw_shared_ptr<crimson::admin::AdminSocket> asok) final;
 private:
   template <class... Args>
   auto do_with_op_gate(Args&&... args) const {
@@ -138,6 +140,7 @@ private:
   const std::string type;
   const std::string path;
   const ConfigValues values;
+  seastar::lw_shared_ptr<crimson::admin::AdminSocket> asok;
   uint64_t used_bytes = 0;
   std::unique_ptr<ObjectStore> store;
   std::unique_ptr<CephContext> cct;

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -9,9 +9,11 @@
 #include <vector>
 
 #include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
 
 #include "os/Transaction.h"
 #include "crimson/osd/exceptions.h"
+#include "crimson/admin/admin_socket.h"
 #include "include/buffer_fwd.h"
 #include "include/uuid.h"
 #include "osd/osd_types.h"
@@ -20,6 +22,9 @@ namespace ceph::os {
 class Transaction;
 }
 
+namespace crimson::admin {
+class AdminSocket;
+}
 namespace crimson::os {
 class FuturizedCollection;
 
@@ -170,6 +175,8 @@ public:
     const std::string& key) = 0;
   virtual uuid_d get_fsid() const  = 0;
   virtual unsigned get_max_attr_name_length() const = 0;
+  virtual void set_admin_socket(seastar::lw_shared_ptr<crimson::admin::AdminSocket> asok) {};
+
 };
 
 inline void intrusive_ptr_add_ref(FuturizedStore::OmapIterator* iter) {

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -100,6 +100,7 @@ OSD::OSD(int id, uint32_t nonce,
     log_client(cluster_msgr.get(), LogClient::NO_FLAGS),
     clog(log_client.create_channel())
 {
+  store.set_admin_socket(asok);
   osdmaps[0] = boost::make_local_shared<OSDMap>();
   for (auto msgr : {std::ref(cluster_msgr), std::ref(public_msgr),
                     std::ref(hb_front_msgr), std::ref(hb_back_msgr)}) {

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -29,8 +29,10 @@ class SubsystemMap;
 
 class Log : private Thread
 {
-  using EntryRing = boost::circular_buffer<ConcreteEntry>;
+protected:
   using EntryVector = std::vector<ConcreteEntry>;
+private:
+  using EntryRing = boost::circular_buffer<ConcreteEntry>;
 
   static const std::size_t DEFAULT_MAX_NEW = 100;
   static const std::size_t DEFAULT_MAX_RECENT = 10000;
@@ -81,9 +83,9 @@ class Log : private Thread
 
   void _log_safe_write(std::string_view sv);
   void _flush_logbuf();
-  void _flush(EntryVector& q, bool crash);
-
   void _log_message(std::string_view s, bool crash);
+protected:
+  virtual void _flush(EntryVector& q, bool crash);
 
 public:
   using Thread::is_started;


### PR DESCRIPTION
Introduced gluer that exposed classic admin socket commands through crimson admin socket.
This works only for alien_store.

It is based on #46618

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
