### PR TITLE
[DNM] pybind/mgr: fixing some local unit test/mypy issues

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -275,7 +275,7 @@ class TestMonitoring:
 
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, AlertManagerSpec()):
-                y = dedent(self._get_config('http://localhost:8080')).lstrip()
+                y = dedent(self._get_config('http://localhost.localdomain:8080')).lstrip()
                 _run_cephadm.assert_called_with(
                     'test',
                     'alertmanager.test',

--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -23,6 +23,8 @@ from . import APIDoc, APIRouter, BaseController, CreatePermission, \
     DeletePermission, Endpoint, EndpointDoc, ReadPermission, RESTController, \
     Task, UIRouter, UpdatePermission, allow_empty_body
 
+from typing import Dict, Union, Optional
+
 logger = logging.getLogger(__name__)
 
 RBD_SCHEMA = ([{
@@ -309,7 +311,7 @@ class RbdStatus(BaseController):
     @Endpoint()
     @ReadPermission
     def status(self):
-        status = {'available': True, 'message': None}
+        status: Dict[str, Optional[Union[bool, str]]] = {'available': True, 'message': None}
         if not CephService.get_pool_list('rbd'):
             status['available'] = False
             status['message'] = 'No RBD pools in the cluster. Please create a pool '\


### PR DESCRIPTION
Signed-off-by: Adam King <adking@redhat.com>

While the Jenkins jobs seems to be passing on PRs, when running the tests locally I'm seeing a couple failures.

```
============================================================================================ short test summary info ============================================================================================
FAILED cephadm/tests/test_services.py::TestMonitoring::test_alertmanager_config - AssertionError: Expected call: _run_cephadm('test', 'alertmanager.test', 'deploy', ['--name', 'alertmanager.test', '--meta-j...
============================================================================ 1 failed, 1266 passed, 5 skipped, 6 warnings in 20.97s =============================================================================
```
```
E           AssertionError: Expected call: _run_cephadm('test', 'alertmanager.test', 'deploy', ['--name', 'alertmanager.test', '--meta-json', '{"service_name": "alertmanager", "ports": [9093, 9094], "ip": null, "deployed_by": [], "rank": null, "rank_generation": null, "extra_container_args": null}', '--config-json', '-', '--tcp-ports', '9093 9094'], image='', stdin='{"files": {"alertmanager.yml": "# This file is generated by cephadm.\\n# See https://prometheus.io/docs/alerting/configuration/ for documentation.\\n\\nglobal:\\n  resolve_timeout: 5m\\n  http_config:\\n    tls_config:\\n      insecure_skip_verify: true\\n\\nroute:\\n  receiver: \'default\'\\n  routes:\\n    - group_by: [\'alertname\']\\n      group_wait: 10s\\n      group_interval: 10s\\n      repeat_interval: 1h\\n      receiver: \'ceph-dashboard\'\\n\\nreceivers:\\n- name: \'default\'\\n  webhook_configs:\\n- name: \'ceph-dashboard\'\\n  webhook_configs:\\n  - url: \'http://localhost:8080/api/prometheus_receiver\'\\n"}, "peers": []}')
E           Actual call: _run_cephadm('test', 'alertmanager.test', 'deploy', ['--name', 'alertmanager.test', '--meta-json', '{"service_name": "alertmanager", "ports": [9093, 9094], "ip": null, "deployed_by": [], "rank": null, "rank_generation": null, "extra_container_args": null}', '--config-json', '-', '--tcp-ports', '9093 9094'], image='', stdin='{"files": {"alertmanager.yml": "# This file is generated by cephadm.\\n# See https://prometheus.io/docs/alerting/configuration/ for documentation.\\n\\nglobal:\\n  resolve_timeout: 5m\\n  http_config:\\n    tls_config:\\n      insecure_skip_verify: true\\n\\nroute:\\n  receiver: \'default\'\\n  routes:\\n    - group_by: [\'alertname\']\\n      group_wait: 10s\\n      group_interval: 10s\\n      repeat_interval: 1h\\n      receiver: \'ceph-dashboard\'\\n\\nreceivers:\\n- name: \'default\'\\n  webhook_configs:\\n- name: \'ceph-dashboard\'\\n  webhook_configs:\\n  - url: \'http://localhost.localdomain:8080/api/prometheus_receiver\'\\n"}, "peers": []}')

```
```
dashboard/plugins/feature_toggles.py:12: note: In module imported here,
dashboard/module.py:55: note: ... from here,
dashboard/__init__.py:60: note: ... from here:
dashboard/controllers/rbd.py: note: In member "status" of class "RbdStatus":
dashboard/controllers/rbd.py:315: error: Incompatible types in assignment (expression has type "str", target has type "Optional[bool]")
Found 1 error in 1 file (checked 31 source files)
```

This PR is testing whether changes that make these pass locally also work in the Jenkins jobs. If so, maybe we could merge them in. It's likely a different in python version or something of the sort causing the discrepancy. 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
