### PR TITLE
pacific: mgr/cephadm: capture exception when not able to list upgrade tags

### DIFF
--- a/src/pybind/mgr/cephadm/registry.py
+++ b/src/pybind/mgr/cephadm/registry.py
@@ -39,7 +39,11 @@ class Registry:
         headers = {'Accept': 'application/json'}
         url = f'https://{self.api_domain}/v2/{image}/tags/list'
         while True:
-            r = requests.get(url, headers=headers)
+            try:
+                r = requests.get(url, headers=headers)
+            except requests.exceptions.ConnectionError as e:
+                msg = f"Cannot get tags from url '{url}': {e}"
+                raise ValueError(msg) from e
             if r.status_code == 401:
                 if 'Authorization' in headers:
                     raise ValueError('failed authentication')

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -266,7 +266,11 @@ class CephadmUpgrade:
             "registry": reg_name,
             "bare_image": bare_image,
         }
-        ls = reg.get_tags(bare_image)
+
+        try:
+            ls = reg.get_tags(bare_image)
+        except ValueError as e:
+            raise OrchestratorError(f'{e}')
         if not tags:
             for t in ls:
                 if t[0] != 'v':


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55948

---

backport of https://github.com/ceph/ceph/pull/46445
parent tracker: https://tracker.ceph.com/issues/55801

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh