### PR TITLE
quincy: cephadm: preserve cephadm user during RPM upgrade

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1575,8 +1575,7 @@ exit 0
 
 %if ! 0%{?suse_version}
 %postun -n cephadm
-userdel -r cephadm || true
-exit 0
+[ $1 -ne 0 ] || userdel cephadm || :
 %endif
 
 %files -n cephadm


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55951

---

backport of https://github.com/ceph/ceph/pull/46272
parent tracker: https://tracker.ceph.com/issues/55664

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh