### PR TITLE
quincy: python-common: allow crush device class to be set from osd service spec

### DIFF
--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -150,7 +150,7 @@ class DriveGroupSpec(ServiceSpec):
         "data_devices", "db_devices", "wal_devices", "journal_devices",
         "data_directories", "osds_per_device", "objectstore", "osd_id_claims",
         "journal_size", "unmanaged", "filter_logic", "preview_only", "extra_container_args",
-        "data_allocate_fraction", "method"
+        "data_allocate_fraction", "method", "crush_device_class",
     ]
 
     def __init__(self,
@@ -177,6 +177,7 @@ class DriveGroupSpec(ServiceSpec):
                  extra_container_args=None,  # type: Optional[List[str]]
                  data_allocate_fraction=None,  # type: Optional[float]
                  method=None,  # type: Optional[OSDMethod]
+                 crush_device_class=None,  # type: Optional[str]
                  ):
         assert service_type is None or service_type == 'osd'
         super(DriveGroupSpec, self).__init__('osd', service_id=service_id,
@@ -241,6 +242,9 @@ class DriveGroupSpec(ServiceSpec):
         self.data_allocate_fraction = data_allocate_fraction
 
         self.method = method
+
+        #: Crush device class to assign to OSDs
+        self.crush_device_class = crush_device_class
 
     @classmethod
     def _from_json_impl(cls, json_drive_group):

--- a/src/python-common/ceph/deployment/translate.py
+++ b/src/python-common/ceph/deployment/translate.py
@@ -109,6 +109,9 @@ class to_ceph_volume(object):
                 cmds[i] += " --yes"
                 cmds[i] += " --no-systemd"
 
+            if self.spec.crush_device_class:
+                cmds[i] += " --crush-device-class {}".format(self.spec.crush_device_class)
+
             if self.preview:
                 cmds[i] += " --report"
                 cmds[i] += " --format json"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55992

---

backport of https://github.com/ceph/ceph/pull/46480
parent tracker: https://tracker.ceph.com/issues/55813

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh