### PR TITLE
quincy: mgr/nfs: validate virtual_ip parameter

### DIFF
--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -1,3 +1,4 @@
+import ipaddress
 import logging
 import json
 import re
@@ -103,7 +104,13 @@ class NFSCluster:
             ingress: Optional[bool] = None,
             port: Optional[int] = None,
     ) -> Tuple[int, str, str]:
+
         try:
+            if virtual_ip:
+                # validate virtual_ip value: ip_address throws a ValueError
+                # exception in case it's not a valid ipv4 or ipv6 address
+                ip = virtual_ip.split('/')[0]
+                ipaddress.ip_address(ip)
             if virtual_ip and not ingress:
                 raise NFSInvalidOperation('virtual_ip can only be provided with ingress enabled')
             if not virtual_ip and ingress:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56069

---

backport of https://github.com/ceph/ceph/pull/46364
parent tracker: https://tracker.ceph.com/issues/54581

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh