### PR TITLE
pacific: mgr/snap_schedule: persist all updates to RADOS

### DIFF
--- a/qa/tasks/cephfs/test_snap_schedules.py
+++ b/qa/tasks/cephfs/test_snap_schedules.py
@@ -438,8 +438,9 @@ class TestSnapSchedules(CephFSTestCase):
         self.fs_snap_schedule_cmd('deactivate', path=testdir, snap_schedule='1M')
 
         new_stats = self.get_snap_stats(testdir)
-        self.assertTrue(new_stats['fs_count'] == new_stats['db_count'] + old_stats['db_count'])
+        self.assertTrue(new_stats['fs_count'] == new_stats['db_count'])
         self.assertTrue(new_stats['fs_count'] > old_stats['fs_count'])
+        self.assertTrue(new_stats['db_count'] > old_stats['db_count'])
 
         # cleanup
         self.fs_snap_schedule_cmd('remove', path=testdir, snap_schedule='1M')

--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -264,9 +264,9 @@ class SnapSchedClient(CephfsClient):
 
     def create_scheduled_snapshot(self, fs_name, path, retention, start, repeat):
         log.debug(f'Scheduled snapshot of {path} triggered')
-        try:
-            with self.get_schedule_db(fs_name) as conn_mgr:
-                db = conn_mgr.dbinfo.db
+        with self.get_schedule_db(fs_name) as conn_mgr:
+            db = conn_mgr.dbinfo.db
+            try:
                 try:
                     sched = Schedule.get_db_schedules(path,
                                                       db,
@@ -282,19 +282,22 @@ class SnapSchedClient(CephfsClient):
                     log.debug(f'created scheduled snapshot {snap_name}')
                     sched.update_last(time, db)
                 except cephfs.Error:
-                    self._log_exception('create_scheduled_snapshot')
+                    self._log_exception('create_scheduled_snapshot: '
+                                        'unexpected exception; '
+                                        f'deactivating schedule fs:"{fs_name}" '
+                                        f'path:"{path}" repeat:"{repeat}" '
+                                        f'retention:"{retention}"')
                     sched.set_inactive(db)
                 except Exception:
                     # catch all exceptions cause otherwise we'll never know since this
                     # is running in a thread
                     self._log_exception('create_scheduled_snapshot')
-        finally:
-            with self.get_schedule_db(fs_name) as conn_mgr:
-                db = conn_mgr.dbinfo.db
+            finally:
                 self.refresh_snap_timers(fs_name, path, db)
-            self.prune_snapshots(sched)
+                self.prune_snapshots(sched, db)
+                self.store_schedule_db(fs_name, db)
 
-    def prune_snapshots(self, sched):
+    def prune_snapshots(self, sched, db):
         try:
             log.debug('Pruning snapshots')
             ret = sched.retention
@@ -319,9 +322,7 @@ class SnapSchedClient(CephfsClient):
                     log.debug(f'rmdir on {dirname}')
                     fs_handle.rmdir(f'{path}/.snap/{dirname}')
                 if to_prune:
-                    with self.get_schedule_db(sched.fs) as conn_mgr:
-                        db = conn_mgr.dbinfo.db
-                        sched.update_pruned(time, db, len(to_prune))
+                    sched.update_pruned(time, db, len(to_prune))
         except Exception:
             self._log_exception('prune_snapshots')
 
@@ -360,6 +361,7 @@ class SnapSchedClient(CephfsClient):
         with self.get_schedule_db(fs) as conn_mgr:
             db = conn_mgr.dbinfo.db
             Schedule.rm_schedule(db, path, schedule, start)
+            self.store_schedule_db(fs, db)
 
     @updates_schedule_db
     def add_retention_spec(self,
@@ -373,6 +375,7 @@ class SnapSchedClient(CephfsClient):
         with self.get_schedule_db(fs) as conn_mgr:
             db = conn_mgr.dbinfo.db
             Schedule.add_retention(db, path, retention_spec)
+            self.store_schedule_db(fs, db)
 
     @updates_schedule_db
     def rm_retention_spec(self,
@@ -386,6 +389,7 @@ class SnapSchedClient(CephfsClient):
         with self.get_schedule_db(fs) as conn_mgr:
             db = conn_mgr.dbinfo.db
             Schedule.rm_retention(db, path, retention_spec)
+            self.store_schedule_db(fs, db)
 
     @updates_schedule_db
     def activate_snap_schedule(self,
@@ -400,6 +404,7 @@ class SnapSchedClient(CephfsClient):
                                                   start=start)
             for s in schedules:
                 s.set_active(db)
+            self.store_schedule_db(fs, db)
 
     @updates_schedule_db
     def deactivate_snap_schedule(self,
@@ -413,3 +418,4 @@ class SnapSchedClient(CephfsClient):
                                                   start=start)
             for s in schedules:
                 s.set_inactive(db)
+            self.store_schedule_db(fs, db)


### PR DESCRIPTION
Pacific version of snap-schedule uses an in-memory sqlite db for schedule management.
Schedule was only written to persistent storage when a new one was added and not for all the mutation commands that were executed on it. This caused changes to be lost across mgr restart.

This PR fixes the issue by dumping db to persistent RADOS store for every db update.

NOTE: This is a pacific only PR and not a backport

Fixes: https://tracker.ceph.com/issues/56152
Signed-off-by: Milind Changire <mchangir@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
