### PR TITLE
osd/PeeringState: Avoid past interval start mismatch

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3410,19 +3410,7 @@ void PeeringState::merge_from(
       info.history.same_interval_since = info.history.last_epoch_clean;
     }
 
-    // if the past_intervals start is later than last_epoch_clean, it
-    // implies the source repeered again but the target didn't, or
-    // that the source became clean in a later epoch than the target.
-    // avoid the discrepancy but adjusting the interval start
-    // backwards to match so that check_past_interval_bounds() will
-    // not complain.
-    auto pib = past_intervals.get_bounds();
-    if (info.history.last_epoch_clean < pib.first) {
-      psdout(10) << __func__ << " last_epoch_clean "
-		 << info.history.last_epoch_clean << " < past_interval start "
-		 << pib.first << ", adjusting start backwards" << dendl;
-      past_intervals.adjust_start_backwards(info.history.last_epoch_clean);
-    }
+    past_intervals.adjust_start_backwards(info.history.last_epoch_clean, dpp);
 
     // Similarly, if the same_interval_since value is later than
     // last_epoch_clean, the next interval change will result in a

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4680,6 +4680,7 @@ boost::statechart::result PeeringState::Reset::react(const AdvMap& advmap)
       context< PeeringMachine >().get_cur_transaction());
   }
   ps->remove_down_peer_info(advmap.osdmap);
+  ps->past_intervals.adjust_start_backwards(ps->info.history.last_epoch_clean, ps->dpp);
   ps->check_past_interval_bounds();
   return discard_event();
 }
@@ -6688,6 +6689,7 @@ PeeringState::GetInfo::GetInfo(my_context ctx)
 
 
   DECLARE_LOCALS;
+  ps->past_intervals.adjust_start_backwards(ps->info.history.last_epoch_clean, ps->dpp);
   ps->check_past_interval_bounds();
   ps->log_weirdness();
   PastIntervals::PriorSet &prior_set = context< Peering >().prior_set;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -4321,6 +4321,22 @@ bool PastIntervals::check_new_interval(
   }
 }
 
+void PastIntervals::adjust_start_backwards(
+  epoch_t last_epoch_clean,
+  const DoutPrefixProvider *dpp)
+{
+  ceph_assert(past_intervals);
+  auto pib = past_intervals->get_bounds();
+  if (last_epoch_clean < pib.first) {
+    ldpp_dout(dpp, 10)
+      << __func__
+      << "past_interval start interval adjusted"
+      << " backwards to last_epoch_clean("
+      << last_epoch_clean << ")" << dendl;
+    past_intervals->adjust_start_backwards(last_epoch_clean);
+  }
+}
+
 // true if the given map affects the prior set
 bool PastIntervals::PriorSet::affected_by_map(
   const OSDMap &osdmap,

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -3475,10 +3475,16 @@ public:
     return past_intervals->get_bounds();
   }
 
-  void adjust_start_backwards(epoch_t last_epoch_clean) {
-    ceph_assert(past_intervals);
-    past_intervals->adjust_start_backwards(last_epoch_clean);
-  }
+  /* if the past_intervals start is later than last_epoch_clean, it
+   * implies the source repeered again but the target didn't, or
+   * that the source became clean in a later epoch than the target.
+   * avoid the discrepancy but adjusting the interval start
+   * backwards to match so that check_past_interval_bounds() will
+   * not complain.
+   */
+  void adjust_start_backwards(
+    epoch_t last_epoch_clean,
+    const DoutPrefixProvider *dpp);
 
   enum osd_state_t {
     UP,


### PR DESCRIPTION
Following b79442efce479fde7f8bda8fdadf86e91003a327. When merging, we solve the similar issue by adjusting the the past interval start (pg_history) backwards to match `last_epoch_started`. 

> In this case, the source will have a past_intervals start that is later than the last_epoch_clean implied in the pg_pool_t.
This situation is harmless because we do not allow the actual mappings of source and target to diverge during the merge window, so if the source's past intervals was adjusted we can still use it.

* The suggested strategy here is added both to `PeeringState::GetInfo::GetInfo()` and `PeeringState::Reset::react()` before `check_past_interval_bounds`.

  Failures from related trackers:
  ```
  1: (ceph::__ceph_abort(...) [0x56463c23fb99]
  2: (PeeringState::check_past_interval_bounds() const+0x6d5) [0x56463c6357c5]
  3: (PeeringState::Reset::react(...) [0x56463c64ecdc]
  ```
  ```
  1: (ceph::__ceph_abort(...) [0x55aed1c5a7e0]
  2: (PeeringState::check_past_interval_bounds() const+0x6ed) [0x55aed1fdc62d]
  3: (PeeringState::GetInfo::GetInfo(...) [0x55aed2009d95]
  ```

* A different approach is preventing this situation beforehand by adjusting (if needed) the start epoch when splitting the pgs. (Therefore, This PR is marked as draft for now)

Tracker: https://tracker.ceph.com/issues/49689

For more details on the tracker see: https://gist.github.com/Matan-B/ca564b6789f6ae6fc2ebc6a5b7e2aa69

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
