### PR TITLE
quincy: rbd-mirror: generally skip replay/resync if remote image is not primary

### DIFF
--- a/src/test/rbd_mirror/image_replayer/journal/test_mock_PrepareReplayRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/journal/test_mock_PrepareReplayRequest.cc
@@ -154,12 +154,11 @@ public:
 
   MockPrepareReplayRequest* create_request(
       MockStateBuilder& mock_state_builder,
-      librbd::mirror::PromotionState remote_promotion_state,
       const std::string& local_mirror_uuid,
       bool* resync_requested, bool* syncing, Context* on_finish) {
     return new MockPrepareReplayRequest(
-      local_mirror_uuid, remote_promotion_state, nullptr, &mock_state_builder,
-      resync_requested, syncing, on_finish);
+      local_mirror_uuid, nullptr, &mock_state_builder, resync_requested,
+      syncing, on_finish);
   }
 
   librbd::ImageCtx *m_local_image_ctx = nullptr;
@@ -204,9 +203,8 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, Success) {
                                       mirror_peer_client_meta);
   bool resync_requested;
   bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
+  auto request = create_request(mock_state_builder, "local mirror uuid",
+                                &resync_requested, &syncing, &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
   ASSERT_FALSE(resync_requested);
@@ -228,9 +226,8 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, NoLocalJournal) {
                                       mirror_peer_client_meta);
   bool resync_requested;
   bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
+  auto request = create_request(mock_state_builder, "local mirror uuid",
+                                &resync_requested, &syncing, &ctx);
   request->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -257,9 +254,8 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, ResyncRequested) {
                                       mirror_peer_client_meta);
   bool resync_requested;
   bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
+  auto request = create_request(mock_state_builder, "local mirror uuid",
+                                &resync_requested, &syncing, &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
   ASSERT_TRUE(resync_requested);
@@ -286,9 +282,8 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, ResyncRequestedError) {
                                       mirror_peer_client_meta);
   bool resync_requested;
   bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
+  auto request = create_request(mock_state_builder, "local mirror uuid",
+                                &resync_requested, &syncing, &ctx);
   request->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -315,9 +310,8 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, Syncing) {
                                       mirror_peer_client_meta);
   bool resync_requested;
   bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
+  auto request = create_request(mock_state_builder, "local mirror uuid",
+                                &resync_requested, &syncing, &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
   ASSERT_FALSE(resync_requested);
@@ -355,9 +349,8 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, GetRemoteTagClassError)
                                       mirror_peer_client_meta);
   bool resync_requested;
   bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
+  auto request = create_request(mock_state_builder, "local mirror uuid",
+                                &resync_requested, &syncing, &ctx);
   request->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -401,9 +394,8 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, GetRemoteTagsError) {
                                       mirror_peer_client_meta);
   bool resync_requested;
   bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
+  auto request = create_request(mock_state_builder, "local mirror uuid",
+                                &resync_requested, &syncing, &ctx);
   request->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -472,9 +464,8 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, LocalDemotedRemoteSynci
                                       mirror_peer_client_meta);
   bool resync_requested;
   bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
+  auto request = create_request(mock_state_builder, "local mirror uuid",
+                                &resync_requested, &syncing, &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
   ASSERT_FALSE(resync_requested);
@@ -520,9 +511,8 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, UpdateClientError) {
                                       mirror_peer_client_meta);
   bool resync_requested;
   bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
+  auto request = create_request(mock_state_builder, "local mirror uuid",
+                                &resync_requested, &syncing, &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
   ASSERT_FALSE(resync_requested);
@@ -577,9 +567,8 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, RemoteDemotePromote) {
                                       mirror_peer_client_meta);
   bool resync_requested;
   bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
+  auto request = create_request(mock_state_builder, "local mirror uuid",
+                                &resync_requested, &syncing, &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
   ASSERT_FALSE(resync_requested);
@@ -644,9 +633,8 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, MultipleRemoteDemotePro
                                       mirror_peer_client_meta);
   bool resync_requested;
   bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
+  auto request = create_request(mock_state_builder, "local mirror uuid",
+                                &resync_requested, &syncing, &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
   ASSERT_FALSE(resync_requested);
@@ -699,9 +687,8 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, LocalDemoteRemotePromot
                                       mirror_peer_client_meta);
   bool resync_requested;
   bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
+  auto request = create_request(mock_state_builder, "local mirror uuid",
+                                &resync_requested, &syncing, &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
   ASSERT_FALSE(resync_requested);
@@ -752,9 +739,8 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, SplitBrainForcePromote)
                                       mirror_peer_client_meta);
   bool resync_requested;
   bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
+  auto request = create_request(mock_state_builder, "local mirror uuid",
+                                &resync_requested, &syncing, &ctx);
   request->send();
   ASSERT_EQ(-EEXIST, ctx.wait());
 }

--- a/src/test/rbd_mirror/image_replayer/journal/test_mock_PrepareReplayRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/journal/test_mock_PrepareReplayRequest.cc
@@ -293,35 +293,6 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, ResyncRequestedError) {
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
 
-TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, UnlinkedRemoteNonPrimary) {
-  InSequence seq;
-
-  librbd::MockJournal mock_journal;
-  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
-  mock_local_image_ctx.journal = &mock_journal;
-
-  // check initial state
-  expect_is_resync_requested(mock_journal, false, 0);
-  expect_journal_get_tag_tid(mock_journal, 345);
-  expect_journal_get_tag_data(mock_journal, {"blah"});
-
-  C_SaferCond ctx;
-  ::journal::MockJournaler mock_remote_journaler;
-  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
-  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
-  mirror_peer_client_meta.image_id = mock_local_image_ctx.id;
-  MockStateBuilder mock_state_builder(mock_local_image_ctx,
-                                      mock_remote_journaler,
-                                      mirror_peer_client_meta);
-  bool resync_requested;
-  bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_NON_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
-  request->send();
-  ASSERT_EQ(-EREMOTEIO, ctx.wait());
-}
-
 TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, Syncing) {
   InSequence seq;
 
@@ -556,37 +527,6 @@ TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, UpdateClientError) {
   ASSERT_EQ(0, ctx.wait());
   ASSERT_FALSE(resync_requested);
   ASSERT_FALSE(syncing);
-}
-
-TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, NonPrimaryRemoteNotTagOwner) {
-  InSequence seq;
-
-  librbd::MockJournal mock_journal;
-  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
-  mock_local_image_ctx.journal = &mock_journal;
-
-  // check initial state
-  expect_is_resync_requested(mock_journal, false, 0);
-  expect_journal_get_tag_tid(mock_journal, 345);
-  expect_journal_get_tag_data(mock_journal, {librbd::Journal<>::LOCAL_MIRROR_UUID,
-                                             librbd::Journal<>::ORPHAN_MIRROR_UUID,
-                                             true, 344, 0});
-
-  C_SaferCond ctx;
-  ::journal::MockJournaler mock_remote_journaler;
-  librbd::journal::MirrorPeerClientMeta mirror_peer_client_meta;
-  mirror_peer_client_meta.state = librbd::journal::MIRROR_PEER_STATE_REPLAYING;
-  mirror_peer_client_meta.image_id = mock_local_image_ctx.id;
-  MockStateBuilder mock_state_builder(mock_local_image_ctx,
-                                      mock_remote_journaler,
-                                      mirror_peer_client_meta);
-  bool resync_requested;
-  bool syncing;
-  auto request = create_request(
-    mock_state_builder, librbd::mirror::PROMOTION_STATE_NON_PRIMARY,
-    "local mirror uuid", &resync_requested, &syncing, &ctx);
-  request->send();
-  ASSERT_EQ(-EREMOTEIO, ctx.wait());
 }
 
 TEST_F(TestMockImageReplayerJournalPrepareReplayRequest, RemoteDemotePromote) {

--- a/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
@@ -986,7 +986,7 @@ TEST_F(TestMockImageReplayerBootstrapRequest, PrepareReplayDisconnected) {
 
   // prepare replay
   expect_prepare_replay(mock_state_builder, false, false, 0);
-  expect_is_disconnected(mock_state_builder, false);
+  expect_is_disconnected(mock_state_builder, true);
 
   // close remote image
   expect_replay_requires_remote_image(mock_state_builder, false);

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -385,8 +385,8 @@ void ImageReplayer<I>::handle_bootstrap(int r) {
     on_start_fail(0, "local image is primary");
     return;
   } else if (r == -EREMOTEIO) {
-    dout(5) << "remote image is non-primary" << dendl;
-    on_start_fail(-EREMOTEIO, "remote image is non-primary");
+    dout(5) << "remote image is not primary" << dendl;
+    on_start_fail(-EREMOTEIO, "remote image is not primary");
     return;
   } else if (r == -EEXIST) {
     on_start_fail(r, "split-brain detected");

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
@@ -135,7 +135,7 @@ void BootstrapRequest<I>::handle_prepare_local_image(int r) {
   if (r == -ENOENT) {
     dout(10) << "local image does not exist" << dendl;
   } else if (r < 0) {
-    derr << "error preparing local image for replay" << cpp_strerror(r)
+    derr << "error preparing local image for replay: " << cpp_strerror(r)
          << dendl;
     finish(r);
     return;
@@ -200,7 +200,8 @@ void BootstrapRequest<I>::handle_prepare_remote_image(int r) {
     }
     return;
   } else if (r < 0) {
-    derr << "error retrieving remote image id" << cpp_strerror(r) << dendl;
+    derr << "error preparing remote image for replay: " << cpp_strerror(r)
+         << dendl;
     finish(r);
     return;
   }

--- a/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.cc
@@ -65,10 +65,7 @@ void PrepareRemoteImageRequest<I>::handle_get_remote_image_id(int r) {
   dout(10) << "r=" << r << ", "
            << "remote_image_id=" << m_remote_image_id << dendl;
 
-  if (r == -ENOENT) {
-    finish(r);
-    return;
-  } else if (r < 0) {
+  if (r < 0) {
     finish(r);
     return;
   }

--- a/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.cc
@@ -116,15 +116,6 @@ void PrepareRemoteImageRequest<I>::handle_get_mirror_info(int r) {
     dout(5) << "remote image mirroring is being disabled" << dendl;
     finish(-ENOENT);
     return;
-  } else if (m_promotion_state != librbd::mirror::PROMOTION_STATE_PRIMARY &&
-             (state_builder == nullptr ||
-              state_builder->local_image_id.empty() ||
-              state_builder->local_promotion_state ==
-                librbd::mirror::PROMOTION_STATE_UNKNOWN)) {
-    // no local image and remote isn't primary -- don't sync it
-    dout(5) << "remote image is not primary -- not syncing" << dendl;
-    finish(-EREMOTEIO);
-    return;
   }
 
   switch (m_mirror_image.mode) {

--- a/src/tools/rbd_mirror/image_replayer/StateBuilder.cc
+++ b/src/tools/rbd_mirror/image_replayer/StateBuilder.cc
@@ -45,6 +45,15 @@ bool StateBuilder<I>::is_local_primary() const {
 }
 
 template <typename I>
+bool StateBuilder<I>::is_remote_primary() const {
+  if (remote_promotion_state == librbd::mirror::PROMOTION_STATE_PRIMARY) {
+    ceph_assert(!remote_image_id.empty());
+    return true;
+  }
+  return false;
+}
+
+template <typename I>
 bool StateBuilder<I>::is_linked() const {
   if (local_promotion_state == librbd::mirror::PROMOTION_STATE_NON_PRIMARY) {
     ceph_assert(!local_image_id.empty());

--- a/src/tools/rbd_mirror/image_replayer/StateBuilder.cc
+++ b/src/tools/rbd_mirror/image_replayer/StateBuilder.cc
@@ -36,16 +36,21 @@ StateBuilder<I>::~StateBuilder() {
 }
 
 template <typename I>
-bool StateBuilder<I>::is_local_primary() const  {
-  return (!local_image_id.empty() &&
-          local_promotion_state == librbd::mirror::PROMOTION_STATE_PRIMARY);
+bool StateBuilder<I>::is_local_primary() const {
+  if (local_promotion_state == librbd::mirror::PROMOTION_STATE_PRIMARY) {
+    ceph_assert(!local_image_id.empty());
+    return true;
+  }
+  return false;
 }
 
 template <typename I>
 bool StateBuilder<I>::is_linked() const {
-  return ((local_promotion_state ==
-             librbd::mirror::PROMOTION_STATE_NON_PRIMARY) &&
-          is_linked_impl());
+  if (local_promotion_state == librbd::mirror::PROMOTION_STATE_NON_PRIMARY) {
+    ceph_assert(!local_image_id.empty());
+    return is_linked_impl();
+  }
+  return false;
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_replayer/StateBuilder.h
+++ b/src/tools/rbd_mirror/image_replayer/StateBuilder.h
@@ -44,6 +44,7 @@ public:
   virtual bool is_disconnected() const = 0;
 
   bool is_local_primary() const;
+  bool is_remote_primary() const;
   bool is_linked() const;
 
   virtual cls::rbd::MirrorImageMode get_mirror_image_mode() const = 0;

--- a/src/tools/rbd_mirror/image_replayer/StateBuilder.h
+++ b/src/tools/rbd_mirror/image_replayer/StateBuilder.h
@@ -81,13 +81,13 @@ public:
 
   std::string local_image_id;
   librbd::mirror::PromotionState local_promotion_state =
-    librbd::mirror::PROMOTION_STATE_PRIMARY;
+    librbd::mirror::PROMOTION_STATE_UNKNOWN;
   ImageCtxT* local_image_ctx = nullptr;
 
   std::string remote_mirror_uuid;
   std::string remote_image_id;
   librbd::mirror::PromotionState remote_promotion_state =
-    librbd::mirror::PROMOTION_STATE_NON_PRIMARY;
+    librbd::mirror::PROMOTION_STATE_UNKNOWN;
   ImageCtxT* remote_image_ctx = nullptr;
 
 protected:

--- a/src/tools/rbd_mirror/image_replayer/journal/PrepareReplayRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/journal/PrepareReplayRequest.cc
@@ -68,17 +68,6 @@ void PrepareReplayRequest<I>::send() {
            << "local tag data=" << m_local_tag_data << dendl;
   image_locker.unlock();
 
-  if (m_local_tag_data.mirror_uuid != m_state_builder->remote_mirror_uuid &&
-      m_remote_promotion_state != librbd::mirror::PROMOTION_STATE_PRIMARY) {
-    // if the local mirror is not linked to the (now) non-primary image,
-    // stop the replay. Otherwise, we ignore that the remote is non-primary
-    // so that we can replay the demotion
-    dout(5) << "remote image is not primary -- skipping image replay"
-            << dendl;
-    finish(-EREMOTEIO);
-    return;
-  }
-
   if (*m_resync_requested) {
     finish(0);
     return;

--- a/src/tools/rbd_mirror/image_replayer/journal/PrepareReplayRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/journal/PrepareReplayRequest.h
@@ -30,20 +30,18 @@ class PrepareReplayRequest : public BaseRequest {
 public:
   static PrepareReplayRequest* create(
       const std::string& local_mirror_uuid,
-      librbd::mirror::PromotionState remote_promotion_state,
       ProgressContext* progress_ctx,
       StateBuilder<ImageCtxT>* state_builder,
       bool* resync_requested,
       bool* syncing,
       Context* on_finish) {
     return new PrepareReplayRequest(
-      local_mirror_uuid, remote_promotion_state, progress_ctx, state_builder,
-      resync_requested, syncing, on_finish);
+      local_mirror_uuid, progress_ctx, state_builder, resync_requested,
+      syncing, on_finish);
   }
 
   PrepareReplayRequest(
       const std::string& local_mirror_uuid,
-      librbd::mirror::PromotionState remote_promotion_state,
       ProgressContext* progress_ctx,
       StateBuilder<ImageCtxT>* state_builder,
       bool* resync_requested,
@@ -51,7 +49,6 @@ public:
       Context* on_finish)
     : BaseRequest(on_finish),
       m_local_mirror_uuid(local_mirror_uuid),
-      m_remote_promotion_state(remote_promotion_state),
       m_progress_ctx(progress_ctx),
       m_state_builder(state_builder),
       m_resync_requested(resync_requested),
@@ -83,7 +80,6 @@ private:
   typedef std::list<cls::journal::Tag> Tags;
 
   std::string m_local_mirror_uuid;
-  librbd::mirror::PromotionState m_remote_promotion_state;
   ProgressContext* m_progress_ctx;
   StateBuilder<ImageCtxT>* m_state_builder;
   bool* m_resync_requested;

--- a/src/tools/rbd_mirror/image_replayer/journal/StateBuilder.cc
+++ b/src/tools/rbd_mirror/image_replayer/journal/StateBuilder.cc
@@ -97,8 +97,8 @@ BaseRequest* StateBuilder<I>::create_prepare_replay_request(
     bool* syncing,
     Context* on_finish) {
   return PrepareReplayRequest<I>::create(
-    local_mirror_uuid, this->remote_promotion_state, progress_ctx, this,
-    resync_requested, syncing, on_finish);
+    local_mirror_uuid, progress_ctx, this, resync_requested, syncing,
+    on_finish);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_replayer/snapshot/PrepareReplayRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/PrepareReplayRequest.h
@@ -28,20 +28,18 @@ class PrepareReplayRequest : public BaseRequest {
 public:
   static PrepareReplayRequest* create(
       const std::string& local_mirror_uuid,
-      librbd::mirror::PromotionState remote_promotion_state,
       ProgressContext* progress_ctx,
       StateBuilder<ImageCtxT>* state_builder,
       bool* resync_requested,
       bool* syncing,
       Context* on_finish) {
     return new PrepareReplayRequest(
-      local_mirror_uuid, remote_promotion_state, progress_ctx, state_builder,
-      resync_requested, syncing, on_finish);
+      local_mirror_uuid, progress_ctx, state_builder, resync_requested,
+      syncing, on_finish);
   }
 
   PrepareReplayRequest(
       const std::string& local_mirror_uuid,
-      librbd::mirror::PromotionState remote_promotion_state,
       ProgressContext* progress_ctx,
       StateBuilder<ImageCtxT>* state_builder,
       bool* resync_requested,
@@ -49,7 +47,6 @@ public:
       Context* on_finish)
     : BaseRequest(on_finish),
       m_local_mirror_uuid(local_mirror_uuid),
-      m_remote_promotion_state(remote_promotion_state),
       m_progress_ctx(progress_ctx),
       m_state_builder(state_builder),
       m_resync_requested(resync_requested),
@@ -75,7 +72,6 @@ private:
    */
 
   std::string m_local_mirror_uuid;
-  librbd::mirror::PromotionState m_remote_promotion_state;
   ProgressContext* m_progress_ctx;
   StateBuilder<ImageCtxT>* m_state_builder;
   bool* m_resync_requested;

--- a/src/tools/rbd_mirror/image_replayer/snapshot/StateBuilder.cc
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/StateBuilder.cc
@@ -96,8 +96,8 @@ BaseRequest* StateBuilder<I>::create_prepare_replay_request(
     bool* syncing,
     Context* on_finish) {
   return PrepareReplayRequest<I>::create(
-    local_mirror_uuid, this->remote_promotion_state, progress_ctx, this,
-    resync_requested, syncing, on_finish);
+    local_mirror_uuid, progress_ctx, this, resync_requested, syncing,
+    on_finish);
 }
 
 template <typename I>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56167

---

backport of https://github.com/ceph/ceph/pull/46759
parent tracker: https://tracker.ceph.com/issues/54448