### PR TITLE
rgw/bench: rgw atomic writter benchmarking.

### DIFF
--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -229,6 +229,11 @@ add_executable(unittest_log_backing test_log_backing.cc)
 target_link_libraries(unittest_log_backing radostest-cxx ${UNITTEST_LIBS}
   ${rgw_libs})
 
+# unittest_store_bench
+add_executable(unittest_rgw_store_bench test_store_bench.cc)
+target_link_libraries(unittest_rgw_store_bench ${UNITTEST_LIBS}
+  ${rgw_libs})
+
 add_executable(unittest_rgw_lua test_rgw_lua.cc)
 add_ceph_unittest(unittest_rgw_lua)
 target_link_libraries(unittest_rgw_lua ${rgw_libs})

--- a/src/test/rgw/test_store_bench.cc
+++ b/src/test/rgw/test_store_bench.cc
@@ -1,0 +1,340 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "common/async/yield_context.h"
+#include "common/ceph_argparse.h"
+#include "common/ceph_context.h"
+#include "common/ceph_time.h"
+#include "common/code_environment.h"
+#include "common/common_init.h"
+#include "common/dout.h"
+#include "include/buffer_fwd.h"
+#include "include/msgr.h"
+#include "include/types.h"
+#include "rgw_basic_types.h"
+#include "rgw_common.h"
+#include "rgw_op.h"
+#include "rgw_sal.h"
+#include "rgw_tools.h"
+#include <bits/stdint-intn.h>
+#include <bits/stdint-uintn.h>
+#include <chrono>
+#include <climits>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+
+#define CONF Config::instance()
+
+struct Range {
+  int start, end;
+  /*
+    A range is a string written like int..int or int alone.
+    Example:
+    2..32 is a range from 2 to 32
+    32 is a range from 0 to 32
+   */
+  Range() : start(0), end(0) {}
+
+  Range(std::string range) {
+    size_t dot_index = range.find('.');
+    start = 0;
+    end = 0;
+
+    // no points let's assume it's a single int
+    if (dot_index == std::string::npos || dot_index + 2 >= range.length() || range[dot_index+1] != '.') {
+      if(is_number(range)) {
+        end = std::stoi(range);
+      }
+    } else {
+      std::string lh = range.substr(0, dot_index);
+      std::string rh = range.substr(dot_index + 2, range.length());
+      if (is_number(lh)) {
+        start = std::stoi(lh);
+      }
+      if (is_number(rh)) {
+        end = std::stoi(rh);
+      }
+    }
+  }
+
+  friend std::ostream& operator<< (std::ostream &out, const Range &range) {
+    out << range.start << ".." << range.end;
+    return out;
+  }
+
+
+private:
+  bool is_number(std::string &n) {
+    for (auto c : n) {
+      if (!std::isdigit(c)) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+class Config {
+public:
+  DoutPrefixProvider *dpp;
+  CephContext *cct;
+  rgw::sal::Store *store;
+  rgw_user uid;
+  rgw_bucket bucket;
+  std::string tenant;
+
+  Config() : tenant("tenant1") {
+    uid = rgw_user(tenant, "user1");
+    bucket.name = "bucket1";
+    bucket.tenant = tenant;
+  }
+  static Config &instance() {
+    static Config _instance;
+    return _instance;
+  }
+};
+
+void create_user() {
+  std::string display_name("user1");
+  std::string email("foo@bar.com");
+  std::string access_key;
+  std::string secret_key;
+  std::string key_type_str;
+  std::string caps;
+  std::string tenant_name;
+  std::string op_mask_str;
+  std::string default_placement_str;
+  std::string placement_tags_str;
+
+  RGWUserAdminOpState op_state(CONF.store);
+
+  op_state.set_user_id(Config::instance().uid);
+  op_state.set_display_name(display_name);
+  op_state.set_user_email(email);
+  op_state.set_caps(caps);
+  op_state.set_access_key(access_key);
+  op_state.set_secret_key(secret_key);
+
+  RGWNullFlusher flusher;
+  optional_yield y = null_yield;
+  RGWEnv env;
+  struct req_state s(CONF.cct, &env, 1);
+  int err = RGWUserAdminOp_User::create(&s, CONF.store, op_state, flusher, y);
+  if (err == -ERR_USER_EXIST) {
+    std::cout << "create user: " << Config::instance().uid << " already exists!"
+              << std::endl;
+  }
+  std::cout << "create user: " << err << std::endl;
+}
+
+void list_users() {
+  RGWUserAdminOpState op_state(CONF.store);
+  JSONFormatter jf;
+  std::stringstream ss;
+  RGWStreamFlusher flusher(&jf, ss);
+  int err = RGWUserAdminOp_User::list(CONF.dpp, CONF.store, op_state, flusher);
+  std::cout << "list user: " << err << std::endl;
+  std::cout << "list " << ss.str() << std::endl;
+}
+
+void create_bucket() {
+  Config c = Config::instance();
+  RGWBucketInfo info;
+  RGWUserInfo owner;
+  obj_version objv;
+  rgw_placement_rule rule(
+      c.store->get_zone()->get_zonegroup().get_default_placement_name(),
+      RGW_STORAGE_CLASS_STANDARD);
+  std::map<std::string, bufferlist> attrs;
+  owner.user_id.id = Config::instance().uid.id;
+
+  // idk what this is
+  objv.ver = 2;
+  objv.tag = "write_tag";
+  rule.name = "rule1";
+  rule.storage_class = "sc1";
+  auto user = c.store->get_user(Config::instance().uid);
+  rgw_placement_rule r(
+      c.store->get_zone()->get_zonegroup().get_default_placement_name(),
+      RGW_STORAGE_CLASS_STANDARD);
+  owner.default_placement = r;
+  RGWQuotaInfo qi;
+  auto zone = c.store->get_zone();
+  RGWAccessControlPolicy cp;
+  RGWEnv env;
+  req_info req_i(c.cct, &env);
+  std::unique_ptr<rgw::sal::Bucket> bucket;
+  std::string swift_var_location;
+  bool existed = false;
+  int ret =
+      user->create_bucket(c.dpp, c.bucket, zone->get_zonegroup().get_id(), r,
+                          swift_var_location, &qi, cp, attrs, info, objv, false,
+                          false, &existed, req_i, &bucket, null_yield);
+  std::cout << "create bucket: " << ret << std::endl;
+  std::cout << "existed: " << existed << std::endl;
+}
+
+void list_buckets() {
+  auto c = Config::instance();
+  auto user = c.store->get_user(c.uid);
+  rgw::sal::BucketList buckets;
+  std::string marker, end_marker;
+  user->list_buckets(c.dpp, marker, end_marker, 10, 0, buckets, null_yield);
+  std::cout << "Buckets: ";
+  for (auto &[name, bucket] : buckets.get_buckets()) {
+    std::cout << name << " ";
+  }
+  std::cout << std::endl;
+}
+
+static bufferlist *bl = nullptr;
+// bl->length() doesn't work?????
+static uint32_t bufferlist_length = 0;
+
+uint64_t create_object(rgw_obj_key key, uint32_t obj_size) {
+  // For now let's have one bufferlist as append might be too expensive
+  if (bl == nullptr) {
+    bl = new bufferlist();
+    bl->append_zero(obj_size);
+    bufferlist_length = obj_size;
+  }
+  if (bufferlist_length != obj_size) {
+    bl->clear();
+    bl->append_zero(obj_size);
+    bufferlist_length = obj_size;
+  }
+
+  std::unique_ptr<rgw::sal::Bucket> bucket{nullptr};
+  auto ruser = CONF.store->get_user(CONF.uid);
+  CONF.store->get_bucket(CONF.dpp, ruser.get(), CONF.bucket, &bucket,
+                         null_yield);
+  std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(key);
+  std::unique_ptr<rgw::sal::Writer> processor;
+  rgw_placement_rule pr("p1", "");
+
+  std::string etag = "";
+  rgw::sal::Attrs attrs;
+  bufferlist etag_bl;
+
+  // time prepare->process->complete
+  std::chrono::steady_clock::time_point t1 = std::chrono::steady_clock::now();
+  etag_bl.append(etag.c_str(), etag.size());
+  attrs.emplace(RGW_ATTR_ETAG, etag_bl);
+  obj->set_obj_attrs(CONF.dpp, &attrs, nullptr, null_yield);
+  processor = CONF.store->get_atomic_writer(
+      CONF.dpp, null_yield, std::move(obj), Config::instance().uid, &pr, 1, "");
+  processor->prepare(null_yield);
+  auto proc_ret = processor->process(std::move(*bl), 0);
+  if (proc_ret < 0) {
+    std::cerr << "Error processor process " << proc_ret << std::endl;
+  }
+  auto time = real_time();
+  char *if_match = NULL;
+  char *if_nomatch = NULL;
+  std::string user_data;
+  rgw_zone_set zs;
+  bool pcanceled = false;
+  int op_ret = processor->complete(obj_size, "", &time, real_time(), attrs,
+                                   real_time(), if_match, if_nomatch,
+                                   &user_data, &zs, &pcanceled, null_yield);
+  if (op_ret < 0) {
+    std::cerr << "Error processor complete " << op_ret << std::endl;
+  }
+  std::chrono::steady_clock::time_point t2 = std::chrono::steady_clock::now();
+  return std::chrono::duration_cast<std::chrono::milliseconds>((t2 - t1))
+      .count();
+}
+
+int main(int argc, char **argv) {
+  std::map<std::string, std::string> defaults = {
+      {"debug_rgw", "1/5"},
+      {"keyring", "$rgw_data/keyring"},
+      {"objecter_inflight_ops", "24576"},
+      // require a secure mon connection by default
+      {"ms_mon_client_mode", "secure"},
+      {"auth_client_required", "cephx"}};
+  int flags = CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS;
+  flags |= CINIT_FLAG_DEFER_DROP_PRIVILEGES;
+  auto args = argv_to_vec(argc, argv);
+  auto cct = rgw_global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
+                             CODE_ENVIRONMENT_DAEMON, flags);
+
+  auto args_copy = args;
+  std::string val;
+  Range pow_2_increments;
+  size_t iterations = 1;
+  for (std::vector<const char *>::iterator i = args_copy.begin();
+       i != args_copy.end();) {
+    if (ceph_argparse_witharg(args_copy, i, &val, "--pow-2-increments",
+                              (char *)NULL)) {
+      std::cout << val << std::endl;
+      pow_2_increments = Range{val};
+    } else if (ceph_argparse_witharg(args_copy, i, &val, "--iterations",
+                                     (char *)NULL)) {
+      iterations = std::stoul(val);
+    } else {
+      ++i;
+    }
+  }
+  if (pow_2_increments.start < 0) {
+    std::cerr << "Wrong number of increments: " << pow_2_increments.start
+              << std::endl;
+    exit(1);
+  }
+
+  // obj_size is unsigned int, 2^32 append_zero fails in assertion of length
+  if (pow_2_increments.end > 31) {
+    pow_2_increments.end = 31;
+  }
+
+  std::cout << "number of power of 2 increments = " << pow_2_increments
+            << std::endl;
+  std::cout << "iterations = " << iterations << std::endl;
+  DoutPrefix dp(cct.get(), 1, "test");
+  DoutPrefixProvider *dpp = dynamic_cast<DoutPrefixProvider *>(&dp);
+  rgw::sal::Store *store = StoreManager::get_storage(
+      dpp, cct.get(), "rados", false, false, false, false, false);
+
+  if (store == nullptr) {
+    std::cerr << "get raw storage failed" << std::endl;
+    exit(1);
+  }
+
+  Config::instance().store = store;
+  Config::instance().dpp = dpp;
+  Config::instance().cct = cct.get();
+
+  create_user();
+  list_users();
+
+  create_bucket();
+  list_buckets();
+
+  for (int p2 = pow_2_increments.start; p2 <= pow_2_increments.end; p2++) {
+    uint64_t time = 0;
+    uint32_t obj_size = (1 << p2);
+    for (size_t i = 0; i < iterations; i++) {
+      rgw_obj_key key("foo", std::to_string(i));
+      time += create_object(key, obj_size);
+    }
+    if (iterations > 0) {
+      std::cout << "Average time per object size of " << obj_size
+                << " bytes: " << (time / iterations) << "[ms]" << std::endl;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Right know the only thing that can be benchmarked is atomic writers and get the average time it takes to create objects with a range of powers of 2 as `obj_size`.
 
Example input:
```
bin/unittest_rgw_store_bench -c ceph.conf --pow-2-increments 5..10 --iterations 10
```
Example output:

```
Average time per object size of 32 bytes: 143[ms]
Average time per object size of 64 bytes: 113[ms]
Average time per object size of 128 bytes: 111[ms]
Average time per object size of 256 bytes: 117[ms]
Average time per object size of 512 bytes: 118[ms]
Average time per object size of 1024 bytes: 109[ms]

```

I like flamegraphs so here you can see one run of 180 seconds uploading 1GB object: https://htmlpreview.github.io/?https://github.com/pereman2/ceph-mgr-bench/blob/main/rgw/rgw-atomic-writer-fg.html

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
