### PR TITLE
mgr/dashboard: Simplification of matchers-list (silencers-form)

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.html
@@ -4,10 +4,11 @@
   <div class="input-group my-2">
     <ng-container *ngFor="let config of matcherConfig">
       <div class="input-group-prepend">
-        <span class="input-group-text"
+        <span class="input-group-text" *ngIf="config.attribute === 'isRegex'"
               [ngbTooltip]="config.tooltip">
-          <i [ngClass]="[config.icon]"></i>
-        </span>
+            <i *ngIf="matcher[config.attribute]; else elseBlock">~</i>
+            <ng-template #elseBlock>=</ng-template>
+      </span>
       </div>
 
       <ng-container *ngIf="config.attribute !== 'isRegex'">
@@ -17,18 +18,6 @@
                [value]="matcher[config.attribute]"
                disabled
                readonly>
-      </ng-container>
-
-      <ng-container *ngIf="config.attribute === 'isRegex'">
-        <div class="input-group-append">
-          <div class="input-group-text">
-            <input type="checkbox"
-                   id="matcher-{{config.attribute}}-{{index}}"
-                   [checked]="matcher[config.attribute]"
-                   disabled
-                   readonly>
-          </div>
-        </div>
       </ng-container>
     </ng-container>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.ts
@@ -50,18 +50,15 @@ export class SilenceFormComponent {
   matcherConfig = [
     {
       tooltip: $localize`Attribute name`,
-      icon: this.icons.paragraph,
-      attribute: 'name'
-    },
-    {
-      tooltip: $localize`Value`,
-      icon: this.icons.terminal,
-      attribute: 'value'
+      attribute: 'name',
     },
     {
       tooltip: $localize`Regular expression`,
-      icon: this.icons.magic,
       attribute: 'isRegex'
+    },
+    {
+      tooltip: $localize`Value`,
+      attribute: 'value',
     }
   ];
 


### PR DESCRIPTION
This PR simplifies the silence-form matchers list layout. 

This was done by removing icons which seemed unmeaning to the matchers list and instead now showing a `=` for "equality" among a name and it's value. And `~` for "likeness", which means the user has selected `regex` for the specific matcher.

| Symbol      | Description |
| ----------- | ----------- |
| =      | Regex not selected      |
| ~   |  Regex has been selected        |


![image](https://user-images.githubusercontent.com/68972382/175354751-ac388777-38e9-48bc-9acc-b27e1d6de4bc.png)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
