### PR TITLE
mds: Don't blocklist clients in any replay state

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3513,7 +3513,7 @@ void MDSRankDispatcher::handle_osd_map()
   // reconnect state will journal blocklisted clients (journal
   // is opened for writing in `replay_done` before moving to
   // up:resolve).
-  if (!is_replay()) {
+  if (!is_any_replay()) {
     std::set<entity_addr_t> newly_blocklisted;
     objecter->consume_blocklist_events(&newly_blocklisted);
     auto epoch = objecter->with_osdmap([](const OSDMap &o){return o.get_epoch();});


### PR DESCRIPTION
The mds in 'standby-replay' state should not blocklist clients.
Attempting to do so would hit an assert while journaling.

Before the commit https://github.com/ceph/ceph/commit/79f7576401cc9d857f84396314d7476336c0e271 the 'Server:apply_blocklist' used to
fetch the blocklist addresses from 'Objecter::consume_blocklist_events'
which returns blocklist addresses only if 'blocklist_events_enabled'
are enabled. This is not enabled for mds in 'standby-replay' state.
Hence this issue wasn't seen.

After the commit https://github.com/ceph/ceph/commit/79f7576401cc9d857f84396314d7476336c0e271 the 'Server::apply_blocklist' fetches the
blocklist addresses from the osdmap. This would return the blocklist
addresses irrespective of the mds state. The mds in 'replay' state
doesn't blocklist the clients but if the mds is in 'standby-replay'
state, it tries to journal the blocklist and asserts. This patch
fixes the same by not allowing the blocklist if the mds is in any
replay state.

Introduced-by: https://github.com/ceph/ceph/commit/79f7576401cc9d857f84396314d7476336c0e271
Fixes: https://tracker.ceph.com/issues/56012
Signed-off-by: Kotresh HR <khiremat@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
