### PR TITLE
mgr: Remove service_daemon handling from MMgrUpdate

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -567,7 +567,7 @@ bool DaemonServer::handle_update(const ref_t<MMgrUpdate>& m)
       dout(20) << "updating existing DaemonState for " << key << dendl;
 
       daemon = daemon_state.get(key);
-      if (m->need_metadata_update == true &&
+      if (m->need_metadata_update &&
           !m->daemon_metadata.empty()) {
         daemon_state.update_metadata(daemon, m->daemon_metadata);
       }

--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -256,8 +256,7 @@ void MgrClient::_send_update()
     } else {
       update->daemon_name = cct->_conf->name.get_id();
     }
-    if (service_daemon) {
-      update->service_daemon = service_daemon;
+    if (need_metadata_update) {
       update->daemon_metadata = daemon_metadata;
     }
     update->need_metadata_update = need_metadata_update;
@@ -596,13 +595,12 @@ int MgrClient::update_daemon_metadata(
     return -EEXIST;
   }
   ldout(cct,1) << service << "." << name << " metadata " << metadata << dendl;
-  service_daemon = true;
   service_name = service;
   daemon_name = name;
   daemon_metadata = metadata;
   daemon_dirty_status = true;
 
-  if (need_metadata_update == true &&
+  if (need_metadata_update &&
       !daemon_metadata.empty()) {
     _send_update();
     need_metadata_update = false;

--- a/src/tools/ceph-dencoder/common_types.h
+++ b/src/tools/ceph-dencoder/common_types.h
@@ -455,3 +455,6 @@ MESSAGE(MTimeCheck2)
 
 #include "messages/MWatchNotify.h"
 MESSAGE(MWatchNotify)
+
+#include "messages/MMgrUpdate.h" 
+MESSAGE(MMgrUpdate)


### PR DESCRIPTION
The service_daemon is only required if client services
needs to be registered with mgr. The service_daemon
handling is not required in case of MMgrUpdate as it
handles mon metadata updates only.

Fixes: https://tracker.ceph.com/issues/55322

Signed-off-by: Prashant D <pdhange@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
