### PR TITLE
Packet drop alert overly sensitive

### DIFF
--- a/monitoring/ceph-mixin/prometheus_alerts.yml
+++ b/monitoring/ceph-mixin/prometheus_alerts.yml
@@ -653,7 +653,7 @@ groups:
           ) >= 0.0001 or (
             increase(node_network_receive_drop_total{device!="lo"}[1m]) +
             increase(node_network_transmit_drop_total{device!="lo"}[1m])
-          ) >= 10
+          ) >= 600
         labels:
           severity: warning
           type: ceph_default


### PR DESCRIPTION
The alert description states > 10 packets/s, but the actual alert
logic is looking at whether there have been >= 10 packets dropped
over a minute sized window. If the intent is to only alert if there
are more than 10 packets/s dropped, the check should be >= 600.

Signed-off-by: kbader <kbader@redhat.com>
