### PR TITLE
Quincy: osd/scrubber/pg_scrubber.cc: fix bug where scrub machine gets stuck

### DIFF
--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -127,7 +127,7 @@ bool PgScrubber::verify_against_abort(epoch_t epoch_to_verify)
 	   << " vs last-aborted: " << m_last_aborted << dendl;
 
   // if we were not aware of the abort before - kill the scrub.
-  if (epoch_to_verify > m_last_aborted) {
+  if (epoch_to_verify >= m_last_aborted) {
     scrub_clear_state();
     m_last_aborted = std::max(epoch_to_verify, m_epoch_start);
   }
@@ -146,9 +146,7 @@ bool PgScrubber::should_abort() const
       dout(10) << "nodeep_scrub set, aborting" << dendl;
       return true;
     }
-  }
-
-  if (get_osdmap()->test_flag(CEPH_OSDMAP_NOSCRUB) ||
+  } else if (get_osdmap()->test_flag(CEPH_OSDMAP_NOSCRUB) ||
       m_pg->pool.info.has_flag(pg_pool_t::FLAG_NOSCRUB)) {
     dout(10) << "noscrub set, aborting" << dendl;
     return true;


### PR DESCRIPTION
Fixes a scenario where the scrub machine gets stuck if starting
a deep scrub while the noscrub flag is set. It was dropping a
scrub reschedule op, without clearing scrub state, leaving the FSM
stuck in ActiveScrubbing,PendingTimer state.

backport tracker: https://tracker.ceph.com/issues/56408
Fixes: https://tracker.ceph.com/issues/54172
Signed-off-by: Cory Snyder <csnyder@iland.com>
(cherry picked from commit a46a61fdf795af93566dfb8fd92b0b18811083b6)
