### PR TITLE
test/objectstore: Consistent corruption replication of deferred writes

### DIFF
--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -147,6 +147,13 @@ if(WITH_BLUESTORE)
   add_ceph_unittest(unittest_bdev)
   target_link_libraries(unittest_bdev os global)
 
+  # unittest_deferred
+  add_executable(unittest_deferred
+    test_deferred.cc
+    )
+  add_ceph_unittest(unittest_deferred)
+  target_link_libraries(unittest_deferred os global)
+
 endif(WITH_BLUESTORE)
 
 # unittest_transaction

--- a/src/test/objectstore/run_test_deferred.sh
+++ b/src/test/objectstore/run_test_deferred.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+
+if [[ ! (-x ./bin/unittest_deferred) || ! (-x ./bin/ceph-kvstore-tool) || ! (-x ./bin/ceph-objectstore-tool)]]
+then
+    echo Test must be run from ceph build directory
+    echo with unittest_deferred, ceph-kvstore-tool and ceph-objectstore-tool compiled
+    exit 1
+fi
+
+# Create BlueStore, only main block device, 4K AU, forced deferred 4K, 64K AU for BlueFS
+
+# Create file zapchajdziura, that is 0xe000 in size.
+# This adds to 0x0000 - 0x1000 of BlueStore superblock and 0x1000 - 0x2000 of BlueFS superblock,
+# making 0x00000 - 0x10000 filled, nicely aligning for 64K BlueFS requirements
+
+# Prefill 10 objects Object-0 .. Object-9, each 64K. Sync to disk.
+# Do transactions like:
+# - fill Object-x+1 16 times at offsets 0x0000, 0x1000, ... 0xf000 with 8bytes, trigerring deferred writes
+# - fill Object-x with 64K data
+# Repeat for Object-0 to Object-8.
+
+# Right after getting notification on_complete for all 9 transactions, immediately exit(1).
+./bin/unittest_deferred --log-to-stderr=false
+
+# Now we should have a considerable amount of pending deferred writes.
+# They do refer disk regions that do not belong to any object.
+
+# Perform compaction on RocksDB
+# This initializes BlueFS, but does not replay deferred writes.
+# It jiggles RocksDB files around. CURRENT and MANIFEST are recreated, with some .sst files too.
+# The hope here is that newly created RocksDB files will occupy space that is free,
+# but targetted by pending deferred writes.
+./bin/ceph-kvstore-tool bluestore-kv bluestore.test_temp_dir/ compact --log-to-stderr=false
+
+# It this step we (hopefully) get RocksDB files overwritten
+# We initialize BlueFS and RocksDB, there should be no problem here.
+# Then we apply deferred writes. Now some of RocksDB files might get corrupted.
+# It is very likely that this will not cause any problems, since CURRENT and MANIFEST are only read at bootup.
+./bin/ceph-objectstore-tool --no-mon-config --data-path bluestore.test_temp_dir/ --pgid 11.1 --op list --no-superblock --log-to-stderr=false
+
+# If we were lucky, this command now fails
+./bin/ceph-objectstore-tool --no-mon-config --data-path bluestore.test_temp_dir/ --pgid 11.1 --op list --no-superblock --debug-bluestore=30/30 --debug-bdev=30/30 --log-file=log-cot-crash.txt --log-to-file --log-to-stderr=false
+if [[ $? != 0 ]]
+then
+    echo "Deferred writes corruption successfully created !"
+else
+    echo "No deferred write problems detected."
+fi
+
+#cleanup
+rm -rf bluestore.test_temp_dir/

--- a/src/test/objectstore/test_deferred.cc
+++ b/src/test/objectstore/test_deferred.cc
@@ -1,0 +1,146 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <stdio.h>
+#include <string.h>
+#include <iostream>
+#include <memory>
+#include <time.h>
+
+#include "os/ObjectStore.h"
+#include "os/bluestore/BlueStore.h"
+#include "include/Context.h"
+#include "common/ceph_argparse.h"
+#include "global/global_init.h"
+#include "common/ceph_mutex.h"
+#include "common/Cond.h"
+#include "common/errno.h"
+#include "common/options.h" // for the size literals
+#include <semaphore.h>
+
+
+
+class C_do_action : public Context {
+public:
+  std::function<void()> action;
+  C_do_action(std::function<void()> action)
+    : action(action) {}
+
+  void finish(int r) override {
+    action();
+  }
+};
+
+void create_deferred_and_terminate() {
+  std::unique_ptr<ObjectStore> store;
+
+  g_ceph_context->_conf._clear_safe_to_start_threads();
+  g_ceph_context->_conf.set_val_or_die("bluestore_prefer_deferred_size", "4096");
+  g_ceph_context->_conf.set_val_or_die("bluestore_allocator", "bitmap");
+  g_ceph_context->_conf.set_val_or_die("bluestore_block_size", "10240000000");
+  g_ceph_context->_conf.apply_changes(nullptr);
+
+  int64_t poolid;
+  coll_t cid;
+  ghobject_t hoid;
+  ObjectStore::CollectionHandle ch;
+  ceph_assert(::mkdir("bluestore.test_temp_dir", 0777) == 0);
+  store = ObjectStore::create(g_ceph_context,
+                              "bluestore",
+                              "bluestore.test_temp_dir",
+                              "store_test_temp_journal");
+  ceph_assert(store->mkfs() == 0);
+  ceph_assert(store->mount() == 0);
+
+  poolid = 11;
+  cid = coll_t(spg_t(pg_t(1, poolid), shard_id_t::NO_SHARD));
+  ch = store->create_new_collection(cid);
+  int r;
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    r = store->queue_transaction(ch, std::move(t));
+    ceph_assert(r == 0);
+  }
+
+  {
+    ObjectStore::Transaction t;
+    std::string oid = "zapchajdziura";
+    ghobject_t hoid(hobject_t(oid, "", CEPH_NOSNAP, 1, poolid, ""));
+    bufferlist bl;
+    bl.append(std::string(0xe000, '-'));
+    t.write(cid, hoid, 0, 0xe000, bl);
+    r = store->queue_transaction(ch, std::move(t));
+    ceph_assert(r == 0);
+  }
+
+  size_t object_count = 10;
+
+  // initial fill
+  bufferlist bl_64K;
+  bl_64K.append(std::string(64 * 1024, '-'));
+
+  std::atomic<size_t> prefill_counter{0};
+  sem_t prefill_mutex;
+  sem_init(&prefill_mutex, 0, 0);
+
+  for (size_t o = 0; o < object_count; o++) {
+    ObjectStore::Transaction t;
+    std::string oid = "object-" + std::to_string(o);
+    ghobject_t hoid(hobject_t(oid, "", CEPH_NOSNAP, 1, poolid, ""));
+
+    t.write(cid, hoid, 0, bl_64K.length(), bl_64K);
+    t.register_on_commit(new C_do_action([&] {
+      if (++prefill_counter == object_count) {
+	sem_post(&prefill_mutex);
+      }
+    }));
+
+    r = store->queue_transaction(ch, std::move(t));
+    ceph_assert(r == 0);
+  }
+  sem_wait(&prefill_mutex);
+
+  // small deferred writes over object
+  // and complete overwrite of previous one
+  bufferlist bl_8_bytes;
+  bl_8_bytes.append("abcdefgh");
+  std::atomic<size_t> deferred_counter{0};
+  for (size_t o = 0; o < object_count - 1; o++) {
+    ObjectStore::Transaction t;
+
+    // sprinkle deferred writes
+    std::string oid_d = "object-" + std::to_string(o + 1);
+    ghobject_t hoid_d(hobject_t(oid_d, "", CEPH_NOSNAP, 1, poolid, ""));
+
+    for(int i = 0; i < 16; i++) {
+      t.write(cid, hoid_d, 4096 * i, bl_8_bytes.length(), bl_8_bytes);
+    }
+
+    // overwrite previous object
+    std::string oid_m = "object-" + std::to_string(o);
+    ghobject_t hoid_m(hobject_t(oid_m, "", CEPH_NOSNAP, 1, poolid, ""));
+    t.write(cid, hoid_m, 0, bl_64K.length(), bl_64K);
+
+    t.register_on_commit(new C_do_action([&] {
+      if (++deferred_counter == object_count - 1) {
+        exit(0);
+      }
+    }));
+    r = store->queue_transaction(ch, std::move(t));
+    ceph_assert(r == 0);
+  }
+  sleep(10);
+  ceph_assert(0 && "should not reach here");
+}
+
+int main(int argc, char **argv) {
+  auto args = argv_to_vec(argc, argv);
+  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+			 CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+
+  create_deferred_and_terminate();
+  return 0;
+}


### PR DESCRIPTION
Add test that recreates situation when BlueStore deferred writes
can cause RocksDB files corruption.

This is a starting point for devising a solution.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
