### PR TITLE
osd/scrub: late-arriving reservation grants are not an error

### DIFF
--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1634,7 +1634,7 @@ void PgScrubber::handle_scrub_reserve_grant(OpRequestRef op, pg_shard_t from)
   if (m_reservations.has_value()) {
     m_reservations->handle_reserve_grant(op, from);
   } else {
-    derr << __func__ << ": received unsolicited reservation grant from osd "
+    dout(20) << __func__ << ": late/unsolicited reservation grant from osd "
 	 << from << " (" << op << ")" << dendl;
   }
 }


### PR DESCRIPTION
... as, barring a bug, these are simply the successful grants
received after one replica had failed to secure the required
resources.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
