### PR TITLE
mon/Elector: make paxos_size() an int

### DIFF
--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -90,7 +90,7 @@ public:
    * by making a paxos commit, but not by injecting values while
    * an election is ongoing.)
    */
-  virtual unsigned paxos_size() const = 0;
+  virtual int paxos_size() const = 0;
   /**
    * Retrieve a set of ranks which are not allowed to become the leader.
    * Like paxos_size(), This set can change between elections, but not

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -130,9 +130,9 @@ bool Elector::ever_participated() const
   return mon->has_ever_joined;
 }
 
-unsigned Elector::paxos_size() const
+int Elector::paxos_size() const
 {
-  return (unsigned)mon->monmap->size();
+  return mon->monmap->size();
 }
 
 void Elector::shutdown()

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -240,7 +240,7 @@ class Elector : public ElectionOwner, RankProvider {
   /* Retrieve the Monitor::has_ever_joined member */
   bool ever_participated() const;
   /* Retrieve monmap->size() */
-  unsigned paxos_size() const;
+  int paxos_size() const;
   /* Right now we don't disallow anybody */
   std::set<int> disallowed_leaders;
   const std::set<int>& get_disallowed_leaders() const { return disallowed_leaders; }

--- a/src/test/mon/test_election.cc
+++ b/src/test/mon/test_election.cc
@@ -147,7 +147,7 @@ struct Owner : public ElectionOwner, RankProvider {
     logic.start();
   }
   bool ever_participated() const { return ever_joined; }
-  unsigned paxos_size() const { return parent->get_paxos_size(); }
+  int paxos_size() const { return parent->get_paxos_size(); }
   const set<int>& get_disallowed_leaders() const {
     return parent->get_disallowed_leaders();
   }


### PR DESCRIPTION
We want to get rid of the warning:

‘int’ and ‘unsigned int’ [-Wsign-compare]
```
if (rank_removed < paxos_size()) {
~~~~~~~~~~~~^~~~~~~~~~~~~
```

Also, according to google style guide, we should
"try to avoid unsigned types and not use an
unsigned type merely to assert that a variable
is non-negative".

https://google.github.io/styleguide/cppguide.html#Integer_Types

NOTE: this warning was introduced by this PR: https://github.com/ceph/ceph/pull/46029/

Fixes: https://tracker.ceph.com/issues/56392

Signed-off-by: Kamoltat <ksirivad@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
