### PR TITLE
qa/workunits/cephtool: check_response didn't find erasure-code string

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1028,6 +1028,8 @@ function test_mon_mds()
   ceph fs new $FS_NAME fs_metadata mds-ec-pool --force 2>$TMPFILE
   check_response 'erasure-code' $? 22
   ceph fs new $FS_NAME mds-ec-pool fs_data 2>$TMPFILE
+  check_response 'already used by filesystem' $? 22
+  ceph fs new $FS_NAME mds-ec-pool fs_data --force 2>$TMPFILE
   check_response 'erasure-code' $? 22
   ceph fs new $FS_NAME mds-ec-pool mds-ec-pool 2>$TMPFILE
   check_response 'erasure-code' $? 22
@@ -1067,8 +1069,12 @@ function test_mon_mds()
   ceph fs new $FS_NAME fs_metadata mds-tier --force 2>$TMPFILE
   check_response 'in use as a cache tier' $? 22
   ceph fs new $FS_NAME mds-tier fs_data 2>$TMPFILE
+  check_response 'already used by filesystem' $? 22
+  ceph fs new $FS_NAME mds-tier fs_data --force 2>$TMPFILE
   check_response 'in use as a cache tier' $? 22
   ceph fs new $FS_NAME mds-tier mds-tier 2>$TMPFILE
+  check_response 'already used by filesystem' $? 22
+  ceph fs new $FS_NAME mds-tier mds-tier --force 2>$TMPFILE
   check_response 'in use as a cache tier' $? 22
   set -e
 
@@ -1099,6 +1105,8 @@ function test_mon_mds()
   # ...but not as the metadata pool
   set +e
   ceph fs new $FS_NAME mds-ec-pool fs_data 2>$TMPFILE
+  check_response 'already used by filesystem' $? 22
+  ceph fs new $FS_NAME mds-ec-pool fs_data --force 2>$TMPFILE
   check_response 'erasure-code' $? 22
   set -e
 


### PR DESCRIPTION
1. If data or metadata pool is already in-use by filesystem
then it is not allowed to reuse the same pool for another
filesystems.

2. Test is failing because above(1) restrictions/checks comes
before checking erasure-code pools. Hence test is failing
and not finding expected error string in output.

3. Proposed fix checks newly added error string instead of
'erasure-code'.

4. Also adding new tests to verify string 'erasure-code'
by passing --force option so that check for pools reuse(1)
will be skipped and check for 'erasure-code' will be hit.

Fixes: https://tracker.ceph.com/issues/56384
Signed-off-by: Nikhilkumar Shelke <nshelke@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
