### PR TITLE
Pacific: osd/scrub: late-arriving reservation grants are not an error

### DIFF
--- a/src/osd/pg_scrubber.cc
+++ b/src/osd/pg_scrubber.cc
@@ -1514,8 +1514,8 @@ void PgScrubber::handle_scrub_reserve_grant(OpRequestRef op, pg_shard_t from)
   if (m_reservations.has_value()) {
     m_reservations->handle_reserve_grant(op, from);
   } else {
-    derr << __func__ << ": received unsolicited reservation grant from osd " << from
-	 << " (" << op << ")" << dendl;
+    dout(20) << __func__ << ": late/unsolicited reservation grant from osd "
+	 << from << " (" << op << ")" << dendl;
   }
 }
 


### PR DESCRIPTION
... as, barring a bug, these are simply the successful grants
received after one replica had failed to secure the required
resources.

Fixes: https://tracker.ceph.com/issues/56400
Backport tracker: https://tracker.ceph.com/issues/56404

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
(cherry picked from commit 141bce2929ef057e3ec80b3823de95ceedf62b7d)

Conflicts:
	src/osd/scrubber/pg_scrubber.cc

No real conflict. Solved by selecting the changed line.
