### PR TITLE
doc/cephadm: osd: minor fixes in OSD config examples

### DIFF
--- a/doc/cephadm/services/osd.rst
+++ b/doc/cephadm/services/osd.rst
@@ -643,6 +643,7 @@ See a full list in the DriveGroupSpecs
    :members:
    :exclude-members: from_json
 
+
 Examples
 ========
 
@@ -746,7 +747,7 @@ This can be described with two layouts.
       host_pattern: '*'
     spec:
       data_devices:
-        rotational: 0
+        rotational: 1
       db_devices:
         model: MC-55-44-XZ
         limit: 2 # db_slots is actually to be favoured here, but it's not implemented yet
@@ -762,7 +763,7 @@ This can be described with two layouts.
         vendor: VendorC
 
 This would create the desired layout by using all HDDs as data_devices with two SSD assigned as dedicated db/wal devices.
-The remaining SSDs(8) will be data_devices that have the 'VendorC' NVMEs assigned as dedicated db/wal devices.
+The remaining SSDs(10) will be data_devices that have the 'VendorC' NVMEs assigned as dedicated db/wal devices.
 
 Multiple hosts with the same disk layout
 ----------------------------------------
@@ -782,11 +783,11 @@ Node1-5
 .. code-block:: none
 
     20 HDDs
-    Vendor: Intel
+    Vendor: VendorA
     Model: SSD-123-foo
     Size: 4TB
     2 SSDs
-    Vendor: VendorA
+    Vendor: VendorB
     Model: MC-55-44-ZX
     Size: 512GB
 
@@ -795,11 +796,11 @@ Node6-10
 .. code-block:: none
 
     5 NVMEs
-    Vendor: Intel
+    Vendor: VendorA
     Model: SSD-123-foo
     Size: 4TB
     20 SSDs
-    Vendor: VendorA
+    Vendor: VendorB
     Model: MC-55-44-ZX
     Size: 512GB
 
@@ -826,6 +827,7 @@ You can use the 'placement' key in the layout to target certain nodes.
         model: MC-55-44-XZ
       db_devices:
         model: SSD-123-foo
+
 
 This applies different OSD specs to different hosts depending on the `placement` key.
 See :ref:`orchestrator-cli-placement-spec`


### PR DESCRIPTION
doc: Corrected drive counts, rotational flag use, and vendor names in the OSD deployment examples.

Adjusted SSD count in item notes and rotational flag use (inconsistent with HDD) for the "Multiple OSD specs for a single host" example
Adjusted vendor names in "Multiple hosts with the same disk layout" for consistency of examples

Signed-off-by: Alex Handy <thinko@redhat.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
