### PR TITLE
rgw/qa: fix for teuthology failure related to role metadata sync

### DIFF
--- a/src/test/rgw/rgw_multi/multisite.py
+++ b/src/test/rgw/rgw_multi/multisite.py
@@ -169,6 +169,9 @@ class Zone(SystemObject, SystemObject.CreateDelete, SystemObject.GetSet, SystemO
     def has_buckets(self):
         return True
 
+    def has_roles(self):
+        return True
+
     def get_conn(self, credentials):
         return ZoneConn(self, credentials) # not implemented, but can be used
 

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -505,6 +505,7 @@ def create_role_per_zone(zonegroup_conns, roles_per_zone = 1):
     for zone in zonegroup_conns.rw_zones:
         for i in range(roles_per_zone):
             role_name = gen_role_name()
+            log.info('create role zone=%s name=%s', zone.name, role_name)
             policy_document = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/testuser\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
             role = zone.create_role("", role_name, policy_document, "")
             roles.append(role_name)
@@ -600,7 +601,8 @@ def check_bucket_eq(zone_conn1, zone_conn2, bucket):
         zone_conn2.check_bucket_eq(zone_conn1, bucket.name)
 
 def check_role_eq(zone_conn1, zone_conn2, role):
-    zone_conn2.check_role_eq(zone_conn1, role['create_role_response']['create_role_result']['role']['role_name'])
+    if zone_conn2.zone.has_roles():
+        zone_conn2.check_role_eq(zone_conn1, role['create_role_response']['create_role_result']['role']['role_name'])
 
 def test_object_sync():
     zonegroup = realm.master_zonegroup()

--- a/src/test/rgw/rgw_multi/zone_az.py
+++ b/src/test/rgw/rgw_multi/zone_az.py
@@ -26,6 +26,8 @@ class AZone(Zone):  # pylint: disable=too-many-ancestors
     def has_buckets(self):
         return False
 
+    def has_roles(self):
+        return True
 
 class AZoneConfig:
     """ archive zone configuration """

--- a/src/test/rgw/rgw_multi/zone_cloud.py
+++ b/src/test/rgw/rgw_multi/zone_cloud.py
@@ -257,6 +257,9 @@ class CloudZone(Zone):
     def has_buckets(self):
         return False
 
+    def has_roles(self):
+        return False
+
     class Conn(ZoneConn):
         def __init__(self, zone, credentials):
             super(CloudZone.Conn, self).__init__(zone, credentials)

--- a/src/test/rgw/rgw_multi/zone_es.py
+++ b/src/test/rgw/rgw_multi/zone_es.py
@@ -199,6 +199,9 @@ class ESZone(Zone):
     def has_buckets(self):
         return False
 
+    def has_roles(self):
+        return False
+
     class Conn(ZoneConn):
         def __init__(self, zone, credentials):
             super(ESZone.Conn, self).__init__(zone, credentials)

--- a/src/test/rgw/rgw_multi/zone_ps.py
+++ b/src/test/rgw/rgw_multi/zone_ps.py
@@ -54,6 +54,8 @@ class PSZone(Zone):  # pylint: disable=too-many-ancestors
     def has_buckets(self):
         return False
 
+    def has_roles(self):
+        return False
 
 NO_HTTP_BODY = ''
 


### PR DESCRIPTION
in case of pub sub zone.

fixes: https://tracker.ceph.com/issues/56175

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
