### PR TITLE
osd/scrub: modify scrub behaviour under no-scrub

### DIFF
--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -466,10 +466,11 @@ function TEST_just_deep_scrubs() {
     done
     rm -f $TESTDATA
 
-    # set 'no scrub', then request a deep-scrub.
+    # set both 'no scrub' & 'no deep-scrub', then request a deep-scrub.
     # we do not expect to see the scrub scheduled.
 
     ceph osd set noscrub || return 1
+    ceph osd set nodeep-scrub || return 1
     sleep 6 # the 'noscrub' command takes a long time to reach the OSDs
     local now_is=`date -I"ns"`
     declare -A sched_data
@@ -492,8 +493,8 @@ function TEST_just_deep_scrubs() {
     (( ${sc_data_2['dmp_last_duration']} == 0)) || return 1
     (( ${sc_data_2['query_scrub_seq']} == $dbg_counter_at_start)) || return 1
 
-    # unset the 'no scrub'. Deep scrubbing should start now.
-    ceph osd unset noscrub || return 1
+    # unset the 'no deep-scrub'. Deep scrubbing should start now.
+    ceph osd unset nodeep-scrub || return 1
     sleep 5
     declare -A expct_qry_duration=( ['query_last_duration']="0" ['query_last_duration_neg']="not0" )
     sc_data_2=()

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -431,6 +431,7 @@ void PG::queue_scrub_after_repair()
   m_planned_scrub.must_deep_scrub = true;
   m_planned_scrub.check_repair = true;
   m_planned_scrub.must_scrub = true;
+  m_planned_scrub.calculated_to_deep = true;
 
   if (is_scrub_queued_or_active()) {
     dout(10) << __func__ << ": scrubbing already ("
@@ -1352,7 +1353,7 @@ Scrub::schedule_result_t PG::sched_scrub()
   // analyse the combination of the requested scrub flags, the osd/pool configuration
   // and the PG status to determine whether we should scrub now, and what type of scrub
   // should that be.
-  auto updated_flags = verify_scrub_mode();
+  auto updated_flags = validate_scrub_mode();
   if (!updated_flags) {
     // the stars do not align for starting a scrub for this PG at this time
     // (due to configuration or priority issues)
@@ -1393,12 +1394,20 @@ double PG::next_deepscrub_interval() const
 }
 
 bool PG::is_time_for_deep(bool allow_deep_scrub,
-			  bool allow_scrub,
+			  bool allow_shallow_scrub,
 			  bool has_deep_errors,
 			  const requested_scrub_t& planned) const
 {
-  dout(10) << __func__ << ": need_auto?" << planned.need_auto << " allow_deep_scrub? "
-	   << allow_deep_scrub << dendl;
+  dout(10) << fmt::format(
+		"{}: need-auto? {} allowed? {}/{} deep-errors? {} "
+		"last_deep_scrub_stamp {}",
+		__func__,
+		planned.need_auto,
+		allow_shallow_scrub,
+		allow_deep_scrub,
+		has_deep_errors,
+		info.history.last_deep_scrub_stamp)
+	   << dendl;
 
   if (!allow_deep_scrub)
     return false;
@@ -1409,21 +1418,24 @@ bool PG::is_time_for_deep(bool allow_deep_scrub,
   }
 
   if (ceph_clock_now() >= next_deepscrub_interval()) {
-    dout(20) << __func__ << ": now (" << ceph_clock_now() << ") >= time for deep ("
-	     << next_deepscrub_interval() << ")" << dendl;
+    dout(20) << __func__ << ": now (" << ceph_clock_now()
+             << ") >= time for deep (" << next_deepscrub_interval() << ")"
+             << dendl;
     return true;
   }
 
   if (has_deep_errors) {
+    // note: the text below is matched by 'standalone' tests
     osd->clog->info() << "osd." << osd->whoami << " pg " << info.pgid
-		      << " Deep scrub errors, upgrading scrub to deep-scrub";
+                      << " Deep scrub errors, upgrading scrub to deep-scrub";
     return true;
   }
 
-  // we only flip coins if 'allow_scrub' is asserted. Otherwise - as this function is
-  // called often, we will probably be deep-scrubbing most of the time.
-  if (allow_scrub) {
-    bool deep_coin_flip =
+  // we only flip coins if 'allow_shallow_scrub' is asserted. Otherwise - as
+  // this function is called often, we will probably be deep-scrubbing most of
+  // the time.
+  if (allow_shallow_scrub) {
+    const bool deep_coin_flip =
       (rand() % 100) < cct->_conf->osd_deep_scrub_randomize_ratio * 100;
 
     dout(15) << __func__ << ": time_for_deep=" << planned.time_for_deep
@@ -1436,110 +1448,233 @@ bool PG::is_time_for_deep(bool allow_deep_scrub,
   return false;
 }
 
-bool PG::verify_periodic_scrub_mode(bool allow_deep_scrub,
-			      bool try_to_auto_repair,
-			      bool allow_regular_scrub,
-			      bool has_deep_errors,
-			      requested_scrub_t& planned) const
+/*
+ clang-format off
+
+   Request details    |  none    |  no-scrub  | no-scrub+no-deep | no-deep
+   ------------------------------------------------------------------------
+   ------------------------------------------------------------------------
+   initiated          |  shallow |  shallow   |  shallow         | shallow
+   ------------------------------------------------------------------------
+   init. + t.f.deep   |  deep    |  deep      |  shallow         | shallow
+   ------------------------------------------------------------------------
+   initiated deep     |  deep    |  deep      |  deep            | deep
+   ------------------------------------------------------------------------
+
+ clang-format on
+*/
+std::optional<requested_scrub_t> PG::validate_initiated_scrub(
+  bool allow_deep_scrub,
+  bool try_to_auto_repair,
+  bool time_for_deep,
+  bool has_deep_errors,
+  const requested_scrub_t& planned) const
+{
+  requested_scrub_t upd_flags{planned};
+
+  upd_flags.time_for_deep = time_for_deep;
+  upd_flags.deep_scrub_on_error = false;
+  upd_flags.auto_repair = false;  // will only be considered for periodic scrubs
+
+  if (upd_flags.must_deep_scrub) {
+    upd_flags.calculated_to_deep = true;
+  } else if (upd_flags.time_for_deep && allow_deep_scrub) {
+    upd_flags.calculated_to_deep = true;
+  } else {
+    upd_flags.calculated_to_deep = false;
+    if (has_deep_errors) {
+      osd->clog->error() << fmt::format(
+	"osd.{} pg {} Regular scrub request, deep-scrub details will be lost",
+	osd->whoami,
+	info.pgid);
+    }
+  }
+
+  return upd_flags;
+}
+
+/*
+ clang-format off
+
+   for periodic scrubs:
+
+   Periodic  type     |  none    |  no-scrub  | no-scrub+no-deep | no-deep
+   ------------------------------------------------------------------------
+   ------------------------------------------------------------------------
+   periodic           |  shallow |  x         |  x               | shallow
+   ------------------------------------------------------------------------
+   periodic + t.f.deep|  deep    |  deep      |  x               | shallow
+   ------------------------------------------------------------------------
+
+ clang-format on
+*/
+std::optional<requested_scrub_t> PG::validate_periodic_mode(
+  bool allow_deep_scrub,
+  bool try_to_auto_repair,
+  bool allow_shallow_scrub,
+  bool time_for_deep,
+  bool has_deep_errors,
+  const requested_scrub_t& planned) const
 
 {
   ceph_assert(!planned.must_deep_scrub && !planned.must_repair);
 
   if (!allow_deep_scrub && has_deep_errors) {
-      osd->clog->error()
-	<< "osd." << osd->whoami << " pg " << info.pgid
-	<< " Regular scrub skipped due to deep-scrub errors and nodeep-scrub set";
-      return false;
+    osd->clog->error()
+      << "osd." << osd->whoami << " pg " << info.pgid
+      << " Regular scrub skipped due to deep-scrub errors and nodeep-scrub set";
+    return std::nullopt;  // no scrubbing
   }
 
-  if (allow_deep_scrub) {
-    // Initial entry and scheduled scrubs without nodeep_scrub set get here
+  requested_scrub_t upd_flags{planned};
 
-    planned.time_for_deep =
-      is_time_for_deep(allow_deep_scrub, allow_regular_scrub, has_deep_errors, planned);
+  upd_flags.time_for_deep = time_for_deep;
+  upd_flags.deep_scrub_on_error = false;
+  upd_flags.auto_repair = false;
+  upd_flags.calculated_to_deep = false;
 
-    if (try_to_auto_repair) {
-      if (planned.time_for_deep) {
-	dout(20) << __func__ << ": auto repair with deep scrubbing" << dendl;
-	planned.auto_repair = true;
-      } else if (allow_regular_scrub) {
-	dout(20) << __func__ << ": auto repair with scrubbing, rescrub if errors found"
+  dout(20) << fmt::format("{}: allowed:{}/{} t.f.d:{} req:{}",
+			  __func__,
+			  allow_shallow_scrub,
+			  allow_deep_scrub,
+			  upd_flags.time_for_deep,
+			  planned)
+	   << dendl;
+
+  // should we perform a shallow scrub?
+  if (allow_shallow_scrub) {
+    if (!upd_flags.time_for_deep || !allow_deep_scrub) {
+      if (try_to_auto_repair) {
+	dout(10) << __func__
+		 << ": auto repair with scrubbing, rescrub if errors found"
 		 << dendl;
-	planned.deep_scrub_on_error = true;
+	upd_flags.deep_scrub_on_error = true;
       }
+      dout(20) << __func__ << " will do shallow scrub (time_for_deep = "
+	       << upd_flags.time_for_deep << ")" << dendl;
+      return upd_flags;
     }
+    // else - either deep-scrub or nothing
   }
 
-  dout(20) << __func__ << " updated flags: " << planned
-	   << " allow_regular_scrub: " << allow_regular_scrub << dendl;
-
-  // NOSCRUB so skip regular scrubs
-  if (!allow_regular_scrub && !planned.time_for_deep) {
-    return false;
+  if (upd_flags.time_for_deep) {
+    if (allow_deep_scrub) {
+      if (try_to_auto_repair) {
+	dout(20) << __func__ << ": auto repair with deep scrubbing" << dendl;
+	upd_flags.auto_repair = true;
+      }
+      upd_flags.calculated_to_deep = true;
+      dout(20) << fmt::format("{}: final: {}", __func__, upd_flags) << dendl;
+      return upd_flags;
+    }
+    if (allow_shallow_scrub) {
+      dout(20) << fmt::format("{}: final:{}", __func__, upd_flags) << dendl;
+      return upd_flags;
+    }
+    return std::nullopt;
   }
 
-  return true;
+  return std::nullopt;	// no scrubbing
 }
 
-std::optional<requested_scrub_t> PG::verify_scrub_mode() const
+
+/*
+ From docs.ceph.com (osd-internals/scrub):
+
+ clang-format off
+
+   Desired no-scrub flags & scrub type interactions:
+
+   Periodic  type     |  none    |  no-scrub  | no-scrub+no-deep | no-deep
+   ------------------------------------------------------------------------
+   ------------------------------------------------------------------------
+   periodic           |  shallow |  x         |  x               | shallow
+   ------------------------------------------------------------------------
+   periodic + t.f.deep|  deep    |  deep      |  x               | shallow
+   ------------------------------------------------------------------------
+   initiated          |  shallow |  shallow   |  shallow         | shallow
+   ------------------------------------------------------------------------
+   init. + t.f.deep   |  deep    |  deep      |  shallow         | shallow
+   ------------------------------------------------------------------------
+   initiated deep     |  deep    |  deep      |  deep            | deep
+   ------------------------------------------------------------------------
+
+   "periodic" - if !must_scrub && !must_deep_scrub;
+   "initiated deep" - if must_scrub && must_deep_scrub;
+   "initiated" - if must_scrub && !must_deep_scrub;
+
+ clang-format on
+*/
+/*
+ *  The returned flags collection (requested_scrub_t) is based on
+ *   m_planned_scrub with the following modifications:
+ *
+ *   - calculated_to_deep will be set to shallow or deep, depending on the
+ *     scrub type (according to the decision table above);
+ *   - deep_scrub_on_error will be determined;
+ *   - same for auto_repair;
+ *   - time_for_deep will be set to true if the scrub is periodic and the
+ *     time for a deep scrub has been reached (+ some other conditions);
+ *   and
+ *   - need_auto is cleared
+ */
+std::optional<requested_scrub_t> PG::validate_scrub_mode() const
 {
-  const bool allow_regular_scrub =
+  const bool allow_shallow_scrub =
     !(get_osdmap()->test_flag(CEPH_OSDMAP_NOSCRUB) ||
       pool.info.has_flag(pg_pool_t::FLAG_NOSCRUB));
   const bool allow_deep_scrub =
-    allow_regular_scrub &&
     !(get_osdmap()->test_flag(CEPH_OSDMAP_NODEEP_SCRUB) ||
       pool.info.has_flag(pg_pool_t::FLAG_NODEEP_SCRUB));
   const bool has_deep_errors = (info.stats.stats.sum.num_deep_scrub_errors > 0);
   const bool try_to_auto_repair = (cct->_conf->osd_scrub_auto_repair &&
-                                   get_pgbackend()->auto_repair_supported());
+				   get_pgbackend()->auto_repair_supported());
 
   dout(10) << __func__ << " pg: " << info.pgid
-           << " allow: " << allow_regular_scrub << "/" << allow_deep_scrub
-           << " deep errs: " << has_deep_errors
-           << " auto-repair: " << try_to_auto_repair << " ("
-           << cct->_conf->osd_scrub_auto_repair << ")" << dendl;
-
-  auto upd_flags = m_planned_scrub;
-
-  upd_flags.time_for_deep = false;
-  // Clear these in case user issues the scrub/repair command during
-  // the scheduling of the scrub/repair (e.g. request reservation)
-  upd_flags.deep_scrub_on_error = false;
-  upd_flags.auto_repair = false;
-
-  if (upd_flags.must_scrub && !upd_flags.must_deep_scrub && has_deep_errors) {
-    osd->clog->error()
-      << "osd." << osd->whoami << " pg " << info.pgid
-      << " Regular scrub request, deep-scrub details will be lost";
-  }
-
-  if (!upd_flags.must_scrub) {
-    // All periodic scrub handling goes here because must_scrub is
-    // always set for must_deep_scrub and must_repair.
-
-    const bool can_start_periodic = verify_periodic_scrub_mode(
-      allow_deep_scrub, try_to_auto_repair, allow_regular_scrub,
-      has_deep_errors, upd_flags);
-    if (!can_start_periodic) {
-      // "I don't want no scrub"
-      dout(20) << __func__ << ": no periodic scrubs allowed" << dendl;
-      return std::nullopt;
-    }
-  }
+	   << " allow: " << allow_shallow_scrub << "/" << allow_deep_scrub
+	   << " deep errs: " << has_deep_errors
+	   << " auto-repair: " << try_to_auto_repair << " ("
+	   << cct->_conf->osd_scrub_auto_repair << ")" << dendl;
 
   //  scrubbing while recovering?
-
-  bool prevented_by_recovery =
+  const bool prevented_by_recovery =
     osd->is_recovery_active() && !cct->_conf->osd_scrub_during_recovery &&
-    (!cct->_conf->osd_repair_during_recovery || !upd_flags.must_repair);
+    (!cct->_conf->osd_repair_during_recovery || !m_planned_scrub.must_repair);
 
   if (prevented_by_recovery) {
     dout(20) << __func__ << ": scrubbing prevented during recovery" << dendl;
     return std::nullopt;
   }
 
-  upd_flags.need_auto = false;
+  const bool time_for_deep = is_time_for_deep(allow_deep_scrub,
+					      allow_shallow_scrub,
+					      has_deep_errors,
+					      m_planned_scrub);
+  std::optional<requested_scrub_t> upd_flags;
+
+  if (m_planned_scrub.must_scrub) {
+    upd_flags = validate_initiated_scrub(allow_deep_scrub,
+					 try_to_auto_repair,
+					 time_for_deep,
+					 has_deep_errors,
+					 m_planned_scrub);
+  } else {
+    ceph_assert(!m_planned_scrub.must_deep_scrub);
+    upd_flags = validate_periodic_mode(allow_deep_scrub,
+				       try_to_auto_repair,
+				       allow_shallow_scrub,
+				       time_for_deep,
+				       has_deep_errors,
+				       m_planned_scrub);
+    if (!upd_flags) {
+      dout(20) << __func__ << ": no periodic scrubs allowed" << dendl;
+      return std::nullopt;
+    }
+  }
+
+  dout(10) << fmt::format("{}: next scrub flags: {}", __func__, *upd_flags)
+	   << dendl;
+  upd_flags->need_auto = false;
   return upd_flags;
 }
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -717,23 +717,32 @@ private:
 
   /// should we perform deep scrub?
   bool is_time_for_deep(bool allow_deep_scrub,
-		        bool allow_scrub,
-		        bool has_deep_errors,
-		        const requested_scrub_t& planned) const;
+                        bool allow_shallow_scrub,
+                        bool has_deep_errors,
+                        const requested_scrub_t& planned) const;
 
   /**
-   * Verify the various 'next scrub' flags in m_planned_scrub against configuration
+   * Validate the various 'next scrub' flags in m_planned_scrub against configuration
    * and scrub-related timestamps.
    *
    * @returns an updated copy of the m_planned_flags (or nothing if no scrubbing)
    */
-  std::optional<requested_scrub_t> verify_scrub_mode() const;
+  std::optional<requested_scrub_t> validate_scrub_mode() const;
 
-  bool verify_periodic_scrub_mode(bool allow_deep_scrub,
-				  bool try_to_auto_repair,
-				  bool allow_regular_scrub,
-				  bool has_deep_errors,
-				  requested_scrub_t& planned) const;
+  std::optional<requested_scrub_t> validate_periodic_mode(
+    bool allow_deep_scrub,
+    bool try_to_auto_repair,
+    bool allow_shallow_scrub,
+    bool time_for_deep,
+    bool has_deep_errors,
+    const requested_scrub_t& planned) const;
+
+  std::optional<requested_scrub_t> validate_initiated_scrub(
+    bool allow_deep_scrub,
+    bool try_to_auto_repair,
+    bool time_for_deep,
+    bool has_deep_errors,
+    const requested_scrub_t& planned) const;
 
   using ScrubAPI = void (ScrubPgIF::*)(epoch_t epoch_queued);
   void forward_scrub_event(ScrubAPI fn, epoch_t epoch_queued, std::string_view desc);

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -431,7 +431,7 @@ class PgScrubber : public ScrubPgIF,
    * flag-set; PG_STATE_SCRUBBING, and possibly PG_STATE_DEEP_SCRUB &
    * PG_STATE_REPAIR are set.
    */
-  void set_op_parameters(requested_scrub_t& request) final;
+  void set_op_parameters(const requested_scrub_t& request) final;
 
   void cleanup_store(ObjectStore::Transaction* t) final;
 


### PR DESCRIPTION
Fix no-scrub & nodeep-scrub related code to match requirements:
- deep scrubs should be allowed to execute when no-scrub is set;
- some initiated scrubs (i.e. not periodic ones) might be changed
  from the requested 'deep' to 'shallow'.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
