### PR TITLE
mgr/cephadm: fixing scheduler consistent hashing

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -879,7 +879,7 @@ class NodeAssignmentTest5(NamedTuple):
 
 
 @pytest.mark.parametrize("service_type, placement, available_hosts, expected_candidates",
-    [
+    [   # noqa: E128
         NodeAssignmentTest5(
             'alertmanager',
             PlacementSpec(hosts='host1 host2 host3 host4'.split()),


### PR DESCRIPTION
https://tracker.ceph.com/issues/56415
(related https://tracker.ceph.com/issues/55879)

cephadm used to distribute the load randomly across the cluster (when creating new daemons) but this was broken by the change: https://github.com/ceph/ceph/commit/adceaa9b28278601c56a7db1c3f42eaa592ec4d1 (introduced as part of the PR https://github.com/ceph/ceph/pull/41007). So all versions containing this change suffer from this issue.

As consequence, right now cephadm uses static placement where daemons are placed mostly on the 'root' node (used to bootstrap the cluster) creating a hotspot on this node. In case of a count >=2 the next node on the list is selected and so on.

As part of this PR:

1.  I'm fixing the _consistent hashing_ (in fact it's a different,  simpler algorithm but similar to consistent hashing) 
2. Adding some new UT to make sure we are testing the pseudo-random distribution (wasn't tested in the current UT)
3. Removing a small code portion that doesn't affect the behavior
4. Moving a UT table to the corresponding place (just cosmetic change, not related with this PR)

====================== **Testing** ======================
To test the fix I basically tested the same load with main branch (without the fix) and with the fix. The test consists in: 

1. boostreap a **cluster of 4 nodes** 
2. create several daemons of different services using **count=2**
3. check the cluster state to see how daemons are distributed
4. scale down the number of daemons to **count=1**
3. check the cluster state to see how daemons are now distributed

Following is the daemons list used to perform the testing:

```
ceph orch apply alertmanager 2
ceph orch apply grafana 2
ceph orch apply prometheus 2
ceph orch apply cephfs-mirror 2
ceph orch apply rbd-mirror 2
ceph orch apply rgw
ceph fs volume create foofs
ceph nfs cluster create foo --ingress --virtual-ip 192.168.100.111/24 --port 2049
```

=========== **Testing on main branch (WITHOUT  the fix)** 

```
1) --> daemons count per node after fresh installation

   [ceph: root@ceph-node-0 /]# for i in `seq 0 3`; do echo ceph-node-$i; ceph orch ps | grep ceph-node-$i | wc -l; done
   ceph-node-0   8
   ceph-node-1   5
   ceph-node-2   4
   ceph-node-3   4

2)  daemons count per node after creating some daemons (see above)

   [ceph: root@ceph-node-0 /]# for i in `seq 0 3`; do echo ceph-node-$i; ceph orch ps | grep ceph-node-$i | wc -l; done
   ceph-node-0   15
   ceph-node-1   14
   ceph-node-2   4
   ceph-node-3   4

3)  daemons count per node after scaling down some daemons to 1

   [ceph: root@ceph-node-0 /]# for i in `seq 0 3`; do echo ceph-node-$i; ceph orch ps | grep ceph-node-$i | wc -l; done
   ceph-node-0   14
   ceph-node-1   10
   ceph-node-2   4
   ceph-node-3   4

```

=========== **Testing a branch which includes the fix** 

```
1) --> daemons count per node after fresh installation

   [ceph: root@ceph-node-0 /]# for i in `seq 0 3`; do echo ceph-node-$i; ceph orch ps | grep ceph-node-$i | wc -l; done
   ceph-node-0   7
   ceph-node-1   4
   ceph-node-2   5
   ceph-node-3   5

2)  daemons count per node after creating some daemons (see above)

   [ceph: root@ceph-node-0 /]# for i in `seq 0 3`; do echo ceph-node-$i; ceph orch ps | grep ceph-node-$i | wc -l; done
   ceph-node-0   8
   ceph-node-1   8
   ceph-node-2   11
   ceph-node-3   10

1)  daemons count per node after scaling down some daemons to 1 and

   [ceph: root@ceph-node-0 /]# for i in `seq 0 3`; do echo ceph-node-$i; ceph orch ps | grep ceph-node-$i | wc -l; done
   ceph-node-0   7
   ceph-node-1   8
   ceph-node-2   9
   ceph-node-3   8

```


Signed-off-by: Redouane Kachach <rkachach@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
