### PR TITLE
ceph-volume: allow symlinks as devices

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -73,7 +73,8 @@ def get_physical_osds(devices, args):
                                      abs_size,
                                      args.osds_per_device,
                                      osd_id,
-                                     'dmcrypt' if args.dmcrypt else None))
+                                     'dmcrypt' if args.dmcrypt else None,
+                                     dev.symlink))
     return ret
 
 
@@ -568,7 +569,8 @@ class Batch(object):
                      abs_size,
                      slots,
                      id_,
-                     encryption):
+                     encryption,
+                     symlink=None):
             self.id_ = id_
             self.data = self.VolSpec(path=data_path,
                                 rel_size=rel_size,
@@ -578,6 +580,7 @@ class Batch(object):
             self.fast = None
             self.very_fast = None
             self.encryption = encryption
+            self.symlink = symlink
 
         def add_fast_device(self, path, rel_size, abs_size, slots, type_):
             self.fast = self.VolSpec(path=path,
@@ -629,9 +632,12 @@ class Batch(object):
             if self.encryption:
                 report += templates.osd_encryption.format(
                     enc=self.encryption)
+            path = self.data.path
+            if self.symlink:
+                path = f'{self.symlink} -> {self.data.path}'
             report += templates.osd_component.format(
                 _type=self.data.type_,
-                path=self.data.path,
+                path=path,
                 size=self.data.abs_size,
                 percent=self.data.rel_size)
             if self.fast:

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -171,8 +171,8 @@ class Zap(object):
         pv = api.get_single_pv(filters={'lv_uuid': lv.lv_uuid})
         self.unmount_lv(lv)
 
-        wipefs(device.abspath)
-        zap_data(device.abspath)
+        wipefs(device.path)
+        zap_data(device.path)
 
         if self.args.destroy:
             lvs = api.get_lvs(filters={'vg_name': device.vg_name})
@@ -188,8 +188,8 @@ class Zap(object):
                 mlogger.info('More than 1 LV left in VG, will proceed to '
                              'destroy LV only')
                 mlogger.info('Removing LV because --destroy was given: %s',
-                             device.abspath)
-                api.remove_lv(device.abspath)
+                             device.path)
+                api.remove_lv(device.path)
         elif lv:
             # just remove all lvm metadata, leaving the LV around
             lv.clear_tags()
@@ -209,15 +209,15 @@ class Zap(object):
                 if os.path.realpath(mapper_path) in holders:
                     self.dmcrypt_close(mapper_uuid)
 
-        if system.device_is_mounted(device.abspath):
-            mlogger.info("Unmounting %s", device.abspath)
-            system.unmount(device.abspath)
+        if system.device_is_mounted(device.path):
+            mlogger.info("Unmounting %s", device.path)
+            system.unmount(device.path)
 
-        wipefs(device.abspath)
-        zap_data(device.abspath)
+        wipefs(device.path)
+        zap_data(device.path)
 
         if self.args.destroy:
-            mlogger.info("Destroying partition since --destroy was used: %s" % device.abspath)
+            mlogger.info("Destroying partition since --destroy was used: %s" % device.path)
             disk.remove_partition(device)
 
     def zap_lvm_member(self, device):
@@ -230,7 +230,7 @@ class Zap(object):
         """
         for lv in device.lvs:
             if lv.lv_name:
-                mlogger.info('Zapping lvm member {}. lv_path is {}'.format(device.abspath, lv.lv_path))
+                mlogger.info('Zapping lvm member {}. lv_path is {}'.format(device.path, lv.lv_path))
                 self.zap_lv(Device(lv.lv_path))
             else:
                 vg = api.get_single_vg(filters={'vg_name': lv.vg_name})
@@ -259,15 +259,15 @@ class Zap(object):
         for part_name in device.sys_api.get('partitions', {}).keys():
             self.zap_partition(Device('/dev/%s' % part_name))
 
-        wipefs(device.abspath)
-        zap_data(device.abspath)
+        wipefs(device.path)
+        zap_data(device.path)
 
     @decorators.needs_root
     def zap(self, devices=None):
         devices = devices or self.args.devices
 
         for device in devices:
-            mlogger.info("Zapping: %s", device.abspath)
+            mlogger.info("Zapping: %s", device.path)
             if device.is_mapper and not device.is_mpath:
                 terminal.error("Refusing to zap the mapper device: {}".format(device))
                 raise SystemExit(1)

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -63,6 +63,7 @@ def mock_device():
     dev.path = '/dev/foo'
     dev.vg_name = 'vg_foo'
     dev.lv_name = 'lv_foo'
+    dev.symlink = None
     dev.vgs = [lvm.VolumeGroup(vg_name=dev.vg_name, lv_name=dev.lv_name)]
     dev.available_lvm = True
     dev.vg_size = [21474836480]

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_migrate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_migrate.py
@@ -69,7 +69,7 @@ class TestFindAssociatedDevices(object):
 
         result = migrate.find_associated_devices(osd_id='0', osd_fsid='1234')
         assert len(result) == 1
-        assert result[0][0].abspath == '/dev/VolGroup/lv1'
+        assert result[0][0].path == '/dev/VolGroup/lv1'
         assert result[0][0].lvs == [vol]
         assert result[0][1] == 'block'
 
@@ -96,10 +96,10 @@ class TestFindAssociatedDevices(object):
         assert len(result) == 2
         for d in result:
           if d[1] == 'block':
-            assert d[0].abspath == '/dev/VolGroup/lv1'
+            assert d[0].path == '/dev/VolGroup/lv1'
             assert d[0].lvs == [vol]
           elif d[1] == 'wal':
-            assert d[0].abspath == '/dev/VolGroup/lv2'
+            assert d[0].path == '/dev/VolGroup/lv2'
             assert d[0].lvs == [vol2]
           else:
             assert False
@@ -133,13 +133,13 @@ class TestFindAssociatedDevices(object):
         assert len(result) == 3
         for d in result:
           if d[1] == 'block':
-            assert d[0].abspath == '/dev/VolGroup/lv1'
+            assert d[0].path == '/dev/VolGroup/lv1'
             assert d[0].lvs == [vol]
           elif d[1] == 'wal':
-            assert d[0].abspath == '/dev/VolGroup/lv2'
+            assert d[0].path == '/dev/VolGroup/lv2'
             assert d[0].lvs == [vol2]
           elif d[1] == 'db':
-            assert d[0].abspath == '/dev/VolGroup/lv3'
+            assert d[0].path == '/dev/VolGroup/lv3'
             assert d[0].lvs == [vol3]
           else:
             assert False

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_zap.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_zap.py
@@ -69,7 +69,7 @@ class TestFindAssociatedDevices(object):
         monkeypatch.setattr(process, 'call', lambda x, **kw: ('', '', 0))
 
         result = zap.find_associated_devices(osd_id='0')
-        assert result[0].abspath == '/dev/VolGroup/lv'
+        assert result[0].path == '/dev/VolGroup/lv'
 
     def test_lv_is_matched_fsid(self, monkeypatch):
         tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,' +\
@@ -82,7 +82,7 @@ class TestFindAssociatedDevices(object):
         monkeypatch.setattr(process, 'call', lambda x, **kw: ('', '', 0))
 
         result = zap.find_associated_devices(osd_fsid='asdf-lkjh')
-        assert result[0].abspath == '/dev/VolGroup/lv'
+        assert result[0].path == '/dev/VolGroup/lv'
 
     def test_lv_is_matched_id_fsid(self, monkeypatch):
         tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,' +\
@@ -95,7 +95,7 @@ class TestFindAssociatedDevices(object):
         monkeypatch.setattr(process, 'call', lambda x, **kw: ('', '', 0))
 
         result = zap.find_associated_devices(osd_id='0', osd_fsid='asdf-lkjh')
-        assert result[0].abspath == '/dev/VolGroup/lv'
+        assert result[0].path == '/dev/VolGroup/lv'
 
 
 class TestEnsureAssociatedLVs(object):

--- a/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
@@ -88,7 +88,7 @@ class TestValidDevice(object):
         lsblk = {"TYPE": "disk", "NAME": "sda"}
         device_info(lsblk=lsblk)
         result = self.validator('/dev/sda')
-        assert result.abspath == '/dev/sda'
+        assert result.path == '/dev/sda'
 
     @patch('ceph_volume.util.arg_validators.disk.has_bluestore_label', return_value=False)
     def test_path_is_invalid(self, m_has_bs_label,

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -277,6 +277,40 @@ class TestDevice(object):
         assert not disk.available
 
     @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
+    @patch('ceph_volume.util.device.os.path.realpath')
+    @patch('ceph_volume.util.device.os.path.islink')
+    def test_accept_symlink_to_device(self,
+                                      m_os_path_islink,
+                                      m_os_path_realpath,
+                                      device_info,
+                                      fake_call):
+        m_os_path_islink.return_value = True
+        m_os_path_realpath.return_value = '/dev/sdb'
+        data = {"/dev/sdb": {"ro": 0, "size": 5368709120}}
+        lsblk = {"TYPE": "disk"}
+        device_info(devices=data,lsblk=lsblk)
+        disk = device.Device("/dev/test_symlink")
+        print(disk)
+        print(disk.sys_api)
+        assert disk.available
+
+    @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
+    @patch('ceph_volume.util.device.os.readlink')
+    @patch('ceph_volume.util.device.os.path.islink')
+    def test_reject_symlink_to_device_mapper(self,
+                                             m_os_path_islink,
+                                             m_os_readlink,
+                                             device_info,
+                                             fake_call):
+        m_os_path_islink.return_value = True
+        m_os_readlink.return_value = '/dev/dm-0'
+        data = {"/dev/mapper/mpatha": {"ro": 0, "size": 5368709120}}
+        lsblk = {"TYPE": "disk"}
+        device_info(devices=data,lsblk=lsblk)
+        disk = device.Device("/dev/mapper/mpatha")
+        assert disk.available
+
+    @patch("ceph_volume.util.disk.has_bluestore_label", lambda x: False)
     def test_reject_readonly_device(self, fake_call, device_info):
         data = {"/dev/cdrom": {"ro": 1}}
         lsblk = {"TYPE": "disk", "NAME": "cdrom"}

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -420,7 +420,7 @@ class TestDevice(object):
         # low-level behavior of has_bluestore_label
         with patch.object(device.Device, "__init__", lambda self, path, with_lsm=False: None):
             disk = device.Device("/dev/sda")
-            disk.abspath = "/dev/sda"
+            disk.path = "/dev/sda"
             with patch('builtins.open', mock_open(read_data=b'bluestore block device\n')):
                 assert disk.has_bluestore_label
             with patch('builtins.open', mock_open(read_data=b'not a bluestore block device\n')):

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -99,6 +99,15 @@ class Device(object):
 
     def __init__(self, path, with_lsm=False, lvs=None, lsblk_all=None, all_devices_vgs=None):
         self.path = path
+        # LVs can have a vg/lv path, while disks will have /dev/sda
+        self.symlink = None
+        # check if we are a symlink
+        if os.path.islink(self.path):
+            self.symlink = self.path
+            real_path = os.path.realpath(self.path)
+            # check if we are not a device mapper
+            if "dm-" not in real_path:
+                self.path = real_path
         if not sys_info.devices:
             sys_info.devices = disk.get_devices()
         self.sys_api = sys_info.devices.get(self.path, {})

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -99,11 +99,9 @@ class Device(object):
 
     def __init__(self, path, with_lsm=False, lvs=None, lsblk_all=None, all_devices_vgs=None):
         self.path = path
-        # LVs can have a vg/lv path, while disks will have /dev/sda
-        self.abspath = path
         if not sys_info.devices:
             sys_info.devices = disk.get_devices()
-        self.sys_api = sys_info.devices.get(self.abspath, {})
+        self.sys_api = sys_info.devices.get(self.path, {})
         self.partitions = self._get_partitions()
         self.lv_api = None
         self.lvs = [] if not lvs else lvs
@@ -169,7 +167,7 @@ class Device(object):
         lv = None
         if not self.sys_api:
             # if no device was found check if we are a partition
-            partname = self.abspath.split('/')[-1]
+            partname = self.path.split('/')[-1]
             for device, info in sys_info.devices.items():
                 part = info['partitions'].get(partname, {})
                 if part:
@@ -200,7 +198,7 @@ class Device(object):
         if lv:
             self.lv_api = lv
             self.lvs = [lv]
-            self.abspath = lv.lv_path
+            self.path = lv.lv_path
             self.vg_name = lv.vg_name
             self.lv_name = lv.name
             self.ceph_device = lvm.is_ceph_device(lv)
@@ -231,7 +229,7 @@ class Device(object):
             prefix = 'Partition'
         elif self.is_device:
             prefix = 'Raw Device'
-        return '<%s: %s>' % (prefix, self.abspath)
+        return '<%s: %s>' % (prefix, self.path)
 
     def pretty_report(self):
         def format_value(v):
@@ -263,7 +261,7 @@ class Device(object):
 
     def report(self):
         return report_template.format(
-            dev=self.abspath,
+            dev=self.path,
             size=self.size_human,
             rot=self.rotational,
             available=self.available,
@@ -283,7 +281,7 @@ class Device(object):
         """
         props = ['ID_VENDOR', 'ID_MODEL', 'ID_MODEL_ENC', 'ID_SERIAL_SHORT', 'ID_SERIAL',
                  'ID_SCSI_SERIAL']
-        p = disk.udevadm_property(self.abspath, props)
+        p = disk.udevadm_property(self.path, props)
         if p.get('ID_MODEL','').startswith('LVM PV '):
             p['ID_MODEL'] = p.get('ID_MODEL_ENC', '').replace('\\x20', ' ').strip()
         if 'ID_VENDOR' in p and 'ID_MODEL' in p and 'ID_SCSI_SERIAL' in p:
@@ -312,7 +310,7 @@ class Device(object):
             # VGs, should we consider it as part of LVM? We choose not to
             # here, because most likely, we need to use VGs from this PV.
             self._is_lvm_member = False
-            device_to_check = [self.abspath]
+            device_to_check = [self.path]
             device_to_check.extend(self.partitions)
 
             # a pv can only be in one vg, so this should be safe
@@ -338,14 +336,14 @@ class Device(object):
         partition. Return a list of paths to be checked for a pv.
         """
         partitions = []
-        path_dir = os.path.dirname(self.abspath)
+        path_dir = os.path.dirname(self.path)
         for partition in self.sys_api.get('partitions', {}).keys():
             partitions.append(os.path.join(path_dir, partition))
         return partitions
 
     @property
     def exists(self):
-        return os.path.exists(self.abspath)
+        return os.path.exists(self.path)
 
     @property
     def has_fs(self):
@@ -422,7 +420,7 @@ class Device(object):
 
     @property
     def has_bluestore_label(self):
-        return disk.has_bluestore_label(self.abspath)
+        return disk.has_bluestore_label(self.path)
 
     @property
     def is_mapper(self):
@@ -493,7 +491,7 @@ class Device(object):
         elif self.is_partition:
             return 'crypto_LUKS' in crypt_reports
         elif self.is_mapper:
-            active_mapper = encryption_status(self.abspath)
+            active_mapper = encryption_status(self.path)
             if active_mapper:
                 # normalize a bit to ensure same values regardless of source
                 encryption_type = active_mapper['type'].lower().strip('12')  # turn LUKS1 or LUKS2 into luks
@@ -578,7 +576,7 @@ class Device(object):
         except OSError as e:
             # likely failed to open the device. assuming it is BlueStore is the safest option
             # so that a possibly-already-existing OSD doesn't get overwritten
-            logger.error('failed to determine if device {} is BlueStore. device should not be used to avoid false negatives. err: {}'.format(self.abspath, e))
+            logger.error('failed to determine if device {} is BlueStore. device should not be used to avoid false negatives. err: {}'.format(self.path, e))
             rejected.append('Failed to determine if device is BlueStore')
 
         if self.is_partition:
@@ -588,7 +586,7 @@ class Device(object):
             except OSError as e:
                 # likely failed to open the device. assuming the parent is BlueStore is the safest
                 # option so that a possibly-already-existing OSD doesn't get overwritten
-                logger.error('failed to determine if partition {} (parent: {}) has a BlueStore parent. partition should not be used to avoid false negatives. err: {}'.format(self.abspath, self.parent_device, e))
+                logger.error('failed to determine if partition {} (parent: {}) has a BlueStore parent. partition should not be used to avoid false negatives. err: {}'.format(self.path, self.parent_device, e))
                 rejected.append('Failed to determine if parent device is BlueStore')
 
         if self.has_gpt_headers:

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -134,10 +134,10 @@ def remove_partition(device):
 
     :param device: A ``Device()`` object
     """
-    udev_info = udevadm_property(device.abspath)
+    udev_info = udevadm_property(device.path)
     partition_number = udev_info.get('ID_PART_ENTRY_NUMBER')
     if not partition_number:
-        raise RuntimeError('Unable to detect the partition number for device: %s' % device.abspath)
+        raise RuntimeError('Unable to detect the partition number for device: %s' % device.path)
 
     process.run(
         ['parted', device.parent_device, '--script', '--', 'rm', partition_number]

--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -273,6 +273,6 @@ def legacy_encrypted(device):
     devices = [Device(i['NAME']) for i in device_family(parent_device)]
     for d in devices:
         if d.ceph_disk.type == 'lockbox':
-            metadata['lockbox'] = d.abspath
+            metadata['lockbox'] = d.path
             break
     return metadata


### PR DESCRIPTION
This MR creates ability to use symlinks as devices for ceph-volume.
One example of use will include usage of custom udev rules to map disk slots in enclosures to block device labels like:

/dev/data1 -> /dev/sda
/dev/data2 -> /dev/sdb

Fixes: https://tracker.ceph.com/issues/49103

Signed-off-by: Jan Sobczak <jsobczak@cloudferro.com>
Co-authored-by: Guillaume Abrioux <gabrioux@redhat.com>
