### PR TITLE
mgr/cephadm: check for events key before accessing it

### DIFF
--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -83,11 +83,16 @@ class TestNFS(MgrTestCase):
         '''
         event_occurred = False
         # Wait few seconds for NFS daemons' status to be updated
-        with contextutil.safe_while(sleep=10, tries=12, _raise=False) as proceed:
+        with contextutil.safe_while(sleep=10, tries=18, _raise=False) as proceed:
             while not event_occurred and proceed():
                 daemons_details = json.loads(
                     self._fetch_nfs_daemons_details(enable_json=True))
                 log.info('daemons details %s', daemons_details)
+                # 'events' key may not exist in the daemon description
+                # after a mgr fail over and could take some time to appear
+                # (it's populated on first daemon event)
+                if 'events' not in daemons_details[0]:
+                    continue
                 for event in daemons_details[0]['events']:
                     log.info('daemon event %s', event)
                     if expected_event in event:


### PR DESCRIPTION
This is an attempt to fix the issue. Current code assumes that `events` key always exists which is not correct as this key **is  optional** on the Daemon description and it's only populated once the first daemon event occurs. For example, after a mgr fail over this key doesn't exist. I'm also increasing the timeout to **3 min** instead of **2 min** as nfs daemon sometimes could take more than 2 min to get up&running (after a mgr fail over). 

Fixes: https://tracker.ceph.com/issues/55808
Signed-off-by: Redouane Kachach <rkachach@redhat.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
