### PR TITLE
mgr/cephadm: limiting ingress/keepalived pass to 8 chars

### DIFF
--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 class IngressService(CephService):
     TYPE = 'ingress'
+    MAX_KEEPALIVED_PASS_LEN = 8
 
     def primary_daemon_type(self) -> str:
         return 'haproxy'
@@ -77,7 +78,7 @@ class IngressService(CephService):
         password = self.mgr.get_store(pw_key)
         if password is None:
             if not spec.monitor_password:
-                password = ''.join(random.choice(string.ascii_lowercase) for _ in range(20))
+                password = ''.join(random.choice(string.ascii_lowercase) for _ in range(self.MAX_KEEPALIVED_PASS_LEN))
                 self.mgr.set_store(pw_key, password)
         else:
             if spec.monitor_password:
@@ -176,7 +177,7 @@ class IngressService(CephService):
         password = self.mgr.get_store(pw_key)
         if password is None:
             if not spec.keepalived_password:
-                password = ''.join(random.choice(string.ascii_lowercase) for _ in range(20))
+                password = ''.join(random.choice(string.ascii_lowercase) for _ in range(self.MAX_KEEPALIVED_PASS_LEN))
                 self.mgr.set_store(pw_key, password)
         else:
             if spec.keepalived_password:


### PR DESCRIPTION
https://tracker.ceph.com/issues/55491

In fact the limitation is not at `keepalived` level but [VRRP](https://datatracker.ietf.org/doc/html/rfc2338) protocol limitation

Authentication section from the generated file (`auth_pass` is now 8 chars len):

```
[root@ceph-node-0 ~]#    grep authentication -A 3 /var/lib/ceph/4fee27c0-f86b-11ec-a127-525400ebd66f/keepalived.nfs.test.ceph-node-0.abmwrh/keepalived.conf 
  authentication {
      auth_type PASS
      auth_pass paywbgcr
  }

```
No more `Truncating auth_pass to 8 characters`  is shown:

```
[root@ceph-node-0 ~]# journalctl -u ceph-4fee27c0-f86b-11ec-a127-525400ebd66f@keepalived.nfs.test.ceph-node-0.abmwrh.service | grep -i truncating
[root@ceph-node-0 ~]# 

```
Fixes: https://tracker.ceph.com/issues/55491
Signed-off-by: Redouane Kachach <rkachach@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
