### PR TITLE
quincy: librbd: update progress for non-existent objects on deep-copy

### DIFF
--- a/src/librbd/deep_copy/ImageCopyRequest.h
+++ b/src/librbd/deep_copy/ImageCopyRequest.h
@@ -109,7 +109,7 @@ private:
   void handle_compute_diff(int r);
 
   void send_object_copies();
-  int send_next_object_copy();
+  void send_next_object_copy();
   void handle_object_copy(uint64_t object_no, int r);
 
   void finish(int r);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56430

---

backport of https://github.com/ceph/ceph/pull/46858
parent tracker: https://tracker.ceph.com/issues/56181