### PR TITLE
quincy: rgw/dbstore: Fix build errors on centos9

### DIFF
--- a/src/rgw/store/dbstore/CMakeLists.txt
+++ b/src/rgw/store/dbstore/CMakeLists.txt
@@ -23,6 +23,7 @@ set(link_targets spawn)
 if(WITH_JAEGER)
   list(APPEND link_targets ${jaeger_base})
 endif()
+list(APPEND link_targets rgw_common)
 target_link_libraries(dbstore_lib PUBLIC ${link_targets})
 
 set (CMAKE_LINK_LIBRARIES ${CMAKE_LINK_LIBRARIES} dbstore_lib)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55495
cherry-picked from github.com/ceph/ceph/pull/46049

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
