### PR TITLE
.readthedocs.yml: Always build latest doc/releases pages

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,15 +1,23 @@
 ---
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+#
+# The pre_build command checks if we're building a named branch (i.e., not a PR).
+# If so, check out doc/releases from the main branch before building so
+# it's always up to date on docs.ceph.com/en/*.
 
 version: 2
 formats: []
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
   apt_packages:
     - ditaa
+  jobs:
+    pre_build:
+      - bash admin/rtd-checkout-main
 python:
-  version: 3.8
   install:
     - requirements: admin/doc-requirements.txt
     - requirements: admin/doc-read-the-docs.txt

--- a/admin/rtd-checkout-main
+++ b/admin/rtd-checkout-main
@@ -1,0 +1,6 @@
+# See .readthedocs.yml
+set -ex
+if git symbolic-ref HEAD; then
+  git checkout origin/main -- doc/releases
+fi
+git status


### PR DESCRIPTION
We don't backport PRs merged into doc/releases.  Therefore, when one browses to an older Ceph release version on docs.ceph.com (e.g., https://docs.ceph.com/en/pacific/), the information is out of date at best.

The doc/releases page is only accurate if browsing https://docs.ceph.com/en/latest/, for example.

So this post_checkout command will make sure we've checked out doc/releases from main before building and publishing.

Signed-off-by: David Galloway <dgallowa@redhat.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
