### PR TITLE
monitoring:package SNMP MIB file as an rpm

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1244,6 +1244,13 @@ Group:          System/Monitoring
 %description prometheus-alerts
 This package provides Ceph default alerts for Prometheus.
 
+%package mib
+Summary:        MIB for SNMP alerts
+BuildArch:      noarch
+Group:          System/Monitoring
+%description mib
+This package provides a Ceph MIB for SNMP traps.
+
 #################################################################################
 # common
 #################################################################################
@@ -1482,6 +1489,9 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rbd-mirror
 
 # prometheus alerts
 install -m 644 -D monitoring/ceph-mixin/prometheus_alerts.yml %{buildroot}/etc/prometheus/ceph/ceph_default_alerts.yml
+
+# SNMP MIB
+install -m 644 -D -p monitoring/snmp/CEPH-MIB.txt %{buildroot}/usr/share/snmp/mib
 
 %if 0%{?suse_version}
 # create __pycache__ directories and their contents
@@ -2561,5 +2571,9 @@ exit 0
 %endif
 %attr(0755,root,root) %dir %{_sysconfdir}/prometheus/ceph
 %config %{_sysconfdir}/prometheus/ceph/ceph_default_alerts.yml
+
+%files mib
+%attr(0755,root,root) %dir %{_datadir}/snmp
+%attr(0655,-,-,) %{_datadir}/snmp/mib
 
 %changelog

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1247,7 +1247,9 @@ This package provides Ceph default alerts for Prometheus.
 %package mib
 Summary:        MIB for SNMP alerts
 BuildArch:      noarch
+%if 0%{?suse_version}
 Group:          System/Monitoring
+%endif
 %description mib
 This package provides a Ceph MIB for SNMP traps.
 
@@ -1491,7 +1493,7 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rbd-mirror
 install -m 644 -D monitoring/ceph-mixin/prometheus_alerts.yml %{buildroot}/etc/prometheus/ceph/ceph_default_alerts.yml
 
 # SNMP MIB
-install -m 644 -D -p monitoring/snmp/CEPH-MIB.txt %{buildroot}/usr/share/snmp/mib
+install -m 644 -D -p monitoring/snmp/CEPH-MIB.txt %{buildroot}/${_datadir}/snmp/mibs
 
 %if 0%{?suse_version}
 # create __pycache__ directories and their contents
@@ -2574,6 +2576,6 @@ exit 0
 
 %files mib
 %attr(0755,root,root) %dir %{_datadir}/snmp
-%attr(0655,-,-,) %{_datadir}/snmp/mib
+%dir %{_datadir}/snmp/mibs
 
 %changelog


### PR DESCRIPTION
Adds a new subpackage 'ceph-mib' that installs the Ceph MIB file in a
standard location '/usr/share/snmp/CEPH-MIB.txt'. This allows users to
use their own snmp manager in order to receive events from Ceph

Fixes: https://tracker.ceph.com/issues/56433
Signed-off-by: Justin Caratzas jcaratza@redhat.com


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
