### PR TITLE
mgr/diskprediction_local: Support Python 3.9 for disk prediction module.

### DIFF
--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -54,7 +54,7 @@ class TestModuleSelftest(MgrTestCase):
         self._load_module("selftest")
         python_version = self.mgr_cluster.mon_manager.raw_cluster_cmd(
             "mgr", "self-test", "python-version")
-        if tuple(int(v) for v in python_version.split('.')) >= (3, 8):
+        if tuple(int(v) for v in python_version.split('.')) == (3, 8):
             # https://tracker.ceph.com/issues/45147
             self.skipTest(f'python {python_version} not compatible with '
                           'diskprediction_local')

--- a/src/common/options/CMakeLists.txt
+++ b/src/common/options/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 set(mgr_disabled_modules "")
 if(WITH_MGR)
   # https://tracker.ceph.com/issues/45147
-  if(Python3_VERSION VERSION_GREATER_EQUAL 3.8)
+  if(Python3_VERSION VERSION_EQUAL 3.8)
     set(mgr_disabled_modules "diskprediction_local")
     message(STATUS "mgr module disabled for ${Python3_VERSION}: ${mgr_disabled_modules}")
   endif()


### PR DESCRIPTION
mgr/diskprediction_local: Support Python 3.9 for disk prediction module.

I've been using the disk prediction module to keep track of the health data of my drives and monitor it regularly. Lately, they are showing as STALE and I realized the module was no longer available. Probably because the module requires Python 3.7 or earlier to run and the default version of Python for Debian Bullseye is 3.9. 

Debian is usually really careful when they upgrade to newer versions so for them to go to 3.9 and keep a stable branch there seems like a good indicator that upgrading the module to 3.9 too would be beneficial to some users.

This PR aims to update some of the module dependencies and change the required version of Python. I've run the unit tests and they pass for this code which is promising. I'm trying to test it in my test cluster and I'll return with more on that later.

I'm creating the PR here for discussion and to see if I perhaps have misunderstood the situation or missed some implementation detail.

Thank you for your time and keep up the great work.

Fixes: https://tracker.ceph.com/issues/50196
Signed-off-by: Daniel Persson <mailto.woden@gmail.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
