### PR TITLE
doc/cephfs/dirfrags: clarify the unit of threshold limits

### DIFF
--- a/doc/cephfs/dirfrags.rst
+++ b/doc/cephfs/dirfrags.rst
@@ -46,8 +46,8 @@ Size thresholds
 ===============
 
 A directory fragment is eligible for splitting when its size exceeds
-``mds_bal_split_size`` (default 10000).  Ordinarily this split is
-delayed by ``mds_bal_fragment_interval``, but if the fragment size
+``mds_bal_split_size`` (default 10000 directory entries).  Ordinarily this
+split is delayed by ``mds_bal_fragment_interval``, but if the fragment size
 exceeds a factor of ``mds_bal_fragment_fast_factor`` the split size,
 the split will happen immediately (holding up any client metadata
 IO on the directory).
@@ -58,14 +58,15 @@ ENOSPC errors if they try to create files in the fragment.  On
 a properly configured system, this limit should never be reached on
 ordinary directories, as they will have split long before.  By default,
 this is set to 10 times the split size, giving a dirfrag size limit of
-100000.  Increasing this limit may lead to oversized directory fragment
-objects in the metadata pool, which the OSDs may not be able to handle.
+100000 directory entries.  Increasing this limit may lead to oversized
+directory fragment objects in the metadata pool, which the OSDs may not
+be able to handle.
 
 A directory fragment is eligible for merging when its size is less
 than ``mds_bal_merge_size``.  There is no merge equivalent of the
 "fast splitting" explained above: fast splitting exists to avoid
 creating oversized directory fragments, there is no equivalent issue
-to avoid when merging.  The default merge size is 50.
+to avoid when merging.  The default merge size is 50 directory entries.
 
 Activity thresholds
 ===================
@@ -79,16 +80,19 @@ operations on directory fragments.  The decaying load counters have an
 exponential decay based on the ``mds_decay_halflife`` setting.
 
 On writes, the write counter is
-incremented, and compared with ``mds_bal_split_wr``, triggering a 
+incremented, and compared with ``mds_bal_split_wr``, triggering a
 split if the threshold is exceeded.  Write operations include metadata IO
-such as renames, unlinks and creations. 
+such as renames, unlinks and creations.
 
 The ``mds_bal_split_rd`` threshold is applied based on the read operation
 load counter, which tracks readdir operations.
 
-By the default, the read threshold is 25000 and the write threshold is
-10000, i.e. 2.5x as many reads as writes would be required to trigger
-a split.
+The ``mds_bal_split_rd`` and ``mds_bal_split_wr`` configs represent the
+popularity threshold. In the MDS these are measured as "read/write temperatures"
+which is closely related to the number of respective read/write operations.
+By default, the read threshold is 25000 operations and the write
+threshold is 10000 operations, i.e. 2.5x as many reads as writes would be
+required to trigger a split.
 
 After fragments are split due to the activity thresholds, they are only
 merged based on the size threshold (``mds_bal_merge_size``), so 


### PR DESCRIPTION
**Rationale:** There are many threshold limits for split and merge in this doc that just says like:
                 "A directory fragment is eligible for splitting when its size exceeds `mds_bal_split_size`
                 (default 10000)". Need to clarify what 10000 actually means. This applies to all other
                 such entries in this doc.

Signed-off-by: Dhairya Parmar <dparmar@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
