### PR TITLE
mon: Limit health detail message in the cluster log

### DIFF
--- a/qa/standalone/mon/mon-health-detail.sh
+++ b/qa/standalone/mon/mon-health-detail.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2022 Red Hat <contact@redhat.com>
+#
+# Author: Prashant D <pdhange@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7108" # git grep '\<7108\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+function TEST_health_detail_check_truncate() {
+    local dir=$1
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
+    run_osd $dir 3 || return 1
+    run_osd $dir 4 || return 1
+    run_osd $dir 5 || return 1
+
+    ceph osd erasure-code-profile set ec-profile m=2 k=2 crush-failure-domain=osd
+    ceph osd pool create ec 256 256 erasure ec-profile
+    wait_for_clean || 1
+    ceph config set mon mon_health_detail_check_message_max_bytes 1024
+    ceph config set mon mon_health_to_clog_interval 20
+
+    ceph osd set noup
+    ceph osd down 0
+    ceph osd down 1
+    ceph osd down 2
+    ceph osd down 3
+    ceph osd down 4
+    ceph osd down 5
+    sleep 60
+  
+    test "$(grep "<truncated>" $dir/log | wc -l)" -ge "1" || return 1
+}
+
+main mon-health-detail "$@"

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -290,6 +290,12 @@ options:
   desc: log health detail to cluster log
   default: true
   with_legacy: true
+- name: mon_health_detail_check_message_max_bytes
+  type: uint
+  level: advanced
+  desc: max health detail check message size in bytes
+  default: 8192
+  with_legacy: true
 - name: mon_warn_on_filestore_osds
   type: bool
   level: dev

--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -463,7 +463,8 @@ health_status_t HealthMonitor::get_health_status(
   Formatter *f,
   std::string *plain,
   const char *sep1,
-  const char *sep2)
+  const char *sep2,
+  bool truncate_detail)
 {
   health_check_map_t all;
   gather_all_health_checks(&all);
@@ -494,44 +495,47 @@ health_status_t HealthMonitor::get_health_status(
     f->close_section();
   } else {
     auto now = ceph_clock_now();
-    // one-liner: HEALTH_FOO[ thing1[; thing2 ...]]
-    string summary;
-    for (auto& p : all.checks) {
-      if (!mutes.count(p.first)) {
-	if (!summary.empty()) {
-	  summary += sep2;
-	}
-	summary += p.second.summary;
+    if (sep1 != nullptr &&
+        sep2 != nullptr) {
+      // one-liner: HEALTH_FOO[ thing1[; thing2 ...]]
+      string summary;
+      for (auto& p : all.checks) {
+        if (!mutes.count(p.first)) {
+          if (!summary.empty()) {
+            summary += sep2;
+          }
+          summary += p.second.summary;
+        }
       }
-    }
-    *plain = stringify(r);
-    if (summary.size()) {
-      *plain += sep1;
-      *plain += summary;
-    }
-    if (!mutes.empty()) {
+      *plain = stringify(r);
       if (summary.size()) {
-	*plain += sep2;
-      } else {
-	*plain += sep1;
+        *plain += sep1;
+        *plain += summary;
       }
-      *plain += "(muted:";
-      for (auto& p : mutes) {
-	*plain += " ";
-	*plain += p.first;
-	if (p.second.ttl) {
-	  if (p.second.ttl > now) {
-	    auto left = p.second.ttl;
-	    left -= now;
-	    *plain += "("s + utimespan_str(left) + ")";
-	  } else {
-	    *plain += "(0s)";
-	  }
-	}
+      if (!mutes.empty()) {
+        if (summary.size()) {
+          *plain += sep2;
+        } else {
+          *plain += sep1;
+        }
+        *plain += "(muted:";
+        for (auto& p : mutes) {
+          *plain += " ";
+          *plain += p.first;
+          if (p.second.ttl) {
+            if (p.second.ttl > now) {
+              auto left = p.second.ttl;
+              left -= now;
+              *plain += "("s + utimespan_str(left) + ")";
+            } else {
+              *plain += "(0s)";
+            }
+          }
+        }
+        *plain += ")";
       }
-      *plain += ")";
+      *plain += "\n";
     }
-    *plain += "\n";
     // detail
     if (want_detail) {
       for (auto& p : all.checks) {
@@ -555,11 +559,20 @@ health_status_t HealthMonitor::get_health_status(
 	}
 	*plain += "["s + short_health_string(p.second.severity) + "] " +
 	  p.first + ": " + p.second.summary + "\n";
+        size_t maxmsg_size = g_conf()->mon_health_detail_check_message_max_bytes;
+        string check_detail;
 	for (auto& d : p.second.detail) {
-	  *plain += "    ";
-	  *plain += d;
-	  *plain += "\n";
+	  check_detail += "    ";
+	  check_detail += d;
+	  check_detail += "\n";
 	}
+        if (truncate_detail &&
+            check_detail.size() > maxmsg_size) {
+          check_detail.resize(maxmsg_size);
+          check_detail += " ...<truncated>";
+          check_detail += "\n";
+        }
+        *plain += check_detail;
       }
     }
   }

--- a/src/mon/HealthMonitor.h
+++ b/src/mon/HealthMonitor.h
@@ -53,7 +53,8 @@ public:
     ceph::Formatter *f,
     std::string *plain,
     const char *sep1 = " ",
-    const char *sep2 = "; ");
+    const char *sep2 = "; ",
+    bool truncate_detail = false);
 
   /**
    * @} // HealthMonitor_Inherited_h

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -706,7 +706,8 @@ void MgrMonitor::send_digests()
     auto mdigest = make_message<MMgrDigest>();
 
     JSONFormatter f;
-    mon.healthmon()->get_health_status(true, &f, nullptr, nullptr, nullptr);
+    mon.healthmon()->get_health_status(true, &f, nullptr,
+                                       nullptr, nullptr);
     f.flush(mdigest->health_json);
     f.reset();
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2864,7 +2864,8 @@ void Monitor::do_health_to_clog(bool force)
       summary != health_status_cache.summary &&
       level != HEALTH_OK) {
     string details;
-    level = healthmon()->get_health_status(true, nullptr, &details);
+    level = healthmon()->get_health_status(true, nullptr, &details,
+                                           nullptr, nullptr, true);
     clog->health(level) << "Health detail: " << details;
   } else {
     clog->health(level) << "overall " << summary;


### PR DESCRIPTION
In case a particular health check message is too large
to dump in the cluster log; then it will lead to a
situation where MON(s) becomes unresponsive which further
results in mon quorum loss. While logging health detail
in the cluster log, truncate the health check message to
`mon_health_detail_check_message_max_bytes` to avoid
this scenario.

Fixes: https://tracker.ceph.com/issues/55693

Signed-off-by: Prashant D <pdhange@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
