### PR TITLE
mgr/dashboard: auto-coloring-badges-component

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/cd-label/cd-label.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/cd-label/cd-label.component.html
@@ -1,0 +1,11 @@
+<span *ngIf="!key; else key_value"
+      class="badge badge-{{value}}"
+      ngClass="{{value | colorClassFromText}}">
+  {{ value }}
+</span>
+
+<ng-template #key_value>
+  <span class="badge badge-background-primary badge-{{key}}-{{value}}">
+        {{ key }}: {{ value }}
+  </span>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/cd-label/cd-label.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/cd-label/cd-label.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CdLabelComponent } from './cd-label.component';
+import { ColorClassFromTextPipe } from './color-class-from-text.pipe';
+
+describe('CdLabelComponent', () => {
+  let component: CdLabelComponent;
+  let fixture: ComponentFixture<CdLabelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CdLabelComponent, ColorClassFromTextPipe]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CdLabelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/cd-label/cd-label.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/cd-label/cd-label.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'cd-label',
+  templateUrl: './cd-label.component.html',
+  styleUrls: ['./cd-label.component.scss']
+})
+export class CdLabelComponent {
+  @Input() key?: string;
+  @Input() value?: string;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/cd-label/color-class-from-text.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/cd-label/color-class-from-text.pipe.ts
@@ -1,0 +1,28 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'colorClassFromText'
+})
+export class ColorClassFromTextPipe implements PipeTransform {
+  readonly cssClasses: string[] = [
+    'badge-cd-label-green',
+    'badge-cd-label-cyan',
+    'badge-cd-label-purple',
+    'badge-cd-label-light-blue',
+    'badge-cd-label-gold',
+    'badge-cd-label-light-green'
+  ];
+
+  transform(text: string): string {
+    let hash = 0;
+    let charCode = 0;
+    if (text) {
+      for (let i = 0; i < text.length; i++) {
+        charCode = text.charCodeAt(i);
+        // tslint:disable-next-line:no-bitwise
+        hash = Math.abs((hash << 5) - hash + charCode);
+      }
+    }
+    return this.cssClasses[hash % this.cssClasses.length];
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -21,6 +21,8 @@ import { DirectivesModule } from '../directives/directives.module';
 import { PipesModule } from '../pipes/pipes.module';
 import { AlertPanelComponent } from './alert-panel/alert-panel.component';
 import { BackButtonComponent } from './back-button/back-button.component';
+import { CdLabelComponent } from './cd-label/cd-label.component';
+import { ColorClassFromTextPipe } from './cd-label/color-class-from-text.pipe';
 import { ConfigOptionComponent } from './config-option/config-option.component';
 import { ConfirmationModalComponent } from './confirmation-modal/confirmation-modal.component';
 import { Copy2ClipboardButtonComponent } from './copy2clipboard-button/copy2clipboard-button.component';
@@ -97,7 +99,9 @@ import { WizardComponent } from './wizard/wizard.component';
     FormButtonPanelComponent,
     MotdComponent,
     WizardComponent,
-    CustomLoginBannerComponent
+    CustomLoginBannerComponent,
+    CdLabelComponent,
+    ColorClassFromTextPipe
   ],
   providers: [],
   exports: [
@@ -126,7 +130,8 @@ import { WizardComponent } from './wizard/wizard.component';
     FormButtonPanelComponent,
     MotdComponent,
     WizardComponent,
-    CustomLoginBannerComponent
+    CustomLoginBannerComponent,
+    CdLabelComponent
   ]
 })
 export class ComponentsModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -105,6 +105,36 @@ $grid-breakpoints: (
   color: $gray-700;
 }
 
+.badge-cd-label-green {
+  background-color: $green-300;
+  color: $white;
+}
+
+.badge-cd-label-cyan {
+  background-color: $cyan-300;
+  color: $white;
+}
+
+.badge-cd-label-purple {
+  background-color: $purple-300;
+  color: $white;
+}
+
+.badge-cd-label-light-blue {
+  background-color: $light-blue-300;
+  color: $white;
+}
+
+.badge-cd-label-gold {
+  background-color: $gold-300;
+  color: $white;
+}
+
+.badge-cd-label-light-green {
+  background-color: $light-green-300;
+  color: $white;
+}
+
 // angular-tree-component
 tree-root {
   tree-viewport {

--- a/src/pybind/mgr/dashboard/frontend/src/styles/defaults/_bootstrap-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/defaults/_bootstrap-defaults.scss
@@ -33,6 +33,14 @@ $danger: $red !default;
 $light: $gray-100 !default;
 $dark: #777 !default;
 
+//badges colors
+$green-300: #6ec664;
+$cyan-300: #009596;
+$purple-300: #a18fff;
+$light-blue-300: #35caed;
+$gold-300: #f4c145;
+$light-green-300: #ace12e;
+
 // Extra theme colors.
 $accent: $red !default;
 $warning-dark: $orange !default;


### PR DESCRIPTION
Signed-off-by: Pedro Gonzalez Gomez <pegonzal@redhat.com>
Fixes: https://tracker.ceph.com/issues/55922

New component, cd-label, to help manage bootstrap badges with default bootstrap class or custom ones, it also supports hashing texts to colors for a semi-random color chooser (there are 6 different colors). 
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
