### PR TITLE
pacific: make-dist: patch boost source to support python 3.10

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -86,6 +86,48 @@ download_boost() {
         --exclude="$boost_version_underscore/tools/auto_index" \
         --exclude='doc' --exclude='more' --exclude='status'
     mv src/boost_${boost_version_underscore} src/boost
+    patch -p1 <<EOF
+From d9f06052e28873037db7f98629bce72182a42410 Mon Sep 17 00:00:00 2001
+From: Pat Riehecky <riehecky@fnal.gov>
+Date: Mon, 29 Jun 2020 10:51:58 -0500
+Subject: [PATCH] Convert Python 3.1+ to use public C API for filenames
+
+---
+ src/exec.cpp | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/src/exec.cpp b/src/exec.cpp
+index 171c6f4189..b2eabe59f6 100644
+--- a/src/boost/libs/python/src/exec.cpp
++++ b/src/boost/libs/python/src/exec.cpp
+@@ -104,14 +104,22 @@ object BOOST_PYTHON_DECL exec_file(char const *filename, object global, object l
+   if (local.is_none()) local = global;
+   // should be 'char const *' but older python versions don't use 'const' yet.
+   char *f = const_cast<char *>(filename);
+-  // Let python open the file to avoid potential binary incompatibilities.
+-#if PY_VERSION_HEX >= 0x03040000
+-  FILE *fs = _Py_fopen(f, "r");
++#if PY_VERSION_HEX >= 0x03010000
++  // Let python manage any UTF bits to avoid potential incompatibilities.
++  PyObject *fo = Py_BuildValue("s", f);
++  PyObject *fb = Py_None;
++  PyUnicode_FSConverter(fo, &fb);
++  f = PyBytes_AsString(fb);
++  FILE *fs = fopen(f, "r");
++  Py_DECREF(fo);
++  Py_DECREF(fb);
+ #elif PY_VERSION_HEX >= 0x03000000
++  // Let python open the file to avoid potential binary incompatibilities.
+   PyObject *fo = Py_BuildValue("s", f);
+-  FILE *fs = _Py_fopen(fo, "r");
++  FILE *fs = _Py_fopen(fo, "r"); // Private CPython API
+   Py_DECREF(fo);
+ #else
++  // Let python open the file to avoid potential binary incompatibilities.
+   PyObject *pyfile = PyFile_FromString(f, const_cast<char*>("r"));
+   if (!pyfile) throw std::invalid_argument(std::string(f) + " : no such file");
+   python::handle<> file(pyfile);
+EOF
     tar cf ${outfile}.boost.tar ${outfile}/src/boost
     rm -rf src/boost
 }


### PR DESCRIPTION
Python 3.10 doesn't include the `_Py_fopen()` function.  Boost 1.75.0 includes a patch which switches to using `fopen()` for
python versions >= 3.1, but Pacific is using boost 1.73.0, which still uses `_Py_fopen()`.  This commit adds the boost
1.75.0 patch to `make-dist`, so it's applied to our copy of the boost source which is then used when building RPM packages.

Fixes: https://tracker.ceph.com/issues/56466
Signed-off-by: Tim Serong <tserong@suse.com>

(This is already in the SUSE downstream as mentioned in https://github.com/ceph/ceph/pull/46365#issuecomment-1150664898)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
