### PR TITLE
 crimson/osd: fix ignoring --no-mon-config

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -315,6 +315,8 @@ int main(int argc, const char* argv[])
           }
           if (config.count("no-mon-config") == 0) {
             fetch_config().get();
+          } else {
+            logger().info("bypassing the config fetch due to --no-mon-config");
           }
           if (config.count("mkfs")) {
             auto osd_uuid = local_conf().get_val<uuid_d>("osd_uuid");

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -202,7 +202,6 @@ int main(int argc, const char* argv[])
     ("mkfs", "create a [new] data directory")
     ("debug", "enable debug output on all loggers")
     ("trace", "enable trace output on all loggers")
-    ("no-mon-config", "do not retrieve configuration from monitors on boot")
     ("prometheus_port", bpo::value<uint16_t>()->default_value(0),
      "Prometheus port. Set to zero to disable")
     ("prometheus_address", bpo::value<std::string>()->default_value("0.0.0.0"),
@@ -313,10 +312,10 @@ int main(int argc, const char* argv[])
           if (config.count("mkkey")) {
             make_keyring().get();
           }
-          if (config.count("no-mon-config") == 0) {
-            fetch_config().get();
-          } else {
+          if (local_conf()->no_mon_config) {
             logger().info("bypassing the config fetch due to --no-mon-config");
+          } else {
+            fetch_config().get();
           }
           if (config.count("mkfs")) {
             auto osd_uuid = local_conf().get_val<uuid_d>("osd_uuid");


### PR DESCRIPTION
Before we were treating the `--no-mon-config` as one of the `seastar_n_early_args`. However, this was wrong as it truly belongs to `config_proxy_args` as:

```cpp
int md_config_t::parse_argv(ConfigValues& values,
                            const ConfigTracker& tracker,
                            std::vector<const char*>& args, int level)
{
    // ...
    else if (ceph_argparse_flag(args, i, "--no-mon-config", (char*)NULL)) {
      values.no_mon_config = true;
    }
    // ...
}
```

The net result of this ignoring `--no-mon-config` which was the reason behind many dead jobs at Sepia.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

-------


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
