### PR TITLE
mgr/dashboard: Improve level A accessibility for buttons

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/overview/overview.component.html
@@ -20,7 +20,8 @@
           <div class="input-group-append">
             <button class="btn btn-light"
                     id="editSiteName"
-                    (click)="updateSiteName()">
+                    (click)="updateSiteName()"
+                    [attr.title]="editing ? 'Save' : 'Edit'">
               <i [ngClass]="icons.edit"
                  *ngIf="!editing"></i>
               <i [ngClass]="icons.check"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
@@ -120,7 +120,8 @@
         <div class="input-group-append">
           <button type="button"
                   class="btn btn-light"
-                  (click)="clearSearchKey()">
+                  (click)="clearSearchKey()"
+                  title="Clear">
             <i class="icon-prepend {{ icons.destroy }}"></i>
           </button>
         </div>
@@ -143,7 +144,8 @@
         <span class="input-group-append">
           <button type="button"
                   class="btn btn-light"
-                  (click)="clearDate()">
+                  (click)="clearDate()"
+                  title="Clear">
             <i class="icon-prepend {{ icons.destroy }}"></i>
           </button>
         </span>


### PR DESCRIPTION
Add titles and aria-labels for icon only buttons so that they can be detected by screen readers
Most of the button accessibility issues come from the datatable component and have been fixed in #46958

![image](https://user-images.githubusercontent.com/15856785/178327553-24e34710-fd98-4e41-8e8a-e4be719d0bf2.png)

![image](https://user-images.githubusercontent.com/15856785/178327896-4493aab1-69c5-4d63-9d4c-582538d0c1e4.png)


Fixes: https://tracker.ceph.com/issues/56018
Signed-off-by: nsedrickm <nsedrick101@gmail.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
