### PR TITLE
pacific: mgr/cephadm: fixing scheduler consistent hashing

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -879,7 +879,7 @@ class NodeAssignmentTest5(NamedTuple):
 
 
 @pytest.mark.parametrize("service_type, placement, available_hosts, expected_candidates",
-    [
+    [   # noqa: E128
         NodeAssignmentTest5(
             'alertmanager',
             PlacementSpec(hosts='host1 host2 host3 host4'.split()),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56455

---

backport of https://github.com/ceph/ceph/pull/46892
parent tracker: https://tracker.ceph.com/issues/56415

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh