### PR TITLE
pacific: doc/cephadm: Add post-upgrade section

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -96,6 +96,12 @@ You can stop the upgrade process at any time by running the following command:
 
   ceph orch upgrade stop
 
+Post upgrade actions
+====================
+
+In case the new version is based on ``cephadm``, once done with the upgrade the user
+has to update the ``cephadm`` package (or ceph-common package in case the user
+doesn't use ``cephadm shell``) to a version compatible with the new version.
 
 Potential problems
 ==================


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56158

---

backport of https://github.com/ceph/ceph/pull/46716
parent tracker: https://tracker.ceph.com/issues/54474

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh