### PR TITLE
ceph-volume: fix `simple scan`

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -329,7 +329,7 @@ def lsblk_all(device='', columns=None, abspath=False):
         if dev['NAME'] == os.path.basename(device):
             return dev
 
-    raise RuntimeError(f"{device} not found in lsblk output")
+    return {}
 
 def is_device(dev):
     """


### PR DESCRIPTION
`lsblk_all()` should return an empty dict `{}` if nothing was found.
If we raise `RuntimeError()` then the loop in `scan.Scan.main` will stop
and make ceph-volume fails because we don't try to catch this exception.
`scan.Scan.main()` has its own logic in order to detect the given path
is a ceph-disk created OSD anyway.

Fixes: https://tracker.ceph.com/issues/56482

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
