### PR TITLE
qa/cephfs: upgrade caps_helper.py

### DIFF
--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -1,11 +1,39 @@
 """
 Helper methods to test that MON and MDS caps are enforced properly.
 """
+from os.path import join as os_path_join
+
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 
 from teuthology.orchestra.run import Raw
 
 class CapsHelper(CephFSTestCase):
+
+    def write_test_files(self, mounts):
+        """
+        Exercising 'r' and 'w' access levels on a file on CephFS mount is
+        pretty routine across all tests for caps. Adding to method to write
+        that file will reduce clutter in these tests.
+
+        This methods writes a fixed data in a file with a fixed name located
+        at a fixed path for given list of mounts.
+        """
+        filepaths, filedata = [], 'testdata'
+        dirname, filename = 'testdir', 'testfile'
+
+        for mount_x in mounts:
+            dirpath = os_path_join(mount_x.hostfs_mntpt, dirname)
+            mount_x.run_shell(f'mkdir {dirpath}')
+            filepath = os_path_join(dirpath, filename)
+            mount_x.write_file(filepath, filedata)
+            filepaths.append(filepath)
+
+        return filepaths, (filedata,), mounts
+
+    def run_cap_tests(self, filepaths, filedata, mounts, perm):
+        # TODO
+        #self.run_mon_cap_tests()
+        self.run_mds_cap_tests(filepaths, filedata, mounts, perm)
 
     def run_mon_cap_tests(self, moncap, keyring):
         keyring_path = self.fs.admin_remote.mktemp(data=keyring)

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -33,7 +33,7 @@ class CapTester(CephFSTestCase):
         at the path passed in testpath for the given list of mounts. If
         testpath is empty, the file is created at the root of the CephFS.
         """
-        dirname, filename, filedata = 'testdir', 'testfile', 'testdata'
+        dirname, filename = 'testdir', 'testfile'
         self.test_set = []
         # XXX: The reason behind testpath[1:] below is that the testpath is
         # supposed to contain a path inside CephFS (which might be passed as
@@ -51,6 +51,15 @@ class CapTester(CephFSTestCase):
             dirpath = os_path_join(mount_x.hostfs_mntpt, testpath, dirname)
             mount_x.run_shell(f'mkdir {dirpath}')
             filepath = os_path_join(dirpath, filename)
+            # XXX: the reason behind adding filepathm, cephfs_name and both
+            # mntpts is to avoid a test bug where we mount cephfs1 but what
+            # ends up being mounted cephfs2. since filepath and filedata are
+            # identical, how would tests figure otherwise that they are
+            # accessing the right filename but on wrong CephFS.
+            filedata = (f'filepath = {filepath}\n'
+                        f'cephfs_name = {mount_x.cephfs_name}\n'
+                        f'cephfs_mntpt = {mount_x.cephfs_mntpt}\n'
+                        f'hostfs_mntpt = {mount_x.hostfs_mntpt}')
             mount_x.write_file(filepath, filedata)
             self.test_set.append((mount_x, filepath, filedata))
 

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -179,9 +179,10 @@ class CapTester(CephFSTestCase):
             log.info(f'write perm was tested was successfully: data '
                      f'"{data}" was successfully written to file "{path}".')
 
-    def conduct_neg_test_for_write_caps(self):
+    def conduct_neg_test_for_write_caps(self, sudo_write=False):
         possible_errmsgs = ('permission denied', 'operation not permitted')
-        cmdargs = ['echo', 'some random data', Raw('|'), 'tee']
+        cmdargs = ['echo', 'some random data', Raw('|')]
+        cmdargs += ['sudo', 'tee'] if sudo_write else ['tee']
 
         # don't use data, cmd args to write are set already above.
         for mount, path, data in self.test_set:

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -7,7 +7,21 @@ from tasks.cephfs.cephfs_test_case import CephFSTestCase
 
 from teuthology.orchestra.run import Raw
 
-class CapsHelper(CephFSTestCase):
+
+class CapTester(CephFSTestCase):
+    """
+    Test that MON and MDS caps are enforced.
+
+    MDS caps are tested by exercising read-write permissions and MON caps are
+    tested using output of command "ceph fs ls". Besides, it provides
+    write_test_files() which creates test files at the given path on CephFS
+    mounts passed to it.
+
+    USAGE: Call write_test_files() method at the beginning of the test and
+    once the caps that needs to be tested are assigned to the client and
+    CephFS be remount for caps to effective, call run_cap_tests(),
+    run_mon_cap_tests() or run_mds_cap_tests() as per the need.
+    """
 
     def write_test_files(self, mounts, testpath=''):
         """
@@ -16,9 +30,11 @@ class CapsHelper(CephFSTestCase):
         that file will reduce clutter in these tests.
 
         This methods writes a fixed data in a file with a fixed name located
-        at a fixed path for given list of mounts.
+        at the path passed in testpath for the given list of mounts. If
+        testpath is empty, the file is created at the root of the CephFS.
         """
-        filepaths, filedata = [], 'testdata'
+        self.mounts = mounts
+        self.filepaths, self.filedata = [], 'testdata'
         dirname, filename = 'testdir', 'testfile'
         # XXX: The reason behind testpath[1:] below is that the testpath is
         # supposed to contain a path inside CephFS (which might be passed as
@@ -32,21 +48,23 @@ class CapsHelper(CephFSTestCase):
         if testpath == '/':
             testpath = ''
 
-        for mount_x in mounts:
+        for mount_x in self.mounts:
             dirpath = os_path_join(mount_x.hostfs_mntpt, testpath, dirname)
             mount_x.run_shell(f'mkdir {dirpath}')
             filepath = os_path_join(dirpath, filename)
-            mount_x.write_file(filepath, filedata)
-            filepaths.append(filepath)
+            mount_x.write_file(filepath, self.filedata)
+            self.filepaths.append(filepath)
 
-        return filepaths, (filedata,), mounts
-
-    def run_cap_tests(self, filepaths, filedata, mounts, perm, mntpt=None):
+    def run_cap_tests(self, perm, mntpt=None):
         # TODO
         #self.run_mon_cap_tests()
-        self.run_mds_cap_tests(filepaths, filedata, mounts, perm, mntpt=mntpt)
+        self.run_mds_cap_tests(perm, mntpt=mntpt)
 
     def run_mon_cap_tests(self, moncap, keyring):
+        """
+        Check that MON cap is enforced for a client by searching for a Ceph
+        FS name in output of cmd "fs ls" executed with that client's caps.
+        """
         keyring_path = self.fs.admin_remote.mktemp(data=keyring)
 
         fsls = self.run_cluster_cmd(f'fs ls --id {self.client_id} -k '
@@ -60,44 +78,46 @@ class CapsHelper(CephFSTestCase):
         fss = (self.fs1.name, self.fs2.name) if hasattr(self, 'fs1') else \
             (self.fs.name,)
         for fsname in fss:
-                if fsname in moncap:
-                    self.assertIn('name: ' + fsname, fsls)
-                else:
-                    self.assertNotIn('name: ' + fsname, fsls)
+            if fsname in moncap:
+                self.assertIn('name: ' + fsname, fsls)
+            else:
+                self.assertNotIn('name: ' + fsname, fsls)
 
-    def run_mds_cap_tests(self, filepaths, filedata, mounts, perm, mntpt=None):
+    def run_mds_cap_tests(self, perm, mntpt=None):
+        """
+        Run test for read perm and, for write perm, run positive test if it
+        is present and run negative test if not.
+        """
         # XXX: mntpt is path inside cephfs that serves as root for current
-        # mount. Therefore, this path must me deleted from filepaths.
+        # mount. Therefore, this path must me deleted from self.filepaths.
         # Example -
         #   orignal path: /mnt/cephfs_x/dir1/dir2/testdir
         #   cephfs dir serving as root for current mnt: /dir1/dir2
         #   therefore, final path: /mnt/cephfs_x//testdir
         if mntpt:
-            filepaths = [x.replace(mntpt, '') for x in filepaths]
+            self.filepaths = [x.replace(mntpt, '') for x in self.filepaths]
 
-        self.conduct_pos_test_for_read_caps(filepaths, filedata, mounts)
+        self.conduct_pos_test_for_read_caps()
 
         if perm == 'rw':
-            self.conduct_pos_test_for_write_caps(filepaths, mounts)
+            self.conduct_pos_test_for_write_caps()
         elif perm == 'r':
-            self.conduct_neg_test_for_write_caps(filepaths, mounts)
+            self.conduct_neg_test_for_write_caps()
         else:
             raise RuntimeError(f'perm = {perm}\nIt should be "r" or "rw".')
 
-    def conduct_pos_test_for_read_caps(self, filepaths, filedata, mounts):
-        for mount in mounts:
-            for path, data in zip(filepaths, filedata):
+    def conduct_pos_test_for_read_caps(self):
+        for mount in self.mounts:
+            for path, data in zip(self.filepaths, (self.filedata,)):
                 # XXX: conduct tests only if path belongs to current mount; in
                 # teuth tests client are located on same machines.
                 if path.find(mount.hostfs_mntpt) != -1:
                     contents = mount.read_file(path)
                     self.assertEqual(data, contents)
 
-    def conduct_pos_test_for_write_caps(self, filepaths, mounts):
-        filedata = ('some new data on first fs', 'some new data on second fs')
-
-        for mount in mounts:
-            for path, data in zip(filepaths, filedata):
+    def conduct_pos_test_for_write_caps(self):
+        for mount in self.mounts:
+            for path, data in zip(self.filepaths, (self.filedata,)):
                 if path.find(mount.hostfs_mntpt) != -1:
                     # test that write was successful
                     mount.write_file(path=path, data=data)
@@ -106,12 +126,12 @@ class CapsHelper(CephFSTestCase):
                     contents1 = mount.read_file(path=path)
                     self.assertEqual(data, contents1)
 
-    def conduct_neg_test_for_write_caps(self, filepaths, mounts):
+    def conduct_neg_test_for_write_caps(self):
         possible_errmsgs = ('permission denied', 'operation not permitted')
         cmdargs = ['echo', 'some random data', Raw('|'), 'tee']
 
-        for mount in mounts:
-            for path in filepaths:
+        for mount in self.mounts:
+            for path in self.filepaths:
                 if path.find(mount.hostfs_mntpt) != -1:
                     cmdargs.append(path)
                     mount.negtestcmd(args=cmdargs, retval=1,

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -9,7 +9,7 @@ from teuthology.orchestra.run import Raw
 
 class CapsHelper(CephFSTestCase):
 
-    def write_test_files(self, mounts):
+    def write_test_files(self, mounts, testpath=''):
         """
         Exercising 'r' and 'w' access levels on a file on CephFS mount is
         pretty routine across all tests for caps. Adding to method to write
@@ -20,9 +20,20 @@ class CapsHelper(CephFSTestCase):
         """
         filepaths, filedata = [], 'testdata'
         dirname, filename = 'testdir', 'testfile'
+        # XXX: The reason behind testpath[1:] below is that the testpath is
+        # supposed to contain a path inside CephFS (which might be passed as
+        # an absolute path). os.path.join() deletes all previous path
+        # components when it encounters a path component starting with '/'.
+        # Deleting the first '/' from the string in testpath ensures that
+        # previous path components are not deleted by os.path.join().
+        if testpath:
+            testpath = testpath[1:] if testpath[0] == '/' else testpath
+        # XXX: passing just '/' screw up os.path.join() ahead.
+        if testpath == '/':
+            testpath = ''
 
         for mount_x in mounts:
-            dirpath = os_path_join(mount_x.hostfs_mntpt, dirname)
+            dirpath = os_path_join(mount_x.hostfs_mntpt, testpath, dirname)
             mount_x.run_shell(f'mkdir {dirpath}')
             filepath = os_path_join(dirpath, filename)
             mount_x.write_file(filepath, filedata)
@@ -30,10 +41,10 @@ class CapsHelper(CephFSTestCase):
 
         return filepaths, (filedata,), mounts
 
-    def run_cap_tests(self, filepaths, filedata, mounts, perm):
+    def run_cap_tests(self, filepaths, filedata, mounts, perm, mntpt=None):
         # TODO
         #self.run_mon_cap_tests()
-        self.run_mds_cap_tests(filepaths, filedata, mounts, perm)
+        self.run_mds_cap_tests(filepaths, filedata, mounts, perm, mntpt=mntpt)
 
     def run_mon_cap_tests(self, moncap, keyring):
         keyring_path = self.fs.admin_remote.mktemp(data=keyring)
@@ -54,7 +65,16 @@ class CapsHelper(CephFSTestCase):
                 else:
                     self.assertNotIn('name: ' + fsname, fsls)
 
-    def run_mds_cap_tests(self, filepaths, filedata, mounts, perm):
+    def run_mds_cap_tests(self, filepaths, filedata, mounts, perm, mntpt=None):
+        # XXX: mntpt is path inside cephfs that serves as root for current
+        # mount. Therefore, this path must me deleted from filepaths.
+        # Example -
+        #   orignal path: /mnt/cephfs_x/dir1/dir2/testdir
+        #   cephfs dir serving as root for current mnt: /dir1/dir2
+        #   therefore, final path: /mnt/cephfs_x//testdir
+        if mntpt:
+            filepaths = [x.replace(mntpt, '') for x in filepaths]
+
         self.conduct_pos_test_for_read_caps(filepaths, filedata, mounts)
 
         if perm == 'rw':

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -33,9 +33,8 @@ class CapTester(CephFSTestCase):
         at the path passed in testpath for the given list of mounts. If
         testpath is empty, the file is created at the root of the CephFS.
         """
-        self.mounts = mounts
-        self.filepaths, self.filedata = [], 'testdata'
-        dirname, filename = 'testdir', 'testfile'
+        dirname, filename, filedata = 'testdir', 'testfile', 'testdata'
+        self.test_set = []
         # XXX: The reason behind testpath[1:] below is that the testpath is
         # supposed to contain a path inside CephFS (which might be passed as
         # an absolute path). os.path.join() deletes all previous path
@@ -48,12 +47,12 @@ class CapTester(CephFSTestCase):
         if testpath == '/':
             testpath = ''
 
-        for mount_x in self.mounts:
+        for mount_x in mounts:
             dirpath = os_path_join(mount_x.hostfs_mntpt, testpath, dirname)
             mount_x.run_shell(f'mkdir {dirpath}')
             filepath = os_path_join(dirpath, filename)
-            mount_x.write_file(filepath, self.filedata)
-            self.filepaths.append(filepath)
+            mount_x.write_file(filepath, filedata)
+            self.test_set.append((mount_x, filepath, filedata))
 
     def run_cap_tests(self, perm, mntpt=None):
         # TODO
@@ -95,7 +94,8 @@ class CapTester(CephFSTestCase):
         #   cephfs dir serving as root for current mnt: /dir1/dir2
         #   therefore, final path: /mnt/cephfs_x//testdir
         if mntpt:
-            self.filepaths = [x.replace(mntpt, '') for x in self.filepaths]
+            self.test_set = [(x, y.replace(mntpt, ''), z) for x, y, z in \
+                             self.test_set]
 
         self.conduct_pos_test_for_read_caps()
 
@@ -107,36 +107,25 @@ class CapTester(CephFSTestCase):
             raise RuntimeError(f'perm = {perm}\nIt should be "r" or "rw".')
 
     def conduct_pos_test_for_read_caps(self):
-        for mount in self.mounts:
-            for path, data in zip(self.filepaths, (self.filedata,)):
-                # XXX: conduct tests only if path belongs to current mount; in
-                # teuth tests client are located on same machines.
-                if path.find(mount.hostfs_mntpt) != -1:
-                    contents = mount.read_file(path)
-                    self.assertEqual(data, contents)
+        for mount, path, data in self.test_set:
+            contents = mount.read_file(path)
+            self.assertEqual(data, contents)
 
     def conduct_pos_test_for_write_caps(self):
-        for mount in self.mounts:
-            for path, data in zip(self.filepaths, (self.filedata,)):
-                if path.find(mount.hostfs_mntpt) != -1:
-                    # test that write was successful
-                    mount.write_file(path=path, data=data)
-                    # verify that contents written was same as the one that was
-                    # intended
-                    contents1 = mount.read_file(path=path)
-                    self.assertEqual(data, contents1)
+        for mount, path, data in self.test_set:
+            mount.write_file(path=path, data=data)
+            contents = mount.read_file(path=path)
+            self.assertEqual(data, contents)
 
     def conduct_neg_test_for_write_caps(self):
         possible_errmsgs = ('permission denied', 'operation not permitted')
         cmdargs = ['echo', 'some random data', Raw('|'), 'tee']
 
-        for mount in self.mounts:
-            for path in self.filepaths:
-                if path.find(mount.hostfs_mntpt) != -1:
-                    cmdargs.append(path)
-                    mount.negtestcmd(args=cmdargs, retval=1,
-                                     errmsgs=possible_errmsgs)
-                    cmdargs.pop(-1)
+        # don't use data, cmd args to write are set already above.
+        for mount, path, data in self.test_set:
+            cmdargs.append(path)
+            mount.negtestcmd(args=cmdargs, retval=1, errmsgs=possible_errmsgs)
+            cmdargs.pop(-1)
 
     def get_mon_cap_from_keyring(self, client_name):
         keyring = self.run_cluster_cmd(cmd=f'auth get {client_name}')

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -6,7 +6,6 @@ import uuid
 from io import StringIO
 from os.path import join as os_path_join
 
-from teuthology.orchestra.run import Raw
 from teuthology.exceptions import CommandFailedError
 
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
@@ -1223,22 +1222,16 @@ class TestFsAuthorize(CephFSTestCase):
         self.captester.run_mds_cap_tests(PERM)
 
     def test_single_path_rootsquash(self):
-        filedata, filename = 'some data on fs 1', 'file_on_fs1'
-        filepath = os_path_join(self.mount_a.hostfs_mntpt, filename)
-        self.mount_a.write_file(filepath, filedata)
+        PERM = 'rw'
+        FS_AUTH_CAPS = (('/', PERM, 'root_squash'),)
+        self.captester = CapTester()
+        self.setup_test_env(FS_AUTH_CAPS)
 
-        keyring = self.fs.authorize(self.client_id, ('/', 'rw', 'root_squash'))
-        keyring_path = self.mount_a.client_remote.mktemp(data=keyring)
-        self.mount_a.remount(client_id=self.client_id,
-                             client_keyring_path=keyring_path,
-                             cephfs_mntpt='/')
-
-        if filepath.find(self.mount_a.hostfs_mntpt) != -1:
-            # can read, but not write as root
-            contents = self.mount_a.read_file(filepath)
-            self.assertEqual(filedata, contents)
-            cmdargs = ['echo', 'some random data', Raw('|'), 'sudo', 'tee', filepath]
-            self.mount_a.negtestcmd(args=cmdargs, retval=1, errmsgs='permission denied')
+        # testing MDS caps...
+        # Since root_squash is set in client caps, client can read but not
+        # write even thought access level is set to "rw".
+        self.captester.conduct_pos_test_for_read_caps()
+        self.captester.conduct_neg_test_for_write_caps(sudo_write=True)
 
     def test_single_path_authorize_on_nonalphanumeric_fsname(self):
         """

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -12,7 +12,7 @@ from teuthology.exceptions import CommandFailedError
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from tasks.cephfs.filesystem import FileLayout, FSMissing
 from tasks.cephfs.fuse_mount import FuseMount
-from tasks.cephfs.caps_helper import CapsHelper
+from tasks.cephfs.caps_helper import CapTester
 
 log = logging.getLogger(__name__)
 
@@ -1200,25 +1200,27 @@ class TestMirroringCommands(CephFSTestCase):
         self._verify_mirroring(self.fs.name, "disabled")
 
 
-class TestFsAuthorize(CapsHelper):
+class TestFsAuthorize(CephFSTestCase):
     client_id = 'testuser'
     client_name = 'client.' + client_id
 
     def test_single_path_r(self):
-        perm = 'r'
-        filepaths, filedata, mounts, keyring = self.setup_test_env(perm)
-        moncap = self.get_mon_cap_from_keyring(self.client_name)
+        PERM = 'r'
+        FS_AUTH_CAPS = (('/', PERM),)
+        self.captester = CapTester()
+        self.setup_test_env(FS_AUTH_CAPS)
 
-        self.run_mon_cap_tests(moncap, keyring)
-        self.run_mds_cap_tests(filepaths, filedata, mounts, perm)
+        self.captester.run_mon_cap_tests(self.fs, self.client_id)
+        self.captester.run_mds_cap_tests(PERM)
 
     def test_single_path_rw(self):
-        perm = 'rw'
-        filepaths, filedata, mounts, keyring = self.setup_test_env(perm)
-        moncap = self.get_mon_cap_from_keyring(self.client_name)
+        PERM = 'rw'
+        FS_AUTH_CAPS = (('/', PERM),)
+        self.captester = CapTester()
+        self.setup_test_env(FS_AUTH_CAPS)
 
-        self.run_mon_cap_tests(moncap, keyring)
-        self.run_mds_cap_tests(filepaths, filedata, mounts, perm)
+        self.captester.run_mon_cap_tests(self.fs, self.client_id)
+        self.captester.run_mds_cap_tests(PERM)
 
     def test_single_path_rootsquash(self):
         filedata, filename = 'some data on fs 1', 'file_on_fs1'
@@ -1240,7 +1242,8 @@ class TestFsAuthorize(CapsHelper):
 
     def test_single_path_authorize_on_nonalphanumeric_fsname(self):
         """
-        That fs authorize command works on filesystems with names having [_.-] characters
+        That fs authorize command works on filesystems with names having [_.-]
+        characters
         """
         self.mount_a.umount_wait(require_clean=True)
         self.mds_cluster.delete_all_filesystems()
@@ -1252,41 +1255,42 @@ class TestFsAuthorize(CapsHelper):
                              f'osd "allow rw pool={self.fs.get_data_pool_name()}" '
                              f'mds allow')
         self.mount_a.remount(cephfs_name=self.fs.name)
-        perm = 'rw'
-        filepaths, filedata, mounts, keyring = self.setup_test_env(perm)
-        self.run_mds_cap_tests(filepaths, filedata, mounts, perm)
+        PERM = 'rw'
+        FS_AUTH_CAPS = (('/', PERM),)
+        self.captester = CapTester()
+        self.setup_test_env(FS_AUTH_CAPS)
+        self.captester.run_mds_cap_tests(PERM)
 
     def test_multiple_path_r(self):
-        perm, paths = 'r', ('/dir1', '/dir2/dir22')
-        filepaths, filedata, mounts, keyring = self.setup_test_env(perm, paths)
-        moncap = self.get_mon_cap_from_keyring(self.client_name)
+        PERM = 'r'
+        FS_AUTH_CAPS = (('/dir1/dir12', PERM), ('/dir2/dir22', PERM))
+        for c in FS_AUTH_CAPS:
+            self.mount_a.run_shell(f'mkdir -p .{c[0]}')
+        self.captesters = (CapTester(), CapTester())
+        self.setup_test_env(FS_AUTH_CAPS)
 
-        keyring_path = self.mount_a.client_remote.mktemp(data=keyring)
-        for path in paths:
-            self.mount_a.remount(client_id=self.client_id,
-                                 client_keyring_path=keyring_path,
-                                 cephfs_mntpt=path)
-
-
-            # actual tests...
-            self.run_mon_cap_tests(moncap, keyring)
-            self.run_mds_cap_tests(filepaths, filedata, mounts, perm)
+        self.run_cap_test_one_by_one(FS_AUTH_CAPS)
 
     def test_multiple_path_rw(self):
-        perm, paths = 'rw', ('/dir1', '/dir2/dir22')
-        filepaths, filedata, mounts, keyring = self.setup_test_env(perm, paths)
-        moncap = self.get_mon_cap_from_keyring(self.client_name)
+        PERM = 'rw'
+        FS_AUTH_CAPS = (('/dir1/dir12', PERM), ('/dir2/dir22', PERM))
+        for c in FS_AUTH_CAPS:
+            self.mount_a.run_shell(f'mkdir -p .{c[0]}')
+        self.captesters = (CapTester(), CapTester())
+        self.setup_test_env(FS_AUTH_CAPS)
 
-        keyring_path = self.mount_a.client_remote.mktemp(data=keyring)
-        for path in paths:
-            self.mount_a.remount(client_id=self.client_id,
-                                 client_keyring_path=keyring_path,
-                                 cephfs_mntpt=path)
+        self.run_cap_test_one_by_one(FS_AUTH_CAPS)
 
-
+    def run_cap_test_one_by_one(self, fs_auth_caps):
+        keyring = self.run_cluster_cmd(f'auth get {self.client_name}')
+        for i, c in enumerate(fs_auth_caps):
+            self.assertIn(i, (0, 1))
+            PATH = c[0]
+            PERM = c[1]
+            self._remount(keyring, PATH)
             # actual tests...
-            self.run_mon_cap_tests(moncap, keyring)
-            self.run_mds_cap_tests(filepaths, filedata, mounts, perm)
+            self.captesters[i].run_mon_cap_tests(self.fs, self.client_id)
+            self.captesters[i].run_mds_cap_tests(PERM, PATH)
 
     def tearDown(self):
         self.mount_a.umount_wait()
@@ -1294,49 +1298,29 @@ class TestFsAuthorize(CapsHelper):
 
         super(type(self), self).tearDown()
 
-    def setup_for_single_path(self, perm):
-        filedata, filename = 'some data on fs 1', 'file_on_fs1'
-
-        filepath = os_path_join(self.mount_a.hostfs_mntpt, filename)
-        self.mount_a.write_file(filepath, filedata)
-
-        keyring = self.fs.authorize(self.client_id, ('/', perm))
+    def _remount(self, keyring, path='/'):
         keyring_path = self.mount_a.client_remote.mktemp(data=keyring)
-
         self.mount_a.remount(client_id=self.client_id,
                              client_keyring_path=keyring_path,
-                             cephfs_mntpt='/')
+                             cephfs_mntpt=path)
 
-        return filepath, filedata, keyring
+    def setup_for_single_path(self, fs_auth_caps):
+        self.captester.write_test_files((self.mount_a,), '/')
+        keyring = self.fs.authorize(self.client_id, fs_auth_caps)
+        self._remount(keyring)
 
-    def setup_for_multiple_paths(self, perm, paths):
-        filedata, filename = 'some data on fs 1', 'file_on_fs1'
+    def setup_for_multiple_paths(self, fs_auth_caps):
+        for i, c in enumerate(fs_auth_caps):
+            PATH = c[0]
+            self.captesters[i].write_test_files((self.mount_a,), PATH)
 
-        self.mount_a.run_shell('mkdir -p dir1/dir12/dir13 dir2/dir22/dir23')
+        self.fs.authorize(self.client_id, fs_auth_caps)
 
-        filepaths = []
-        for path in paths:
-            filepath = os_path_join(self.mount_a.hostfs_mntpt, path[1:], filename)
-            self.mount_a.write_file(filepath, filedata)
-            filepaths.append(filepath.replace(path, ''))
-        filepaths = tuple(filepaths)
-
-        keyring = self.fs.authorize(self.client_id, (paths[0], perm, paths[1],
-                                                     perm))
-
-        return filepaths, filedata, keyring
-
-    def setup_test_env(self, perm, paths=()):
-        filepaths, filedata, keyring = self.setup_for_multiple_paths(perm, paths) if paths \
-            else self.setup_for_single_path(perm)
-
-        if not isinstance(filepaths, tuple):
-            filepaths = (filepaths, )
-        if not isinstance(filedata, tuple):
-            filedata = (filedata, )
-        mounts = (self.mount_a, )
-
-        return filepaths, filedata, mounts, keyring
+    def setup_test_env(self, fs_auth_caps):
+        if len(fs_auth_caps) == 1:
+            self.setup_for_single_path(fs_auth_caps[0])
+        else:
+            self.setup_for_multiple_paths(fs_auth_caps)
 
 
 class TestAdminCommandIdempotency(CephFSTestCase):


### PR DESCRIPTION
Related PR - PR https://github.com/ceph/ceph/pull/41779. Commits on this PR originally were located on PR https://github.com/ceph/ceph/pull/41779. These have been moved to a separate PR for ease of review, testing, merging and, more importantly to get these commits merged sooner so that this code can be reused to write other PRs.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
  - [x] QA Improvements
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>