### PR TITLE
crimson/osd: add support for OSD Service Specification

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -202,6 +202,8 @@ int main(int argc, const char* argv[])
     ("mkfs", "create a [new] data directory")
     ("debug", "enable debug output on all loggers")
     ("trace", "enable trace output on all loggers")
+    ("osdspec-affinity", bpo::value<std::string>()->default_value(std::string{}),
+     "set affinity to an osdspec")
     ("prometheus_port", bpo::value<uint16_t>()->default_value(0),
      "Prometheus port. Set to zero to disable")
     ("prometheus_address", bpo::value<std::string>()->default_value("0.0.0.0"),
@@ -327,7 +329,8 @@ int main(int argc, const char* argv[])
               0,
               &crimson::osd::OSD::mkfs,
               osd_uuid,
-              local_conf().get_val<uuid_d>("fsid")).get();
+              local_conf().get_val<uuid_d>("fsid"),
+              config["osdspec-affinity"].as<std::string>()).get();
           }
           if (config.count("mkkey") || config.count("mkfs")) {
             return EXIT_SUCCESS;

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -152,7 +152,10 @@ CompatSet get_osd_initial_compat_set()
 }
 }
 
-seastar::future<> OSD::mkfs(uuid_d osd_uuid, uuid_d cluster_fsid)
+seastar::future<> OSD::mkfs(
+  uuid_d osd_uuid,
+  uuid_d cluster_fsid,
+  std::string osdspec_affinity)
 {
   return store.start().then([this, osd_uuid] {
     return store.mkfs(osd_uuid).handle_error(
@@ -184,6 +187,8 @@ seastar::future<> OSD::mkfs(uuid_d osd_uuid, uuid_d cluster_fsid)
     return store.write_meta("whoami", std::to_string(whoami));
   }).then([this] {
     return _write_key_meta();
+  }).then([this, osdspec_affinity=std::move(osdspec_affinity)] {
+    return store.write_meta("osdspec_affinity", osdspec_affinity);
   }).then([this] {
     return store.write_meta("ready", "ready");
   }).then([cluster_fsid, this] {

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -128,7 +128,9 @@ public:
       crimson::net::MessengerRef hb_back_msgr);
   ~OSD() final;
 
-  seastar::future<> mkfs(uuid_d osd_uuid, uuid_d cluster_fsid);
+  seastar::future<> mkfs(uuid_d osd_uuid,
+                         uuid_d cluster_fsid,
+                         std::string osdspec_affinity);
 
   seastar::future<> start();
   seastar::future<> stop();


### PR DESCRIPTION
This patch is a crimson's counterpart of 1b44b6709d9400102c14ad3ea40fca19ab4ed214 that brought the support for `--osdspec-affinity` to the classical OSD.

`cephadm` started passing this argv which caused the problem reported by Li, Jianxin <jianxin1.li@intel.com>.
See:

  * https://gist.github.com/rzarzynski/4d1225971b6c28758cb2b68fbda3bf5f?permalink_comment_id=4223998#gistcomment-4223998
  * https://docs.ceph.com/en/octopus/cephadm/drivegroups/

Testing
-------

```diff
diff --git a/src/vstart.sh b/src/vstart.sh
index 51ebcf26cdb..2a5b485e8d7 100755
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1014,7 +1014,7 @@ EOF
             echo "{\"cephx_secret\": \"$OSD_SECRET\"}" > $CEPH_DEV_DIR/osd$osd/new.json
             ceph_adm osd new $uuid -i $CEPH_DEV_DIR/osd$osd/new.json
             rm $CEPH_DEV_DIR/osd$osd/new.json
-            prun $SUDO $CEPH_BIN/$ceph_osd $extra_osd_args -i $osd $ARGS --mkfs --key $OSD_SECRET --osd-uuid $uuid $extra_seastar_args \
+            prun $SUDO $CEPH_BIN/$ceph_osd $extra_osd_args -i $osd $ARGS --mkfs --osdspec-affinity None --key $OSD_SECRET --osd-uuid $uuid $extra_seastar_args \
                 2>&1 | tee $CEPH_OUT_DIR/osd-mkfs.$osd.log

             local key_fn=$CEPH_DEV_DIR/osd$osd/keyring
```

The new meta is truly set:

```
$ bin/ceph-bluestore-tool --path dev/osd0/ show-label
inferring bluefs devices from bluestore path
{
    "dev/osd0/block": {
        "osd_uuid": "c0534f3a-3d2b-4080-91da-cefc76387e4b",
        "size": 107374182400,
        "btime": "2022-07-07T09:56:34.306383+0000",
        "description": "main",
        "bfm_blocks": "26214400",
        "bfm_blocks_per_key": "128",
        "bfm_bytes_per_block": "4096",
        "bfm_size": "107374182400",
        "bluefs": "1",
        "ceph_fsid": "c4b8836d-cbf6-434f-ac4c-4ed1f869ec31",
        "kv_backend": "rocksdb",
        "magic": "ceph osd volume v026",
        "mkfs_done": "yes",
        "osd_key": "AQDRrcZitoB+HxAAsJNAHtv9S2Kyrh0HfJOpzw==",
        "osdspec_affinity": "None",
        "ready": "ready",
        "require_osd_release": "17",
        "whoami": "0"
    },
    "dev/osd0/block.wal": {
        "osd_uuid": "c0534f3a-3d2b-4080-91da-cefc76387e4b",
        "size": 1048576000,
        "btime": "2022-07-07T09:56:34.311501+0000",
        "description": "bluefs wal"
    },
    "dev/osd0/block.db": {
        "osd_uuid": "c0534f3a-3d2b-4080-91da-cefc76387e4b",
        "size": 1073741824,
        "btime": "2022-07-07T09:56:34.308145+0000",
        "description": "bluefs db"
    }
}
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
