### PR TITLE
test/test_global_doublefree: fix link error w/ gcc10/11

### DIFF
--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -300,7 +300,7 @@ if(WITH_CEPHFS)
     test_global_doublefree.cc
     )
   add_ceph_unittest(unittest_global_doublefree)
-  target_link_libraries(unittest_global_doublefree cephfs librados)
+  target_link_libraries(unittest_global_doublefree stdc++ cephfs librados)
 endif(WITH_CEPHFS)
 
 if(NOT WIN32)


### PR DESCRIPTION
"error adding symbols" - the same issue solved
by https://github.com/ceph/ceph/pull/46837
(solved here by applying the same change to the CMakeLists)

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
Co-authored-by: Radoslaw Zarzynski <rzarzyns@redhat.com>
