### PR TITLE
ceph.spec.in: disable system_pmdk on s390x

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -39,7 +39,11 @@
 %if 0%{?rhel} < 9
 %bcond_with system_pmdk
 %else
+%ifarch s390x
+%bcond_with system_pmdk
+%else
 %bcond_without system_pmdk
+%endif
 %endif
 %bcond_without selinux
 %bcond_without cephfs_java


### PR DESCRIPTION
The pwl_cache plugin depends on libpmem. This is not available on s390x for RHEL 8, RHEL 9, or Fedora.

Fixes: https://tracker.ceph.com/issues/56491