### PR TITLE
pacific: ceph-volume: allow listing devices by OSD ID

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -1137,6 +1137,14 @@ def get_single_lv(fields=LV_FIELDS, filters=None, tags=None):
     return lvs[0]
 
 
+def get_lvs_from_osd_id(osd_id):
+    return get_lvs(tags={'ceph.osd_id': osd_id})
+
+
+def get_single_lv_from_osd_id(osd_id):
+    return get_single_lv(tags={'ceph.osd_id': osd_id})
+
+
 def get_lv_by_name(name):
     stdout, stderr, returncode = process.call(
         ['lvs', '--noheadings', '-o', LV_FIELDS, '-S',

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -1188,3 +1188,14 @@ def get_lv_by_fullname(full_name):
     except ValueError:
         res_lv = None
     return res_lv
+
+def get_lvs_from_path(devpath):
+    lvs = []
+    if os.path.isabs(devpath):
+        # we have a block device
+        lvs = get_device_lvs(devpath)
+        if not lvs:
+            # maybe this was a LV path /dev/vg_name/lv_name or /dev/mapper/
+            lvs = get_lvs(filters={'path': devpath})
+
+    return lvs

--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 import argparse
 import json
 import logging
-import os.path
 from textwrap import dedent
 from ceph_volume import decorators
 from ceph_volume.api import lvm as api
@@ -140,22 +139,6 @@ class List(object):
         """
         return self.create_report(api.get_lvs())
 
-    def get_lvs_from_path(self, device):
-        lvs = []
-        if os.path.isabs(device):
-            # we have a block device
-            lvs = api.get_device_lvs(device)
-            if not lvs:
-                # maybe this was a LV path /dev/vg_name/lv_name or /dev/mapper/
-                lvs = api.get_lvs(filters={'path': device})
-        else:
-            # vg_name/lv_name was passed
-            vg_name, lv_name = device.split('/')
-            lvs = api.get_lvs(filters={'lv_name': lv_name,
-                                       'vg_name': vg_name})
-
-        return lvs
-
     def single_report(self, arg):
         """
         Generate a report for a single device. This can be either a logical
@@ -167,7 +150,7 @@ class List(object):
         if isinstance(arg, int) or arg.isdigit():
             lv = api.get_lvs_from_osd_id(arg)
         elif arg[0] == '/':
-            lv = self.get_lvs_from_path(arg)
+            lv = api.get_lvs_from_path(arg)
         else:
             lv = [api.get_single_lv(filters={'lv_name': arg.split('/')[1]})]
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56493

---

backport of https://github.com/ceph/ceph/pull/38368
parent tracker: https://tracker.ceph.com/issues/41294

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh