### PR TITLE
crimson/os/seastore: simplify backref cache

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -666,7 +666,8 @@ public:
       submit_transaction_direct_iertr::future<>;
     virtual submit_transaction_direct_ret submit_transaction_direct(
       Transaction &t,
-      std::optional<journal_seq_t> seq_to_trim = std::nullopt) = 0;
+      std::optional<journal_seq_t> seq_to_trim = std::nullopt,
+      std::optional<std::pair<paddr_t, paddr_t>> gc_range = std::nullopt) = 0;
   };
 
 private:
@@ -835,7 +836,8 @@ public:
 
   void mark_space_free(
     paddr_t addr,
-    extent_len_t len);
+    extent_len_t len,
+    bool init_scan = false);
 
   SpaceTrackerIRef get_empty_space_tracker() const {
     return space_tracker->make_empty();
@@ -1110,7 +1112,7 @@ private:
 
   using retrieve_live_extents_iertr = work_iertr;
   using retrieve_live_extents_ret =
-    retrieve_live_extents_iertr::future<journal_seq_t>;
+    retrieve_live_extents_iertr::future<>;
   retrieve_live_extents_ret _retrieve_live_extents(
     Transaction &t,
     std::set<

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -437,30 +437,10 @@ BtreeBackrefManager::get_cached_backrefs_in_range(
   return cache.get_backrefs_in_range(start, end);
 }
 
-Cache::backref_buf_entry_query_set_t
-BtreeBackrefManager::get_cached_backref_removals_in_range(
-  paddr_t start,
-  paddr_t end)
-{
-  return cache.get_del_backrefs_in_range(start, end);
-}
-
-const backref_buf_entry_t::set_t&
-BtreeBackrefManager::get_cached_backref_removals()
-{
-  return cache.get_del_backrefs();
-}
-
-const backref_buf_entry_t::set_t&
+const backref_set_t&
 BtreeBackrefManager::get_cached_backrefs()
 {
   return cache.get_backrefs();
-}
-
-backref_buf_entry_t
-BtreeBackrefManager::get_cached_backref_removal(paddr_t addr)
-{
-  return cache.get_del_backref(addr);
 }
 
 Cache::backref_extent_buf_entry_query_set_t
@@ -501,10 +481,6 @@ BtreeBackrefManager::retrieve_backref_extents(
       extents.emplace_back(std::move(ext));
     });
   });
-}
-
-bool BtreeBackrefManager::backref_should_be_removed(paddr_t paddr) {
-  return cache.backref_should_be_removed(paddr);
 }
 
 } // namespace crimson::os::seastore::backref

--- a/src/crimson/os/seastore/backref/btree_backref_manager.h
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.h
@@ -104,15 +104,7 @@ public:
   get_cached_backrefs_in_range(
     paddr_t start,
     paddr_t end) final;
-
-  Cache::backref_buf_entry_query_set_t
-  get_cached_backref_removals_in_range(
-    paddr_t start,
-    paddr_t end) final;
-
-  const backref_buf_entry_t::set_t& get_cached_backref_removals() final;
-  const backref_buf_entry_t::set_t& get_cached_backrefs() final;
-  backref_buf_entry_t get_cached_backref_removal(paddr_t addr) final;
+  const backref_set_t& get_cached_backrefs() final;
 
   Cache::backref_extent_buf_entry_query_set_t
   get_cached_backref_extents_in_range(
@@ -125,8 +117,6 @@ public:
     std::vector<CachedExtentRef> &extents) final;
 
   void cache_new_backref_extent(paddr_t paddr, extent_types_t type) final;
-
-  bool backref_should_be_removed(paddr_t paddr) final;
 
 private:
   SegmentManagerGroup &sm_group;

--- a/src/crimson/os/seastore/backref_manager.h
+++ b/src/crimson/os/seastore/backref_manager.h
@@ -87,22 +87,12 @@ public:
   get_cached_backrefs_in_range(
     paddr_t start,
     paddr_t end) = 0;
-
-  virtual Cache::backref_buf_entry_query_set_t
-  get_cached_backref_removals_in_range(
-    paddr_t start,
-    paddr_t end) = 0;
-
-  virtual const backref_buf_entry_t::set_t& get_cached_backref_removals() = 0;
-  virtual const backref_buf_entry_t::set_t& get_cached_backrefs() = 0;
-  virtual backref_buf_entry_t get_cached_backref_removal(paddr_t addr) = 0;
+  virtual const backref_set_t& get_cached_backrefs() = 0;
 
   virtual Cache::backref_extent_buf_entry_query_set_t
   get_cached_backref_extents_in_range(
     paddr_t start,
     paddr_t end) = 0;
-
-  virtual bool backref_should_be_removed(paddr_t paddr) = 0;
 
   using retrieve_backref_extents_iertr = trans_iertr<
     crimson::errorator<

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1043,7 +1043,6 @@ SeaStore::tm_ret SeaStore::_do_transaction_step(
   std::vector<OnodeRef> &d_onodes,
   ceph::os::Transaction::iterator &i)
 {
-  LOG_PREFIX(SeaStore::_do_transaction_step);
   auto op = i.decode_op();
 
   using ceph::os::Transaction;
@@ -1088,6 +1087,7 @@ SeaStore::tm_ret SeaStore::_do_transaction_step(
     }
   }
   return fut.si_then([&, op, this](auto&& get_onode) -> tm_ret {
+    LOG_PREFIX(SeaStore::_do_transaction_step);
     OnodeRef &o = onodes[op->oid];
     if (!o) {
       assert(get_onode);

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -484,7 +484,8 @@ public:
   using AsyncCleaner::ExtentCallbackInterface::submit_transaction_direct_ret;
   submit_transaction_direct_ret submit_transaction_direct(
     Transaction &t,
-    std::optional<journal_seq_t> seq_to_trim = std::nullopt) final;
+    std::optional<journal_seq_t> seq_to_trim = std::nullopt,
+    std::optional<std::pair<paddr_t, paddr_t>> gc_range = std::nullopt) final;
 
   /**
    * flush

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -402,9 +402,8 @@ struct transaction_manager_test_t :
       [this, &tracker](auto &t) {
 	return backref_manager->scan_mapped_space(
 	  t,
-	  [&tracker, this](auto offset, auto len, depth_t, extent_types_t) {
-	    if (offset.get_addr_type() == addr_types_t::SEGMENT &&
-		!backref_manager->backref_should_be_removed(offset)) {
+	  [&tracker](auto offset, auto len, depth_t, extent_types_t) {
+	    if (offset.get_addr_type() == addr_types_t::SEGMENT) {
 	      logger().debug("check_usage: tracker alloc {}~{}",
 		offset, len);
 	      tracker->allocate(
@@ -416,12 +415,17 @@ struct transaction_manager_test_t :
 	    auto &backrefs = backref_manager->get_cached_backrefs();
 	    for (auto &backref : backrefs) {
 	      if (backref.paddr.get_addr_type() == addr_types_t::SEGMENT) {
-		logger().debug("check_usage: by backref, tracker alloc {}~{}",
-		  backref.paddr, backref.len);
-		tracker->allocate(
-		  backref.paddr.as_seg_paddr().get_segment_id(),
-		  backref.paddr.as_seg_paddr().get_segment_off(),
-		  backref.len);
+		if (backref.laddr == L_ADDR_NULL) {
+		  tracker->release(
+		    backref.paddr.as_seg_paddr().get_segment_id(),
+		    backref.paddr.as_seg_paddr().get_segment_off(),
+		    backref.len);
+		} else {
+		  tracker->allocate(
+		    backref.paddr.as_seg_paddr().get_segment_id(),
+		    backref.paddr.as_seg_paddr().get_segment_off(),
+		    backref.len);
+		}
 	      }
 	    }
 	    return seastar::now();


### PR DESCRIPTION
Currently, the following transaction exec sequence would lead to
loss of backref:

1. Trans `A` merge a alloc backref for extent `X`
2. Trans `B` add a release backref for extent `X` to backref cache,
   during which it finds an in-cache alloc backref for extent `X` and
   decide not to add the release backref to cache
3. Trans `A` commit

In the above sequece, the release backref for extent `X` is lost.

This is a regression introduced when we try to optimize the backref cache.

This commit fix the issue by caching inflight backrefs in a multiset,
alloc/release ops that happen on the same paddr are queued in the order of
their happening. When doing gc, all those backrefs are merged.

Fixes: https://tracker.ceph.com/issues/56519
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
