### PR TITLE
mon: make paxos_size() unsigned

### DIFF
--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -90,7 +90,7 @@ public:
    * by making a paxos commit, but not by injecting values while
    * an election is ongoing.)
    */
-  virtual int paxos_size() const = 0;
+  virtual unsigned paxos_size() const = 0;
   /**
    * Retrieve a set of ranks which are not allowed to become the leader.
    * Like paxos_size(), This set can change between elections, but not

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -130,7 +130,7 @@ bool Elector::ever_participated() const
   return mon->has_ever_joined;
 }
 
-int Elector::paxos_size() const
+unsigned Elector::paxos_size() const
 {
   return mon->monmap->size();
 }
@@ -708,7 +708,7 @@ void Elector::notify_rank_changed(int new_rank)
   dead_pinging.erase(new_rank);
 }
 
-void Elector::notify_rank_removed(int rank_removed)
+void Elector::notify_rank_removed(unsigned rank_removed)
 {
   peer_tracker.notify_rank_removed(rank_removed);
   /* we have to clean up the pinging state, which is annoying

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -240,7 +240,7 @@ class Elector : public ElectionOwner, RankProvider {
   /* Retrieve the Monitor::has_ever_joined member */
   bool ever_participated() const;
   /* Retrieve monmap->size() */
-  int paxos_size() const;
+  unsigned paxos_size() const;
   /* Right now we don't disallow anybody */
   std::set<int> disallowed_leaders;
   const std::set<int>& get_disallowed_leaders() const { return disallowed_leaders; }
@@ -371,7 +371,7 @@ class Elector : public ElectionOwner, RankProvider {
    * This is safe to call even if we haven't joined or are currently
    * in a quorum.
    */
-  void notify_rank_removed(int rank_removed);
+  void notify_rank_removed(unsigned rank_removed);
   void notify_strategy_maybe_changed(int strategy);
   /**
    * Set the disallowed leaders.

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -107,7 +107,7 @@ class MonMap {
   /* ranks which were removed when this map took effect.
      There should only be one at a time, but leave support
      for arbitrary numbers just to be safe. */
-  std::set<int> removed_ranks;
+  std::set<unsigned> removed_ranks;
 
   /**
    * Persistent Features are all those features that once set on a

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -6589,7 +6589,7 @@ void Monitor::notify_new_monmap(bool can_change_external_state)
   dout(30) << __func__ << "we have " << monmap->removed_ranks.size() << " removed ranks" << dendl;
   for (auto i = monmap->removed_ranks.rbegin();
        i != monmap->removed_ranks.rend(); ++i) {
-    int rank = *i;
+    unsigned rank = *i;
     dout(10) << __func__ << "removing rank " << rank << dendl;
     elector.notify_rank_removed(rank);
   }

--- a/src/test/mon/test_election.cc
+++ b/src/test/mon/test_election.cc
@@ -147,7 +147,7 @@ struct Owner : public ElectionOwner, RankProvider {
     logic.start();
   }
   bool ever_participated() const { return ever_joined; }
-  int paxos_size() const { return parent->get_paxos_size(); }
+  unsigned paxos_size() const { return parent->get_paxos_size(); }
   const set<int>& get_disallowed_leaders() const {
     return parent->get_disallowed_leaders();
   }


### PR DESCRIPTION
* make paxos_size() unsigned, as paxos_size() returns the size of
  MonMap::mon_info, so it should be always a non-negative value,
  and more importantly, it represents a size.
* change the type of MonMap::removed_ranks from std::set<int>
  to std::set<unsigned>. for two reasons:
  - removed_ranks only tracks the rank which is greater or equal to 0
  - helps to silence the warnings listed below.
  MonMap::removed_ranks is persisted using encode()/decode(), but this
  change is backward compatible, as we use the raw encoder to encode
  signed and unsigned integers, the difference between the encoding
  schema between them only matters when MSB in the number is used,
  but this is not likely happen, as we neither have a negative
  rank in removed_ranks, no have a rank greater than `(unsigned)-1`,
  i.e., 0xffffffff.

this change partially reverts f75dfbc055ccf4e43b817ed5aa52898ff680e19e

to address the compiling warnings like:
```
/home/kefu/dev/ceph/src/mon/ElectionLogic.cc: In member function ‘void ElectionLogic::end_election_period()’:
/home/kefu/dev/ceph/src/mon/ElectionLogic.cc:173:23: error: comparison of integer expressions of different signedness: ‘std::set<int>::size_type’ {aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
  173 |       acked_me.size() > (elector->paxos_size() / 2)) {
      |       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kefu/dev/ceph/src/mon/ElectionLogic.cc: In member function ‘void ElectionLogic::propose_connectivity_handler(int, epoch_t, const ConnectionTracker*)’:
/home/kefu/dev/ceph/src/mon/ElectionLogic.cc:338:28: error: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Werror=sign-compare]
  338 |     for (unsigned i = 0; i < elector->paxos_size(); ++i) {
      |                          ~~^~~~~~~~~~~~~~~~~~~~~~~
/home/kefu/dev/ceph/src/mon/ElectionLogic.cc: In member function ‘void ElectionLogic::receive_ack(int, epoch_t)’:
/home/kefu/dev/ceph/src/mon/ElectionLogic.cc:469:25: error: comparison of integer expressions of different signedness: ‘std::set<int>::size_type’ {aka ‘long unsigned int’} and ‘int’ [-Werror=sign-compare]
  469 |     if (acked_me.size() == elector->paxos_size()) {
      |         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[3]: *** [src/mon/CMakeFiles/mon.dir/build.make:328: src/mon/CMakeFiles/mon.dir/ElectionLogic.cc.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: Leaving directory '/home/kefu/dev/ceph/build'
[ 48%] Built target libglobal_objs
/home/kefu/dev/ceph/src/mon/Elector.cc: In member function ‘void Elector::notify_rank_removed(int)’:
/home/kefu/dev/ceph/src/mon/Elector.cc:734:43: error: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Werror=sign-compare]
  734 |     for (unsigned i = rank_removed + 1; i <= paxos_size() ; ++i) {
      |                                         ~~^~~~~~~~~~~~~~~
```
Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
