### PR TITLE
quincy: doc/dev: s/github/GitHub/ in essentials.rst

### DIFF
--- a/doc/dev/developer_guide/essentials.rst
+++ b/doc/dev/developer_guide/essentials.rst
@@ -307,12 +307,12 @@ The rest (including the actual backporting) will be taken care of by the
 Dependabot
 ----------
 
-Dependabot is a github bot that scans the dependencies in the repositories for
+Dependabot is a GitHub bot that scans the dependencies in the repositories for
 security vulnerabilities (CVEs). If a fix is available for a discovered CVE,
 Dependabot creates a pull request to update the dependency.
 
 Dependabot also indicates the compatibility score of the upgrade. This score is
-based on the number of CI failures that occur in other Github repositories
+based on the number of CI failures that occur in other GitHub repositories
 where the fix was applied. 
 
 With some configuration, Dependabot can perform non-security updates (for


### PR DESCRIPTION
This addresses a typo that Anthony D'Atri pointed out in
PR#47032. It didn't get addressed there, so it's being
addressed here.

Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit f7581e05b08d6ab55446088b0fb9f29b1dd6441b)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
