### PR TITLE
quincy: doc/dev: edit delayed-delete.rst

### DIFF
--- a/doc/dev/delayed-delete.rst
+++ b/doc/dev/delayed-delete.rst
@@ -2,11 +2,12 @@
  CephFS delayed deletion
 =========================
 
-When you delete a file, the data is not immediately removed. Each
-object in the file needs to be removed independently, and sending
-``size_of_file / stripe_size * replication_count`` messages would slow
-the client down too much, and use a too much of the clients
-bandwidth. Additionally, snapshots may mean some objects should not be
-deleted.
+The deletion of a file does not immediately remove its data. Each of the file's
+underlying objects must be removed independently. If these objects were removed 
+immediately, the client would have to send ``size_of_file / stripe_size *
+replication_count`` messages. This would consume significant bandwith and would
+slow the client unacceptably. If snapshots exist, their existence can prevent
+the deletion of objects associated with them.
 
-Instead, the file is marked as deleted on the MDS, and deleted lazily.
+In these cases, such files are (1) marked as deleted on the MDS and (2) deleted
+lazily.


### PR DESCRIPTION
This PR improves the English in the "CephFS Delayed
Deletion" chapter of the Ceph Internals Guide (which
is stored in the doc/dev/ directory).

There was no pressing need to rewrite this. I just saw
that it could be tightened up, and I had the fifteen
minutes I needed to do it.

Co-author: Anthony D'Atri <anthony.datri@gmail.com>
Signed-off-by: Zac Dover <zac.dover@gmail.com>
(cherry picked from commit c186c5ec6cb2ea1999cb14500aaa64d6aa72dddd)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
