### PR TITLE
cephadm: update LATEST_STABLE_RELEASE

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -63,7 +63,7 @@ DEFAULT_JAEGER_QUERY_IMAGE = 'quay.io/jaegertracing/jaeger-query:1.29'
 DEFAULT_REGISTRY = 'docker.io'   # normalize unqualified digests to this
 # ------------------------------------------------------------------------------
 
-LATEST_STABLE_RELEASE = 'pacific'
+LATEST_STABLE_RELEASE = 'quincy'
 DATA_DIR = '/var/lib/ceph'
 LOG_DIR = '/var/log/ceph'
 LOCK_DIR = '/run/cephadm'


### PR DESCRIPTION
The latest stable release of Ceph is Quincy.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
