### PR TITLE
quincy: ceph.spec: fixing cephadm build deps

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -268,6 +268,8 @@ BuildRequires:	python%{python3_pkgversion}-dateutil
 BuildRequires:	python%{python3_pkgversion}-coverage
 BuildRequires:	python%{python3_pkgversion}-pyOpenSSL
 BuildRequires:	socat
+BuildRequires:	python%{python3_pkgversion}-asyncssh
+BuildRequires:	python%{python3_pkgversion}-natsort
 %endif
 %if 0%{with zbd}
 BuildRequires:  libzbd-devel


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56501

---

backport of https://github.com/ceph/ceph/pull/45643
parent tracker: https://tracker.ceph.com/issues/52514

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh