### PR TITLE
quincy: mgr/cephadm: limiting ingress/keepalived pass to 8 chars

### DIFF
--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 class IngressService(CephService):
     TYPE = 'ingress'
+    MAX_KEEPALIVED_PASS_LEN = 8
 
     def primary_daemon_type(self) -> str:
         return 'haproxy'
@@ -77,7 +78,7 @@ class IngressService(CephService):
         password = self.mgr.get_store(pw_key)
         if password is None:
             if not spec.monitor_password:
-                password = ''.join(random.choice(string.ascii_lowercase) for _ in range(20))
+                password = ''.join(random.choice(string.ascii_lowercase) for _ in range(self.MAX_KEEPALIVED_PASS_LEN))
                 self.mgr.set_store(pw_key, password)
         else:
             if spec.monitor_password:
@@ -176,7 +177,7 @@ class IngressService(CephService):
         password = self.mgr.get_store(pw_key)
         if password is None:
             if not spec.keepalived_password:
-                password = ''.join(random.choice(string.ascii_lowercase) for _ in range(20))
+                password = ''.join(random.choice(string.ascii_lowercase) for _ in range(self.MAX_KEEPALIVED_PASS_LEN))
                 self.mgr.set_store(pw_key, password)
         else:
             if spec.keepalived_password:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56494

---

backport of https://github.com/ceph/ceph/pull/46907
parent tracker: https://tracker.ceph.com/issues/55491

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh