### PR TITLE
quincy: cephadm: improve message when removing osd

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2773,7 +2773,10 @@ Then run the following:
 
         # trigger the serve loop to initiate the removal
         self._kick_serve_loop()
-        return "Scheduled OSD(s) for removal"
+        warning_zap = "" if not zap else ("\nVG/LV for the OSDs won't be zapped (--zap wasn't passed).\n"
+                                          "Run the `ceph-volume lvm zap` command with `--destroy`"
+                                          " against the VG/LV if you want them to be destroyed.")
+        return f"Scheduled OSD(s) for removal.{warning_zap}"
 
     @handle_orch_error
     def stop_remove_osds(self, osd_ids: List[str]) -> str:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56475

---

backport of https://github.com/ceph/ceph/pull/46735
parent tracker: https://tracker.ceph.com/issues/56092

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh