### PR TITLE
quincy: pybind/mgr/cephadm/serve: don't remove ceph.conf which leads to qa failure

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1065,6 +1065,8 @@ class CephadmServe:
             self.mgr.cache.update_client_file(host, path, digest, mode, uid, gid)
             updated_files = True
         for path in old_files.keys():
+            if path == '/etc/ceph/ceph.conf':
+                continue
             self.log.info(f'Removing {host}:{path}')
             cmd = ['rm', '-f', path]
             self.mgr.ssh.check_execute_command(host, cmd)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56474

---

backport of https://github.com/ceph/ceph/pull/46676
parent tracker: https://tracker.ceph.com/issues/56024

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh