### PR TITLE
cephadm: reduce spam to cephadm.log

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -239,7 +239,7 @@ class Podman(ContainerEngine):
         return self._version
 
     def get_version(self, ctx: CephadmContext) -> None:
-        out, _, _ = call_throws(ctx, [self.path, 'version', '--format', '{{.Client.Version}}'])
+        out, _, _ = call_throws(ctx, [self.path, 'version', '--format', '{{.Client.Version}}'], verbosity=CallVerbosity.QUIET)
         self._version = _parse_podman_version(out)
 
     def __str__(self) -> str:
@@ -620,14 +620,14 @@ class Monitoring(object):
                 _, err, code = call(ctx, [
                     ctx.container_engine.path, 'exec', container_id, cmd,
                     '--version'
-                ], verbosity=CallVerbosity.DEBUG)
+                ], verbosity=CallVerbosity.QUIET)
                 if code == 0:
                     break
             cmd = 'alertmanager'  # reset cmd for version extraction
         else:
             _, err, code = call(ctx, [
                 ctx.container_engine.path, 'exec', container_id, cmd, '--version'
-            ], verbosity=CallVerbosity.DEBUG)
+            ], verbosity=CallVerbosity.QUIET)
         if code == 0 and \
                 err.startswith('%s, version ' % cmd):
             version = err.split(' ')[2]
@@ -718,7 +718,7 @@ class NFSGanesha(object):
         out, err, code = call(ctx,
                               [ctx.container_engine.path, 'exec', container_id,
                                NFSGanesha.entrypoint, '-v'],
-                              verbosity=CallVerbosity.DEBUG)
+                              verbosity=CallVerbosity.QUIET)
         if code == 0:
             match = re.search(r'NFS-Ganesha Release\s*=\s*[V]*([\d.]+)', out)
             if match:
@@ -850,7 +850,7 @@ class CephIscsi(object):
         out, err, code = call(ctx,
                               [ctx.container_engine.path, 'exec', container_id,
                                '/usr/bin/python3', '-c', "import pkg_resources; print(pkg_resources.require('ceph_iscsi')[0].version)"],
-                              verbosity=CallVerbosity.DEBUG)
+                              verbosity=CallVerbosity.QUIET)
         if code == 0:
             version = out.strip()
         return version
@@ -1484,20 +1484,21 @@ class FileLock(object):
         try:
             while True:
                 if not self.is_locked:
-                    logger.debug('Acquiring lock %s on %s', lock_id,
-                                 lock_filename)
+                    logger.log(QUIET_LOG_LEVEL, 'Acquiring lock %s on %s', lock_id,
+                               lock_filename)
                     self._acquire()
 
                 if self.is_locked:
-                    logger.debug('Lock %s acquired on %s', lock_id,
-                                 lock_filename)
+                    logger.log(QUIET_LOG_LEVEL, 'Lock %s acquired on %s', lock_id,
+                               lock_filename)
                     break
                 elif timeout >= 0 and time.time() - start_time > timeout:
                     logger.warning('Timeout acquiring lock %s on %s', lock_id,
                                    lock_filename)
                     raise Timeout(self._lock_file)
                 else:
-                    logger.debug(
+                    logger.log(
+                        QUIET_LOG_LEVEL,
                         'Lock %s not acquired on %s, waiting %s seconds ...',
                         lock_id, lock_filename, poll_intervall
                     )
@@ -2469,7 +2470,7 @@ def check_unit(ctx, unit_name):
     installed = False
     try:
         out, err, code = call(ctx, ['systemctl', 'is-enabled', unit_name],
-                              verbosity=CallVerbosity.DEBUG)
+                              verbosity=CallVerbosity.QUIET)
         if code == 0:
             enabled = True
             installed = True
@@ -2483,7 +2484,7 @@ def check_unit(ctx, unit_name):
     state = 'unknown'
     try:
         out, err, code = call(ctx, ['systemctl', 'is-active', unit_name],
-                              verbosity=CallVerbosity.DEBUG)
+                              verbosity=CallVerbosity.QUIET)
         out = out.strip()
         if out in ['active']:
             state = 'running'
@@ -3146,7 +3147,7 @@ def extract_uid_gid(ctx, img='', file_path='/var/lib/ceph'):
                 image=img,
                 entrypoint='stat',
                 args=['-c', '%u %g', fp]
-            ).run()
+            ).run(verbosity=CallVerbosity.QUIET_UNLESS_ERROR)
             uid, gid = out.split(' ')
             return int(uid), int(gid)
         except RuntimeError as e:
@@ -4071,10 +4072,10 @@ class CephContainer:
         ]
         return ret
 
-    def run(self, timeout=DEFAULT_TIMEOUT):
-        # type: (Optional[int]) -> str
+    def run(self, timeout=DEFAULT_TIMEOUT, verbosity=CallVerbosity.VERBOSE_ON_FAILURE):
+        # type: (Optional[int], CallVerbosity) -> str
         out, _, _ = call_throws(self.ctx, self.run_cmd(),
-                                desc=self.entrypoint, timeout=timeout)
+                                desc=self.entrypoint, timeout=timeout, verbosity=verbosity)
         return out
 
 
@@ -4621,7 +4622,7 @@ def _pull_image(ctx, image, insecure=False):
     cmd_str = ' '.join(cmd)
 
     for sleep_secs in [1, 4, 25]:
-        out, err, ret = call(ctx, cmd)
+        out, err, ret = call(ctx, cmd, verbosity=CallVerbosity.QUIET_UNLESS_ERROR)
         if not ret:
             return
 
@@ -5104,7 +5105,8 @@ def wait_for_mon(
         timeout = ctx.timeout if ctx.timeout else 60  # seconds
         out, err, ret = call(ctx, c.run_cmd(),
                              desc=c.entrypoint,
-                             timeout=timeout)
+                             timeout=timeout,
+                             verbosity=CallVerbosity.QUIET_UNLESS_ERROR)
         return ret == 0
 
     is_available(ctx, 'mon', is_mon_available)
@@ -5131,7 +5133,9 @@ def create_mgr(
         # type: () -> bool
         timeout = ctx.timeout if ctx.timeout else 60  # seconds
         try:
-            out = clifunc(['status', '-f', 'json-pretty'], timeout=timeout)
+            out = clifunc(['status', '-f', 'json-pretty'],
+                          timeout=timeout,
+                          verbosity=CallVerbosity.QUIET_UNLESS_ERROR)
             j = json.loads(out)
             return j.get('mgrmap', {}).get('available', False)
         except Exception as e:
@@ -5574,8 +5578,8 @@ def command_bootstrap(ctx):
     tmp_config = write_tmp(config, uid, gid)
 
     # a CLI helper to reduce our typing
-    def cli(cmd, extra_mounts={}, timeout=DEFAULT_TIMEOUT):
-        # type: (List[str], Dict[str, str], Optional[int]) -> str
+    def cli(cmd, extra_mounts={}, timeout=DEFAULT_TIMEOUT, verbosity=CallVerbosity.VERBOSE_ON_FAILURE):
+        # type: (List[str], Dict[str, str], Optional[int], CallVerbosity) -> str
         mounts = {
             log_dir: '/var/log/ceph:z',
             admin_keyring.name: '/etc/ceph/ceph.client.admin.keyring:z',
@@ -5590,7 +5594,7 @@ def command_bootstrap(ctx):
             entrypoint='/usr/bin/ceph',
             args=cmd,
             volume_mounts=mounts,
-        ).run(timeout=timeout)
+        ).run(timeout=timeout, verbosity=verbosity)
 
     wait_for_mon(ctx, mon_id, mon_dir, admin_keyring.name, tmp_config.name)
 
@@ -5627,9 +5631,9 @@ def command_bootstrap(ctx):
         # stat' command first, then fall back to 'mgr dump' if
         # necessary
         try:
-            j = json_loads_retry(lambda: cli(['mgr', 'stat']))
+            j = json_loads_retry(lambda: cli(['mgr', 'stat'], verbosity=CallVerbosity.QUIET_UNLESS_ERROR))
         except Exception:
-            j = json_loads_retry(lambda: cli(['mgr', 'dump']))
+            j = json_loads_retry(lambda: cli(['mgr', 'dump'], verbosity=CallVerbosity.QUIET_UNLESS_ERROR))
         epoch = j['epoch']
 
         # wait for mgr to have it
@@ -6121,7 +6125,7 @@ def command_ceph_volume(ctx):
         volume_mounts=mounts,
     )
 
-    out, err, code = call_throws(ctx, c.run_cmd())
+    out, err, code = call_throws(ctx, c.run_cmd(), verbosity=CallVerbosity.QUIET_UNLESS_ERROR)
     if not code:
         print(out)
 
@@ -6186,7 +6190,7 @@ def _list_ipv4_networks(ctx: CephadmContext) -> Dict[str, Dict[str, Set[str]]]:
     execstr: Optional[str] = find_executable('ip')
     if not execstr:
         raise FileNotFoundError("unable to find 'ip' command")
-    out, _, _ = call_throws(ctx, [execstr, 'route', 'ls'])
+    out, _, _ = call_throws(ctx, [execstr, 'route', 'ls'], verbosity=CallVerbosity.QUIET_UNLESS_ERROR)
     return _parse_ipv4_route(out)
 
 
@@ -6214,8 +6218,8 @@ def _list_ipv6_networks(ctx: CephadmContext) -> Dict[str, Dict[str, Set[str]]]:
     execstr: Optional[str] = find_executable('ip')
     if not execstr:
         raise FileNotFoundError("unable to find 'ip' command")
-    routes, _, _ = call_throws(ctx, [execstr, '-6', 'route', 'ls'])
-    ips, _, _ = call_throws(ctx, [execstr, '-6', 'addr', 'ls'])
+    routes, _, _ = call_throws(ctx, [execstr, '-6', 'route', 'ls'], verbosity=CallVerbosity.QUIET_UNLESS_ERROR)
+    ips, _, _ = call_throws(ctx, [execstr, '-6', 'addr', 'ls'], verbosity=CallVerbosity.QUIET_UNLESS_ERROR)
     return _parse_ipv6_route(routes, ips)
 
 
@@ -6321,14 +6325,14 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
     out, err, code = call(
         ctx,
         [container_path, 'stats', '--format', '{{.ID}},{{.MemUsage}}', '--no-stream'],
-        verbosity=CallVerbosity.DEBUG
+        verbosity=CallVerbosity.QUIET
     )
     seen_memusage_cid_len, seen_memusage = _parse_mem_usage(code, out)
 
     out, err, code = call(
         ctx,
         [container_path, 'stats', '--format', '{{.ID}},{{.CPUPerc}}', '--no-stream'],
-        verbosity=CallVerbosity.DEBUG
+        verbosity=CallVerbosity.QUIET
     )
     seen_cpuperc_cid_len, seen_cpuperc = _parse_cpu_perc(code, out)
 
@@ -6357,7 +6361,7 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                             try:
                                 out, err, code = call(ctx,
                                                       ['ceph', '-v'],
-                                                      verbosity=CallVerbosity.DEBUG)
+                                                      verbosity=CallVerbosity.QUIET)
                                 if not code and out.startswith('ceph version '):
                                     host_version = out.split(' ')[2]
                             except Exception:
@@ -6408,7 +6412,7 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                         container_path, 'image', 'inspect', image_id,
                                         '--format', '{{.RepoDigests}}',
                                     ],
-                                    verbosity=CallVerbosity.DEBUG)
+                                    verbosity=CallVerbosity.QUIET)
                                 if not code:
                                     image_digests = list(set(map(
                                         normalize_image_digest,
@@ -6427,7 +6431,7 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                     out, err, code = call(ctx,
                                                           [container_path, 'exec', container_id,
                                                            'ceph', '-v'],
-                                                          verbosity=CallVerbosity.DEBUG)
+                                                          verbosity=CallVerbosity.QUIET)
                                     if not code and \
                                        out.startswith('ceph version '):
                                         version = out.split(' ')[2]
@@ -6436,7 +6440,7 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                     out, err, code = call(ctx,
                                                           [container_path, 'exec', container_id,
                                                            'grafana-server', '-v'],
-                                                          verbosity=CallVerbosity.DEBUG)
+                                                          verbosity=CallVerbosity.QUIET)
                                     if not code and \
                                        out.startswith('Version '):
                                         version = out.split(' ')[1]
@@ -6452,7 +6456,7 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                     out, err, code = call(ctx,
                                                           [container_path, 'exec', container_id,
                                                            'haproxy', '-v'],
-                                                          verbosity=CallVerbosity.DEBUG)
+                                                          verbosity=CallVerbosity.QUIET)
                                     if not code and \
                                        out.startswith('HA-Proxy version '):
                                         version = out.split(' ')[2]
@@ -6461,7 +6465,7 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                     out, err, code = call(ctx,
                                                           [container_path, 'exec', container_id,
                                                            'keepalived', '--version'],
-                                                          verbosity=CallVerbosity.DEBUG)
+                                                          verbosity=CallVerbosity.QUIET)
                                     if not code and \
                                        err.startswith('Keepalived '):
                                         version = err.split(' ')[1]
@@ -6571,7 +6575,7 @@ def get_container_stats(ctx: CephadmContext, container_path: str, fsid: str, dae
             '--format', '{{.Id}},{{.Config.Image}},{{.Image}},{{.Created}},{{index .Config.Labels "io.ceph.version"}}',
             name
         ]
-        out, err, code = call(ctx, cmd, verbosity=CallVerbosity.DEBUG)
+        out, err, code = call(ctx, cmd, verbosity=CallVerbosity.QUIET)
         if not code:
             break
     return out, err, code
@@ -8663,7 +8667,7 @@ class HostFacts():
             security = {}
             try:
                 out, err, code = call(self.ctx, ['sestatus'],
-                                      verbosity=CallVerbosity.DEBUG)
+                                      verbosity=CallVerbosity.QUIET)
                 security['type'] = 'SELinux'
                 status, mode, policy = '', '', ''
                 for line in out.split('\n'):

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -86,6 +86,7 @@ CUSTOM_PS1 = r'[ceph: \u@\h \W]\$ '
 DEFAULT_TIMEOUT = None  # in seconds
 DEFAULT_RETRY = 15
 DATEFMT = '%Y-%m-%dT%H:%M:%S.%fZ'
+QUIET_LOG_LEVEL = 9  # DEBUG is 10, so using 9 to be lower level than DEBUG
 
 logger: logging.Logger = None  # type: ignore
 
@@ -1575,14 +1576,47 @@ class FileLock(object):
 # Popen wrappers, lifted from ceph-volume
 
 class CallVerbosity(Enum):
+    #####
+    # Format:
+    # Normal Operation: <log-level-when-no-errors>, Errors: <log-level-when-error>
+    #
+    # NOTE: QUIET log level is custom level only used when --verbose is passed
+    #####
+
+    # Normal Operation: None, Errors: None
     SILENT = 0
-    # log stdout/stderr to logger.debug
-    DEBUG = 1
-    # On a non-zero exit status, it will forcefully set
-    # logging ON for the terminal
-    VERBOSE_ON_FAILURE = 2
-    # log at info (instead of debug) level.
-    VERBOSE = 3
+    # Normal Operation: QUIET, Error: QUIET
+    QUIET = 1
+    # Normal Operation: DEBUG, Error: DEBUG
+    DEBUG = 2
+    # Normal Operation: QUIET, Error: INFO
+    QUIET_UNLESS_ERROR = 3
+    # Normal Operation: DEBUG, Error: INFO
+    VERBOSE_ON_FAILURE = 4
+    # Normal Operation: INFO, Error: INFO
+    VERBOSE = 5
+
+    def success_log_level(self) -> int:
+        _verbosity_level_to_log_level = {
+            self.SILENT: 0,
+            self.QUIET: QUIET_LOG_LEVEL,
+            self.DEBUG: logging.DEBUG,
+            self.QUIET_UNLESS_ERROR: QUIET_LOG_LEVEL,
+            self.VERBOSE_ON_FAILURE: logging.DEBUG,
+            self.VERBOSE: logging.INFO
+        }
+        return _verbosity_level_to_log_level[self]  # type: ignore
+
+    def error_log_level(self) -> int:
+        _verbosity_level_to_log_level = {
+            self.SILENT: 0,
+            self.QUIET: QUIET_LOG_LEVEL,
+            self.DEBUG: logging.DEBUG,
+            self.QUIET_UNLESS_ERROR: logging.INFO,
+            self.VERBOSE_ON_FAILURE: logging.INFO,
+            self.VERBOSE: logging.INFO
+        }
+        return _verbosity_level_to_log_level[self]  # type: ignore
 
 
 if sys.version_info < (3, 8):
@@ -1730,10 +1764,6 @@ def call(ctx: CephadmContext,
         async for line in reader:
             message = line.decode('utf-8')
             collected.write(message)
-            if verbosity == CallVerbosity.VERBOSE:
-                logger.info(prefix + message.rstrip())
-            elif verbosity != CallVerbosity.SILENT:
-                logger.debug(prefix + message.rstrip())
         return collected.getvalue()
 
     async def run_with_timeout() -> Tuple[str, str, int]:
@@ -1755,13 +1785,14 @@ def call(ctx: CephadmContext,
             return stdout, stderr, returncode
 
     stdout, stderr, returncode = async_run(run_with_timeout())
-    if returncode != 0 and verbosity == CallVerbosity.VERBOSE_ON_FAILURE:
-        logger.info('Non-zero exit code %d from %s',
-                    returncode, ' '.join(command))
-        for line in stdout.splitlines():
-            logger.info(prefix + 'stdout ' + line)
-        for line in stderr.splitlines():
-            logger.info(prefix + 'stderr ' + line)
+    log_level = verbosity.success_log_level()
+    if returncode != 0:
+        log_level = verbosity.error_log_level()
+        logger.log(log_level, f'Non-zero exit code {returncode} from {" ".join(command)}')
+    for line in stdout.splitlines():
+        logger.log(log_level, prefix + 'stdout ' + line)
+    for line in stderr.splitlines():
+        logger.log(log_level, prefix + 'stderr ' + line)
     return stdout, stderr, returncode
 
 
@@ -9542,6 +9573,7 @@ def cephadm_init_logging(ctx: CephadmContext, args: List[str]) -> None:
     """Configure the logging for cephadm as well as updating the system
     to have the expected log dir and logrotate configuration.
     """
+    logging.addLevelName(QUIET_LOG_LEVEL, 'QUIET')
     global logger
     if not os.path.exists(LOG_DIR):
         os.makedirs(LOG_DIR)
@@ -9552,6 +9584,7 @@ def cephadm_init_logging(ctx: CephadmContext, args: List[str]) -> None:
         dictConfig(logging_config)
 
     logger = logging.getLogger()
+    logger.setLevel(QUIET_LOG_LEVEL)
 
     if not os.path.exists(ctx.logrotate_dir + '/cephadm'):
         with open(ctx.logrotate_dir + '/cephadm', 'w') as f:
@@ -9567,8 +9600,8 @@ def cephadm_init_logging(ctx: CephadmContext, args: List[str]) -> None:
 
     if ctx.verbose:
         for handler in logger.handlers:
-            if handler.name == 'console':
-                handler.setLevel(logging.DEBUG)
+            if handler.name in ['console', 'log_file', 'console_stdout']:
+                handler.setLevel(QUIET_LOG_LEVEL)
     logger.debug('%s\ncephadm %s' % ('-' * 80, args))
 
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/56552

Signed-off-by: Adam King <adking@redhat.com>

By introducing a new QUIET log level that only prints to the console or log file when --verbose is passed, we can reduce how much our regular metadata gathering commands spam the log while still allowing us to see the full output when running the command manually for debugging purposes.

Example output in cephadm.log after running

`cephadm ls`
`cephadm --verbose ls`
`cephadm shell -- ceph orch ps`
`cephadm --verbose shell -- ceph orch ps`

Note that before this change everything being logged at QUIET level in this output would have been printed to the log every time these commands were run (but at DEBUG level)

```
2022-07-13 22:07:54,863 7f332c5ffb80 DEBUG --------------------------------------------------------------------------------
cephadm ['ls']
2022-07-13 22:08:01,081 7f8516cc9b80 DEBUG --------------------------------------------------------------------------------
cephadm ['--verbose', 'ls']
2022-07-13 22:08:01,242 7f8516cc9b80 QUIET /usr/bin/podman: stdout 4.0.2
2022-07-13 22:08:01,432 7f8516cc9b80 QUIET /usr/bin/podman: stdout 06f4c7d03a9c,55.04MB / 41.96GB
2022-07-13 22:08:01,433 7f8516cc9b80 QUIET /usr/bin/podman: stdout 16b28ebd9b29,467.1MB / 41.96GB
2022-07-13 22:08:01,434 7f8516cc9b80 QUIET /usr/bin/podman: stdout 5d5302ddbf13,50.5MB / 41.96GB
2022-07-13 22:08:01,434 7f8516cc9b80 QUIET /usr/bin/podman: stdout 796918b51ecd,19.78MB / 41.96GB
2022-07-13 22:08:01,434 7f8516cc9b80 QUIET /usr/bin/podman: stdout 7b38712c8e47,23.6MB / 41.96GB
2022-07-13 22:08:01,435 7f8516cc9b80 QUIET /usr/bin/podman: stdout 8278e4f2802f,6.816MB / 41.96GB
2022-07-13 22:08:01,616 7f8516cc9b80 QUIET /usr/bin/podman: stdout 06f4c7d03a9c,3.86%
2022-07-13 22:08:01,617 7f8516cc9b80 QUIET /usr/bin/podman: stdout 16b28ebd9b29,5.29%
2022-07-13 22:08:01,617 7f8516cc9b80 QUIET /usr/bin/podman: stdout 5d5302ddbf13,9.35%
2022-07-13 22:08:01,618 7f8516cc9b80 QUIET /usr/bin/podman: stdout 796918b51ecd,2.68%
2022-07-13 22:08:01,618 7f8516cc9b80 QUIET /usr/bin/podman: stdout 7b38712c8e47,7.24%
2022-07-13 22:08:01,618 7f8516cc9b80 QUIET /usr/bin/podman: stdout 8278e4f2802f,6.55%
2022-07-13 22:08:01,650 7f8516cc9b80 QUIET systemctl: stdout enabled
2022-07-13 22:08:01,663 7f8516cc9b80 QUIET systemctl: stdout active
2022-07-13 22:08:01,836 7f8516cc9b80 QUIET /usr/bin/podman: stdout 5d5302ddbf13757d7908bedf73af4d77bcecfaea3066afefe29bb4f8534642c5,quay.io/adk3798/ceph:testing,0114a0cdcf9dbb2b593c53f9acc05ba8d543c96ade970cd71777bff2f03473fa,2022-07-13 21:55:06.529026914 +0000 UTC,
2022-07-13 22:08:02,015 7f8516cc9b80 QUIET /usr/bin/podman: stdout [quay.io/adk3798/ceph@sha256:dba7ffeb0f6239c6ef7155ac4e102141e5e83f3acb24337accd794ff2b0d572b]
2022-07-13 22:08:02,373 7f8516cc9b80 QUIET /usr/bin/podman: stdout ceph version 17.0.0-12762-g63f84c50 (63f84c50e0851d456fc38b3330945c54162dd544) quincy (dev)
2022-07-13 22:08:02,388 7f8516cc9b80 QUIET systemctl: stdout enabled
2022-07-13 22:08:02,401 7f8516cc9b80 QUIET systemctl: stdout active
2022-07-13 22:08:02,568 7f8516cc9b80 QUIET /usr/bin/podman: stdout 16b28ebd9b29eaf50c70b750137dc7587e807f85409dd072fc4462307a364cad,quay.io/adk3798/ceph:testing,0114a0cdcf9dbb2b593c53f9acc05ba8d543c96ade970cd71777bff2f03473fa,2022-07-13 21:55:08.215025028 +0000 UTC,
2022-07-13 22:08:02,605 7f8516cc9b80 QUIET systemctl: stdout enabled
2022-07-13 22:08:02,616 7f8516cc9b80 QUIET systemctl: stdout active
2022-07-13 22:08:02,782 7f8516cc9b80 QUIET /usr/bin/podman: stdout 7b38712c8e473697a2afb7b62caa15ddbf0c80a01696238e11f06b607ff6bbcc,quay.io/prometheus/alertmanager:v0.23.0,ba2b418f427c0636d654de8757e830c80168e76482bcc46bb2138e569d6c91d4,2022-07-13 21:58:28.0207151 +0000 UTC,
2022-07-13 22:08:02,992 7f8516cc9b80 QUIET /usr/bin/podman: stdout [quay.io/prometheus/alertmanager@sha256:3915fd90525daa23260082194e3ca8a75c51af5d436b64eeff16f0c7e54ef829 quay.io/prometheus/alertmanager@sha256:9ab73a421b65b80be072f96a88df756fc5b52a1bc8d983537b8ec5be8b624c5a]
2022-07-13 22:08:03,284 7f8516cc9b80 QUIET /usr/bin/podman: stdout alertmanager, version 0.23.0 (branch: HEAD, revision: 61046b17771a57cfd4c4a51be370ab930a4d7d54)
2022-07-13 22:08:03,285 7f8516cc9b80 QUIET /usr/bin/podman: stdout   build user:       root@e21a959be8d2
2022-07-13 22:08:03,285 7f8516cc9b80 QUIET /usr/bin/podman: stdout   build date:       20210825-10:48:55
2022-07-13 22:08:03,285 7f8516cc9b80 QUIET /usr/bin/podman: stdout   go version:       go1.16.7
2022-07-13 22:08:03,285 7f8516cc9b80 QUIET /usr/bin/podman: stdout   platform:         linux/amd64
2022-07-13 22:08:03,302 7f8516cc9b80 QUIET systemctl: stdout enabled
2022-07-13 22:08:03,315 7f8516cc9b80 QUIET systemctl: stdout active
2022-07-13 22:08:03,497 7f8516cc9b80 QUIET /usr/bin/podman: stdout 8278e4f2802fe36564f3da5fc9cb519fb0a6e760b10c687b60e32bf6ddb0d304,quay.io/adk3798/ceph@sha256:dba7ffeb0f6239c6ef7155ac4e102141e5e83f3acb24337accd794ff2b0d572b,0114a0cdcf9dbb2b593c53f9acc05ba8d543c96ade970cd71777bff2f03473fa,2022-07-13 21:56:20.914716287 +0000 UTC,
2022-07-13 22:08:03,512 7f8516cc9b80 QUIET systemctl: stdout enabled
2022-07-13 22:08:03,522 7f8516cc9b80 QUIET systemctl: stdout active
2022-07-13 22:08:03,706 7f8516cc9b80 QUIET /usr/bin/podman: stdout 06f4c7d03a9cba5056ffb039abeb34c0d73ffb621d96df4d7f7586f0f9ec9af3,quay.io/ceph/ceph-grafana:8.3.5,dad864ee21e98e69f4029d1e417aa085001566be0d322fbc75bc6f29b0050c01,2022-07-13 21:58:31.545394351 +0000 UTC,
2022-07-13 22:08:03,954 7f8516cc9b80 QUIET /usr/bin/podman: stdout [quay.io/ceph/ceph-grafana@sha256:09d5d36bc52314dc0f86e616d959d147bb61d4120dcce1f9be244b324c4b0f36 quay.io/ceph/ceph-grafana@sha256:f5273853535cbeb49c24ab539ad6e21ca41c9e894753f33b992f232ce40d6c00]
2022-07-13 22:08:04,396 7f8516cc9b80 QUIET /usr/bin/podman: stdout Version 8.3.5 (commit: a53fcac7b1, branch: HEAD)
2022-07-13 22:08:04,431 7f8516cc9b80 QUIET systemctl: stdout enabled
2022-07-13 22:08:04,444 7f8516cc9b80 QUIET systemctl: stdout active
2022-07-13 22:08:04,610 7f8516cc9b80 QUIET /usr/bin/podman: stdout 796918b51ecda59578b27590d8dc20f2b92fe6e1c464807d497d28668020e6f4,quay.io/prometheus/node-exporter:v1.3.1,1dbe0e931976487e20e5cfb272087e08a9779c88fd5e9617ed7042dd9751ec26,2022-07-13 21:56:41.162162502 +0000 UTC,
2022-07-13 22:08:04,806 7f8516cc9b80 QUIET /usr/bin/podman: stdout [quay.io/prometheus/node-exporter@sha256:d5b2a2e2bb07a4a5a7c4bd9e54641cab63e1d2627622dbde17efc04849d3d30d quay.io/prometheus/node-exporter@sha256:f2269e73124dd0f60a7d19a2ce1264d33d08a985aed0ee6b0b89d0be470592cd]
2022-07-13 22:08:05,092 7f8516cc9b80 QUIET /usr/bin/podman: stdout node_exporter, version 1.3.1 (branch: HEAD, revision: a2321e7b940ddcff26873612bccdf7cd4c42b6b6)
2022-07-13 22:08:05,092 7f8516cc9b80 QUIET /usr/bin/podman: stdout   build user:       root@243aafa5525c
2022-07-13 22:08:05,093 7f8516cc9b80 QUIET /usr/bin/podman: stdout   build date:       20211205-11:09:49
2022-07-13 22:08:05,093 7f8516cc9b80 QUIET /usr/bin/podman: stdout   go version:       go1.17.3
2022-07-13 22:08:05,093 7f8516cc9b80 QUIET /usr/bin/podman: stdout   platform:         linux/amd64
2022-07-13 22:08:11,686 7f5aaf777b80 DEBUG --------------------------------------------------------------------------------
cephadm ['gather-facts']
2022-07-13 22:08:26,417 7fd5c0a96b80 DEBUG --------------------------------------------------------------------------------
cephadm ['shell', '--', 'ceph', 'orch', 'ps']
2022-07-13 22:08:26,574 7fd5c0a96b80 DEBUG Using default config /etc/ceph/ceph.conf
2022-07-13 22:08:26,939 7fd5c0a96b80 INFO Inferring fsid 5e370bfe-02f6-11ed-abab-525400271ee5
2022-07-13 22:08:27,308 7fd5c0a96b80 INFO Inferring config /var/lib/ceph/5e370bfe-02f6-11ed-abab-525400271ee5/mon.vm-00/config
2022-07-13 22:08:27,481 7fd5c0a96b80 DEBUG /usr/bin/podman: stdout quay.io/adk3798/ceph@sha256:dba7ffeb0f6239c6ef7155ac4e102141e5e83f3acb24337accd794ff2b0d572b|0114a0cdcf9d|testing|2022-07-13 21:52:44 +0000 UTC
2022-07-13 22:08:28,048 7fd5c0a96b80 DEBUG Using container info for daemon 'mon'
2022-07-13 22:08:28,049 7fd5c0a96b80 INFO Using ceph image with id '0114a0cdcf9d' and tag 'testing' created on 2022-07-13 21:52:44 +0000 UTC
quay.io/adk3798/ceph@sha256:dba7ffeb0f6239c6ef7155ac4e102141e5e83f3acb24337accd794ff2b0d572b
2022-07-13 22:08:28,469 7fd5c0a96b80 DEBUG Running command (timeout=None): /usr/bin/podman run --rm --ipc=host --net=host --privileged --group-add=disk --init -i -e CONTAINER_IMAGE=quay.io/adk3798/ceph@sha256:dba7ffeb0f6239c6ef7155ac4e102141e5e83f3acb24337accd794ff2b0d572b -e NODE_NAME=vm-00 -e CEPH_USE_RANDOM_NONCE=1 -v /var/run/ceph/5e370bfe-02f6-11ed-abab-525400271ee5:/var/run/ceph:z -v /var/log/ceph/5e370bfe-02f6-11ed-abab-525400271ee5:/var/log/ceph:z -v /var/lib/ceph/5e370bfe-02f6-11ed-abab-525400271ee5/crash:/var/lib/ceph/crash:z -v /run/systemd/journal:/run/systemd/journal -v /dev:/dev -v /run/udev:/run/udev -v /sys:/sys -v /run/lvm:/run/lvm -v /run/lock/lvm:/run/lock/lvm -v /var/lib/ceph/5e370bfe-02f6-11ed-abab-525400271ee5/selinux:/sys/fs/selinux:ro -v /:/rootfs -v /var/lib/ceph/5e370bfe-02f6-11ed-abab-525400271ee5/mon.vm-00/config:/etc/ceph/ceph.conf:z -v /var/lib/ceph/5e370bfe-02f6-11ed-abab-525400271ee5/config/ceph.client.admin.keyring:/etc/ceph/ceph.keyring:z --entrypoint ceph quay.io/adk3798/ceph@sha256:dba7ffeb0f6239c6ef7155ac4e102141e5e83f3acb24337accd794ff2b0d572b orch ps
2022-07-13 22:08:35,523 7f039b296b80 DEBUG --------------------------------------------------------------------------------
cephadm ['--verbose', 'shell', '--', 'ceph', 'orch', 'ps']
2022-07-13 22:08:35,574 7f039b296b80 QUIET /usr/bin/podman: stdout 4.0.2
2022-07-13 22:08:35,574 7f039b296b80 DEBUG Using default config /etc/ceph/ceph.conf
2022-07-13 22:08:35,736 7f039b296b80 QUIET /usr/bin/podman: stdout 06f4c7d03a9c,56.09MB / 41.96GB
2022-07-13 22:08:35,738 7f039b296b80 QUIET /usr/bin/podman: stdout 16b28ebd9b29,467.3MB / 41.96GB
2022-07-13 22:08:35,738 7f039b296b80 QUIET /usr/bin/podman: stdout 5d5302ddbf13,50.45MB / 41.96GB
2022-07-13 22:08:35,739 7f039b296b80 QUIET /usr/bin/podman: stdout 796918b51ecd,21.39MB / 41.96GB
2022-07-13 22:08:35,739 7f039b296b80 QUIET /usr/bin/podman: stdout 7b38712c8e47,23.6MB / 41.96GB
2022-07-13 22:08:35,739 7f039b296b80 QUIET /usr/bin/podman: stdout 8278e4f2802f,6.816MB / 41.96GB
2022-07-13 22:08:35,933 7f039b296b80 QUIET /usr/bin/podman: stdout 06f4c7d03a9c,4.07%
2022-07-13 22:08:35,934 7f039b296b80 QUIET /usr/bin/podman: stdout 16b28ebd9b29,5.41%
2022-07-13 22:08:35,935 7f039b296b80 QUIET /usr/bin/podman: stdout 5d5302ddbf13,9.81%
2022-07-13 22:08:35,935 7f039b296b80 QUIET /usr/bin/podman: stdout 796918b51ecd,2.84%
2022-07-13 22:08:35,935 7f039b296b80 QUIET /usr/bin/podman: stdout 7b38712c8e47,7.73%
2022-07-13 22:08:35,936 7f039b296b80 QUIET /usr/bin/podman: stdout 8278e4f2802f,6.55%
2022-07-13 22:08:35,938 7f039b296b80 INFO Inferring fsid 5e370bfe-02f6-11ed-abab-525400271ee5
2022-07-13 22:08:36,119 7f039b296b80 QUIET /usr/bin/podman: stdout 06f4c7d03a9c,56.09MB / 41.96GB
2022-07-13 22:08:36,120 7f039b296b80 QUIET /usr/bin/podman: stdout 16b28ebd9b29,467.3MB / 41.96GB
2022-07-13 22:08:36,120 7f039b296b80 QUIET /usr/bin/podman: stdout 5d5302ddbf13,50.45MB / 41.96GB
2022-07-13 22:08:36,121 7f039b296b80 QUIET /usr/bin/podman: stdout 796918b51ecd,21.39MB / 41.96GB
2022-07-13 22:08:36,121 7f039b296b80 QUIET /usr/bin/podman: stdout 7b38712c8e47,23.6MB / 41.96GB
2022-07-13 22:08:36,121 7f039b296b80 QUIET /usr/bin/podman: stdout 8278e4f2802f,6.816MB / 41.96GB
2022-07-13 22:08:36,302 7f039b296b80 QUIET /usr/bin/podman: stdout 06f4c7d03a9c,4.07%
2022-07-13 22:08:36,303 7f039b296b80 QUIET /usr/bin/podman: stdout 16b28ebd9b29,5.41%
2022-07-13 22:08:36,304 7f039b296b80 QUIET /usr/bin/podman: stdout 5d5302ddbf13,9.82%
2022-07-13 22:08:36,304 7f039b296b80 QUIET /usr/bin/podman: stdout 796918b51ecd,2.84%
2022-07-13 22:08:36,304 7f039b296b80 QUIET /usr/bin/podman: stdout 7b38712c8e47,7.73%
2022-07-13 22:08:36,305 7f039b296b80 QUIET /usr/bin/podman: stdout 8278e4f2802f,6.55%
2022-07-13 22:08:36,306 7f039b296b80 INFO Inferring config /var/lib/ceph/5e370bfe-02f6-11ed-abab-525400271ee5/mon.vm-00/config
2022-07-13 22:08:36,482 7f039b296b80 DEBUG /usr/bin/podman: stdout quay.io/adk3798/ceph@sha256:dba7ffeb0f6239c6ef7155ac4e102141e5e83f3acb24337accd794ff2b0d572b|0114a0cdcf9d|testing|2022-07-13 21:52:44 +0000 UTC
2022-07-13 22:08:36,568 7f039b296b80 QUIET /usr/bin/podman: stdout 06f4c7d03a9c,56.09MB / 41.96GB
2022-07-13 22:08:36,568 7f039b296b80 QUIET /usr/bin/podman: stdout 16b28ebd9b29,467.3MB / 41.96GB
2022-07-13 22:08:36,568 7f039b296b80 QUIET /usr/bin/podman: stdout 5d5302ddbf13,50.45MB / 41.96GB
2022-07-13 22:08:36,568 7f039b296b80 QUIET /usr/bin/podman: stdout 796918b51ecd,21.39MB / 41.96GB
2022-07-13 22:08:36,568 7f039b296b80 QUIET /usr/bin/podman: stdout 7b38712c8e47,23.6MB / 41.96GB
2022-07-13 22:08:36,568 7f039b296b80 QUIET /usr/bin/podman: stdout 8278e4f2802f,6.816MB / 41.96GB
2022-07-13 22:08:36,728 7f039b296b80 QUIET /usr/bin/podman: stdout 06f4c7d03a9c,4.07%
2022-07-13 22:08:36,729 7f039b296b80 QUIET /usr/bin/podman: stdout 16b28ebd9b29,5.41%
2022-07-13 22:08:36,729 7f039b296b80 QUIET /usr/bin/podman: stdout 5d5302ddbf13,9.82%
2022-07-13 22:08:36,729 7f039b296b80 QUIET /usr/bin/podman: stdout 796918b51ecd,2.84%
2022-07-13 22:08:36,729 7f039b296b80 QUIET /usr/bin/podman: stdout 7b38712c8e47,7.73%
2022-07-13 22:08:36,730 7f039b296b80 QUIET /usr/bin/podman: stdout 8278e4f2802f,6.55%
2022-07-13 22:08:36,935 7f039b296b80 QUIET /usr/bin/podman: stdout 5d5302ddbf13757d7908bedf73af4d77bcecfaea3066afefe29bb4f8534642c5,quay.io/adk3798/ceph:testing,0114a0cdcf9dbb2b593c53f9acc05ba8d543c96ade970cd71777bff2f03473fa,2022-07-13 21:55:06.529026914 +0000 UTC,
2022-07-13 22:08:36,937 7f039b296b80 DEBUG Using container info for daemon 'mon'
2022-07-13 22:08:36,937 7f039b296b80 INFO Using ceph image with id '0114a0cdcf9d' and tag 'testing' created on 2022-07-13 21:52:44 +0000 UTC
quay.io/adk3798/ceph@sha256:dba7ffeb0f6239c6ef7155ac4e102141e5e83f3acb24337accd794ff2b0d572b
2022-07-13 22:08:37,417 7f039b296b80 QUIET stat: stdout 167 167
2022-07-13 22:08:37,436 7f039b296b80 QUIET sestatus: stdout SELinux status:                 enabled
2022-07-13 22:08:37,437 7f039b296b80 QUIET sestatus: stdout SELinuxfs mount:                /sys/fs/selinux
2022-07-13 22:08:37,437 7f039b296b80 QUIET sestatus: stdout SELinux root directory:         /etc/selinux
2022-07-13 22:08:37,437 7f039b296b80 QUIET sestatus: stdout Loaded policy name:             targeted
2022-07-13 22:08:37,437 7f039b296b80 QUIET sestatus: stdout Current mode:                   permissive
2022-07-13 22:08:37,437 7f039b296b80 QUIET sestatus: stdout Mode from config file:          permissive
2022-07-13 22:08:37,437 7f039b296b80 QUIET sestatus: stdout Policy MLS status:              enabled
2022-07-13 22:08:37,437 7f039b296b80 QUIET sestatus: stdout Policy deny_unknown status:     allowed
2022-07-13 22:08:37,437 7f039b296b80 QUIET sestatus: stdout Memory protection checking:     actual (secure)
2022-07-13 22:08:37,437 7f039b296b80 QUIET sestatus: stdout Max kernel policy version:      33
2022-07-13 22:08:37,442 7f039b296b80 QUIET sestatus: stdout SELinux status:                 enabled
2022-07-13 22:08:37,443 7f039b296b80 QUIET sestatus: stdout SELinuxfs mount:                /sys/fs/selinux
2022-07-13 22:08:37,443 7f039b296b80 QUIET sestatus: stdout SELinux root directory:         /etc/selinux
2022-07-13 22:08:37,443 7f039b296b80 QUIET sestatus: stdout Loaded policy name:             targeted
2022-07-13 22:08:37,443 7f039b296b80 QUIET sestatus: stdout Current mode:                   permissive
2022-07-13 22:08:37,443 7f039b296b80 QUIET sestatus: stdout Mode from config file:          permissive
2022-07-13 22:08:37,443 7f039b296b80 QUIET sestatus: stdout Policy MLS status:              enabled
2022-07-13 22:08:37,443 7f039b296b80 QUIET sestatus: stdout Policy deny_unknown status:     allowed
2022-07-13 22:08:37,443 7f039b296b80 QUIET sestatus: stdout Memory protection checking:     actual (secure)
2022-07-13 22:08:37,443 7f039b296b80 QUIET sestatus: stdout Max kernel policy version:      33
2022-07-13 22:08:37,444 7f039b296b80 DEBUG Running command (timeout=None): /usr/bin/podman run --rm --ipc=host --net=host --privileged --group-add=disk --init -i -e CONTAINER_IMAGE=quay.io/adk3798/ceph@sha256:dba7ffeb0f6239c6ef7155ac4e102141e5e83f3acb24337accd794ff2b0d572b -e NODE_NAME=vm-00 -e CEPH_USE_RANDOM_NONCE=1 -v /var/run/ceph/5e370bfe-02f6-11ed-abab-525400271ee5:/var/run/ceph:z -v /var/log/ceph/5e370bfe-02f6-11ed-abab-525400271ee5:/var/log/ceph:z -v /var/lib/ceph/5e370bfe-02f6-11ed-abab-525400271ee5/crash:/var/lib/ceph/crash:z -v /run/systemd/journal:/run/systemd/journal -v /dev:/dev -v /run/udev:/run/udev -v /sys:/sys -v /run/lvm:/run/lvm -v /run/lock/lvm:/run/lock/lvm -v /var/lib/ceph/5e370bfe-02f6-11ed-abab-525400271ee5/selinux:/sys/fs/selinux:ro -v /:/rootfs -v /var/lib/ceph/5e370bfe-02f6-11ed-abab-525400271ee5/mon.vm-00/config:/etc/ceph/ceph.conf:z -v /var/lib/ceph/5e370bfe-02f6-11ed-abab-525400271ee5/config/ceph.client.admin.keyring:/etc/ceph/ceph.keyring:z --entrypoint ceph quay.io/adk3798/ceph@sha256:dba7ffeb0f6239c6ef7155ac4e102141e5e83f3acb24337accd794ff2b0d572b orch ps
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
