### PR TITLE
quincy: mgr/dashboard: don't log tracebacks on 404s

### DIFF
--- a/src/pybind/mgr/dashboard/services/exception.py
+++ b/src/pybind/mgr/dashboard/services/exception.py
@@ -45,15 +45,14 @@ def dashboard_exception_handler(handler, *args, **kwargs):
     try:
         with handle_rados_error(component=None):  # make the None controller the fallback.
             return handler(*args, **kwargs)
-    # Don't catch cherrypy.* Exceptions.
+    # pylint: disable=try-except-raise
+    except (cherrypy.HTTPRedirect, cherrypy.NotFound, cherrypy.HTTPError):
+        raise
     except (ViewCacheNoDataException, DashboardException) as error:
         logger.exception('Dashboard Exception')
         cherrypy.response.headers['Content-Type'] = 'application/json'
         cherrypy.response.status = getattr(error, 'status', 400)
         return json.dumps(serialize_dashboard_exception(error)).encode('utf-8')
-    except cherrypy.HTTPRedirect:
-        # No internal errors
-        raise
     except Exception as error:
         logger.exception('Internal Server Error')
         raise error


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56547

---

backport of https://github.com/ceph/ceph/pull/46898
parent tracker: https://tracker.ceph.com/issues/55720

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh