### PR TITLE
perfcounters: Reduce number of Prio USEFUL perfcounters across ceph.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5007,37 +5007,37 @@ void BlueStore::_init_logger()
   //****************************************
   b.add_time_avg(l_bluestore_state_prepare_lat, "state_prepare_lat",
 		 "Average prepare state latency",
-		 "sprl", PerfCountersBuilder::PRIO_USEFUL);
+		 "sprl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_state_aio_wait_lat, "state_aio_wait_lat",
 		 "Average aio_wait state latency",
-		 "sawl", PerfCountersBuilder::PRIO_INTERESTING);
+		 "sawl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_state_io_done_lat, "state_io_done_lat",
 		 "Average io_done state latency",
-		 "sidl", PerfCountersBuilder::PRIO_USEFUL);
+		 "sidl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_state_kv_queued_lat, "state_kv_queued_lat",
 		"Average kv_queued state latency",
-		"skql", PerfCountersBuilder::PRIO_USEFUL);
+		"skql", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_state_kv_committing_lat, "state_kv_commiting_lat",
 		 "Average kv_commiting state latency",
-		 "skcl", PerfCountersBuilder::PRIO_USEFUL);
+		 "skcl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_state_kv_done_lat, "state_kv_done_lat",
 		 "Average kv_done state latency",
-		 "skdl", PerfCountersBuilder::PRIO_USEFUL);
+		 "skdl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_state_finishing_lat, "state_finishing_lat",
 		 "Average finishing state latency",
-		 "sfnl", PerfCountersBuilder::PRIO_USEFUL);
+		 "sfnl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_state_done_lat, "state_done_lat",
 		 "Average done state latency",
-		 "sdnl", PerfCountersBuilder::PRIO_USEFUL);
+		 "sdnl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_state_deferred_queued_lat, "state_deferred_queued_lat",
 		 "Average deferred_queued state latency",
-		 "sdql", PerfCountersBuilder::PRIO_USEFUL);
+		 "sdql", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_state_deferred_aio_wait_lat, "state_deferred_aio_wait_lat",
 		 "Average aio_wait state latency",
-		 "sdal", PerfCountersBuilder::PRIO_USEFUL);
+		 "sdal", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_state_deferred_cleanup_lat, "state_deferred_cleanup_lat",
 		 "Average cleanup state latency",
-		 "sdcl", PerfCountersBuilder::PRIO_USEFUL);
+		 "sdcl", PerfCountersBuilder::PRIO_UNINTERESTING);
   //****************************************
 
   // Update Transaction stats
@@ -5058,18 +5058,18 @@ void BlueStore::_init_logger()
   //****************************************
   b.add_time_avg(l_bluestore_read_onode_meta_lat, "read_onode_meta_lat",
 		 "Average read onode metadata latency",
-		 "roml", PerfCountersBuilder::PRIO_USEFUL);
+		 "roml", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_read_wait_aio_lat, "read_wait_aio_lat",
 		 "Average read I/O waiting latency",
-		 "rwal", PerfCountersBuilder::PRIO_USEFUL);
+		 "rwal", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_csum_lat, "csum_lat",
 		 "Average checksum latency",
-		 "csml", PerfCountersBuilder::PRIO_USEFUL);
+		 "csml", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_u64_counter(l_bluestore_read_eio, "read_eio",
                     "Read EIO errors propagated to high level callers");
   b.add_u64_counter(l_bluestore_reads_with_retries, "reads_with_retries",
                     "Read operations that required at least one retry due to failed checksum validation",
-		    "rd_r", PerfCountersBuilder::PRIO_USEFUL);
+		    "rd_r", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_read_lat, "read_lat",
 		 "Average read latency",
 		 "r_l", PerfCountersBuilder::PRIO_CRITICAL);
@@ -5079,16 +5079,16 @@ void BlueStore::_init_logger()
   //****************************************
   b.add_time_avg(l_bluestore_kv_flush_lat, "kv_flush_lat",
 		 "Average kv_thread flush latency",
-		 "kfsl", PerfCountersBuilder::PRIO_INTERESTING);
+		 "kfsl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_kv_commit_lat, "kv_commit_lat",
 		 "Average kv_thread commit latency",
-		 "kcol", PerfCountersBuilder::PRIO_USEFUL);
+		 "kcol", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_kv_sync_lat, "kv_sync_lat",
 		 "Average kv_sync thread latency",
-		 "kscl", PerfCountersBuilder::PRIO_INTERESTING);
+		 "kscl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_kv_final_lat, "kv_final_lat",
 		 "Average kv_finalize thread latency",
-		 "kfll", PerfCountersBuilder::PRIO_INTERESTING);
+		 "kfll", PerfCountersBuilder::PRIO_UNINTERESTING);
   //****************************************
 
   // write op stats
@@ -5168,7 +5168,7 @@ void BlueStore::_init_logger()
   //****************************************
   b.add_u64(l_bluestore_compressed, "compressed",
 	    "Sum for stored compressed bytes",
-	    "c", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
+	    "c", PerfCountersBuilder::PRIO_UNINTERESTING, unit_t(UNIT_BYTES));
   b.add_u64(l_bluestore_compressed_allocated, "compressed_allocated",
 	    "Sum for bytes allocated for compressed data",
 	    "c_a", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
@@ -5177,10 +5177,10 @@ void BlueStore::_init_logger()
 	    "c_o", PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
   b.add_time_avg(l_bluestore_compress_lat, "compress_lat",
 	    "Average compress latency",
-	    "_cpl", PerfCountersBuilder::PRIO_USEFUL);
+	    "_cpl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_decompress_lat, "decompress_lat",
 	    "Average decompress latency",
-	    "dcpl", PerfCountersBuilder::PRIO_USEFUL);
+	    "dcpl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_u64_counter(l_bluestore_compress_success_count, "compress_success_count",
 	    "Sum for beneficial compress ops");
   b.add_u64_counter(l_bluestore_compress_rejected_count, "compress_rejected_count",
@@ -5256,33 +5256,33 @@ void BlueStore::_init_logger()
   //****************************************
   b.add_time_avg(l_bluestore_omap_seek_to_first_lat, "omap_seek_to_first_lat",
     "Average omap iterator seek_to_first call latency",
-    "osfl", PerfCountersBuilder::PRIO_USEFUL);
+    "osfl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_omap_upper_bound_lat, "omap_upper_bound_lat",
     "Average omap iterator upper_bound call latency",
-    "oubl", PerfCountersBuilder::PRIO_USEFUL);
+    "oubl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_omap_lower_bound_lat, "omap_lower_bound_lat",
     "Average omap iterator lower_bound call latency",
-    "olbl", PerfCountersBuilder::PRIO_USEFUL);
+    "olbl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_omap_next_lat, "omap_next_lat",
     "Average omap iterator next call latency",
-    "onxl", PerfCountersBuilder::PRIO_USEFUL);
+    "onxl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_omap_get_keys_lat, "omap_get_keys_lat",
     "Average omap get_keys call latency",
-    "ogkl", PerfCountersBuilder::PRIO_USEFUL);
+    "ogkl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_omap_get_values_lat, "omap_get_values_lat",
     "Average omap get_values call latency",
-    "ogvl", PerfCountersBuilder::PRIO_USEFUL);
+    "ogvl", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_omap_clear_lat, "omap_clear_lat",
     "Average omap clear call latency");
   b.add_time_avg(l_bluestore_clist_lat, "clist_lat",
     "Average collection listing latency",
-    "cl_l", PerfCountersBuilder::PRIO_USEFUL);
+    "cl_l", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_remove_lat, "remove_lat",
     "Average removal latency",
-    "rm_l", PerfCountersBuilder::PRIO_USEFUL);
+    "rm_l", PerfCountersBuilder::PRIO_UNINTERESTING);
   b.add_time_avg(l_bluestore_truncate_lat, "truncate_lat",
     "Average truncate latency",
-    "tr_l", PerfCountersBuilder::PRIO_USEFUL);
+    "tr_l", PerfCountersBuilder::PRIO_UNINTERESTING);
   //****************************************
 
   // Resulting size axis configuration for op histograms, values are in bytes

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -32,7 +32,7 @@ PerfCounters *build_osd_logger(CephContext *cct) {
 
   osd_plb.add_u64(
     l_osd_op_wip, "op_wip",
-    "Replication operations currently being processed (primary)");
+    "Replication operations currently being processed (primary)", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
   osd_plb.add_u64_counter(
     l_osd_op, "op",
     "Client operations",
@@ -48,13 +48,13 @@ PerfCounters *build_osd_logger(CephContext *cct) {
   osd_plb.add_time_avg(
     l_osd_op_lat,   "op_latency",
     "Latency of client operations (including queue time)",
-    "l", 9);
+    "l", PerfCountersBuilder::PRIO_UNINTERESTING);
   osd_plb.add_time_avg(
     l_osd_op_process_lat, "op_process_latency",
-    "Latency of client operations (excluding queue time)");
+    "Latency of client operations (excluding queue time)", NULL, PerfCountersBuilder::PRIO_INTERESTING);
   osd_plb.add_time_avg(
     l_osd_op_prepare_lat, "op_prepare_latency",
-    "Latency of client operations (excluding queue time and wait for finished)");
+    "Latency of client operations (excluding queue time and wait for finished)", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
 
   osd_plb.add_u64_counter(
     l_osd_op_r, "op_r", "Client read operations");
@@ -69,10 +69,10 @@ PerfCounters *build_osd_logger(CephContext *cct) {
     "Histogram of operation latency (including queue time) + data read");
   osd_plb.add_time_avg(
     l_osd_op_r_process_lat, "op_r_process_latency",
-    "Latency of read operation (excluding queue time)");
+    "Latency of read operation (excluding queue time)", NULL, PerfCountersBuilder::PRIO_INTERESTING);
   osd_plb.add_time_avg(
     l_osd_op_r_prepare_lat, "op_r_prepare_latency",
-    "Latency of read operations (excluding queue time and wait for finished)");
+    "Latency of read operations (excluding queue time and wait for finished)", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
   osd_plb.add_u64_counter(
     l_osd_op_w, "op_w", "Client write operations");
   osd_plb.add_u64_counter(
@@ -83,16 +83,16 @@ PerfCounters *build_osd_logger(CephContext *cct) {
   osd_plb.add_u64_counter_histogram(
     l_osd_op_w_lat_inb_hist, "op_w_latency_in_bytes_histogram",
     op_hist_x_axis_config, op_hist_y_axis_config,
-    "Histogram of operation latency (including queue time) + data written");
+    "Histogram of operation latency (including queue time) + data written", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
   osd_plb.add_time_avg(
     l_osd_op_w_process_lat, "op_w_process_latency",
     "Latency of write operation (excluding queue time)");
   osd_plb.add_time_avg(
     l_osd_op_w_prepare_lat, "op_w_prepare_latency",
-    "Latency of write operations (excluding queue time and wait for finished)");
+    "Latency of write operations (excluding queue time and wait for finished)", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
   osd_plb.add_u64_counter(
     l_osd_op_rw, "op_rw",
-    "Client read-modify-write operations");
+    "Client read-modify-write operations", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
   osd_plb.add_u64_counter(
     l_osd_op_rw_inb, "op_rw_in_bytes",
     "Client read-modify-write operations write in", NULL, PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
@@ -101,21 +101,21 @@ PerfCounters *build_osd_logger(CephContext *cct) {
     "Client read-modify-write operations read out ", NULL, PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
   osd_plb.add_time_avg(
     l_osd_op_rw_lat, "op_rw_latency",
-    "Latency of read-modify-write operation (including queue time)");
+    "Latency of read-modify-write operation (including queue time)", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
   osd_plb.add_u64_counter_histogram(
     l_osd_op_rw_lat_inb_hist, "op_rw_latency_in_bytes_histogram",
     op_hist_x_axis_config, op_hist_y_axis_config,
-    "Histogram of rw operation latency (including queue time) + data written");
+    "Histogram of rw operation latency (including queue time) + data written", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
   osd_plb.add_u64_counter_histogram(
     l_osd_op_rw_lat_outb_hist, "op_rw_latency_out_bytes_histogram",
     op_hist_x_axis_config, op_hist_y_axis_config,
-    "Histogram of rw operation latency (including queue time) + data read");
+    "Histogram of rw operation latency (including queue time) + data read", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
   osd_plb.add_time_avg(
     l_osd_op_rw_process_lat, "op_rw_process_latency",
-    "Latency of read-modify-write operation (excluding queue time)");
+    "Latency of read-modify-write operation (excluding queue time)", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
   osd_plb.add_time_avg(
     l_osd_op_rw_prepare_lat, "op_rw_prepare_latency",
-    "Latency of read-modify-write operations (excluding queue time and wait for finished)");
+    "Latency of read-modify-write operations (excluding queue time and wait for finished)", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
 
   // Now we move on to some more obscure stats, revert to assuming things
   // are low priority unless otherwise specified.

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -28,7 +28,7 @@ PerfCounters *build_osd_logger(CephContext *cct) {
 
 
   // All the basic OSD operation stats are to be considered useful
-  osd_plb.set_prio_default(PerfCountersBuilder::PRIO_USEFUL);
+  osd_plb.set_prio_default(PerfCountersBuilder::PRIO_DEBUGONLY);
 
   osd_plb.add_u64(
     l_osd_op_wip, "op_wip",
@@ -51,48 +51,50 @@ PerfCounters *build_osd_logger(CephContext *cct) {
     "l", PerfCountersBuilder::PRIO_UNINTERESTING);
   osd_plb.add_time_avg(
     l_osd_op_process_lat, "op_process_latency",
-    "Latency of client operations (excluding queue time)", NULL, PerfCountersBuilder::PRIO_INTERESTING);
+    "Latency of client operations (excluding queue time)");
   osd_plb.add_time_avg(
     l_osd_op_prepare_lat, "op_prepare_latency",
-    "Latency of client operations (excluding queue time and wait for finished)", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
+    "Latency of client operations (excluding queue time and wait for finished)");
 
   osd_plb.add_u64_counter(
-    l_osd_op_r, "op_r", "Client read operations");
-  osd_plb.add_u64_counter(
-    l_osd_op_r_outb, "op_r_out_bytes", "Client data read", NULL, PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
-  osd_plb.add_time_avg(
-    l_osd_op_r_lat, "op_r_latency",
-    "Latency of read operation (including queue time)");
+			  l_osd_op_r, "op_r", "Client read operations", NULL, PerfCounterBuilder::PRIO_USEFUL);
+  osd_plb.add_u64_counter(l_osd_op_r_outb, "op_r_out_bytes", "Client data read",
+			  NULL, PerfCountersBuilder::PRIO_USEFUL,
+			  unit_t(UNIT_BYTES));
+  osd_plb.add_time_avg(l_osd_op_r_lat, "op_r_latency",
+		       "Latency of read operation (including queue time)", NULL,
+		       PerfCounterBuilder::PRIO_USEFUL);
   osd_plb.add_u64_counter_histogram(
-    l_osd_op_r_lat_outb_hist, "op_r_latency_out_bytes_histogram",
-    op_hist_x_axis_config, op_hist_y_axis_config,
-    "Histogram of operation latency (including queue time) + data read");
+      l_osd_op_r_lat_outb_hist, "op_r_latency_out_bytes_histogram",
+      op_hist_x_axis_config, op_hist_y_axis_config,
+      "Histogram of operation latency (including queue time) + data read");
   osd_plb.add_time_avg(
     l_osd_op_r_process_lat, "op_r_process_latency",
-    "Latency of read operation (excluding queue time)", NULL, PerfCountersBuilder::PRIO_INTERESTING);
+    "Latency of read operation (excluding queue time)");
   osd_plb.add_time_avg(
     l_osd_op_r_prepare_lat, "op_r_prepare_latency",
-    "Latency of read operations (excluding queue time and wait for finished)", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
-  osd_plb.add_u64_counter(
-    l_osd_op_w, "op_w", "Client write operations");
-  osd_plb.add_u64_counter(
-    l_osd_op_w_inb, "op_w_in_bytes", "Client data written");
-  osd_plb.add_time_avg(
-    l_osd_op_w_lat,  "op_w_latency",
-    "Latency of write operation (including queue time)");
+    "Latency of read operations (excluding queue time and wait for finished)");
+  osd_plb.add_u64_counter(l_osd_op_w, "op_w", "Client write operations", NULL,
+			  PerfCounterBuilder::PRIO_USEFUL);
+  osd_plb.add_u64_counter(l_osd_op_w_inb, "op_w_in_bytes",
+			  "Client data written", NULL,
+                          PerfCountersBuilder::PRIO_USEFUL);
+  osd_plb.add_time_avg(l_osd_op_w_lat, "op_w_latency",
+                       "Latency of write operation (including queue time)",
+                       NULL, PerfCounterBuilder::PRIO_USEFUL);
   osd_plb.add_u64_counter_histogram(
     l_osd_op_w_lat_inb_hist, "op_w_latency_in_bytes_histogram",
     op_hist_x_axis_config, op_hist_y_axis_config,
-    "Histogram of operation latency (including queue time) + data written", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
+    "Histogram of operation latency (including queue time) + data written");
   osd_plb.add_time_avg(
     l_osd_op_w_process_lat, "op_w_process_latency",
     "Latency of write operation (excluding queue time)");
   osd_plb.add_time_avg(
     l_osd_op_w_prepare_lat, "op_w_prepare_latency",
-    "Latency of write operations (excluding queue time and wait for finished)", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
+    "Latency of write operations (excluding queue time and wait for finished)");
   osd_plb.add_u64_counter(
     l_osd_op_rw, "op_rw",
-    "Client read-modify-write operations", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
+    "Client read-modify-write operations");
   osd_plb.add_u64_counter(
     l_osd_op_rw_inb, "op_rw_in_bytes",
     "Client read-modify-write operations write in", NULL, PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
@@ -101,25 +103,24 @@ PerfCounters *build_osd_logger(CephContext *cct) {
     "Client read-modify-write operations read out ", NULL, PerfCountersBuilder::PRIO_USEFUL, unit_t(UNIT_BYTES));
   osd_plb.add_time_avg(
     l_osd_op_rw_lat, "op_rw_latency",
-    "Latency of read-modify-write operation (including queue time)", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
+    "Latency of read-modify-write operation (including queue time)");
   osd_plb.add_u64_counter_histogram(
     l_osd_op_rw_lat_inb_hist, "op_rw_latency_in_bytes_histogram",
     op_hist_x_axis_config, op_hist_y_axis_config,
-    "Histogram of rw operation latency (including queue time) + data written", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
+    "Histogram of rw operation latency (including queue time) + data written");
   osd_plb.add_u64_counter_histogram(
     l_osd_op_rw_lat_outb_hist, "op_rw_latency_out_bytes_histogram",
     op_hist_x_axis_config, op_hist_y_axis_config,
-    "Histogram of rw operation latency (including queue time) + data read", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
+    "Histogram of rw operation latency (including queue time) + data read");
   osd_plb.add_time_avg(
     l_osd_op_rw_process_lat, "op_rw_process_latency",
-    "Latency of read-modify-write operation (excluding queue time)", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
+    "Latency of read-modify-write operation (excluding queue time)");
   osd_plb.add_time_avg(
     l_osd_op_rw_prepare_lat, "op_rw_prepare_latency",
-    "Latency of read-modify-write operations (excluding queue time and wait for finished)", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
+    "Latency of read-modify-write operations (excluding queue time and wait for finished)");
 
   // Now we move on to some more obscure stats, revert to assuming things
   // are low priority unless otherwise specified.
-  osd_plb.set_prio_default(PerfCountersBuilder::PRIO_DEBUGONLY);
 
   osd_plb.add_time_avg(l_osd_op_before_queue_op_lat, "op_before_queue_op_lat",
     "Latency of IO before calling queue(before really queue into ShardedOpWq)"); // client io before queue op_wq latency
@@ -155,7 +156,7 @@ PerfCounters *build_osd_logger(CephContext *cct) {
   osd_plb.add_u64_counter(
     l_osd_rop, "recovery_ops",
     "Started recovery operations",
-    "rop", PerfCountersBuilder::PRIO_INTERESTING);
+    "rop", PerfCountersBuilder::PRIO_USEFUL);
 
   osd_plb.add_u64_counter(
    l_osd_rbytes, "recovery_bytes",

--- a/src/rgw/rgw_perf_counters.cc
+++ b/src/rgw/rgw_perf_counters.cc
@@ -61,8 +61,8 @@ int rgw_perf_start(CephContext *cct)
   plb.add_u64_counter(l_rgw_pubsub_missing_conf, "pubsub_missing_conf", "Pubsub events could not be handled because of missing configuration");
   
   plb.add_u64_counter(l_rgw_lua_script_ok, "lua_script_ok", "Successfull executions of lua scripts");
-  plb.add_u64_counter(l_rgw_lua_script_fail, "lua_script_fail", "Failed executions of lua scripts");
-  plb.add_u64(l_rgw_lua_current_vms, "lua_current_vms", "Number of Lua VMs currently being executed");
+  plb.add_u64_counter(l_rgw_lua_script_fail, "lua_script_fail", "Failed executions of lua scripts", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
+  plb.add_u64(l_rgw_lua_current_vms, "lua_current_vms", "Number of Lua VMs currently being executed", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
   
   perfcounter = plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(perfcounter);

--- a/src/rgw/rgw_perf_counters.cc
+++ b/src/rgw/rgw_perf_counters.cc
@@ -52,13 +52,13 @@ int rgw_perf_start(CephContext *cct)
 
   plb.add_u64_counter(l_rgw_pubsub_event_triggered, "pubsub_event_triggered", "Pubsub events with at least one topic");
   plb.add_u64_counter(l_rgw_pubsub_event_lost, "pubsub_event_lost", "Pubsub events lost");
-  plb.add_u64_counter(l_rgw_pubsub_store_ok, "pubsub_store_ok", "Pubsub events successfully stored");
-  plb.add_u64_counter(l_rgw_pubsub_store_fail, "pubsub_store_fail", "Pubsub events failed to be stored");
-  plb.add_u64(l_rgw_pubsub_events, "pubsub_events", "Pubsub events in store");
+  plb.add_u64_counter(l_rgw_pubsub_store_ok, "pubsub_store_ok", "Pubsub events successfully stored", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
+  plb.add_u64_counter(l_rgw_pubsub_store_fail, "pubsub_store_fail", "Pubsub events failed to be stored", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
+  plb.add_u64(l_rgw_pubsub_events, "pubsub_events", "Pubsub events in store", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
   plb.add_u64_counter(l_rgw_pubsub_push_ok, "pubsub_push_ok", "Pubsub events pushed to an endpoint");
   plb.add_u64_counter(l_rgw_pubsub_push_failed, "pubsub_push_failed", "Pubsub events failed to be pushed to an endpoint");
   plb.add_u64(l_rgw_pubsub_push_pending, "pubsub_push_pending", "Pubsub events pending reply from endpoint");
-  plb.add_u64_counter(l_rgw_pubsub_missing_conf, "pubsub_missing_conf", "Pubsub events could not be handled because of missing configuration");
+  plb.add_u64_counter(l_rgw_pubsub_missing_conf, "pubsub_missing_conf", "Pubsub events could not be handled because of missing configuration", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);
   
   plb.add_u64_counter(l_rgw_lua_script_ok, "lua_script_ok", "Successfull executions of lua scripts");
   plb.add_u64_counter(l_rgw_lua_script_fail, "lua_script_fail", "Failed executions of lua scripts", NULL, PerfCountersBuilder::PRIO_UNINTERESTING);


### PR DESCRIPTION
Perfcounters are a bottleneck in the mgr, in specific promtheus. OSDs for example can scale to thousands creating tons of unnecessary load of metrics because of perfcounters labeled as USEFUL when don't even use most of the perfcounters in prometheus/grafana.

ceph_osd perfcounters labeled as useful -> 28
ceph_osd perfcounters labeled as useful used in prometheus/grafana ceph + rook + odf -> 12
That means that if we have around 1000 OSDs, we are sending 16 * 1000 unnecessary perfcounters.

I've modified perfcounters which we found weren't used by grepping in the grafana dashboards in ceph, rook and odf. **We should evaluate in each component which perfcounters are useful for both telemetry and prometheus**.

**todo**:
- [ ] OSDs
- [ ] Bluestore
- [ ] MON
- [ ] RBD
- [ ] Pools

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
