### PR TITLE
cephfs-top: fix the rsp/wsp display

### DIFF
--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -370,7 +370,6 @@ class FSTop(object):
 
     def refresh_client(self, client_id, metrics, counters, client_meta, x_coord_map, y_coord):
         global last_time
-        size = 0
         cur_time = time.time()
         duration = cur_time - last_time
         last_time = cur_time
@@ -399,7 +398,6 @@ class FSTop(object):
                 return
 
         cidx = 0
-        client_id = x_coord_map[FS_TOP_MAIN_WINDOW_COL_CLIENT_ID]
         for item in counters:
             if item in MAIN_WINDOW_TOP_LINE_METRICS_LEGACY:
                 cidx += 1
@@ -452,18 +450,21 @@ class FSTop(object):
                         remaining_hlen = 0
                     else:
                         remaining_hlen -= coord[1]
+                    size = 0
                     if key == "READ_IO_SIZES":
-                        global last_read_size
-                        last_size = last_read_size.get(client_id, 0)
-                        size = m[1] - last_size
-                        last_read_size[client_id] = m[1]
+                        if m[1] > 0:
+                            global last_read_size
+                            last_size = last_read_size.get(client_id, 0)
+                            size = m[1] - last_size
+                            last_read_size[client_id] = m[1]
                     if key == "WRITE_IO_SIZES":
-                        global last_write_size
-                        last_size = last_write_size.get(client_id, 0)
-                        size = m[1] - last_size
-                        last_write_size[client_id] = m[1]
+                        if m[1] > 0:
+                            global last_write_size
+                            last_size = last_write_size.get(client_id, 0)
+                            size = m[1] - last_size
+                            last_write_size[client_id] = m[1]
                     self.mainw.addnstr(y_coord, coord[0],
-                                       f'{calc_speed(size, duration)}',
+                                       f'{calc_speed(abs(size), duration)}',
                                        hlen)
                 else:
                     # display 0th element from metric tuple


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/56537

[1] introduced by [PR#40514](https://github.com/ceph/ceph/pull/40514) caused the changing rsp/wsp values in unrelated clients. This [1] is unnecessary, as `client_id` is already available in refresh_client()'s parameter. Did some checks to avoid 0 and negative calculated size values.

[1] https://github.com/ceph/ceph/blob/main/src/tools/cephfs/top/cephfs-top#L402




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>