### PR TITLE
cmake: don't compile for installing pybinds

### DIFF
--- a/cmake/modules/Distutils.cmake
+++ b/cmake/modules/Distutils.cmake
@@ -149,7 +149,7 @@ function(distutils_install_cython_module name)
            build ${maybe_verbose} --build-base ${CYTHON_MODULE_DIR}
            --build-platlib ${CYTHON_MODULE_DIR}/lib.3
            build_ext --cython-c-in-temp --build-temp ${CMAKE_CURRENT_BINARY_DIR} --cython-include-dirs ${PROJECT_SOURCE_DIR}/src/pybind/rados
-           install \${options} --single-version-externally-managed --record /dev/null
+           install \${options} --skip-build --single-version-externally-managed --record /dev/null
            egg_info --egg-base ${CMAKE_CURRENT_BINARY_DIR}
            ${maybe_verbose}
        WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\"


### PR DESCRIPTION
please refer to the output of `setup.py --help-commands`

> Standard commands:
>   build             build everything needed to install
>   build_py          "build" pure Python modules (copy to build directory)
>   build_ext         build C/C++ extensions (compile/link to build directory)
>   build_clib        build C/C++ libraries used by Python extensions
>   build_scripts     "build" scripts (copy and fixup #! line)
>   clean             clean up temporary files from 'build' command
>   install           install everything from build directory
>   install_lib       install all Python modules (extensions and pure Python)
>   install_headers   install C/C++ header files
>   install_scripts   install scripts (Python or otherwise)
>   install_data      install data files
>   sdist             create a source distribution (tarball, zip file, etc.)
>   register          register the distribution with the Python package index
>   bdist             create a built (binary) distribution
>   bdist_dumb        create a "dumb" built distribution
>   bdist_rpm         create an RPM distribution
>   bdist_wininst     create an executable installer for MS Windows
>   upload            upload binary package to PyPI
>
> Extra commands:
>   rotate            delete older distributions, keeping N newest files
>   develop           install package in 'development mode'
>   setopt            set an option in setup.cfg or another config file
>   saveopts          save supplied options to setup.cfg or other config file
>   egg_info          create a distribution's .egg-info directory
>   upload_sphinx     Upload Sphinx documentation to PyPI
>   install_egg_info  Install an .egg-info directory for the package
>   alias             define a shortcut to invoke one or more commands
>   easy_install      Find/get/install Python packages
>   bdist_egg         create an "egg" distribution
>   test              run unit tests after in-place build
>   build_sphinx      Build Sphinx documentation

before this change, we simply run `build build_ext install egg_info`
commands. by default, `install` invokes `install_scripts`. the latter
tries to compile the scripts before installing the scripts.

but the problem is, we only specify the cython constant of `BUILD_DOC`
for `build_ext` command. and to cythonize the .pyx files, we need to
define this constant, otherwise `setup.py` complains like:

```
Error compiling Cython file:
------------------------------------------------------------
...
from datetime import datetime
import errno
from itertools import chain
import time

IF BUILD_DOC:
  ^
------------------------------------------------------------

rbd.pyx:36:3: Compile-time name 'BUILD_DOC' not defined
```

this does not hurt, as we don't really need to install any script
not to mention building them. but this error message is still
annoying and confusing. it repeats itself whenever we install
a python binding using the `distutils_install_cython_module()`
cmake function.

so in this change, instead of passing `--skip-build` to the
`install_scripts` command. we just replace `install` with `install_lib`,
in other words, to trade the wholesale version with a more specific one.
because the python bindings are but python modules, so we
are safe to skip other install steps.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
