### PR TITLE
quincy: osd/SnapMapper: fix legacy key conversion in snapmapper class

### DIFF
--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -100,6 +100,7 @@ public:
  * particular snap will group under up to 8 prefixes.
  */
 class SnapMapper {
+  friend class MapperVerifier;
 public:
   CephContext* cct;
   struct object_snaps {
@@ -173,6 +174,10 @@ public:
 
     void run();
   };
+
+  static std::string convert_legacy_key(
+    const std::string& old_key,
+    const bufferlist& value);
 
   static int convert_legacy(
     CephContext *cct,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56578

---

backport of https://github.com/ceph/ceph/pull/46908
parent tracker: https://tracker.ceph.com/issues/56147

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh