### PR TITLE
mgr/dashboard: fix dashboard cephadm e2e errors

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -371,7 +371,7 @@ class Osd(RESTController):
                     option]['encrypted'] = data[0]['encrypted']
                 orch.osds.create([DriveGroupSpec.from_json(
                     predefined_drive_groups[option])])
-            except (ValueError, TypeError, DriveGroupValidationError) as e:
+            except (ValueError, TypeError, KeyError, DriveGroupValidationError) as e:
                 raise DashboardException(e, component='osd')
 
     def _create_bare(self, data):

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
@@ -41,7 +41,7 @@
                        [id]="'label_' + optionName"
                        [for]="optionName"
                        i18n>{{ deploymentOptions?.options[optionName].title }}
-                       {{ deploymentOptions.recommended_option === optionName ? "(Recommended)" : "" }}
+                       {{ deploymentOptions?.recommended_option === optionName ? "(Recommended)" : "" }}
                   <cd-helper>
                     <span>{{ deploymentOptions?.options[optionName].desc }}</span>
                   </cd-helper>


### PR DESCRIPTION
**Error 1**
```
1 failing

  1) when cluster creation is completed
       Hosts page
         should check if mon daemon is running on all hosts:
     HttpErrorResponse: The following error originated from your application code, not from Cypress.

  > Http failure response for https://192.168.100.100:8443/api/prometheus/rules: 400 Bad Request

When Cypress detects uncaught errors originating from your application it will automatically fail the current test.

This behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.

https://on.cypress.io/uncaught-exception-from-application
```

this was because the prometheus and alertmanager api urls were using an fqdn, and the kcli environment is having some issue with the fqdn names.

**Error 2**
```
Jun 16 15:07:02 ceph-node-00 ceph-mgr[11812]: [dashboard INFO request] [::ffff:192.168.100.1:55338] [GET] [200] [0.017s] [admin] [266.0B] /ui-api/osd/deployment_options
Jun 16 15:07:02 ceph-node-00 ceph-mgr[11812]: [dashboard ERROR frontend.error] (https://192.168.100.100:8443/#/expand-cluster): Cannot read properties of undefined (reading 'recommended_option')
                                               TypeError: Cannot read properties of undefined (reading 'recommended_option')
                                                  at OsdFormComponent_div_1_div_13_Template (https://192.168.100.100:8443/main.js:9235:185)
                                                  at executeTemplate (https://192.168.100.100:8443/vendor.js:24051:9)
                                                  at refreshView (https://192.168.100.100:8443/vendor.js:23917:13)
                                                  at refreshEmbeddedViews (https://192.168.100.100:8443/vendor.js:25042:17)
                                                  at refreshView (https://192.168.100.100:8443/vendor.js:23941:9)
                                                  at refreshEmbeddedViews (https://192.168.100.100:8443/vendor.js:25042:17)
                                                  at refreshView (https://192.168.100.100:8443/vendor.js:23941:9)
                                                  at refreshComponent (https://192.168.100.100:8443/vendor.js:25088:13)
                                                  at refreshChildComponents (https://192.168.100.100:8443/vendor.js:23713:9)
                                                  at refreshView (https://192.168.100.100:8443/vendor.js:23967:13)
Jun 16 15:07:02 ceph-node-00 ceph-mgr[11812]: [dashboard INFO request] [::ffff:192.168.100.1:55338] [POST] [200] [0.003s] [admin] [24.0B] /ui-api/logging/js-error
Jun 16 15:07:02 ceph-node-00 ceph-mgr[11812]: [dashboard ERROR frontend.error] (https://192.168.100.100:8443/#/expand-cluster): Cannot read properties of undefined (reading 'recommended_option')
                                               TypeError: Cannot read properties of undefined (reading 'recommended_option')
                                                  at OsdFormComponent_div_1_div_13_Template (https://192.168.100.100:8443/main.js:9235:185)
                                                  at executeTemplate (https://192.168.100.100:8443/vendor.js:24051:9)
                                                  at refreshView (https://192.168.100.100:8443/vendor.js:23917:13)
                                                  at refreshEmbeddedViews (https://192.168.100.100:8443/vendor.js:25042:17)
                                                  at refreshView (https://192.168.100.100:8443/vendor.js:23941:9)
                                                  at refreshEmbeddedViews (https://192.168.100.100:8443/vendor.js:25042:17)
                                                  at refreshView (https://192.168.100.100:8443/vendor.js:23941:9)
                                                  at refreshComponent (https://192.168.100.100:8443/vendor.js:25088:13)
                                                  at refreshChildComponents (https://192.168.100.100:8443/vendor.js:23713:9)
                                                  at refreshView (https://192.168.100.100:8443/vendor.js:23967:13)
                                                  
```
initially the `deploymentOption` is undefined. so I updated the html condition as `deploymentOption?.recommended`.

**Error 3**
```
Jun 16 15:07:23 ceph-node-00 ceph-mgr[11812]: [dashboard ERROR taskexec] Error while calling Task(ns=osd/create, md={'tracking_id': 'Cost/Capacity-optimized deployment'})
                                              Traceback (most recent call last):
                                                File "/usr/share/ceph/mgr/dashboard/tools.py", line 550, in _run
                                                  val = self.task.fn(*self.task.fn_args, **self.task.fn_kwargs)  # type: ignore
                                                File "/usr/share/ceph/mgr/dashboard/controllers/osd.py", line 417, in create
                                                  return self._create_predefined_drive_group(data)
                                                File "/usr/share/ceph/mgr/dashboard/controllers/osd.py", line 371, in _create_predefined_drive_group
                                                  option]['encrypted'] = data[0]['encrypted']
                                              KeyError: 'encrypted'
                                              
```
Here I just caught the `KeyError` in the `try` block




https://tracker.ceph.com/issues/56079
Signed-off-by: Nizamudeen A <nia@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
