### PR TITLE
pacific: mgr/dashboard: prevent alert redirect 

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -511,6 +511,13 @@ class StandbyModule(MgrStandbyModule, CherryPyConfig):
             def default(self, *args, **kwargs):
                 if module.get_module_option('standby_behaviour', 'redirect') == 'redirect':
                     active_uri = module.get_active_uri()
+
+                    if cherrypy.request.path_info.startswith('/api/prometheus_receiver'):
+                        module.log.debug("Suppressed redirecting alert to active '%s'",
+                                         active_uri)
+                        cherrypy.response.status = 204
+                        return None
+
                     if active_uri:
                         module.log.info("Redirecting to active '%s'", active_uri)
                         raise cherrypy.HTTPRedirect(active_uri)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56594

---

backport of https://github.com/ceph/ceph/pull/47011
parent tracker: https://tracker.ceph.com/issues/56401

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh