### PR TITLE
quincy: ceph-volume: fix `simple scan`

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -329,7 +329,7 @@ def lsblk_all(device='', columns=None, abspath=False):
         if dev['NAME'] == os.path.basename(device):
             return dev
 
-    raise RuntimeError(f"{device} not found in lsblk output")
+    return {}
 
 def is_device(dev):
     """


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56496

---

backport of https://github.com/ceph/ceph/pull/46992
parent tracker: https://tracker.ceph.com/issues/56482

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh