### PR TITLE
build: fix atomic linking with LTO on s390x

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -324,7 +324,6 @@ BuildRequires:  systemtap-sdt-devel
 %if 0%{?fedora}
 BuildRequires:  libubsan
 BuildRequires:  libasan
-BuildRequires:  libatomic
 %endif
 %if 0%{?rhel}
 BuildRequires:  gcc-toolset-11-annobin-plugin-gcc
@@ -366,6 +365,7 @@ Requires:	systemd
 BuildRequires:  boost-random
 BuildRequires:	nss-devel
 BuildRequires:	keyutils-libs-devel
+BuildRequires:  libatomic
 BuildRequires:	libibverbs-devel
 BuildRequires:  librdmacm-devel
 BuildRequires:  ninja-build

--- a/cmake/modules/CheckCxxAtomic.cmake
+++ b/cmake/modules/CheckCxxAtomic.cmake
@@ -27,6 +27,7 @@ struct tagged_ptr {
   std::size_t tag;
 };
 
+void atomic16(std::atomic<tagged_ptr> *ptr) __attribute__ ((used));
 void atomic16(std::atomic<tagged_ptr> *ptr)
 {
   tagged_ptr p{nullptr, 1};


### PR DESCRIPTION
Prior to this change, Fedora and RHEL 9 on s390x would incorrectly pass the `HAVE_CXX11_ATOMIC` check. As a consequence, the rest of Ceph would fail to link because of missing atomic methods `__atomic_load_16`, `__atomic_store_16`, and `__atomic_compare_exchange_16`.

Mark this method so that it is not optimized out, even with LTO. With this change, s390x properly fails `HAVE_CXX11_ATOMIC` and falls back to `HAVE_LIBATOMIC`.

Move the `BuildRequires: libatomic` RPM line out from the seastar+fedora conditional and into the main fedora+rhel conditional so that the `HAVE_LIBATOMIC` check will pass.

Fixes: https://tracker.ceph.com/issues/54514
Fixes: https://tracker.ceph.com/issues/56492