### PR TITLE
cmake: unset all cxx flags before testing cxx_atomics

### DIFF
--- a/cmake/modules/CheckCxxAtomic.cmake
+++ b/cmake/modules/CheckCxxAtomic.cmake
@@ -6,7 +6,10 @@ include(CMakePushCheckState)
 
 
 function(check_cxx_atomics var)
-  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
+  set(CMAKE_REQUIRED_FLAGS "-std=c++11")
+  unset(CMAKE_CXX_FLAGS)
+  unset(CMAKE_REQUIRED_DEFINITIONS)
+  unset(CMAKE_REQUIRED_LINK_OPTIONS)
     check_cxx_source_compiles("
 #include <atomic>
 #include <cstdint>
@@ -52,6 +55,7 @@ int main() {
 endfunction(check_cxx_atomics)
 
 cmake_push_check_state()
+unset(CMAKE_REQUIRED_LIBRARIES)
 check_cxx_atomics(HAVE_CXX11_ATOMIC)
 cmake_pop_check_state()
 


### PR DESCRIPTION
so we are immune to the flags set by the flags set by user. please
note, neither CFLAGS nor CXXFLAGS is populated to the
`check_cxx_source_compiles()` function. so this change is not related
to LTO optimization which is implemented using `_lto_cflags`, which
is added to CFLAGS and CXXFLAGS, as part of `__global_compiler_flags`.

See-also: https://tracker.ceph.com/issues/54514
See-also: https://tracker.ceph.com/issues/56492
Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
