### PR TITLE
pacific: mgr/dashboard: do not recommend throughput for ssd's only cluster 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -506,16 +506,17 @@ class OsdUi(Osd):
                 if device.available:
                     if device.human_readable_type == 'hdd':
                         hdds += 1
+                    # SSDs and NVMe are both counted as 'ssd'
+                    # so differentiating nvme using its path
+                    elif '/dev/nvme' in device.path:
+                        nvmes += 1
                     else:
                         ssds += 1
-                        # we still don't know how to infer nvmes
-                        # Tracker: https://tracker.ceph.com/issues/55728
-                        nvmes += 1
 
         if hdds:
             res.options[OsdDeploymentOptions.COST_CAPACITY].available = True
             res.recommended_option = OsdDeploymentOptions.COST_CAPACITY
-        if ssds:
+        if hdds and ssds:
             res.options[OsdDeploymentOptions.THROUGHPUT].available = True
             res.recommended_option = OsdDeploymentOptions.THROUGHPUT
         if nvmes:

--- a/src/pybind/mgr/dashboard/tests/test_osd.py
+++ b/src/pybind/mgr/dashboard/tests/test_osd.py
@@ -373,8 +373,8 @@ class OsdTest(ControllerTestCase):
 
         res = self._get_deployment_options(fake_client, devices_data)
         self.assertFalse(res['options'][OsdDeploymentOptions.COST_CAPACITY]['available'])
-        self.assertTrue(res['options'][OsdDeploymentOptions.THROUGHPUT]['available'])
-        self.assertEqual(res['recommended_option'], 'throughput_optimized')
+        self.assertFalse(res['options'][OsdDeploymentOptions.THROUGHPUT]['available'])
+        self.assertEqual(res['recommended_option'], None)
 
     @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
     def test_deployment_options_throughput(self, instance):
@@ -393,5 +393,42 @@ class OsdTest(ControllerTestCase):
         res = self._get_deployment_options(fake_client, devices_data)
         self.assertTrue(res['options'][OsdDeploymentOptions.COST_CAPACITY]['available'])
         self.assertTrue(res['options'][OsdDeploymentOptions.THROUGHPUT]['available'])
-        self.assertTrue(res['options'][OsdDeploymentOptions.IOPS]['available'])
+        self.assertFalse(res['options'][OsdDeploymentOptions.IOPS]['available'])
         assert res['recommended_option'] == OsdDeploymentOptions.THROUGHPUT
+
+    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    def test_deployment_options_with_hdds_and_nvmes(self, instance):
+        fake_client = mock.Mock()
+        instance.return_value = fake_client
+        fake_client.get_missing_features.return_value = []
+
+        devices_data = [
+            {'type': 'ssd', 'path': '/dev/nvme01', 'host': 'host1'},
+            {'type': 'ssd', 'path': '/dev/nvme02', 'host': 'host1'},
+            {'type': 'ssd', 'path': '/dev/nvme03', 'host': 'host2'},
+            {'type': 'hdd', 'path': '/dev/sde', 'host': 'host1'},
+            {'type': 'hdd', 'path': '/dev/sdd', 'host': 'host2'},
+        ]
+
+        res = self._get_deployment_options(fake_client, devices_data)
+        self.assertTrue(res['options'][OsdDeploymentOptions.COST_CAPACITY]['available'])
+        self.assertFalse(res['options'][OsdDeploymentOptions.THROUGHPUT]['available'])
+        self.assertTrue(res['options'][OsdDeploymentOptions.IOPS]['available'])
+        assert res['recommended_option'] == OsdDeploymentOptions.COST_CAPACITY
+
+    @mock.patch('dashboard.controllers.orchestrator.OrchClient.instance')
+    def test_deployment_options_iops(self, instance):
+        fake_client = mock.Mock()
+        instance.return_value = fake_client
+        fake_client.get_missing_features.return_value = []
+
+        devices_data = [
+            {'type': 'ssd', 'path': '/dev/nvme01', 'host': 'host1'},
+            {'type': 'ssd', 'path': '/dev/nvme02', 'host': 'host1'},
+            {'type': 'ssd', 'path': '/dev/nvme03', 'host': 'host2'}
+        ]
+
+        res = self._get_deployment_options(fake_client, devices_data)
+        self.assertFalse(res['options'][OsdDeploymentOptions.COST_CAPACITY]['available'])
+        self.assertFalse(res['options'][OsdDeploymentOptions.THROUGHPUT]['available'])
+        self.assertTrue(res['options'][OsdDeploymentOptions.IOPS]['available'])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56615

---

backport of https://github.com/ceph/ceph/pull/46889
parent tracker: https://tracker.ceph.com/issues/56413

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh