### PR TITLE
quincy: mgr/dashboard: do not recommend throughput for ssd's only cluster

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -505,16 +505,17 @@ class OsdUi(Osd):
                 if device.available:
                     if device.human_readable_type == 'hdd':
                         hdds += 1
+                    # SSDs and NVMe are both counted as 'ssd'
+                    # so differentiating nvme using its path
+                    elif '/dev/nvme' in device.path:
+                        nvmes += 1
                     else:
                         ssds += 1
-                        # we still don't know how to infer nvmes
-                        # Tracker: https://tracker.ceph.com/issues/55728
-                        nvmes += 1
 
         if hdds:
             res.options[OsdDeploymentOptions.COST_CAPACITY].available = True
             res.recommended_option = OsdDeploymentOptions.COST_CAPACITY
-        if ssds:
+        if hdds and ssds:
             res.options[OsdDeploymentOptions.THROUGHPUT].available = True
             res.recommended_option = OsdDeploymentOptions.THROUGHPUT
         if nvmes:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56616

---

backport of https://github.com/ceph/ceph/pull/46889
parent tracker: https://tracker.ceph.com/issues/56413

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh