### PR TITLE
pacific: qa/suites/rbd: disable workunit timeout for dynamic_features_no_cache

### DIFF
--- a/qa/suites/rbd/maintenance/workloads/dynamic_features_no_cache.yaml
+++ b/qa/suites/rbd/maintenance/workloads/dynamic_features_no_cache.yaml
@@ -11,3 +11,4 @@ op_workload:
           - rbd/qemu_dynamic_features.sh
         env:
           IMAGE_NAME: client.0.1-clone
+        timeout: 0


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56607

---

backport of https://github.com/ceph/ceph/pull/47136
parent tracker: https://tracker.ceph.com/issues/48038