### PR TITLE
ceph-volume: improve mpath devices reporting

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -769,17 +769,28 @@ allow_loop_devices = AllowLoopDevices()
 
 
 def get_block_devs_sysfs(_sys_block_path='/sys/block', _sys_dev_block_path='/sys/dev/block'):
+    def holder_inner_loop():
+        for holder in holders:
+            # /sys/block/sdy/holders/dm-8/dm/uuid
+            holder_dm_type = get_file_contents(os.path.join(_sys_block_path, dev, f'holders/{holder}/dm/uuid')).split('-')[0].lower()
+            if holder_dm_type == 'mpath':
+                return True
+
     # First, get devices that are _not_ partitions
     result = list()
     dev_names = os.listdir(_sys_block_path)
     for dev in dev_names:
         name = kname = os.path.join("/dev", dev)
         type_ = 'disk'
+        holders = os.listdir(os.path.join(_sys_block_path, dev, 'holders'))
         if get_file_contents(os.path.join(_sys_block_path, dev, 'removable')) == "1":
+            continue
+        if holder_inner_loop():
             continue
         dm_dir_path = os.path.join(_sys_block_path, dev, 'dm')
         if os.path.isdir(dm_dir_path):
-            type_ = 'lvm'
+            dm_type = get_file_contents(os.path.join(dm_dir_path, 'uuid'))
+            type_ = dm_type.split('-')[0].lower()
             basename = get_file_contents(os.path.join(dm_dir_path, 'name'))
             name = os.path.join("/dev/mapper", basename)
         if dev.startswith('loop'):


### PR DESCRIPTION
An environment with mpath devices looks like following:

`lsblk` output:

```
sdy        65:128  0    6G  0 disk
`-mpathm  252:8    0    6G  0 mpath
sdz        65:144  0    6G  0 disk
`-mpathm  252:8    0    6G  0 mpath
```

`multipath -ll` output:

```
mpathm (3600140575bbe2d3c0c6493fb6e6ed84c) dm-8 LIO-ORG,TCMU device
size=6.0G features='0' hwhandler='1 alua' wp=rw
|-+- policy='service-time 0' prio=50 status=active
| `- 2:0:0:30 sdz  65:144 active ready running
`-+- policy='service-time 0' prio=10 status=enabled
  `- 3:0:0:30 sdy  65:128 active ready running
```

`ceph-volume inventory` output:
```
Device Path               Size         rotates available Model name
/dev/mapper/mpathm        6.00 GB      True    True
/dev/sdy                  6.00 GB      True    False     TCMU device
/dev/sdz                  6.00 GB      True    False     TCMU device
```

ceph-volume shouldn't report devices `/dev/sdy` and `/dev/sdz`, they will never be
available in such a scenario. Considering this, in a host with a bunch of mpath devices
it will pollute the inventory output.

Fixes: https://tracker.ceph.com/issues/56621

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
