### PR TITLE
ceph-volume: report slave devices in inventory

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -311,3 +311,11 @@ def device_info(monkeypatch, patch_bluestore_label):
 @pytest.fixture(params=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.999, 1.0])
 def data_allocate_fraction(request):
     return request.param
+
+@pytest.fixture
+def fake_filesystem(fs):
+
+    fs.create_dir('/sys/block/sda/slaves')
+    fs.create_dir('/sys/block/sda/queue')
+    fs.create_dir('/sys/block/rbd0')
+    yield fs

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -287,7 +287,11 @@ def patch_bluestore_label():
 def device_info(monkeypatch, patch_bluestore_label):
     def apply(devices=None, lsblk=None, lv=None, blkid=None, udevadm=None,
               has_bluestore_label=False):
-        devices = devices if devices else {}
+        if devices:
+            for dev in devices.keys():
+                devices[dev]['device_nodes'] = os.path.basename(dev)
+        else:
+            devices = {}
         lsblk = lsblk if lsblk else {}
         blkid = blkid if blkid else {}
         udevadm = udevadm if udevadm else {}

--- a/src/ceph-volume/ceph_volume/tests/devices/simple/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/simple/test_activate.py
@@ -5,9 +5,9 @@ from ceph_volume.devices.simple import activate
 
 class TestActivate(object):
 
-    def test_no_data_uuid(self, factory, tmpfile, is_root, monkeypatch, capture):
-        json_config = tmpfile(contents='{}')
-        args = factory(osd_id='0', osd_fsid='1234', json_config=json_config)
+    def test_no_data_uuid(self, factory, is_root, monkeypatch, capture, fake_filesystem):
+        fake_filesystem.create_file('/tmp/json-config', contents='{}')
+        args = factory(osd_id='0', osd_fsid='1234', json_config='/tmp/json-config')
         with pytest.raises(RuntimeError):
             activate.Activate([]).activate(args)
 
@@ -45,9 +45,9 @@ class TestActivate(object):
 
 class TestEnableSystemdUnits(object):
 
-    def test_nothing_is_activated(self, tmpfile, is_root, capsys):
-        json_config = tmpfile(contents='{}')
-        activation = activate.Activate(['--no-systemd', '--file', json_config, '0', '1234'], from_trigger=True)
+    def test_nothing_is_activated(self, is_root, capsys, fake_filesystem):
+        fake_filesystem.create_file('/tmp/json-config', contents='{}')
+        activation = activate.Activate(['--no-systemd', '--file', '/tmp/json-config', '0', '1234'], from_trigger=True)
         activation.activate = lambda x: True
         activation.main()
         activation.enable_systemd_units('0', '1234')
@@ -56,69 +56,69 @@ class TestEnableSystemdUnits(object):
         assert 'Skipping masking of ceph-disk' in stderr
         assert 'Skipping enabling and starting OSD simple' in stderr
 
-    def test_no_systemd_flag_is_true(self, tmpfile, is_root):
-        json_config = tmpfile(contents='{}')
-        activation = activate.Activate(['--no-systemd', '--file', json_config, '0', '1234'], from_trigger=True)
+    def test_no_systemd_flag_is_true(self, is_root, fake_filesystem):
+        fake_filesystem.create_file('/tmp/json-config', contents='{}')
+        activation = activate.Activate(['--no-systemd', '--file', '/tmp/json-config', '0', '1234'], from_trigger=True)
         activation.activate = lambda x: True
         activation.main()
         assert activation.skip_systemd is True
 
-    def test_no_systemd_flag_is_false(self, tmpfile, is_root):
-        json_config = tmpfile(contents='{}')
-        activation = activate.Activate(['--file', json_config, '0', '1234'], from_trigger=True)
+    def test_no_systemd_flag_is_false(self, is_root, fake_filesystem):
+        fake_filesystem.create_file('/tmp/json-config', contents='{}')
+        activation = activate.Activate(['--file', '/tmp/json-config', '0', '1234'], from_trigger=True)
         activation.activate = lambda x: True
         activation.main()
         assert activation.skip_systemd is False
 
-    def test_masks_ceph_disk(self, tmpfile, is_root, monkeypatch, capture):
+    def test_masks_ceph_disk(self, is_root, monkeypatch, capture, fake_filesystem):
         monkeypatch.setattr('ceph_volume.systemd.systemctl.mask_ceph_disk', capture)
         monkeypatch.setattr('ceph_volume.systemd.systemctl.enable_volume', lambda *a: True)
         monkeypatch.setattr('ceph_volume.systemd.systemctl.enable_osd', lambda *a: True)
         monkeypatch.setattr('ceph_volume.systemd.systemctl.start_osd', lambda *a: True)
 
-        json_config = tmpfile(contents='{}')
-        activation = activate.Activate(['--file', json_config, '0', '1234'], from_trigger=False)
+        fake_filesystem.create_file('/tmp/json-config', contents='{}')
+        activation = activate.Activate(['--file', '/tmp/json-config', '0', '1234'], from_trigger=False)
         activation.activate = lambda x: True
         activation.main()
         activation.enable_systemd_units('0', '1234')
         assert len(capture.calls) == 1
 
-    def test_enables_simple_unit(self, tmpfile, is_root, monkeypatch, capture):
+    def test_enables_simple_unit(self, is_root, monkeypatch, capture, fake_filesystem):
         monkeypatch.setattr('ceph_volume.systemd.systemctl.mask_ceph_disk', lambda *a: True)
         monkeypatch.setattr('ceph_volume.systemd.systemctl.enable_volume', capture)
         monkeypatch.setattr('ceph_volume.systemd.systemctl.enable_osd', lambda *a: True)
         monkeypatch.setattr('ceph_volume.systemd.systemctl.start_osd', lambda *a: True)
 
-        json_config = tmpfile(contents='{}')
-        activation = activate.Activate(['--file', json_config, '0', '1234'], from_trigger=False)
+        fake_filesystem.create_file('/tmp/json-config', contents='{}')
+        activation = activate.Activate(['--file', '/tmp/json-config', '0', '1234'], from_trigger=False)
         activation.activate = lambda x: True
         activation.main()
         activation.enable_systemd_units('0', '1234')
         assert len(capture.calls) == 1
         assert capture.calls[0]['args'] == ('0', '1234', 'simple')
 
-    def test_enables_osd_unit(self, tmpfile, is_root, monkeypatch, capture):
+    def test_enables_osd_unit(self, is_root, monkeypatch, capture, fake_filesystem):
         monkeypatch.setattr('ceph_volume.systemd.systemctl.mask_ceph_disk', lambda *a: True)
         monkeypatch.setattr('ceph_volume.systemd.systemctl.enable_volume', lambda *a: True)
         monkeypatch.setattr('ceph_volume.systemd.systemctl.enable_osd', capture)
         monkeypatch.setattr('ceph_volume.systemd.systemctl.start_osd', lambda *a: True)
 
-        json_config = tmpfile(contents='{}')
-        activation = activate.Activate(['--file', json_config, '0', '1234'], from_trigger=False)
+        fake_filesystem.create_file('/tmp/json-config', contents='{}')
+        activation = activate.Activate(['--file', '/tmp/json-config', '0', '1234'], from_trigger=False)
         activation.activate = lambda x: True
         activation.main()
         activation.enable_systemd_units('0', '1234')
         assert len(capture.calls) == 1
         assert capture.calls[0]['args'] == ('0',)
 
-    def test_starts_osd_unit(self, tmpfile, is_root, monkeypatch, capture):
+    def test_starts_osd_unit(self, is_root, monkeypatch, capture, fake_filesystem):
         monkeypatch.setattr('ceph_volume.systemd.systemctl.mask_ceph_disk', lambda *a: True)
         monkeypatch.setattr('ceph_volume.systemd.systemctl.enable_volume', lambda *a: True)
         monkeypatch.setattr('ceph_volume.systemd.systemctl.enable_osd', lambda *a: True)
         monkeypatch.setattr('ceph_volume.systemd.systemctl.start_osd', capture)
 
-        json_config = tmpfile(contents='{}')
-        activation = activate.Activate(['--file', json_config, '0', '1234'], from_trigger=False)
+        fake_filesystem.create_file('/tmp/json-config', contents='{}')
+        activation = activate.Activate(['--file', '/tmp/json-config', '0', '1234'], from_trigger=False)
         activation.activate = lambda x: True
         activation.main()
         activation.enable_systemd_units('0', '1234')

--- a/src/ceph-volume/ceph_volume/tests/devices/simple/test_scan.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/simple/test_scan.py
@@ -5,20 +5,23 @@ from ceph_volume.devices.simple import scan
 
 class TestGetContents(object):
 
-    def test_multiple_lines_are_left_as_is(self, tmpfile):
-        magic_file = tmpfile(contents='first\nsecond\n')
-        scanner = scan.Scan([])
-        assert scanner.get_contents(magic_file) == 'first\nsecond\n'
+    def setup(self):
+        self.magic_file_name = '/tmp/magic-file'
 
-    def test_extra_whitespace_gets_removed(self, tmpfile):
-        magic_file = tmpfile(contents='first   ')
+    def test_multiple_lines_are_left_as_is(self, fake_filesystem):
+        magic_file = fake_filesystem.create_file(self.magic_file_name, contents='first\nsecond\n')
         scanner = scan.Scan([])
-        assert scanner.get_contents(magic_file) == 'first'
+        assert scanner.get_contents(magic_file.path) == 'first\nsecond\n'
 
-    def test_single_newline_values_are_trimmed(self, tmpfile):
-        magic_file = tmpfile(contents='first\n')
+    def test_extra_whitespace_gets_removed(self, fake_filesystem):
+        magic_file = fake_filesystem.create_file(self.magic_file_name, contents='first   ')
         scanner = scan.Scan([])
-        assert scanner.get_contents(magic_file) == 'first'
+        assert scanner.get_contents(magic_file.path) == 'first'
+
+    def test_single_newline_values_are_trimmed(self, fake_filesystem):
+        magic_file = fake_filesystem.create_file(self.magic_file_name, contents='first\n')
+        scanner = scan.Scan([])
+        assert scanner.get_contents(magic_file.path) == 'first'
 
 
 class TestEtcPath(object):
@@ -36,10 +39,10 @@ class TestEtcPath(object):
         assert scanner.etc_path == path
         assert os.path.isdir(path)
 
-    def test_complains_when_file(self, tmpfile):
-        path = tmpfile()
+    def test_complains_when_file(self, fake_filesystem):
+        etc_dir = fake_filesystem.create_file('/etc/ceph/osd')
         scanner = scan.Scan([])
-        scanner._etc_path = path
+        scanner._etc_path = etc_dir.path
         with pytest.raises(RuntimeError):
             scanner.etc_path
 

--- a/src/ceph-volume/ceph_volume/tests/test_inventory.py
+++ b/src/ceph-volume/ceph_volume/tests/test_inventory.py
@@ -30,7 +30,8 @@ def device_report_keys(device_info):
                      'size': 1999844147200.0,
                      'support_discard': '',
                      'vendor': 'DELL',
-                     'device_id': 'Vendor-Model-Serial'}
+                     'device_id': 'Vendor-Model-Serial',
+                     'device_nodes': 'sdb'}
     }
  )
     report = Devices().json_report()[0]
@@ -58,7 +59,8 @@ def device_sys_api_keys(device_info):
                      'sectorsize': '512',
                      'size': 1999844147200.0,
                      'support_discard': '',
-                     'vendor': 'DELL'}
+                     'vendor': 'DELL',
+                     'device_nodes': 'sdb'}
     }
  )
     report = Devices().json_report()[0]
@@ -89,6 +91,7 @@ def device_data(device_info):
                 'size': 1999844147200.0,
                 'support_discard': '',
                 'vendor': 'DELL',
+                'device_nodes': 'sdb'
             }
         }
     )
@@ -144,6 +147,7 @@ class TestInventory(object):
         'size',
         'support_discard',
         'vendor',
+        'device_nodes'
     ]
 
     expected_lsm_keys = [

--- a/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
@@ -78,13 +78,14 @@ class TestExcludeGroupOptions(object):
 
 class TestValidDevice(object):
 
-    def setup(self):
+    def setup(self, fake_filesystem):
         self.validator = arg_validators.ValidDevice()
 
     @patch('ceph_volume.util.arg_validators.disk.has_bluestore_label', return_value=False)
     def test_path_is_valid(self, m_has_bs_label,
                            fake_call, patch_bluestore_label,
-                           device_info):
+                           device_info, monkeypatch):
+        monkeypatch.setattr('ceph_volume.util.device.Device.exists', lambda: True)
         lsblk = {"TYPE": "disk", "NAME": "sda"}
         device_info(lsblk=lsblk)
         result = self.validator('/dev/sda')

--- a/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
@@ -16,11 +16,12 @@ class TestOSDPath(object):
         with pytest.raises(exceptions.SuperUserError):
             self.validator('')
 
-    def test_path_is_not_a_directory(self, is_root, tmpfile, monkeypatch):
+    def test_path_is_not_a_directory(self, is_root, monkeypatch, fake_filesystem):
+        fake_file = fake_filesystem.create_file('/tmp/foo')
         monkeypatch.setattr(arg_validators.disk, 'is_partition', lambda x: False)
         validator = arg_validators.OSDPath()
         with pytest.raises(argparse.ArgumentError):
-            validator(tmpfile())
+            validator(fake_file.path)
 
     def test_files_are_missing(self, is_root, tmpdir, monkeypatch):
         tmppath = str(tmpdir)

--- a/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
@@ -48,9 +48,9 @@ class TestStatus(object):
 
 class TestDmcryptClose(object):
 
-    def test_mapper_exists(self, fake_run, tmpfile):
-        file_name = tmpfile(name='mapper-device')
-        encryption.dmcrypt_close(file_name)
+    def test_mapper_exists(self, fake_run, fake_filesystem):
+        file_name = fake_filesystem.create_file('mapper-device')
+        encryption.dmcrypt_close(file_name.path)
         arguments = fake_run.calls[0]['args'][0]
         assert arguments[0] == 'cryptsetup'
         assert arguments[1] == 'remove'

--- a/src/ceph-volume/ceph_volume/tests/util/test_system.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_system.py
@@ -182,13 +182,13 @@ class TestGetMounts(object):
 
 class TestIsBinary(object):
 
-    def test_is_binary(self, tmpfile):
-        binary_path = tmpfile(contents='asd\n\nlkjh\x00')
-        assert system.is_binary(binary_path)
+    def test_is_binary(self, fake_filesystem):
+        binary_path = fake_filesystem.create_file('/tmp/fake-file', contents='asd\n\nlkjh\x00')
+        assert system.is_binary(binary_path.path)
 
-    def test_is_not_binary(self, tmpfile):
-        binary_path = tmpfile(contents='asd\n\nlkjh0')
-        assert system.is_binary(binary_path) is False
+    def test_is_not_binary(self, fake_filesystem):
+        binary_path = fake_filesystem.create_file('/tmp/fake-file', contents='asd\n\nlkjh0')
+        assert system.is_binary(binary_path.path) is False
 
 
 class TestGetFileContents(object):
@@ -197,21 +197,21 @@ class TestGetFileContents(object):
         filepath = os.path.join(str(tmpdir), 'doesnotexist')
         assert system.get_file_contents(filepath, 'default') == 'default'
 
-    def test_path_has_contents(self, tmpfile):
-        interesting_file = tmpfile(contents="1")
-        result = system.get_file_contents(interesting_file)
+    def test_path_has_contents(self, fake_filesystem):
+        interesting_file = fake_filesystem.create_file('/tmp/fake-file', contents="1")
+        result = system.get_file_contents(interesting_file.path)
         assert result == "1"
 
-    def test_path_has_multiline_contents(self, tmpfile):
-        interesting_file = tmpfile(contents="0\n1")
-        result = system.get_file_contents(interesting_file)
+    def test_path_has_multiline_contents(self, fake_filesystem):
+        interesting_file = fake_filesystem.create_file('/tmp/fake-file', contents="0\n1")
+        result = system.get_file_contents(interesting_file.path)
         assert result == "0\n1"
 
-    def test_exception_returns_default(self, tmpfile):
-        interesting_file = tmpfile(contents="0")
+    def test_exception_returns_default(self, fake_filesystem):
+        interesting_file = fake_filesystem.create_file('/tmp/fake-file', contents="0")
         # remove read, causes IOError
-        os.chmod(interesting_file, 0o000)
-        result = system.get_file_contents(interesting_file)
+        os.chmod(interesting_file.path, 0o000)
+        result = system.get_file_contents(interesting_file.path)
         assert result == ''
 
 

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 report_template = """
-{dev:<25} {size:<12} {rot!s:<7} {available!s:<9} {model}"""
+{dev:<25} {size:<12} {device_nodes:<15} {rot!s:<7} {available!s:<9} {model}"""
 
 
 def encryption_status(abspath):
@@ -56,6 +56,8 @@ class Devices(object):
                 rot='rotates',
                 model='Model name',
                 available='available',
+                device_nodes='Device nodes',
+
             )]
         for device in sorted(self.devices):
             output.append(device.report())
@@ -110,6 +112,8 @@ class Device(object):
                 self.path = real_path
         if not sys_info.devices:
             sys_info.devices = disk.get_devices()
+        if sys_info.devices.get(self.path, {}):
+            self.device_nodes = sys_info.devices[self.path]['device_nodes']
         self.sys_api = sys_info.devices.get(self.path, {})
         self.partitions = self._get_partitions()
         self.lv_api = None
@@ -275,6 +279,7 @@ class Device(object):
             rot=self.rotational,
             available=self.available,
             model=self.model,
+            device_nodes=self.device_nodes
         )
 
     def json_report(self):

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -866,6 +866,12 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         for key, file_ in facts:
             metadata[key] = get_file_contents(os.path.join(sysdir, file_))
 
+        device_slaves = os.listdir(os.path.join(sysdir, 'slaves'))
+        if device_slaves:
+            metadata['device_nodes'] = ','.join(device_slaves)
+        else:
+            metadata['device_nodes'] = devname
+
         metadata['scheduler_mode'] = ""
         scheduler = get_file_contents(sysdir + "/queue/scheduler")
         if scheduler is not None:

--- a/src/ceph-volume/tox.ini
+++ b/src/ceph-volume/tox.ini
@@ -7,6 +7,7 @@ deps=
   pytest
   pytest-xdist
   mock
+  pyfakefs
 install_command=./tox_install_command.sh {opts} {packages}
 commands=py.test --numprocesses=auto -vv {posargs:ceph_volume/tests} --ignore=ceph_volume/tests/functional
 


### PR DESCRIPTION
`ceph-volume inventory` currently reports the following:

```

Device Path               Size        rotates available Model name
/dev/mapper/mpatha        50.00 GB    True    True
/dev/mapper/mpathaa       6.00 GB     True    True
/dev/mapper/mpathab       6.00 GB     True    True
/dev/mapper/mpathac       6.00 GB     True    True
/dev/mapper/mpathad       6.00 GB     True    True
/dev/mapper/mpathae       6.00 GB     True    True
```

whereas something like following would be useful:

```

Device Path               Size         Device nodes    rotates available Model name
/dev/mapper/mpatha        50.00 GB     sdf,sde         True    True
/dev/mapper/mpathaa       6.00 GB      sdbe,sdat       True    True
/dev/mapper/mpathab       6.00 GB      sdav,sdbf       True    True
/dev/mapper/mpathac       6.00 GB      sdbb,sdbl       True    True
/dev/mapper/mpathad       6.00 GB      sdas,sdbc       True    True
/dev/mapper/mpathae       6.00 GB      sdax,sdbh       True    True
```

Fixes: https://tracker.ceph.com/issues/56624

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
