### PR TITLE
quincy: mgr/cephadm: fix the loki address in grafana, promtail configuration files

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2360,8 +2360,9 @@ Then run the following:
         else:
             need = {
                 'prometheus': ['mgr', 'alertmanager', 'node-exporter', 'ingress'],
-                'grafana': ['prometheus'],
+                'grafana': ['prometheus', 'loki'],
                 'alertmanager': ['mgr', 'alertmanager', 'snmp-gateway'],
+                'promtail': ['loki'],
             }
             for dep_type in need.get(daemon_type, []):
                 for dd in self.cache.get_daemons_by_type(dep_type):

--- a/src/pybind/mgr/cephadm/templates/services/promtail.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/promtail.yml.j2
@@ -12,10 +12,6 @@ clients:
 scrape_configs:
 - job_name: system
   static_configs:
-  - targets:
-{% for url in hostnames %}
-    - {{ url }}
-{% endfor %}
-    labels:
+  - labels:
       job: Cluster Logs
       __path__: /var/log/ceph/**/*.log

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -498,14 +498,12 @@ class TestMonitoring:
                   filename: /tmp/positions.yaml
 
                 clients:
-                  - url: http://1::4:3100/loki/api/v1/push
+                  - url: http://:3100/loki/api/v1/push
 
                 scrape_configs:
                 - job_name: system
                   static_configs:
-                  - targets:
-                    - 1::4
-                    labels:
+                  - labels:
                       job: Cluster Logs
                       __path__: /var/log/ceph/**/*.log""").lstrip()
 
@@ -583,7 +581,7 @@ class TestMonitoring:
                             type: 'loki'
                             access: 'proxy'
                             orgId: 2
-                            url: 'http://[1::4]:3100'
+                            url: ''
                             basicAuth: false
                             isDefault: true
                             editable: false""").lstrip(),
@@ -651,7 +649,7 @@ class TestMonitoring:
                                     "    type: 'loki'\n"
                                     "    access: 'proxy'\n"
                                     '    orgId: 2\n'
-                                    "    url: 'http://[1::4]:3100'\n"
+                                    "    url: ''\n"
                                     '    basicAuth: false\n'
                                     '    isDefault: true\n'
                                     '    editable: false',


### PR DESCRIPTION
Backport of #46924

- Fix to use loki address instead of MGR address(grafana datasource, promtail loki host)
- Add a loki dependency on grafana and promtail services

Signed-off-by: jinhong.kim <jinhong.kim0@navercorp.com>
(cherry picked from commit 829c8040749b34e816df0a3e4989c00c3880af42)

Added #47299 to this, as it's needed to stop promtail and grafana from flapping with the original change,



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
