### PR TITLE
pacific: rgw/notifications: Change in multipart upload notification behavior

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -35,6 +35,11 @@
 >=16.2.8
 --------
 
+* RGW: The behavior for Multipart Upload was modified so that only 
+  CompleteMultipartUpload notification is sent at the end of the multipart upload. 
+  The POST notification at the beginning of the upload, and PUT notifications that 
+  were sent on each part are not sent anymore.
+
 * MON/MGR: Pools can now be created with `--bulk` flag. Any pools created with `bulk`
   will use a profile of the `pg_autoscaler` that provides more performance from the start.
   However, any pools created without the `--bulk` flag will remain using it's old behavior

--- a/doc/radosgw/s3-notification-compatibility.rst
+++ b/doc/radosgw/s3-notification-compatibility.rst
@@ -109,6 +109,10 @@ Event Types
 
    The ``s3:ObjectRemoved:DeleteMarkerCreated`` event presents information on the latest version of the object
 
+.. note::
+
+   In case of multipart upload, an ``ObjectCreated:CompleteMultipartUpload`` notification will be sent at the end of the process.
+
 Topic Configuration
 -------------------
 In the case of bucket notifications, the topics management API will be derived from `AWS Simple Notification Service API`_. 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/51943

---

backport of https://github.com/ceph/ceph/pull/42350
parent tracker: https://tracker.ceph.com/issues/51520

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh