### PR TITLE
rgw: Fix Segmentation fault in s3website when bucket is NULL

### DIFF
--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -180,6 +180,10 @@ int rgw_process_authenticated(RGWHandler_REST * const handler,
    * if you are using the REST endpoint either (ergo, no authenticated access)
    */
   if (! skip_retarget) {
+    if (!s->bucket_exists) {
+      dout(0) << "ERROR: No such bucket or bucket is null" << dendl;
+      return -ERR_NO_SUCH_BUCKET;
+    }
     ldpp_dout(op, 2) << "recalculating target" << dendl;
     ret = handler->retarget(op, &op, y);
     if (ret < 0) {


### PR DESCRIPTION
RGWs crashed when s3website called without bucket, `retarget` calls from `process_request` and RGW crashed.

Full LOG:

```
---- RGW LOG ----
  -638> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 HTTP_ACCEPT=text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
  -637> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 HTTP_ACCEPT_ENCODING=gzip, deflate
  -636> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 HTTP_ACCEPT_LANGUAGE=en-US,en;q=0.9,fr;q=0.8
  -630> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 HTTP_CACHE_CONTROL=max-age=0
  -628> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 HTTP_HOST=s3-website.XXX.com
  -627> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 HTTP_UPGRADE_INSECURE_REQUESTS=1
  -626> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 HTTP_USER_AGENT=Mozlila/5.0 (Linux; Android 7.0; SM-G892A Bulid/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/60.0.3112.107 Mobile Safari/537.36
  -625> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 HTTP_VERSION=1.1
  -621> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 HTTP_X_SCHEME=http
  -619> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 REQUEST_METHOD=GET
  -618> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 REQUEST_URI=/
  -617> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 SCRIPT_URI=/
  -616> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 SERVER_PORT=1234
  -615> 2022-07-16T06:05:24.159+0430 7fbd26b71700  1 ====== starting new request req=0x7fbc4a034620 =====
  -614> 2022-07-16T06:05:24.159+0430 7fbd26b71700  2 req 14431852651046008579 0.000000000s initializing for trans_id = tx00000c8483d85dc607703-0062d215dc-15359a41-default
  -613> 2022-07-16T06:05:24.159+0430 7fbd26b71700 10 req 14431852651046008579 0.000000000s rgw api priority: s3=8 s3website=7
  -612> 2022-07-16T06:05:24.159+0430 7fbd26b71700 10 req 14431852651046008579 0.000000000s host=s3-website.XXX.com
  -611> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 req 14431852651046008579 0.000000000s subdomain= domain=s3-website.XXX.com in_hosted_domain=1 in_hosted_domain_s3website=1
  -610> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 req 14431852651046008579 0.000000000s final domain/bucket subdomain= domain=s3-website.XXX.com in_hosted_domain=1 in_hosted_domain_s3website=1 s->info.domain=s3-website.XXX.com s->info.request_uri=/
  -609> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 req 14431852651046008579 0.000000000s get_handler handler=33RGWHandler_REST_Service_S3Website
  -608> 2022-07-16T06:05:24.159+0430 7fbd26b71700 10 req 14431852651046008579 0.000000000s handler=33RGWHandler_REST_Service_S3Website
  -607> 2022-07-16T06:05:24.159+0430 7fbd26b71700  2 req 14431852651046008579 0.000000000s getting op 0
  -606> 2022-07-16T06:05:24.159+0430 7fbd26b71700 10 req 14431852651046008579 0.000000000s s3:get_obj scheduling with throttler client=2 cost=1
  -605> 2022-07-16T06:05:24.159+0430 7fbd26b71700 10 req 14431852651046008579 0.000000000s s3:get_obj op=28RGWGetObj_ObjStore_S3Website
  -604> 2022-07-16T06:05:24.159+0430 7fbd26b71700  2 req 14431852651046008579 0.000000000s s3:get_obj verifying requester
  -603> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 req 14431852651046008579 0.000000000s s3:get_obj rgw::auth::StrategyRegistry::s3_main_strategy_t: trying rgw::auth::s3::AWSAuthStrategy
  -602> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 req 14431852651046008579 0.000000000s s3:get_obj rgw::auth::s3::AWSAuthStrategy: trying rgw::auth::s3::S3AnonymousEngine
  -601> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 req 14431852651046008579 0.000000000s s3:get_obj rgw::auth::s3::S3AnonymousEngine granted access
  -600> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 req 14431852651046008579 0.000000000s s3:get_obj rgw::auth::s3::AWSAuthStrategy granted access
  -599> 2022-07-16T06:05:24.159+0430 7fbd26b71700  2 req 14431852651046008579 0.000000000s s3:get_obj normalizing buckets and tenants
  -598> 2022-07-16T06:05:24.159+0430 7fbd26b71700 10 req 14431852651046008579 0.000000000s s->object=<NULL> s->bucket=
  -597> 2022-07-16T06:05:24.159+0430 7fbd26b71700  2 req 14431852651046008579 0.000000000s s3:get_obj init permissions
  -596> 2022-07-16T06:05:24.159+0430 7fbd26b71700 20 req 14431852651046008579 0.000000000s s3:get_obj RGWSI_User_RADOS::read_user_info(): anonymous user
  -595> 2022-07-16T06:05:24.159+0430 7fbd26b71700  2 req 14431852651046008579 0.000000000s s3:get_obj recalculating target
  -594> 2022-07-16T06:05:24.159+0430 7fbd26b71700 10 req 14431852651046008579 0.000000000s retarget Starting retarget
  -291> 2022-07-16T06:05:24.191+0430 7fbd26b71700 -1 *** Caught signal (Segmentation fault) 
  ---- END OF LOG ----
```

Stack_Sig: 310d2f225070c57edbbd5ed9c5155e0b9d68ad26119e6cfc6f1f4c845140d5e5
Fixes: https://tracker.ceph.com/issues/53913
Signed-off-by: RaminNietzsche <Ramin.Najarbashi@Gmail.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
