### PR TITLE
mgr/dashboard: fix rgw connect when using ssl

### DIFF
--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -83,7 +83,7 @@ def _determine_rgw_addr(daemon_info: Dict[str, Any]) -> RgwDaemon:
     Parse RGW daemon info to determine the configured host (IP address) and port.
     """
     daemon = RgwDaemon()
-    daemon.host = _parse_addr(daemon_info['addr'])
+    daemon.host = daemon_info['metadata']['hostname']
     daemon.port, daemon.ssl = _parse_frontend_config(daemon_info['metadata']['frontend_config#0'])
 
     return daemon

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -290,7 +290,8 @@ class RgwStub(Stub):
                     'id': 'daemon1',
                     'realm_name': 'realm1',
                     'zonegroup_name': 'zonegroup1',
-                    'zone_name': 'zone1'
+                    'zone_name': 'zone1',
+                    'hostname': 'daemon1.server.lan'
                 }
             },
             '5398': {
@@ -300,7 +301,8 @@ class RgwStub(Stub):
                     'id': 'daemon2',
                     'realm_name': 'realm2',
                     'zonegroup_name': 'zonegroup2',
-                    'zone_name': 'zone2'
+                    'zone_name': 'zone2',
+                    'hostname': 'daemon2.server.lan'
                 }
             }
         }}}})


### PR DESCRIPTION
The dashboard trys to connect via ssl to an ip address instead of a dns name:

Exception:
```
Traceback (most recent call last):
  File "/usr/share/ceph/mgr/dashboard/rest_client.py", line 399, in do_request
    url, headers=request_headers, params=params, auth=self.auth)
  File "/lib/python3.6/site-packages/requests/sessions.py", line 546, in get
    return self.request('GET', url, **kwargs)
  File "/usr/share/ceph/mgr/dashboard/rest_client.py", line 48, in request
    return super(TimeoutRequestsSession, self).request(*args, **kwargs)
  File "/lib/python3.6/site-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/lib/python3.6/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/lib/python3.6/site-packages/requests/adapters.py", line 514, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='10.88.7.67', port=443): Max retries exceeded with url: /admin/metadata/user?myself (Caused by SSLError(CertificateError("hostname '10.88.7.67' doesn't match either of 's3dev-c01rg
w.lan', '*.s3dev-c01rgw.lan', 's3dev-c01rgw01.lan', '*.s3dev-c01rgw01.lan', 's3dev-c01rgw02.lan', '*.s3dev-c01rgw02.lan', 's3dev-c01rgw03.lan', '*.s3dev-c01rgw03.lan'"
,),))

```
Fixes: http://tracker.ceph.com/issues/56970



