### PR TITLE
include/compat: define aligned_free() as a function not a macro

### DIFF
--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -15,6 +15,7 @@
 #include "acconfig.h"
 #include <sys/types.h>
 #include <errno.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #if defined(__linux__)
@@ -349,7 +350,9 @@ extern _CRTIMP errno_t __cdecl _putenv_s(const char *_Name,const char *_Value);
 #define compat_closesocket closesocket
 // Use "aligned_free" when freeing memory allocated using posix_memalign or
 // _aligned_malloc. Using "free" will crash.
-#define aligned_free(ptr) _aligned_free(ptr)
+static inline void aligned_free(void* ptr) {
+  _aligned_free(ptr);
+}
 
 // O_CLOEXEC is not defined on Windows. Since handles aren't inherited
 // with subprocesses unless explicitly requested, we'll define this
@@ -363,7 +366,9 @@ extern _CRTIMP errno_t __cdecl _putenv_s(const char *_Name,const char *_Value);
 
 #define SOCKOPT_VAL_TYPE void*
 
-#define aligned_free(ptr) free(ptr)
+static inline void aligned_free(void* ptr) {
+  free(ptr);
+}
 static inline int compat_closesocket(int fildes) {
   return close(fildes);
 }


### PR DESCRIPTION
so it does not get substituted by the preprocessor unconditionally.
this change helps to address the compiling failure when using boost
1.79 using MinGW, like:

../build.deps/mingw/boost/include/boost/align/aligned_allocator.hpp: In member function 'void boost::alignment::aligned_allocator<T, Alignment>::deallocate(boost::alignment::aligned_allocator<T, Alignment>::pointer, boost::alignment::aligned_allocator<T, Alignment>::size_type)':
../src/include/compat.h:352:27: error: '_aligned_free' is not a member of 'boost::alignment'; did you mean 'aligned_free'?
  352 | #define aligned_free(ptr) _aligned_free(ptr)
      |                           ^~~~~~~~~~~~~

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
