### PR TITLE
[WIP] kv/RocksDBStore: Improved RocksDB Settings and Tombstone behavior

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3548,6 +3548,36 @@ options:
 # osd_*_priority determines the ratio of available io between client and
 # recovery.  Each option may be set between
 # 1..63.
+- name: rocksdb_cf_compact_on_deletion
+  type: bool
+  level: dev
+  desc: Compact the column family when a certain number of tombstones are observed within a given window.
+  long_desc: 'This setting instructs RocksDB to compact a column family when a certain
+    number of tombstones are observed during iteration within a certain sliding window.
+    For instance if rocksdb_cf_compact_on_deletion_sliding_window is 8192 and
+    rocksdb_cf_compact_on_deletion_trigger is 4096,  then once 4096 tombstones are
+    observed after iteration over 8192 entries, the column family will be compacted.'
+  default: true
+  with_legacy: true
+  see_also:
+  - rocksdb_cf_compact_on_deletion_sliding_window
+  - rocksdb_cf_compact_on_deletion_trigger
+- name: rocksdb_cf_compact_on_deletion_sliding_window
+  type: int
+  level: dev
+  desc: The sliding window to use when rocksdb_cf_compact_on_deletion is enabled.
+  default: 32768
+  with_legacy: true
+  see_also:
+  - rocksdb_cf_compact_on_deletion
+- name: rocksdb_cf_compact_on_deletion_trigger
+  type: int
+  level: dev
+  desc: The trigger to use when rocksdb_cf_compact_on_deletion is enabled.
+  default: 16384
+  with_legacy: true
+  see_also:
+  - rocksdb_cf_compact_on_deletion
 - name: osd_client_op_priority
   type: uint
   level: advanced

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4911,7 +4911,7 @@ options:
   type: str
   level: advanced
   desc: Full set of rocksdb settings to override
-  default: compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456,writable_file_max_buffer_size=0,compaction_readahead_size=2097152,max_background_compactions=2,max_total_wal_size=1073741824
+  default: compression=kNoCompression,max_write_buffer_number=128,min_write_buffer_number_to_merge=16,compaction_style=kCompactionStyleLevel,write_buffer_size=8388608,max_background_jobs=4,level0_file_num_compaction_trigger=8,max_bytes_for_level_base=1073741824,max_bytes_for_level_multiplier=8,compaction_readahead_size=2MB,max_total_wal_size=1073741824,writable_file_max_buffer_size=0
   with_legacy: true
 - name: bluestore_rocksdb_options_annex
   type: str

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4911,7 +4911,7 @@ options:
   type: str
   level: advanced
   desc: Full set of rocksdb settings to override
-  default: compression=kNoCompression,max_write_buffer_number=128,min_write_buffer_number_to_merge=16,compaction_style=kCompactionStyleLevel,write_buffer_size=8388608,max_background_jobs=4,level0_file_num_compaction_trigger=8,max_bytes_for_level_base=1073741824,max_bytes_for_level_multiplier=8,compaction_readahead_size=2MB,max_total_wal_size=1073741824,writable_file_max_buffer_size=0
+  default: compression=kNoCompression,max_write_buffer_number=128,min_write_buffer_number_to_merge=16,compaction_style=kCompactionStyleLevel,write_buffer_size=8388608,max_background_jobs=4,level0_file_num_compaction_trigger=8,max_bytes_for_level_base=1073741824,max_bytes_for_level_multiplier=8,compaction_readahead_size=2MB,max_total_wal_size=1073741824,writable_file_max_buffer_size=0,ttl=21600
   with_legacy: true
 - name: bluestore_rocksdb_options_annex
   type: str

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -18,6 +18,7 @@
 #include "rocksdb/cache.h"
 #include "rocksdb/filter_policy.h"
 #include "rocksdb/utilities/convenience.h"
+#include "rocksdb/utilities/table_properties_collectors.h"
 #include "rocksdb/merge_operator.h"
 
 #include "common/perf_counters.h"
@@ -933,6 +934,14 @@ int RocksDBStore::update_column_family_options(const std::string& base_name,
       // apply_block_cache_options already does all necessary douts
       return r;
     }
+  }
+
+  // Set Compact on Deletion Factory
+  if (cct->_conf->rocksdb_cf_compact_on_deletion) {
+    size_t sliding_window = cct->_conf->rocksdb_cf_compact_on_deletion_sliding_window;
+    size_t trigger = cct->_conf->rocksdb_cf_compact_on_deletion_trigger;
+    cf_opt->table_properties_collector_factories.emplace_back(
+        rocksdb::NewCompactOnDeletionCollectorFactory(sliding_window, trigger));
   }
   return 0;
 }

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1579,6 +1579,9 @@ To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
                 msg = f"{msg}\nSome channels are disabled, please enable with:\n"\
                         f"`ceph telemetry enable channel{disabled_channels}`"
 
+            # wake up serve() to reset health warning
+            self.event.set()
+
             return 0, msg, ''
 
     @CLICommand('telemetry off')


### PR DESCRIPTION
Multi-part PR for implementing RocksDB tuning improvements for higher performance and better tombstone cleanup during iteration.  So far mostly just rocksdb tuning settings from the new blog article, last-ditch attempts to compact when data gets too old, and compaction during iteration when we have an excessively high number of tombstone entries.  Does not yet solve the problem of slow iteration over tombstones in memtables.  That will likely require issuing a per-coumn family memtable flush.  Thus, next step is per-column family memtable flushing and DB compaction on rmkey(s). 

See commit messages from this PR and addition information at:

https://tracker.ceph.com/issues/53926
https://github.com/ceph/ceph.io/pull/413

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
