### PR TITLE
mgr/zabbix: fix config issues and add timeout option

### DIFF
--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -124,7 +124,10 @@ class Module(MgrModule):
 
         self.log.debug('Setting in-memory config option %s to: %s', option,
                        value)
-        self.config[option] = value
+        if option in ['zabbix_port', 'interval', 'discovery_interval']:
+            self.config[option] = int(value)
+        else:
+            self.config[option] = value
         return True
 
     def _parse_zabbix_hosts(self) -> None:
@@ -399,7 +402,7 @@ class Module(MgrModule):
             self.set_module_option(key, value)
             if key == 'zabbix_host' or key == 'zabbix_port':
                 self._parse_zabbix_hosts()
-                return 0, 'Configuration option {0} updated'.format(key), ''
+            return 0, 'Configuration option {0} updated'.format(key), ''
         return 1,\
             'Failed to update configuration option {0}'.format(key), ''
 

--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -22,17 +22,18 @@ def avg(data: Sequence[Union[int, float]]) -> float:
 
 
 class ZabbixSender(object):
-    def __init__(self, sender: str, host: str, port: int, log: logging.Logger) -> None:
+    def __init__(self, sender: str, host: str, port: int, timeout: int, log: logging.Logger) -> None:
         self.sender = sender
         self.host = host
         self.port = port
         self.log = log
+        self.timeout = timeout
 
     def send(self, hostname: str, data: Mapping[str, Union[int, float, str]]) -> None:
         if len(data) == 0:
             return
 
-        cmd = [self.sender, '-z', self.host, '-p', str(self.port), '-s',
+        cmd = ['/usr/bin/timeout', str(self.timeout), self.sender, '-z', self.host, '-p', str(self.port), '-s',
                hostname, '-vv', '-i', '-']
 
         self.log.debug('Executing: %s', cmd)
@@ -44,7 +45,9 @@ class ZabbixSender(object):
             proc.stdin.write('{0} ceph.{1} {2}\n'.format(hostname, key, value))
 
         stdout, stderr = proc.communicate()
-        if proc.returncode != 0:
+        if proc.returncode == 124:
+            raise RuntimeError('%s timed out while sending data' % (self.sender))
+        elif proc.returncode != 0:
             raise RuntimeError('%s exited non-zero: %s' % (self.sender,
                                                            stderr))
 
@@ -82,6 +85,10 @@ class Module(MgrModule):
             type='secs',
             default=60),
         Option(
+            name='timeout',
+            type='secs',
+            default=2),
+        Option(
             name='discovery_interval',
             type='uint',
             default=100)
@@ -106,7 +113,7 @@ class Module(MgrModule):
             raise RuntimeError('{0} is a unknown configuration '
                                'option'.format(option))
 
-        if option in ['zabbix_port', 'interval', 'discovery_interval']:
+        if option in ['zabbix_port', 'interval', 'timeout', 'discovery_interval']:
             try:
                 int_value = int(value)  # type: ignore
             except (ValueError, TypeError):
@@ -124,7 +131,7 @@ class Module(MgrModule):
 
         self.log.debug('Setting in-memory config option %s to: %s', option,
                        value)
-        if option in ['zabbix_port', 'interval', 'discovery_interval']:
+        if option in ['zabbix_port', 'interval', 'timeout', 'discovery_interval']:
             self.config[option] = int(value)
         else:
             self.config[option] = value
@@ -312,7 +319,8 @@ class Module(MgrModule):
             try:
                 zabbix = ZabbixSender(cast(str, self.config['zabbix_sender']),
                                       cast(str, server['zabbix_host']),
-                                      cast(int, server['zabbix_port']), self.log)
+                                      cast(int, server['zabbix_port']),
+                                      cast(int, self.config['timeout']), self.log)
                 zabbix.send(identifier, data)
             except Exception as exc:
                 self.log.exception('Failed to send.')


### PR DESCRIPTION
- Retype int options as integers correctly in set_config_option
- Return 0 from config_set if config was set correctly.

Fixes: https://tracker.ceph.com/issues/56671
Signed-off-by: Rafael Lopez <rafael.lopez@softiron.com>
