### PR TITLE
ceph_dencoder: make it to be compatible with vstart.sh.

### DIFF
--- a/src/tools/ceph-dencoder/CMakeLists.txt
+++ b/src/tools/ceph-dencoder/CMakeLists.txt
@@ -90,9 +90,6 @@ if(WITH_CEPHFS)
     mds)
 endif()
 
-target_compile_definitions(ceph-dencoder PRIVATE
-  "CEPH_DENC_MOD_DIR=\"${denc_plugin_dir}\"")
-
 target_link_libraries(ceph-dencoder
   StdFilesystem::filesystem
   global


### PR DESCRIPTION
The vstart.sh will set the "plugin_dir" option to
"$CEPH_BUILD_DIR/lib" and there has no "denc/" under it.

If there has a "denc/" it should be from system install path
"${CEPH_INSTALL_FULL_PKGLIBDIR}/denc".

Signed-off-by: Xiubo Li <xiubli@redhat.com>

===

If no ceph was installed and only build it from source, and then start a cephfs cluster with the vstart.sh:

```
[root@ceph build]# ./bin/rados --pool cephfs.a.data getxattr 10000002e14.00000000 parent | ./bin/ceph-dencoder type inode_backtrace_t import - decode dump_json
error getting xattr cephfs.a.data/10000002e14.00000000/parent: (2) No such file or directory
unable to load dencoders from "/usr/local/lib64/ceph/denc". it is not a directory.
class 'inode_backtrace_t' unknown
```




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
