### PR TITLE
pacific: common: notify all when max backlog reached in OutputDataSocket

### DIFF
--- a/src/common/OutputDataSocket.cc
+++ b/src/common/OutputDataSocket.cc
@@ -396,6 +396,8 @@ void OutputDataSocket::append_output(ceph::buffer::list& bl)
       skipped = 1;
     } else
       ++skipped;
+
+    cond.notify_all();
     return;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55830

---

backport of https://github.com/ceph/ceph/pull/46019
parent tracker: https://tracker.ceph.com/issues/55422

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh