### PR TITLE
quincy: ceph.spec.in: disable system_pmdk on s390x

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -39,7 +39,11 @@
 %if 0%{?rhel} < 9
 %bcond_with system_pmdk
 %else
+%ifarch s390x
+%bcond_with system_pmdk
+%else
 %bcond_without system_pmdk
+%endif
 %endif
 %bcond_without selinux
 %if 0%{?rhel} >= 8


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56681

---

backport of https://github.com/ceph/ceph/pull/47014
parent tracker: https://tracker.ceph.com/issues/56491