### PR TITLE
[DNM] build: avoid boost/valgrind issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -709,7 +709,7 @@ endif()
 option(WITH_GRAFANA "install grafana dashboards" OFF)
 add_subdirectory(monitoring/ceph-mixin)
 
-CMAKE_DEPENDENT_OPTION(WITH_BOOST_VALGRIND "Boost support for valgrind" OFF
+CMAKE_DEPENDENT_OPTION(WITH_BOOST_VALGRIND "Boost support for valgrind" ON
   "NOT WITH_SYSTEM_BOOST" OFF)
 
 include(CTags)

--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -39,12 +39,7 @@ function get_processors() {
 
 function detect_ceph_dev_pkgs() {
     local cmake_opts
-    local boost_root=/opt/ceph
-    if test -f $boost_root/include/boost/config.hpp; then
-        cmake_opts+=" -DWITH_SYSTEM_BOOST=ON -DBOOST_ROOT=$boost_root"
-    else
-        cmake_opts+=" -DBOOST_J=$(get_processors)"
-    fi
+    cmake_opts+=" -DBOOST_J=$(get_processors)"
 
     source /etc/os-release
     if [[ "$ID" == "ubuntu" ]]; then


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

valgrind issues are still visible with this change (on centos8):

http://pulpito.front.sepia.ceph.com/yuvalif-2022-07-21_18:07:44-rgw:verify-wip-yuval-valgrind-boost-distro-default-smithi/


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
