### PR TITLE
osd/scrub: log refs to non-existing snaps

### DIFF
--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -15,7 +15,6 @@
 #ifndef SNAPMAPPER_H
 #define SNAPMAPPER_H
 
-#include <cstring>
 #include <set>
 #include <string>
 #include <utility>

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -15,15 +15,16 @@
 #ifndef SNAPMAPPER_H
 #define SNAPMAPPER_H
 
-#include <string>
-#include <set>
-#include <utility>
 #include <cstring>
+#include <set>
+#include <string>
+#include <utility>
 
-#include "common/map_cacher.hpp"
 #include "common/hobject.h"
+#include "common/map_cacher.hpp"
 #include "include/buffer.h"
 #include "include/encoding.h"
+#include "include/expected.hpp"
 #include "include/object.h"
 #include "os/ObjectStore.h"
 #include "osd/OSDMap.h"
@@ -331,6 +332,9 @@ public:
     const hobject_t &oid,     ///< [in] oid to get snaps for
     std::set<snapid_t> *snaps ///< [out] snaps
     ); ///< @return error, -ENOENT if oid is not recorded
+
+  // alternative interface to the same data:
+  tl::expected<std::set<snapid_t>, int> get_snaps(const hobject_t& hoid);
 };
 WRITE_CLASS_ENCODER(SnapMapper::object_snaps)
 WRITE_CLASS_ENCODER(SnapMapper::Mapping)

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -550,6 +550,12 @@ class PgScrubber : public ScrubPgIF,
     return m_pg->snap_mapper.get_snaps(hoid, snaps_set);
   }
 
+  tl::expected<std::set<snapid_t>, int> get_snaps(
+    const hobject_t& hoid) const final
+  {
+    return m_pg->snap_mapper.get_snaps(hoid);
+  }
+
   void log_cluster_warning(const std::string& warning) const final;
 
  protected:

--- a/src/osd/scrubber/scrub_backend.h
+++ b/src/osd/scrubber/scrub_backend.h
@@ -120,11 +120,6 @@ struct SnapMapperAccessor {
   virtual ~SnapMapperAccessor() = default;
 };
 
-/*
-return tl::unexpected(info->last_error);
-
-*/
-
 enum class snap_mapper_op_t {
   add,
   update,
@@ -551,6 +546,13 @@ class ScrubBackend {
     const hobject_t& hoid,
     const SnapSet& snapset,
     SnapMapperAccessor& snaps_getter);
+
+  /**
+   * check a set of snap-ids agains the existing snaps. Returns
+   * the first "should not exist" snap-id, or none if all are fine.
+   */
+  std::optional<snapid_t> check_for_rmed_snaps(
+    const std::set<snapid_t>& snaps);
 
   // accessing the PG backend for this translation service
   uint64_t logical_to_ondisk_size(uint64_t logical_size) const;

--- a/src/osd/scrubber/scrub_backend.h
+++ b/src/osd/scrubber/scrub_backend.h
@@ -46,6 +46,7 @@
 #include <string_view>
 
 #include "common/LogClient.h"
+#include "include/expected.hpp"
 #include "osd/OSDMap.h"
 #include "common/scrub_types.h"
 #include "osd/osd_types_fmt.h"
@@ -113,9 +114,16 @@ struct ScrubBeListener {
 
 struct SnapMapperAccessor {
   virtual int get_snaps(const hobject_t& hoid,
-                        std::set<snapid_t>* snaps_set) const = 0;
+			std::set<snapid_t>* snaps_set) const = 0;
+  virtual tl::expected<std::set<snapid_t>, int> get_snaps(
+    const hobject_t& hoid) const = 0;
   virtual ~SnapMapperAccessor() = default;
 };
+
+/*
+return tl::unexpected(info->last_error);
+
+*/
 
 enum class snap_mapper_op_t {
   add,

--- a/src/test/osd/test_scrubber_be.cc
+++ b/src/test/osd/test_scrubber_be.cc
@@ -206,9 +206,8 @@ tl::expected<std::set<snapid_t>, int> TestScrubber::get_snaps(
   auto r = get_snaps(oid, &snapset);
   if (r >= 0) {
     return snapset;
-  } else {
-    return tl::make_unexpected(r);
   }
+  return tl::make_unexpected(r);
 }
 
 

--- a/src/test/osd/test_scrubber_be.cc
+++ b/src/test/osd/test_scrubber_be.cc
@@ -11,6 +11,7 @@
 #include "common/ceph_argparse.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
+#include "include/expected.hpp"
 #include "mon/MonClient.h"
 #include "msg/Messenger.h"
 #include "os/ObjectStore.h"
@@ -142,6 +143,8 @@ class TestScrubber : public ScrubBeListener, public SnapMapperAccessor {
 
   int get_snaps(const hobject_t& hoid,
 		std::set<snapid_t>* snaps_set) const final;
+  tl::expected<std::set<snapid_t>, int> get_snaps(
+    const hobject_t& oid) const final;
 
   void set_snaps(const hobject_t& hoid, const std::vector<snapid_t>& snaps)
   {
@@ -194,6 +197,18 @@ int TestScrubber::get_snaps(const hobject_t& hoid,
 			   *snaps_set)
 	    << std::endl;
   return 0;
+}
+
+tl::expected<std::set<snapid_t>, int> TestScrubber::get_snaps(
+    const hobject_t& oid) const
+{
+  std::set<snapid_t> snapset;
+  auto r = get_snaps(oid, &snapset);
+  if (r >= 0) {
+    return snapset;
+  } else {
+    return tl::make_unexpected(r);
+  }
 }
 
 

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -1,26 +1,25 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
-* Ceph - scalable distributed file system
-*
-* Copyright (C) 2012 Inktank, Inc.
-*
-* This is free software; you can redistribute it and/or
-* modify it under the terms of the GNU Lesser General Public
-* License version 2.1, as published by the Free Software
-* Foundation. See file COPYING.
-*/
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2012 Inktank, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ */
+#include <fstream>
 #include <map>
 #include <set>
 #include <string>
-#include <fstream>
 
 #include "common/ceph_argparse.h"
 #include "common/config.h"
 #include "common/errno.h"
 #include "common/strtol.h"
 #include "common/url_escape.h"
-
 #include "global/global_context.h"
 #include "global/global_init.h"
 
@@ -28,14 +27,17 @@
 
 using namespace std;
 
-void usage(const char *pname)
+void usage(const char* pname)
 {
-  std::cout << "Usage: " << pname << " <leveldb|rocksdb|bluestore-kv> <store path> command [args...]\n"
+  std::cout
+    << "Usage: " << pname
+    << " <leveldb|rocksdb|bluestore-kv> <store path> command [args...]\n"
     << "\n"
     << "Commands:\n"
     << "  list [prefix]\n"
     << "  list-crc [prefix]\n"
     << "  dump [prefix]\n"
+    << "  mapper [out <file>]\n"
     << "  exists <prefix> [key]\n"
     << "  get <prefix> <key> [out <file>]\n"
     << "  crc <prefix> <key>\n"
@@ -48,13 +50,14 @@ void usage(const char *pname)
     << "  compact\n"
     << "  compact-prefix <prefix>\n"
     << "  compact-range <prefix> <start> <end>\n"
-    << "  destructive-repair  (use only as last resort! may corrupt healthy data)\n"
+    << "  destructive-repair  (use only as last resort! may corrupt healthy "
+       "data)\n"
     << "  stats\n"
     << "  histogram [prefix]\n"
     << std::endl;
 }
 
-int main(int argc, const char *argv[])
+int main(int argc, const char* argv[])
 {
   auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
@@ -66,19 +69,18 @@ int main(int argc, const char *argv[])
     exit(0);
   }
 
-  map<string,string> defaults = {
-    { "debug_rocksdb", "2" }
-  };
+  map<string, string> defaults = {{"debug_rocksdb", "2"}};
 
-  auto cct = global_init(
-    &defaults, args,
-    CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
-    CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  auto cct = global_init(&defaults,
+			 args,
+			 CEPH_ENTITY_TYPE_CLIENT,
+			 CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);
 
   ceph_assert((int)args.size() < argc);
-  for(size_t i=0; i<args.size(); i++)
-    argv[i+1] = args[i];
+  for (size_t i = 0; i < args.size(); i++)
+    argv[i + 1] = args[i];
   argc = args.size() + 1;
 
   if (args.size() < 3) {
@@ -90,9 +92,7 @@ int main(int argc, const char *argv[])
   string path(args[1]);
   string cmd(args[2]);
 
-  if (type != "leveldb" &&
-      type != "rocksdb" &&
-      type != "bluestore-kv")  {
+  if (type != "leveldb" && type != "rocksdb" && type != "bluestore-kv") {
 
     std::cerr << "Unrecognized type: " << args[0] << std::endl;
     usage(argv[0]);
@@ -139,9 +139,69 @@ int main(int argc, const char *argv[])
 
     bool ret = st.exists(prefix, key);
     std::cout << "(" << url_escape(prefix) << ", " << url_escape(key) << ") "
-      << (ret ? "exists" : "does not exist")
-      << std::endl;
+	      << (ret ? "exists" : "does not exist") << std::endl;
     return (ret ? 0 : 1);
+
+  } else if (cmd == "snasna") {
+    if (argc < 5) {
+      usage(argv[0]);
+      return 1;
+    }
+    if (argc > 5) {
+      st.corrupt_snap_v2(argv[4], atoi(argv[5]));
+        } else {
+    st.corrupt_snaps(argv[4]);
+        }
+    std::cout << std::endl;
+    return 0;
+  } else if (cmd == "objobj") {
+    if (argc < 5) {
+      usage(argv[0]);
+      return 1;
+    }
+    st.corrupt_obj_entries(argv[4]);
+    std::cout << std::endl;
+    return 0;
+  } else if (cmd == "mapper") {
+    // if (argc < 6) {
+    //   usage(argv[0]);
+    //   return 1;
+    // }
+    // string prefix(url_unescape(argv[4]));
+    // string key(url_unescape(argv[5]));
+
+    std::cout << std::endl;
+    bufferlist bl = st.mapmapper("p", true);
+    std::cout << std::endl;
+
+    if (argc >= 7) {
+      string subcmd(argv[6]);
+      if (subcmd != "out") {
+	std::cerr << "unrecognized subcmd '" << subcmd << "'" << std::endl;
+	return 1;
+      }
+      if (argc < 8) {
+	std::cerr << "output path not specified" << std::endl;
+	return 1;
+      }
+      string out(argv[7]);
+
+      if (out.empty()) {
+	std::cerr << "unspecified out file" << std::endl;
+	return 1;
+      }
+
+      int err = bl.write_file(argv[7], 0644);
+      if (err < 0) {
+	std::cerr << "error writing value to '" << out
+		  << "': " << cpp_strerror(err) << std::endl;
+	return 1;
+      }
+    } else {
+      ostringstream os;
+      bl.hexdump(os);
+      std::cout << os.str() << std::endl;
+    }
 
   } else if (cmd == "get") {
     if (argc < 6) {
@@ -163,26 +223,25 @@ int main(int argc, const char *argv[])
     if (argc >= 7) {
       string subcmd(argv[6]);
       if (subcmd != "out") {
-        std::cerr << "unrecognized subcmd '" << subcmd << "'"
-                  << std::endl;
-        return 1;
+	std::cerr << "unrecognized subcmd '" << subcmd << "'" << std::endl;
+	return 1;
       }
       if (argc < 8) {
-        std::cerr << "output path not specified" << std::endl;
-        return 1;
+	std::cerr << "output path not specified" << std::endl;
+	return 1;
       }
       string out(argv[7]);
 
       if (out.empty()) {
-        std::cerr << "unspecified out file" << std::endl;
-        return 1;
+	std::cerr << "unspecified out file" << std::endl;
+	return 1;
       }
 
       int err = bl.write_file(argv[7], 0644);
       if (err < 0) {
-        std::cerr << "error writing value to '" << out << "': "
-                  << cpp_strerror(err) << std::endl;
-        return 1;
+	std::cerr << "error writing value to '" << out
+		  << "': " << cpp_strerror(err) << std::endl;
+	return 1;
       }
     } else {
       ostringstream os;
@@ -224,11 +283,11 @@ int main(int argc, const char *argv[])
     bufferlist bl = st.get(prefix, key, exists);
     if (!exists) {
       std::cerr << "(" << url_escape(prefix) << "," << url_escape(key)
-                << ") does not exist" << std::endl;
+		<< ") does not exist" << std::endl;
       return 1;
     }
     std::cout << "(" << url_escape(prefix) << "," << url_escape(key)
-              << ") size " << byte_u_t(bl.length()) << std::endl;
+	      << ") size " << byte_u_t(bl.length()) << std::endl;
 
   } else if (cmd == "set") {
     if (argc < 8) {
@@ -242,17 +301,17 @@ int main(int argc, const char *argv[])
     bufferlist val;
     string errstr;
     if (subcmd == "ver") {
-      version_t v = (version_t) strict_strtoll(argv[7], 10, &errstr);
+      version_t v = (version_t)strict_strtoll(argv[7], 10, &errstr);
       if (!errstr.empty()) {
-        std::cerr << "error reading version: " << errstr << std::endl;
-        return 1;
+	std::cerr << "error reading version: " << errstr << std::endl;
+	return 1;
       }
       encode(v, val);
     } else if (subcmd == "in") {
       int ret = val.read_file(argv[7], &errstr);
       if (ret < 0 || !errstr.empty()) {
-        std::cerr << "error reading file: " << errstr << std::endl;
-        return 1;
+	std::cerr << "error reading file: " << errstr << std::endl;
+	return 1;
       }
     } else {
       std::cerr << "unrecognized subcommand '" << subcmd << "'" << std::endl;
@@ -262,8 +321,8 @@ int main(int argc, const char *argv[])
 
     bool ret = st.set(prefix, key, val);
     if (!ret) {
-      std::cerr << "error setting ("
-                << url_escape(prefix) << "," << url_escape(key) << ")" << std::endl;
+      std::cerr << "error setting (" << url_escape(prefix) << ","
+		<< url_escape(key) << ")" << std::endl;
       return 1;
     }
   } else if (cmd == "rm") {
@@ -276,9 +335,8 @@ int main(int argc, const char *argv[])
 
     bool ret = st.rm(prefix, key);
     if (!ret) {
-      std::cerr << "error removing ("
-                << url_escape(prefix) << "," << url_escape(key) << ")"
-		<< std::endl;
+      std::cerr << "error removing (" << url_escape(prefix) << ","
+		<< url_escape(key) << ")" << std::endl;
       return 1;
     }
   } else if (cmd == "rm-prefix") {
@@ -290,13 +348,12 @@ int main(int argc, const char *argv[])
 
     bool ret = st.rm_prefix(prefix);
     if (!ret) {
-      std::cerr << "error removing prefix ("
-                << url_escape(prefix) << ")"
+      std::cerr << "error removing prefix (" << url_escape(prefix) << ")"
 		<< std::endl;
       return 1;
     }
   } else if (cmd == "store-copy") {
-    int num_keys_per_tx = 128; // magic number that just feels right.
+    int num_keys_per_tx = 128;	// magic number that just feels right.
     if (argc < 5) {
       usage(argv[0]);
       return 1;
@@ -304,8 +361,8 @@ int main(int argc, const char *argv[])
       string err;
       num_keys_per_tx = strict_strtol(argv[5], 10, &err);
       if (!err.empty()) {
-        std::cerr << "invalid num_keys_per_tx: " << err << std::endl;
-        return 1;
+	std::cerr << "invalid num_keys_per_tx: " << err << std::endl;
+	return 1;
       }
     }
     string other_store_type = argv[1];
@@ -313,10 +370,11 @@ int main(int argc, const char *argv[])
       other_store_type = argv[6];
     }
 
-    int ret = st.copy_store_to(argv[1], argv[4], num_keys_per_tx, other_store_type);
+    int ret =
+      st.copy_store_to(argv[1], argv[4], num_keys_per_tx, other_store_type);
     if (ret < 0) {
       std::cerr << "error copying store to path '" << argv[4]
-                << "': " << cpp_strerror(ret) << std::endl;
+		<< "': " << cpp_strerror(ret) << std::endl;
       return 1;
     }
 

--- a/src/tools/kvstore_tool.cc
+++ b/src/tools/kvstore_tool.cc
@@ -3,14 +3,28 @@
 
 #include "kvstore_tool.h"
 
+#include <charconv>
+#include <cstring>
 #include <iostream>
+#include <set>
+#include <utility>
 
+#include "common/Formatter.h"
 #include "common/errno.h"
-#include "common/url_escape.h"
+#include "common/hobject.h"
 #include "common/pretty_binary.h"
+#include "common/sharedptr_registry.hpp"
+#include "common/url_escape.h"
+#include "include/Context.h"
 #include "include/buffer.h"
+#include "include/encoding.h"
+#include "include/object.h"
 #include "kv/KeyValueDB.h"
 #include "kv/KeyValueHistogram.h"
+#include "os/bluestore/bluestore_types.h"
+#include "osd/OSDMap.h"
+#include "osd/osd_types_fmt.h"
+
 
 using namespace std;
 
@@ -18,7 +32,7 @@ StoreTool::StoreTool(const string& type,
 		     const string& path,
 		     bool to_repair,
 		     bool need_stats)
-  : store_path(path)
+    : store_path(path)
 {
 
   if (need_stats) {
@@ -38,9 +52,9 @@ StoreTool::StoreTool(const string& type,
     auto db_ptr = KeyValueDB::create(g_ceph_context, type, path);
     if (!to_repair) {
       if (int r = db_ptr->open(std::cerr); r < 0) {
-        cerr << "failed to open type " << type << " path " << path << ": "
-             << cpp_strerror(r) << std::endl;
-        exit(1);
+	cerr << "failed to open type " << type << " path " << path << ": "
+	     << cpp_strerror(r) << std::endl;
+	exit(1);
       }
     }
     db.reset(db_ptr);
@@ -49,20 +63,20 @@ StoreTool::StoreTool(const string& type,
 
 int StoreTool::load_bluestore(const string& path, bool to_repair)
 {
-    auto bluestore = new BlueStore(g_ceph_context, path);
-    KeyValueDB *db_ptr;
-    int r = bluestore->open_db_environment(&db_ptr, to_repair);
-    if (r < 0) {
-     return -EINVAL;
-    }
-    db = decltype(db){db_ptr, Deleter(bluestore)};
-    return 0;
+  auto bluestore = new BlueStore(g_ceph_context, path);
+  KeyValueDB* db_ptr;
+  int r = bluestore->open_db_environment(&db_ptr, to_repair);
+  if (r < 0) {
+    return -EINVAL;
+  }
+  db = decltype(db){db_ptr, Deleter(bluestore)};
+  return 0;
 }
 
 uint32_t StoreTool::traverse(const string& prefix,
-                             const bool do_crc,
-                             const bool do_value_dump,
-                             ostream *out)
+			     const bool do_crc,
+			     const bool do_value_dump,
+			     ostream* out)
 {
   KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
 
@@ -74,12 +88,14 @@ uint32_t StoreTool::traverse(const string& prefix,
   uint32_t crc = -1;
 
   while (iter->valid()) {
-    pair<string,string> rk = iter->raw_key();
+    pair<string, string> rk = iter->raw_key();
     if (!prefix.empty() && (rk.first != prefix))
       break;
 
     if (out)
       *out << url_escape(rk.first) << "\t" << url_escape(rk.second);
+    if (out)
+      *out << "[" << rk.first << "]\t[" << rk.second << "]\n";
     if (do_crc) {
       bufferlist bl;
       bl.append(rk.first);
@@ -88,7 +104,7 @@ uint32_t StoreTool::traverse(const string& prefix,
 
       crc = bl.crc32c(crc);
       if (out) {
-        *out << "\t" << bl.crc32c(0);
+	*out << "\t" << bl.crc32c(0);
       }
     }
     if (out)
@@ -100,6 +116,7 @@ uint32_t StoreTool::traverse(const string& prefix,
       ostringstream os;
       value.hexdump(os);
       std::cout << os.str() << std::endl;
+      *out << os.str() << std::endl;
     }
     iter->next();
   }
@@ -107,10 +124,493 @@ uint32_t StoreTool::traverse(const string& prefix,
   return crc;
 }
 
-void StoreTool::list(const string& prefix, const bool do_crc,
-                     const bool do_value_dump)
+static bool snapmapper_entry(std::string k)
 {
-  traverse(prefix, do_crc, do_value_dump,& std::cout);
+  return k.find("SNA_") != string::npos || k.find("OBJ_") != string::npos ||
+	 k.find("MAP_") != string::npos;
+}
+using ceph::decode;
+
+void hobject_t::decode(bufferlist::const_iterator& bl)
+{
+  DECODE_START_LEGACY_COMPAT_LEN(4, 3, 3, bl);
+  if (struct_v >= 1)
+    decode(key, bl);
+  decode(oid, bl);
+  decode(snap, bl);
+  decode(hash, bl);
+  if (struct_v >= 2)
+    decode(max, bl);
+  else
+    max = false;
+  if (struct_v >= 4) {
+    decode(nspace, bl);
+    decode(pool, bl);
+    // for compat with hammer, which did not handle the transition
+    // from pool -1 -> pool INT64_MIN for MIN properly.  this object
+    // name looks a bit like a pgmeta object for the meta collection,
+    // but those do not ever exist (and is_pgmeta() pool >= 0).
+    if (pool == -1 && snap == 0 && hash == 0 && !max && oid.name.empty()) {
+      pool = INT64_MIN;
+      ceph_assert(is_min());
+    }
+
+    // for compatibility with some earlier verisons which might encoded
+    // a non-canonical max object
+    if (max) {
+      *this = hobject_t::get_max();
+    }
+  }
+  DECODE_FINISH(bl);
+  build_hash_cache();
+}
+
+struct object_snaps {
+  hobject_t oid;
+  std::set<snapid_t> snaps;
+  object_snaps(hobject_t oid, const std::set<snapid_t>& snaps)
+      : oid(oid)
+      , snaps(snaps)
+  {}
+  object_snaps() {}
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p)
+  {
+    DECODE_START(1, p);
+    decode(oid, p);
+    __u32 n;
+    decode(n, p);
+    snaps.clear();
+    while (n--) {
+      uint64_t v;
+      decode(v, p);
+      snaps.insert(v);
+    }
+    DECODE_FINISH(p);
+  }
+};
+
+
+struct Mapping {
+  snapid_t snap;
+  hobject_t hoid;
+  explicit Mapping(const std::pair<snapid_t, hobject_t>& in)
+      : snap(in.first)
+      , hoid(in.second)
+  {}
+  Mapping() : snap(0) {}
+  void encode(ceph::buffer::list& bl) const
+  {
+    ENCODE_START(1, 1, bl);
+    encode(snap, bl);
+    encode(hoid, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(ceph::buffer::list::const_iterator& bl)
+  {
+    DECODE_START(1, bl);
+    decode(snap, bl);
+    decode(hoid, bl);
+    DECODE_FINISH(bl);
+  }
+};
+
+static void decode_sna_key(string key, std::ostream* o)
+{
+  // two possible formats (w./o the shard id):
+  //   "SNA_2_0000000000000001_0000000000000002.347FB131.7.xxxx"
+  //   "SNA_2_0000000000000001_.a_0000000000000002.347FB131.7.xxxx";
+  // ZZ SNA_ =========== SNA_2_0000000000000001_.1_0000000000000002.A3F603B4.1.eeee..
+  int plid{0};
+  long unsigned int snpid;
+  long int shardid{-2};
+  int64_t snap;
+  char oname[1024];
+  unsigned int hash{0};
+  long unsigned int pool;
+
+  *o << "\nZZ SNA_ =========== " << key << std::endl;
+
+  auto n = sscanf(key.c_str(),
+		  "SNA_%d_%016X_%lx.%8X.%lx.%s",
+		  &plid,
+		  &snpid,
+		  &pool,
+		  &hash,
+		  &snap,
+		  oname);
+  if (n != 6) {
+    // we do have shard-id to parse
+    n = sscanf(key.c_str(),
+	       "SNA_%d_%016X_.%lX_%lx.%8X.%lx.%s",
+	       &plid,
+	       &snpid,
+	       &shardid,
+	       &pool,
+	       &hash,
+	       &snap,
+	       oname);
+
+    if (n != 7) {
+      *o << "invalid SNA key " << n << std::endl;
+      return;
+    }
+  }
+  *o << fmt::format(
+    "ZZ sna-rec: pid:{} snpid:{} shardid:{:x} [pool:{} hash:{:x} snap:{} nm:{}]\n",
+    plid,
+    snpid,
+    shardid,
+    pool,
+    hash,
+    snap,
+    oname);
+}
+
+// ZZ OBJ_ =========== OBJ_.1_0000000000000002.A3F603B4.1.eeee..
+// ZZ obj-rec: shardid:-ffffffff [pool:2 hash:a3f603b4 clone:1 nm:eeee..]
+
+static void decode_obj_key(string key, std::ostream* o)
+{
+  // two possible formats (w./o the shard id):
+  //   "OBJ_0000000000000002.347FB131.7.xxxx"
+  //   "OBJ_.a_0000000000000002.347FB131.7.xxxx";
+  long int shardid{-2};
+  int64_t clone;
+  char oname[1024];
+  unsigned int hash{0};
+  long unsigned int pool;
+
+  *o << "\nZZ OBJ_ =========== " << key << std::endl;
+
+  auto n =
+    sscanf(key.c_str(), "OBJ_%lx.%8X.%lx.%s", &pool, &hash, &clone, oname);
+  if (n != 4) {
+    // we do have shard-id to parse
+    n = sscanf(key.c_str(),
+	       "OBJ_.%lx_%lx.%8X.%lx.%s",
+	       &shardid,
+	       &pool,
+	       &hash,
+	       &clone,
+	       oname);
+
+    if (n != 5) {
+      *o << "invalid OBJ key " << n << std::endl;
+      return;
+    }
+  }
+  *o << fmt::format("ZZ obj-rec: shardid:{:x} [pool:{} hash:{:x} clone:{} nm:{}]\n",
+		    shardid,
+		    pool,
+		    hash,
+		    clone,
+		    oname);
+}
+
+
+std::pair<snapid_t, hobject_t> from_raw(
+  const pair<std::string, bufferlist>& image)
+{
+  using ceph::decode;
+  bufferlist bl(image.second);
+  auto bp = bl.cbegin();
+
+  Mapping m;
+  m.decode(bp);
+
+  return std::make_pair(m.snap, m.hoid);
+}
+
+
+static void parse_mp_kv(string k,
+			ceph::bufferlist v,
+			std::ostream* o,
+			std::ofstream* bo)
+{
+  if (k.find("SNA_") != string::npos) {
+    // k: "SNA_"
+    //   + ("%lld" % poolid)
+    //   + "_"
+    //   + ("%016x" % snapid)
+    //   + "_"
+    //   + (".%x" % shard_id)
+    //   + "_"
+    //   + hobject_t::to_str() ("%llx.%8x.%lx.name...." % pool, hash, snap)
+    // -> SnapMapping::Mapping { snap, hoid }
+
+
+    decode_sna_key(k.substr(k.find("SNA")), o);
+
+    auto [snap, hoid] = from_raw(make_pair("", v));
+    /* for the IDE */ hobject_t ho = hoid;
+
+    *o << "\n///sna// key: " << k << " -//- snap: " << snap.val
+       << " hobject:" << ho << " p:" << ho.pool << std::endl;
+
+    // and the grepable version:
+    *o << fmt::format("ZZ sna-recv snap:{} hoid:{}\n", snap.val, ho);
+
+  } else if (k.find("OBJ_") != string::npos) {
+    //  "OBJ_" +
+    //   + (".%x" % shard_id)
+    //   + hobject_t::to_str()
+    //    -> SnapMapper::object_snaps { oid, set<snapid_t> }
+
+    decode_obj_key(k.substr(k.find("OBJ")), o);
+    auto bp = v.cbegin();
+    object_snaps os;
+    try {
+      os.decode(bp);
+    } catch (...) {
+      *o << "decode failed" << std::endl;
+    }
+
+    *o << "\n///obj// key: " << k << " -//- oid: " << os.oid << std::endl;
+    *o << "\tsnaps -> " << os.snaps << std::endl;
+
+    // and the grepable version:
+    *o << fmt::format("ZZ obj-recv hoid:{} snaps:{}\n", os.oid, os.snaps);
+
+  } else if (k.find("MAP_") != string::npos) {
+    //   "MAP_"
+    //   + ("%016x" % snapid)
+    //   + "_"
+    //   + (".%x" % shard_id)
+    //   + "_"
+    //   + hobject_t::to_str() ("%llx.%8x.%lx.name...." % pool, hash, snap)
+    //   -> SnapMapping::Mapping { snap, hoid }
+
+  } else {
+  }
+}
+
+
+bufferlist StoreTool::mapmapper(const string& known_prfx, bool do_value_dump)
+{
+  KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
+
+  if (known_prfx.empty())
+    iter->seek_to_first();
+  else
+    iter->seek_to_first(known_prfx);
+
+  bufferlist ret;
+
+  while (iter->valid()) {
+    // pair<string, string> rk = iter->raw_key();
+    auto [prefix, key] = iter->raw_key();
+    if (!known_prfx.empty() && (prefix != known_prfx))
+      break;
+
+    // related to the snap mapper?
+    if (!snapmapper_entry(key)) {
+      std::cout << "NOT RLVNT [" << key << "]\n";
+      iter->next();
+      continue;
+    }
+
+    // if (out)
+    std::cout << "[" << key << "]\n";
+    if (do_value_dump) {
+      bufferptr bp = iter->value_as_ptr();
+      bufferlist this_value;
+      this_value.append(bp);
+
+      ostringstream os1;
+      parse_mp_kv(key, this_value, &os1, nullptr);
+      std::cout << os1.str() << std::endl;
+
+      ostringstream os;
+      this_value.hexdump(os);
+      std::cout << os.str() << std::endl;
+      ret.append(bp);
+    }
+    iter->next();
+  }
+
+  return ret;
+}
+
+
+void StoreTool::corrupt_snaps(string keypart)
+{
+  KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
+  iter->seek_to_first("p");
+
+  bufferlist ret;
+
+  while (iter->valid()) {
+    pair<string, string> rk = iter->raw_key();
+
+    // is this the one we wish to corrupt?
+    if ((rk.second.find("SNA_") != string::npos) &&
+	(rk.second.find(keypart) != string::npos)) {
+      /*
+
+	      the key should look like this:
+	      [something]SNA_[poolid]_[?]_[?].[hobject]
+
+	      truncate at the 3rd underscore.
+
+      */
+
+
+      // get the value
+      bufferptr bp = iter->value_as_ptr();
+      bufferlist bl;
+      bl.append(bp);
+
+      // better do RE here, but for now:
+      auto mod_s = rk.second;
+      mod_s.resize(
+	mod_s.find("_", mod_s.find("_", mod_s.find("SNA_") + 4) + 1) + 1);
+      set(rk.first, mod_s, bl);
+      rm(rk.first, rk.second);
+      break;
+    }
+    iter->next();
+  }
+}
+
+
+// TODO remove the duplicate code here (the whole function...)
+static int decode_sna_key_snap(string key, std::ostream* o)
+{
+  // two possible formats (w./o the shard id):
+  //   "SNA_2_0000000000000001_0000000000000002.347FB131.7.xxxx"
+  //   "SNA_2_0000000000000001_.a_0000000000000002.347FB131.7.xxxx";
+  // ZZ SNA_ =========== SNA_2_0000000000000001_.1_0000000000000002.A3F603B4.1.eeee..
+  int plid{0};
+  long unsigned int snpid;
+  long int shardid{-2};
+  int64_t clone;
+  char oname[1024];
+  unsigned int hash{0};
+  long unsigned int pool;
+
+  *o << "\nZZ SNA_ =========== " << key << std::endl;
+
+  auto n = sscanf(key.c_str(),
+		  "SNA_%d_%016X_%lx.%8X.%lx.%s",
+		  &plid,
+		  &snpid,
+		  &pool,
+		  &hash,
+		  &clone,
+		  oname);
+  if (n != 6) {
+    // we do have shard-id to parse
+    n = sscanf(key.c_str(),
+	       "SNA_%d_%016X_.%lX_%lx.%8X.%lx.%s",
+	       &plid,
+	       &snpid,
+	       &shardid,
+	       &pool,
+	       &hash,
+	       &clone,
+	       oname);
+
+    if (n != 7) {
+      *o << "invalid SNA key " << n << std::endl;
+      return 999;
+    }
+  }
+  *o << fmt::format(
+    "ZZ sna-rec: pid:{} snpid:{} shardid:{:x} [pool:{} hash:{:x} clone:{} nm:{}]\n",
+    plid,
+    snpid,
+    shardid,
+    pool,
+    hash,
+    clone,
+    oname);
+
+  return snpid;
+}
+
+void StoreTool::corrupt_snap_v2(string keypart, int snp)
+{
+  KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
+  iter->seek_to_first("p");
+
+  bufferlist ret;
+
+  while (iter->valid()) {
+    auto [prefix, key] = iter->raw_key();
+
+    // is this the one we wish to corrupt?
+    if ((key.find("SNA_") != string::npos) &&
+	(key.find(keypart) != string::npos)) {
+      /*
+
+	      the key should look like this:
+	      [something]SNA_[poolid]_[?]_[?].[hobject]
+
+	      truncate at the 3rd underscore.
+
+      */
+      ostringstream os1;
+      auto ksnap = decode_sna_key_snap(key.substr(key.find("SNA")), &os1);
+      std::cout << os1.str() << std::endl;
+      if (ksnap != snp) {
+        iter->next();
+        continue;
+        }
+
+      // get the value
+      bufferptr bp = iter->value_as_ptr();
+      bufferlist bl;
+      bl.append(bp);
+
+      // better do RE here, but for now:
+      auto mod_s = key;
+      mod_s.resize(
+	mod_s.find("_", mod_s.find("_", mod_s.find("SNA_") + 4) + 1) + 1);
+      set(prefix, mod_s, bl);
+      rm(prefix, key);
+      break;
+    }
+    iter->next();
+  }
+}
+
+void StoreTool::corrupt_obj_entries(string keypart)
+{
+  KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
+  iter->seek_to_first("p");
+
+  bufferlist ret;
+
+  while (iter->valid()) {
+    pair<string, string> rk = iter->raw_key();
+
+    // is this the one we wish to corrupt?
+    if ((rk.second.find("OBJ_") != string::npos) &&
+	(rk.second.find(keypart) != string::npos)) {
+
+      std::cout << "corrupting OBJ_ entry " << rk.second << std::endl;
+      // get the value
+      bufferptr bp = iter->value_as_ptr();
+      bufferlist bl;
+      bl.append(bp);
+
+      auto mod_s = rk.second;
+      mod_s.resize(mod_s.find("OBJ_") + 3);
+      set(rk.first, mod_s, bl);
+      rm(rk.first, rk.second);
+      break;
+    }
+    iter->next();
+  }
+}
+
+
+void StoreTool::list(const string& prefix,
+		     const bool do_crc,
+		     const bool do_value_dump)
+{
+  traverse(prefix, do_crc, do_value_dump, &std::cout);
 }
 
 bool StoreTool::exists(const string& prefix)
@@ -133,13 +633,11 @@ bool StoreTool::exists(const string& prefix, const string& key)
   return exists;
 }
 
-bufferlist StoreTool::get(const string& prefix,
-			  const string& key,
-			  bool& exists)
+bufferlist StoreTool::get(const string& prefix, const string& key, bool& exists)
 {
   ceph_assert(!prefix.empty() && !key.empty());
 
-  map<string,bufferlist> result;
+  map<string, bufferlist> result;
   std::set<std::string> keys;
   keys.insert(key);
   db->get(prefix, keys, &result);
@@ -155,7 +653,7 @@ bufferlist StoreTool::get(const string& prefix,
 
 uint64_t StoreTool::get_size()
 {
-  map<string,uint64_t> extras;
+  map<string, uint64_t> extras;
   uint64_t s = db->get_estimated_size(extras);
   for (auto& [name, size] : extras) {
     std::cout << name << " - " << size << std::endl;
@@ -164,7 +662,7 @@ uint64_t StoreTool::get_size()
   return s;
 }
 
-bool StoreTool::set(const string &prefix, const string &key, bufferlist &val)
+bool StoreTool::set(const string& prefix, const string& key, bufferlist& val)
 {
   ceph_assert(!prefix.empty());
   ceph_assert(!key.empty());
@@ -200,16 +698,19 @@ bool StoreTool::rm_prefix(const string& prefix)
   return (ret == 0);
 }
 
-void StoreTool::print_summary(const uint64_t total_keys, const uint64_t total_size,
-                              const uint64_t total_txs, const string& store_path,
-                              const string& other_path, const int duration) const
+void StoreTool::print_summary(const uint64_t total_keys,
+			      const uint64_t total_size,
+			      const uint64_t total_txs,
+			      const string& store_path,
+			      const string& other_path,
+			      const int duration) const
 {
   std::cout << "summary:" << std::endl;
   std::cout << "  copied " << total_keys << " keys" << std::endl;
   std::cout << "  used " << total_txs << " transactions" << std::endl;
   std::cout << "  total size " << byte_u_t(total_size) << std::endl;
   std::cout << "  from '" << store_path << "' to '" << other_path << "'"
-            << std::endl;
+	    << std::endl;
   std::cout << "  duration " << duration << " seconds" << std::endl;
 }
 
@@ -227,12 +728,12 @@ int StoreTool::print_stats() const
     ostr << "db_statistics not enabled";
     f->flush(ostr);
   }
-  std::cout <<  ostr.str() << std::endl;
+  std::cout << ostr.str() << std::endl;
   delete f;
   return ret;
 }
 
-//Itrerates through the db and collects the stats
+// Itrerates through the db and collects the stats
 int StoreTool::build_size_histogram(const string& prefix0) const
 {
   ostringstream ostr;
@@ -288,13 +789,15 @@ int StoreTool::build_size_histogram(const string& prefix0) const
   delete f;
 
   std::cout << ostr.str() << std::endl;
-  std::cout << __func__ << " finished in " << duration << " seconds" << std::endl;
+  std::cout << __func__ << " finished in " << duration << " seconds"
+	    << std::endl;
   return 0;
 }
 
-int StoreTool::copy_store_to(const string& type, const string& other_path,
-                             const int num_keys_per_tx,
-                             const string& other_type)
+int StoreTool::copy_store_to(const string& type,
+			     const string& other_path,
+			     const int num_keys_per_tx,
+			     const string& other_type)
 {
   if (num_keys_per_tx <= 0) {
     std::cerr << "must specify a number of keys/tx > 0" << std::endl;
@@ -303,9 +806,8 @@ int StoreTool::copy_store_to(const string& type, const string& other_path,
 
   // open or create a leveldb store at @p other_path
   boost::scoped_ptr<KeyValueDB> other;
-  KeyValueDB *other_ptr = KeyValueDB::create(g_ceph_context,
-					     other_type,
-					     other_path);
+  KeyValueDB* other_ptr =
+    KeyValueDB::create(g_ceph_context, other_type, other_path);
   if (int err = other_ptr->create_and_open(std::cerr); err < 0) {
     return err;
   }
@@ -317,7 +819,7 @@ int StoreTool::copy_store_to(const string& type, const string& other_path,
   uint64_t total_size = 0;
   uint64_t total_txs = 0;
 
-  auto duration = [start=coarse_mono_clock::now()] {
+  auto duration = [start = coarse_mono_clock::now()] {
     const auto now = coarse_mono_clock::now();
     auto seconds = std::chrono::duration<double>(now - start);
     return seconds.count();
@@ -346,13 +848,16 @@ int StoreTool::copy_store_to(const string& type, const string& other_path,
       other->submit_transaction_sync(tx);
 
     std::cout << "ts = " << duration() << "s, copied " << total_keys
-              << " keys so far (" << byte_u_t(total_size) << ")"
-              << std::endl;
+	      << " keys so far (" << byte_u_t(total_size) << ")" << std::endl;
 
   } while (it->valid());
 
-  print_summary(total_keys, total_size, total_txs, store_path, other_path,
-                duration());
+  print_summary(total_keys,
+		total_size,
+		total_txs,
+		store_path,
+		other_path,
+		duration());
 
   return 0;
 }
@@ -368,8 +873,8 @@ void StoreTool::compact_prefix(const string& prefix)
 }
 
 void StoreTool::compact_range(const string& prefix,
-                              const string& start,
-                              const string& end)
+			      const string& start,
+			      const string& end)
 {
   db->compact_range(prefix, start, end);
 }

--- a/src/tools/kvstore_tool.h
+++ b/src/tools/kvstore_tool.h
@@ -78,4 +78,11 @@ public:
 
   int print_stats() const;
   int build_size_histogram(const std::string& prefix) const;
+  ceph::bufferlist mapmapper(const std::string& prefix,
+                             bool do_value_dump/*,
+                             std::ostream* out*/);
+
+  void corrupt_snaps(std::string keypart);
+  void corrupt_obj_entries(std::string keypart);
+  void corrupt_snap_v2(std::string keypart, int snp);
 };


### PR DESCRIPTION
 Add two checks to the snap-mapping checks performed during scrub:

    - flag objects' snap-set entries that refer to deleted snaps;
 
    - flag the corresponding entries in the SnapMapper DB (again -
      if referencing a deleted snap)

The added checks are part of the required changes that became apparent
following  https://tracker.ceph.com/issues/56147

Note: current draft includes an extra PR that won't make it to the final version:
- [Tools: modifying the kvstore tool to parse the snapmapper](https://github.com/ceph/ceph/commit/5bb1f4361dde92ae3eae277aced48ff81cd4a4dc)
just some hacks to the kvstore tool, to be used in testing the fix.
 
Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
