### PR TITLE
common: fix the fmtlib handling of empty vectors

### DIFF
--- a/src/include/types_fmt.h
+++ b/src/include/types_fmt.h
@@ -48,10 +48,13 @@ struct fmt::formatter<std::vector<A>> {
   constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
   template <typename FormatContext>
-  auto format(const std::vector<A>& l, FormatContext& ctx)
+  auto format(const std::vector<A>& v, FormatContext& ctx)
   {
+    if (v.empty()) {
+      return fmt::format_to(ctx.out(), "[]");;
+    }
     std::string_view sep = "[";
-    for (const auto& e : l) {
+    for (const auto& e : v) {
       fmt::format_to(ctx.out(), "{}{}", sep, e);
       sep = ",";
     }


### PR DESCRIPTION
Fixing the implementation of fmt::formatter<std::vector<...>>
to correctly handle empty vectors.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
