### PR TITLE
include/types_fmt: use fmt::join() to format containers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -296,7 +296,7 @@ include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/xxHash")
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/rapidjson/include")
 
 option(WITH_FMT_HEADER_ONLY "use header-only version of fmt library" OFF)
-find_package(fmt 6.0.0 QUIET)
+find_package(fmt 7.0.0 QUIET)
 if(fmt_FOUND)
   include_directories(SYSTEM "${fmt_INCLUDE_DIR}")
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -306,6 +306,8 @@ else()
   add_subdirectory(fmt)
   set(BUILD_SHARED_LIBS ${old_BUILD_SHARED_LIBS})
   unset(old_BUILD_SHARED_LIBS)
+  target_compile_definitions(fmt PUBLIC
+    $<$<BOOL:${WIN32}>:FMT_USE_TZSET=0>)
   include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/fmt/include")
 endif()
 

--- a/src/include/types_fmt.h
+++ b/src/include/types_fmt.h
@@ -11,6 +11,17 @@
 
 #include "include/types.h"
 
+template <class Key, class T>
+struct fmt::formatter<std::pair<const Key, T>> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const std::pair<const Key, T>& p, FormatContext& ctx)
+  {
+    return fmt::format_to(ctx.out(), "{}={}", p.first, p.second);
+  }
+};
+
 template <class A, class B, class Comp, class Alloc>
 struct fmt::formatter<std::map<A, B, Comp, Alloc>> {
   constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
@@ -18,59 +29,39 @@ struct fmt::formatter<std::map<A, B, Comp, Alloc>> {
   template <typename FormatContext>
   auto format(const std::map<A, B, Comp, Alloc>& m, FormatContext& ctx)
   {
-    std::string_view sep = "{";
-    for (const auto& [k, v] : m) {
-      fmt::format_to(ctx.out(), "{}{}={}", sep, k, v);
-      sep = ",";
-    }
-    return fmt::format_to(ctx.out(), "}}");
+    return fmt::format_to(ctx.out(), "{{{}}}", fmt::join(m, ","));
   }
 };
 
-template <class A>
-struct fmt::formatter<std::list<A>> {
+template <class... Args>
+struct fmt::formatter<std::list<Args...>> {
   constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
   template <typename FormatContext>
-  auto format(const std::list<A>& l, FormatContext& ctx)
+  auto format(const std::list<Args...>& l, FormatContext& ctx)
   {
-    std::string_view sep = "";
-    for (const auto& e : l) {
-      fmt::format_to(ctx.out(), "{}{}", sep, e);
-      sep = ",";
-    }
-    return ctx.out();
+    return fmt::format_to(ctx.out(), "{}", fmt::join(l, ","));
   }
 };
 
-template <class A>
-struct fmt::formatter<std::vector<A>> {
+template <class... Args>
+struct fmt::formatter<std::vector<Args...>> {
   constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
   template <typename FormatContext>
-  auto format(const std::vector<A>& l, FormatContext& ctx)
+  auto format(const std::vector<Args...>& v, FormatContext& ctx)
   {
-    std::string_view sep = "[";
-    for (const auto& e : l) {
-      fmt::format_to(ctx.out(), "{}{}", sep, e);
-      sep = ",";
-    }
-    return fmt::format_to(ctx.out(), "]");
+    return fmt::format_to(ctx.out(), "[{}]", fmt::join(v, ","));
   }
 };
 
-template <class A>
-struct fmt::formatter<std::set<A>> {
+template <class... Args>
+struct fmt::formatter<std::set<Args...>> {
   constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
   template <typename FormatContext>
-  auto format(const std::set<A>& l, FormatContext& ctx)
+  auto format(const std::set<Args...>& s, FormatContext& ctx)
   {
-    std::string_view sep = "";
-    for (const auto& e : l) {
-      fmt::format_to(ctx.out(), "{}{}", sep, e);
-      sep = ",";
-    }
-    return ctx.out();
+    return fmt::format_to(ctx.out(), "{}", fmt::join(s, ","));
   }
 };


### PR DESCRIPTION
* use template parameter pack to represent container template argument,
  simpler this way. also, this enables us to print specialized
  classes which uses non-default template parameters.
* use fmt::join() to print container elements. see also
  https://fmt.dev/latest/api.html#_CPPv4I0EN3fmt4joinE9join_viewIN6detail10iterator_tI5RangeEEN6detail10sentinel_tI5RangeEEERR5Range11string_view

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
