### PR TITLE
doc/radosgw/operations: Document how to fix empty autoscale-status output

### DIFF
--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -117,6 +117,27 @@ with large amount of PGs for performance purposes. On the other hand,
 pools without the ``bulk`` flag are expected to be smaller e.g.,
 .mgr or meta pools.
 
+.. note::
+
+   If ``ceph osd pool autoscale-status`` returns no output at all, most likely
+   you have at least one pool that spans multiple CRUSH roots.  One scenario is
+   when a new deployment auto-creates the ``.mgr`` pool on the ``default`` CRUSH
+   root, then subsequent pools are created with rules that constrain them to a
+   specific shadow CRUSH tree.  If one, for example, creates an RBD metadata pool
+   constrained to ``deviceclass = ssd`` and an RBD data pool constrained to
+   ``deviceclass = hdd``, this will occur.  This may be remedied by simply
+   constraining the spanning pool to one device class.  In the above scenario
+   most likely there is a ``replicated-ssd`` CRUSH rule defined, so one would
+   run the below if the ``.mgr`` pool should be constrained to ``ssd`` devices:
+
+.. code-block:: bash
+
+   root# ceph osd pool set .mgr crush_rule replicated-ssd
+   set pool 1 crush_rule to replicated-ssd
+
+This will result in a small amount of backfill traffic that should complete
+quickly.
+
 
 Automated scaling
 -----------------


### PR DESCRIPTION
doc/radosgw/operations: Document how to fix empty autoscale-status output

When a new deployment auto-creates `.mgr` or some other pool spans the default root, then additional pools are created constrained to e.g. a device class, the autoscaler can't even, and the status command returns nothing at all.

This happened to me last week with Rook, and someone on the list encountered it yesterday, so there is
value in documenting the solution.

Signed-off-by: Anthony D'Atri <anthonyeleven@users.noreply.github.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
