### PR TITLE
quincy: mgr/cephadm: add parsing for config on osd specs

### DIFF
--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -150,7 +150,7 @@ class DriveGroupSpec(ServiceSpec):
         "data_devices", "db_devices", "wal_devices", "journal_devices",
         "data_directories", "osds_per_device", "objectstore", "osd_id_claims",
         "journal_size", "unmanaged", "filter_logic", "preview_only", "extra_container_args",
-        "data_allocate_fraction", "method", "crush_device_class",
+        "data_allocate_fraction", "method", "crush_device_class", "config",
     ]
 
     def __init__(self,
@@ -178,11 +178,13 @@ class DriveGroupSpec(ServiceSpec):
                  data_allocate_fraction=None,  # type: Optional[float]
                  method=None,  # type: Optional[OSDMethod]
                  crush_device_class=None,  # type: Optional[str]
+                 config=None,  # type: Optional[Dict[str, str]]
                  custom_configs=None,  # type: Optional[List[CustomConfig]]
                  ):
         assert service_type is None or service_type == 'osd'
         super(DriveGroupSpec, self).__init__('osd', service_id=service_id,
                                              placement=placement,
+                                             config=config,
                                              unmanaged=unmanaged,
                                              preview_only=preview_only,
                                              extra_container_args=extra_container_args,


### PR DESCRIPTION
Backport of #47164

Cephadm, while parsing spec files, can parse ceph configuration
for almost all the services, except for OSDs, where it fails
with a nasty "unexpected keyword argument config".

This commit fixes this issue.

Signed-off-by: Luis Domingues <domingues.luis@protonmail.ch>
(cherry picked from commit 74273e7e6e79c474e33fc41480399dc27ad2ae64)
