### PR TITLE
qa/workunits/cephadm: update test_repos master -> main

### DIFF
--- a/qa/workunits/cephadm/test_repos.sh
+++ b/qa/workunits/cephadm/test_repos.sh
@@ -24,7 +24,7 @@ sudo $CEPHADM -v add-repo --release octopus
 test_install_uninstall
 sudo $CEPHADM -v rm-repo
 
-sudo $CEPHADM -v add-repo --dev master
+sudo $CEPHADM -v add-repo --dev main
 test_install_uninstall
 sudo $CEPHADM -v rm-repo
 


### PR DESCRIPTION
Missed this one, it seems the test was still passing until
recently but I guess the "master" builds are now gone

Signed-off-by: Adam King <adking@redhat.com>