### PR TITLE
pacific: libcephsqlite: ceph-mgr crashes when compiled with gcc12

### DIFF
--- a/src/libcephsqlite.cc
+++ b/src/libcephsqlite.cc
@@ -380,8 +380,8 @@ static int FileSize(sqlite3_file *file, sqlite_int64 *osize)
 
 static bool parsepath(std::string_view path, struct cephsqlite_fileloc* fileloc)
 {
-  static const std::regex re1{"^/*(\\*[[:digit:]]+):([[:alnum:]-_.]*)/([[:alnum:]-._]+)$"};
-  static const std::regex re2{"^/*([[:alnum:]-_.]+):([[:alnum:]-_.]*)/([[:alnum:]-._]+)$"};
+  static const std::regex re1{"^/*(\\*[[:digit:]]+):([[:alnum:]\\-_.]*)/([[:alnum:]\\-._]+)$"};
+  static const std::regex re2{"^/*([[:alnum:]\\-_.]+):([[:alnum:]\\-_.]*)/([[:alnum:]\\-._]+)$"};
 
   std::cmatch cm;
   if (!std::regex_match(path.data(), cm, re1)) {


### PR DESCRIPTION
libcephsqlite: ceph-mgr crashes when compiled with gcc12
regex in libcephsqlite, when compiled with GCC12 treats '-' as a range
operator resulting in the following error.
"Invalid start of '[x-x]' range in regular expression"

Fixes: https://tracker.ceph.com/issues/55304
Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>
(cherry picked from commit ac043a09c5ffb4b434b8644920004b3d5b7f9d8c)

Backport tracker - https://tracker.ceph.com/issues/56701