### PR TITLE
test/osd/TestPGLog: Fix confusing description between log and olog.

### DIFF
--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -1703,8 +1703,8 @@ TEST_F(PGLogTest, proc_replica_log) {
             |        |       |         |
             +--------+-------+---------+
 
-      The log entry (1,3) deletes the object x9 but the olog entry
-      (2,3) modifies it : remove it from omissing.
+      The log entry (2,3) deletes the object x9 but the olog entry
+      (1,3) modifies it : remove it from omissing.
 
   */
   {


### PR DESCRIPTION
TestPGLog.cc has mistake description, need to fix it.

Fix https://tracker.ceph.com/issues/56709
Signed-off-by: dheart <dheart_joe@163.com>