### PR TITLE
pybind: Fix the install path about ceph_argparse.py

### DIFF
--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -37,10 +37,7 @@ execute_process(
      print(\
      sysconfig.get_path(\
      scheme='deb_system' in sysconfig.get_scheme_names() and 'deb_system' or 'posix_prefix',\
-     name='purelib',\
-     vars=\
-     {'base': '${PYTHON_INSTALL_TEMPLATE}',\
-      'py_version_short': sysconfig.get_config_var('py_version_short')}))"
+     name='purelib'))"
   OUTPUT_VARIABLE "PYTHON3_INSTDIR"
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 


### PR DESCRIPTION
Currently, ceph_argparse.py will install to
/usr/local/local/lib/python3.10/dist-packages, which is a error path.
Don't add vars parameter, the path is true.
```python
>>> sysconfig.get_path(name='purelib')
'/usr/local/lib/python3.10/dist-packages'

>>> sysconfig.get_path(name='purelib', vars={'base':'',
'py_version_short': sysconfig.get_config_var('py_version_short')})
'/local/lib/python3.10/dist-packages'

>>> sysconfig.get_path(name='purelib', vars={'base':'/usr/local',
'py_version_short': sysconfig.get_config_var('py_version_short')})
'/usr/local/local/lib/python3.10/dist-packages'

>>> sysconfig.get_path(name='purelib', vars={'base':'/',
'py_version_short': sysconfig.get_config_var('py_version_short')})
'//local/lib/python3.10/dist-packages'
```
Signed-off-by: Feng, Hualong <hualong.feng@intel.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
