### PR TITLE
quincy: mgr/telemetry: reset health warning after re-opting-in

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -1579,6 +1579,9 @@ To enable, add '--license {LICENSE}' to the 'ceph telemetry on' command.'''
                 msg = f"{msg}\nSome channels are disabled, please enable with:\n"\
                         f"`ceph telemetry enable channel{disabled_channels}`"
 
+            # wake up serve() to reset health warning
+            self.event.set()
+
             return 0, msg, ''
 
     @CLICommand('telemetry off')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56719

-----

backport of: https://github.com/ceph/ceph/pull/47001
parent tracker: https://tracker.ceph.com/issues/56486