### PR TITLE
pacific: include/buffer: include <memory>

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -41,6 +41,7 @@
 #include <iosfwd>
 #include <iomanip>
 #include <list>
+#include <memory>
 #include <vector>
 #include <string>
 #if __cplusplus >= 201703L

--- a/src/rgw/rgw_string.h
+++ b/src/rgw/rgw_string.h
@@ -8,6 +8,8 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <string_view>
+#include <string>
+#include <stdexcept>
 
 #include <boost/container/small_vector.hpp>
 

--- a/src/test/encoding.cc
+++ b/src/test/encoding.cc
@@ -334,11 +334,11 @@ void lame_decoder(int which) {
 }
 
 TEST(EncodingException, Macros) {
-  for (unsigned i = 0; i < sizeof(expected_what)/sizeof(expected_what[0]); i++) {
+  for (unsigned i = 0; i < std::size(expected_what); i++) {
     try {
       lame_decoder(i);
     } catch (const exception& e) {
-      ASSERT_EQ(string(expected_what[i]), string(e.what()));
+      ASSERT_NE(string(e.what()).find(expected_what[i]), string::npos);
     }
   }
 }


### PR DESCRIPTION
to address following FTBFS:

/usr/bin/ccache /usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_ASIO_DISABLE_CONCEPTS -DBOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION -DBOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_T$
In file included from /var/ssd/ceph/src/crimson/os/seastore/seastore_types.cc:4:
In file included from /var/ssd/ceph/src/crimson/os/seastore/seastore_types.h:14:
In file included from /var/ssd/ceph/src/include/denc.h:47:
/var/ssd/ceph/src/include/buffer.h:98:37: error: no template named 'unique_ptr' in namespace 'std'; did you mean 'boost::movelib::unique_ptr'?
struct unique_leakable_ptr : public std::unique_ptr<T, ceph::nop_delete<T>> {
                                    ^~~~~~~~~~~~~~~
                                    boost::movelib::unique_ptr
/opt/ceph/include/boost/move/unique_ptr.hpp:354:7: note: 'boost::movelib::unique_ptr' declared here
class unique_ptr
      ^

Fixes: https://tracker.ceph.com/issues/53896
Signed-off-by: Kefu Chai <tchaikov@gmail.com>
(cherry picked from commit 7c381ba985bd1398ef7d145cc00fae9d0db510e3)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
