### PR TITLE
pacific: mgr/telemetry: reset health warning after re-opting-in

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -787,6 +787,9 @@ class Module(MgrModule):
         self.set_module_option('enabled', True)
         self.set_module_option('last_opt_revision', REVISION)
 
+        # wake up serve() to reset health warning
+        self.event.set()
+
     def off(self):
         self.set_module_option('enabled', False)
         self.set_module_option('last_opt_revision', 1)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56720

-----

backport of: https://github.com/ceph/ceph/pull/47001
parent tracker: https://tracker.ceph.com/issues/56486
