### PR TITLE
rgw: better tenant id from the uri on anonymous access

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2805,7 +2805,12 @@ int RGWHandler_REST_SWIFT::postauth_init(optional_yield y)
   struct req_init_state* t = &s->init_state;
 
   /* XXX Stub this until Swift Auth sets account into URL. */
-  s->bucket_tenant = s->user->get_tenant();
+  if (g_conf()->rgw_swift_account_in_url
+      && s->user->get_id().id == RGW_USER_ANON_ID) {
+    s->bucket_tenant = s->account_name;
+  } else {
+    s->bucket_tenant = s->user->get_tenant();
+  }
   s->bucket_name = t->url_bucket;
 
   if (!s->object) {


### PR DESCRIPTION
When anonymous tries to access a public bucket, it gets 404,
because rgw doesn't check tenant correctly.

A previous fix for this broke legacy implicit tenants,
because it didn't check for anonymous access.  This version
restricts its behavior to the anonymous user.

Fixes: https://tracker.ceph.com/issues/48001 https://tracker.ceph.com/issues/48382

 