### PR TITLE
quincy: qa/workunits/cephadm: update test_repos master -> main

### DIFF
--- a/qa/workunits/cephadm/test_repos.sh
+++ b/qa/workunits/cephadm/test_repos.sh
@@ -24,7 +24,7 @@ sudo $CEPHADM -v add-repo --release octopus
 test_install_uninstall
 sudo $CEPHADM -v rm-repo
 
-sudo $CEPHADM -v add-repo --dev master
+sudo $CEPHADM -v add-repo --dev main
 test_install_uninstall
 sudo $CEPHADM -v rm-repo
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56738

---

backport of https://github.com/ceph/ceph/pull/47269
parent tracker: https://tracker.ceph.com/issues/56652

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh