### PR TITLE
pacific: cephadm: add "su root root" to cephadm.log logrotate config

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -9112,6 +9112,7 @@ def cephadm_init_logging(ctx: CephadmContext, args: List[str]) -> None:
     compress
     missingok
     notifempty
+    su root root
 }
 """)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56739

---

backport of https://github.com/ceph/ceph/pull/47178
parent tracker: https://tracker.ceph.com/issues/56639

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh