### PR TITLE
pacific: ceph.spec: fixing cephadm build deps

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -246,6 +246,8 @@ BuildRequires:	python%{python3_pkgversion}-dateutil
 BuildRequires:	python%{python3_pkgversion}-coverage
 BuildRequires:	python%{python3_pkgversion}-pyOpenSSL
 BuildRequires:	socat
+BuildRequires:	python%{python3_pkgversion}-asyncssh
+BuildRequires:	python%{python3_pkgversion}-natsort
 %endif
 %if 0%{with zbd}
 BuildRequires:  libzbd-devel


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56502

---

backport of https://github.com/ceph/ceph/pull/45643
parent tracker: https://tracker.ceph.com/issues/52514

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh