### PR TITLE
qa: add scan_logs calls for unit tests

### DIFF
--- a/qa/suites/rbd/basic/tasks/rbd_cls_tests.yaml
+++ b/qa/suites/rbd/basic/tasks/rbd_cls_tests.yaml
@@ -2,6 +2,6 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - cls/test_cls_rbd.sh
+        - cls/test_cls_rbd.sh scan_logs
         - cls/test_cls_lock.sh
         - cls/test_cls_journal.sh

--- a/qa/suites/rgw/crypt/4-tests/s3tests.yaml
+++ b/qa/suites/rgw/crypt/4-tests/s3tests.yaml
@@ -1,6 +1,7 @@
 tasks:
 - s3tests:
     client.0:
+      scan_logs: False
       barbican:
         kms_key: my-key-1
         kms_key2: my-key-2

--- a/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
@@ -4,6 +4,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
+      scan_logs: False
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/rgw/sts/tasks/first.yaml
+++ b/qa/suites/rgw/sts/tasks/first.yaml
@@ -5,6 +5,7 @@ tasks:
       keycloak_version: 11.0.0
 - s3tests:
     client.0:
+      scan_logs: False
       sts_tests: True
       rgw_server: client.0
       extra_attrs: ['webidentity_test']

--- a/qa/suites/rgw/sts/tasks/ststests.yaml
+++ b/qa/suites/rgw/sts/tasks/ststests.yaml
@@ -1,6 +1,7 @@
 tasks:
 - s3tests:
     client.0:
+      scan_logs: False
       sts_tests: True
       extra_attrs: ["test_of_sts"]
       rgw_server: client.0

--- a/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
@@ -1,6 +1,7 @@
 tasks:
 - s3tests:
     client.0:
+      scan_logs: False
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/rgw/verify/tasks/s3tests.yaml
+++ b/qa/suites/rgw/verify/tasks/s3tests.yaml
@@ -1,4 +1,5 @@
 tasks:
 - s3tests:
     client.0:
+      scan_logs: False
       rgw_server: client.0

--- a/qa/suites/rgw/website/tasks/s3tests-website.yaml
+++ b/qa/suites/rgw/website/tasks/s3tests-website.yaml
@@ -12,5 +12,6 @@ tasks:
       dns-s3website-name: s3-website.
 - s3tests:
     client.0:
+      scan_logs: False
       rgw_server: client.0
       rgw_website_server: client.1

--- a/qa/suites/smoke/basic/tasks/test/rgw_ec_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rgw_ec_s3tests.yaml
@@ -7,6 +7,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
+      scan_logs: False
       force-branch: ceph-master
       rgw_server: client.0
 overrides:

--- a/qa/suites/smoke/basic/tasks/test/rgw_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rgw_s3tests.yaml
@@ -4,6 +4,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
+      scan_logs: False
       force-branch: ceph-master
       rgw_server: client.0
 overrides:

--- a/qa/suites/teuthology/rgw/tasks/s3tests-fastcgi.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests-fastcgi.yaml
@@ -10,6 +10,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
+      scan_logs: False
       rgw_server: client.0
       force-branch: ceph-master
 overrides:

--- a/qa/suites/teuthology/rgw/tasks/s3tests-fcgi.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests-fcgi.yaml
@@ -11,6 +11,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
+      scan_logs: False
       rgw_server: client.0
       force-branch: ceph-master
 overrides:

--- a/qa/suites/teuthology/rgw/tasks/s3tests.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests.yaml
@@ -10,6 +10,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
+      scan_logs: False
       rgw_server: client.0
       force-branch: ceph-master
 overrides:

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -371,6 +371,7 @@ def run_tests(ctx, config):
             'S3TEST_CONF={tdir}/archive/s3-tests.{client}.conf'.format(tdir=testdir, client=client),
             'BOTO_CONFIG={tdir}/boto-{client}.cfg'.format(tdir=testdir, client=client)
             ]
+        scan_logs_tests = []
         # the 'requests' library comes with its own ca bundle to verify ssl
         # certificates - override that to use the system's ca bundle, which
         # is where the ssl task installed this certificate
@@ -397,10 +398,13 @@ def run_tests(ctx, config):
             ]
         if 'extra_args' in client_config:
             args.append(client_config['extra_args'])
+        if 'scan_logs' in client_config and client_config['scan_logs']:
+            scan_logs_tests += ["nose"]
 
         remote.run(
             args=args,
-            label="s3 tests against rgw"
+            label="s3 tests against rgw",
+            scan_tests_errors=scan_logs_tests,
             )
     yield
 

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -386,6 +386,10 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
                       if os.path.commonpath([w, dir_or_fname]) == dir_or_fname]
             if not to_run:
                 raise RuntimeError('Spec did not match any workunits: {spec!r}'.format(spec=spec))
+            scan_logs_tests = None
+            if 'scan_logs' in optional_args:
+                scan_logs_tests = ['gtest']
+                optional_args.remove('scan_logs')
             for workunit in to_run:
                 log.info('Running workunit %s...', workunit)
                 args = [
@@ -424,7 +428,8 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
                 remote.run(
                     logger=log.getChild(role),
                     args=args + optional_args,
-                    label="workunit test {workunit}".format(workunit=workunit)
+                    label="workunit test {workunit}".format(workunit=workunit),
+                    scan_tests_errors=scan_logs_tests,
                 )
                 if cleanup:
                     args=['sudo', 'rm', '-rf', '--', scratch_tmp]


### PR DESCRIPTION
This PR enables scanning of teuthology logs for unit tests error to output better failure messages.
Related PR: ceph/teuthology#1768

Previous unit test error message:
nose- https://pulpito.ceph.com/vallariag-2022-06-18_18:11:22-smoke-quincy-release-distro-default-smithi/6885520/

New unit test error messages: 
nose- https://pulpito.ceph.com/vallariag-2022-06-20_13:16:35-smoke-quincy-release-distro-default-smithi/6887782/
gtest- https://pulpito.ceph.com/vallariag-2022-06-22_16:34:18-rbd:basic-gtest-vallariag-test-distro-default-smithi/6892240/

Scanning of logs can be opted-in for the following tests- 
1. python's nose tests (by passing `scan_logs: True`)
2. c++ gtests (by passing `scan_logs` as optional argument)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
