### PR TITLE
cephadm: Fix repo_gpgkey should return 2 vars

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -7458,7 +7458,7 @@ class Apt(Packager):
         self.update()
 
     def rm_repo(self) -> None:
-        for name in ['autobuild', 'release']:
+        for name in ['autobuild', 'release', 'manual']:
             p = '/etc/apt/trusted.gpg.d/ceph.%s.gpg' % name
             if os.path.exists(p):
                 logger.info('Removing repo GPG key %s...' % p)

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -7394,7 +7394,7 @@ class Packager(object):
 
     def repo_gpgkey(self) -> Tuple[str, str]:
         if self.ctx.gpg_url:
-            return self.ctx.gpg_url
+            return self.ctx.gpg_url, 'manual'
         if self.stable or self.version:
             return 'https://download.ceph.com/keys/release.gpg', 'release'
         else:


### PR DESCRIPTION
when option --gpg-url is specified, the name used for the gpg filename is missing and throws an exception
this adds the string "manual" to the gpg key : /etc/apt/trusted.gpg.d/ceph.manual.gpg

Fixes: https://tracker.ceph.com/issues/56950

Signed-off-by: Laurent Barbe <laurent@ksperis.com>
