### PR TITLE
quincy: ceph-volume: improve mpath devices reporting

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -268,8 +268,8 @@ def device_info_not_ceph_disk_member(monkeypatch, request):
                                       'PARTLABEL': request.param[1]})
 
 @pytest.fixture
-def patched_get_block_devs_lsblk():
-    with patch('ceph_volume.util.disk.get_block_devs_lsblk') as p:
+def patched_get_block_devs_sysfs():
+    with patch('ceph_volume.util.disk.get_block_devs_sysfs') as p:
         yield p
 
 @pytest.fixture

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from copy import deepcopy
 from ceph_volume.util import device
@@ -79,6 +80,22 @@ class TestDevice(object):
         device_info(devices=data, lsblk=lsblk)
         disk = device.Device("/dev/sda")
         assert disk.is_device is True
+
+    def test_loop_device_is_not_device(self, fake_call, device_info):
+        data = {"/dev/loop0": {"foo": "bar"}}
+        lsblk = {"TYPE": "loop"}
+        device_info(devices=data, lsblk=lsblk)
+        disk = device.Device("/dev/loop0")
+        assert disk.is_device is False
+
+    def test_loop_device_is_device(self, fake_call, device_info):
+        data = {"/dev/loop0": {"foo": "bar"}}
+        lsblk = {"TYPE": "loop"}
+        os.environ["CEPH_VOLUME_USE_LOOP_DEVICES"] = "1"
+        device_info(devices=data, lsblk=lsblk)
+        disk = device.Device("/dev/loop0")
+        assert disk.is_device is True
+        del os.environ["CEPH_VOLUME_USE_LOOP_DEVICES"]
 
     def test_device_is_rotational(self, fake_call, device_info):
         data = {"/dev/sda": {"rotational": "1"}}

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -91,11 +91,11 @@ class TestDevice(object):
     def test_loop_device_is_device(self, fake_call, device_info):
         data = {"/dev/loop0": {"foo": "bar"}}
         lsblk = {"TYPE": "loop"}
-        os.environ["CEPH_VOLUME_USE_LOOP_DEVICES"] = "1"
+        os.environ["CEPH_VOLUME_ALLOW_LOOP_DEVICES"] = "1"
         device_info(devices=data, lsblk=lsblk)
         disk = device.Device("/dev/loop0")
         assert disk.is_device is True
-        del os.environ["CEPH_VOLUME_USE_LOOP_DEVICES"]
+        del os.environ["CEPH_VOLUME_ALLOW_LOOP_DEVICES"]
 
     def test_device_is_rotational(self, fake_call, device_info):
         data = {"/dev/sda": {"rotational": "1"}}

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -331,6 +331,15 @@ class TestGetDevices(object):
         result = disk.get_devices(_sys_block_path=block_path)
         assert result[sda_path]['rotational'] == '1'
 
+    def test_is_ceph_rbd(self, tmpfile, tmpdir, patched_get_block_devs_lsblk):
+        rbd_path = '/dev/rbd0'
+        patched_get_block_devs_lsblk.return_value = [[rbd_path, rbd_path, 'disk']]
+        block_path = self.setup_path(tmpdir)
+        block_rbd_path = os.path.join(block_path, 'rbd0')
+        os.makedirs(block_rbd_path)
+        result = disk.get_devices(_sys_block_path=block_path)
+        assert rbd_path not in result
+
 
 class TestSizeCalculations(object):
 

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -549,3 +549,14 @@ class TestSizeSpecificFormatting(object):
         result = "%s" % size.tb
         assert "%s" % size.tb == "%s" % size.terabytes
         assert result == "1027.00 TB"
+
+
+class TestAllowLoopDevsWarning(object):
+    def test_loop_dev_warning(self, fake_call, caplog):
+        assert disk.allow_loop_devices() is False
+        assert not caplog.records
+        os.environ['CEPH_VOLUME_ALLOW_LOOP_DEVICES'] = "y"
+        assert disk.allow_loop_devices() is True
+        log = caplog.records[0]
+        assert log.levelname == "WARNING"
+        assert "will never be supported in production" in log.message

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -8,6 +8,7 @@ from ceph_volume.api import lvm
 from ceph_volume.util import disk, system
 from ceph_volume.util.lsmdisk import LSMDisk
 from ceph_volume.util.constants import ceph_disk_guids
+from ceph_volume.util.disk import allow_loop_devices
 
 
 logger = logging.getLogger(__name__)
@@ -214,7 +215,7 @@ class Device(object):
             device_type = dev.get('TYPE', '')
             # always check is this is an lvm member
             valid_types = ['part', 'disk']
-            if os.environ.get("CEPH_VOLUME_USE_LOOP_DEVICES", False):
+            if allow_loop_devices():
                 valid_types.append('loop')
             if device_type in valid_types:
                 self._set_lvm_membership()
@@ -466,7 +467,7 @@ class Device(object):
             api = self.blkid_api
         if api:
             valid_types = ['disk', 'device', 'mpath']
-            if os.environ.get("CEPH_VOLUME_USE_LOOP_DEVICES", False):
+            if allow_loop_devices():
                 valid_types.append('loop')
             return self.device_type in valid_types
         return False

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -743,25 +743,6 @@ def is_locked_raw_device(disk_path):
     return 0
 
 
-def get_block_devs_lsblk(device=''):
-    '''
-    This returns a list of lists with 3 items per inner list.
-    KNAME - reflects the kernel device name , for example /dev/sda or /dev/dm-0
-    NAME - the device name, for example /dev/sda or
-           /dev/mapper/<vg_name>-<lv_name>
-    TYPE - the block device type: disk, partition, lvm and such
-
-    '''
-    cmd = ['lsblk', '-plno', 'KNAME,NAME,TYPE']
-    if device:
-        cmd.extend(['--nodeps', device])
-    stdout, stderr, rc = process.call(cmd)
-    # lsblk returns 1 on failure
-    if rc == 1:
-        raise OSError('lsblk returned failure, stderr: {}'.format(stderr))
-    return [re.split(r'\s+', line) for line in stdout]
-
-
 class AllowLoopDevices(object):
     allow = False
     warned = False

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -769,17 +769,28 @@ allow_loop_devices = AllowLoopDevices()
 
 
 def get_block_devs_sysfs(_sys_block_path='/sys/block', _sys_dev_block_path='/sys/dev/block'):
+    def holder_inner_loop():
+        for holder in holders:
+            # /sys/block/sdy/holders/dm-8/dm/uuid
+            holder_dm_type = get_file_contents(os.path.join(_sys_block_path, dev, f'holders/{holder}/dm/uuid')).split('-')[0].lower()
+            if holder_dm_type == 'mpath':
+                return True
+
     # First, get devices that are _not_ partitions
     result = list()
     dev_names = os.listdir(_sys_block_path)
     for dev in dev_names:
         name = kname = os.path.join("/dev", dev)
         type_ = 'disk'
+        holders = os.listdir(os.path.join(_sys_block_path, dev, 'holders'))
         if get_file_contents(os.path.join(_sys_block_path, dev, 'removable')) == "1":
+            continue
+        if holder_inner_loop():
             continue
         dm_dir_path = os.path.join(_sys_block_path, dev, 'dm')
         if os.path.isdir(dm_dir_path):
-            type_ = 'lvm'
+            dm_type = get_file_contents(os.path.join(dm_dir_path, 'uuid'))
+            type_ = dm_type.split('-')[0].lower()
             basename = get_file_contents(os.path.join(dm_dir_path, 'name'))
             name = os.path.join("/dev/mapper", basename)
         if dev.startswith('loop'):

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -373,6 +373,13 @@ def is_partition(dev):
     return False
 
 
+def is_ceph_rbd(dev):
+    """
+    Boolean to determine if a given device is a ceph RBD device, like /dev/rbd0
+    """
+    return dev.startswith(('/dev/rbd'))
+
+
 class BaseFloatUnit(float):
     """
     Base class to support float representations of size values. Suffix is
@@ -839,6 +846,10 @@ def get_devices(_sys_block_path='/sys/block', device=''):
             continue
         sysdir = os.path.join(_sys_block_path, devname)
         metadata = {}
+
+        # If the device is ceph rbd it gets excluded
+        if is_ceph_rbd(diskname):
+            continue
 
         # If the mapper device is a logical volume it gets excluded
         if is_mapper_device(diskname):

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -340,16 +340,18 @@ def is_device(dev):
     """
     if not os.path.exists(dev):
         return False
-    # use lsblk first, fall back to using stat
-    TYPE = lsblk(dev).get('TYPE')
-    if TYPE:
-        return TYPE in ['disk', 'mpath']
+    if not dev.startswith('/dev/'):
+        return False
+    if dev[len('/dev/'):].startswith('loop'):
+        if os.environ.get("CEPH_VOLUME_USE_LOOP_DEVICES", False) is False:
+            return False
+        logger.info(
+            "Allowing the use of loop devices since "
+            "CEPH_VOLUME_USE_LOOP_DEVICES is set."
+        )
 
     # fallback to stat
     return _stat_is_device(os.lstat(dev).st_mode)
-    if stat.S_ISBLK(os.lstat(dev)):
-        return True
-    return False
 
 
 def is_partition(dev):
@@ -756,6 +758,40 @@ def get_block_devs_lsblk(device=''):
         raise OSError('lsblk returned failure, stderr: {}'.format(stderr))
     return [re.split(r'\s+', line) for line in stdout]
 
+
+def get_block_devs_sysfs(_sys_block_path='/sys/block', _sys_dev_block_path='/sys/dev/block'):
+    # First, get devices that are _not_ partitions
+    result = list()
+    dev_names = os.listdir(_sys_block_path)
+    for dev in dev_names:
+        name = kname = os.path.join("/dev", dev)
+        type_ = 'disk'
+        if get_file_contents(os.path.join(_sys_block_path, dev, 'removable')) == "1":
+            continue
+        dm_dir_path = os.path.join(_sys_block_path, dev, 'dm')
+        if os.path.isdir(dm_dir_path):
+            type_ = 'lvm'
+            basename = get_file_contents(os.path.join(dm_dir_path, 'name'))
+            name = os.path.join("/dev/mapper", basename)
+        if dev.startswith('loop'):
+            if os.environ.get("CEPH_VOLUME_USE_LOOP_DEVICES", False) is False:
+                continue
+            # Skip loop devices that are not attached
+            if not os.path.exists(os.path.join(_sys_block_path, dev, 'loop')):
+                continue
+            type_ = 'loop'
+        result.append([kname, name, type_])
+    # Next, look for devices that _are_ partitions
+    for item in os.listdir(_sys_dev_block_path):
+        is_part = get_file_contents(os.path.join(_sys_dev_block_path, item, 'partition')) == "1"
+        dev = os.path.basename(os.readlink(os.path.join(_sys_dev_block_path, item)))
+        if not is_part:
+            continue
+        name = kname = os.path.join("/dev", dev)
+        result.append([name, kname, "part"])
+    return sorted(result, key=lambda x: x[0])
+
+
 def get_devices(_sys_block_path='/sys/block', device=''):
     """
     Captures all available block devices as reported by lsblk.
@@ -769,12 +805,16 @@ def get_devices(_sys_block_path='/sys/block', device=''):
 
     device_facts = {}
 
-    block_devs = get_block_devs_lsblk(device=device)
+    block_devs = get_block_devs_sysfs(_sys_block_path)
+
+    block_types = ['disk', 'mpath']
+    if os.environ.get("CEPH_VOLUME_USE_LOOP_DEVICES", False) is not False:
+        block_types.append('loop')
 
     for block in block_devs:
         devname = os.path.basename(block[0])
         diskname = block[1]
-        if block[2] not in ['disk', 'mpath']:
+        if block[2] not in block_types:
             continue
         sysdir = os.path.join(_sys_block_path, devname)
         metadata = {}
@@ -820,6 +860,7 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         metadata['human_readable_size'] = human_readable_size(metadata['size'])
         metadata['path'] = diskname
         metadata['locked'] = is_locked_raw_device(metadata['path'])
+        metadata['type'] = block[2]
 
         device_facts[diskname] = metadata
     return device_facts

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -343,12 +343,8 @@ def is_device(dev):
     if not dev.startswith('/dev/'):
         return False
     if dev[len('/dev/'):].startswith('loop'):
-        if os.environ.get("CEPH_VOLUME_USE_LOOP_DEVICES", False) is False:
+        if not allow_loop_devices():
             return False
-        logger.info(
-            "Allowing the use of loop devices since "
-            "CEPH_VOLUME_USE_LOOP_DEVICES is set."
-        )
 
     # fallback to stat
     return _stat_is_device(os.lstat(dev).st_mode)
@@ -759,6 +755,31 @@ def get_block_devs_lsblk(device=''):
     return [re.split(r'\s+', line) for line in stdout]
 
 
+class AllowLoopDevices(object):
+    allow = False
+    warned = False
+
+    @classmethod
+    def __call__(cls):
+        val = os.environ.get("CEPH_VOLUME_ALLOW_LOOP_DEVICES", "false").lower()
+        if val not in ("false", 'no', '0'):
+            cls.allow = True
+            if not cls.warned:
+                logger.warning(
+                    "CEPH_VOLUME_ALLOW_LOOP_DEVICES is set in your "
+                    "environment, so we will allow the use of unattached loop"
+                    " devices as disks. This feature is intended for "
+                    "development purposes only and will never be supported in"
+                    " production. Issues filed based on this behavior will "
+                    "likely be ignored."
+                )
+                cls.warned = True
+        return cls.allow
+
+
+allow_loop_devices = AllowLoopDevices()
+
+
 def get_block_devs_sysfs(_sys_block_path='/sys/block', _sys_dev_block_path='/sys/dev/block'):
     # First, get devices that are _not_ partitions
     result = list()
@@ -774,7 +795,7 @@ def get_block_devs_sysfs(_sys_block_path='/sys/block', _sys_dev_block_path='/sys
             basename = get_file_contents(os.path.join(dm_dir_path, 'name'))
             name = os.path.join("/dev/mapper", basename)
         if dev.startswith('loop'):
-            if os.environ.get("CEPH_VOLUME_USE_LOOP_DEVICES", False) is False:
+            if not allow_loop_devices():
                 continue
             # Skip loop devices that are not attached
             if not os.path.exists(os.path.join(_sys_block_path, dev, 'loop')):
@@ -808,7 +829,7 @@ def get_devices(_sys_block_path='/sys/block', device=''):
     block_devs = get_block_devs_sysfs(_sys_block_path)
 
     block_types = ['disk', 'mpath']
-    if os.environ.get("CEPH_VOLUME_USE_LOOP_DEVICES", False) is not False:
+    if allow_loop_devices():
         block_types.append('loop')
 
     for block in block_devs:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56960

---

backport of https://github.com/ceph/ceph/pull/47169
parent tracker: https://tracker.ceph.com/issues/56621

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh