### PR TITLE
pacific: ceph-volume: improve mpath devices reporting

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -752,7 +752,6 @@ def get_block_devs_lsblk(device=''):
     NAME - the device name, for example /dev/sda or
            /dev/mapper/<vg_name>-<lv_name>
     TYPE - the block device type: disk, partition, lvm and such
-
     '''
     cmd = ['lsblk', '-plno', 'KNAME,NAME,TYPE']
     if device:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56959

---

backport of https://github.com/ceph/ceph/pull/47169
parent tracker: https://tracker.ceph.com/issues/56621

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh