### PR TITLE
pacific: ceph-volume: report slave devices in inventory

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -283,7 +283,11 @@ def patch_bluestore_label():
 def device_info(monkeypatch, patch_bluestore_label):
     def apply(devices=None, lsblk=None, lv=None, blkid=None, udevadm=None,
               has_bluestore_label=False):
-        devices = devices if devices else {}
+        if devices:
+            for dev in devices.keys():
+                devices[dev]['device_nodes'] = os.path.basename(dev)
+        else:
+            devices = {}
         lsblk = lsblk if lsblk else {}
         blkid = blkid if blkid else {}
         udevadm = udevadm if udevadm else {}

--- a/src/ceph-volume/ceph_volume/tests/test_inventory.py
+++ b/src/ceph-volume/ceph_volume/tests/test_inventory.py
@@ -28,7 +28,8 @@ def device_report_keys(device_info):
                      'size': 1999844147200.0,
                      'support_discard': '',
                      'vendor': 'DELL',
-                     'device_id': 'Vendor-Model-Serial'}
+                     'device_id': 'Vendor-Model-Serial',
+                     'device_nodes': 'sdb'}
     }
  )
     report = Devices().json_report()[0]
@@ -55,7 +56,8 @@ def device_sys_api_keys(device_info):
                      'sectorsize': '512',
                      'size': 1999844147200.0,
                      'support_discard': '',
-                     'vendor': 'DELL'}
+                     'vendor': 'DELL',
+                     'device_nodes': 'sdb'}
     }
  )
     report = Devices().json_report()[0]
@@ -85,6 +87,7 @@ def device_data(device_info):
                 'size': 1999844147200.0,
                 'support_discard': '',
                 'vendor': 'DELL',
+                'device_nodes': 'sdb'
             }
         }
     )
@@ -140,6 +143,7 @@ class TestInventory(object):
         'size',
         'support_discard',
         'vendor',
+        'device_nodes'
     ]
 
     expected_lsm_keys = [

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 report_template = """
-{dev:<25} {size:<12} {rot!s:<7} {available!s:<9} {model}"""
+{dev:<25} {size:<12} {device_nodes:<15} {rot!s:<7} {available!s:<9} {model}"""
 
 
 def encryption_status(abspath):
@@ -55,6 +55,8 @@ class Devices(object):
                 rot='rotates',
                 model='Model name',
                 available='available',
+                device_nodes='Device nodes',
+
             )]
         for device in sorted(self.devices):
             output.append(device.report())
@@ -102,7 +104,9 @@ class Device(object):
         self.abspath = path
         if not sys_info.devices:
             sys_info.devices = disk.get_devices()
-        self.sys_api = sys_info.devices.get(self.abspath, {})
+        if sys_info.devices.get(self.path, {}):
+            self.device_nodes = sys_info.devices[self.path]['device_nodes']
+        self.sys_api = sys_info.devices.get(self.path, {})
         self.partitions = self._get_partitions()
         self.lv_api = None
         self.lvs = [] if not lvs else lvs
@@ -268,6 +272,7 @@ class Device(object):
             rot=self.rotational,
             available=self.available,
             model=self.model,
+            device_nodes=self.device_nodes
         )
 
     def json_report(self):

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -811,6 +811,12 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         for key, file_ in facts:
             metadata[key] = get_file_contents(os.path.join(sysdir, file_))
 
+        device_slaves = os.listdir(os.path.join(sysdir, 'slaves'))
+        if device_slaves:
+            metadata['device_nodes'] = ','.join(device_slaves)
+        else:
+            metadata['device_nodes'] = devname
+
         metadata['scheduler_mode'] = ""
         scheduler = get_file_contents(sysdir + "/queue/scheduler")
         if scheduler is not None:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56957

---

backport of https://github.com/ceph/ceph/pull/47170
parent tracker: https://tracker.ceph.com/issues/56624

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh