### PR TITLE
quincy: mgr/dashboard: add required validation for frontend and monitor port

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -177,8 +177,26 @@ export class ServiceFormComponent extends CdForm implements OnInit {
           })
         ]
       ],
-      frontend_port: [null, [CdValidators.number(false)]],
-      monitor_port: [null, [CdValidators.number(false)]],
+      frontend_port: [
+        null,
+        [
+          CdValidators.number(false),
+          CdValidators.requiredIf({
+            service_type: 'ingress',
+            unmanaged: false
+          })
+        ]
+      ],
+      monitor_port: [
+        null,
+        [
+          CdValidators.number(false),
+          CdValidators.requiredIf({
+            service_type: 'ingress',
+            unmanaged: false
+          })
+        ]
+      ],
       virtual_interface_networks: [null],
       // RGW, Ingress & iSCSI
       ssl: [false],


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56965

---

backport of https://github.com/ceph/ceph/pull/47260
parent tracker: https://tracker.ceph.com/issues/56688

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh