### PR TITLE
ceph-volume: fix simple scan

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -515,3 +515,10 @@ class TestAllowLoopDevsWarning(object):
         log = caplog.records[0]
         assert log.levelname == "WARNING"
         assert "will never be supported in production" in log.message
+
+
+class TestHasBlueStoreLabel(object):
+    def test_device_path_is_a_path(self, fake_filesystem):
+        device_path = '/var/lib/ceph/osd/ceph-0'
+        fake_filesystem.create_dir(device_path)
+        assert not disk.has_bluestore_label(device_path)

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -903,10 +903,13 @@ def has_bluestore_label(device_path):
 
     # throws OSError on failure
     logger.info("opening device {} to check for BlueStore label".format(device_path))
-    with open(device_path, "rb") as fd:
-        # read first 22 bytes looking for bluestore disk signature
-        signature = fd.read(22)
-        if signature.decode('ascii', 'replace') == bluestoreDiskSignature:
-            isBluestore = True
+    try:
+        with open(device_path, "rb") as fd:
+            # read first 22 bytes looking for bluestore disk signature
+            signature = fd.read(22)
+            if signature.decode('ascii', 'replace') == bluestoreDiskSignature:
+                isBluestore = True
+    except IsADirectoryError:
+        logger.info(f'{device_path} is a directory, skipping.')
 
     return isBluestore


### PR DESCRIPTION
When the class `Device` is instantiated with a path instead of a
block device, it fails like following.

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/site-packages/ceph_volume/util/device.py", line 130, in __init__
    self._parse()
  File "/usr/lib/python3.6/site-packages/ceph_volume/util/device.py", line 233, in _parse
    self.ceph_device = disk.has_bluestore_label(self.path)
  File "/usr/lib/python3.6/site-packages/ceph_volume/util/disk.py", line 906, in has_bluestore_label
    with open(device_path, "rb") as fd:
IsADirectoryError: [Errno 21] Is a directory: '/var/lib/ceph/osd/ceph-0/'
```

passing a path instead of a block device is valid, `simple scan` needs it.

Fixes: https://tracker.ceph.com/issues/56969

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
