### PR TITLE
mgr/dashboard: register fqdn as service address instead of the ip

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import threading
 import time
+import socket
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
@@ -193,7 +194,7 @@ class CherryPyConfig(object):
             server_addr = self.get_mgr_ip()  # type: ignore
         base_url = build_url(
             scheme='https' if use_ssl else 'http',
-            host=server_addr,
+            host=socket.gethostbyaddr(server_addr)[0],
             port=server_port,
         )
         uri = f'{base_url}{self.url_prefix}/'


### PR DESCRIPTION
If you visit the ceph dashboard of an inactive ceph mgr instance the mgr will redirect you to the active dashboard. Unfortunately the dashboard redirects to an ip address instead of a dns name, this results in a certifacte error when using SSL.

I'm not really happy doing a reverse dns lookup, but I did not find a better solution to get the dns name. But maybe this PR points to the problematic code line and helps to discuss the problem.

Fixes: http://tracker.ceph.com/issues/56971

Signed-off-by: Henry Hirsch <henry.hirsch@1und1.de>




https://tracker.ceph.com/issues/56971
