### PR TITLE
quincy: mgr/volumes: Fix subvolume creation in FIPS enabled system.

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -7191,7 +7191,7 @@ class TestMisc(TestVolumesHelper):
 
         # emulate a old-fashioned subvolume in the default group
         createpath1 = os.path.join(".", "volumes", "_nogroup", subvol1)
-        self.mount_a.run_shell(['mkdir', '-p', createpath1], sudo=True)
+        self.mount_a.run_shell(['sudo', 'mkdir', '-p', createpath1], omit_sudo=False)
 
         # add required xattrs to subvolume
         default_pool = self.mount_a.getfattr(".", "ceph.dir.layout.pool")
@@ -7203,7 +7203,7 @@ class TestMisc(TestVolumesHelper):
         # Create malicious .meta file in legacy subvolume root. Copy v2 subvolume
         # .meta into legacy subvol1's root
         subvol2_metapath = os.path.join(".", "volumes", "_nogroup", subvol2, ".meta")
-        self.mount_a.run_shell(["cp", subvol2_metapath, createpath1], sudo=True)
+        self.mount_a.run_shell(['sudo', 'cp', subvol2_metapath, createpath1], omit_sudo=False)
 
         # Upgrade legacy subvol1 to v1
         subvolpath1 = self._fs_cmd("subvolume", "getpath", self.volname, subvol1)
@@ -7245,7 +7245,7 @@ class TestMisc(TestVolumesHelper):
 
         # emulate a old-fashioned subvolume -- in a custom group
         createpath = os.path.join(".", "volumes", group, subvol)
-        self.mount_a.run_shell(['mkdir', '-p', createpath], sudo=True)
+        self.mount_a.run_shell(['sudo', 'mkdir', '-p', createpath], omit_sudo=False)
 
         # add required xattrs to subvolume
         default_pool = self.mount_a.getfattr(".", "ceph.dir.layout.pool")
@@ -7288,7 +7288,7 @@ class TestMisc(TestVolumesHelper):
 
         # emulate a old-fashioned subvolume -- in a custom group
         createpath = os.path.join(".", "volumes", group, subvol)
-        self.mount_a.run_shell(['mkdir', '-p', createpath], sudo=True)
+        self.mount_a.run_shell(['sudo', 'mkdir', '-p', createpath], omit_sudo=False)
 
         # add required xattrs to subvolume
         default_pool = self.mount_a.getfattr(".", "ceph.dir.layout.pool")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56979

---

backport of https://github.com/ceph/ceph/pull/47300
parent tracker: https://tracker.ceph.com/issues/56727

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh