### PR TITLE
quincy: mgr/cephadm: clear error message when resuming upgrade

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -456,6 +456,7 @@ class CephadmUpgrade:
         if not self.upgrade_state.paused:
             return 'Upgrade to %s not paused' % self.target_image
         self.upgrade_state.paused = False
+        self.upgrade_state.error = ''
         self.mgr.log.info('Upgrade: Resumed upgrade to %s' % self.target_image)
         self._save_upgrade_state()
         self.mgr.event.set()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56986

---

backport of https://github.com/ceph/ceph/pull/47280
parent tracker: https://tracker.ceph.com/issues/56714

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh