### PR TITLE
pacific: cephadm: Fix repo_gpgkey should return 2 vars

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6648,7 +6648,7 @@ class Apt(Packager):
         self.update()
 
     def rm_repo(self) -> None:
-        for name in ['autobuild', 'release']:
+        for name in ['autobuild', 'release', 'manual']:
             p = '/etc/apt/trusted.gpg.d/ceph.%s.gpg' % name
             if os.path.exists(p):
                 logger.info('Removing repo GPG key %s...' % p)

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6584,7 +6584,7 @@ class Packager(object):
 
     def repo_gpgkey(self) -> Tuple[str, str]:
         if self.ctx.gpg_url:
-            return self.ctx.gpg_url
+            return self.ctx.gpg_url, 'manual'
         if self.stable or self.version:
             return 'https://download.ceph.com/keys/release.gpg', 'release'
         else:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56984

---

backport of https://github.com/ceph/ceph/pull/47338
parent tracker: https://tracker.ceph.com/issues/56950

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh