### PR TITLE
quincy: ceph-volume: fix simple scan

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -549,3 +549,10 @@ class TestSizeSpecificFormatting(object):
         result = "%s" % size.tb
         assert "%s" % size.tb == "%s" % size.terabytes
         assert result == "1027.00 TB"
+
+
+class TestHasBlueStoreLabel(object):
+    def test_device_path_is_a_path(self, fake_filesystem):
+        device_path = '/var/lib/ceph/osd/ceph-0'
+        fake_filesystem.create_dir(device_path)
+        assert not disk.has_bluestore_label(device_path)

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -830,10 +830,13 @@ def has_bluestore_label(device_path):
 
     # throws OSError on failure
     logger.info("opening device {} to check for BlueStore label".format(device_path))
-    with open(device_path, "rb") as fd:
-        # read first 22 bytes looking for bluestore disk signature
-        signature = fd.read(22)
-        if signature.decode('ascii', 'replace') == bluestoreDiskSignature:
-            isBluestore = True
+    try:
+        with open(device_path, "rb") as fd:
+            # read first 22 bytes looking for bluestore disk signature
+            signature = fd.read(22)
+            if signature.decode('ascii', 'replace') == bluestoreDiskSignature:
+                isBluestore = True
+    except IsADirectoryError:
+        logger.info(f'{device_path} is a directory, skipping.')
 
     return isBluestore


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56981

---

backport of https://github.com/ceph/ceph/pull/47361
parent tracker: https://tracker.ceph.com/issues/56969

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh