### PR TITLE
pacific: mon/ConfigMonitor: fix config get key with whitespaces

### DIFF
--- a/qa/workunits/mon/config.sh
+++ b/qa/workunits/mon/config.sh
@@ -62,6 +62,17 @@ ceph config rm client.foo.bar debug_asok
 ceph config get client.foo.bar.baz debug_asok | grep 33
 ceph config rm global debug_asok
 
+# whitespace keys
+ceph config set client.foo 'debug asok' 44
+ceph config get client.foo 'debug asok' | grep 44
+ceph config set client.foo debug_asok 55
+ceph config get client.foo 'debug asok' | grep 55
+ceph config set client.foo 'debug asok' 66
+ceph config get client.foo debug_asok | grep 66
+ceph config rm client.foo debug_asok
+ceph config set client.foo debug_asok 66
+ceph config rm client.foo 'debug asok'
+
 # help
 ceph config help debug_asok | grep debug_asok
 

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -203,6 +203,7 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
     stringstream ss;
     string name;
     cmd_getval(cmdmap, "key", name);
+    name = ConfFile::normalize_key_name(name);
     const Option *opt = g_conf().find_option(name);
     if (!opt) {
       opt = mon.mgrmon()->find_module_option(name);
@@ -333,11 +334,13 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
       &src);
 
     if (cmd_getval(cmdmap, "key", name)) {
+      name = ConfFile::normalize_key_name(name);
       const Option *opt = g_conf().find_option(name);
       if (!opt) {
 	opt = mon.mgrmon()->find_module_option(name);
       }
       if (!opt) {
+        ss << "unrecognized key '" << name << "'";
 	err = -ENOENT;
 	goto reply;
       }
@@ -547,7 +550,8 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
     cmd_getval(cmdmap, "name", name);
     cmd_getval(cmdmap, "value", value);
     cmd_getval(cmdmap, "force", force);
-
+    name = ConfFile::normalize_key_name(name);
+    
     if (prefix == "config set" && !force) {
       const Option *opt = g_conf().find_option(name);
       if (!opt) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55156

---

backport of https://github.com/ceph/ceph/pull/44656
parent tracker: https://tracker.ceph.com/issues/44092

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh