### PR TITLE
pacific: monitoring/ceph-mixin: OSD overview typo fix

### DIFF
--- a/monitoring/ceph-mixin/dashboards/osd.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/osd.libsonnet
@@ -211,7 +211,7 @@ local g = import 'grafonnet/grafana.libsonnet';
       )
       .addTarget(
         $.addTargetSchema(
-          'absent(ceph_bluefs_wal_total_bytes{%(matchers)s)} * count(ceph_osd_metadata{%(matchers)s})' % $.matchers(), 'filestore', 'time_series', 2
+          'absent(ceph_bluefs_wal_total_bytes{%(matchers)s}) * count(ceph_osd_metadata{%(matchers)s})' % $.matchers(), 'filestore', 'time_series', 2
         )
       ) + { gridPos: { x: 4, y: 8, w: 4, h: 8 } },
       $.simplePieChart(

--- a/monitoring/ceph-mixin/dashboards_out/osds-overview.json
+++ b/monitoring/ceph-mixin/dashboards_out/osds-overview.json
@@ -483,7 +483,7 @@
                "refId": "A"
             },
             {
-               "expr": "absent(ceph_bluefs_wal_total_bytes{job=~\"$job\")} * count(ceph_osd_metadata{job=~\"$job\"})",
+               "expr": "absent(ceph_bluefs_wal_total_bytes{job=~\"$job\"}) * count(ceph_osd_metadata{job=~\"$job\"})",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "filestore",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56990

---

backport of https://github.com/ceph/ceph/pull/47334
parent tracker: https://tracker.ceph.com/issues/56948

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh