### PR TITLE
osd/scrub: verify SnapMapper consistency

### DIFF
--- a/qa/standalone/scrub/osd-mapper.sh
+++ b/qa/standalone/scrub/osd-mapper.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# -*- mode:text; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+# vim: ts=8 sw=2 smarttab
+#
+# test the handling of a corrupted SnapMapper DB by Scrub
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+source $CEPH_ROOT/qa/standalone/scrub/scrub-helpers.sh
+
+function run() {
+  local dir=$1
+  shift
+
+  export CEPH_MON="127.0.0.1:7144" # git grep '\<7144\>' : there must be only one
+  export CEPH_ARGS
+  CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+  CEPH_ARGS+="--mon-host=$CEPH_MON "
+
+  export -n CEPH_CLI_TEST_DUP_COMMAND
+  local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+  for func in $funcs ; do
+    setup $dir || return 1
+    $func $dir || return 1
+    teardown $dir || return 1
+  done
+}
+
+# one clone & multiple snaps (according to the number of parameters)
+function make_a_clone()
+{
+  #turn off '-x' (but remember previous state)
+  local saved_echo_flag=${-//[^x]/}
+  set +x
+  local pool=$1
+  local obj=$2
+  echo $RANDOM | rados -p $pool put $obj - || return 1
+  shift 2
+  for snap in $@ ; do
+    rados -p $pool mksnap $snap || return 1
+  done
+  if [[ -n "$saved_echo_flag" ]]; then set -x; fi
+}
+
+function TEST_truncated_sna_record() {
+    local dir=$1
+    local -A cluster_conf=(
+        ['osds_num']="3" 
+        ['pgs_in_pool']="4"
+        ['pool_name']="test"
+    )
+
+    local extr_dbg=1
+    (( extr_dbg > 1 )) && echo "Dir: $dir"
+    standard_scrub_cluster $dir cluster_conf
+    ceph tell osd.* config set osd_stats_update_period_not_scrubbing "1"
+    ceph tell osd.* config set osd_stats_update_period_scrubbing "1"
+
+    local osdn=${cluster_conf['osds_num']}
+    local poolid=${cluster_conf['pool_id']}
+    local poolname=${cluster_conf['pool_name']}
+    local objname="objxxx"
+
+    # create an object and clone it
+    make_a_clone $poolname $objname snap01 snap02 || return 1
+    make_a_clone $poolname $objname snap13 || return 1
+    make_a_clone $poolname $objname snap24 snap25 || return 1
+    echo $RANDOM | rados -p $poolname put $objname - || return 1
+
+    #identify the PG and the primary OSD
+    local pgid=`ceph --format=json-pretty osd map $poolname $objname | jq -r '.pgid'`
+    local osd=`ceph --format=json-pretty osd map $poolname $objname | jq -r '.up[0]'`
+    echo "pgid is $pgid (primary: osd.$osd)"
+    # turn on the publishing of test data in the 'scrubber' section of 'pg query' output
+    set_query_debug $pgid
+
+    # verify the existence of these clones
+    (( extr_dbg >= 1 )) && rados --format json-pretty -p $poolname listsnaps $objname
+
+    # scrub the PG
+    ceph pg $pgid deep_scrub || return 1
+
+    # we aren't just waiting for the scrub to terminate, but also for the
+    # logs to be published
+    sleep 3
+    ceph pg dump pgs
+    until grep -a -q -- "event: --^^^^---- ScrubFinished" $dir/osd.$osd.log ; do
+        sleep 0.2
+    done
+
+    ceph pg dump pgs
+    ceph osd set noscrub || return 1
+    ceph osd set nodeep-scrub || return 1
+    sleep 5
+    grep -a -q -v "ERR" $dir/osd.$osd.log || return 1
+
+    # kill the OSDs
+    kill_daemons $dir TERM osd || return 1
+
+    (( extr_dbg >= 2 )) && ceph-kvstore-tool bluestore-kv $dir/0 dump "p"
+    (( extr_dbg >= 2 )) && ceph-kvstore-tool bluestore-kv $dir/2 dump "p" | grep -a SNA_
+    (( extr_dbg >= 2 )) && grep -a SNA_ /tmp/oo2.dump
+    (( extr_dbg >= 2 )) && ceph-kvstore-tool bluestore-kv $dir/2 dump p 2> /dev/null
+
+    for sdn in $(seq 0 $(expr $osdn - 1))
+    do
+        kvdir=$dir/$sdn
+        echo "corrupting the SnapMapper DB of osd.$sdn (db: $kvdir)"
+        (( extr_dbg >= 3 )) && ceph-kvstore-tool bluestore-kv $kvdir dump "p"
+
+        # truncate the 'mapping' (SNA_) entry corresponding to the snap13 clone
+        KY=`ceph-kvstore-tool bluestore-kv $kvdir dump p 2> /dev/null | grep -a -e 'SNA_[0-9]_0000000000000003_000000000000000' \
+            | awk -e '{print $2;}'`
+        (( extr_dbg >= 1 )) && echo "SNA key: $KY" | cat -v
+
+        tmp_fn1=`mktemp -p /tmp --suffix="_the_val"`
+        (( extr_dbg >= 1 )) && echo "Value dumped in: $tmp_fn1"
+        ceph-kvstore-tool bluestore-kv $kvdir get p "$KY" out $tmp_fn1 2> /dev/null
+        (( extr_dbg >= 2 )) && od -xc $tmp_fn1
+
+        NKY=${KY:0:-30}
+        ceph-kvstore-tool bluestore-kv $kvdir rm "p" "$KY" 2> /dev/null
+        ceph-kvstore-tool bluestore-kv $kvdir set "p" "$NKY" in $tmp_fn1 2> /dev/null
+
+        (( extr_dbg >= 1 )) || rm $tmp_fn1
+    done
+
+    orig_osd_args=" ${cluster_conf['osd_args']}"
+    orig_osd_args=" $(echo $orig_osd_args)"
+    (( extr_dbg >= 2 )) && echo "Copied OSD args: /$orig_osd_args/ /${orig_osd_args:1}/"
+    for sdn in $(seq 0 $(expr $osdn - 1))
+    do
+      CEPH_ARGS="$CEPH_ARGS $orig_osd_args" activate_osd $dir $sdn
+    done
+    sleep 1
+
+    for sdn in $(seq 0 $(expr $osdn - 1))
+    do
+      timeout 60 ceph tell osd.$sdn version
+    done
+
+    # when scrubbing now - we expect the scrub to emit a cluster log ERR message regarding SnapMapper internal inconsistency
+    ceph osd unset nodeep-scrub || return 1
+    ceph osd unset noscrub || return 1
+
+    # what is the primary now?
+    local cur_prim=`ceph --format=json-pretty osd map $poolname $objname | jq -r '.up[0]'`
+    ceph pg dump pgs
+    sleep 2
+    ceph pg $pgid deep_scrub || return 1
+    sleep 5
+    ceph pg dump pgs
+    (( extr_dbg >= 1 )) && grep -a "ERR" $dir/osd.$cur_prim.log
+    grep -a -q "ERR" $dir/osd.$cur_prim.log || return 1
+}
+
+
+
+main osd-mapper "$@"

--- a/qa/standalone/scrub/scrub-helpers.sh
+++ b/qa/standalone/scrub/scrub-helpers.sh
@@ -243,7 +243,7 @@ function standard_scrub_cluster() {
 
     for osd in $(seq 0 $(expr $OSDS - 1))
     do
-      run_osd $dir $osd $ceph_osd_args || return 1
+      run_osd $dir $osd $(echo $ceph_osd_args) || return 1
     done
 
     create_pool $poolname $pg_num $pg_num
@@ -254,6 +254,7 @@ function standard_scrub_cluster() {
     name_n_id=`ceph osd dump | awk '/^pool.*'$poolname'/ { gsub(/'"'"'/," ",$3); print $3," ", $2}'`
     echo "standard_scrub_cluster: $debug_msg: test pool is $name_n_id"
     args['pool_id']="${name_n_id##* }"
+    args['osd_args']=$ceph_osd_args
     if [[ -n "$saved_echo_flag" ]]; then set -x; fi
 }
 

--- a/src/common/hobject_fmt.h
+++ b/src/common/hobject_fmt.h
@@ -6,6 +6,7 @@
  * \file fmtlib formatters for some hobject.h classes
  */
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "common/hobject.h"
 #include "include/object_fmt.h"

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -297,7 +297,6 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
 
      virtual bool check_failsafe_full() = 0;
 
-     virtual bool pg_is_repair() = 0;
      virtual void inc_osd_stat_repaired() = 0;
      virtual bool pg_is_remote_backfilling() = 0;
      virtual void pg_add_local_num_bytes(int64_t num_bytes) = 0;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -442,9 +442,6 @@ public:
     release_object_locks(manager);
   }
 
-  bool pg_is_repair() override {
-    return is_repair();
-  }
   void inc_osd_stat_repaired() override {
     osd->inc_osd_stat_repaired();
   }

--- a/src/osd/SnapMapReaderI.h
+++ b/src/osd/SnapMapReaderI.h
@@ -1,0 +1,68 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+
+/**
+ * \file
+ * \brief Defines the interface for the snap-mapper used by the scrubber.
+ */
+#include <set>
+
+#include "common/scrub_types.h"
+#include "include/expected.hpp"
+
+namespace Scrub {
+/*
+ * snaps-related aux structures:
+ * the scrub-backend scans the snaps associated with each scrubbed object, and
+ * fixes corrupted snap-sets.
+ * The actual access to the PG's snap_mapper, and the actual I/O transactions,
+ * are performed by the main PgScrubber object.
+ * the following aux structures are used to facilitate the required exchanges:
+ * - pre-fix snap-sets are accessed by the scrub-backend, and:
+ * - a list of fix-orders (either insert or replace operations) are returned
+ */
+
+struct SnapMapReaderI {
+  struct result_t {
+    enum class code_t { success, backend_error, not_found, inconsistent };
+    code_t code{code_t::success};
+    int backend_error{0};  ///< errno returned by the backend
+  };
+
+  /**
+   *  get SnapMapper's snap-set for a given object
+   *  \returns a set of snaps, or an error code
+   *  \attn: only OBJ_ DB entries are consulted
+   */
+  virtual tl::expected<std::set<snapid_t>, result_t> get_snaps(
+    const hobject_t& hoid) const = 0;
+
+  /**
+   *  get SnapMapper's snap-set for a given object.
+   *  The snaps gleaned from the OBJ_ entry are verified against the
+   *  mapping ('SNA_') entries.
+   *  A mismatch between both sets of entries will result in an error.
+   *  \returns a set of snaps, or an error code.
+   */
+  virtual tl::expected<std::set<snapid_t>, result_t>
+  get_snaps_check_consistency(const hobject_t& hoid) const = 0;
+
+  virtual ~SnapMapReaderI() = default;
+};
+
+}  // namespace Scrub
+
+enum class snap_mapper_op_t {
+  add,
+  update,
+  overwrite,  //< the mapper's data is internally inconsistent. Similar
+	      //<  to an 'update' operation, but the logs are different.
+};
+
+struct snap_mapper_fix_t {
+  snap_mapper_op_t op;
+  hobject_t hoid;
+  std::set<snapid_t> snaps;
+  std::set<snapid_t> wrong_snaps;  // only collected & returned for logging sake
+};

--- a/src/osd/SnapMapReaderI.h
+++ b/src/osd/SnapMapReaderI.h
@@ -51,8 +51,6 @@ struct SnapMapReaderI {
   virtual ~SnapMapReaderI() = default;
 };
 
-}  // namespace Scrub
-
 enum class snap_mapper_op_t {
   add,
   update,
@@ -66,3 +64,5 @@ struct snap_mapper_fix_t {
   std::set<snapid_t> snaps;
   std::set<snapid_t> wrong_snaps;  // only collected & returned for logging sake
 };
+
+}  // namespace Scrub

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -15,18 +15,19 @@
 #ifndef SNAPMAPPER_H
 #define SNAPMAPPER_H
 
-#include <string>
-#include <set>
-#include <utility>
 #include <cstring>
+#include <set>
+#include <string>
+#include <utility>
 
-#include "common/map_cacher.hpp"
 #include "common/hobject.h"
+#include "common/map_cacher.hpp"
 #include "include/buffer.h"
 #include "include/encoding.h"
 #include "include/object.h"
 #include "os/ObjectStore.h"
 #include "osd/OSDMap.h"
+#include "osd/SnapMapReaderI.h"
 
 class OSDriver : public MapCacher::StoreDriver<std::string, ceph::buffer::list> {
   ObjectStore *os;
@@ -61,6 +62,11 @@ public:
 
   OSTransaction get_transaction(
     ObjectStore::Transaction *t) {
+    return OSTransaction(ch->cid, hoid, t);
+  }
+
+  OSTransaction get_transaction(
+    ObjectStore::Transaction *t) const {
     return OSTransaction(ch->cid, hoid, t);
   }
 
@@ -99,7 +105,7 @@ public:
  * snap will sort together, and so that all objects in a pg for a
  * particular snap will group under up to 8 prefixes.
  */
-class SnapMapper {
+class SnapMapper : public Scrub::SnapMapReaderI {
   friend class MapperVerifier;
 public:
   CephContext* cct;
@@ -213,8 +219,9 @@ private:
     snapid_t end, std::map<std::string,ceph::buffer::list> *m);
   static std::string make_purged_snap_key(int64_t pool, snapid_t last);
 
-
-  MapCacher::MapCacher<std::string, ceph::buffer::list> backend;
+  // note: marked 'mutable', as functions as a cache and used in some 'const'
+  // functions.
+  mutable MapCacher::MapCacher<std::string, ceph::buffer::list> backend;
 
   static std::string get_legacy_prefix(snapid_t snap);
   std::string to_legacy_raw_key(
@@ -223,19 +230,28 @@ private:
 
   static std::string get_prefix(int64_t pool, snapid_t snap);
   std::string to_raw_key(
-    const std::pair<snapid_t, hobject_t> &to_map);
+    const std::pair<snapid_t, hobject_t> &to_map) const;
+
+  std::string to_raw_key(snapid_t snap, const hobject_t& clone) const;
 
   std::pair<std::string, ceph::buffer::list> to_raw(
-    const std::pair<snapid_t, hobject_t> &to_map);
+    const std::pair<snapid_t, hobject_t> &to_map) const;
 
   static bool is_mapping(const std::string &to_test);
 
   static std::pair<snapid_t, hobject_t> from_raw(
     const std::pair<std::string, ceph::buffer::list> &image);
 
-  std::string to_object_key(const hobject_t &hoid);
+  static std::pair<snapid_t, hobject_t> from_raw(
+    const ceph::buffer::list& image);
 
-  int get_snaps(const hobject_t &oid, object_snaps *out);
+  std::string to_object_key(const hobject_t &hoid) const;
+
+  int get_snaps(const hobject_t &oid, object_snaps *out) const;
+
+  std::set<std::string> to_raw_keys(
+    const hobject_t &clone,
+    const std::set<snapid_t> &snaps) const;
 
   void set_snaps(
     const hobject_t &oid,
@@ -254,7 +270,11 @@ private:
     MapCacher::Transaction<std::string, ceph::buffer::list> *t ///< [out] transaction
     );
 
-public:
+  /// Get snaps (as an 'object_snaps' object) for oid
+  tl::expected<object_snaps, SnapMapReaderI::result_t> get_snaps_common(
+    const hobject_t &hoid) const;
+
+ public:
   static std::string make_shard_prefix(shard_id_t shard) {
     if (shard == shard_id_t::NO_SHARD)
       return std::string();
@@ -330,7 +350,20 @@ public:
   int get_snaps(
     const hobject_t &oid,     ///< [in] oid to get snaps for
     std::set<snapid_t> *snaps ///< [out] snaps
-    ); ///< @return error, -ENOENT if oid is not recorded
+    ) const; ///< @return error, -ENOENT if oid is not recorded
+
+  /// Get snaps for oid - alternative interface
+  tl::expected<std::set<snapid_t>, SnapMapReaderI::result_t> get_snaps(
+    const hobject_t &hoid) const final;
+
+  /**
+   * get_snaps_check_consistency
+   *
+   * Returns snaps for hoid as in get_snaps(), but additionally validates the
+   * snap->hobject_t mappings ('SNA_' entries).
+   */
+  tl::expected<std::set<snapid_t>, SnapMapReaderI::result_t>
+  get_snaps_check_consistency(const hobject_t &hoid) const final;
 };
 WRITE_CLASS_ENCODER(SnapMapper::object_snaps)
 WRITE_CLASS_ENCODER(SnapMapper::Mapping)

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -61,11 +61,6 @@ public:
   };
 
   OSTransaction get_transaction(
-    ObjectStore::Transaction *t) {
-    return OSTransaction(ch->cid, hoid, t);
-  }
-
-  OSTransaction get_transaction(
     ObjectStore::Transaction *t) const {
     return OSTransaction(ch->cid, hoid, t);
   }

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -106,7 +106,8 @@ public:
  * particular snap will group under up to 8 prefixes.
  */
 class SnapMapper : public Scrub::SnapMapReaderI {
-  friend class MapperVerifier;
+  friend class MapperVerifier; // unit-test support
+  friend class DirectMapper; // unit-test support
 public:
   CephContext* cct;
   struct object_snaps {

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -881,7 +881,8 @@ class PgScrubber : public ScrubPgIF,
   Scrub::MapsCollectionStatus m_maps_status;
 
   void persist_scrub_results(inconsistent_objs_t&& all_errors);
-  void apply_snap_mapper_fixes(const std::vector<snap_mapper_fix_t>& fix_list);
+  void apply_snap_mapper_fixes(
+    const std::vector<Scrub::snap_mapper_fix_t>& fix_list);
 
   // our latest periodic 'publish_stats_to_osd()'. Required frequency depends on
   // scrub state.

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -102,10 +102,8 @@ struct BuildMap;
  * std::vector: no need to pre-reserve.
  */
 class ReplicaReservations {
-  using OrigSet = decltype(std::declval<PG>().get_actingset());
-
   PG* m_pg;
-  OrigSet m_acting_set;
+  std::set<pg_shard_t> m_acting_set;
   OSDService* m_osds;
   std::vector<pg_shard_t> m_waited_for_peers;
   std::vector<pg_shard_t> m_reserved_peers;
@@ -273,7 +271,6 @@ ostream& operator<<(ostream& out, const scrub_flags_t& sf);
  */
 class PgScrubber : public ScrubPgIF,
                    public ScrubMachineListener,
-                   public SnapMapperAccessor,
                    public ScrubBeListener {
  public:
   explicit PgScrubber(PG* pg);
@@ -549,11 +546,10 @@ class PgScrubber : public ScrubPgIF,
   utime_t scrub_begin_stamp;
   std::ostream& gen_prefix(std::ostream& out) const final;
 
-  //  fetching the snap-set for a given object (used by the scrub-backend)
-  int get_snaps(const hobject_t& hoid,
-		std::set<snapid_t>* snaps_set) const final
+  /// facilitate scrub-backend access to SnapMapper mappings
+  Scrub::SnapMapReaderI& get_snap_mapper_accessor()
   {
-    return m_pg->snap_mapper.get_snaps(hoid, snaps_set);
+    return m_pg->snap_mapper;
   }
 
   void log_cluster_warning(const std::string& warning) const final;

--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -1892,13 +1892,15 @@ std::optional<snap_mapper_fix_t> ScrubBackend::scan_object_snaps(
 }
 
 /*
- * Process:
  * Building a map of objects suitable for snapshot validation.
- * The data in m_cleaned_meta_map is the leftover partial items that need to
- * be completed before they can be processed.
  *
- * Snapshots in maps precede the head object, which is why we are scanning
- * backwards.
+ * We are moving all "full" clone sets, i.e. the head and (preceding it, as
+ * snapshots precede the head entry) the clone entries, into 'for_meta_scrub'.
+ * That collection, not containing partial items, will be scrubbed by
+ * scrub_snapshot_metadata().
+ *
+ * What's left in m_cleaned_meta_map is the leftover partial items that need to
+ * be completed before they can be processed.
  */
 ScrubMap ScrubBackend::clean_meta_map(ScrubMap& cleaned, bool max_reached)
 {

--- a/src/osd/scrubber/scrub_backend.h
+++ b/src/osd/scrubber/scrub_backend.h
@@ -103,7 +103,7 @@ struct ScrubBeListener {
 // objects:
 struct objs_fix_list_t {
   inconsistent_objs_t inconsistent_objs;
-  std::vector<snap_mapper_fix_t> snap_fix_list;
+  std::vector<Scrub::snap_mapper_fix_t> snap_fix_list;
 };
 
 /**
@@ -321,7 +321,7 @@ class ScrubBackend {
    */
   void update_repair_status(bool should_repair);
 
-  std::vector<snap_mapper_fix_t> replica_clean_meta(
+  std::vector<Scrub::snap_mapper_fix_t> replica_clean_meta(
     ScrubMap& smap,
     bool max_reached,
     const hobject_t& start,
@@ -500,7 +500,7 @@ class ScrubBackend {
   /**
    * returns a list of snaps "fix orders"
    */
-  std::vector<snap_mapper_fix_t> scan_snaps(
+  std::vector<Scrub::snap_mapper_fix_t> scan_snaps(
     ScrubMap& smap,
     Scrub::SnapMapReaderI& snaps_getter);
 
@@ -508,7 +508,7 @@ class ScrubBackend {
    * an aux used by scan_snaps(), possibly returning a fix-order
    * for a specific hobject.
    */
-  std::optional<snap_mapper_fix_t> scan_object_snaps(
+  std::optional<Scrub::snap_mapper_fix_t> scan_object_snaps(
     const hobject_t& hoid,
     const SnapSet& snapset,
     Scrub::SnapMapReaderI& snaps_getter);

--- a/src/test/osd/test_scrubber_be.cc
+++ b/src/test/osd/test_scrubber_be.cc
@@ -595,6 +595,7 @@ TEST_F(TestTScrubberBe_data_1, smaps_creation_1)
 /// corrupt the snap_mapper data
 TEST_F(TestTScrubberBe_data_1, snapmapper_1)
 {
+  using snap_mapper_op_t = Scrub::snap_mapper_op_t;
   ASSERT_TRUE(sbe);
 
   // a bogus version of hobj_ms1_snp30 (a clone) snap_ids


### PR DESCRIPTION
Whenever the scrubber accesses the SnapMapper for the snaps of a specific
clone, the mapper will now verify that the snaps have the required
mapping DB entries (the 'SNA_' keys).
    
Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

