### PR TITLE
mgr/dashboard: send_command raise exception if service is not found

### DIFF
--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -8,6 +8,7 @@ from mgr_module import CommandResult
 from mgr_util import get_most_recent_rate, get_time_series_rates
 
 from .. import mgr
+from ..exceptions import DashboardException
 
 try:
     from typing import Any, Dict, Optional, Union
@@ -210,6 +211,10 @@ class CephService(object):
         :raises TimedOut: See rados.make_ex
         :raises ValueError: return code != 0
         """
+        if not CephService.get_service_map(srv_type):
+            raise DashboardException(msg=f'{srv_type} service might be down', http_status_code=500,
+                                     code='send_command_no_service')
+
         argdict = {
             "prefix": prefix,
             "format": "json",

--- a/src/pybind/mgr/dashboard/tests/test_ceph_service.py
+++ b/src/pybind/mgr/dashboard/tests/test_ceph_service.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 
+from ..exceptions import DashboardException
 from ..services.ceph_service import CephService
 
 
@@ -65,6 +66,13 @@ class CephServiceTest(unittest.TestCase):
 
     def test_get_pg_status_without_match(self):
         self.assertEqual(self.service.get_pool_pg_status('no-pool'), {})
+
+    @mock.patch('dashboard.services.ceph_service.CephService.get_service_map')
+    def test_send_command(self, get_service_map):
+        get_service_map.return_value = {}
+        with self.assertRaises(DashboardException) as ctx:
+            CephService.send_command('mds', 'session ls')
+        self.assertEqual(str(ctx.exception), 'mds service might be down')
 
 
 @contextmanager


### PR DESCRIPTION
Sending a command to a mds service after killing all `ceph-mds` if you try to expand a filesystem it will cause a segmentation fault. In the dashboard side in can be easily solved by not seding mds commands when there aren't mds services available.

Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>
Fixes: https://tracker.ceph.com/issues/52811


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
