### PR TITLE
crimson/osd: fix a nullptr deref due to no seq point on call's args eval

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1036,8 +1036,11 @@ seastar::future<> OSD::handle_rep_op(crimson::net::ConnectionRef conn,
 seastar::future<> OSD::handle_rep_op_reply(crimson::net::ConnectionRef conn,
 					   Ref<MOSDRepOpReply> m)
 {
+  // XXX: there is no sequence point between evaluation of arguments on
+  // function call. If so, we can't do `m->do(), [m=std::move(m)] {}`.
+  const auto* m_no_seq_point_workarounder = m.get();
   return pg_shard_manager.with_pg(
-    m->get_spg(),
+    m_no_seq_point_workarounder->get_spg(),
     [conn=std::move(conn), m=std::move(m)](auto &&pg) {
       if (pg) {
 	m->finish_decode();


### PR DESCRIPTION
In the following expression:

  ```cpp
  f(a, b);
  ```

the order in which `a` and `b` are evaluated is unspecified. This is true even in C++17 got some changes to the sequencing:

> 15) In a function call, value computations and side effects
> of the initialization of every parameter are indeterminately
sequenced with respect to value computations and side effects
of any other parameter.

"Indeterminately sequenced" means:

> evaluations of A and B are indeterminately sequenced: they may
> be performed in any order but may not overlap: either A will
> be complete before B, or B will be complete before A. The order
> may be the opposite the next time the same expression is evaluated.

See: https://en.cppreference.com/w/cpp/language/eval_order

Our dependency on a specific order of arguments evaluation in:

  ```cpp
    return pg_shard_manager.with_pg(
      m->get_spg(),
      [/* ... */ m=std::move(m)](auto &&pg) {
  ```

can explain the following crash:

```
DEBUG 2022-08-01 07:01:14,901 [shard 0] osd - ShardServices::dispatch_context_transaction: empty transaction
WARN  2022-08-01 07:01:14,941 [shard 0] osd - handle_rep_op_reply: osd_repop_reply(client.4180.0:1 1.0 e12/11) v2
ceph-osd: /home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/17.0.0-13668-gb57274cd/rpm/el8/BUILD/ceph-17.0.0-13668-gb57274cd/x86_64-redhat-linux-gnu/boost/include/boost/smart_ptr/intrusive_ptr.hpp:199: T* boost::intrusive_ptr<T>::operator->() const [with T = MOSDRepOpReply]: Assertion `px != 0' failed.
Aborting on shard 0.
```

assuming the second argument got evaluated before the first.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
