### PR TITLE
ceph-volume: create fake /sys/block/rbd0/slaves dir

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -317,5 +317,5 @@ def fake_filesystem(fs):
 
     fs.create_dir('/sys/block/sda/slaves')
     fs.create_dir('/sys/block/sda/queue')
-    fs.create_dir('/sys/block/rbd0')
+    fs.create_dir('/sys/block/rbd0/slaves')
     yield fs


### PR DESCRIPTION
Fascinatingly, this test hasn't fail on branch main but is failing
in a recent Quincy backport.
Creating this fake sub-directory in the fake fs so it won't complain
anymore.

```
E       FileNotFoundError: [Errno 2] No such file or directory in the fake filesystem: '/sys/block/rbd0/slaves'
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
