### PR TITLE
pacific: mgr/dashboard: rbd striping setting pre-population and pop-over

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -319,7 +319,7 @@
             <div class="form-group row">
               <label i18n
                      class="cd-col-form-label"
-                     for="size">Object size</label>
+                     for="size">Object size<cd-helper>Objects in the Ceph Storage Cluster have a maximum configurable size (e.g., 2MB, 4MB, etc.). The object size should be large enough to accommodate many stripe units, and should be a multiple of the stripe unit.</cd-helper></label>
               <div class="cd-col-form-input">
                 <select id="obj_size"
                         name="obj_size"
@@ -336,7 +336,7 @@
               <label class="cd-col-form-label"
                      [ngClass]="{'required': rbdForm.getValue('stripingCount')}"
                      for="stripingUnit"
-                     i18n>Stripe unit</label>
+                     i18n>Stripe unit<cd-helper>Stripes have a configurable unit size (e.g., 64kb). The Ceph Client divides the data it will write to objects into equally sized stripe units, except for the last stripe unit. A stripe width, should be a fraction of the Object Size so that an object may contain many stripe units.</cd-helper></label>
               <div class="cd-col-form-input">
                 <select id="stripingUnit"
                         name="stripingUnit"
@@ -361,7 +361,7 @@
               <label class="cd-col-form-label"
                      [ngClass]="{'required': rbdForm.getValue('stripingUnit')}"
                      for="stripingCount"
-                     i18n>Stripe count</label>
+                     i18n>Stripe count<cd-helper>The Ceph Client writes a sequence of stripe units over a series of objects determined by the stripe count. The series of objects is called an object set. After the Ceph Client writes to the last object in the object set, it returns to the first object in the object set.</cd-helper></label>
               <div class="cd-col-form-input">
                 <input id="stripingCount"
                        name="stripingCount"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -99,6 +99,11 @@ export class RbdFormComponent extends CdForm implements OnInit {
     '16 MiB',
     '32 MiB'
   ];
+
+  defaultStripingUnit = '4 MiB';
+
+  defaultStripingCount = 1;
+
   action: string;
   resource: string;
   private rbdImage = new ReplaySubject(1);
@@ -193,8 +198,8 @@ export class RbdFormComponent extends CdForm implements OnInit {
           validators: [Validators.pattern(/^([0-9]+)d|([0-9]+)h|([0-9]+)m$/)] // check schedule interval to be in format - 1d or 1h or 1m
         }),
         mirroringMode: new FormControl(this.mirroringOptions[0]),
-        stripingUnit: new FormControl(null),
-        stripingCount: new FormControl(null, {
+        stripingUnit: new FormControl(this.defaultStripingUnit),
+        stripingCount: new FormControl(this.defaultStripingCount, {
           updateOn: 'blur'
         })
       },
@@ -437,7 +442,8 @@ export class RbdFormComponent extends CdForm implements OnInit {
         objectSizeControl.value != null ? objectSizeControl.value : this.defaultObjectSize
       );
       const stripingCountControl = formGroup.get('stripingCount');
-      const stripingCount = stripingCountControl.value != null ? stripingCountControl.value : 1;
+      const stripingCount =
+        stripingCountControl.value != null ? stripingCountControl.value : this.defaultStripingCount;
       let sizeControlErrors = null;
       if (sizeControl.value === null) {
         sizeControlErrors = { required: true };


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/56566

---

backport of https://github.com/ceph/ceph/pull/46014
parent tracker: https://tracker.ceph.com/issues/39726

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh