### PR TITLE
crimson/net: don't throw on failure when renewing tickets and keyrings

### DIFF
--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -140,9 +140,7 @@ seastar::future<> Connection::renew_tickets()
     logger().info("{}: retrieving new tickets", __func__);
     return do_auth(request_t::general).then([](const auth_result_t r) {
       if (r == auth_result_t::failure)  {
-        throw std::system_error(
-	  make_error_code(
-	    crimson::net::error::negotiation_failure));
+        logger().info("renew_tickets: ignoring failed auth reply");
       }
     });
   } else {
@@ -174,8 +172,7 @@ seastar::future<> Connection::renew_rotating_keyring()
   last_rotating_renew_sent = now;
   return do_auth(request_t::rotating).then([](const auth_result_t r) {
     if (r == auth_result_t::failure)  {
-      throw std::system_error(make_error_code(
-        crimson::net::error::negotiation_failure));
+      logger().info("renew_rotating_keyring: ignoring failed auth reply");
     }
   });
 }


### PR DESCRIPTION
In the classical `MonClient` renewal of tickets and rotating secrets, generally speaking, doesn't verify the `MAuthReply`. The only difference is breaking the renewal loop:

```cpp
void MonClient::_finish_auth(int auth_err)
{
  // ...
  if (!auth_err && active_con) {
    ceph_assert(auth);
    _check_auth_tickets();
  }
  // ...
}
```

However, `crimson::mon::Client` throws `error::negotiation_failure` which is finally handled in `Gated::dispatch()`. As the handler there doesn't expect this particular error, it aborts the entire process. This was the reason for failing one of the jobs at Sepia:

```
rzarzynski@teuthology:/a/rzarzynski-2022-08-01_11:01:29-crimson-rados-main-distro-default-smithi/6954468$ less ./remote/smithi174/log/ceph-osd.1.log.gz
...
DEBUG 2022-08-01 11:26:13,772 [shard 0] monc - renew_rotating_keyring secrets are up-to-date (they expire after 1659353143.772506)
INFO  2022-08-01 11:26:13,772 [shard 0] monc - renew_tickets: retrieving new tickets
INFO  2022-08-01 11:26:13,772 [shard 0] monc - sending auth(proto 2 132 bytes epoch 0) v1
INFO  2022-08-01 11:26:13,772 [shard 0] monc - waiting
INFO  2022-08-01 11:26:13,773 [shard 0] monc - handle_auth_reply mon v2:172.21.15.174:6802/101543 => v2:172.21.15.174:3300/0 returns auth_reply(proto 2 0 (0) Success) v1: 0
INFO  2022-08-01 11:26:13,773 [shard 0] monc - handle_auth_reply
INFO  2022-08-01 11:26:13,773 [shard 0] monc - renew_tickets: retrieving new tickets
INFO  2022-08-01 11:26:13,773 [shard 0] monc - sending auth(proto 2 132 bytes epoch 0) v1
DEBUG 2022-08-01 11:26:13,773 [shard 0] monc - renew_rotating_keyring secrets are up-to-date (they expire after 1659353143.7732666)
INFO  2022-08-01 11:26:13,773 [shard 0] monc - waiting
INFO  2022-08-01 11:26:13,773 [shard 0] monc - do_auth_single: mon v2:172.21.15.174:6802/101543 => v2:172.21.15.174:3300/0 returns auth_reply(proto 2 0 (0) Success) v1: 0
INFO  2022-08-01 11:26:13,773 [shard 0] monc - handle_auth_reply mon v2:172.21.15.174:6802/101543 => v2:172.21.15.174:3300/0 returns auth_reply(proto 2 0 (0) Success) v1: 0
INFO  2022-08-01 11:26:13,773 [shard 0] monc - handle_auth_reply
INFO  2022-08-01 11:26:13,773 [shard 0] monc - do_auth_single: mon v2:172.21.15.174:6802/101543 => v2:172.21.15.174:3300/0 returns auth_reply(proto 2 0 (0) Success) v1: 0
WARN  2022-08-01 11:26:13,773 [shard 0] auth - cephx client: could not verify service_ticket reply
ERROR 2022-08-01 11:26:13,773 [shard 0] monc - do_auth_single: got error -13 on mon v2:172.21.15.174:3300/0
DEBUG 2022-08-01 11:26:13,773 [shard 0] monc - renew_tickets: don't need new tickets
DEBUG 2022-08-01 11:26:13,774 [shard 0] monc - renew_rotating_keyring secrets are up-to-date (they expire after 1659353143.773988)
ERROR 2022-08-01 11:26:13,774 [shard 0] osd - mon.osd.1 dispatch() ms_dispatch caught exception: std::system_error (error crimson::net:3, negotiation failure)
```

```
2022-08-01T11:26:13.798 INFO:tasks.ceph.osd.1.smithi174.stderr:ceph-osd: /home/jenkins-build/build/workspace/ceph-dev-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/giga
ntic/release/17.0.0-13947-g4f4eedf5/rpm/el8/BUILD/ceph-17.0.0-13947-g4f4eedf5/src/crimson/common/gated.h:36: crimson::common::Gated::dispatch<crimson::mon::Client::ms_dispatch(crimson::net::ConnectionRef, MessageRef)::<lambda()>&, crimson::mon::Client>(const char*, crimson::mon::Client&, crimson::mon::Client::ms_dispatch(crimson::net::ConnectionRef, MessageRef)::<lambda()>&)::<lambda(std::__exception_ptr::exception_ptr)>: Assertion `*eptr.__cxa_exception_type() == typeid(seastar::gate_closed_exception)' failed.
2022-08-01T11:26:13.811 INFO:tasks.ceph.osd.1.smithi174.stderr:Aborting on shard 0.
```

```cpp
class Gated {
  // ...
  template <typename Func, typename T>
  inline seastar::future<> dispatch(const char* what, T& who, Func&& func) {
    return seastar::with_gate(pending_dispatch, std::forward<Func>(func)
    ).handle_exception([what, &who] (std::exception_ptr eptr) {
      if (*eptr.__cxa_exception_type() == typeid(system_shutdown_exception)) {
        gated_logger().debug(
            "{}, {} skipped, system shutdown", who, what);
        return;
      }
      gated_logger().error(
          "{} dispatch() {} caught exception: {}", who, what, eptr);
      assert(*eptr.__cxa_exception_type()
        == typeid(seastar::gate_closed_exception));
    });
  }
```

See: http://pulpito.front.sepia.ceph.com/rzarzynski-2022-08-01_11:01:29-crimson-rados-main-distro-default-smithi/6954468/

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
