### PR TITLE
crimson/os: rewrite ordering using std::strong_ordering

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -77,7 +77,7 @@ void tree_cursor_t::assert_next_to(
   } else if (is_tracked()) {
     auto key = get_key_view(magic);
     auto prv_key = prv.get_key_view(magic);
-    assert(key.compare_to(prv_key) == MatchKindCMP::GT);
+    assert(key > prv_key);
     if (ref_leaf_node == prv.ref_leaf_node) {
       position.assert_next_to(prv.position);
     } else {
@@ -103,32 +103,32 @@ tree_cursor_t::erase<true>(context_t, bool);
 template eagain_ifuture<Ref<tree_cursor_t>>
 tree_cursor_t::erase<false>(context_t, bool);
 
-MatchKindCMP tree_cursor_t::compare_to(
+std::strong_ordering tree_cursor_t::compare_to(
     const tree_cursor_t& o, value_magic_t magic) const
 {
   if (!is_tracked() && !o.is_tracked()) {
-    return MatchKindCMP::EQ;
+    return std::strong_ordering::equal;
   } else if (!is_tracked()) {
-    return MatchKindCMP::GT;
+    return std::strong_ordering::greater;
   } else if (!o.is_tracked()) {
-    return MatchKindCMP::LT;
+    return std::strong_ordering::less;
   }
 
   assert(is_tracked() && o.is_tracked());
   // all tracked cursors are singletons
   if (this == &o) {
-    return MatchKindCMP::EQ;
+    return std::strong_ordering::equal;
   }
 
-  MatchKindCMP ret;
+  std::strong_ordering ret = std::strong_ordering::equal;
   if (ref_leaf_node == o.ref_leaf_node) {
-    ret = position.compare_to(o.position);
+    ret = position <=> o.position;
   } else {
     auto key = get_key_view(magic);
     auto o_key = o.get_key_view(magic);
-    ret = key.compare_to(o_key);
+    ret = key <=> o_key;
   }
-  assert(ret != MatchKindCMP::EQ);
+  assert(ret != 0);
   return ret;
 }
 
@@ -259,7 +259,7 @@ void tree_cursor_t::Cache::validate_is_latest(const search_position_t& pos) cons
 
   auto [_key_view, _p_value_header] = ref_leaf_node->get_kv(pos);
   assert(p_node_base == ref_leaf_node->read());
-  assert(key_view->compare_to(_key_view) == MatchKindCMP::EQ);
+  assert(key_view ==_key_view);
   assert(p_value_header == _p_value_header);
 #endif
 }
@@ -1465,7 +1465,7 @@ eagain_ifuture<Ref<InternalNode>> InternalNode::insert_or_split(
   // XXX: check the insert_child is unlinked from this node
 #ifndef NDEBUG
   auto _insert_key = *insert_child->impl->get_pivot_index();
-  assert(insert_key.compare_to(_insert_key) == MatchKindCMP::EQ);
+  assert(insert_key == _insert_key);
 #endif
   auto insert_value = insert_child->impl->laddr();
   auto insert_pos = pos;
@@ -1730,7 +1730,7 @@ void InternalNode::validate_child(const Node& child) const
     key_view_t index_key;
     const laddr_packed_t* p_child_addr;
     impl->get_slot(child_pos, &index_key, &p_child_addr);
-    assert(index_key.compare_to(*child.impl->get_pivot_index()) == MatchKindCMP::EQ);
+    assert(index_key == *child.impl->get_pivot_index());
     assert(p_child_addr->value == child.impl->laddr());
   }
   // XXX(multi-type)
@@ -1752,7 +1752,7 @@ void InternalNode::validate_child_inconsistent(const Node& child) const
   const laddr_packed_t* p_value;
   impl->get_slot(child_pos, &current_key, &p_value);
   key_view_t new_key = *child.impl->get_pivot_index();
-  assert(current_key.compare_to(new_key) != MatchKindCMP::EQ);
+  assert(current_key != new_key);
   assert(p_value->value == child.impl->laddr());
 #endif
 }
@@ -2184,7 +2184,7 @@ void LeafNode::validate_cursor(const tree_cursor_t& cursor) const
   // behaviors.
   auto [key, p_value_header] = get_kv(cursor.get_position());
   auto magic = p_value_header->magic;
-  assert(key.compare_to(cursor.get_key_view(magic)) == MatchKindCMP::EQ);
+  assert(key == cursor.get_key_view(magic));
   assert(p_value_header == cursor.read_value_header(magic));
 #endif
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <compare>
 #include <map>
 #include <memory>
 #include <ostream>
@@ -123,7 +124,7 @@ class tree_cursor_t final
   template <bool FORCE_MERGE = false>
   eagain_ifuture<Ref<tree_cursor_t>> erase(context_t, bool get_next);
 
-  MatchKindCMP compare_to(const tree_cursor_t&, value_magic_t) const;
+  std::strong_ordering compare_to(const tree_cursor_t&, value_magic_t) const;
 
   // public to Value
 
@@ -274,11 +275,11 @@ class Node
     void validate_input_key(const key_hobj_t& key, value_magic_t magic) const {
 #ifndef NDEBUG
       if (match() == MatchKindBS::EQ) {
-        assert(key.compare_to(p_cursor->get_key_view(magic)) == MatchKindCMP::EQ);
+        assert(key == p_cursor->get_key_view(magic));
       } else {
         assert(match() == MatchKindBS::NE);
         if (p_cursor->is_tracked()) {
-          assert(key.compare_to(p_cursor->get_key_view(magic)) == MatchKindCMP::LT);
+          assert(key < p_cursor->get_key_view(magic));
         } else if (p_cursor->is_end()) {
           // good
         } else {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -523,7 +523,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
         full_key_t<KeyT::VIEW> index;
         stage_t::template get_slot<true, false>(
             node_stage, result_raw.position, &index, nullptr);
-        assert(index.compare_to(*index_key) == MatchKindCMP::EQ);
+        assert(index == *index_key);
       }
 #endif
     } else {
@@ -545,10 +545,10 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
       // currently only internal node checks mstat
       if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
         if (result_raw.mstat == MSTAT_LT2) {
-          auto cmp = compare_to<KeyT::HOBJ>(
-              key, node_stage[result_raw.position.index].shard_pool);
-          assert(cmp != MatchKindCMP::GT);
-          if (cmp != MatchKindCMP::EQ) {
+          auto cmp =
+              key <=> node_stage[result_raw.position.index].shard_pool;
+          assert(cmp != std::strong_ordering::greater);
+          if (cmp != 0) {
             result_raw.mstat = MSTAT_LT3;
           }
         }
@@ -595,7 +595,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
 #ifndef NDEBUG
     full_key_t<KeyT::VIEW> index;
     get_slot(insert_pos, &index, nullptr);
-    assert(index.compare_to(key) == MatchKindCMP::EQ);
+    assert(index == key);
 #endif
     return ret;
   }
@@ -775,14 +775,14 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
 #ifndef NDEBUG
       full_key_t<KeyT::VIEW> index;
       get_slot(_insert_pos, &index, nullptr);
-      assert(index.compare_to(key) == MatchKindCMP::EQ);
+      assert(index == key);
 #endif
     } else {
       SUBDEBUG(seastore_onode, "-- left trim ...");
 #ifndef NDEBUG
       full_key_t<KeyT::VIEW> index;
       right_impl.get_slot(_insert_pos, &index, nullptr);
-      assert(index.compare_to(key) == MatchKindCMP::EQ);
+      assert(index == key);
 #endif
       extent.split_replayable(split_at);
     }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
@@ -149,21 +149,7 @@ struct staged_position_t {
     }
   }
 
-  MatchKindCMP compare_to(const me_t& o) const {
-    if (index > o.index) {
-      return MatchKindCMP::GT;
-    } else if (index < o.index) {
-      return MatchKindCMP::LT;
-    } else {
-      return nxt.compare_to(o.nxt);
-    }
-  }
-  bool operator>(const me_t& o) const { return (int)compare_to(o) > 0; }
-  bool operator>=(const me_t& o) const { return (int)compare_to(o) >= 0; }
-  bool operator<(const me_t& o) const { return (int)compare_to(o) < 0; }
-  bool operator<=(const me_t& o) const { return (int)compare_to(o) <= 0; }
-  bool operator==(const me_t& o) const { return (int)compare_to(o) == 0; }
-  bool operator!=(const me_t& o) const { return (int)compare_to(o) != 0; }
+  auto operator<=>(const me_t& o) const = default;
 
   void assert_next_to(const me_t& prv) const {
 #ifndef NDEBUG
@@ -251,21 +237,7 @@ struct staged_position_t<STAGE_BOTTOM> {
     return index;
   }
 
-  MatchKindCMP compare_to(const staged_position_t<STAGE_BOTTOM>& o) const {
-    if (index > o.index) {
-      return MatchKindCMP::GT;
-    } else if (index < o.index) {
-      return MatchKindCMP::LT;
-    } else {
-      return MatchKindCMP::EQ;
-    }
-  }
-  bool operator>(const me_t& o) const { return (int)compare_to(o) > 0; }
-  bool operator>=(const me_t& o) const { return (int)compare_to(o) >= 0; }
-  bool operator<(const me_t& o) const { return (int)compare_to(o) < 0; }
-  bool operator<=(const me_t& o) const { return (int)compare_to(o) <= 0; }
-  bool operator==(const me_t& o) const { return (int)compare_to(o) == 0; }
-  bool operator!=(const me_t& o) const { return (int)compare_to(o) != 0; }
+  auto operator<=>(const me_t&) const = default;
 
   me_t& operator-=(const me_t& o) {
     assert(is_valid_index(o.index));

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
@@ -95,12 +95,7 @@ class Btree {
           *p_tree->nm, p_tree->value_builder, p_cursor);
     }
 
-    bool operator>(const Cursor& o) const { return (int)compare_to(o) > 0; }
-    bool operator>=(const Cursor& o) const { return (int)compare_to(o) >= 0; }
-    bool operator<(const Cursor& o) const { return (int)compare_to(o) < 0; }
-    bool operator<=(const Cursor& o) const { return (int)compare_to(o) <= 0; }
-    bool operator==(const Cursor& o) const { return (int)compare_to(o) == 0; }
-    bool operator!=(const Cursor& o) const { return (int)compare_to(o) != 0; }
+    bool operator==(const Cursor& o) const { return operator<=>(o) == 0; }
 
     eagain_ifuture<Cursor> get_next(Transaction& t) {
       assert(!is_end());
@@ -146,7 +141,7 @@ class Btree {
     }
     Cursor(Btree* p_tree) : p_tree{p_tree} {}
 
-    MatchKindCMP compare_to(const Cursor& o) const {
+    std::strong_ordering operator<=>(const Cursor& o) const {
       assert(p_tree == o.p_tree);
       return p_cursor->compare_to(
           *o.p_cursor, p_tree->value_builder.get_header_magic());

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -135,7 +135,7 @@ class KVPool {
   }
 
   void shuffle() {
-    std::random_shuffle(random_p_kvs.begin(), random_p_kvs.end());
+    std::shuffle(random_p_kvs.begin(), random_p_kvs.end(), std::default_random_engine{});
   }
 
   void erase_from_random(iterator_t begin, iterator_t end) {

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1193,7 +1193,7 @@ class DummyChildPool {
       // erase and merge
       [[maybe_unused]] auto pivot_key = node_to_split->get_pivot_key();
       logger().info("\n\nERASE-MERGE {}:", node_to_split->get_name());
-      assert(pivot_key.compare_to(key_hobj_t(key)) == MatchKindCMP::EQ);
+      assert(pivot_key == key_hobj_t(key));
       with_trans_intr(pool_clone.get_context().t, [&] (auto &t) {
         return node_to_split->merge(
           pool_clone.get_context(), std::move(node_to_split));

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -368,7 +368,7 @@ TEST_F(b_dummy_tree_test_t, 3_random_insert_erase_leaf_node)
       {make_ghobj(4, 4, 4, "ns4", "oid4", 4, 4), values.pick()}};
     auto [smallest_key, smallest_value] = kvs[0];
     auto [largest_key, largest_value] = kvs[kvs.size() - 1];
-    std::random_shuffle(kvs.begin(), kvs.end());
+    std::shuffle(kvs.begin(), kvs.end(), std::default_random_engine{});
     std::for_each(kvs.begin(), kvs.end(), [&f_insert_erase_insert] (auto& kv) {
       f_insert_erase_insert(kv.first, kv.second);
     });
@@ -424,7 +424,7 @@ TEST_F(b_dummy_tree_test_t, 3_random_insert_erase_leaf_node)
     logger().info("\n{}\n", oss.str());
 
     // randomized erase until empty
-    std::random_shuffle(kvs.begin(), kvs.end());
+    std::shuffle(kvs.begin(), kvs.end(), std::default_random_engine{});
     for (auto& [k, v] : kvs) {
       auto e_size = with_trans_intr(*ref_t, [this, &k=k](auto& tr) {
         return tree->erase(tr, k);


### PR DESCRIPTION
crimson/os: rewrite ordering using std::strong_ordering

the goals are

1. to use std::strong_ordering mechinary for better readability
   and maintainbility
2. to remove unnecessary abstraction
3. use concept for better error message and readability.

changes:

* replace MatchKindCMP with std::strong_ordering
* replace compare_to() with operator<=>
* introduce a concept `IsFullKey` so we can use it when developing
  generic facilities to operate on both materialized key or view.
* use `IsFullKey` in place of `KeyT`.
* use type instead of `KeyT` when appropriate.
* use the constrained key type instead of `full_key_t<KT>`
  full_key_t<KT>`


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
