### PR TITLE
quincy: mgr/dashboard: remove token logging

### DIFF
--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -178,7 +178,6 @@ class AuthManagerTool(cherrypy.Tool):
     def _check_authentication(self):
         JwtManager.reset_user()
         token = JwtManager.get_token_from_header()
-        self.logger.debug("token: %s", token)
         if token:
             user = JwtManager.get_user(token)
             if user:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57009

---

backport of https://github.com/ceph/ceph/pull/47418
parent tracker: https://tracker.ceph.com/issues/57006

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh