### PR TITLE
rgw/cmake: add WITH_RADOSGW_URING to use asio's uring backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,6 +439,7 @@ option(WITH_RADOSGW_DBSTORE "DBStore backend for Rados Gateway" ON)
 option(WITH_RADOSGW_MOTR "CORTX-Motr backend for Rados Gateway" OFF)
 option(WITH_RADOSGW_DAOS "DAOS backend for RADOS Gateway" OFF)
 option(WITH_RADOSGW_SELECT_PARQUET "Support for s3 select on parquet objects" ON)
+option(WITH_RADOSGW_URING "Use io_uring backend for boost::asio" ON)
 
 option(WITH_SYSTEM_ARROW "Use system-provided arrow" OFF)
 option(WITH_SYSTEM_UTF8PROC "Use system-provided utf8proc" OFF)

--- a/cmake/modules/Finduring.cmake
+++ b/cmake/modules/Finduring.cmake
@@ -5,7 +5,7 @@
 # uring_FOUND - True if uring found.
 
 find_path(URING_INCLUDE_DIR liburing.h)
-find_library(URING_LIBRARIES liburing.a liburing)
+find_library(URING_LIBRARIES liburing.a liburing uring)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(uring DEFAULT_MSG URING_LIBRARIES URING_INCLUDE_DIR)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -367,6 +367,12 @@ target_link_libraries(rgw_a
     rgw_common
     spawn)
 
+if(WITH_RADOSGW_URING)
+  find_package(uring REQUIRED)
+  target_link_libraries(rgw_a PUBLIC uring::uring)
+  target_compile_definitions(rgw_a PUBLIC "-DBOOST_ASIO_HAS_IO_URING -DBOOST_ASIO_DISABLE_EPOLL")
+endif()
+
 if(WITH_CURL_OPENSSL)
   # used by rgw_http_client_curl.cc
   target_link_libraries(rgw_a PRIVATE OpenSSL::Crypto)

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -103,6 +103,12 @@ int main(int argc, char *argv[])
   DoutPrefix dp(cct.get(), dout_subsys, "rgw main: ");
   rgw::AppMain main(&dp);
 
+#if BOOST_ASIO_HAS_IO_URING_AS_DEFAULT
+  ldpp_dout(&dp, 1) << "Using io_uring backend" << dendl;
+#else
+  ldpp_dout(&dp, 1) << "Using epoll backend" << dendl;
+#endif
+
   main.init_frontends1(false /* nfs */);
   main.init_numa();
 


### PR DESCRIPTION
now that we've upgraded to boost 1.79, we can start experimenting with asio's io_uring backend

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
