### PR TITLE
pacific: librados: rados_ioctx_destroy check for initialized ioctx

### DIFF
--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -1157,7 +1157,9 @@ extern "C" void LIBRADOS_C_API_DEFAULT_F(rados_ioctx_destroy)(rados_ioctx_t io)
 {
   tracepoint(librados, rados_ioctx_destroy_enter, io);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
-  ctx->put();
+  if (ctx) {
+    ctx->put();
+  }
   tracepoint(librados, rados_ioctx_destroy_exit);
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_ioctx_destroy);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57029

---

backport of https://github.com/ceph/ceph/pull/47165
parent tracker: https://tracker.ceph.com/issues/55001

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh