### PR TITLE
cls/rgw_gc: cls config interface missing

### DIFF
--- a/src/cls/rgw_gc/cls_rgw_gc.cc
+++ b/src/cls/rgw_gc/cls_rgw_gc.cc
@@ -34,6 +34,7 @@ CLS_NAME(rgw_gc)
 static int cls_rgw_gc_queue_init(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
   auto in_iter = in->cbegin();
+  const ConfigProxy& conf = cls_get_config(hctx);
 
   cls_rgw_gc_queue_init_op op;
   try {
@@ -51,7 +52,7 @@ static int cls_rgw_gc_queue_init(cls_method_context_t hctx, bufferlist *in, buff
   CLS_LOG(10, "INFO: cls_rgw_gc_queue_init: queue size is %lu\n", op.size);
 
   init_op.queue_size = op.size;
-  init_op.max_urgent_data_size = g_ceph_context->_conf->rgw_gc_max_deferred_entries_size;
+  init_op.max_urgent_data_size = conf->rgw_gc_max_deferred_entries_size;
   encode(urgent_data, init_op.bl_urgent_data);
 
   return queue_init(hctx, init_op);


### PR DESCRIPTION
Missing config interface causing segmented fault
Signed-off-by: Nitzan Mordechai <nmordec@redhat.com>
