### PR TITLE
osd: Implement Context based completion for mon cmd to set a config option

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2028,7 +2028,7 @@ private:
                          int64_t onum,
                          double *elapsed,
                          std::ostream& ss);
-  int mon_cmd_set_config(const std::string &key, const std::string &val);
+  void mon_cmd_set_config(const std::string &key, const std::string &val);
   bool unsupported_objstore_for_qos();
 
   void scrub_purged_snaps();


### PR DESCRIPTION
The method, OSD::mon_cmd_set_config() currently sets a config option
related to mClock during OSD boot-up. The method used to wait on a
condition variable until the mon ack'ed the command. This was generally
not a problem.

But there could be scenarios where monitor could be slow to respond, or
due to a flaky network, response could be delayed. The OSD could therefore
be blocked from booting-up. To avoid this, the conditional wait can be
replaced with an async Context completion.

Moreover, persisting this in the monitor store is not very critical. An
existing fallback mechanism stores this value in the in-memory "values"
map of the config subsystem. This can be read by the OSD at any point
during its operation.

The issue of the OSDs being blocked from booting-up properly was
observed when running tests with failure injections during OSD boot-up.

Following are the changes:

The changes to mon_cmd_set_config() are generic and any osd specific
option may be set in the config monitor store using this method.

- Implement Context based completion tracking of the mon command using
  MonCmdSetConfigOnFinish which is derived from the base Context class.
  In case of failures, the finish() method is overriden to save the config
  option in the config subsystem's "values" map at CONF_DEFAULT level
  using set_val_default() method. This allows users to modify this at a
  later point using "ceph config set" cli command.

- Additionally, if requested, finish() also checks if the config option
  needs to be applied on each op shard and calls update_scheduler_config()
  on each shard. This is required for some config options related to the
  mClock scheduler.

Fixes: https://tracker.ceph.com/issues/57040
Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
