### PR TITLE
pacific: mgr/volumes: add interface to check the presence of subvolumegroups/subvolumes

### DIFF
--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -135,6 +135,16 @@ The output format is JSON and contains fields as follows.
 * created_at: time of creation of subvolume group in the format "YYYY-MM-DD HH:MM:SS"
 * data_pool: data pool the subvolume group belongs to
 
+Check the presence of any subvolume group using::
+
+    $ ceph fs subvolumegroup exist <vol_name>
+
+The strings returned by the 'exist' command:
+    * "subvolumegroup exists": if any subvolumegroup is present
+    * "no subvolumegroup exists": if no subvolumegroup is present
+
+.. note:: It checks for the presence of custom groups and not the default one. To validate the emptiness of the volume, subvolumegroup existence check alone is not sufficient. The subvolume existence also needs to be checked as there might be subvolumes in the default group.
+
 Resize a subvolume group using::
 
     $ ceph fs subvolumegroup resize <vol_name> <group_name> <new_size> [--no_shrink]
@@ -274,6 +284,14 @@ List subvolumes using::
     $ ceph fs subvolume ls <vol_name> [--group_name <subvol_group_name>]
 
 .. note:: subvolumes that are removed but have snapshots retained, are also listed.
+
+Check the presence of any subvolume using::
+
+    $ ceph fs subvolume exist <vol_name> [--group_name <subvol_group_name>]
+
+The strings returned by the 'exist' command:
+    * "subvolume exists": if any subvolume of given group_name is present
+    * "no subvolume exists": if no subvolume of given group_name is present
 
 Set custom metadata on the subvolume as a key-value pair using::
 

--- a/src/pybind/mgr/volumes/fs/fs_util.py
+++ b/src/pybind/mgr/volumes/fs/fs_util.py
@@ -78,6 +78,28 @@ def listdir(fs, dirpath, filter_entries=None):
         raise VolumeException(-e.args[0], e.args[1])
     return dirs
 
+
+def has_subdir(fs, dirpath, filter_entries=None):
+    """
+    Check the presence of directory (only dirs) for a given path
+    """
+    res = False
+    if filter_entries is None:
+        filter_entries = [b".", b".."]
+    else:
+        filter_entries.extend([b".", b".."])
+    try:
+        with fs.opendir(dirpath) as dir_handle:
+            d = fs.readdir(dir_handle)
+            while d:
+                if (d.d_name not in filter_entries) and d.is_dir():
+                    res = True
+                    break
+                d = fs.readdir(dir_handle)
+    except cephfs.Error as e:
+        raise VolumeException(-e.args[0], e.args[1])
+    return res
+
 def is_inherited_snap(snapname):
     """
     Returns True if the snapname is inherited else False

--- a/src/pybind/mgr/volumes/fs/operations/group.py
+++ b/src/pybind/mgr/volumes/fs/operations/group.py
@@ -8,7 +8,7 @@ import cephfs
 from .snapshot_util import mksnap, rmsnap
 from .pin_util import pin
 from .template import GroupTemplate
-from ..fs_util import listdir, listsnaps, get_ancestor_xattr, create_base_dir
+from ..fs_util import listdir, listsnaps, get_ancestor_xattr, create_base_dir, has_subdir
 from ..exception import VolumeException
 
 log = logging.getLogger(__name__)
@@ -61,6 +61,15 @@ class Group(GroupTemplate):
             # listing a default group when it's not yet created
             if ve.errno == -errno.ENOENT and self.is_default_group():
                 return []
+            raise
+
+    def has_subvolumes(self):
+        try:
+            return has_subdir(self.fs, self.path)
+        except VolumeException as ve:
+            # listing a default group when it's not yet created
+            if ve.errno == -errno.ENOENT and self.is_default_group():
+                return False
             raise
 
     def pin(self, pin_type, pin_setting):

--- a/src/pybind/mgr/volumes/fs/vol_spec.py
+++ b/src/pybind/mgr/volumes/fs/vol_spec.py
@@ -1,4 +1,9 @@
 import os
+from .operations.index import Index
+from .operations.group import Group
+from .operations.trash import Trash
+from .operations.versions.subvolume_base import SubvolumeBase
+
 
 class VolSpec(object):
     """
@@ -11,6 +16,8 @@ class VolSpec(object):
     DEFAULT_NS_PREFIX = "fsvolumens_"
     # default mode for subvol prefix and group
     DEFAULT_MODE = 0o755
+    # internal directories
+    INTERNAL_DIRS = [Group.NO_GROUP_NAME, Index.GROUP_NAME, Trash.GROUP_NAME, SubvolumeBase.LEGACY_CONF_DIR]
 
     def __init__(self, snapshot_prefix, subvolume_prefix=None, pool_ns_prefix=None):
         self.snapshot_prefix = snapshot_prefix

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -99,6 +99,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'perm': 'rw'
         },
         {
+            'cmd': 'fs subvolumegroup exist '
+                   'name=vol_name,type=CephString ',
+            'desc': "Check a volume for the existence of subvolumegroup",
+            'perm': 'r'
+        },
+        {
             'cmd': 'fs subvolume ls '
                    'name=vol_name,type=CephString '
                    'name=group_name,type=CephString,req=false ',
@@ -195,6 +201,14 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=group_name,type=CephString,req=false ',
             'desc': "Get the information of a CephFS subvolume in a volume, "
                     "and optionally, in a specific subvolume group",
+            'perm': 'r'
+        },
+        {
+            'cmd': 'fs subvolume exist '
+                   'name=vol_name,type=CephString '
+                   'name=group_name,type=CephString,req=false ',
+            'desc': "Check a volume for the existence of a subvolume, "
+                    "optionally in a specified subvolume group",
             'perm': 'r'
         },
         {
@@ -549,6 +563,10 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.vc.list_subvolume_groups(vol_name=cmd['vol_name'])
 
     @mgr_cmd_wrap
+    def _cmd_fs_subvolumegroup_exist(self, inbuf, cmd):
+        return self.vc.subvolume_group_exists(vol_name=cmd['vol_name'])
+
+    @mgr_cmd_wrap
     def _cmd_fs_subvolume_create(self, inbuf, cmd):
         """
         :return: a 3-tuple of return code(int), empty string(str), error message (str)
@@ -638,6 +656,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                       sub_name=cmd['sub_name'],
                                       group_name=cmd.get('group_name', None))
 
+    @mgr_cmd_wrap
+    def _cmd_fs_subvolume_exist(self, inbuf, cmd):
+        return self.vc.subvolume_exists(vol_name=cmd['vol_name'],
+                                        group_name=cmd.get('group_name', None))
+    
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_metadata_set(self, inbuf, cmd):
         return self.vc.set_user_metadata(vol_name=cmd['vol_name'],


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57041

---

backport of https://github.com/ceph/ceph/pull/46876
parent tracker: https://tracker.ceph.com/issues/55821

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh