### PR TITLE
dokan: cast variable to the expected type before comparison

### DIFF
--- a/src/dokan/ceph_dokan.cc
+++ b/src/dokan/ceph_dokan.cc
@@ -954,7 +954,7 @@ int do_map() {
           <<". Mountpoint: " << to_string(g_cfg->mountpoint) << dendl;
 
   DWORD status = DokanMain(dokan_options, dokan_operations);
-  switch (status) {
+  switch (static_cast<int>(status)) {
   case DOKAN_SUCCESS:
     dout(2) << "Dokan has returned successfully" << dendl;
     break;

--- a/src/dokan/dbg.cc
+++ b/src/dokan/dbg.cc
@@ -139,7 +139,7 @@ void print_open_params(
   check_flag(o, FlagsAndAttributes, SECURITY_EFFECTIVE_ONLY);
   check_flag(o, FlagsAndAttributes, SECURITY_SQOS_PRESENT);
 
-  o << "\n\tIsDirectory: " << (DokanFileInfo->IsDirectory != NULL);
+  o << "\n\tIsDirectory: " << static_cast<bool>(DokanFileInfo->IsDirectory);
 
   o << "\n\tCreateOptions: " << hex << CreateOptions << " ";
   check_flag(o, CreateOptions, FILE_DIRECTORY_FILE);


### PR DESCRIPTION
to fix the FTBFS due to following warning:

```
/home/jenkins-build/build/workspace/ceph-windows-pull-requests/ceph/build.deps/src/dokany/dokan/dokan.h:723:22: error: narrowing conversion of '-1' from 'int' to 'long unsigned int' [-Wnarrowing]
  723 | #define DOKAN_ERROR -1
      |                      ^
```

also, clean up the following warning:

```
/home/jenkins-build/build/workspace/ceph-windows-pull-requests/ceph/src/dokan/dbg.cc:142:62: warning: NULL used in arithmetic [-Wpointer-arith]
  142 |   o << "\n\tIsDirectory: " << (DokanFileInfo->IsDirectory != NULL);
      |
```

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
