### PR TITLE
do_cmake:sh: use newer gcc if available

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -59,6 +59,19 @@ if type ccache > /dev/null 2>&1 ; then
     ARGS+=" -DWITH_CCACHE=ON"
 fi
 
+cxx_compiler="g++"
+c_compiler="gcc"
+# 20 is used for more future-proof
+for i in $(seq 20 -1 11); do
+  if type -t gcc-$i > /dev/null; then
+    cxx_compiler="g++-$i"
+    c_compiler="gcc-$i"
+    break
+  fi
+done
+ARGS+=" -DCMAKE_CXX_COMPILER=$cxx_compiler"
+ARGS+=" -DCMAKE_C_COMPILER=$c_compiler"
+
 mkdir $BUILD_DIR
 cd $BUILD_DIR
 if type cmake3 > /dev/null 2>&1 ; then


### PR DESCRIPTION
despite that we are using clang in `run-make-check.sh`, `do_cmake.sh`
is still used by some workflows like jenkins' ceph-pr-api job.
now that we've migrated to C++20, we need to use GCC-11 or up for
building the tree. GCC-11 is installed from PPA repo in
`install-deps.sh`, but to avoid interfere with the build of older
branches which do not use GCC-11, as their builds might break if
we use GCC-11 for building them. we don't use the alternative machinary
to point gcc to gcc-11, see 8f342a32ce4a236c45c67497ae34f508e032a9e1.

so, in this change, we try to use the newest GCC in system when
running `do_cmake.sh`.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
