### PR TITLE
.github/workflows: add create-backport action

### DIFF
--- a/.github/workflows/create-backport-trackers.yml
+++ b/.github/workflows/create-backport-trackers.yml
@@ -1,0 +1,50 @@
+---
+name: Create backport trackers for trackers in "Pending Backport" state
+on:
+  # To manually trigger this: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      issues:
+        description: 'whitespace-separated list of issue numbers'
+        type: string
+        default: ''      
+      debug:
+        description: '--debug: Show debug-level messages'
+        default: false
+        type: boolean
+      resolveParent:
+        description: '--resolve-parent: Resolve parent issue if all backports resolved/rejected'
+        default: false
+        type: boolean
+      force:
+        description: >
+          --force: When issue numbers provided, process them even if not in
+          'Pending Backport' status.
+          Otherwise, process all issues in 'Pending Backport' status even if
+          already processed (tag 'backport_processed' added)'
+        default: false
+        type: boolean
+      dryRun:
+        description: '--dry-run: Do not write anything to Redmine'
+        default: false
+        type: boolean
+  schedule:
+    # Every 5 minutes: https://crontab.guru/every-5-minutes
+    - cron: '*/5 * * * *'
+jobs:
+  create-backports:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: Bhacaz/checkout-files@e3e34e7daef91a5f237485bb88a260aee4be29dd
+        with:
+          files: src/script/backport-create-issue src/script/requirements.backport-create-issue.txt
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '>=3.6'
+          cache: 'pip'
+          cache-dependency-path: src/script/requirements.backport-create-issue.txt
+      - run: pip install -r src/script/requirements.backport-create-issue.txt
+      - run: python3 src/script/backport-create-issue ${{ inputs.debug && '--debug' || '' }} ${{ inputs.resolveParent && '--resolve-parent' || '' }} ${{ inputs.force && '--force' || '' }} ${{ inputs.dryRun && '--dry-run' || '' }} ${{ inputs.issues }}
+        env:
+          REDMINE_API_KEY: ${{ secrets.REDMINE_API_KEY_BACKPORT_BOT }}

--- a/src/script/backport-create-issue
+++ b/src/script/backport-create-issue
@@ -39,8 +39,12 @@ from redminelib.exceptions import ResourceAttrError
 redmine_endpoint = "https://tracker.ceph.com"
 project_name = "Ceph"
 release_id = 16
+custom_field_tag = 'cf_3'
+tag_separator = ' '
+tag_backport_processed = 'backport_processed'
 delay_seconds = 5
 redmine_key_file="~/.redmine_key"
+redmine_key_env="REDMINE_API_KEY"
 #
 # NOTE: release_id is hard-coded because
 # http://www.redmine.org/projects/redmine/wiki/Rest_CustomFields
@@ -60,11 +64,12 @@ resolve_parent = None
 
 def usage():
     logging.error("Redmine credentials are required to perform this operation. "
-                  "Please provide either a Redmine key (via %s) "
+                  "Please provide either a Redmine key (via %s or $%s) "
                   "or a Redmine username and password (via --user and --password). "
                   "Optionally, one or more issue numbers can be given via positional "
                   "argument(s). In the absence of positional arguments, the script "
-                  "will loop through all issues in Pending Backport status." % redmine_key_file)
+                  "will loop through all issues in Pending Backport status.",
+                  redmine_key_file, redmine_key_env)
     exit(-1)
 
 def parse_arguments():
@@ -78,9 +83,14 @@ def parse_arguments():
                         action="store_true")
     parser.add_argument("--dry-run", help="Do not write anything to Redmine",
                         action="store_true")
-    parser.add_argument("--force", help="Create backport issues even if status not Pending Backport",
+    parser.add_argument("--force", help="When issue numbers provided, process "
+                        "them even if not in 'Pending Backport' status. "
+                        "Otherwise, process all issues in 'Pending Backport' "
+                        "status even if already processed "
+                        f"(tag '{tag_backport_processed}' added)",
                         action="store_true")
     return parser.parse_args()
+
 
 def set_logging_level(a):
     if a.debug:
@@ -117,6 +127,9 @@ def connect_to_redmine(a):
     elif redmine_key:
         logging.info("Redmine key was read from '%s'; using it" % redmine_key_file)
         return Redmine(redmine_endpoint, key=redmine_key)
+    elif os.getenv(redmine_key_env):
+        logging.info("Redmine key was read from '$%s'; using it", redmine_key_env)
+        return Redmine(redmine_endpoint, key=os.getenv(redmine_key_env))
     else:
         usage()
 
@@ -285,6 +298,27 @@ def maybe_resolve(issue, backports, dry_run):
     else:
         logging.debug("Some backport issues are still unresolved: leaving parent issue open")
 
+
+def mark_as_processed(r, issue):
+    """
+    This script will add a custom Tag to indicate whether the tracker was
+    already processed for backport tracker creation.
+    """
+    custom_fields = list(issue['custom_fields'].values())
+    for i, field in enumerate(custom_fields):
+        if field['name'] == 'Tags':
+            if tag_backport_processed not in field['value']:
+                if field['value']:
+                    custom_fields[i]['value'] += (tag_separator +
+                                                  tag_backport_processed)
+                else:
+                    custom_fields[i]['value'] = tag_backport_processed
+                logging.info("%s adding tag '%s'", url(issue),
+                             tag_backport_processed)
+                r.issue.update(issue.id, custom_fields=custom_fields)
+                return
+
+
 def iterate_over_backports(r, issues, dry_run=False):
     counter = 0
     for issue in issues:
@@ -303,6 +337,8 @@ def iterate_over_backports(r, issues, dry_run=False):
         if len(issue['backports']) == 0:
             logging.error(url(issue) + " the backport field is empty")
         update_relations(r, issue, dry_run)
+        if not dry_run:
+            mark_as_processed(r, issue)
     print('                                     \r', end='', flush=True)
     logging.info("Processed {} issues".format(counter))
     return None
@@ -337,10 +373,20 @@ if __name__ == '__main__':
                                           issue_id=issue_list,
                                           status_id=pending_backport_status_id)
     else:
-        if args.force:
-            logging.warn("ignoring --force option, which can only be used with an explicit issue list")
-        issues = redmine.issue.filter(project_id=ceph_project_id,
-                                      status_id=pending_backport_status_id)
+        if args.force or args.resolve_parent:
+            if args.force:
+                logging.warn("--force option was given: ignoring '%s' tag!",
+                             tag_backport_processed)
+            issues = redmine.issue.filter(project_id=ceph_project_id,
+                                          status_id=pending_backport_status_id)
+        else:
+            # https://python-redmine.com/resources/issue.html#filter
+            issues = redmine.issue.filter(project_id=ceph_project_id,
+                                          status_id=pending_backport_status_id,
+                                          **{
+                                              custom_field_tag:
+                                              '!~' +
+                                              tag_backport_processed})
     if force_create:
         logging.info("Processing {} issues regardless of status"
                      .format(len(issues)))

--- a/src/script/requirements.backport-create-issue.txt
+++ b/src/script/requirements.backport-create-issue.txt
@@ -1,0 +1,1 @@
+python-redmine == 2.3.0


### PR DESCRIPTION
@batrick set up a cron job in a teuthology VM to run a script to find all trackers in "Pending Backport" and to create their corresponding backport trackers. This is done through the [Backport Bot](https://tracker.ceph.com/users/12172) Redmine account.

This PR intends to run this cron job task as a periodic Github Action. This would simplify the management and visibility of this.

[[Sample run in forked repo]](https://github.com/epuertat/ceph/runs/7723015524?check_suite_focus=true)

### From the CLI
```
usage: backport-create-issue [-h] [--user USER] [--password PASSWORD] [--resolve-parent] [--debug] [--dry-run]
                             [--force]
                             [issue_numbers [issue_numbers ...]]

positional arguments:
  issue_numbers        Issue number

optional arguments:
  -h, --help           show this help message and exit
  --user USER          Redmine user
  --password PASSWORD  Redmine password
  --resolve-parent     Resolve parent issue if all backports resolved/rejected
  --debug              Show debug-level messages
  --dry-run            Do not write anything to Redmine
  --force              When issue numbers provided, process them even if not in 'Pending Backport' status. Otherwise,
                       process all issues in 'Pending Backport' status even if already processed (tag
                       'backport_processed' added)
```

### From Github

![image](https://user-images.githubusercontent.com/37327689/183886972-cbf50084-7483-4c91-ab45-740d138d0cdd.png)

## Open questions:

- [x] Using Github's pip cache
- [x] Just checking out the Ceph repo (with fetch depth 0)  takes 1 minute. If this action is meant to run every 5 minutes, that's too much overhead (checking the 500 trackers in "Pending Backport" took another 4 minutes). There are a few alternatives:
  - [ ] ~Moving this to a separate repo (@ceph/scripts). It'd make total sense given many of these tools are always run from main, and it'd be a first step breaking down the monorepo.~
  - [x] Just curl-ing the 2-3 files required from the repo.
- [x] While the cron job is set to run every 5 mins, it seems that Github, based on current workload and other constraints, may relax that frequency. The actual period is closer to 20-25 mins than to 5.
- [x] It still takes 2.5 minutes to go through the 500s trackers in `Pending Backports` state. 90% of them don't require any action, as they have already been previously processed by this script. So we should 'mark' the trackers that have already been processed. Alternatives are:
	- [ ] ~New state: `Pending Backports` -> `Backports in Progress`~
	- [x] New tag: `backport_processed`.
- [x] Add support for script flags (debug, dry-run, force, resolve parent). 

Signed-off-by: Ernesto Puerta <37327689+epuertat@users.noreply.github.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
