### PR TITLE
crimson/os/seastore: introduce JournalTrimmer with refactors

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -861,9 +861,6 @@ public:
   void update_journal_tails(
       journal_seq_t dirty_tail, journal_seq_t alloc_tail) final;
 
-  using release_ertr = SegmentManagerGroup::release_ertr;
-  release_ertr::future<> maybe_release_segment(Transaction &t);
-
   void adjust_segment_util(double old_usage, double new_usage) {
     auto old_index = get_bucket_index(old_usage);
     auto new_index = get_bucket_index(new_usage);

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -267,9 +267,9 @@ private:
 std::ostream &operator<<(std::ostream &, const segments_info_t &);
 
 /**
- * Callback interface for managing available segments
+ * Callback interface for journal trimming
  */
-class SegmentProvider {
+class JournalTrimmer {
 public:
   // get the committed journal head
   virtual journal_seq_t get_journal_head() const = 0;
@@ -292,6 +292,14 @@ public:
   virtual void update_journal_tails(
       journal_seq_t dirty_tail, journal_seq_t alloc_tail) = 0;
 
+  virtual ~JournalTrimmer() {}
+};
+
+/**
+ * Callback interface for managing available segments
+ */
+class SegmentProvider {
+public:
   virtual const segment_info_t& get_seg_info(segment_id_t id) const = 0;
 
   virtual segment_id_t allocate_segment(
@@ -519,7 +527,7 @@ public:
 };
 
 
-class AsyncCleaner : public SegmentProvider {
+class AsyncCleaner : public SegmentProvider, public JournalTrimmer {
 public:
   /// Config
   struct config_t {

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -27,6 +27,7 @@ namespace crimson::os::seastore {
 
 class BackrefManager;
 class AsyncCleaner;
+class SegmentProvider;
 
 struct backref_entry_t {
   backref_entry_t(
@@ -680,6 +681,18 @@ public:
   );
 
   /**
+   * set_segment_provider
+   *
+   * Set to provide segment information to help identify out-dated delta.
+   *
+   * FIXME: This is specific to the segmented implementation
+   */
+  void set_segment_provider(SegmentProvider &sp) {
+    assert(segment_provider == nullptr);
+    segment_provider = &sp;
+  }
+
+  /**
    * prepare_record
    *
    * Construct the record for Journal from transaction.
@@ -967,6 +980,9 @@ private:
   ExtentIndex extents;             ///< set of live extents
 
   journal_seq_t last_commit = JOURNAL_SEQ_MIN;
+
+  // FIXME: This is specific to the segmented implementation
+  SegmentProvider *segment_provider = nullptr;
 
   /**
    * dirty

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -699,7 +699,8 @@ public:
    */
   record_t prepare_record(
     Transaction &t, ///< [in, out] current transaction
-    SegmentProvider *cleaner
+    const journal_seq_t &journal_head,
+    const journal_seq_t &journal_dirty_tail
   );
 
   /**

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -14,7 +14,7 @@ SegmentedOolWriter::SegmentedOolWriter(
   reclaim_gen_t gen,
   SegmentProvider& sp,
   SegmentSeqAllocator &ssa)
-  : segment_allocator(segment_type_t::OOL, category, gen, sp, ssa),
+  : segment_allocator(nullptr, category, gen, sp, ssa),
     record_submitter(crimson::common::get_conf<uint64_t>(
                        "seastore_journal_iodepth_limit"),
                      crimson::common::get_conf<uint64_t>(

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -250,10 +250,6 @@ public:
       return crimson::do_for_each(md_writers_by_gen, [](auto &writer) {
         return writer->close();
       });
-    }).safe_then([this] {
-      devices_by_id.clear();
-      devices_by_id.resize(DEVICE_ID_MAX, nullptr);
-      primary_device = nullptr;
     });
   }
 

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -7,16 +7,19 @@
 
 namespace crimson::os::seastore::journal {
 
-JournalRef make_segmented(SegmentProvider &provider)
+JournalRef make_segmented(
+  SegmentProvider &provider,
+  JournalTrimmer &trimmer)
 {
-  return std::make_unique<SegmentedJournal>(provider);
+  return std::make_unique<SegmentedJournal>(provider, trimmer);
 }
 
 JournalRef make_circularbounded(
+  JournalTrimmer &trimmer,
   crimson::os::seastore::random_block_device::RBMDevice* device,
   std::string path)
 {
-  return std::make_unique<CircularBoundedJournal>(device, path);
+  return std::make_unique<CircularBoundedJournal>(trimmer, device, path);
 }
 
 }

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -17,6 +17,7 @@ class RBMDevice;
 
 class SegmentManagerGroup;
 class SegmentProvider;
+class JournalTrimmer;
 
 enum class journal_type_t {
   SEGMENT_JOURNAL = 0,
@@ -25,6 +26,7 @@ enum class journal_type_t {
 
 class Journal {
 public:
+  virtual JournalTrimmer &get_trimmer() = 0;
   /**
    * initializes journal for mkfs writes -- must run prior to calls
    * to submit_record.
@@ -108,9 +110,12 @@ using JournalRef = std::unique_ptr<Journal>;
 
 namespace journal {
 
-JournalRef make_segmented(SegmentProvider &provider);
+JournalRef make_segmented(
+  SegmentProvider &provider,
+  JournalTrimmer &trimmer);
 
 JournalRef make_circularbounded(
+  JournalTrimmer &trimmer,
   crimson::os::seastore::random_block_device::RBMDevice* device,
   std::string path);
 

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.cc
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.cc
@@ -5,6 +5,7 @@
 
 #include "crimson/common/errorator-loop.h"
 #include "include/intarith.h"
+#include "crimson/os/seastore/async_cleaner.h"
 #include "crimson/os/seastore/journal/circular_bounded_journal.h"
 #include "crimson/os/seastore/logging.h"
 
@@ -24,9 +25,11 @@ std::ostream &operator<<(std::ostream &out,
              << ")";
 }
 
-CircularBoundedJournal::CircularBoundedJournal(RBMDevice* device,
+CircularBoundedJournal::CircularBoundedJournal(
+    JournalTrimmer &trimmer,
+    RBMDevice* device,
     const std::string &path)
-  : device(device), path(path) {}
+  : trimmer(trimmer), device(device), path(path) {}
 
 CircularBoundedJournal::mkfs_ret
 CircularBoundedJournal::mkfs(const mkfs_config_t& config)
@@ -236,6 +239,7 @@ CircularBoundedJournal::submit_record_ret CircularBoundedJournal::submit_record(
       paddr,
       write_result
     };
+    trimmer.set_journal_head(write_result.start_seq);
     return submit_result;
   });
 }

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.h
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.h
@@ -20,7 +20,6 @@
 #include "crimson/os/seastore/random_block_manager/rbm_device.h"
 #include <list>
 
-
 namespace crimson::os::seastore::journal {
 
 constexpr rbm_abs_addr CBJOURNAL_START_ADDRESS = 0;
@@ -77,8 +76,13 @@ public:
     }
   };
 
-  CircularBoundedJournal(RBMDevice* device, const std::string &path);
+  CircularBoundedJournal(
+      JournalTrimmer &trimmer, RBMDevice* device, const std::string &path);
   ~CircularBoundedJournal() {}
+
+  JournalTrimmer &get_trimmer() final {
+    return trimmer;
+  }
 
   open_for_mkfs_ret open_for_mkfs() final;
 
@@ -280,6 +284,7 @@ public:
 
 private:
   cbj_header_t header;
+  JournalTrimmer &trimmer;
   RBMDevice* device;
   std::string path;
   WritePipeline *write_pipeline = nullptr;

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.h
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.h
@@ -277,9 +277,7 @@ public:
   rbm_abs_addr get_journal_end() const {
     return get_start_addr() + header.size + get_block_size(); // journal size + header length
   }
-  void add_device(RBMDevice* dev) {
-    device = dev;
-  }
+
 private:
   cbj_header_t header;
   RBMDevice* device;

--- a/src/crimson/os/seastore/journal/segment_allocator.h
+++ b/src/crimson/os/seastore/journal/segment_allocator.h
@@ -16,6 +16,7 @@
 
 namespace crimson::os::seastore {
   class SegmentProvider;
+  class JournalTrimmer;
 }
 
 namespace crimson::os::seastore::journal {
@@ -30,7 +31,7 @@ class SegmentAllocator {
       crimson::ct_error::input_output_error>;
 
  public:
-  SegmentAllocator(segment_type_t type,
+  SegmentAllocator(JournalTrimmer *trimmer,
                    data_category_t category,
                    reclaim_gen_t gen,
                    SegmentProvider &sp,
@@ -128,7 +129,7 @@ class SegmentAllocator {
   seastore_off_t written_to;
   SegmentSeqAllocator &segment_seq_allocator;
   segment_nonce_t current_segment_nonce;
-  //3. journal tail written to both segment_header_t and segment_tail_t
+  JournalTrimmer *trimmer;
 };
 
 /**

--- a/src/crimson/os/seastore/journal/segmented_journal.h
+++ b/src/crimson/os/seastore/journal/segmented_journal.h
@@ -24,8 +24,14 @@ namespace crimson::os::seastore::journal {
  */
 class SegmentedJournal : public Journal {
 public:
-  SegmentedJournal(SegmentProvider &segment_provider);
+  SegmentedJournal(
+      SegmentProvider &segment_provider,
+      JournalTrimmer &trimmer);
   ~SegmentedJournal() {}
+
+  JournalTrimmer &get_trimmer() final {
+    return trimmer;
+  }
 
   open_for_mkfs_ret open_for_mkfs() final;
 
@@ -55,11 +61,11 @@ private:
     OrderingHandle &handle
   );
 
-  SegmentProvider& segment_provider;
   SegmentSeqAllocatorRef segment_seq_allocator;
   SegmentAllocator journal_segment_allocator;
   RecordSubmitter record_submitter;
   SegmentManagerGroup &sm_group;
+  JournalTrimmer &trimmer;
   WritePipeline* write_pipeline = nullptr;
 
   /// return ordered vector of segments to replay

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -82,15 +82,7 @@ public:
     const std::string& root,
     MDStoreRef mdstore,
     DeviceRef device,
-    TransactionManagerRef tm,
-    CollectionManagerRef cm,
-    OnodeManagerRef om);
-  SeaStore(
-    const std::string& root,
-    DeviceRef device,
-    TransactionManagerRef tm,
-    CollectionManagerRef cm,
-    OnodeManagerRef om);
+    bool is_test);
   ~SeaStore();
     
   seastar::future<> stop() final;
@@ -331,14 +323,18 @@ private:
     const std::optional<std::string> &_start,
     OMapManager::omap_list_config_t config);
 
+  void init_managers();
+
   std::string root;
   MDStoreRef mdstore;
   DeviceRef device;
+  const uint32_t max_object_size = 0;
+  bool is_test;
+
   std::vector<DeviceRef> secondaries;
   TransactionManagerRef transaction_manager;
   CollectionManagerRef collection_manager;
   OnodeManagerRef onode_manager;
-  const uint32_t max_object_size = 0;
 
   using tm_iertr = TransactionManager::base_iertr;
   using tm_ret = tm_iertr::future<>;
@@ -447,4 +443,8 @@ private:
 seastar::future<std::unique_ptr<SeaStore>> make_seastore(
   const std::string &device,
   const ConfigValues &config);
+
+std::unique_ptr<SeaStore> make_test_seastore(
+  DeviceRef device,
+  SeaStore::MDStoreRef mdstore);
 }

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -226,15 +226,6 @@ public:
     }
   }
 
-  void mark_segment_to_release(segment_id_t segment) {
-    assert(to_release == NULL_SEG_ID);
-    to_release = segment;
-  }
-
-  segment_id_t get_segment_to_release() const {
-    return to_release;
-  }
-
   auto get_delayed_alloc_list() {
     std::list<LogicalCachedExtentRef> ret;
     for (auto& extent : delayed_alloc_list) {
@@ -363,7 +354,6 @@ public:
     backref_tree_stats = {};
     ool_write_stats = {};
     rewrite_version_stats = {};
-    to_release = NULL_SEG_ID;
     conflicted = false;
     if (!has_reset) {
       has_reset = true;
@@ -518,9 +508,6 @@ private:
   tree_stats_t backref_tree_stats;
   ool_write_stats_t ool_write_stats;
   version_stat_t rewrite_version_stats;
-
-  ///< if != NULL_SEG_ID, release this segment after completion
-  segment_id_t to_release = NULL_SEG_ID;
 
   bool conflicted = false;
 

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -389,9 +389,6 @@ TransactionManager::submit_transaction_direct(
       async_cleaner->update_journal_tails(
 	cache->get_oldest_dirty_from().value_or(start_seq),
 	cache->get_oldest_backref_dirty_from().value_or(start_seq));
-      return async_cleaner->maybe_release_segment(tref);
-    }).safe_then([FNAME, &tref] {
-      SUBTRACET(seastore_t, "completed", tref);
       return tref.get_handle().complete();
     }).handle_error(
       submit_transaction_iertr::pass_further{},

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -335,7 +335,10 @@ TransactionManager::submit_transaction_direct(
       cache->trim_backref_bufs(*trim_alloc_to);
     }
 
-    auto record = cache->prepare_record(tref, async_cleaner.get());
+    auto record = cache->prepare_record(
+      tref,
+      async_cleaner->get_journal_head(),
+      async_cleaner->get_dirty_tail());
 
     tref.get_handle().maybe_release_collection_lock();
 

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -654,6 +654,10 @@ TransactionManagerRef make_transaction_manager(
     *backref_manager,
     cleaner_is_detailed);
 
+  if (primary_device->get_device_type() == device_type_t::SEGMENTED) {
+    cache->set_segment_provider(*async_cleaner);
+  }
+
   auto p_device_type = primary_device->get_device_type();
   JournalRef journal;
   if (p_device_type == device_type_t::SEGMENTED) {

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -624,7 +624,7 @@ TransactionManager::~TransactionManager() {}
 TransactionManagerRef make_transaction_manager(tm_make_config_t config)
 {
   LOG_PREFIX(make_transaction_manager);
-  auto epm = std::make_unique<ExtentPlacementManager>(config.epm_prefer_ool);
+  auto epm = std::make_unique<ExtentPlacementManager>();
   auto cache = std::make_unique<Cache>(*epm);
   auto lba_manager = lba_manager::create_lba_manager(*cache);
   auto sms = std::make_unique<SegmentManagerGroup>();

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -37,14 +37,11 @@ class Journal;
 struct tm_make_config_t {
   bool is_test;
   journal_type_t j_type;
-  bool epm_prefer_ool;
-  reclaim_gen_t default_generation;
 
   static tm_make_config_t get_default() {
     return tm_make_config_t {
       false,
-      journal_type_t::SEGMENT_JOURNAL,
-      false
+      journal_type_t::SEGMENT_JOURNAL
     };
   }
   static tm_make_config_t get_test_segmented_journal() {
@@ -52,8 +49,7 @@ struct tm_make_config_t {
     SUBWARN(seastore_tm, "test mode enabled!");
     return tm_make_config_t {
       true,
-      journal_type_t::SEGMENT_JOURNAL,
-      false
+      journal_type_t::SEGMENT_JOURNAL
     };
   }
   static tm_make_config_t get_test_cb_journal() {
@@ -61,8 +57,7 @@ struct tm_make_config_t {
     SUBWARN(seastore_tm, "test mode enabled!");
     return tm_make_config_t {
       true,
-      journal_type_t::CIRCULARBOUNDED_JOURNAL,
-      true
+      journal_type_t::CIRCULARBOUNDED_JOURNAL
     };
   }
 
@@ -71,10 +66,8 @@ struct tm_make_config_t {
 private:
   tm_make_config_t(
     bool is_test,
-    journal_type_t j_type,
-    bool epm_prefer_ool)
-    : is_test(is_test), j_type(j_type),
-      epm_prefer_ool(epm_prefer_ool)
+    journal_type_t j_type)
+    : is_test(is_test), j_type(j_type)
   {}
 };
 

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -131,13 +131,12 @@ seastar::future<bufferlist> TMDriver::read(
 
 void TMDriver::init()
 {
+  std::vector<Device*> sec_devices;
 #ifndef NDEBUG
-  tm = make_transaction_manager(
-      tm_make_config_t::get_test_segmented_journal());
+  tm = make_transaction_manager(device.get(), sec_devices, true);
 #else
-  tm = make_transaction_manager(tm_make_config_t::get_default());
+  tm = make_transaction_manager(device.get(), sec_devices, false);
 #endif
-  tm->add_device(device.get(), true);
 }
 
 void TMDriver::clear()

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -84,7 +84,6 @@ struct fltree_onode_manager_test_t
   virtual FuturizedStore::mkfs_ertr::future<> _mkfs() final {
     return TMTestState::_mkfs(
     ).safe_then([this] {
-      tm->add_device(segment_manager.get(), true);
       return tm->mount(
       ).safe_then([this] {
 	return repeat_eagain([this] {

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -94,7 +94,7 @@ struct btree_test_base :
   virtual void complete_commit(Transaction &t) {}
   seastar::future<> submit_transaction(TransactionRef t)
   {
-    auto record = cache->prepare_record(*t, this);
+    auto record = cache->prepare_record(*t, JOURNAL_SEQ_NULL, JOURNAL_SEQ_NULL);
     return journal->submit_record(std::move(record), t->get_handle()).safe_then(
       [this, t=std::move(t)](auto submit_result) mutable {
 	cache->complete_commit(

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -115,7 +115,7 @@ struct btree_test_base :
     }).safe_then([this] {
       sms.reset(new SegmentManagerGroup());
       journal = journal::make_segmented(*this);
-      epm.reset(new ExtentPlacementManager(false));
+      epm.reset(new ExtentPlacementManager());
       cache.reset(new Cache(*epm));
 
       block_size = segment_manager->get_block_size();

--- a/src/test/crimson/seastore/test_cbjournal.cc
+++ b/src/test/crimson/seastore/test_cbjournal.cc
@@ -121,9 +121,6 @@ struct entry_validator_t {
 
 struct cbjournal_test_t : public seastar_test_suite_t
 {
-  segment_manager::EphemeralSegmentManagerRef segment_manager; // Need to be deleted, just for Cache
-  ExtentPlacementManagerRef epm;
-  Cache cache;
   std::vector<entry_validator_t> entries;
   std::unique_ptr<CircularBoundedJournal> cbj;
   random_block_device::RBMDevice *device;
@@ -133,11 +130,7 @@ struct cbjournal_test_t : public seastar_test_suite_t
   CircularBoundedJournal::mkfs_config_t config;
   WritePipeline pipeline;
 
-  cbjournal_test_t() :
-      segment_manager(segment_manager::create_test_ephemeral()),
-      epm(new ExtentPlacementManager(true)),
-      cache(*epm)
-  {
+  cbjournal_test_t() {
     device = new random_block_device::TestMemory(CBTEST_DEFAULT_TEST_SIZE + CBTEST_DEFAULT_BLOCK_SIZE);
     cbj.reset(new CircularBoundedJournal(device, std::string()));
     device_id_t d_id = 1 << (std::numeric_limits<device_id_t>::digits - 1);

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -88,7 +88,7 @@ struct cache_test_t : public seastar_test_suite_t {
       return segment_manager->mkfs(
         segment_manager::get_ephemeral_device_config(0, 1));
     }).safe_then([this] {
-      epm.reset(new ExtentPlacementManager(false));
+      epm.reset(new ExtentPlacementManager());
       cache.reset(new Cache(*epm));
       current = paddr_t::make_seg_paddr(segment_id_t(segment_manager->get_device_id(), 0), 0);
       epm->add_device(segment_manager.get(), true);

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -30,7 +30,7 @@ struct cache_test_t : public seastar_test_suite_t {
 
   seastar::future<paddr_t> submit_transaction(
     TransactionRef t) {
-    auto record = cache->prepare_record(*t, nullptr);
+    auto record = cache->prepare_record(*t, JOURNAL_SEQ_NULL, JOURNAL_SEQ_NULL);
 
     bufferlist bl;
     for (auto &&block : record.extents) {

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -75,9 +75,9 @@ struct transaction_manager_test_t :
   seastar::future<> set_up_fut() final {
     std::string j_type = GetParam();
     if (j_type == "segmented") {
-      return tm_setup(tm_make_config_t::get_test_segmented_journal());
+      return tm_setup(journal_type_t::SEGMENT_JOURNAL);
     } else if (j_type == "circularbounded") {
-      return tm_setup(tm_make_config_t::get_test_cb_journal());
+      return tm_setup(journal_type_t::CIRCULARBOUNDED_JOURNAL);
     } else {
       ceph_assert(0 == "no support");
     }


### PR DESCRIPTION
The refactor direction is to decouple `TransactionManager` and `Cache` from segment/random_block specific logic.

`AsyncCleaner` might also be moved from `TransactionManager` to `ExtentPlacementManager` to extend EPM to manage the heterogeneous device tiers.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
