### PR TITLE
pybind/mgr/dashboard: do not use distutils.version.StrictVersion

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -600,6 +600,7 @@ Group:          System/Filesystems
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-grafana-dashboards = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-prometheus-alerts = %{_epoch_prefix}%{version}-%{release}
+Requires:       python%{python3_pkgversion}-setuptools
 %if 0%{?fedora} || 0%{?rhel}
 Requires:       python%{python3_pkgversion}-cherrypy
 Requires:       python%{python3_pkgversion}-jwt

--- a/debian/ceph-mgr-dashboard.requires
+++ b/debian/ceph-mgr-dashboard.requires
@@ -5,6 +5,7 @@ PyJWT
 pyopenssl
 requests
 Routes
+pkg-resources
 prettytable
 pytest
 pyyaml

--- a/src/mypy-constrains.txt
+++ b/src/mypy-constrains.txt
@@ -12,6 +12,7 @@ types-PyYAML==5.4.0
 
 # src/pybind
 types-backports==0.1.2
+types-pkg_resources==0.1.3
 
 # qa/
 types-boto==0.1.0

--- a/src/pybind/mgr/dashboard/cherrypy_backports.py
+++ b/src/pybind/mgr/dashboard/cherrypy_backports.py
@@ -32,7 +32,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-from distutils.version import StrictVersion
+from pkg_resources import parse_version
 
 # The SSL code in CherryPy 3.5.0 is buggy.  It was fixed long ago,
 # but 3.5.0 is still shipping in major linux distributions
@@ -42,7 +42,7 @@ from distutils.version import StrictVersion
 def patch_http_connection_init(v):
     # It was fixed in 3.7.0.  Exact lower bound version is probably earlier,
     # but 3.5.0 is what this monkey patch is tested on.
-    if StrictVersion("3.5.0") <= v < StrictVersion("3.7.0"):
+    if parse_version("3.5.0") <= v < parse_version("3.7.0"):
         from cherrypy.wsgiserver.wsgiserver2 import CP_fileobject, HTTPConnection
 
         def fixed_init(hc_self, server, sock, makefile=CP_fileobject):
@@ -63,7 +63,7 @@ def patch_http_connection_init(v):
 def skip_wait_for_occupied_port(v):
     # the issue was fixed in 3.2.3. it's present in 3.2.2 (current version on
     # centos:7) and back to at least 3.0.0.
-    if StrictVersion("3.1.2") <= v < StrictVersion("3.2.3"):
+    if parse_version("3.1.2") <= v < parse_version("3.2.3"):
         # https://github.com/cherrypy/cherrypy/issues/1100
         from cherrypy.process import servers
         servers.wait_for_occupied_port = lambda host, port: None
@@ -71,7 +71,7 @@ def skip_wait_for_occupied_port(v):
 
 # cherrypy.wsgiserver was extracted wsgiserver into cheroot in cherrypy v9.0.0
 def patch_builtin_ssl_wrap(v, new_wrap):
-    if v < StrictVersion("9.0.0"):
+    if v < parse_version("9.0.0"):
         from cherrypy.wsgiserver.ssl_builtin import BuiltinSSLAdapter as builtin_ssl
     else:
         from cheroot.ssl.builtin import BuiltinSSLAdapter as builtin_ssl  # type: ignore
@@ -81,7 +81,7 @@ def patch_builtin_ssl_wrap(v, new_wrap):
 def accept_exceptions_from_builtin_ssl(v):
     # the fix was included by cheroot v5.2.0, which was included by cherrypy
     # 10.2.0.
-    if v < StrictVersion("10.2.0"):
+    if v < parse_version("10.2.0"):
         # see https://github.com/cherrypy/cheroot/pull/4
         import ssl
 
@@ -117,11 +117,11 @@ def accept_socket_error_0(v):
     # see https://github.com/cherrypy/cherrypy/issues/1618
     try:
         import cheroot
-        cheroot_version = cheroot.__version__
+        cheroot_version = parse_version(cheroot.__version__)
     except ImportError:
         pass
 
-    if v < StrictVersion("9.0.0") or cheroot_version < StrictVersion("6.5.5"):
+    if v < parse_version("9.0.0") or cheroot_version < parse_version("6.5.5"):
         generic_socket_error = OSError
 
         def accept_socket_error_0(func):
@@ -157,7 +157,7 @@ def patch_request_unique_id(v):
     Monkey-patching is preferred over alternatives as inheritance, as it'd break
     type checks (cherrypy/lib/cgtools.py: `isinstance(obj, _cprequest.Request)`)
     """
-    if v < StrictVersion('11.1.0'):
+    if v < parse_version('11.1.0'):
         import uuid
         from functools import update_wrapper
 
@@ -191,8 +191,9 @@ def patch_request_unique_id(v):
 
 
 def patch_cherrypy(v):
-    patch_http_connection_init(v)
-    skip_wait_for_occupied_port(v)
-    accept_exceptions_from_builtin_ssl(v)
-    accept_socket_error_0(v)
-    patch_request_unique_id(v)
+    ver = parse_version(v)
+    patch_http_connection_init(ver)
+    skip_wait_for_occupied_port(ver)
+    accept_exceptions_from_builtin_ssl(ver)
+    accept_socket_error_0(ver)
+    patch_request_unique_id(ver)

--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -10,3 +10,4 @@ prettytable
 pytest
 pyyaml
 natsort
+setuptools

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -113,6 +113,7 @@ deps =
     -c{toxinidir}/../../mypy-constrains.txt
     mypy
     types-backports
+    types-pkg_resources
     types-python-dateutil
     types-requests
     types-PyYAML


### PR DESCRIPTION
replace `distutils.version.StrictVersion` with
`packaging.version.Version`.

as the former is deprecated, see https://peps.python.org/pep-0632/.
let's use `pkg_resources` instead. this change also addresses
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1010894.
we have this issue when testing with an ubuntu jammy test node.
see https://bugs.launchpad.net/ubuntu/+source/ceph/+bug/1967139

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
