### PR TITLE
pacific: osd: remove invalid put on message

### DIFF
--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -156,8 +156,6 @@ void PGBackend::handle_recovery_delete(OpRequestRef op)
     [=](int r) {
       if (r != -EAGAIN) {
 	get_parent()->send_message_osd_cluster(reply, conn.get());
-      } else {
-	reply->put();
       }
     }));
   gather.activate();

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -557,7 +557,7 @@ public:
   }
   void send_message_osd_cluster(
     MessageRef m, Connection *con) override {
-    osd->send_message_osd_cluster(m, con);
+    osd->send_message_osd_cluster(std::move(m), con);
   }
   void send_message_osd_cluster(
     Message *m, const ConnectionRef& con) override {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57076

---

backport of https://github.com/ceph/ceph/pull/47379
parent tracker: https://tracker.ceph.com/issues/52124

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh