### PR TITLE
pacific: rgw: fix bug deleting a non-existent object also generates a delete marker

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4849,7 +4849,11 @@ void RGWDeleteObj::execute(optional_yield y)
         obj_size = astate->size;
         etag = astate->attrset[RGW_ATTR_ETAG].to_str();
       }
-
+      if(s->bucket->get_info().versioning_enabled()&&!s->object->have_instance()){
+        rgw_bucket_olh_entry olh;
+        op_ret = store->getRados()->bi_get_olh(this,s->bucket->get_info(),s->object->get_obj(),&olh);
+        if(op_ret < 0) return;
+      }
       // ignore return value from get_obj_attrs in all other cases
       op_ret = 0;
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->


fix:https://tracker.ceph.com/issues/56992
Signed-off-by: Yuxuan Yang [xuanyu.yang@sincerecloud.com](mailto:xuanyu.yang@sincerecloud.com)
I don't think rgw should create a delete marker for a non-existent object

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
