### PR TITLE
pacific: qa/import-legacy: install python3 package for nautilus ceph

### DIFF
--- a/qa/suites/fs/upgrade/volumes/import-legacy/tasks/0-nautilus.yaml
+++ b/qa/suites/fs/upgrade/volumes/import-legacy/tasks/0-nautilus.yaml
@@ -12,11 +12,12 @@ tasks:
       - ceph-mgr-cephadm
       - cephadm
       - ceph-immutable-object-cache
+    extra_packages:
+      - librados2
       - python3-rados
       - python3-rgw
       - python3-rbd
       - python3-cephfs
-    extra_packages: ['librados2']
 - print: "**** done installing nautilus"
 - ceph:
     log-ignorelist:

--- a/qa/suites/fs/upgrade/volumes/import-legacy/tasks/3-verify.yaml
+++ b/qa/suites/fs/upgrade/volumes/import-legacy/tasks/3-verify.yaml
@@ -14,12 +14,12 @@ tasks:
      - fs/upgrade/volume_client
    env:
      ACTION: verify
-   cleanup: false
+   cleanup: true
 - workunit:
    clients:
      client.1:
      - fs/upgrade/volume_client
    env:
      ACTION: verify
-   cleanup: false
+   cleanup: true
 - print: "**** fs/volume_client verify"


### PR DESCRIPTION
The 'volume_client' script will use the python3 and will import
the'ceph_volume_client' volume, we need to install the python3
packages when installing the nautilus ceph.

Or it will fail to generate the keyring contents for the
'client.vol_data_isolated', and then when authenticating from mon
the mon will only receive a corrupt payload.

Fixes: https://tracker.ceph.com/issues/57083
Signed-off-by: Xiubo Li <xiubli@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
