### PR TITLE
crimson/osd: process signal when osd stop for shutdown

### DIFF
--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -95,6 +95,7 @@ class OSD final : public crimson::net::Dispatcher,
   osd_stat_t osd_stat;
   uint32_t osd_stat_seq = 0;
   void update_stats();
+  void osd_check_down();
   MessageURef get_stats() const final;
 
   // AuthHandler methods


### PR DESCRIPTION
main function added wait for signals SIGINT and SIGTERM,
when mon command 'ceph osd stop' the osd didn't stopped since
OSD::stop function waited.

Signed-off-by: Nitzan Mordechai <nmordec@redhat.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
