### PR TITLE
cmake: find motr libraries and header before using them

### DIFF
--- a/cmake/modules/Findmotr.cmake
+++ b/cmake/modules/Findmotr.cmake
@@ -1,0 +1,50 @@
+# - Find libmotr
+# Find the motr and motrhl libraries and includes
+#
+# motr_INCLUDE_DIR - where to find motr.hpp etc.
+# motr_LIBRARIES - List of libraries when using motr.
+# motr_FOUND - True if motr found.
+
+find_package(PkgConfig QUIET REQUIRED)
+pkg_search_module(PC_motr QUIET motr)
+
+find_path(motr_INCLUDE_DIR
+  NAMES motr/config.h
+  HINTS ${PC_motr_INCLUDE_DIRS})
+find_library(motr_LIBRARY
+  NAMES motr
+  HINTS ${PC_motr_LIBRARY_DIRS})
+find_library(motr_helpers_LIBRARY
+  NAMES motr-helpers
+  HINTS ${PC_motr_LIBRARY_DIRS})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(motr
+  DEFAULT_MSG
+  motr_INCLUDE_DIR
+  motr_LIBRARY
+  motr_helpers_LIBRARY)
+
+mark_as_advanced(
+  motr_INCLUDE_DIR
+  motr_LIBRARY
+  motr_helpers_LIBRARY)
+
+if(motr_FOUND)
+  set(motr_LIBRARIES ${motr_LIBRARY} ${motr_helpers_LIBRARY})
+  if(NOT (TARGET motr::helpers))
+    add_library(motr::helpers UNKNOWN IMPORTED)
+    set_target_properties(motr::helpers PROPERTIES
+      IMPORTED_LOCATION "${motr_helpers_LIBRARY}")
+  endif()
+  if(NOT (TARGET motr::motr))
+    add_library(motr::motr UNKNOWN IMPORTED)
+    set_target_properties(motr::motr PROPERTIES
+      INTERFACE_COMPILE_DEFINITIONS "M0_EXTERN=extern;M0_INTERNAL="
+      INTERFACE_COMPILE_OPTIONS "-Wno-attributes"
+      INTERFACE_INCLUDE_DIRECTORIES "${motr_INCLUDE_DIR}"
+      INTERFACE_LINK_LIBRARIES motr::helpers
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${motr_LIBRARY}")
+  endif()
+endif()

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -264,11 +264,8 @@ if(WITH_RADOSGW_DBSTORE)
 endif()
 
 if(WITH_RADOSGW_MOTR)
-  target_include_directories(rgw_common PRIVATE "/usr/include/motr")
-  target_compile_options(rgw_common PRIVATE "-Wno-attributes")
-  target_compile_definitions(rgw_common
-    PRIVATE "M0_EXTERN=extern" "M0_INTERNAL=")
-  target_link_libraries(rgw_common PRIVATE motr motr-helpers)
+  find_package(motr REQUIRED)
+  target_link_libraries(rgw_common PRIVATE motr::motr)
 endif()
 
 set(rgw_a_srcs


### PR DESCRIPTION
cmake should fail when generating the building system, if the necessary
development libraries or the header files are missing.

in this change, Findmotr.cmake is added to detect the motr library
and header so that we can use it to find the motr package before using
it.

See-also: https://tracker.ceph.com/issues/57079
Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
