### PR TITLE
ceph.spec.in: %enable_devtoolset11 only if the macro is defined

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -122,6 +122,7 @@
 %{!?python3_pkgversion: %global python3_pkgversion 3}
 %{!?python3_version_nodots: %global python3_version_nodots 3}
 %{!?python3_version: %global python3_version 3}
+%{!?gts_prefix: %global gts_prefix gcc-toolset-11}
 
 %if ! 0%{?suse_version}
 # use multi-threaded xz compression: xz level 7 using ncpus threads
@@ -206,10 +207,10 @@ BuildRequires:	fuse-devel
 BuildRequires:	gcc-c++ >= 11
 %endif
 %if 0%{?rhel} >= 8
-BuildRequires:	gcc-toolset-11-gcc-c++
-BuildRequires:	gcc-toolset-11-build
+BuildRequires:	%{gts_prefix}-gcc-c++
+BuildRequires:	%{gts_prefix}-build
 %ifarch aarch64
-BuildRequires:	gcc-toolset-11-libatomic-devel
+BuildRequires:	%{gts_prefix}-libatomic-devel
 %endif
 %endif
 %if 0%{?fedora}
@@ -335,10 +336,10 @@ BuildRequires:  libubsan
 BuildRequires:  libasan
 %endif
 %if 0%{?rhel}
-BuildRequires:  gcc-toolset-11-annobin
-BuildRequires:  gcc-toolset-11-annobin-plugin-gcc
-BuildRequires:  gcc-toolset-11-libubsan-devel
-BuildRequires:  gcc-toolset-11-libasan-devel
+BuildRequires:  %{gts_prefix}-annobin
+BuildRequires:  %{gts_prefix}-annobin-plugin-gcc
+BuildRequires:  %{gts_prefix}-libubsan-devel
+BuildRequires:  %{gts_prefix}-libasan-devel
 %endif
 %endif
 #################################################################################

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -153,7 +153,7 @@
 # do not provide gcc-annobin.so anymore, despite that they provide annobin.so. but
 # redhat-rpm-config still passes -fplugin=gcc-annobin to the compiler.
 %undefine _annotated_build
-%if 0%{?rhel} >= 8
+%if 0%{?rhel} >= 8 && 0%{?enable_devtoolset11:1}
 %enable_devtoolset11
 %endif
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -154,7 +154,7 @@
 # do not provide gcc-annobin.so anymore, despite that they provide annobin.so. but
 # redhat-rpm-config still passes -fplugin=gcc-annobin to the compiler.
 %undefine _annotated_build
-%if 0%{?rhel} >= 8 && 0%{?enable_devtoolset11:1}
+%if 0%{?rhel} == 8 && 0%{?enable_devtoolset11:1}
 %enable_devtoolset11
 %endif
 
@@ -203,17 +203,17 @@ BuildRequires:	selinux-policy-devel
 BuildRequires:	gperf
 BuildRequires:  cmake > 3.5
 BuildRequires:	fuse-devel
-%if 0%{?fedora} || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel} == 9
 BuildRequires:	gcc-c++ >= 11
 %endif
-%if 0%{?rhel} >= 8
+%if 0%{?rhel} == 8
 BuildRequires:	%{gts_prefix}-gcc-c++
 BuildRequires:	%{gts_prefix}-build
 %ifarch aarch64
 BuildRequires:	%{gts_prefix}-libatomic-devel
 %endif
 %endif
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?rhel} == 9
 BuildRequires:  libatomic
 %endif
 %if 0%{with tcmalloc}
@@ -335,7 +335,7 @@ BuildRequires:  systemtap-sdt-devel
 BuildRequires:  libubsan
 BuildRequires:  libasan
 %endif
-%if 0%{?rhel}
+%if 0%{?rhel} == 8
 BuildRequires:  %{gts_prefix}-annobin
 BuildRequires:  %{gts_prefix}-annobin-plugin-gcc
 BuildRequires:  %{gts_prefix}-libubsan-devel


### PR DESCRIPTION
there is chance that we are using `yum-builddep` to prepare the
build dependencies. in that case, gcc-toolset-11-build is not
installed. it's like a chicken-egg dilemma, but the point is
`yum-builddep` is able to pull in the gcc-toolset-11-build. once
gcc-toolset-11-build is installed, we will have the %enable_devtoolset11
rpm macro.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
