### PR TITLE
mgr/cephadm: set dashboard grafana-api-password when user provides one

### DIFF
--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -78,7 +78,8 @@ class IngressService(CephService):
         password = self.mgr.get_store(pw_key)
         if password is None:
             if not spec.monitor_password:
-                password = ''.join(random.choice(string.ascii_lowercase) for _ in range(self.MAX_KEEPALIVED_PASS_LEN))
+                password = ''.join(random.choice(string.ascii_lowercase)
+                                   for _ in range(self.MAX_KEEPALIVED_PASS_LEN))
                 self.mgr.set_store(pw_key, password)
         else:
             if spec.monitor_password:
@@ -177,7 +178,8 @@ class IngressService(CephService):
         password = self.mgr.get_store(pw_key)
         if password is None:
             if not spec.keepalived_password:
-                password = ''.join(random.choice(string.ascii_lowercase) for _ in range(self.MAX_KEEPALIVED_PASS_LEN))
+                password = ''.join(random.choice(string.ascii_lowercase)
+                                   for _ in range(self.MAX_KEEPALIVED_PASS_LEN))
                 self.mgr.set_store(pw_key, password)
         else:
             if spec.keepalived_password:

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -79,6 +79,10 @@ class GrafanaService(CephadmService):
                 'http_addr': daemon_spec.ip if daemon_spec.ip else ''
             })
 
+        if 'dashboard' in self.mgr.get('mgr_map')['modules'] and spec.initial_admin_password:
+            self.mgr.check_mon_command(
+                {'prefix': 'dashboard set-grafana-api-password'}, inbuf=spec.initial_admin_password)
+
         config_file = {
             'files': {
                 "grafana.ini": grafana_ini,


### PR DESCRIPTION
If a user provides this in the spec, cephadm will set up the inital admin
user with the given password, but the conig setting accessed with
"ceph dashboard get-grafana-api-password" is never updated. Cephadm
can handle updating it since it's the one setting the password.

Fixes: https://tracker.ceph.com/issues/57095

Signed-off-by: Adam King <adking@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
