### PR TITLE
rgw: fix garbage in log line upon authentication failure w/ rgw_s3_au…

### DIFF
--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -328,7 +328,8 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
   ret = validate.process(null_yield);
   if (ret < 0) {
     ldpp_dout(dpp, 2) << "s3 keystone: token validation ERROR: "
-                  << token_body_bl.c_str() << dendl;
+                  << std::string(token_body_bl.c_str(),
+                                 token_body_bl.length()) << dendl;
     throw ret;
   }
 


### PR DESCRIPTION
…th_use_keystone

When s3 authentication against keystone fails, a log message is produced
that ends with a bl.c_str() string.  Typewise this is a char *, but it's not
a well-formatted C string because there is no guarantee it ends in a nul.
In practice, it frequently contains unrelated data from some previous
use of the memory.  This commit converts it into a std::string
using bl.length() to set the length right.

Fixes: https://tracker.ceph.com/issues/57093




