### PR TITLE
rgw: x-amz-date change breaks certain cases of aws sig v4.

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -220,8 +220,9 @@ bool rgw_create_s3_canonical_header(const DoutPrefixProvider *dpp,
 
     if (header_time) {
       struct tm t;
-      if (!parse_rfc2616(req_date, &t)) {
-        ldpp_dout(dpp, 0) << "NOTICE: failed to parse date for auth header" << dendl;
+      uint32_t ns = 0;
+      if (!parse_rfc2616(req_date, &t) && !parse_iso8601(req_date, &t, &ns, false)) {
+        ldpp_dout(dpp, 0) << "NOTICE: failed to parse date <" << req_date << "> for auth header" << dendl;
         return false;
       }
       if (t.tm_year < 70) {


### PR DESCRIPTION
Once upon a time, x-amz-date strings were in rfc 2616 format, and most
s3 clients are written to make this style of timestamp.  The current protocol
standard specifies iso 8601 timestamps (yyyymmddThhmmssZ), and client
libraries are changing to use this new format.

This change does two things: firstly, if the date parse fails, it logs
the actual offending timestamp for later analysis.  Secondly, if rfc
2616 fails, it tries iso 8601.  The new timestamp is tried secondarily,
because that lgoic also emits a (less useful) error message, which should
not be spamnificated for valid rfc 2616 timestamps.

Fixes: https://tracker.ceph.com/issues/57094
