### PR TITLE
install-deps: fix centos 8's use of gcc-toolset-11

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -209,9 +209,7 @@ BuildRequires:	gcc-c++ >= 11
 %if 0%{?rhel} == 8
 BuildRequires:	%{gts_prefix}-gcc-c++
 BuildRequires:	%{gts_prefix}-build
-%ifarch aarch64
 BuildRequires:	%{gts_prefix}-libatomic-devel
-%endif
 %endif
 %if 0%{?fedora} || 0%{?rhel} == 9
 BuildRequires:  libatomic

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -415,7 +415,7 @@ EOF
 		if test $ID = centos -a $MAJOR_VERSION = 8 ; then
                     # Enable 'powertools' or 'PowerTools' repo
                     $SUDO dnf config-manager --set-enabled $(dnf repolist --all 2>/dev/null|gawk 'tolower($0) ~ /^powertools\s/{print $1}')
-		    dts_ver=10
+		    dts_ver=11
 		    # before EPEL8 and PowerTools provide all dependencies, we use sepia for the dependencies
                     $SUDO dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
                     $SUDO dnf config-manager --setopt=apt-mirror.front.sepia.ceph.com_lab-extras_8_.gpgcheck=0 --save
@@ -425,7 +425,7 @@ EOF
 			  --enable rhel-server-rhscl-8-rpms \
 			  --enable rhel-8-server-optional-rpms \
 			  --enable rhel-8-server-devtools-rpms
-                    dts_ver=10
+                    dts_ver=11
                     $SUDO dnf config-manager --set-enabled "codeready-builder-for-rhel-8-${ARCH}-rpms"
 		    $SUDO dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
 		    $SUDO dnf config-manager --setopt=apt-mirror.front.sepia.ceph.com_lab-extras_8_.gpgcheck=0 --save

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -234,25 +234,22 @@ function version_lt {
 
 function ensure_decent_gcc_on_rh {
     local old=$(gcc -dumpversion)
-    local expected=10.2
     local dts_ver=$1
-    if version_lt $old $expected; then
+    if version_lt $old $dts_ver; then
 	if test -t 1; then
 	    # interactive shell
 	    cat <<EOF
 Your GCC is too old. Please run following command to add DTS to your environment:
 
-scl enable devtoolset-8 bash
+scl enable gcc-toolset-$dts_ver bash
 
-Or add following line to the end of ~/.bashrc to add it permanently:
+Or add the following line to the end of ~/.bashrc and run "source ~/.bashrc" to add it permanently:
 
-source scl_source enable devtoolset-8
-
-see https://www.softwarecollections.org/en/scls/rhscl/devtoolset-7/ for more details.
+source scl_source enable gcc-toolset-$dts_ver
 EOF
 	else
 	    # non-interactive shell
-	    source /opt/rh/devtoolset-$dts_ver/enable
+	    source /opt/rh/gcc-toolset-$dts_ver/enable
 	fi
     fi
 }

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -418,18 +418,7 @@ EOF
 		if test $ID = centos -a $MAJOR_VERSION = 8 ; then
                     # Enable 'powertools' or 'PowerTools' repo
                     $SUDO dnf config-manager --set-enabled $(dnf repolist --all 2>/dev/null|gawk 'tolower($0) ~ /^powertools\s/{print $1}')
-		    case "$ARCH" in
-			x86_64)
-			    $SUDO dnf -y install centos-release-scl
-			    dts_ver=10
-			    ;;
-			aarch64)
-			    $SUDO dnf -y install centos-release-scl-rh
-			    $SUDO dnf config-manager --disable centos-sclo-rh
-			    $SUDO dnf config-manager --enable centos-sclo-rh-testing
-			    dts_ver=10
-			    ;;
-		    esac
+		    dts_ver=10
 		    # before EPEL8 and PowerTools provide all dependencies, we use sepia for the dependencies
                     $SUDO dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
                     $SUDO dnf config-manager --setopt=apt-mirror.front.sepia.ceph.com_lab-extras_8_.gpgcheck=0 --save


### PR DESCRIPTION
removed steps to install the `centos-release-scl` packages. this was accidentally resurrected in 65b1a13139873c1525456e05cd00aeb64da4e881

updated the gcc version detection and error message to reflect the `gcc-toolset-11` packages installed from ceph.spec.in:
```
Your GCC is too old. Please run following command to add DTS to your environment:

scl enable gcc-toolset-11 bash

Or add following line to the end of ~/.bashrc to add it permanently:

source scl_source enable gcc-toolset-11
```

Fixes: https://tracker.ceph.com/issues/57073

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
