### PR TITLE
quincy: ceph.spec.in backports

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -39,7 +39,7 @@
 %if 0%{?rhel} < 9
 %bcond_with system_pmdk
 %else
-%ifarch s390x
+%ifarch s390x aarch64
 %bcond_with system_pmdk
 %else
 %bcond_without system_pmdk

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -153,7 +153,7 @@
 # do not provide gcc-annobin.so anymore, despite that they provide annobin.so. but
 # redhat-rpm-config still passes -fplugin=gcc-annobin to the compiler.
 %undefine _annotated_build
-%if 0%{?rhel} >= 8
+%if 0%{?rhel} >= 8 && 0%{?enable_devtoolset11:1}
 %enable_devtoolset11
 %endif
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -149,14 +149,12 @@
 %endif
 %endif
 
-%if 0%{with seastar}
 # disable -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1, as gcc-toolset-{10,11}-annobin
 # do not provide gcc-annobin.so anymore, despite that they provide annobin.so. but
 # redhat-rpm-config still passes -fplugin=gcc-annobin to the compiler.
 %undefine _annotated_build
-%if 0%{?enable_devtoolset11:1}
+%if 0%{?rhel} >= 8
 %enable_devtoolset11
-%endif
 %endif
 
 #################################################################################

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -211,6 +211,9 @@ BuildRequires:	gcc-toolset-11-build
 BuildRequires:	gcc-toolset-11-libatomic-devel
 %endif
 %endif
+%if 0%{?fedora}
+BuildRequires:  libatomic
+%endif
 %if 0%{with tcmalloc}
 # libprofiler did not build on ppc64le until 2.7.90
 %if 0%{?fedora} || 0%{?rhel} >= 8
@@ -323,7 +326,6 @@ BuildRequires:  systemtap-sdt-devel
 %if 0%{?fedora}
 BuildRequires:  libubsan
 BuildRequires:  libasan
-BuildRequires:  libatomic
 %endif
 %if 0%{?rhel}
 BuildRequires:  gcc-toolset-11-annobin

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -201,7 +201,7 @@ BuildRequires:	gperf
 BuildRequires:  cmake > 3.5
 BuildRequires:	fuse-devel
 %if 0%{with seastar} && 0%{?rhel}
-BuildRequires:	gcc-toolset-9-gcc-c++ >= 9.2.1-2.3
+BuildRequires:	gcc-toolset-10-gcc-c++ >= 10.3.1-1.2
 %else
 %if 0%{?suse_version}
 BuildRequires:	gcc11-c++
@@ -324,10 +324,10 @@ BuildRequires:  libasan
 BuildRequires:  libatomic
 %endif
 %if 0%{?rhel}
-BuildRequires:  gcc-toolset-9-annobin
-BuildRequires:  gcc-toolset-9-libubsan-devel
-BuildRequires:  gcc-toolset-9-libasan-devel
-BuildRequires:  gcc-toolset-9-libatomic-devel
+BuildRequires:  gcc-toolset-10-annobin
+BuildRequires:  gcc-toolset-10-libubsan-devel
+BuildRequires:  gcc-toolset-10-libasan-devel
+BuildRequires:  gcc-toolset-10-libatomic-devel
 %endif
 %endif
 #################################################################################
@@ -1259,7 +1259,7 @@ This package provides Ceph default alerts for Prometheus.
 %endif
 
 %if 0%{with seastar} && 0%{?rhel}
-. /opt/rh/gcc-toolset-9/enable
+. /opt/rh/gcc-toolset-10/enable
 %endif
 
 %if 0%{with cephfs_java}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -154,7 +154,7 @@
 # do not provide gcc-annobin.so anymore, despite that they provide annobin.so. but
 # redhat-rpm-config still passes -fplugin=gcc-annobin to the compiler.
 %undefine _annotated_build
-%if 0%{?rhel} >= 8 && 0%{?enable_devtoolset11:1}
+%if 0%{?rhel} == 8 && 0%{?enable_devtoolset11:1}
 %enable_devtoolset11
 %endif
 
@@ -202,17 +202,17 @@ BuildRequires:	selinux-policy-devel
 BuildRequires:	gperf
 BuildRequires:  cmake > 3.5
 BuildRequires:	fuse-devel
-%if 0%{?fedora} || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel} == 9
 BuildRequires:	gcc-c++ >= 11
 %endif
-%if 0%{?rhel} >= 8
+%if 0%{?rhel} == 8
 BuildRequires:	%{gts_prefix}-gcc-c++
 BuildRequires:	%{gts_prefix}-build
 %ifarch aarch64
 BuildRequires:	%{gts_prefix}-libatomic-devel
 %endif
 %endif
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?rhel} == 9
 BuildRequires:  libatomic
 %endif
 %if 0%{with tcmalloc}
@@ -328,7 +328,7 @@ BuildRequires:  systemtap-sdt-devel
 BuildRequires:  libubsan
 BuildRequires:  libasan
 %endif
-%if 0%{?rhel}
+%if 0%{?rhel} == 8
 BuildRequires:  %{gts_prefix}-annobin
 BuildRequires:  %{gts_prefix}-annobin-plugin-gcc
 BuildRequires:  %{gts_prefix}-libubsan-devel

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -201,7 +201,7 @@ BuildRequires:	gperf
 BuildRequires:  cmake > 3.5
 BuildRequires:	fuse-devel
 %if 0%{with seastar} && 0%{?rhel}
-BuildRequires:	gcc-toolset-10-gcc-c++ >= 10.3.1-1.2
+BuildRequires:	gcc-toolset-11-gcc-c++
 %else
 %if 0%{?suse_version}
 BuildRequires:	gcc11-c++
@@ -324,10 +324,10 @@ BuildRequires:  libasan
 BuildRequires:  libatomic
 %endif
 %if 0%{?rhel}
-BuildRequires:  gcc-toolset-10-annobin
-BuildRequires:  gcc-toolset-10-libubsan-devel
-BuildRequires:  gcc-toolset-10-libasan-devel
-BuildRequires:  gcc-toolset-10-libatomic-devel
+BuildRequires:  gcc-toolset-11-annobin-plugin-gcc
+BuildRequires:  gcc-toolset-11-libubsan-devel
+BuildRequires:  gcc-toolset-11-libasan-devel
+BuildRequires:  gcc-toolset-11-libatomic-devel
 %endif
 %endif
 #################################################################################
@@ -1259,7 +1259,7 @@ This package provides Ceph default alerts for Prometheus.
 %endif
 
 %if 0%{with seastar} && 0%{?rhel}
-. /opt/rh/gcc-toolset-10/enable
+. /opt/rh/gcc-toolset-11/enable
 %endif
 
 %if 0%{with cephfs_java}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1386,6 +1386,9 @@ cmake .. \
 %if 0%{with system_utf8proc}
     -DWITH_SYSTEM_UTF8PROC:BOOL=ON \
 %endif
+%if 0%{with seastar}
+    -DWITH_SEASTAR:BOOL=ON \
+%endif
     -DWITH_GRAFANA:BOOL=ON
 
 %if %{with cmake_verbose_logging}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -328,6 +328,7 @@ BuildRequires:  libasan
 BuildRequires:  libatomic
 %endif
 %if 0%{?rhel}
+BuildRequires:  gcc-toolset-11-annobin
 BuildRequires:  gcc-toolset-11-annobin-plugin-gcc
 BuildRequires:  gcc-toolset-11-libubsan-devel
 BuildRequires:  gcc-toolset-11-libasan-devel

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -203,15 +203,12 @@ BuildRequires:	selinux-policy-devel
 BuildRequires:	gperf
 BuildRequires:  cmake > 3.5
 BuildRequires:	fuse-devel
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?suse_version}
 BuildRequires:	gcc-c++ >= 11
 %endif
 %if 0%{?rhel} >= 8
 BuildRequires:	gcc-toolset-11-gcc-c++
 BuildRequires:	gcc-toolset-11-build
-%endif
-%if 0%{?suse_version}
-BuildRequires:	gcc11-c++
 %endif
 %if 0%{with tcmalloc}
 # libprofiler did not build on ppc64le until 2.7.90
@@ -1295,10 +1292,6 @@ env | sort
 mkdir -p %{_vpath_builddir}
 pushd %{_vpath_builddir}
 cmake .. \
-%if 0%{?suse_version}
-    -DCMAKE_C_COMPILER=gcc-11 \
-    -DCMAKE_CXX_COMPILER=g++-11 \
-%endif
     -DCMAKE_INSTALL_PREFIX=%{_prefix} \
     -DCMAKE_INSTALL_LIBDIR:PATH=%{_libdir} \
     -DCMAKE_INSTALL_LIBEXECDIR:PATH=%{_libexecdir} \

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -149,13 +149,6 @@
 %endif
 %endif
 
-%if 0%{with seastar}
-# disable -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1, as gcc-toolset-{9,10}-annobin
-# do not provide gcc-annobin.so anymore, despite that they provide annobin.so. but
-# redhat-rpm-config still passes -fplugin=gcc-annobin to the compiler.
-%undefine _annotated_build
-%endif
-
 #################################################################################
 # main package definition
 #################################################################################
@@ -1284,6 +1277,12 @@ export CXXFLAGS=$(echo $RPM_OPT_FLAGS | sed -e 's/-Wp,-D_FORTIFY_SOURCE=2//g')
 # remove from CFLAGS too because it causes the arrow submodule to fail with:
 #   warning _FORTIFY_SOURCE requires compiling with optimization (-O)
 export CFLAGS=$(echo $RPM_OPT_FLAGS | sed -e 's/-Wp,-D_FORTIFY_SOURCE=2//g')
+%if 0%{?fedora} || 0%{?rhel}
+# disable -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1, as gcc-toolset-{9,10}-annobin
+# do not provide gcc-annobin.so anymore, despite that they provide annobin.so. but
+# redhat-rpm-config still passes -fplugin=gcc-annobin to the compiler.
+%undefine _annotated_build
+%endif
 %endif
 
 env | sort

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -203,15 +203,15 @@ BuildRequires:	selinux-policy-devel
 BuildRequires:	gperf
 BuildRequires:  cmake > 3.5
 BuildRequires:	fuse-devel
-%if 0%{with seastar} && 0%{?rhel}
+%if 0%{?fedora}
+BuildRequires:	gcc-c++ >= 11
+%endif
+%if 0%{?rhel} >= 8
 BuildRequires:	gcc-toolset-11-gcc-c++
 BuildRequires:	gcc-toolset-11-build
-%else
+%endif
 %if 0%{?suse_version}
 BuildRequires:	gcc11-c++
-%else
-BuildRequires:	gcc-c++
-%endif
 %endif
 %if 0%{with tcmalloc}
 # libprofiler did not build on ppc64le until 2.7.90

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1388,6 +1388,7 @@ cmake .. \
 %endif
 %if 0%{with seastar}
     -DWITH_SEASTAR:BOOL=ON \
+    -DWITH_JAEGER:BOOL=OFF \
 %endif
     -DWITH_GRAFANA:BOOL=ON
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -122,6 +122,7 @@
 %{!?python3_pkgversion: %global python3_pkgversion 3}
 %{!?python3_version_nodots: %global python3_version_nodots 3}
 %{!?python3_version: %global python3_version 3}
+%{!?gts_prefix: %global gts_prefix gcc-toolset-11}
 
 %if ! 0%{?suse_version}
 # use multi-threaded xz compression: xz level 7 using ncpus threads
@@ -205,10 +206,10 @@ BuildRequires:	fuse-devel
 BuildRequires:	gcc-c++ >= 11
 %endif
 %if 0%{?rhel} >= 8
-BuildRequires:	gcc-toolset-11-gcc-c++
-BuildRequires:	gcc-toolset-11-build
+BuildRequires:	%{gts_prefix}-gcc-c++
+BuildRequires:	%{gts_prefix}-build
 %ifarch aarch64
-BuildRequires:	gcc-toolset-11-libatomic-devel
+BuildRequires:	%{gts_prefix}-libatomic-devel
 %endif
 %endif
 %if 0%{?fedora}
@@ -328,10 +329,10 @@ BuildRequires:  libubsan
 BuildRequires:  libasan
 %endif
 %if 0%{?rhel}
-BuildRequires:  gcc-toolset-11-annobin
-BuildRequires:  gcc-toolset-11-annobin-plugin-gcc
-BuildRequires:  gcc-toolset-11-libubsan-devel
-BuildRequires:  gcc-toolset-11-libasan-devel
+BuildRequires:  %{gts_prefix}-annobin
+BuildRequires:  %{gts_prefix}-annobin-plugin-gcc
+BuildRequires:  %{gts_prefix}-libubsan-devel
+BuildRequires:  %{gts_prefix}-libasan-devel
 %endif
 %endif
 #################################################################################

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1411,6 +1411,14 @@ popd
 
 
 %install
+
+%if 0%{with seastar}
+%if 0%{?fedora} || 0%{?rhel}
+%undefine _annotated_build
+. /opt/rh/gcc-toolset-11/enable
+%endif
+%endif
+
 pushd %{_vpath_builddir}
 %make_install
 # we have dropped sysvinit bits

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -149,6 +149,16 @@
 %endif
 %endif
 
+%if 0%{with seastar}
+# disable -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1, as gcc-toolset-{10,11}-annobin
+# do not provide gcc-annobin.so anymore, despite that they provide annobin.so. but
+# redhat-rpm-config still passes -fplugin=gcc-annobin to the compiler.
+%undefine _annotated_build
+%if 0%{?enable_devtoolset11:1}
+%enable_devtoolset11
+%endif
+%endif
+
 #################################################################################
 # main package definition
 #################################################################################
@@ -195,6 +205,7 @@ BuildRequires:  cmake > 3.5
 BuildRequires:	fuse-devel
 %if 0%{with seastar} && 0%{?rhel}
 BuildRequires:	gcc-toolset-11-gcc-c++
+BuildRequires:	gcc-toolset-11-build
 %else
 %if 0%{?suse_version}
 BuildRequires:	gcc11-c++
@@ -1251,10 +1262,6 @@ This package provides Ceph default alerts for Prometheus.
 %define _lto_cflags %{nil}
 %endif
 
-%if 0%{with seastar} && 0%{?rhel}
-. /opt/rh/gcc-toolset-11/enable
-%endif
-
 %if 0%{with cephfs_java}
 # Find jni.h
 for i in /usr/{lib64,lib}/jvm/java/include{,/linux}; do
@@ -1277,12 +1284,6 @@ export CXXFLAGS=$(echo $RPM_OPT_FLAGS | sed -e 's/-Wp,-D_FORTIFY_SOURCE=2//g')
 # remove from CFLAGS too because it causes the arrow submodule to fail with:
 #   warning _FORTIFY_SOURCE requires compiling with optimization (-O)
 export CFLAGS=$(echo $RPM_OPT_FLAGS | sed -e 's/-Wp,-D_FORTIFY_SOURCE=2//g')
-%if 0%{?fedora} || 0%{?rhel}
-# disable -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1, as gcc-toolset-{9,10}-annobin
-# do not provide gcc-annobin.so anymore, despite that they provide annobin.so. but
-# redhat-rpm-config still passes -fplugin=gcc-annobin to the compiler.
-%undefine _annotated_build
-%endif
 %endif
 
 env | sort
@@ -1410,13 +1411,6 @@ popd
 
 
 %install
-
-%if 0%{with seastar}
-%if 0%{?fedora} || 0%{?rhel}
-%undefine _annotated_build
-. /opt/rh/gcc-toolset-11/enable
-%endif
-%endif
 
 pushd %{_vpath_builddir}
 %make_install

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -207,6 +207,9 @@ BuildRequires:	gcc-c++ >= 11
 %if 0%{?rhel} >= 8
 BuildRequires:	gcc-toolset-11-gcc-c++
 BuildRequires:	gcc-toolset-11-build
+%ifarch aarch64
+BuildRequires:	gcc-toolset-11-libatomic-devel
+%endif
 %endif
 %if 0%{with tcmalloc}
 # libprofiler did not build on ppc64le until 2.7.90
@@ -327,7 +330,6 @@ BuildRequires:  gcc-toolset-11-annobin
 BuildRequires:  gcc-toolset-11-annobin-plugin-gcc
 BuildRequires:  gcc-toolset-11-libubsan-devel
 BuildRequires:  gcc-toolset-11-libasan-devel
-BuildRequires:  gcc-toolset-11-libatomic-devel
 %endif
 %endif
 #################################################################################


### PR DESCRIPTION

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
