### PR TITLE
crimson/os/seastore: cleanups to gc reclaim

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -961,23 +961,6 @@ private:
 
   segment_id_t get_next_reclaim_segment() const;
 
-  /**
-   * rewrite_dirty
-   *
-   * Writes out dirty blocks dirtied earlier than limit.
-   */
-  using rewrite_dirty_iertr = work_iertr;
-  using rewrite_dirty_ret = rewrite_dirty_iertr::future<>;
-  rewrite_dirty_ret rewrite_dirty(
-    Transaction &t,
-    journal_seq_t limit);
-
-  using trim_alloc_iertr = work_iertr;
-  using trim_alloc_ret = trim_alloc_iertr::future<journal_seq_t>;
-  trim_alloc_ret trim_alloc(
-    Transaction &t,
-    journal_seq_t limit);
-
   journal_seq_t get_dirty_tail_target() const {
     assert(init_complete);
     auto ret = journal_head;

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1169,13 +1169,6 @@ private:
       backref_entry_t::cmp_t> &&backrefs,
     std::vector<CachedExtentRef> &extents);
 
-  using retrieve_backref_mappings_ertr = work_ertr;
-  using retrieve_backref_mappings_ret =
-    retrieve_backref_mappings_ertr::future<backref_pin_list_t>;
-  retrieve_backref_mappings_ret retrieve_backref_mappings(
-    paddr_t start_paddr,
-    paddr_t end_paddr);
-
   /*
    * Segments calculations
    */

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1154,20 +1154,17 @@ private:
   using gc_trim_alloc_ret = gc_trim_alloc_ertr::future<>;
   gc_trim_alloc_ret gc_trim_alloc();
 
+  using do_reclaim_space_ertr = gc_ertr;
+  using do_reclaim_space_ret = do_reclaim_space_ertr::future<>;
+  do_reclaim_space_ret do_reclaim_space(
+    const std::vector<CachedExtentRef> &backref_extents,
+    const backref_pin_list_t &pin_list,
+    std::size_t &reclaimed,
+    std::size_t &runs);
+
   using gc_reclaim_space_ertr = gc_ertr;
   using gc_reclaim_space_ret = gc_reclaim_space_ertr::future<>;
   gc_reclaim_space_ret gc_reclaim_space();
-
-
-  using retrieve_live_extents_iertr = work_iertr;
-  using retrieve_live_extents_ret =
-    retrieve_live_extents_iertr::future<>;
-  retrieve_live_extents_ret _retrieve_live_extents(
-    Transaction &t,
-    std::set<
-      backref_entry_t,
-      backref_entry_t::cmp_t> &&backrefs,
-    std::vector<CachedExtentRef> &extents);
 
   /*
    * Segments calculations

--- a/src/crimson/os/seastore/backref/btree_backref_manager.h
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.h
@@ -102,15 +102,11 @@ public:
     paddr_t start,
     paddr_t end) final;
 
-  Cache::backref_extent_entry_query_set_t
-  get_cached_backref_extents_in_range(
+  retrieve_backref_extents_in_range_ret
+  retrieve_backref_extents_in_range(
+    Transaction &t,
     paddr_t start,
     paddr_t end) final;
-
-  retrieve_backref_extents_ret retrieve_backref_extents(
-    Transaction &t,
-    Cache::backref_extent_entry_query_set_t &&backref_extents,
-    std::vector<CachedExtentRef> &extents) final;
 
   void cache_new_backref_extent(paddr_t paddr, extent_types_t type) final;
 

--- a/src/crimson/os/seastore/backref_manager.h
+++ b/src/crimson/os/seastore/backref_manager.h
@@ -87,21 +87,14 @@ public:
     paddr_t start,
     paddr_t end) = 0;
 
-  virtual Cache::backref_extent_entry_query_set_t
-  get_cached_backref_extents_in_range(
+  using retrieve_backref_extents_in_range_iertr = base_iertr;
+  using retrieve_backref_extents_in_range_ret =
+    retrieve_backref_extents_in_range_iertr::future<std::vector<CachedExtentRef>>;
+  virtual retrieve_backref_extents_in_range_ret
+  retrieve_backref_extents_in_range(
+    Transaction &t,
     paddr_t start,
     paddr_t end) = 0;
-
-  using retrieve_backref_extents_iertr = trans_iertr<
-    crimson::errorator<
-      crimson::ct_error::input_output_error>
-    >;
-  using retrieve_backref_extents_ret =
-    retrieve_backref_extents_iertr::future<>;
-  virtual retrieve_backref_extents_ret retrieve_backref_extents(
-    Transaction &t,
-    Cache::backref_extent_entry_query_set_t &&backref_extents,
-    std::vector<CachedExtentRef> &extents) = 0;
 
   virtual void cache_new_backref_extent(paddr_t paddr, extent_types_t type) = 0;
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -106,6 +106,8 @@ using backref_entry_ref = std::unique_ptr<backref_entry_t>;
 using backref_entry_mset_t = backref_entry_t::multiset_t;
 using backref_entry_refs_t = std::vector<backref_entry_ref>;
 using backref_entryrefs_by_seq_t = std::map<journal_seq_t, backref_entry_refs_t>;
+using backref_entry_query_set_t = std::set<
+    backref_entry_t, backref_entry_t::cmp_t>;
 
 /**
  * Cache
@@ -538,11 +540,8 @@ private:
   backref_entryrefs_by_seq_t backref_entryrefs_by_seq;
   backref_entry_mset_t backref_entry_mset;
 
-  using backref_entry_query_mset_t =
-    std::multiset<
-      backref_entry_t,
-      backref_entry_t::cmp_t>;
-
+  using backref_entry_query_mset_t = std::multiset<
+      backref_entry_t, backref_entry_t::cmp_t>;
   backref_entry_query_mset_t get_backref_entries_in_range(
     paddr_t start,
     paddr_t end) {

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -521,22 +521,23 @@ TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(
   }
 }
 
-TransactionManager::get_extents_if_live_ret TransactionManager::get_extents_if_live(
+TransactionManager::get_extents_if_live_ret
+TransactionManager::get_extents_if_live(
   Transaction &t,
   extent_types_t type,
-  paddr_t addr,
+  paddr_t paddr,
   laddr_t laddr,
   seastore_off_t len)
 {
   LOG_PREFIX(TransactionManager::get_extent_if_live);
-  TRACET("{} {}~{} {}", t, type, laddr, len, addr);
+  TRACET("{} {}~{} {}", t, type, laddr, len, paddr);
 
-  return cache->get_extent_if_cached(t, addr, type
-  ).si_then([this, FNAME, &t, type, addr, laddr, len](auto extent)
+  return cache->get_extent_if_cached(t, paddr, type
+  ).si_then([=, this, &t](auto extent)
 	    -> get_extents_if_live_ret {
     if (extent && extent->get_length() == (extent_len_t)len) {
       DEBUGT("{} {}~{} {} is live in cache -- {}",
-             t, type, laddr, len, addr, *extent);
+             t, type, laddr, len, paddr, *extent);
       std::list<CachedExtentRef> res;
       res.emplace_back(std::move(extent));
       return get_extents_if_live_ret(
@@ -552,44 +553,35 @@ TransactionManager::get_extents_if_live_ret TransactionManager::get_extents_if_l
       ).si_then([=, this, &t](lba_pin_list_t pin_list) {
 	return seastar::do_with(
 	  std::list<CachedExtentRef>(),
-	  std::move(pin_list),
-	  [=, this, &t](std::list<CachedExtentRef> &list, lba_pin_list_t &pin_list) {
-	    auto &seg_addr = addr.as_seg_paddr();
-	    auto seg_addr_id = seg_addr.get_segment_id();
-	    return trans_intr::parallel_for_each(pin_list, [=, this, &seg_addr, &list, &t](LBAPinRef &pin) ->
-						 Cache::get_extent_iertr::future<> {
-	      auto pin_laddr = pin->get_key();
-	      auto pin_paddr = pin->get_val();
-	      auto pin_len = pin->get_length();
-
-	      auto &pin_seg_addr = pin_paddr.as_seg_paddr();
-	      auto pin_seg_addr_id = pin_seg_addr.get_segment_id();
-
-	      if (pin_seg_addr_id != seg_addr_id ||
-		  pin_paddr < seg_addr ||
-		  pin_paddr.add_offset(pin_len) > seg_addr.add_offset(len)) {
-		return seastar::now();
-	      }
-	      return cache->get_extent_by_type(
-	        t, type, pin_paddr, pin_laddr, pin_len,
-		[this, pin=std::move(pin)](CachedExtent &extent) mutable {
-		  auto lref = extent.cast<LogicalCachedExtent>();
-		  assert(!lref->has_pin());
-		  assert(!lref->has_been_invalidated());
-		  assert(!pin->has_been_invalidated());
-		  lref->set_pin(std::move(pin));
-		  lba_manager->add_pin(lref->get_pin());
-		}
-	      ).si_then([=, &list](auto ret) {
-		list.emplace_back(std::move(ret));
-		return seastar::now();
-	      });
-	    }).si_then([&list] {
-	      return get_extents_if_live_ret(
-	        interruptible::ready_future_marker{},
-		std::move(list));
-	    });
-	  });
+	  [=, this, &t, pin_list=std::move(pin_list)](
+            std::list<CachedExtentRef> &list) mutable
+        {
+          auto paddr_seg_id = paddr.as_seg_paddr().get_segment_id();
+          return trans_intr::parallel_for_each(
+            std::move(pin_list),
+            [=, this, &list, &t](
+              LBAPinRef &pin) -> Cache::get_extent_iertr::future<>
+          {
+            auto pin_paddr = pin->get_val();
+            auto &pin_seg_paddr = pin_paddr.as_seg_paddr();
+            auto pin_paddr_seg_id = pin_seg_paddr.get_segment_id();
+            auto pin_len = pin->get_length();
+            if (pin_paddr_seg_id != paddr_seg_id ||
+                pin_seg_paddr < paddr ||
+                pin_seg_paddr.add_offset(pin_len) > paddr.add_offset(len)) {
+              return seastar::now();
+            }
+            return pin_to_extent_by_type(t, std::move(pin), type
+            ).si_then([&list](auto ret) {
+              list.emplace_back(std::move(ret));
+              return seastar::now();
+            });
+          }).si_then([&list] {
+            return get_extents_if_live_ret(
+              interruptible::ready_future_marker{},
+              std::move(list));
+          });
+        });
       }).handle_error_interruptible(crimson::ct_error::enoent::handle([] {
 	return std::list<CachedExtentRef>();
       }), crimson::ct_error::pass_further_all{});
@@ -597,16 +589,16 @@ TransactionManager::get_extents_if_live_ret TransactionManager::get_extents_if_l
       return lba_manager->get_physical_extent_if_live(
 	t,
 	type,
-	addr,
+	paddr,
 	laddr,
 	len
       ).si_then([=, &t](auto ret) {
         if (ret) {
           DEBUGT("{} {}~{} {} is live as physical extent -- {}",
-                 t, type, laddr, len, addr, *ret);
+                 t, type, laddr, len, paddr, *ret);
         } else {
           DEBUGT("{} {}~{} {} is not live as physical extent",
-                 t, type, laddr, len, addr);
+                 t, type, laddr, len, paddr);
         }
 	std::list<CachedExtentRef> res;
 	res.emplace_back(std::move(ret));

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -598,15 +598,15 @@ TransactionManager::get_extents_if_live(
 	laddr,
 	len
       ).si_then([=, &t](auto ret) {
+        std::list<CachedExtentRef> res;
         if (ret) {
           DEBUGT("{} {}~{} {} is live as physical extent -- {}",
                  t, type, laddr, len, paddr, *ret);
+          res.emplace_back(std::move(ret));
         } else {
           DEBUGT("{} {}~{} {} is not live as physical extent",
                  t, type, laddr, len, paddr);
         }
-	std::list<CachedExtentRef> res;
-	res.emplace_back(std::move(ret));
         return get_extents_if_live_ret(
 	  interruptible::ready_future_marker{},
 	  std::move(res));


### PR DESCRIPTION
This PR is mostly about cleanups. I was originally trying to improve `TransactionManager::get_extents_if_live()` to be common without segment-specific assumptions -- segment reclaiming assumes that no one else can modify the reclaiming extent in parallel except splitting/retiring it. This is why the current implementation expects to read out none or multiple extents from one allocation info.

The issue is that the transaction cannot reliably read out absent extents from backref allocation info, even though the info is correct at the read time. This is because (for example) we have to asynchronously query the lba tree before actually reading an absent logical extent out, and the original alloc-info can be out-dated as the procedure is not atomic.

The instinct solution is to load and add the extent to the transaction read-set first before doing asynchronous queries (also refer to https://github.com/ceph/ceph/pull/45519#discussion_r917219468). But it turns out that this requires some fundamental changes. Specifically, loading an extent from cache requires an `init_func` parameter. For a logical extent it requires a pin as the assumption is the lba tree was queried first. For an lba extent it requires meta information as it assumes that the parent nodes were queried beforehand.

I'm not really sure whether the described issue will be a problem for RBM with overwrite capabilities. For example when decide to load and evict a cold extent from RBM tier to a slower tier, would this leads to evicting an unrelated extent?

What do you think? @myoungwon @xxhdx1985126 @athanatos 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
