### PR TITLE
qa/suite/crimson-rados: Fix rados_python test

### DIFF
--- a/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
+++ b/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
@@ -12,4 +12,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rados/test_python.sh --eval-attr 'not (tier or snap or ec or bench or stats)'
+        - rados/test_python.sh --eval-attr 'not (wait or tier or snap or ec or bench or stats)'

--- a/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
+++ b/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
@@ -10,6 +10,7 @@ overrides:
     - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - workunit:
+    timeout: 1h
     clients:
       client.0:
         - rados/test_python.sh --eval-attr 'not (wait or tier or snap or ec or bench or stats)'

--- a/qa/suites/rados/basic/tasks/rados_python.yaml
+++ b/qa/suites/rados/basic/tasks/rados_python.yaml
@@ -10,6 +10,7 @@ overrides:
     - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - workunit:
+    timeout: 1h
     clients:
       client.0:
         - rados/test_python.sh

--- a/qa/suites/smoke/basic/tasks/test/rados_python.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rados_python.yaml
@@ -10,6 +10,7 @@ tasks:
     - \(POOL_APP_NOT_ENABLED\)
 - ceph-fuse:
 - workunit:
+    timeout: 1h
     clients:
       client.0:
         - rados/test_python.sh

--- a/src/crimson/os/cyanstore/cyan_store.cc
+++ b/src/crimson/os/cyanstore/cyan_store.cc
@@ -687,7 +687,7 @@ int CyanStore::_omap_rmkeyrange(
 
   ObjectRef o = c->get_or_create_object(oid);
   for (auto i = o->omap.lower_bound(first);
-       i != o->omap.end() && i->first <= last;
+       i != o->omap.end() && i->first < last;
        o->omap.erase(i++));
   return 0;
 }

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -943,6 +943,7 @@ class TestIoctx(object):
         r, _, _ = self.rados.mon_command(json.dumps(cmd), b'')
         eq(r, 0)
 
+    @attr('wait')
     def test_aio_read_wait_for_complete(self):
         # use wait_for_complete() and wait for cb by
         # watching retval[0]
@@ -978,6 +979,7 @@ class TestIoctx(object):
         eq(retval[0], payload)
         eq(sys.getrefcount(comp), 2)
 
+    @attr('wait')
     def test_aio_read_wait_for_complete_and_cb(self):
         # use wait_for_complete_and_cb(), verify retval[0] is
         # set by the time we regain control
@@ -1005,6 +1007,7 @@ class TestIoctx(object):
         eq(retval[0], payload)
         eq(sys.getrefcount(comp), 2)
 
+    @attr('wait')
     def test_aio_read_wait_for_complete_and_cb_error(self):
         # error case, use wait_for_complete_and_cb(), verify retval[0] is
         # set by the time we regain control

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -579,7 +579,7 @@ class TestIoctx(object):
             self.ioctx.operate_read_op(read_op, "hw")
             eq(list(iter), [])
 
-    def test_remove_omap_ramge2(self):
+    def test_remove_omap_range2(self):
         keys = ("1", "2", "3", "4")
         values = (b"a", b"bb", b"ccc", b"dddd")
         with WriteOpCtx() as write_op:


### PR DESCRIPTION
* `test_remove_omap_range2`: The failure was caused by inconsistent behavior of cyanstore in comparison to our other backends. `CyanStore::_omap_rmkeyrange` was updated to not remove the last key in the range.
* `test_aio_read_wait_for_complete_*`: These (3) tests excluded are currently hanging with crimson-osd due to Objecter's (un-futurized) call to monc->get_version(). 
* `rados_python.yaml`: This test only runs for few minutes, timeout was reduced from 3h to 1h to avoid hanging jobs.


`rados:basic` run: https://pulpito.ceph.com/matan-2022-08-17_06:20:56-rados:basic-main-distro-default-smithi/
```
2022-08-11T06:07:14.250 INFO:tasks.workunit.client.0.smithi116.stderr:Ran 73 tests in 231.378s
2022-08-11T06:07:14.250 INFO:tasks.workunit.client.0.smithi116.stderr:
2022-08-11T06:07:14.250 INFO:tasks.workunit.client.0.smithi116.stderr:OK
```

`crimson-rados` run: https://pulpito.ceph.com/matan-2022-08-11_08:04:16-crimson-rados-main-distro-default-smithi/
`smoke:basic` run: https://pulpito.ceph.com/matan-2022-08-17_06:21:40-smoke:basic-main-distro-default-smithi/
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
