### PR TITLE
rgw: Fix races in initialization of data sync

### DIFF
--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -1403,31 +1403,30 @@ public:
 };
 
 class RGWContinuousLeaseCR : public RGWCoroutine {
-  RGWAsyncRadosProcessor *async_rados;
+  RGWAsyncRadosProcessor* async_rados;
   rgw::sal::RadosStore* store;
 
   const rgw_raw_obj obj;
 
   const std::string lock_name;
-  const std::string cookie;
+  const std::string cookie{RGWSimpleRadosLockCR::gen_random_cookie(cct)};
 
   int interval;
-  bool going_down{ false };
+  bool going_down{false};
   bool locked{false};
 
-  RGWCoroutine *caller;
+  RGWCoroutine* caller;
 
   bool aborted{false};
 
 public:
-  RGWContinuousLeaseCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
-                       const rgw_raw_obj& _obj,
-                       const std::string& _lock_name, int _interval, RGWCoroutine *_caller)
-    : RGWCoroutine(_store->ctx()), async_rados(_async_rados), store(_store),
-    obj(_obj), lock_name(_lock_name),
-    cookie(RGWSimpleRadosLockCR::gen_random_cookie(cct)),
-    interval(_interval), caller(_caller)
-  {}
+  RGWContinuousLeaseCR(RGWAsyncRadosProcessor* async_rados,
+		       rgw::sal::RadosStore* _store,
+                       rgw_raw_obj obj, std::string lock_name,
+		       int interval, RGWCoroutine* caller)
+    : RGWCoroutine(_store->ctx()), async_rados(async_rados), store(_store),
+      obj(std::move(obj)), lock_name(std::move(lock_name)),
+      interval(interval), caller(caller) {}
 
   virtual ~RGWContinuousLeaseCR() override;
 

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -773,7 +773,7 @@ public:
   int request_complete() override;
 
   static std::string gen_random_cookie(CephContext* cct) {
-#define COOKIE_LEN 16
+    static constexpr std::size_t COOKIE_LEN = 16;
     char buf[COOKIE_LEN + 1];
     gen_rand_alphanumeric(cct, buf, sizeof(buf) - 1);
     return buf;

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -186,11 +186,14 @@ class RGWReadDataSyncStatusCoroutine : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
   rgw_data_sync_status *sync_status;
+  RGWObjVersionTracker* objv_tracker;
 
 public:
   RGWReadDataSyncStatusCoroutine(RGWDataSyncCtx *_sc,
-                                 rgw_data_sync_status *_status)
-    : RGWCoroutine(_sc->cct), sc(_sc), sync_env(sc->env), sync_status(_status)
+                                 rgw_data_sync_status *_status,
+				 RGWObjVersionTracker* objv_tracker)
+    : RGWCoroutine(_sc->cct), sc(_sc), sync_env(sc->env), sync_status(_status),
+      objv_tracker(objv_tracker)
   {}
   int operate(const DoutPrefixProvider *dpp) override;
 };
@@ -204,7 +207,7 @@ int RGWReadDataSyncStatusCoroutine::operate(const DoutPrefixProvider *dpp)
       bool empty_on_enoent = false; // fail on ENOENT
       call(new ReadInfoCR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
                           rgw_raw_obj(sync_env->svc->zone->get_zone_params().log_pool, RGWDataSyncStatusManager::sync_status_oid(sc->source_zone)),
-                          &sync_status->sync_info, empty_on_enoent));
+                          &sync_status->sync_info, empty_on_enoent, objv_tracker));
     }
     if (retcode < 0) {
       ldpp_dout(dpp, 4) << "failed to read sync status info with "
@@ -534,6 +537,7 @@ class RGWInitDataSyncStatusCoroutine : public RGWCoroutine {
   rgw_data_sync_status* const status;
   RGWSyncTraceNodeRef tn;
   boost::intrusive_ptr<RGWContinuousLeaseCR> lease_cr;
+  RGWObjVersionTracker& objv_tracker;
 
   const rgw_pool& pool{ sync_env->svc->zone->get_zone_params().log_pool };
   const string sync_status_oid{
@@ -546,10 +550,11 @@ public:
   RGWInitDataSyncStatusCoroutine(
     RGWDataSyncCtx* _sc, uint32_t num_shards, uint64_t instance_id,
     const RGWSyncTraceNodeRef& tn_parent, rgw_data_sync_status* status,
-    boost::intrusive_ptr<RGWContinuousLeaseCR> lease_cr)
+    boost::intrusive_ptr<RGWContinuousLeaseCR> lease_cr,
+    RGWObjVersionTracker& objv_tracker)
     : RGWCoroutine(_sc->cct), sc(_sc), num_shards(num_shards), status(status),
       tn(sync_env->sync_tracer->add_node(tn_parent, "init_data_sync_status")),
-      lease_cr(std::move(lease_cr)) {
+      lease_cr(std::move(lease_cr)), objv_tracker(objv_tracker) {
     status->sync_info.instance_id = instance_id;
   }
 
@@ -574,7 +579,7 @@ public:
       using WriteInfoCR = RGWSimpleRadosWriteCR<rgw_data_sync_info>;
       yield call(new WriteInfoCR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
                                  rgw_raw_obj{pool, sync_status_oid},
-                                 status->sync_info));
+                                 status->sync_info, &objv_tracker));
       if (retcode < 0) {
         tn->log(0, SSTR("ERROR: failed to write sync status info with " << retcode));
         return set_cr_error(retcode);
@@ -627,7 +632,7 @@ public:
       status->sync_info.state = rgw_data_sync_info::StateBuildingFullSyncMaps;
       yield call(new WriteInfoCR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
                                  rgw_raw_obj{pool, sync_status_oid},
-                                 status->sync_info));
+                                 status->sync_info, &objv_tracker));
       if (retcode < 0) {
         tn->log(0, SSTR("ERROR: failed to write sync status info with " << retcode));
         return set_cr_error(retcode);
@@ -729,7 +734,8 @@ int RGWRemoteDataLog::read_sync_status(const DoutPrefixProvider *dpp, rgw_data_s
   RGWDataSyncCtx sc_local = sc;
   sc_local.env = &sync_env_local;
 
-  ret = crs.run(dpp, new RGWReadDataSyncStatusCoroutine(&sc_local, sync_status));
+  ret = crs.run(dpp, new RGWReadDataSyncStatusCoroutine(&sc_local, sync_status,
+							nullptr));
   http_manager.stop();
   return ret;
 }
@@ -778,6 +784,8 @@ class DataSyncInitCR : public RGWCoroutine {
 
   boost::intrusive_ptr<RGWContinuousLeaseCR> lease_cr;
 
+  RGWObjVersionTracker objv_tracker;
+
 public:
 
   DataSyncInitCR(RGWDataSyncCtx* sc, uint32_t num_shards, uint64_t instance_id,
@@ -809,8 +817,10 @@ public:
 	yield set_sleeping(true);
       }
       tn->log(5, "acquired data sync status lease");
+      objv_tracker.generate_new_write_ver(sc->cct);
       yield call(new RGWInitDataSyncStatusCoroutine(sc, num_shards, instance_id,
-						    tn, sync_status, lease_cr));
+						    tn, sync_status, lease_cr,
+						    objv_tracker));
       lease_cr->go_down();
       lease_cr.reset();
       drain_all();
@@ -2195,6 +2205,7 @@ class RGWDataSyncCR : public RGWCoroutine {
   boost::intrusive_ptr<RGWContinuousLeaseCR> init_lease;
   boost::intrusive_ptr<RGWCoroutinesStack> lease_stack;
 
+  RGWObjVersionTracker obj_version;
 public:
   RGWDataSyncCR(RGWDataSyncCtx *_sc, uint32_t _num_shards, RGWSyncTraceNodeRef& _tn, bool *_reset_backoff) : RGWCoroutine(_sc->cct),
                                                       sc(_sc), sync_env(_sc->env),
@@ -2216,7 +2227,7 @@ public:
     reenter(this) {
 
       /* read sync status */
-      yield call(new RGWReadDataSyncStatusCoroutine(sc, &sync_status));
+      yield call(new RGWReadDataSyncStatusCoroutine(sc, &sync_status, nullptr));
 
       data_sync_module = sync_env->sync_module->get_data_handler();
 
@@ -2244,7 +2255,8 @@ public:
 	tn->log(5, "acquired data sync status lease");
 
 	// Reread sync status now that we've acquired the lock!
-	yield call(new RGWReadDataSyncStatusCoroutine(sc, &sync_status));
+	obj_version.clear();
+	yield call(new RGWReadDataSyncStatusCoroutine(sc, &sync_status, &obj_version));
 	if (retcode < 0) {
 	  tn->log(0, SSTR("ERROR: failed to fetch sync status, retcode=" << retcode));
 	  return set_cr_error(retcode);
@@ -2257,7 +2269,7 @@ public:
         sync_status.sync_info.num_shards = num_shards;
         uint64_t instance_id;
         instance_id = ceph::util::generate_random_number<uint64_t>();
-        yield call(new RGWInitDataSyncStatusCoroutine(sc, num_shards, instance_id, tn, &sync_status, init_lease));
+        yield call(new RGWInitDataSyncStatusCoroutine(sc, num_shards, instance_id, tn, &sync_status, init_lease, obj_version));
         if (retcode < 0) {
           tn->log(0, SSTR("ERROR: failed to init sync, retcode=" << retcode));
 	  init_lease->go_down();
@@ -2345,7 +2357,7 @@ public:
   RGWCoroutine *set_sync_info_cr() {
     return new RGWSimpleRadosWriteCR<rgw_data_sync_info>(sync_env->dpp, sync_env->async_rados, sync_env->svc->sysobj,
                                                          rgw_raw_obj(sync_env->svc->zone->get_zone_params().log_pool, RGWDataSyncStatusManager::sync_status_oid(sc->source_zone)),
-                                                         sync_status.sync_info);
+                                                         sync_status.sync_info, &obj_version);
   }
 
   void wakeup(int shard_id, bc::flat_set<rgw_data_notify_entry>& entries) {

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -527,55 +527,50 @@ bool RGWListRemoteDataLogCR::spawn_next() {
 }
 
 class RGWInitDataSyncStatusCoroutine : public RGWCoroutine {
-  static constexpr uint32_t lock_duration = 30;
-  RGWDataSyncCtx *sc;
-  RGWDataSyncEnv *sync_env;
-  rgw::sal::RadosStore* store; // RGWDataSyncEnv also has a pointer to store
-  const rgw_pool& pool;
+  static constexpr auto lock_name{ "sync_lock"sv };
+  RGWDataSyncCtx* const sc;
+  RGWDataSyncEnv* const sync_env{ sc->env };
   const uint32_t num_shards;
+  rgw_data_sync_status* const status;
+  RGWSyncTraceNodeRef tn;
+  boost::intrusive_ptr<RGWContinuousLeaseCR> lease_cr;
 
-  string sync_status_oid;
+  const rgw_pool& pool{ sync_env->svc->zone->get_zone_params().log_pool };
+  const string sync_status_oid{
+    RGWDataSyncStatusManager::sync_status_oid(sc->source_zone) };
 
-  string lock_name;
-  string cookie;
-  rgw_data_sync_status *status;
   map<int, RGWDataChangesLogInfo> shards_info;
 
-  RGWSyncTraceNodeRef tn;
+
 public:
-  RGWInitDataSyncStatusCoroutine(RGWDataSyncCtx *_sc, uint32_t num_shards,
-                                 uint64_t instance_id,
-                                 RGWSyncTraceNodeRef& _tn_parent,
-                                 rgw_data_sync_status *status)
-    : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env), store(sync_env->store),
-      pool(sync_env->svc->zone->get_zone_params().log_pool),
-      num_shards(num_shards), status(status),
-      tn(sync_env->sync_tracer->add_node(_tn_parent, "init_data_sync_status")) {
-    lock_name = "sync_lock";
-
+  RGWInitDataSyncStatusCoroutine(
+    RGWDataSyncCtx* _sc, uint32_t num_shards, uint64_t instance_id,
+    const RGWSyncTraceNodeRef& tn_parent, rgw_data_sync_status* status,
+    boost::intrusive_ptr<RGWContinuousLeaseCR> lease_cr)
+    : RGWCoroutine(_sc->cct), sc(_sc), num_shards(num_shards), status(status),
+      tn(sync_env->sync_tracer->add_node(tn_parent, "init_data_sync_status")),
+      lease_cr(std::move(lease_cr)) {
     status->sync_info.instance_id = instance_id;
+  }
 
-#define COOKIE_LEN 16
-    char buf[COOKIE_LEN + 1];
-
-    gen_rand_alphanumeric(cct, buf, sizeof(buf) - 1);
-    cookie = buf;
-
-    sync_status_oid = RGWDataSyncStatusManager::sync_status_oid(sc->source_zone);
-
+  static auto continuous_lease_cr(RGWDataSyncCtx* const sc,
+				  RGWCoroutine* const caller) {
+    auto lock_duration = sc->cct->_conf->rgw_sync_lease_period;
+    return new RGWContinuousLeaseCR(
+      sc->env->async_rados, sc->env->store,
+      { sc->env->svc->zone->get_zone_params().log_pool,
+	RGWDataSyncStatusManager::sync_status_oid(sc->source_zone) },
+      string(lock_name), lock_duration, caller);
   }
 
   int operate(const DoutPrefixProvider *dpp) override {
     int ret;
     reenter(this) {
-      using LockCR = RGWSimpleRadosLockCR;
-      yield call(new LockCR(sync_env->async_rados, store,
-                            rgw_raw_obj{pool, sync_status_oid},
-                            lock_name, cookie, lock_duration));
-      if (retcode < 0) {
-        tn->log(0, SSTR("ERROR: failed to take a lock on " << sync_status_oid));
-        return set_cr_error(retcode);
+      if (!lease_cr->is_locked()) {
+	drain_all();
+	return set_cr_error(-ECANCELED);
       }
+
       using WriteInfoCR = RGWSimpleRadosWriteCR<rgw_data_sync_info>;
       yield call(new WriteInfoCR(dpp, sync_env->async_rados, sync_env->svc->sysobj,
                                  rgw_raw_obj{pool, sync_status_oid},
@@ -585,16 +580,11 @@ public:
         return set_cr_error(retcode);
       }
 
-      /* take lock again, we just recreated the object */
-      yield call(new LockCR(sync_env->async_rados, store,
-                            rgw_raw_obj{pool, sync_status_oid},
-                            lock_name, cookie, lock_duration));
-      if (retcode < 0) {
-        tn->log(0, SSTR("ERROR: failed to take a lock on " << sync_status_oid));
-        return set_cr_error(retcode);
-      }
-
-      tn->log(10, "took lease");
+      // In the original code we reacquired the lock. Since
+      // RGWSimpleRadosWriteCR doesn't appear to touch the attributes
+      // and cls_version works across it, this should be unnecessary.
+      // Putting a note here just in case. If we see ECANCELED where
+      // we expect EBUSY, we can revisit this.
 
       /* fetch current position in logs */
       yield {
@@ -642,9 +632,6 @@ public:
         tn->log(0, SSTR("ERROR: failed to write sync status info with " << retcode));
         return set_cr_error(retcode);
       }
-      yield call(new RGWSimpleRadosUnlockCR(sync_env->async_rados, store,
-                                            rgw_raw_obj{pool, sync_status_oid},
-                                            lock_name, cookie));
       return set_cr_done();
     }
     return 0;
@@ -781,6 +768,62 @@ int RGWRemoteDataLog::read_recovering_shards(const DoutPrefixProvider *dpp, cons
   return ret;
 }
 
+namespace RGWRDL {
+class DataSyncInitCR : public RGWCoroutine {
+  RGWDataSyncCtx* const sc;
+  const uint32_t num_shards;
+  uint64_t instance_id;
+  const RGWSyncTraceNodeRef& tn;
+  rgw_data_sync_status* const sync_status;
+
+  boost::intrusive_ptr<RGWContinuousLeaseCR> lease_cr;
+
+public:
+
+  DataSyncInitCR(RGWDataSyncCtx* sc, uint32_t num_shards, uint64_t instance_id,
+		 const RGWSyncTraceNodeRef& tn,
+		 rgw_data_sync_status* sync_status)
+    : RGWCoroutine(sc->cct), sc(sc), num_shards(num_shards),
+      instance_id(instance_id), tn(tn), sync_status(sync_status) {}
+
+  ~DataSyncInitCR() override {
+    if (lease_cr) {
+      lease_cr->abort();
+    }
+  }
+
+  int operate(const DoutPrefixProvider *dpp) override {
+    reenter(this) {
+      lease_cr.reset(
+	RGWInitDataSyncStatusCoroutine::continuous_lease_cr(sc, this));
+
+      yield spawn(lease_cr.get(), false);
+      while (!lease_cr->is_locked()) {
+	if (lease_cr->is_done()) {
+	  tn->log(5, "ERROR: failed to take data sync status lease");
+	  set_status("lease lock failed, early abort");
+	  drain_all();
+	  return set_cr_error(lease_cr->get_ret_status());
+	}
+	tn->log(5, "waiting on data sync status lease");
+	yield set_sleeping(true);
+      }
+      tn->log(5, "acquired data sync status lease");
+      yield call(new RGWInitDataSyncStatusCoroutine(sc, num_shards, instance_id,
+						    tn, sync_status, lease_cr));
+      lease_cr->go_down();
+      lease_cr.reset();
+      drain_all();
+      if (retcode < 0) {
+	set_cr_error(retcode);
+      }
+      return set_cr_done();
+    }
+    return 0;
+  }
+};
+}
+
 int RGWRemoteDataLog::init_sync_status(const DoutPrefixProvider *dpp, int num_shards)
 {
   rgw_data_sync_status sync_status;
@@ -798,7 +841,8 @@ int RGWRemoteDataLog::init_sync_status(const DoutPrefixProvider *dpp, int num_sh
   auto instance_id = ceph::util::generate_random_number<uint64_t>();
   RGWDataSyncCtx sc_local = sc;
   sc_local.env = &sync_env_local;
-  ret = crs.run(dpp, new RGWInitDataSyncStatusCoroutine(&sc_local, num_shards, instance_id, tn, &sync_status));
+  ret = crs.run(dpp, new RGWRDL::DataSyncInitCR(&sc_local, num_shards,
+						instance_id, tn, &sync_status));
   http_manager.stop();
   return ret;
 }
@@ -2147,6 +2191,10 @@ class RGWDataSyncCR : public RGWCoroutine {
   RGWSyncTraceNodeRef tn;
 
   RGWDataSyncModule *data_sync_module{nullptr};
+
+  boost::intrusive_ptr<RGWContinuousLeaseCR> init_lease;
+  boost::intrusive_ptr<RGWCoroutinesStack> lease_stack;
+
 public:
   RGWDataSyncCR(RGWDataSyncCtx *_sc, uint32_t _num_shards, RGWSyncTraceNodeRef& _tn, bool *_reset_backoff) : RGWCoroutine(_sc->cct),
                                                       sc(_sc), sync_env(_sc->env),
@@ -2158,6 +2206,9 @@ public:
   ~RGWDataSyncCR() override {
     for (auto iter : shard_crs) {
       iter.second->put();
+    }
+    if (init_lease) {
+      init_lease->abort();
     }
   }
 
@@ -2174,15 +2225,36 @@ public:
         return set_cr_error(retcode);
       }
 
+      if ((rgw_data_sync_info::SyncState)sync_status.sync_info.state !=
+	  rgw_data_sync_info::StateSync) {
+	init_lease.reset(
+	  RGWInitDataSyncStatusCoroutine::continuous_lease_cr(sc, this));
+	yield lease_stack.reset(spawn(init_lease.get(), false));
+
+	while (!init_lease->is_locked()) {
+	  if (init_lease->is_done()) {
+	    tn->log(5, "ERROR: failed to take data sync status lease");
+	    set_status("lease lock failed, early abort");
+	    drain_all();
+	    return set_cr_error(init_lease->get_ret_status());
+	  }
+	  tn->log(5, "waiting on data sync status lease");
+	  yield set_sleeping(true);
+	}
+	tn->log(5, "acquired data sync status lease");
+      }
+
       /* state: init status */
       if ((rgw_data_sync_info::SyncState)sync_status.sync_info.state == rgw_data_sync_info::StateInit) {
         tn->log(20, SSTR("init"));
         sync_status.sync_info.num_shards = num_shards;
         uint64_t instance_id;
         instance_id = ceph::util::generate_random_number<uint64_t>();
-        yield call(new RGWInitDataSyncStatusCoroutine(sc, num_shards, instance_id, tn, &sync_status));
+        yield call(new RGWInitDataSyncStatusCoroutine(sc, num_shards, instance_id, tn, &sync_status, init_lease));
         if (retcode < 0) {
           tn->log(0, SSTR("ERROR: failed to init sync, retcode=" << retcode));
+	  init_lease->go_down();
+	  drain_all();
           return set_cr_error(retcode);
         }
         // sets state = StateBuildingFullSyncMaps
@@ -2201,6 +2273,12 @@ public:
           tn->log(0, SSTR("ERROR: sync module init_sync() failed, retcode=" << retcode));
           return set_cr_error(retcode);
         }
+
+        if (!init_lease->is_locked()) {
+          init_lease->go_down();
+          drain_all();
+          return set_cr_error(-ECANCELED);
+        }
         /* state: building full sync maps */
         yield call(new RGWListBucketIndexesCR(sc, &sync_status));
         if (retcode < 0) {
@@ -2209,6 +2287,11 @@ public:
         }
         sync_status.sync_info.state = rgw_data_sync_info::StateSync;
 
+        if (!init_lease->is_locked()) {
+          init_lease->go_down();
+          drain_all();
+          return set_cr_error(-ECANCELED);
+        }
         /* update new state */
         yield call(set_sync_info_cr());
         if (retcode < 0) {
@@ -2224,9 +2307,15 @@ public:
         tn->log(0, SSTR("ERROR: failed to start sync, retcode=" << retcode));
         return set_cr_error(retcode);
       }
-      
+
       yield {
         if  ((rgw_data_sync_info::SyncState)sync_status.sync_info.state == rgw_data_sync_info::StateSync) {
+	  if (init_lease) {
+	    init_lease->go_down();
+	    drain_all();
+	    init_lease.reset();
+	    lease_stack.reset();
+	  }
           tn->log(10, SSTR("spawning " << num_shards << " shards sync"));
           for (map<uint32_t, rgw_data_sync_marker>::iterator iter = sync_status.sync_markers.begin();
                iter != sync_status.sync_markers.end(); ++iter) {

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2242,6 +2242,13 @@ public:
 	  yield set_sleeping(true);
 	}
 	tn->log(5, "acquired data sync status lease");
+
+	// Reread sync status now that we've acquired the lock!
+	yield call(new RGWReadDataSyncStatusCoroutine(sc, &sync_status));
+	if (retcode < 0) {
+	  tn->log(0, SSTR("ERROR: failed to fetch sync status, retcode=" << retcode));
+	  return set_cr_error(retcode);
+	}
       }
 
       /* state: init status */

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1647,7 +1647,7 @@ public:
   ~RGWPutLC() override {}
 
   void init(rgw::sal::Store* store, req_state *s, RGWHandler *dialect_handler) override {
-#define COOKIE_LEN 16
+    static constexpr std::size_t COOKIE_LEN = 16;
     char buf[COOKIE_LEN + 1];
 
     RGWOp::init(store, s, dialect_handler);


### PR DESCRIPTION
In a simple, easy process:
- [x] Pull top-level data sync status lock out of `RGWInitDataSyncStatusCoroutine`. In `RGWDataSyncCR` hold the lock through `StateInit` and `StateBuildingFullSyncMaps`, but release once we reach `StateSync`.
- [x] Re-read sync status after acquiring lock in `RGWDataSyncCR`.
- [x] Use `cls_version` for reads/writes to to global sync status to avoid overwrites. (`radosgw-admin data sync init` *should* overwrite, however.)
- [ ] BONUS: Use `cls_version` for reads/writes to per-shard sync status under `DataSyncShardCR`. (Should probably wait until #47422 merges.)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
