### PR TITLE
[DNM] mgr/cephadm: support for max_mds setting in mds specs

### DIFF
--- a/src/pybind/mgr/volumes/fs/fs_util.py
+++ b/src/pybind/mgr/volumes/fs/fs_util.py
@@ -2,7 +2,7 @@ import os
 import errno
 import logging
 
-from ceph.deployment.service_spec import ServiceSpec, PlacementSpec
+from ceph.deployment.service_spec import PlacementSpec, MDSSpec
 
 import cephfs
 import orchestrator
@@ -45,10 +45,11 @@ def rename_filesystem(mgr, fs_name, new_fs_name):
                'yes_i_really_mean_it': True}
     return mgr.mon_command(command)
 
-def create_mds(mgr, fs_name, placement):
-    spec = ServiceSpec(service_type='mds',
+def create_mds(mgr, fs_name, placement, max_mds=None):
+    spec = MDSSpec(service_type='mds',
                                     service_id=fs_name,
-                                    placement=PlacementSpec.from_string(placement))
+                                    placement=PlacementSpec.from_string(placement),
+                                    max_mds=max_mds)
     try:
         completion = mgr.apply([spec], no_overwrite=True)
         orchestrator.raise_if_exception(completion)

--- a/src/pybind/mgr/volumes/fs/operations/volume.py
+++ b/src/pybind/mgr/volumes/fs/operations/volume.py
@@ -55,7 +55,7 @@ def get_pool_names(mgr, volname):
     data_pools = [pools[id] for id in data_pool_ids]
     return metadata_pool, data_pools
 
-def create_volume(mgr, volname, placement):
+def create_volume(mgr, volname, placement, max_mds):
     """
     create volume  (pool, filesystem and mds)
     """
@@ -77,7 +77,7 @@ def create_volume(mgr, volname, placement):
         remove_pool(mgr, data_pool)
         remove_pool(mgr, metadata_pool)
         return r, outb, outs
-    return create_mds(mgr, volname, placement)
+    return create_mds(mgr, volname, placement, max_mds)
 
 
 def delete_volume(mgr, volname, metadata_pool, data_pools):

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -94,10 +94,10 @@ class VolumeClient(CephfsClient["Module"]):
 
     ### volume operations -- create, rm, ls
 
-    def create_fs_volume(self, volname, placement):
+    def create_fs_volume(self, volname, placement, max_mds=None):
         if self.is_stopping():
             return -errno.ESHUTDOWN, "", "shutdown in progress"
-        return create_volume(self.mgr, volname, placement)
+        return create_volume(self.mgr, volname, placement, max_mds)
 
     def delete_fs_volume(self, volname, confirm):
         if self.is_stopping():

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -49,7 +49,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         {
             'cmd': 'fs volume create '
                    f'name=name,type=CephString,goodchars={goodchars} '
-                   'name=placement,type=CephString,req=false ',
+                   'name=placement,type=CephString,req=false '
+                   'name=max_mds,type=CephInt,req=false',
             'desc': "Create a CephFS volume",
             'perm': 'rw'
         },
@@ -529,7 +530,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _cmd_fs_volume_create(self, inbuf, cmd):
         vol_id = cmd['name']
         placement = cmd.get('placement', '')
-        return self.vc.create_fs_volume(vol_id, placement)
+        max_mds = cmd.get('max_mds', None)
+        return self.vc.create_fs_volume(vol_id, placement, max_mds)
 
     @mgr_cmd_wrap
     def _cmd_fs_volume_rm(self, inbuf, cmd):


### PR DESCRIPTION
Users are able to set the max_mds setting for an fs
in order to set how many mds daemons should be active.
So "ceph fs set <fs-name> max_mds 2" would tell the fs
to have 2 mds daemons be active and the rest standby.
This change allows setting this though the mds service
spec and also the "ceph fs volume create" command.

Signed-off-by: Adam King <adking@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
