### PR TITLE
mgr/dashboard: fix nfs exports form issues with squash field 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.ts
@@ -21,7 +21,7 @@ export class NfsFormClientComponent implements OnInit {
 
   @ContentChild('squashHelper', { static: true }) squashHelperTpl: TemplateRef<any>;
 
-  nfsSquash: any[] = this.nfsService.nfsSquash;
+  nfsSquash: any[] = Object.keys(this.nfsService.nfsSquash);
   nfsAccessType: any[] = this.nfsService.nfsAccessType;
   icons = Icons;
   clientsFormArray: FormArray;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -278,9 +278,6 @@
               <option *ngIf="nfsAccessType !== null && nfsAccessType.length === 0"
                       value=""
                       i18n>-- No access type available --</option>
-              <option *ngIf="nfsAccessType !== null && nfsAccessType.length > 0"
-                      value=""
-                      i18n>-- Select the access type --</option>
               <option *ngFor="let accessType of nfsAccessType"
                       [value]="accessType.value">{{ accessType.value }}</option>
             </select>
@@ -304,8 +301,7 @@
         <div class="form-group row">
           <label class="cd-col-form-label"
                  for="squash">
-            <span class="required"
-                  i18n>Squash</span>
+            <span i18n>Squash</span>
             <ng-container *ngTemplateOutlet="squashHelper"></ng-container>
           </label>
           <div class="cd-col-form-input">
@@ -319,9 +315,6 @@
               <option *ngIf="nfsSquash !== null && nfsSquash.length === 0"
                       value=""
                       i18n>-- No squash available --</option>
-              <option *ngIf="nfsSquash !== null && nfsSquash.length > 0"
-                      value=""
-                      i18n>--Select what kind of user id squashing is performed --</option>
               <option *ngFor="let squash of nfsSquash"
                       [value]="squash">{{ squash }}</option>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -56,7 +56,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
 
   defaultAccessType = { RGW: 'RO' };
   nfsAccessType: any[] = this.nfsService.nfsAccessType;
-  nfsSquash: any[] = this.nfsService.nfsSquash;
+  nfsSquash: any[] = Object.keys(this.nfsService.nfsSquash);
 
   action: string;
   resource: string;
@@ -161,12 +161,8 @@ export class NfsFormComponent extends CdForm implements OnInit {
           Validators.pattern('^/[^><|&()]*$')
         ]
       }),
-      access_type: new FormControl('RW', {
-        validators: [Validators.required]
-      }),
-      squash: new FormControl(this.nfsSquash[0], {
-        validators: [Validators.required]
-      }),
+      access_type: new FormControl('RW'),
+      squash: new FormControl(this.nfsSquash[0]),
       transportUDP: new FormControl(true, {
         validators: [
           CdValidators.requiredIf({ transportTCP: false }, (value: boolean) => {
@@ -201,6 +197,12 @@ export class NfsFormComponent extends CdForm implements OnInit {
     res.transportTCP = res.transports.indexOf('TCP') !== -1;
     res.transportUDP = res.transports.indexOf('UDP') !== -1;
     delete res.transports;
+
+    Object.entries(this.nfsService.nfsSquash).forEach(([key, value]) => {
+      if (value.includes(res.squash)) {
+        res.squash = key;
+      }
+    });
 
     res.clients.forEach((client: any) => {
       let addressStr = '';

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nfs.service.ts
@@ -45,7 +45,12 @@ export class NfsService extends ApiClient {
     }
   ];
 
-  nfsSquash = ['no_root_squash', 'root_id_squash', 'root_squash', 'all_squash'];
+  nfsSquash = {
+    no_root_squash: ['no_root_squash', 'noidsquash', 'none'],
+    root_id_squash: ['root_id_squash', 'rootidsquash', 'rootid'],
+    root_squash: ['root_squash', 'rootsquash', 'root'],
+    all_squash: ['all_squash', 'allsquash', 'all', 'allanonymous', 'all_anonymous']
+  };
 
   constructor(private http: HttpClient) {
     super();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.spec.ts
@@ -14,11 +14,11 @@ describe('CephReleaseNamePipe', () => {
     expect(pipe.transform(value)).toBe('mimic');
   });
 
-  it('recognizes a development release as the master branch', () => {
+  it('recognizes a development release as the main branch', () => {
     const value =
       'ceph version 13.1.0-534-g23d3751b89 \
        (23d3751b897b31d2bda57aeaf01acb5ff3c4a9cd) nautilus (dev)';
-    expect(pipe.transform(value)).toBe('master');
+    expect(pipe.transform(value)).toBe('main');
   });
 
   it('transforms with wrong version format', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.ts
@@ -10,8 +10,8 @@ export class CephReleaseNamePipe implements PipeTransform {
     const result = /ceph version\s+[^ ]+\s+\(.+\)\s+(.+)\s+\((.+)\)/.exec(value);
     if (result) {
       if (result[2] === 'dev') {
-        // Assume this is actually master
-        return 'master';
+        // Assume this is actually main
+        return 'main';
       } else {
         // Return the "nautilus" part
         return result[1];


### PR DESCRIPTION

1. Squash is not a mandatory field.
2. If the export is created from backend, then squash can have many
   different names for each types of squash. for eg.
```
['root', 'root_squash', 'rootsquash', 'rootid', 'root_id_squash', 'rootidsquash', 'all', 'all_squash', 'allsquash', 'all_anomnymous', 'allanonymous', 'no_root_squash', 'none', 'noidsquash']
```
so we need a proper matching in the ui too otherwise the edit field will
not have any value for the squash field.

3. Removed unncessary dropdown helper if there are values for the squash
   and access types.

Fixes: https://tracker.ceph.com/issues/57114

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
