### PR TITLE
rgw/s3: align output format with client request

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -197,7 +197,7 @@ endif()
 
 target_link_libraries(rgw_common
   PRIVATE
-    ceph-common
+    global
     cls_2pc_queue_client
     cls_cmpomap_client
     cls_lock_client

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1102,7 +1102,8 @@ struct perm_state_from_req_state : public perm_state_base {
   }
 };
 
-Effect eval_or_pass(const boost::optional<Policy>& policy,
+Effect eval_or_pass(const DoutPrefixProvider* dpp,
+		    const boost::optional<Policy>& policy,
 		    const rgw::IAM::Environment& env,
 		    boost::optional<const rgw::auth::Identity&> id,
 		    const uint64_t op,
@@ -1116,13 +1117,14 @@ Effect eval_or_pass(const boost::optional<Policy>& policy,
 
 }
 
-Effect eval_identity_or_session_policies(const vector<Policy>& policies,
+Effect eval_identity_or_session_policies(const DoutPrefixProvider* dpp,
+			  const vector<Policy>& policies,
                           const rgw::IAM::Environment& env,
                           const uint64_t op,
                           const ARN& arn) {
   auto policy_res = Effect::Pass, prev_res = Effect::Pass;
   for (auto& policy : policies) {
-    if (policy_res = eval_or_pass(policy, env, boost::none, op, arn); policy_res == Effect::Deny)
+    if (policy_res = eval_or_pass(dpp, policy, env, boost::none, op, arn); policy_res == Effect::Deny)
       return policy_res;
     else if (policy_res == Effect::Allow)
       prev_res = Effect::Allow;
@@ -1140,13 +1142,13 @@ bool verify_user_permission(const DoutPrefixProvider* dpp,
                             const rgw::ARN& res,
                             const uint64_t op)
 {
-  auto identity_policy_res = eval_identity_or_session_policies(user_policies, s->env, op, res);
+  auto identity_policy_res = eval_identity_or_session_policies(dpp, user_policies, s->env, op, res);
   if (identity_policy_res == Effect::Deny) {
     return false;
   }
 
   if (! session_policies.empty()) {
-    auto session_policy_res = eval_identity_or_session_policies(session_policies, s->env, op, res);
+    auto session_policy_res = eval_identity_or_session_policies(dpp, session_policies, s->env, op, res);
     if (session_policy_res == Effect::Deny) {
       return false;
     }
@@ -1238,19 +1240,23 @@ bool verify_bucket_permission(const DoutPrefixProvider* dpp,
   if (!verify_requester_payer_permission(s))
     return false;
 
-  auto identity_policy_res = eval_identity_or_session_policies(identity_policies, s->env, op, ARN(bucket));
+  auto identity_policy_res = eval_identity_or_session_policies(dpp, identity_policies, s->env, op, ARN(bucket));
   if (identity_policy_res == Effect::Deny)
     return false;
 
   rgw::IAM::PolicyPrincipal princ_type = rgw::IAM::PolicyPrincipal::Other;
-  auto r = eval_or_pass(bucket_policy, s->env, *s->identity,
+  if (bucket_policy) {
+    ldpp_dout(dpp, 16) << __func__ << ": policy: " << bucket_policy.get()
+		       << "resource: " << ARN(bucket) << dendl;
+  }
+  auto r = eval_or_pass(dpp, bucket_policy, s->env, *s->identity,
 			op, ARN(bucket), princ_type);
   if (r == Effect::Deny)
     return false;
 
   //Take into account session policies, if the identity making a request is a role
   if (!session_policies.empty()) {
-    auto session_policy_res = eval_identity_or_session_policies(session_policies, s->env, op, ARN(bucket));
+    auto session_policy_res = eval_identity_or_session_policies(dpp, session_policies, s->env, op, ARN(bucket));
     if (session_policy_res == Effect::Deny) {
         return false;
     }
@@ -1373,13 +1379,13 @@ bool verify_bucket_permission(const DoutPrefixProvider* dpp, req_state * const s
 int verify_bucket_owner_or_policy(req_state* const s,
 				  const uint64_t op)
 {
-  auto identity_policy_res = eval_identity_or_session_policies(s->iam_user_policies, s->env, op, ARN(s->bucket->get_key()));
+  auto identity_policy_res = eval_identity_or_session_policies(s, s->iam_user_policies, s->env, op, ARN(s->bucket->get_key()));
   if (identity_policy_res == Effect::Deny) {
     return -EACCES;
   }
 
   rgw::IAM::PolicyPrincipal princ_type = rgw::IAM::PolicyPrincipal::Other;
-  auto e = eval_or_pass(s->iam_policy,
+  auto e = eval_or_pass(s, s->iam_policy,
 			s->env, *s->auth.identity,
 			op, ARN(s->bucket->get_key()), princ_type);
   if (e == Effect::Deny) {
@@ -1387,7 +1393,8 @@ int verify_bucket_owner_or_policy(req_state* const s,
   }
 
   if (!s->session_policies.empty()) {
-    auto session_policy_res = eval_identity_or_session_policies(s->session_policies, s->env, op, ARN(s->bucket->get_key()));
+    auto session_policy_res = eval_identity_or_session_policies(s, s->session_policies, s->env, op,
+								ARN(s->bucket->get_key()));
     if (session_policy_res == Effect::Deny) {
         return -EACCES;
     }
@@ -1458,17 +1465,17 @@ bool verify_object_permission(const DoutPrefixProvider* dpp, struct perm_state_b
   if (!verify_requester_payer_permission(s))
     return false;
 
-  auto identity_policy_res = eval_identity_or_session_policies(identity_policies, s->env, op, ARN(obj));
+  auto identity_policy_res = eval_identity_or_session_policies(dpp, identity_policies, s->env, op, ARN(obj));
   if (identity_policy_res == Effect::Deny)
     return false;
 
   rgw::IAM::PolicyPrincipal princ_type = rgw::IAM::PolicyPrincipal::Other;
-  auto r = eval_or_pass(bucket_policy, s->env, *s->identity, op, ARN(obj), princ_type);
+  auto r = eval_or_pass(dpp, bucket_policy, s->env, *s->identity, op, ARN(obj), princ_type);
   if (r == Effect::Deny)
     return false;
 
   if (!session_policies.empty()) {
-    auto session_policy_res = eval_identity_or_session_policies(session_policies, s->env, op, ARN(obj));
+    auto session_policy_res = eval_identity_or_session_policies(dpp, session_policies, s->env, op, ARN(obj));
     if (session_policy_res == Effect::Deny) {
         return false;
     }

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -360,7 +360,7 @@ void set_req_state_err(req_state* s, int err_no)
 
 void dump(req_state* s)
 {
-  if (s->format != RGW_FORMAT_HTML)
+  if (s->format != RGWFormat::HTML)
     s->formatter->open_object_section("Error");
   if (!s->err.err_code.empty())
     s->formatter->dump_string("Code", s->err.err_code);
@@ -371,7 +371,7 @@ void dump(req_state* s)
   if (!s->trans_id.empty())	// TODO: connect to expose_bucket or another toggle
     s->formatter->dump_string("RequestId", s->trans_id);
   s->formatter->dump_string("HostId", s->host_id);
-  if (s->format != RGW_FORMAT_HTML)
+  if (s->format != RGWFormat::HTML)
     s->formatter->close_section();
 }
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -2180,7 +2180,8 @@ bool verify_object_permission_no_policy(const DoutPrefixProvider* dpp,
 
 /** Check if the req_state's user has the necessary permissions
  * to do the requested action */
-rgw::IAM::Effect eval_identity_or_session_policies(const std::vector<rgw::IAM::Policy>& user_policies,
+rgw::IAM::Effect eval_identity_or_session_policies(const DoutPrefixProvider* dpp,
+			  const std::vector<rgw::IAM::Policy>& user_policies,
                           const rgw::IAM::Environment& env,
                           const uint64_t op,
                           const rgw::ARN& arn);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -151,10 +151,33 @@ using ceph::crypto::MD5;
 
 #define RGW_ATTR_TRACE RGW_ATTR_PREFIX "trace"
 
-#define RGW_FORMAT_PLAIN        0
-#define RGW_FORMAT_XML          1
-#define RGW_FORMAT_JSON         2
-#define RGW_FORMAT_HTML         3
+enum class RGWFormat : int8_t {
+  BAD_FORMAT = -1,
+  PLAIN = 0,
+  XML,
+  JSON,
+  HTML,
+};
+
+static inline const char* to_mime_type(const RGWFormat f)
+{
+  switch (f) {
+  case RGWFormat::XML:
+    return "application/xml";
+    break;
+  case RGWFormat::JSON:
+    return "application/json";
+    break;
+  case RGWFormat::HTML:
+    return "text/html";
+    break;
+  case RGWFormat::PLAIN:
+    return "text/plain";
+    break;
+  default:
+    return "invalid format";
+  }
+}
 
 #define RGW_CAP_READ            0x1
 #define RGW_CAP_WRITE           0x2
@@ -1558,7 +1581,7 @@ struct req_state : DoutPrefixProvider {
   std::string ratelimit_bucket_marker;
   std::string ratelimit_user_name;
   bool content_started{false};
-  int format{0};
+  RGWFormat format{RGWFormat::PLAIN};
   ceph::Formatter *formatter{nullptr};
   std::string decoded_uri;
   std::string relative_uri;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -409,7 +409,7 @@ static int read_obj_policy(const DoutPrefixProvider *dpp,
     const rgw_user& bucket_owner = bucket_policy.get_owner().get_id();
     if (bucket_owner.compare(s->user->get_id()) != 0 &&
         ! s->auth.identity->is_admin_of(bucket_owner)) {
-      auto r = eval_identity_or_session_policies(s->iam_user_policies, s->env,
+      auto r = eval_identity_or_session_policies(dpp, s->iam_user_policies, s->env,
                                   rgw::IAM::s3ListBucket, ARN(bucket->get_key()));
       if (r == Effect::Allow)
         return -ENOENT;
@@ -424,7 +424,7 @@ static int read_obj_policy(const DoutPrefixProvider *dpp,
           return -EACCES;
       }
       if (! s->session_policies.empty()) {
-        r = eval_identity_or_session_policies(s->session_policies, s->env,
+        r = eval_identity_or_session_policies(dpp, s->session_policies, s->env,
                                   rgw::IAM::s3ListBucket, ARN(bucket->get_key()));
         if (r == Effect::Allow)
           return -ENOENT;
@@ -3666,7 +3666,7 @@ int RGWPutObj::verify_permission(optional_yield y)
     if (has_s3_resource_tag)
       rgw_iam_add_buckettags(this, s);
 
-    auto identity_policy_res = eval_identity_or_session_policies(s->iam_user_policies, s->env,
+    auto identity_policy_res = eval_identity_or_session_policies(this, s->iam_user_policies, s->env,
                                             rgw::IAM::s3PutObject,
                                             s->object->get_obj());
     if (identity_policy_res == Effect::Deny)
@@ -3686,7 +3686,7 @@ int RGWPutObj::verify_permission(optional_yield y)
     }
 
     if (!s->session_policies.empty()) {
-      auto session_policy_res = eval_identity_or_session_policies(s->session_policies, s->env,
+      auto session_policy_res = eval_identity_or_session_policies(this, s->session_policies, s->env,
                                               rgw::IAM::s3PutObject,
                                               s->object->get_obj());
       if (session_policy_res == Effect::Deny) {
@@ -4262,7 +4262,7 @@ void RGWPostObj::execute(optional_yield y)
   }
 
   if (s->iam_policy || ! s->iam_user_policies.empty() || !s->session_policies.empty()) {
-    auto identity_policy_res = eval_identity_or_session_policies(s->iam_user_policies, s->env,
+    auto identity_policy_res = eval_identity_or_session_policies(this, s->iam_user_policies, s->env,
                                             rgw::IAM::s3PutObject,
                                             s->object->get_obj());
     if (identity_policy_res == Effect::Deny) {
@@ -4285,7 +4285,7 @@ void RGWPostObj::execute(optional_yield y)
     }
 
     if (!s->session_policies.empty()) {
-      auto session_policy_res = eval_identity_or_session_policies(s->session_policies, s->env,
+      auto session_policy_res = eval_identity_or_session_policies(this, s->session_policies, s->env,
                                               rgw::IAM::s3PutObject,
                                               s->object->get_obj());
       if (session_policy_res == Effect::Deny) {
@@ -4844,7 +4844,7 @@ int RGWDeleteObj::verify_permission(optional_yield y)
 
   if (s->iam_policy || ! s->iam_user_policies.empty() || ! s->session_policies.empty()) {
     if (s->bucket->get_info().obj_lock_enabled() && bypass_governance_mode) {
-      auto r = eval_identity_or_session_policies(s->iam_user_policies, s->env,
+      auto r = eval_identity_or_session_policies(this, s->iam_user_policies, s->env,
                                                rgw::IAM::s3BypassGovernanceRetention, ARN(s->bucket->get_key(), s->object->get_name()));
       if (r == Effect::Deny) {
         bypass_perm = false;
@@ -4855,14 +4855,14 @@ int RGWDeleteObj::verify_permission(optional_yield y)
           bypass_perm = false;
         }
       } else if (r == Effect::Pass && !s->session_policies.empty()) {
-        r = eval_identity_or_session_policies(s->session_policies, s->env,
+        r = eval_identity_or_session_policies(this, s->session_policies, s->env,
                                                rgw::IAM::s3BypassGovernanceRetention, ARN(s->bucket->get_key(), s->object->get_name()));
         if (r == Effect::Deny) {
           bypass_perm = false;
         }
       }
     }
-    auto identity_policy_res = eval_identity_or_session_policies(s->iam_user_policies, s->env,
+    auto identity_policy_res = eval_identity_or_session_policies(this, s->iam_user_policies, s->env,
                                               s->object->get_instance().empty() ?
                                               rgw::IAM::s3DeleteObject :
                                               rgw::IAM::s3DeleteObjectVersion,
@@ -4886,7 +4886,7 @@ int RGWDeleteObj::verify_permission(optional_yield y)
       return -EACCES;
 
     if (!s->session_policies.empty()) {
-      auto session_policy_res = eval_identity_or_session_policies(s->session_policies, s->env,
+      auto session_policy_res = eval_identity_or_session_policies(this, s->session_policies, s->env,
                                               s->object->get_instance().empty() ?
                                               rgw::IAM::s3DeleteObject :
                                               rgw::IAM::s3DeleteObjectVersion,
@@ -5182,7 +5182,7 @@ int RGWCopyObj::verify_permission(optional_yield y)
           rgw_iam_add_objtags(this, s, s->src_object.get(), has_s3_existing_tag, has_s3_resource_tag);
 
         ARN obj_arn(s->src_object->get_obj());
-        auto identity_policy_res = eval_identity_or_session_policies(s->iam_user_policies, s->env,
+        auto identity_policy_res = eval_identity_or_session_policies(this, s->iam_user_policies, s->env,
                                                   s->src_object->get_instance().empty() ?
                                                   rgw::IAM::s3GetObject :
                                                   rgw::IAM::s3GetObjectVersion,
@@ -5204,7 +5204,7 @@ int RGWCopyObj::verify_permission(optional_yield y)
 	  return -EACCES;
 	}
         if (!s->session_policies.empty()) {
-        auto session_policy_res = eval_identity_or_session_policies(s->session_policies, s->env,
+	  auto session_policy_res = eval_identity_or_session_policies(this, s->session_policies, s->env,
                                                   s->src_object->get_instance().empty() ?
                                                   rgw::IAM::s3GetObject :
                                                   rgw::IAM::s3GetObjectVersion,
@@ -5287,7 +5287,7 @@ int RGWCopyObj::verify_permission(optional_yield y)
 				   *md_directive);
 
       ARN obj_arn(dest_object->get_obj());
-      auto identity_policy_res = eval_identity_or_session_policies(s->iam_user_policies,
+      auto identity_policy_res = eval_identity_or_session_policies(this, s->iam_user_policies,
                                                                   s->env,
                                                                   rgw::IAM::s3PutObject,
                                                                   obj_arn);
@@ -5306,7 +5306,8 @@ int RGWCopyObj::verify_permission(optional_yield y)
         return -EACCES;
       }
       if (!s->session_policies.empty()) {
-        auto session_policy_res = eval_identity_or_session_policies(s->session_policies, s->env, rgw::IAM::s3PutObject, obj_arn);
+        auto session_policy_res = eval_identity_or_session_policies(this, s->session_policies, s->env,
+								    rgw::IAM::s3PutObject, obj_arn);
         if (session_policy_res == Effect::Deny) {
             return false;
         }
@@ -6108,7 +6109,7 @@ int RGWInitMultipart::verify_permission(optional_yield y)
     rgw_iam_add_objtags(this, s, has_s3_existing_tag, has_s3_resource_tag);
 
   if (s->iam_policy || ! s->iam_user_policies.empty() || !s->session_policies.empty()) {
-    auto identity_policy_res = eval_identity_or_session_policies(s->iam_user_policies, s->env,
+    auto identity_policy_res = eval_identity_or_session_policies(this, s->iam_user_policies, s->env,
                                               rgw::IAM::s3PutObject,
                                               s->object->get_obj());
     if (identity_policy_res == Effect::Deny) {
@@ -6129,7 +6130,7 @@ int RGWInitMultipart::verify_permission(optional_yield y)
     }
 
     if (!s->session_policies.empty()) {
-      auto session_policy_res = eval_identity_or_session_policies(s->session_policies, s->env,
+      auto session_policy_res = eval_identity_or_session_policies(this, s->session_policies, s->env,
                                               rgw::IAM::s3PutObject,
                                               s->object->get_obj());
       if (session_policy_res == Effect::Deny) {
@@ -6222,7 +6223,7 @@ int RGWCompleteMultipart::verify_permission(optional_yield y)
     rgw_iam_add_objtags(this, s, has_s3_existing_tag, has_s3_resource_tag);
 
   if (s->iam_policy || ! s->iam_user_policies.empty() || ! s->session_policies.empty()) {
-    auto identity_policy_res = eval_identity_or_session_policies(s->iam_user_policies, s->env,
+    auto identity_policy_res = eval_identity_or_session_policies(this, s->iam_user_policies, s->env,
                                               rgw::IAM::s3PutObject,
                                               s->object->get_obj());
     if (identity_policy_res == Effect::Deny) {
@@ -6243,7 +6244,7 @@ int RGWCompleteMultipart::verify_permission(optional_yield y)
     }
 
     if (!s->session_policies.empty()) {
-      auto session_policy_res = eval_identity_or_session_policies(s->session_policies, s->env,
+      auto session_policy_res = eval_identity_or_session_policies(this, s->session_policies, s->env,
                                               rgw::IAM::s3PutObject,
                                               s->object->get_obj());
       if (session_policy_res == Effect::Deny) {
@@ -6480,7 +6481,7 @@ int RGWAbortMultipart::verify_permission(optional_yield y)
     rgw_iam_add_objtags(this, s, has_s3_existing_tag, has_s3_resource_tag);
 
   if (s->iam_policy || ! s->iam_user_policies.empty() || !s->session_policies.empty()) {
-    auto identity_policy_res = eval_identity_or_session_policies(s->iam_user_policies, s->env,
+    auto identity_policy_res = eval_identity_or_session_policies(this, s->iam_user_policies, s->env,
                                               rgw::IAM::s3AbortMultipartUpload,
                                               s->object->get_obj());
     if (identity_policy_res == Effect::Deny) {
@@ -6501,7 +6502,7 @@ int RGWAbortMultipart::verify_permission(optional_yield y)
     }
 
     if (!s->session_policies.empty()) {
-      auto session_policy_res = eval_identity_or_session_policies(s->session_policies, s->env,
+      auto session_policy_res = eval_identity_or_session_policies(this, s->session_policies, s->env,
                                               rgw::IAM::s3PutObject,
                                               s->object->get_obj());
       if (session_policy_res == Effect::Deny) {
@@ -6687,7 +6688,7 @@ int RGWDeleteMultiObj::verify_permission(optional_yield y)
   if (s->iam_policy || ! s->iam_user_policies.empty() || ! s->session_policies.empty()) {
     if (s->bucket->get_info().obj_lock_enabled() && bypass_governance_mode) {
       ARN bucket_arn(s->bucket->get_key());
-      auto r = eval_identity_or_session_policies(s->iam_user_policies, s->env,
+      auto r = eval_identity_or_session_policies(this, s->iam_user_policies, s->env,
                                                rgw::IAM::s3BypassGovernanceRetention, ARN(s->bucket->get_key()));
       if (r == Effect::Deny) {
         bypass_perm = false;
@@ -6698,7 +6699,7 @@ int RGWDeleteMultiObj::verify_permission(optional_yield y)
           bypass_perm = false;
         }
       } else if (r == Effect::Pass && !s->session_policies.empty()) {
-        r = eval_identity_or_session_policies(s->session_policies, s->env,
+        r = eval_identity_or_session_policies(this, s->session_policies, s->env,
                                                rgw::IAM::s3BypassGovernanceRetention, ARN(s->bucket->get_key()));
         if (r == Effect::Deny) {
           bypass_perm = false;
@@ -6708,7 +6709,7 @@ int RGWDeleteMultiObj::verify_permission(optional_yield y)
 
     bool not_versioned = rgw::sal::Object::empty(s->object.get()) || s->object->get_instance().empty();
 
-    auto identity_policy_res = eval_identity_or_session_policies(s->iam_user_policies, s->env,
+    auto identity_policy_res = eval_identity_or_session_policies(this, s->iam_user_policies, s->env,
                                               not_versioned ?
                                               rgw::IAM::s3DeleteObject :
                                               rgw::IAM::s3DeleteObjectVersion,
@@ -6732,7 +6733,7 @@ int RGWDeleteMultiObj::verify_permission(optional_yield y)
       return -EACCES;
 
     if (!s->session_policies.empty()) {
-      auto session_policy_res = eval_identity_or_session_policies(s->session_policies, s->env,
+      auto session_policy_res = eval_identity_or_session_policies(this, s->session_policies, s->env,
                                               not_versioned ?
                                               rgw::IAM::s3DeleteObject :
                                               rgw::IAM::s3DeleteObjectVersion,
@@ -6843,7 +6844,7 @@ void RGWDeleteMultiObj::execute(optional_yield y)
     std::string version_id;
     std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(*iter);
     if (s->iam_policy || ! s->iam_user_policies.empty() || !s->session_policies.empty()) {
-      auto identity_policy_res = eval_identity_or_session_policies(s->iam_user_policies, s->env,
+      auto identity_policy_res = eval_identity_or_session_policies(this, s->iam_user_policies, s->env,
                                               iter->instance.empty() ?
                                               rgw::IAM::s3DeleteObject :
                                               rgw::IAM::s3DeleteObjectVersion,
@@ -6871,7 +6872,7 @@ void RGWDeleteMultiObj::execute(optional_yield y)
       }
 
       if (!s->session_policies.empty()) {
-        auto session_policy_res = eval_identity_or_session_policies(s->session_policies, s->env,
+        auto session_policy_res = eval_identity_or_session_policies(this, s->session_policies, s->env,
                                               iter->instance.empty() ?
                                               rgw::IAM::s3DeleteObject :
                                               rgw::IAM::s3DeleteObjectVersion,
@@ -7333,7 +7334,7 @@ bool RGWBulkUploadOp::handle_file_verify_permission(RGWBucketInfo& binfo,
 
   bucket_owner = bacl.get_owner();
   if (policy || ! s->iam_user_policies.empty() || !s->session_policies.empty()) {
-    auto identity_policy_res = eval_identity_or_session_policies(s->iam_user_policies, s->env,
+    auto identity_policy_res = eval_identity_or_session_policies(this, s->iam_user_policies, s->env,
                                               rgw::IAM::s3PutObject, obj);
     if (identity_policy_res == Effect::Deny) {
       return false;
@@ -7348,7 +7349,7 @@ bool RGWBulkUploadOp::handle_file_verify_permission(RGWBucketInfo& binfo,
     }
   
     if (!s->session_policies.empty()) {
-      auto session_policy_res = eval_identity_or_session_policies(s->session_policies, s->env,
+      auto session_policy_res = eval_identity_or_session_policies(this, s->session_policies, s->env,
                                               rgw::IAM::s3PutObject, obj);
       if (session_policy_res == Effect::Deny) {
           return false;

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -591,20 +591,7 @@ void end_header(req_state* s, RGWOp* op, const char *content_type,
      and the content type was not set by the user */
   if (force_content_type ||
       (!content_type &&  s->formatter->get_len()  != 0) || s->is_err()){
-    switch (s->format) {
-    case RGWFormat::XML:
-      ctype = "application/xml";
-      break;
-    case RGWFormat::JSON:
-      ctype = "application/json";
-      break;
-    case RGWFormat::HTML:
-      ctype = "text/html";
-      break;
-    default:
-      ctype = "text/plain";
-      break;
-    }
+    ctype = to_mime_type(s->format);
     if (s->prot_flags & RGW_REST_SWIFT)
       ctype.append("; charset=utf-8");
     content_type = ctype.c_str();

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -547,7 +547,7 @@ protected:
   virtual RGWOp *op_options() { return NULL; }
 
 public:
-  static int allocate_formatter(req_state *s, int default_formatter,
+  static int allocate_formatter(req_state *s, RGWFormat default_formatter,
 				bool configurable);
 
   static constexpr int MAX_BUCKET_NAME_LEN = 255;
@@ -558,7 +558,7 @@ public:
 
   static int validate_bucket_name(const std::string& bucket);
   static int validate_object_name(const std::string& object);
-  static int reallocate_formatter(req_state *s, int type);
+  static int reallocate_formatter(req_state *s, RGWFormat type);
 
   int init_permissions(RGWOp* op, optional_yield y) override;
   int read_permissions(RGWOp* op, optional_yield y) override;

--- a/src/rgw/rgw_rest_iam.cc
+++ b/src/rgw/rgw_rest_iam.cc
@@ -99,7 +99,7 @@ int RGWHandler_REST_IAM::init(rgw::sal::Store* store,
 {
   s->dialect = "iam";
 
-  if (int ret = RGWHandler_REST_IAM::init_from_header(s, RGW_FORMAT_XML, true); ret < 0) {
+  if (int ret = RGWHandler_REST_IAM::init_from_header(s, RGWFormat::XML, true); ret < 0) {
     ldpp_dout(s, 10) << "init_from_header returned err=" << ret <<  dendl;
     return ret;
   }
@@ -113,7 +113,7 @@ int RGWHandler_REST_IAM::authorize(const DoutPrefixProvider* dpp, optional_yield
 }
 
 int RGWHandler_REST_IAM::init_from_header(req_state* s,
-                                          int default_formatter,
+                                          RGWFormat default_formatter,
                                           bool configurable_format)
 {
   string req;

--- a/src/rgw/rgw_rest_iam.h
+++ b/src/rgw/rgw_rest_iam.h
@@ -14,7 +14,7 @@ class RGWHandler_REST_IAM : public RGWHandler_REST {
   void rgw_iam_parse_input();
 public:
 
-  static int init_from_header(req_state *s, int default_formatter, bool configurable_format);
+  static int init_from_header(req_state *s, RGWFormat default_formatter, bool configurable_format);
 
   RGWHandler_REST_IAM(const rgw::auth::StrategyRegistry& auth_registry,
 		      bufferlist& bl_post_body)

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -635,7 +635,7 @@ void RGWGetObjTags_ObjStore_S3::send_response_data(bufferlist& bl)
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   if (!op_ret){
@@ -706,7 +706,7 @@ void RGWPutObjTags_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
 }
@@ -719,7 +719,7 @@ void RGWDeleteObjTags_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 }
 
@@ -728,7 +728,7 @@ void RGWGetBucketTags_ObjStore_S3::send_response_data(bufferlist& bl)
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   if (!op_ret) {
@@ -804,7 +804,7 @@ void RGWPutBucketTags_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 }
 
@@ -817,7 +817,7 @@ void RGWDeleteBucketTags_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 }
 
@@ -1298,7 +1298,7 @@ void RGWGetBucketReplication_ObjStore_S3::send_response_data()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   ReplicationConfiguration conf;
@@ -1373,7 +1373,7 @@ void RGWPutBucketReplication_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 }
 
@@ -1388,7 +1388,7 @@ void RGWDeleteBucketReplication_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 }
 
@@ -1400,7 +1400,7 @@ void RGWListBuckets_ObjStore_S3::send_response_begin(bool has_buckets)
   dump_start(s);
   // Explicitly use chunked transfer encoding so that we can stream the result
   // to the user without having to wait for the full length of it.
-  end_header(s, NULL, "application/xml", CHUNKED_TRANSFER_ENCODING);
+  end_header(s, NULL, to_mime_type(s->format), CHUNKED_TRANSFER_ENCODING);
 
   if (! op_ret) {
     list_all_buckets_start(s);
@@ -1476,7 +1476,7 @@ void RGWGetUsage_ObjStore_S3::send_response()
 
   // Explicitly use chunked transfer encoding so that we can stream the result
   // to the user without having to wait for the full length of it.
-  end_header(s, this, "application/xml", CHUNKED_TRANSFER_ENCODING);
+  end_header(s, this, to_mime_type(s->format), CHUNKED_TRANSFER_ENCODING);
   dump_start(s);
   if (op_ret < 0)
     return;
@@ -1794,7 +1794,7 @@ void RGWListBucket_ObjStore_S3::send_response()
 
   // Explicitly use chunked transfer encoding so that we can stream the result
   // to the user without having to wait for the full length of it.
-  end_header(s, this, "application/xml", CHUNKED_TRANSFER_ENCODING);
+  end_header(s, this, to_mime_type(s->format), CHUNKED_TRANSFER_ENCODING);
   dump_start(s);
   if (op_ret < 0) {
     return;
@@ -1950,7 +1950,7 @@ void RGWListBucket_ObjStore_S3v2::send_response()
 
   // Explicitly use chunked transfer encoding so that we can stream the result
   // to the user without having to wait for the full length of it.
-  end_header(s, this, "application/xml", CHUNKED_TRANSFER_ENCODING);
+  end_header(s, this, to_mime_type(s->format), CHUNKED_TRANSFER_ENCODING);
   dump_start(s);
   if (op_ret < 0) {
     return;
@@ -2016,7 +2016,7 @@ void RGWListBucket_ObjStore_S3v2::send_response()
 void RGWGetBucketLogging_ObjStore_S3::send_response()
 {
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   s->formatter->open_object_section_in_ns("BucketLoggingStatus", XMLNS_AWS_S3);
@@ -2052,7 +2052,7 @@ void RGWGetBucketVersioning_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   s->formatter->open_object_section_in_ns("VersioningConfiguration", XMLNS_AWS_S3);
@@ -2163,7 +2163,7 @@ void RGWSetBucketVersioning_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
 }
 
 int RGWSetBucketWebsite_ObjStore_S3::get_params(optional_yield y)
@@ -2240,7 +2240,7 @@ void RGWSetBucketWebsite_ObjStore_S3::send_response()
   if (op_ret < 0)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
 }
 
 void RGWDeleteBucketWebsite_ObjStore_S3::send_response()
@@ -2250,7 +2250,7 @@ void RGWDeleteBucketWebsite_ObjStore_S3::send_response()
   }
   set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
 }
 
 void RGWGetBucketWebsite_ObjStore_S3::send_response()
@@ -2258,7 +2258,7 @@ void RGWGetBucketWebsite_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   if (op_ret < 0) {
@@ -2642,7 +2642,7 @@ void RGWPutObj_ObjStore_S3::send_response()
       dump_errno(s);
       dump_header_if_nonempty(s, "x-amz-version-id", version_id);
       dump_header_if_nonempty(s, "x-amz-expiration", expires);
-      end_header(s, this, "application/xml");
+      end_header(s, this, to_mime_type(s->format));
       dump_start(s);
       struct tm tmp;
       utime_t ut(mtime);
@@ -3452,7 +3452,7 @@ void RGWCopyObj_ObjStore_S3::send_partial_response(off_t ofs)
 
     // Explicitly use chunked transfer encoding so that we can stream the result
     // to the user without having to wait for the full length of it.
-    end_header(s, this, "application/xml", CHUNKED_TRANSFER_ENCODING);
+    end_header(s, this, to_mime_type(s->format), CHUNKED_TRANSFER_ENCODING);
     dump_start(s);
     if (op_ret == 0) {
       s->formatter->open_object_section_in_ns("CopyObjectResult", XMLNS_AWS_S3);
@@ -3487,7 +3487,7 @@ void RGWGetACLs_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
   rgw_flush_formatter(s, s->formatter);
   dump_body(s, acls);
@@ -3540,7 +3540,7 @@ void RGWPutACLs_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 }
 
@@ -3574,7 +3574,7 @@ void RGWGetLC_ObjStore_S3::send_response()
     }
   }
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   if (op_ret < 0)
@@ -3589,7 +3589,7 @@ void RGWPutLC_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 }
 
@@ -3601,7 +3601,7 @@ void RGWDeleteLC_ObjStore_S3::send_response()
     set_req_state_err(s, op_ret);
   }
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 }
 
@@ -3614,7 +3614,7 @@ void RGWGetCORS_ObjStore_S3::send_response()
       set_req_state_err(s, op_ret);
   }
   dump_errno(s);
-  end_header(s, NULL, "application/xml");
+  end_header(s, NULL, to_mime_type(s->format));
   dump_start(s);
   if (! op_ret) {
     string cors;
@@ -3696,7 +3696,7 @@ void RGWPutCORS_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, NULL, "application/xml");
+  end_header(s, NULL, to_mime_type(s->format));
   dump_start(s);
 }
 
@@ -3753,7 +3753,7 @@ void RGWGetBucketEncryption_ObjStore_S3::send_response()
   }
 
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   if (!op_ret) {
@@ -3777,7 +3777,7 @@ void RGWDeleteBucketEncryption_ObjStore_S3::send_response()
 void RGWGetRequestPayment_ObjStore_S3::send_response()
 {
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   s->formatter->open_object_section_in_ns("RequestPaymentConfiguration", XMLNS_AWS_S3);
@@ -3882,7 +3882,7 @@ void RGWInitMultipart_ObjStore_S3::send_response()
     dump_time_header(s, "x-amz-abort-date", abort_date);
     dump_header_if_nonempty(s, "x-amz-abort-rule-id", rule_id);
   }
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   if (op_ret == 0) {
     dump_start(s);
     s->formatter->open_object_section_in_ns("InitiateMultipartUploadResult", XMLNS_AWS_S3);
@@ -3921,7 +3921,7 @@ void RGWCompleteMultipart_ObjStore_S3::send_response()
     set_req_state_err(s, op_ret);
   dump_errno(s);
   dump_header_if_nonempty(s, "x-amz-version-id", version_id);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   if (op_ret == 0) {
     dump_start(s);
     s->formatter->open_object_section_in_ns("CompleteMultipartUploadResult", XMLNS_AWS_S3);
@@ -3967,7 +3967,7 @@ void RGWListMultipart_ObjStore_S3::send_response()
   dump_errno(s);
   // Explicitly use chunked transfer encoding so that we can stream the result
   // to the user without having to wait for the full length of it.
-  end_header(s, this, "application/xml", CHUNKED_TRANSFER_ENCODING);
+  end_header(s, this, to_mime_type(s->format), CHUNKED_TRANSFER_ENCODING);
 
   if (op_ret == 0) {
     dump_start(s);
@@ -4020,7 +4020,7 @@ void RGWListBucketMultiparts_ObjStore_S3::send_response()
 
   // Explicitly use chunked transfer encoding so that we can stream the result
   // to the user without having to wait for the full length of it.
-  end_header(s, this, "application/xml", CHUNKED_TRANSFER_ENCODING);
+  end_header(s, this, to_mime_type(s->format), CHUNKED_TRANSFER_ENCODING);
   dump_start(s);
   if (op_ret < 0)
     return;
@@ -4114,7 +4114,7 @@ void RGWDeleteMultiObj_ObjStore_S3::begin_response()
   dump_start(s);
   // Explicitly use chunked transfer encoding so that we can stream the result
   // to the user without having to wait for the full length of it.
-  end_header(s, this, "application/xml", CHUNKED_TRANSFER_ENCODING);
+  end_header(s, this, to_mime_type(s->format), CHUNKED_TRANSFER_ENCODING);
   s->formatter->open_object_section_in_ns("DeleteResult", XMLNS_AWS_S3);
 
   rgw_flush_formatter(s, s->formatter);
@@ -4256,7 +4256,7 @@ void RGWGetBucketMetaSearch_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s, NULL, "application/xml");
+  end_header(s, NULL, to_mime_type(s->format));
 
   Formatter *f = s->formatter;
   f->open_array_section("GetBucketMetaSearchResult");
@@ -4305,7 +4305,7 @@ void RGWGetBucketObjectLock_ObjStore_S3::send_response()
     set_req_state_err(s, op_ret);
   }
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   if (op_ret) {
@@ -4344,7 +4344,7 @@ void RGWGetObjRetention_ObjStore_S3::send_response()
     set_req_state_err(s, op_ret);
   }
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   if (op_ret) {
@@ -4369,7 +4369,7 @@ void RGWGetObjLegalHold_ObjStore_S3::send_response()
     set_req_state_err(s, op_ret);
   }
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   if (op_ret) {
@@ -4385,7 +4385,7 @@ void RGWGetBucketPolicyStatus_ObjStore_S3::send_response()
     set_req_state_err(s, op_ret);
   }
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   s->formatter->open_object_section_in_ns("PolicyStatus", XMLNS_AWS_S3);
@@ -4414,7 +4414,7 @@ void RGWGetBucketPublicAccessBlock_ObjStore_S3::send_response()
     set_req_state_err(s, op_ret);
   }
   dump_errno(s);
-  end_header(s, this, "application/xml");
+  end_header(s, this, to_mime_type(s->format));
   dump_start(s);
 
   access_conf.dump_xml(s->formatter);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4751,7 +4751,7 @@ RGWOp *RGWHandler_REST_Obj_S3::op_options()
 
 int RGWHandler_REST_S3::init_from_header(rgw::sal::Store* store,
 					 req_state* s,
-					 int default_formatter,
+					 RGWFormat default_formatter,
 					 bool configurable_format)
 {
   string req;
@@ -5039,7 +5039,7 @@ int RGW_Auth_S3::authorize(const DoutPrefixProvider *dpp,
 int RGWHandler_Auth_S3::init(rgw::sal::Store* store, req_state *state,
                              rgw::io::BasicClient *cio)
 {
-  int ret = RGWHandler_REST_S3::init_from_header(store, state, RGW_FORMAT_JSON, true);
+  int ret = RGWHandler_REST_S3::init_from_header(store, state, RGWFormat::JSON, true);
   if (ret < 0)
     return ret;
 
@@ -5054,8 +5054,8 @@ RGWHandler_REST* RGWRESTMgr_S3::get_handler(rgw::sal::Store* store,
   bool is_s3website = enable_s3website && (s->prot_flags & RGW_REST_WEBSITE);
   int ret =
     RGWHandler_REST_S3::init_from_header(store, s,
-					is_s3website ? RGW_FORMAT_HTML :
-					RGW_FORMAT_XML, true);
+					is_s3website ? RGWFormat::HTML :
+					RGWFormat::XML, true);
   if (ret < 0)
     return NULL;
 

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -649,7 +649,8 @@ class RGWHandler_REST_S3 : public RGWHandler_REST {
 protected:
   const rgw::auth::StrategyRegistry& auth_registry;
 public:
-  static int init_from_header(rgw::sal::Store* store, req_state *s, int default_formatter, bool configurable_format);
+  static int init_from_header(rgw::sal::Store* store, req_state *s, RGWFormat default_formatter,
+			      bool configurable_format);
 
   explicit RGWHandler_REST_S3(const rgw::auth::StrategyRegistry& auth_registry)
     : RGWHandler_REST(),

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -793,7 +793,7 @@ int RGWHandler_REST_STS::init(rgw::sal::Store* store,
 {
   s->dialect = "sts";
 
-  if (int ret = RGWHandler_REST_STS::init_from_header(s, RGW_FORMAT_XML, true); ret < 0) {
+  if (int ret = RGWHandler_REST_STS::init_from_header(s, RGWFormat::XML, true); ret < 0) {
     ldpp_dout(s, 10) << "init_from_header returned err=" << ret <<  dendl;
     return ret;
   }
@@ -810,7 +810,7 @@ int RGWHandler_REST_STS::authorize(const DoutPrefixProvider* dpp, optional_yield
 }
 
 int RGWHandler_REST_STS::init_from_header(req_state* s,
-                                          int default_formatter,
+                                          RGWFormat default_formatter,
                                           bool configurable_format)
 {
   string req;

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -204,7 +204,7 @@ class RGWHandler_REST_STS : public RGWHandler_REST {
   void rgw_sts_parse_input();
 public:
 
-  static int init_from_header(req_state *s, int default_formatter, bool configurable_format);
+  static int init_from_header(req_state *s, RGWFormat default_formatter, bool configurable_format);
 
   RGWHandler_REST_STS(const rgw::auth::StrategyRegistry& auth_registry, const std::string& post_body="")
     : RGWHandler_REST(),

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -167,7 +167,7 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_begin(bool has_buckets)
 {
   if (op_ret) {
     set_req_state_err(s, op_ret);
-  } else if (!has_buckets && s->format == RGW_FORMAT_PLAIN) {
+  } else if (!has_buckets && s->format == RGWFormat::PLAIN) {
     op_ret = STATUS_NO_CONTENT;
     set_req_state_err(s, op_ret);
   }
@@ -414,7 +414,7 @@ void RGWListBucket_ObjStore_SWIFT::send_response()
 
       /* swift is a bit inconsistent here */
       switch (s->format) {
-        case RGW_FORMAT_XML:
+        case RGWFormat::XML:
           s->formatter->dump_string("name", name);
           break;
         default:
@@ -2983,7 +2983,7 @@ int RGWHandler_REST_SWIFT::init_from_header(rgw::sal::Store* store,
     return -ENOENT;
   }
 
-  int ret = allocate_formatter(s, RGW_FORMAT_PLAIN, true);
+  int ret = allocate_formatter(s, RGWFormat::PLAIN, true);
   if (ret < 0)
     return ret;
 

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -541,7 +541,7 @@ public:
            rgw::io::BasicClient* const cio) override {
     state->dialect = "swift";
     state->formatter = new JSONFormatter;
-    state->format = RGW_FORMAT_JSON;
+    state->format = RGWFormat::JSON;
 
     return RGWHandler::init(store, state, cio);
   }
@@ -598,7 +598,7 @@ public:
            rgw::io::BasicClient* const cio) override {
     state->dialect = "swift";
     state->formatter = new JSONFormatter;
-    state->format = RGW_FORMAT_JSON;
+    state->format = RGWFormat::JSON;
 
     return RGWHandler::init(store, state, cio);
   }
@@ -655,7 +655,7 @@ public:
            rgw::io::BasicClient* const cio) override {
     state->dialect = "swift";
     state->formatter = new JSONFormatter;
-    state->format = RGW_FORMAT_JSON;
+    state->format = RGWFormat::JSON;
 
     return RGWHandler::init(store, state, cio);
   }

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -756,7 +756,7 @@ int RGWHandler_SWIFT_Auth::init(rgw::sal::Store* store, req_state *state,
 {
   state->dialect = "swift-auth";
   state->formatter = new JSONFormatter;
-  state->format = RGW_FORMAT_JSON;
+  state->format = RGWFormat::JSON;
 
   return RGWHandler::init(store, state, cio);
 }

--- a/src/rgw/rgw_sync_module_es_rest.cc
+++ b/src/rgw/rgw_sync_module_es_rest.cc
@@ -331,7 +331,7 @@ public:
     if (is_truncated) {
       s->formatter->dump_string("NextMarker", next_marker);
     }
-    if (s->format == RGW_FORMAT_JSON) {
+    if (s->format == RGWFormat::JSON) {
       s->formatter->open_array_section("Objects");
     }
     for (auto& i : response.hits.hits) {
@@ -371,7 +371,7 @@ public:
       rgw_flush_formatter(s, s->formatter);
       s->formatter->close_section();
     };
-    if (s->format == RGW_FORMAT_JSON) {
+    if (s->format == RGWFormat::JSON) {
       s->formatter->close_section();
     }
     s->formatter->close_section();
@@ -410,7 +410,7 @@ RGWHandler_REST* RGWRESTMgr_MDSearch_S3::get_handler(rgw::sal::Store* store,
 {
   int ret =
     RGWHandler_REST_S3::init_from_header(store, s,
-					RGW_FORMAT_XML, true);
+					RGWFormat::XML, true);
   if (ret < 0) {
     return nullptr;
   }

--- a/src/rgw/rgw_sync_module_pubsub_rest.cc
+++ b/src/rgw/rgw_sync_module_pubsub_rest.cc
@@ -504,7 +504,7 @@ RGWHandler_REST* RGWRESTMgr_PubSub::get_handler(rgw::sal::Store* store,
 						const rgw::auth::StrategyRegistry& auth_registry,
 						const std::string& frontend_prefix)
 {
-  if (RGWHandler_REST_S3::init_from_header(store, s, RGW_FORMAT_JSON, true) < 0) {
+  if (RGWHandler_REST_S3::init_from_header(store, s, RGWFormat::JSON, true) < 0) {
     return nullptr;
   }
  
@@ -519,7 +519,7 @@ RGWHandler_REST* RGWRESTMgr_PubSub::get_handler(rgw::sal::Store* store,
   } else if (s->init_state.url_bucket == "notifications") {
     handler = new RGWHandler_REST_PSNotifs(auth_registry);
   } else if (s->info.args.exists("notification")) {
-    const int ret = RGWHandler_REST::allocate_formatter(s, RGW_FORMAT_XML, true);
+    const int ret = RGWHandler_REST::allocate_formatter(s, RGWFormat::XML, true);
     if (ret == 0) {
         handler = new RGWHandler_REST_PSNotifs_S3(auth_registry);
     }


### PR DESCRIPTION
    rgw/s3: align output format with client request
    
    In general, e.g., in the S3 ListBucket response, the
    output Formatter is already of the type requested in the HTTP
    Accept header.
    
    Therefore, while there are still many instances where the of
    Formatter is assumed to be XML, it appears necessarily safe
    and seemingly correct to extend this assumption to end_header(...),
    which sends the response content-type.
    
    Fixes: https://tracker.ceph.com/issues/55680
    
    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
