### PR TITLE
docs: correct add system user to the master zone command

### DIFF
--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -278,7 +278,7 @@ Finally, add the system user to the master zone.
 
 ::
 
-    # radosgw-admin zone modify --rgw-zone=us-east --access-key={access-key} --secret={secret}
+    # radosgw-admin zone modify --rgw-zone={zone-name} --access-key={access-key} --secret={secret}
     # radosgw-admin period update --commit
 
 Update the Period


### PR DESCRIPTION
Signed-off-by: Salar Nosrati-Ershad <snosratiershad@gmail.com>

In progress of following the documentation to implement ceph multisite, I' tried the suggested command: `radosgw-admin zone modify --rgw-zone=us-east --access-key={access-key} --secret={secret}` and got following error:
```
failed to init zone: (2) No such file or directory
```
after a double check I realized that the `us-east` value should be defined as a zone in RGW. so think it's better to replace the command with something like that:
`radosgw-admin zone modify --rgw-zone={zone-name} --access-key={access-key} --secret={secret}`



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
